### PR TITLE
Refine sidebar selection styling

### DIFF
--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -1,16 +1,29 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
 enum MuxyTheme {
     @MainActor static var bg: Color { Color(nsColor: GhosttyService.shared.backgroundColor) }
     @MainActor static var nsBg: NSColor { GhosttyService.shared.backgroundColor }
     @MainActor static var fg: Color { Color(nsColor: GhosttyService.shared.foregroundColor) }
-    @MainActor static var fgMuted: Color { Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.65)) }
-    @MainActor static var fgDim: Color { Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.4)) }
+    @MainActor static var fgMuted: Color {
+        Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.65))
+    }
+    @MainActor static var fgDim: Color {
+        Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.4))
+    }
 
-    @MainActor static var surface: Color { Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.08)) }
-    @MainActor static var border: Color { Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.12)) }
-    @MainActor static var hover: Color { Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.06)) }
+    @MainActor static var surface: Color {
+        Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.08))
+    }
+    @MainActor static var border: Color {
+        Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.12))
+    }
+    @MainActor static var hover: Color {
+        Color(nsColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.06))
+    }
 
     @MainActor static var accent: Color { Color(nsColor: GhosttyService.shared.accentColor) }
+    @MainActor static var accentSoft: Color {
+        Color(nsColor: GhosttyService.shared.accentColor.withAlphaComponent(0.1))
+    }
 }

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -72,8 +72,8 @@ private struct ProjectItem: View {
 
     var body: some View {
         Text(project.name)
-            .font(.system(size: 12, weight: selected ? .semibold : .regular))
-            .foregroundStyle(selected ? .white : MuxyTheme.fgMuted)
+            .font(.system(size: 12))
+            .foregroundStyle(selected ? MuxyTheme.accent : MuxyTheme.fgMuted)
             .lineLimit(1)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 10)
@@ -88,7 +88,7 @@ private struct ProjectItem: View {
     }
 
     private var background: some ShapeStyle {
-        if selected { return AnyShapeStyle(MuxyTheme.accent) }
+        if selected { return AnyShapeStyle(MuxyTheme.accentSoft) }
         if hovered { return AnyShapeStyle(MuxyTheme.hover) }
         return AnyShapeStyle(.clear)
     }


### PR DESCRIPTION
- Use a soft accent background for the selected project row\n- Keep selected text in accent color for clearer contrast\n- Add a reusable soft accent theme token