### PR TITLE
Improve theme discovery fallback

### DIFF
--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -46,6 +46,15 @@ final class ThemeService {
         if let resourcesDir = getenv("GHOSTTY_RESOURCES_DIR").map({ String(cString: $0) }) {
             dirs.append(resourcesDir + "/themes")
         }
+
+        let appBundlePaths = [
+            "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
+            NSHomeDirectory() + "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
+        ]
+        for path in appBundlePaths where !dirs.contains(path) {
+            dirs.append(path)
+        }
+
         dirs.append(NSHomeDirectory() + "/.config/ghostty/themes")
         return dirs
     }

--- a/Muxy/Views/ThemePicker.swift
+++ b/Muxy/Views/ThemePicker.swift
@@ -24,23 +24,40 @@ struct ThemePicker: View {
 
             Divider().overlay(MuxyTheme.border)
 
-            ScrollViewReader { proxy in
-                ScrollView(.vertical, showsIndicators: false) {
-                    LazyVStack(spacing: 0) {
-                        ForEach(Array(filteredThemes.enumerated()), id: \.element.id) { index, theme in
-                            ThemeRow(
-                                theme: theme,
-                                isActive: theme.name == currentTheme,
-                                isHighlighted: index == highlightedIndex,
-                                onSelect: { selectTheme(theme) }
-                            )
-                            .id(theme.id)
+            if themes.isEmpty {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "paintpalette")
+                        .font(.system(size: 24))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                    Text("No themes found")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(MuxyTheme.fg)
+                    Text("Install Ghostty or add theme files to\n~/.config/ghostty/themes")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                        .multilineTextAlignment(.center)
+                }
+                Spacer()
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView(.vertical, showsIndicators: false) {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(filteredThemes.enumerated()), id: \.element.id) { index, theme in
+                                ThemeRow(
+                                    theme: theme,
+                                    isActive: theme.name == currentTheme,
+                                    isHighlighted: index == highlightedIndex,
+                                    onSelect: { selectTheme(theme) }
+                                )
+                                .id(theme.id)
+                            }
                         }
                     }
-                }
-                .onChange(of: highlightedIndex) { _, newIndex in
-                    guard let newIndex, newIndex < filteredThemes.count else { return }
-                    proxy.scrollTo(filteredThemes[newIndex].id, anchor: nil)
+                    .onChange(of: highlightedIndex) { _, newIndex in
+                        guard let newIndex, newIndex < filteredThemes.count else { return }
+                        proxy.scrollTo(filteredThemes[newIndex].id, anchor: nil)
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Add fallback Ghostty app bundle theme directories to theme search paths.
- Keep existing config-based theme path support intact.
- Show a clear empty state in Theme Picker when no themes are available.