### PR TITLE
Keep pinned tabs grouped

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -100,7 +100,10 @@ final class AppState {
     }
 
     func togglePinActiveTab(projectID: UUID) {
-        activeTab(for: projectID)?.isPinned.toggle()
+        guard let area = focusedArea(for: projectID),
+              let tabID = area.activeTabID
+        else { return }
+        area.togglePin(tabID)
     }
 
     func dispatch(_ action: Action) {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -21,6 +21,10 @@ final class TabArea: Identifiable {
         return tabs.first { $0.id == activeTabID }
     }
 
+    private var firstUnpinnedIndex: Int {
+        tabs.firstIndex(where: { !$0.isPinned }) ?? tabs.count
+    }
+
     func createTab() {
         let tab = TerminalTab(pane: TerminalPaneState(projectPath: projectPath))
         tabs.append(tab)
@@ -35,7 +39,8 @@ final class TabArea: Identifiable {
     func createTabAdjacent(to tabID: UUID, side: InsertSide) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         let tab = TerminalTab(pane: TerminalPaneState(projectPath: projectPath))
-        let insertIndex = side == .left ? index : index + 1
+        let desiredIndex = side == .left ? index : index + 1
+        let insertIndex = max(desiredIndex, firstUnpinnedIndex)
         tabs.insert(tab, at: insertIndex)
         if let current = activeTabID {
             tabHistory.append(current)
@@ -70,5 +75,18 @@ final class TabArea: Identifiable {
     func selectTabByIndex(_ index: Int) {
         guard index >= 0, index < tabs.count else { return }
         selectTab(tabs[index].id)
+    }
+
+    func togglePin(_ tabID: UUID) {
+        guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
+        let tab = tabs[index]
+        tab.isPinned.toggle()
+        tabs.remove(at: index)
+        if tab.isPinned {
+            tabs.insert(tab, at: firstUnpinnedIndex)
+        } else {
+            let insertIndex = max(firstUnpinnedIndex, 0)
+            tabs.insert(tab, at: insertIndex)
+        }
     }
 }

--- a/Muxy/Views/TabStrip.swift
+++ b/Muxy/Views/TabStrip.swift
@@ -25,7 +25,8 @@ struct PaneTabStrip: View {
                     },
                     onClose: { onCloseTab(tab.id) },
                     onCreateLeft: { area.createTabAdjacent(to: tab.id, side: .left) },
-                    onCreateRight: { area.createTabAdjacent(to: tab.id, side: .right) }
+                    onCreateRight: { area.createTabAdjacent(to: tab.id, side: .right) },
+                    onTogglePin: { area.togglePin(tab.id) }
                 )
             }
 
@@ -95,6 +96,7 @@ private struct TabCell: View {
     let onClose: () -> Void
     let onCreateLeft: () -> Void
     let onCreateRight: () -> Void
+    let onTogglePin: () -> Void
     @State private var hovered = false
     @State private var isRenaming = false
     @State private var renameText = ""
@@ -179,7 +181,7 @@ private struct TabCell: View {
                 }
                 Divider()
                 Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
-                    tab.isPinned.toggle()
+                    onTogglePin()
                 }
                 if !tab.isPinned {
                     Divider()


### PR DESCRIPTION
- Route pin toggling through TabArea state instead of mutating tab view state directly.
- Keep pinned tabs grouped at the start of each tab area.
- Ensure adjacent tab creation respects the pinned/unpinned boundary.