### PR TITLE
Add tab and project cycling shortcuts

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -149,6 +149,28 @@ struct MuxyCommands: Commands {
         }
 
         CommandGroup(after: .windowList) {
+            Button("Next Tab") {
+                guard isMainWindowFocused else { return }
+                guard let projectID = appState.activeProjectID else { return }
+                appState.selectNextTab(projectID: projectID)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .nextTab).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .nextTab).swiftUIModifiers
+            )
+
+            Button("Previous Tab") {
+                guard isMainWindowFocused else { return }
+                guard let projectID = appState.activeProjectID else { return }
+                appState.selectPreviousTab(projectID: projectID)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .previousTab).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .previousTab).swiftUIModifiers
+            )
+
+            Divider()
+
             ForEach(1 ... 9, id: \.self) { index in
                 if let action = ShortcutAction.tabAction(for: index) {
                     Button("Tab \(index)") {
@@ -165,6 +187,26 @@ struct MuxyCommands: Commands {
         }
 
         CommandGroup(after: .sidebar) {
+            Button("Next Project") {
+                guard isMainWindowFocused else { return }
+                appState.selectNextProject(projects: projectStore.projects)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .nextProject).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .nextProject).swiftUIModifiers
+            )
+
+            Button("Previous Project") {
+                guard isMainWindowFocused else { return }
+                appState.selectPreviousProject(projects: projectStore.projects)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .previousProject).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .previousProject).swiftUIModifiers
+            )
+
+            Divider()
+
             ForEach(1 ... 9, id: \.self) { index in
                 if let action = ShortcutAction.projectAction(for: index) {
                     Button("Project \(index)") {
@@ -198,28 +240,6 @@ struct MuxyCommands: Commands {
             .keyboardShortcut(
                 keyBindings.combo(for: .toggleThemePicker).swiftUIKeyEquivalent,
                 modifiers: keyBindings.combo(for: .toggleThemePicker).swiftUIModifiers
-            )
-        }
-
-        CommandGroup(after: .toolbar) {
-            Button("Next Pane") {
-                guard isMainWindowFocused else { return }
-                guard let projectID = appState.activeProjectID else { return }
-                appState.focusNextArea(projectID: projectID)
-            }
-            .keyboardShortcut(
-                keyBindings.combo(for: .nextPane).swiftUIKeyEquivalent,
-                modifiers: keyBindings.combo(for: .nextPane).swiftUIModifiers
-            )
-
-            Button("Previous Pane") {
-                guard isMainWindowFocused else { return }
-                guard let projectID = appState.activeProjectID else { return }
-                appState.focusPreviousArea(projectID: projectID)
-            }
-            .keyboardShortcut(
-                keyBindings.combo(for: .previousPane).swiftUIKeyEquivalent,
-                modifiers: keyBindings.combo(for: .previousPane).swiftUIModifiers
             )
         }
     }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -11,11 +11,13 @@ final class AppState {
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTabByIndex(projectID: UUID, areaID: UUID?, index: Int)
+        case selectNextTab(projectID: UUID)
+        case selectPreviousTab(projectID: UUID)
         case splitArea(projectID: UUID, areaID: UUID, direction: SplitDirection, projectPath: String)
         case closeArea(projectID: UUID, areaID: UUID)
         case focusArea(projectID: UUID, areaID: UUID)
-        case focusNextArea(projectID: UUID)
-        case focusPreviousArea(projectID: UUID)
+        case selectNextProject(projects: [Project])
+        case selectPreviousProject(projects: [Project])
     }
 
     private let selectionStore: any ActiveProjectSelectionStoring
@@ -95,6 +97,14 @@ final class AppState {
         dispatch(.selectTabByIndex(projectID: projectID, areaID: nil, index: index))
     }
 
+    func selectNextTab(projectID: UUID) {
+        dispatch(.selectNextTab(projectID: projectID))
+    }
+
+    func selectPreviousTab(projectID: UUID) {
+        dispatch(.selectPreviousTab(projectID: projectID))
+    }
+
     func activeTab(for projectID: UUID) -> TerminalTab? {
         focusedArea(for: projectID)?.activeTab
     }
@@ -128,17 +138,17 @@ final class AppState {
         dispatch(.focusArea(projectID: projectID, areaID: areaID))
     }
 
-    func focusNextArea(projectID: UUID) {
-        dispatch(.focusNextArea(projectID: projectID))
-    }
-
-    func focusPreviousArea(projectID: UUID) {
-        dispatch(.focusPreviousArea(projectID: projectID))
-    }
-
     func selectProjectByIndex(_ index: Int, projects: [Project]) {
         guard index >= 0, index < projects.count else { return }
         selectProject(projects[index])
+    }
+
+    func selectNextProject(projects: [Project]) {
+        dispatch(.selectNextProject(projects: projects))
+    }
+
+    func selectPreviousProject(projects: [Project]) {
+        dispatch(.selectPreviousProject(projects: projects))
     }
 
     func removeProject(_ projectID: UUID) {

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -9,8 +9,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case splitRight
     case splitDown
     case closePane
-    case nextPane
-    case previousPane
+    case nextTab
+    case previousTab
     case toggleSidebar
     case toggleThemePicker
     case newProject
@@ -25,6 +25,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case selectTab7
     case selectTab8
     case selectTab9
+    case nextProject
+    case previousProject
     case selectProject1
     case selectProject2
     case selectProject3
@@ -46,8 +48,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .splitRight: "Split Right"
         case .splitDown: "Split Down"
         case .closePane: "Close Pane"
-        case .nextPane: "Next Pane"
-        case .previousPane: "Previous Pane"
+        case .nextTab: "Next Tab"
+        case .previousTab: "Previous Tab"
         case .toggleSidebar: "Toggle Sidebar"
         case .toggleThemePicker: "Theme Picker"
         case .newProject: "New Project"
@@ -62,6 +64,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .selectTab7: "Tab 7"
         case .selectTab8: "Tab 8"
         case .selectTab9: "Tab 9"
+        case .nextProject: "Next Project"
+        case .previousProject: "Previous Project"
         case .selectProject1: "Project 1"
         case .selectProject2: "Project 2"
         case .selectProject3: "Project 3"
@@ -83,11 +87,11 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
             "Tabs"
         case .splitRight,
              .splitDown,
-             .closePane,
-             .nextPane,
-             .previousPane:
+             .closePane:
             "Panes"
-        case .selectTab1,
+        case .nextTab,
+             .previousTab,
+             .selectTab1,
              .selectTab2,
              .selectTab3,
              .selectTab4,
@@ -97,7 +101,9 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .selectTab8,
              .selectTab9:
             "Tab Navigation"
-        case .selectProject1,
+        case .nextProject,
+             .previousProject,
+             .selectProject1,
              .selectProject2,
              .selectProject3,
              .selectProject4,
@@ -149,8 +155,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .splitRight,
              .splitDown,
              .closePane,
-             .nextPane,
-             .previousPane,
+             .nextTab,
+             .previousTab,
              .toggleSidebar,
              .toggleThemePicker,
              .newProject,
@@ -164,6 +170,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .selectTab7,
              .selectTab8,
              .selectTab9,
+             .nextProject,
+             .previousProject,
              .selectProject1,
              .selectProject2,
              .selectProject3,
@@ -260,13 +268,13 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .splitRight, combo: KeyCombo(key: "d", command: true)),
         Self(action: .splitDown, combo: KeyCombo(key: "d", command: true, shift: true)),
         Self(action: .closePane, combo: KeyCombo(key: "w", command: true, shift: true)),
-        Self(action: .nextPane, combo: KeyCombo(key: "]", command: true)),
-        Self(action: .previousPane, combo: KeyCombo(key: "[", command: true)),
         Self(action: .toggleSidebar, combo: KeyCombo(key: "b", command: true)),
         Self(action: .toggleThemePicker, combo: KeyCombo(key: "k", command: true)),
         Self(action: .newProject, combo: KeyCombo(key: "n", command: true)),
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),
         Self(action: .reloadConfig, combo: KeyCombo(key: "r", command: true, shift: true)),
+        Self(action: .nextTab, combo: KeyCombo(key: "]", command: true)),
+        Self(action: .previousTab, combo: KeyCombo(key: "[", command: true)),
         Self(action: .selectTab1, combo: KeyCombo(key: "1", command: true)),
         Self(action: .selectTab2, combo: KeyCombo(key: "2", command: true)),
         Self(action: .selectTab3, combo: KeyCombo(key: "3", command: true)),
@@ -276,6 +284,8 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .selectTab7, combo: KeyCombo(key: "7", command: true)),
         Self(action: .selectTab8, combo: KeyCombo(key: "8", command: true)),
         Self(action: .selectTab9, combo: KeyCombo(key: "9", command: true)),
+        Self(action: .nextProject, combo: KeyCombo(key: "]", control: true)),
+        Self(action: .previousProject, combo: KeyCombo(key: "[", control: true)),
         Self(action: .selectProject1, combo: KeyCombo(key: "1", control: true)),
         Self(action: .selectProject2, combo: KeyCombo(key: "2", control: true)),
         Self(action: .selectProject3, combo: KeyCombo(key: "3", control: true)),

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -77,6 +77,22 @@ final class TabArea: Identifiable {
         selectTab(tabs[index].id)
     }
 
+    func selectNextTab() {
+        guard tabs.count > 1, let activeTabID,
+              let index = tabs.firstIndex(where: { $0.id == activeTabID })
+        else { return }
+        let next = (index + 1) % tabs.count
+        selectTab(tabs[next].id)
+    }
+
+    func selectPreviousTab() {
+        guard tabs.count > 1, let activeTabID,
+              let index = tabs.firstIndex(where: { $0.id == activeTabID })
+        else { return }
+        let previous = (index - 1 + tabs.count) % tabs.count
+        selectTab(tabs[previous].id)
+    }
+
     func togglePin(_ tabID: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         let tab = tabs[index]

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -44,6 +44,14 @@ enum WorkspaceReducer {
             focusArea(area.id, projectID: projectID, state: &state)
             area.selectTabByIndex(index)
 
+        case let .selectNextTab(projectID):
+            guard let area = resolveArea(projectID: projectID, areaID: nil, state: state) else { break }
+            area.selectNextTab()
+
+        case let .selectPreviousTab(projectID):
+            guard let area = resolveArea(projectID: projectID, areaID: nil, state: state) else { break }
+            area.selectPreviousTab()
+
         case let .splitArea(projectID, areaID, direction, projectPath):
             splitArea(areaID, direction: direction, projectID: projectID, projectPath: projectPath, state: &state)
 
@@ -53,11 +61,11 @@ enum WorkspaceReducer {
         case let .focusArea(projectID, areaID):
             focusArea(areaID, projectID: projectID, state: &state)
 
-        case let .focusNextArea(projectID):
-            cycleFocus(projectID: projectID, forward: true, state: &state)
+        case let .selectNextProject(projects):
+            cycleProject(projects: projects, forward: true, state: &state)
 
-        case let .focusPreviousArea(projectID):
-            cycleFocus(projectID: projectID, forward: false, state: &state)
+        case let .selectPreviousProject(projects):
+            cycleProject(projects: projects, forward: false, state: &state)
         }
 
         return effects
@@ -142,14 +150,15 @@ enum WorkspaceReducer {
         state.focusedAreaID[projectID] = areaID
     }
 
-    private static func cycleFocus(projectID: UUID, forward: Bool, state: inout WorkspaceState) {
-        let areas = state.workspaceRoots[projectID]?.allAreas() ?? []
-        guard areas.count > 1,
-              let currentID = state.focusedAreaID[projectID],
-              let index = areas.firstIndex(where: { $0.id == currentID })
+    private static func cycleProject(projects: [Project], forward: Bool, state: inout WorkspaceState) {
+        guard projects.count > 1,
+              let currentID = state.activeProjectID,
+              let index = projects.firstIndex(where: { $0.id == currentID })
         else { return }
-        let next = forward ? (index + 1) % areas.count : (index - 1 + areas.count) % areas.count
-        state.focusedAreaID[projectID] = areas[next].id
+        let next = forward ? (index + 1) % projects.count : (index - 1 + projects.count) % projects.count
+        let project = projects[next]
+        state.activeProjectID = project.id
+        ensureWorkspaceExists(projectID: project.id, projectPath: project.path, state: &state)
     }
 
     private static func removeProject(


### PR DESCRIPTION
- Replace pane cycling shortcuts with next/previous tab shortcuts.
- Add next/previous project shortcuts and command menu actions.
- Wire reducer/state updates for tab and project cycling behavior.