### PR TITLE
Persist workspaces between launches

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -22,6 +22,7 @@ final class AppState {
 
     private let selectionStore: any ActiveProjectSelectionStoring
     private let terminalViews: any TerminalViewRemoving
+    private let workspacePersistence: any WorkspacePersisting
 
     var activeProjectID: UUID? {
         didSet { saveSelection() }
@@ -34,17 +35,35 @@ final class AppState {
 
     init(
         selectionStore: any ActiveProjectSelectionStoring,
-        terminalViews: any TerminalViewRemoving
+        terminalViews: any TerminalViewRemoving,
+        workspacePersistence: any WorkspacePersisting
     ) {
         self.selectionStore = selectionStore
         self.terminalViews = terminalViews
+        self.workspacePersistence = workspacePersistence
     }
 
     func restoreSelection(projects: [Project]) {
+        let restored = WorkspaceRestorer.restoreAll(
+            from: workspacePersistence.loadWorkspaces(),
+            validProjectIDs: Set(projects.map(\.id))
+        )
+        for entry in restored {
+            workspaceRoots[entry.projectID] = entry.root
+            focusedAreaID[entry.projectID] = entry.focusedAreaID
+        }
         guard let id = selectionStore.loadActiveProjectID(),
               let project = projects.first(where: { $0.id == id })
         else { return }
         selectProject(project)
+    }
+
+    func saveWorkspaces() {
+        let snapshots = WorkspaceRestorer.snapshotAll(
+            workspaceRoots: workspaceRoots,
+            focusedAreaID: focusedAreaID
+        )
+        workspacePersistence.saveWorkspaces(snapshots)
     }
 
     private func saveSelection() {
@@ -114,6 +133,7 @@ final class AppState {
               let tabID = area.activeTabID
         else { return }
         area.togglePin(tabID)
+        saveWorkspaces()
     }
 
     func dispatch(_ action: Action) {
@@ -132,6 +152,8 @@ final class AppState {
         for paneID in effects.paneIDsToRemove {
             terminalViews.removeView(for: paneID)
         }
+
+        saveWorkspaces()
     }
 
     func focusArea(_ areaID: UUID, projectID: UUID) {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -3,17 +3,39 @@ import Foundation
 @MainActor
 @Observable
 final class TabArea: Identifiable {
-    let id = UUID()
+    let id: UUID
     let projectPath: String
     var tabs: [TerminalTab] = []
     var activeTabID: UUID?
     private var tabHistory: [UUID] = []
 
     init(projectPath: String) {
+        id = UUID()
         self.projectPath = projectPath
         let tab = TerminalTab(pane: TerminalPaneState(projectPath: projectPath))
         tabs.append(tab)
         activeTabID = tab.id
+    }
+
+    init(restoring snapshot: TabAreaSnapshot) {
+        id = snapshot.id
+        projectPath = snapshot.projectPath
+        tabs = snapshot.tabs.map { TerminalTab(restoring: $0) }
+        if let index = snapshot.activeTabIndex, index >= 0, index < tabs.count {
+            activeTabID = tabs[index].id
+        } else {
+            activeTabID = tabs.first?.id
+        }
+    }
+
+    func snapshot() -> TabAreaSnapshot {
+        let activeIndex = tabs.firstIndex(where: { $0.id == activeTabID })
+        return TabAreaSnapshot(
+            id: id,
+            projectPath: projectPath,
+            tabs: tabs.map { $0.snapshot() },
+            activeTabIndex: activeIndex
+        )
     }
 
     var activeTab: TerminalTab? {

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -10,4 +10,9 @@ final class TerminalPaneState: Identifiable {
     init(projectPath: String) {
         self.projectPath = projectPath
     }
+
+    init(projectPath: String, title: String) {
+        self.projectPath = projectPath
+        self.title = title
+    }
 }

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -13,4 +13,19 @@ final class TerminalTab: Identifiable {
     init(pane: TerminalPaneState) {
         self.pane = pane
     }
+
+    init(restoring snapshot: TerminalTabSnapshot) {
+        customTitle = snapshot.customTitle
+        isPinned = snapshot.isPinned
+        pane = TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle)
+    }
+
+    func snapshot() -> TerminalTabSnapshot {
+        TerminalTabSnapshot(
+            customTitle: customTitle,
+            isPinned: isPinned,
+            projectPath: pane.projectPath,
+            paneTitle: pane.title
+        )
+    }
 }

--- a/Muxy/Models/WorkspaceSnapshot.swift
+++ b/Muxy/Models/WorkspaceSnapshot.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+struct WorkspaceSnapshot: Codable {
+    let projectID: UUID
+    let focusedAreaID: UUID?
+    let root: SplitNodeSnapshot
+}
+
+indirect enum SplitNodeSnapshot: Codable {
+    case tabArea(TabAreaSnapshot)
+    case split(SplitBranchSnapshot)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case tabArea
+        case split
+    }
+
+    private enum NodeType: String, Codable {
+        case tabArea
+        case split
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(NodeType.self, forKey: .type)
+        switch type {
+        case .tabArea:
+            self = try .tabArea(container.decode(TabAreaSnapshot.self, forKey: .tabArea))
+        case .split:
+            self = try .split(container.decode(SplitBranchSnapshot.self, forKey: .split))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .tabArea(area):
+            try container.encode(NodeType.tabArea, forKey: .type)
+            try container.encode(area, forKey: .tabArea)
+        case let .split(branch):
+            try container.encode(NodeType.split, forKey: .type)
+            try container.encode(branch, forKey: .split)
+        }
+    }
+}
+
+struct SplitBranchSnapshot: Codable {
+    let direction: SplitDirectionSnapshot
+    let ratio: Double
+    let first: SplitNodeSnapshot
+    let second: SplitNodeSnapshot
+}
+
+enum SplitDirectionSnapshot: String, Codable {
+    case horizontal
+    case vertical
+}
+
+struct TabAreaSnapshot: Codable {
+    let id: UUID
+    let projectPath: String
+    let tabs: [TerminalTabSnapshot]
+    let activeTabIndex: Int?
+}
+
+struct TerminalTabSnapshot: Codable {
+    let customTitle: String?
+    let isPinned: Bool
+    let projectPath: String
+    let paneTitle: String
+}
+
+struct RestoredWorkspace {
+    let projectID: UUID
+    let root: SplitNode
+    let focusedAreaID: UUID
+}
+
+@MainActor
+enum WorkspaceRestorer {
+    static func restoreAll(
+        from snapshots: [WorkspaceSnapshot],
+        validProjectIDs: Set<UUID>
+    ) -> [RestoredWorkspace] {
+        var results: [RestoredWorkspace] = []
+        for snapshot in snapshots {
+            guard validProjectIDs.contains(snapshot.projectID) else { continue }
+            let root = restoreSplitNode(from: snapshot.root)
+            let areas = root.allAreas()
+            guard !areas.isEmpty else { continue }
+            let focusedID: UUID = if let areaID = snapshot.focusedAreaID, root.findArea(id: areaID) != nil {
+                areaID
+            } else {
+                areas[0].id
+            }
+            results.append(RestoredWorkspace(projectID: snapshot.projectID, root: root, focusedAreaID: focusedID))
+        }
+        return results
+    }
+
+    static func snapshotAll(
+        workspaceRoots: [UUID: SplitNode],
+        focusedAreaID: [UUID: UUID]
+    ) -> [WorkspaceSnapshot] {
+        var snapshots: [WorkspaceSnapshot] = []
+        for (projectID, root) in workspaceRoots {
+            snapshots.append(WorkspaceSnapshot(
+                projectID: projectID,
+                focusedAreaID: focusedAreaID[projectID],
+                root: snapshotSplitNode(root)
+            ))
+        }
+        return snapshots
+    }
+
+    private static func restoreSplitNode(from snapshot: SplitNodeSnapshot) -> SplitNode {
+        switch snapshot {
+        case let .tabArea(areaSnapshot):
+            return .tabArea(TabArea(restoring: areaSnapshot))
+        case let .split(branchSnapshot):
+            let first = restoreSplitNode(from: branchSnapshot.first)
+            let second = restoreSplitNode(from: branchSnapshot.second)
+            let direction: SplitDirection = switch branchSnapshot.direction {
+            case .horizontal: .horizontal
+            case .vertical: .vertical
+            }
+            return .split(SplitBranch(
+                direction: direction,
+                ratio: CGFloat(branchSnapshot.ratio),
+                first: first,
+                second: second
+            ))
+        }
+    }
+
+    private static func snapshotSplitNode(_ node: SplitNode) -> SplitNodeSnapshot {
+        switch node {
+        case let .tabArea(area):
+            return .tabArea(area.snapshot())
+        case let .split(branch):
+            let direction: SplitDirectionSnapshot = switch branch.direction {
+            case .horizontal: .horizontal
+            case .vertical: .vertical
+            }
+            return .split(SplitBranchSnapshot(
+                direction: direction,
+                ratio: Double(branch.ratio),
+                first: snapshotSplitNode(branch.first),
+                second: snapshotSplitNode(branch.second)
+            ))
+        }
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -13,7 +13,8 @@ struct MuxyApp: App {
         _appState = State(
             initialValue: AppState(
                 selectionStore: environment.selectionStore,
-                terminalViews: environment.terminalViews
+                terminalViews: environment.terminalViews,
+                workspacePersistence: environment.workspacePersistence
             )
         )
         _projectStore = State(
@@ -32,6 +33,11 @@ struct MuxyApp: App {
                 .environment(MuxyConfig.shared)
                 .environment(ThemeService.shared)
                 .preferredColorScheme(.dark)
+                .onAppear {
+                    appDelegate.onTerminate = { [appState] in
+                        appState.saveWorkspaces()
+                    }
+                }
         }
         .windowStyle(HiddenTitleBarWindowStyle())
         .defaultSize(width: 1200, height: 800)
@@ -54,6 +60,8 @@ struct MuxyApp: App {
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    var onTerminate: (() -> Void)?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
@@ -61,6 +69,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = GhosttyService.shared
         UpdateService.shared.start()
         ModifierKeyMonitor.shared.start()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        onTerminate?()
     }
 
     @MainActor

--- a/Muxy/Services/AppEnvironment.swift
+++ b/Muxy/Services/AppEnvironment.swift
@@ -5,10 +5,12 @@ struct AppEnvironment {
     let selectionStore: any ActiveProjectSelectionStoring
     let terminalViews: any TerminalViewRemoving
     let projectPersistence: any ProjectPersisting
+    let workspacePersistence: any WorkspacePersisting
 
     static let live = Self(
         selectionStore: UserDefaultsActiveProjectSelectionStore(),
         terminalViews: TerminalViewRegistry.shared,
-        projectPersistence: FileProjectPersistence()
+        projectPersistence: FileProjectPersistence(),
+        workspacePersistence: FileWorkspacePersistence()
     )
 }

--- a/Muxy/Services/WorkspacePersistence.swift
+++ b/Muxy/Services/WorkspacePersistence.swift
@@ -1,0 +1,56 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "WorkspacePersistence")
+
+protocol WorkspacePersisting: Sendable {
+    func loadWorkspaces() -> [WorkspaceSnapshot]
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot])
+}
+
+final class FileWorkspacePersistence: WorkspacePersisting {
+    private let fileURL: URL
+
+    init(fileURL: URL = FileWorkspacePersistence.defaultFileURL()) {
+        self.fileURL = fileURL
+    }
+
+    func loadWorkspaces() -> [WorkspaceSnapshot] {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            return try JSONDecoder().decode([WorkspaceSnapshot].self, from: data)
+        } catch {
+            logger.error("Failed to load workspaces: \(error)")
+            return []
+        }
+    }
+
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            let data = try encoder.encode(workspaces)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            logger.error("Failed to save workspaces: \(error)")
+        }
+    }
+
+    private static func defaultFileURL() -> URL {
+        guard let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+        else {
+            fatalError("Application Support directory unavailable")
+        }
+        let dir = appSupport.appendingPathComponent("Muxy", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return dir.appendingPathComponent("workspaces.json")
+    }
+}


### PR DESCRIPTION
## Summary
- Add workspace snapshot models and file persistence for tab/area state.
- Restore saved workspaces on app startup and keep focused area mappings in sync.
- Save workspace state after tab actions and on app termination to preserve session continuity.