### PR TITLE
Add terminal search support

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -47,6 +47,17 @@ struct MuxyCommands: Commands {
                 .keyboardShortcut("v", modifiers: .command)
             Button("Select All") { NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil) }
                 .keyboardShortcut("a", modifiers: .command)
+
+            Divider()
+
+            Button("Find") {
+                guard isMainWindowFocused else { return }
+                NotificationCenter.default.post(name: .findInTerminal, object: nil)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .findInTerminal).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .findInTerminal).swiftUIModifiers
+            )
         }
 
         CommandGroup(replacing: .newItem) {

--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -3,4 +3,5 @@ import Foundation
 extension Notification.Name {
     static let renameActiveTab = Notification.Name("MuxyRenameActiveTab")
     static let toggleThemePicker = Notification.Name("MuxyToggleThemePicker")
+    static let findInTerminal = Notification.Name("MuxyFindInTerminal")
 }

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -36,6 +36,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case selectProject7
     case selectProject8
     case selectProject9
+    case findInTerminal
 
     var id: String { rawValue }
 
@@ -75,6 +76,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .selectProject7: "Project 7"
         case .selectProject8: "Project 8"
         case .selectProject9: "Project 9"
+        case .findInTerminal: "Find"
         }
     }
 
@@ -113,6 +115,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .selectProject8,
              .selectProject9:
             "Project Navigation"
+        case .findInTerminal:
+            "Terminal"
         case .toggleSidebar,
              .toggleThemePicker,
              .newProject,
@@ -123,7 +127,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     }
 
     static var categories: [String] {
-        ["Tabs", "Panes", "Tab Navigation", "Project Navigation", "App"]
+        ["Tabs", "Panes", "Tab Navigation", "Project Navigation", "Terminal", "App"]
     }
 
     static func tabAction(for index: Int) -> Self? {
@@ -180,7 +184,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .selectProject6,
              .selectProject7,
              .selectProject8,
-             .selectProject9:
+             .selectProject9,
+             .findInTerminal:
             .mainWindow
         }
     }
@@ -295,5 +300,6 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .selectProject7, combo: KeyCombo(key: "7", control: true)),
         Self(action: .selectProject8, combo: KeyCombo(key: "8", control: true)),
         Self(action: .selectProject9, combo: KeyCombo(key: "9", control: true)),
+        Self(action: .findInTerminal, combo: KeyCombo(key: "f", command: true)),
     ]
 }

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -6,6 +6,7 @@ final class TerminalPaneState: Identifiable {
     let id = UUID()
     let projectPath: String
     var title: String = "Terminal"
+    let searchState = TerminalSearchState()
 
     init(projectPath: String) {
         self.projectPath = projectPath

--- a/Muxy/Models/TerminalSearchState.swift
+++ b/Muxy/Models/TerminalSearchState.swift
@@ -1,0 +1,43 @@
+import Combine
+import Foundation
+
+@MainActor
+@Observable
+final class TerminalSearchState {
+    var needle: String = ""
+    var total: Int?
+    var selected: Int?
+    var isVisible: Bool = false
+
+    var displayText: String {
+        guard let total else { return "" }
+        guard let selected else { return "\(total) matches" }
+        return "\(selected) of \(total)"
+    }
+
+    private var needleCancellable: AnyCancellable?
+    private var needleSubject = PassthroughSubject<String, Never>()
+
+    func startPublishing(send: @escaping (String) -> Void) {
+        needleCancellable = needleSubject
+            .removeDuplicates()
+            .map { needle -> AnyPublisher<String, Never> in
+                if needle.isEmpty || needle.count >= 3 {
+                    return Just(needle).eraseToAnyPublisher()
+                }
+                return Just(needle)
+                    .delay(for: .milliseconds(300), scheduler: DispatchQueue.main)
+                    .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .sink { send($0) }
+    }
+
+    func pushNeedle() {
+        needleSubject.send(needle)
+    }
+
+    func stopPublishing() {
+        needleCancellable = nil
+    }
+}

--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -25,19 +25,27 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
             return true
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
             return true
+        case GHOSTTY_ACTION_START_SEARCH:
+            handleStartSearch(target: target, search: action.action.start_search)
+            return true
+        case GHOSTTY_ACTION_END_SEARCH:
+            handleEndSearch(target: target)
+            return true
+        case GHOSTTY_ACTION_SEARCH_TOTAL:
+            handleSearchTotal(target: target, total: action.action.search_total)
+            return true
+        case GHOSTTY_ACTION_SEARCH_SELECTED:
+            handleSearchSelected(target: target, selected: action.action.search_selected)
+            return true
         default:
             return false
         }
     }
 
     private func handleSetTitle(target: ghostty_target_s, title: ghostty_action_set_title_s) {
-        guard target.tag == GHOSTTY_TARGET_SURFACE else { return }
-        guard let surface = target.target.surface else { return }
-        guard let userdata = ghostty_surface_userdata(surface) else { return }
+        guard let view = surfaceView(from: target) else { return }
         guard let titlePtr = title.title else { return }
-
         let titleString = String(cString: titlePtr)
-        let view = Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
         DispatchQueue.main.async {
             view.onTitleChange?(titleString)
         }
@@ -87,6 +95,44 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         DispatchQueue.main.async {
             view.onProcessExit?()
         }
+    }
+
+    private func handleStartSearch(target: ghostty_target_s, search: ghostty_action_start_search_s) {
+        guard let view = surfaceView(from: target) else { return }
+        let needle = search.needle.flatMap { String(cString: $0) }
+        DispatchQueue.main.async {
+            view.onSearchStart?(needle)
+        }
+    }
+
+    private func handleEndSearch(target: ghostty_target_s) {
+        guard let view = surfaceView(from: target) else { return }
+        DispatchQueue.main.async {
+            view.onSearchEnd?()
+        }
+    }
+
+    private func handleSearchTotal(target: ghostty_target_s, total: ghostty_action_search_total_s) {
+        guard let view = surfaceView(from: target) else { return }
+        let value = total.total >= 0 ? Int(total.total) : nil
+        DispatchQueue.main.async {
+            view.onSearchTotal?(value)
+        }
+    }
+
+    private func handleSearchSelected(target: ghostty_target_s, selected: ghostty_action_search_selected_s) {
+        guard let view = surfaceView(from: target) else { return }
+        let value = selected.selected >= 0 ? Int(selected.selected) : nil
+        DispatchQueue.main.async {
+            view.onSearchSelected?(value)
+        }
+    }
+
+    private func surfaceView(from target: ghostty_target_s) -> GhosttyTerminalNSView? {
+        guard target.tag == GHOSTTY_TARGET_SURFACE else { return nil }
+        guard let surface = target.target.surface else { return nil }
+        guard let userdata = ghostty_surface_userdata(surface) else { return nil }
+        return Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
     }
 
     private static func callbackSurface(from userdata: UnsafeMutableRawPointer?) -> ghostty_surface_t? {

--- a/Muxy/Views/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/GhosttyTerminalNSView.swift
@@ -8,6 +8,10 @@ final class GhosttyTerminalNSView: NSView {
     var onTitleChange: ((String) -> Void)?
     var onFocus: (() -> Void)?
     var onProcessExit: (() -> Void)?
+    var onSearchStart: ((String?) -> Void)?
+    var onSearchEnd: (() -> Void)?
+    var onSearchTotal: ((Int?) -> Void)?
+    var onSearchSelected: ((Int?) -> Void)?
     var isFocused: Bool = false
 
     private var _markedRange: NSRange = .init(location: NSNotFound, length: 0)
@@ -412,6 +416,35 @@ final class GhosttyTerminalNSView: NSView {
               let scalar = chars.unicodeScalars.first
         else { return 0 }
         return scalar.value
+    }
+
+    func sendSearchQuery(_ needle: String) {
+        guard let surface else { return }
+        let action = "search:\(needle)"
+        ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
+    }
+
+    func navigateSearch(direction: SearchDirection) {
+        guard let surface else { return }
+        let action = "navigate_search:\(direction.rawValue)"
+        ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
+    }
+
+    func endSearch() {
+        guard let surface else { return }
+        let action = "end_search"
+        ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
+    }
+
+    func startSearch() {
+        guard let surface else { return }
+        let action = "start_search"
+        ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
+    }
+
+    enum SearchDirection: String {
+        case next
+        case previous
     }
 }
 

--- a/Muxy/Views/TabAreaView.swift
+++ b/Muxy/Views/TabAreaView.swift
@@ -42,5 +42,13 @@ struct TabAreaView: View {
                 }
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .findInTerminal)) { _ in
+            guard isFocused, isActiveProject else { return }
+            guard let tabID = area.activeTabID,
+                  let tab = area.tabs.first(where: { $0.id == tabID })
+            else { return }
+            let paneID = tab.pane.id
+            TerminalViewRegistry.shared.existingView(for: paneID)?.startSearch()
+        }
     }
 }

--- a/Muxy/Views/TerminalPane.swift
+++ b/Muxy/Views/TerminalPane.swift
@@ -8,7 +8,28 @@ struct TerminalPane: View {
     let onProcessExit: () -> Void
 
     var body: some View {
-        TerminalBridge(state: state, focused: focused, onFocus: onFocus, onProcessExit: onProcessExit)
+        ZStack(alignment: .topTrailing) {
+            TerminalBridge(state: state, focused: focused, onFocus: onFocus, onProcessExit: onProcessExit)
+
+            if state.searchState.isVisible {
+                TerminalSearchBar(
+                    searchState: state.searchState,
+                    onNavigateNext: {
+                        let view = TerminalViewRegistry.shared.existingView(for: state.id)
+                        view?.navigateSearch(direction: .next)
+                    },
+                    onNavigatePrevious: {
+                        let view = TerminalViewRegistry.shared.existingView(for: state.id)
+                        view?.navigateSearch(direction: .previous)
+                    },
+                    onClose: {
+                        let view = TerminalViewRegistry.shared.existingView(for: state.id)
+                        view?.endSearch()
+                    }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
     }
 }
 
@@ -36,6 +57,7 @@ struct TerminalBridge: NSViewRepresentable {
         view.onTitleChange = { [weak state] title in
             state?.title = title
         }
+        configureSearchCallbacks(view)
         context.coordinator.wasFocused = focused
         context.coordinator.paneID = state.id
         if focused {
@@ -52,6 +74,7 @@ struct TerminalBridge: NSViewRepresentable {
         nsView.onTitleChange = { [weak state] title in
             state?.title = title
         }
+        configureSearchCallbacks(nsView)
         let wasFocused = context.coordinator.wasFocused
         context.coordinator.wasFocused = focused
         nsView.isFocused = focused
@@ -61,6 +84,37 @@ struct TerminalBridge: NSViewRepresentable {
             }
         } else if !focused, wasFocused {
             nsView.notifySurfaceUnfocused()
+        }
+    }
+
+    private func configureSearchCallbacks(_ view: GhosttyTerminalNSView) {
+        view.onSearchStart = { [weak state] needle in
+            guard let state else { return }
+            let searchState = state.searchState
+            if let needle, !needle.isEmpty {
+                searchState.needle = needle
+            }
+            searchState.isVisible = true
+            searchState.startPublishing { [weak view] query in
+                view?.sendSearchQuery(query)
+            }
+            if !searchState.needle.isEmpty {
+                searchState.pushNeedle()
+            }
+        }
+        view.onSearchEnd = { [weak state] in
+            guard let state else { return }
+            state.searchState.stopPublishing()
+            state.searchState.isVisible = false
+            state.searchState.needle = ""
+            state.searchState.total = nil
+            state.searchState.selected = nil
+        }
+        view.onSearchTotal = { [weak state] total in
+            state?.searchState.total = total
+        }
+        view.onSearchSelected = { [weak state] selected in
+            state?.searchState.selected = selected
         }
     }
 }

--- a/Muxy/Views/TerminalSearchBar.swift
+++ b/Muxy/Views/TerminalSearchBar.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct TerminalSearchBar: View {
+    @Bindable var searchState: TerminalSearchState
+    let onNavigateNext: () -> Void
+    let onNavigatePrevious: () -> Void
+    let onClose: () -> Void
+
+    @FocusState private var isFieldFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 6) {
+            HStack(spacing: 4) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+
+                TextField("Search", text: $searchState.needle)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .focused($isFieldFocused)
+                    .onSubmit { onNavigateNext() }
+                    .onChange(of: searchState.needle) {
+                        searchState.pushNeedle()
+                    }
+
+                if !searchState.displayText.isEmpty {
+                    Text(searchState.displayText)
+                        .font(.system(size: 10))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                        .lineLimit(1)
+                        .fixedSize()
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(MuxyTheme.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(MuxyTheme.border, lineWidth: 1)
+            )
+
+            Button(action: onNavigatePrevious) {
+                Image(systemName: "chevron.up")
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .buttonStyle(SearchBarButtonStyle())
+
+            Button(action: onNavigateNext) {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .buttonStyle(SearchBarButtonStyle())
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .buttonStyle(SearchBarButtonStyle())
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(MuxyTheme.bg.opacity(0.95))
+        .onAppear { isFieldFocused = true }
+        .onKeyPress(.escape) {
+            onClose()
+            return .handled
+        }
+    }
+}
+
+private struct SearchBarButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: 22, height: 22)
+            .contentShape(Rectangle())
+            .foregroundStyle(MuxyTheme.fgMuted)
+            .background(configuration.isPressed ? MuxyTheme.surface : .clear)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+}

--- a/Muxy/Views/TerminalViewRegistry.swift
+++ b/Muxy/Views/TerminalViewRegistry.swift
@@ -17,6 +17,10 @@ final class TerminalViewRegistry {
         return view
     }
 
+    func existingView(for paneID: UUID) -> GhosttyTerminalNSView? {
+        views[paneID]
+    }
+
     func removeView(for paneID: UUID) {
         views.removeValue(forKey: paneID)
     }


### PR DESCRIPTION
## Summary
- Add terminal find action and keyboard shortcut to trigger Ghostty search in the active pane.
- Introduce terminal search state and search bar UI with next/previous navigation and live match counts.
- Wire Ghostty runtime search events into SwiftUI so search visibility and results stay in sync.