### PR TITLE
Fix terminal transparency handling

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -3,5 +3,6 @@ import Foundation
 extension Notification.Name {
     static let renameActiveTab = Notification.Name("MuxyRenameActiveTab")
     static let toggleThemePicker = Notification.Name("MuxyToggleThemePicker")
+    static let themeDidChange = Notification.Name("MuxyThemeDidChange")
     static let findInTerminal = Notification.Name("MuxyFindInTerminal")
 }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -106,7 +106,7 @@ struct WindowConfigurator: NSViewRepresentable {
             w.titleVisibility = .hidden
             w.styleMask.insert(.fullSizeContentView)
             w.isMovableByWindowBackground = false
-            w.backgroundColor = MuxyTheme.nsBg
+            Self.applyWindowBackground(w)
             Self.repositionTrafficLights(in: w)
             context.coordinator.observe(window: w)
         }
@@ -114,7 +114,19 @@ struct WindowConfigurator: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        nsView.window?.backgroundColor = MuxyTheme.nsBg
+        guard let w = nsView.window else { return }
+        Self.applyWindowBackground(w)
+    }
+
+    private static func applyWindowBackground(_ window: NSWindow) {
+        let opacity = GhosttyService.shared.backgroundOpacity
+        if opacity < 1.0 {
+            window.isOpaque = false
+            window.backgroundColor = .clear
+        } else {
+            window.isOpaque = true
+            window.backgroundColor = MuxyTheme.nsBg
+        }
     }
 
     static func repositionTrafficLights(in window: NSWindow) {

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -75,6 +75,15 @@ final class GhosttyService {
         tickTimer = timer
     }
 
+    var backgroundOpacity: Double {
+        guard let config else { return 1.0 }
+        var value = 1.0
+        if ghostty_config_get(config, &value, "background-opacity", 18) {
+            return max(0, min(1, value))
+        }
+        return 1.0
+    }
+
     var backgroundColor: NSColor {
         configColor("background") ?? NSColor(srgbRed: 0.11, green: 0.11, blue: 0.14, alpha: 1)
     }

--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -25,6 +25,7 @@ final class ThemeService {
         let sanitized = name.filter { $0 != "\"" && $0 != "\n" && $0 != "\r" }
         config.updateConfigValue("theme", value: "\"\(sanitized)\"")
         ghostty.reloadConfig()
+        NotificationCenter.default.post(name: .themeDidChange, object: nil)
     }
 
     nonisolated private static func discoverThemes() -> [ThemePreview] {

--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -29,4 +29,8 @@ enum MuxyTheme {
     @MainActor static var accentSoft: Color {
         Color(nsColor: GhosttyService.shared.accentColor.withAlphaComponent(0.1))
     }
+
+    @MainActor static var terminalBg: Color {
+        Color(nsColor: GhosttyService.shared.backgroundColor.withAlphaComponent(GhosttyService.shared.backgroundOpacity))
+    }
 }

--- a/Muxy/Views/AppearanceSettingsView.swift
+++ b/Muxy/Views/AppearanceSettingsView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct AppearanceSettingsView: View {
+    @State private var themeService = ThemeService.shared
+    @State private var showThemePicker = false
+    @State private var currentTheme: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Terminal Theme")
+                    .font(.system(size: 12))
+
+                Spacer()
+
+                Button {
+                    showThemePicker.toggle()
+                } label: {
+                    HStack(spacing: 6) {
+                        Text(currentTheme ?? "Default")
+                            .font(.system(size: 12))
+                            .lineLimit(1)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.system(size: 10))
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+                .popover(isPresented: $showThemePicker) {
+                    ThemePicker()
+                        .environment(themeService)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Spacer()
+        }
+        .task {
+            currentTheme = themeService.currentThemeName()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .themeDidChange)) { _ in
+            currentTheme = themeService.currentThemeName()
+        }
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -4,7 +4,6 @@ struct MainWindow: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
     @Environment(GhosttyService.self) private var ghostty
-
     private let sidebarWidth: CGFloat = 160
 
     var body: some View {
@@ -16,19 +15,23 @@ struct MainWindow: View {
                 topBarContent
             }
             .frame(height: 32)
+            .background(MuxyTheme.bg)
 
             Rectangle().fill(MuxyTheme.border).frame(height: 1)
+                .background(MuxyTheme.bg)
 
             HStack(spacing: 0) {
                 if appState.sidebarVisible {
-                    Sidebar()
-                        .frame(width: sidebarWidth)
-                        .background(MuxyTheme.bg)
-                    Rectangle().fill(MuxyTheme.border).frame(width: 1)
+                    HStack(spacing: 0) {
+                        Sidebar()
+                            .frame(width: sidebarWidth)
+                        Rectangle().fill(MuxyTheme.border).frame(width: 1)
+                    }
+                    .background(MuxyTheme.bg)
                 }
 
                 ZStack {
-                    MuxyTheme.bg
+                    MuxyTheme.terminalBg
                     if let project = activeProject {
                         TerminalArea(project: project, isActiveProject: true)
                             .id(project.id)
@@ -39,7 +42,6 @@ struct MainWindow: View {
             }
         }
         .id(ghostty.configVersion)
-        .background(MuxyTheme.bg)
         .background(WindowConfigurator(configVersion: ghostty.configVersion))
         .edgesIgnoringSafeArea(.top)
         .onAppear {

--- a/Muxy/Views/SettingsView.swift
+++ b/Muxy/Views/SettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct SettingsView: View {
     var body: some View {
         TabView {
+            AppearanceSettingsView()
+                .tabItem { Label("Appearance", systemImage: "paintbrush") }
             KeyboardShortcutsSettingsView()
                 .tabItem { Label("Shortcuts", systemImage: "keyboard") }
         }


### PR DESCRIPTION
- Add terminal background opacity support to Ghostty-backed theming.
- Update main window and NSWindow configuration to respect transparent backgrounds.
- Add an Appearance settings tab for theme updates and transparency behavior.