### PR TITLE
Remove projects when workspaces empty

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -23,6 +23,7 @@ final class AppState {
     private let selectionStore: any ActiveProjectSelectionStoring
     private let terminalViews: any TerminalViewRemoving
     private let workspacePersistence: any WorkspacePersisting
+    var onProjectsEmptied: (([UUID]) -> Void)?
 
     var activeProjectID: UUID? {
         didSet { saveSelection() }
@@ -151,6 +152,10 @@ final class AppState {
 
         for paneID in effects.paneIDsToRemove {
             terminalViews.removeView(for: paneID)
+        }
+
+        if !effects.projectIDsToRemove.isEmpty {
+            onProjectsEmptied?(effects.projectIDsToRemove)
         }
 
         saveWorkspaces()

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -11,6 +11,7 @@ struct WorkspaceState {
 @MainActor
 struct WorkspaceSideEffects {
     var paneIDsToRemove: [UUID] = []
+    var projectIDsToRemove: [UUID] = []
 }
 
 @MainActor
@@ -103,6 +104,7 @@ enum WorkspaceReducer {
             state.focusedAreaID.removeValue(forKey: projectID)
             state.focusHistory.removeValue(forKey: projectID)
             state.activeProjectID = nil
+            effects.projectIDsToRemove.append(projectID)
             return
         }
 
@@ -141,6 +143,7 @@ enum WorkspaceReducer {
         state.focusedAreaID.removeValue(forKey: projectID)
         state.focusHistory.removeValue(forKey: projectID)
         state.activeProjectID = nil
+        effects.projectIDsToRemove.append(projectID)
     }
 
     private static func focusArea(_ areaID: UUID, projectID: UUID, state: inout WorkspaceState) {

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -37,6 +37,11 @@ struct MuxyApp: App {
                     appDelegate.onTerminate = { [appState] in
                         appState.saveWorkspaces()
                     }
+                    appState.onProjectsEmptied = { [projectStore] projectIDs in
+                        for id in projectIDs {
+                            projectStore.remove(id: id)
+                        }
+                    }
                 }
         }
         .windowStyle(HiddenTitleBarWindowStyle())


### PR DESCRIPTION
- Track project IDs that become empty during workspace reduction.
- Notify `AppState` when projects are emptied and remove them from `ProjectStore`.
- Keep workspace persistence behavior unchanged after tab close flows.