### PR TITLE
Polish sidebar project actions

### DIFF
--- a/Muxy/Services/ModifierKeyMonitor.swift
+++ b/Muxy/Services/ModifierKeyMonitor.swift
@@ -12,6 +12,7 @@ final class ModifierKeyMonitor {
     private(set) var optionHeld = false
     private(set) var showHints = false
     private var monitor: Any?
+    private var activationObserver: NSObjectProtocol?
     private var hintTimer: Timer?
 
     private static let hintDelay: TimeInterval = 0.5
@@ -24,26 +25,32 @@ final class ModifierKeyMonitor {
             guard let self else { return event }
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             MainActor.assumeIsolated {
-                let wasHoldingModifier = self.commandHeld || self.controlHeld
-                self.commandHeld = flags.contains(.command)
-                self.controlHeld = flags.contains(.control)
-                self.shiftHeld = flags.contains(.shift)
-                self.optionHeld = flags.contains(.option)
-                let isHoldingModifier = self.commandHeld || self.controlHeld
-                if isHoldingModifier, !wasHoldingModifier {
-                    self.scheduleHint()
-                } else if !isHoldingModifier {
-                    self.cancelHint()
-                }
+                self.updateFlags(flags)
             }
             return event
+        }
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let flags = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                self.updateFlags(flags)
+            }
         }
     }
 
     func stop() {
-        guard let monitor else { return }
-        NSEvent.removeMonitor(monitor)
-        self.monitor = nil
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        if let activationObserver {
+            NotificationCenter.default.removeObserver(activationObserver)
+        }
+        monitor = nil
+        activationObserver = nil
         cancelHint()
         commandHeld = false
         controlHeld = false
@@ -60,6 +67,20 @@ final class ModifierKeyMonitor {
         if flags.contains(.option), !optionHeld { return false }
         guard !flags.isEmpty else { return false }
         return true
+    }
+
+    private func updateFlags(_ flags: NSEvent.ModifierFlags) {
+        let wasHoldingModifier = commandHeld || controlHeld
+        commandHeld = flags.contains(.command)
+        controlHeld = flags.contains(.control)
+        shiftHeld = flags.contains(.shift)
+        optionHeld = flags.contains(.option)
+        let isHoldingModifier = commandHeld || controlHeld
+        if isHoldingModifier, !wasHoldingModifier {
+            scheduleHint()
+        } else if !isHoldingModifier {
+            cancelHint()
+        }
     }
 
     private func scheduleHint() {

--- a/Muxy/Views/IconButton.swift
+++ b/Muxy/Views/IconButton.swift
@@ -14,6 +14,7 @@ struct IconButton: View {
                 .font(.system(size: size, weight: .semibold))
                 .foregroundStyle(hovered ? hoverColor : color)
                 .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -3,15 +3,13 @@ import SwiftUI
 struct SidebarToolbar: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
-    @State private var showThemePicker = false
 
     private var showHints: Bool { ModifierKeyMonitor.shared.showHints }
 
     var body: some View {
         HStack(spacing: 4) {
             Spacer()
-            IconButton(symbol: "paintpalette") { showThemePicker.toggle() }
-                .popover(isPresented: $showThemePicker) { ThemePicker() }
+            IconButton(symbol: "folder") { openProject() }
             IconButton(symbol: "plus") { addProject() }
             IconButton(symbol: "sidebar.left") {
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -25,7 +23,7 @@ struct SidebarToolbar: View {
             if showHints {
                 HStack(spacing: 3) {
                     ShortcutBadge(
-                        label: KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString,
+                        label: KeyBindingStore.shared.combo(for: .openProject).displayString,
                         compact: true
                     )
                     ShortcutBadge(
@@ -42,9 +40,22 @@ struct SidebarToolbar: View {
             }
         }
         .background(WindowDragRepresentable())
-        .onReceive(NotificationCenter.default.publisher(for: .toggleThemePicker)) { _ in
-            showThemePicker.toggle()
-        }
+    }
+
+    private func openProject() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Select a project folder"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let project = Project(
+            name: url.lastPathComponent,
+            path: url.path(percentEncoded: false),
+            sortOrder: projectStore.projects.count
+        )
+        projectStore.add(project)
+        appState.selectProject(project)
     }
 
     private func addProject() {
@@ -64,24 +75,54 @@ struct Sidebar: View {
     @Environment(ProjectStore.self) private var projectStore
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(spacing: 2) {
-                ForEach(Array(projectStore.projects.enumerated()), id: \.element.id) {
-                    index, project in
-                    ProjectItem(
-                        project: project,
-                        selected: project.id == appState.activeProjectID,
-                        shortcutIndex: index < 9 ? index + 1 : nil,
-                        onSelect: { appState.selectProject(project) },
-                        onRemove: {
-                            appState.removeProject(project.id)
-                            projectStore.remove(id: project.id)
-                        },
-                        onRename: { projectStore.rename(id: project.id, to: $0) }
-                    )
+        VStack(spacing: 0) {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 2) {
+                    ForEach(Array(projectStore.projects.enumerated()), id: \.element.id) {
+                        index, project in
+                        ProjectItem(
+                            project: project,
+                            selected: project.id == appState.activeProjectID,
+                            shortcutIndex: index < 9 ? index + 1 : nil,
+                            onSelect: { appState.selectProject(project) },
+                            onRemove: {
+                                appState.removeProject(project.id)
+                                projectStore.remove(id: project.id)
+                            },
+                            onRename: { projectStore.rename(id: project.id, to: $0) }
+                        )
+                    }
                 }
+                .padding(6)
             }
-            .padding(6)
+            SidebarFooter()
+        }
+    }
+}
+
+struct SidebarFooter: View {
+    @State private var showThemePicker = false
+
+    private var versionString: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Rectangle().fill(MuxyTheme.border).frame(height: 1)
+            HStack(spacing: 4) {
+                Text("Muxy \(versionString)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                Spacer()
+                IconButton(symbol: "paintpalette") { showThemePicker.toggle() }
+                    .popover(isPresented: $showThemePicker) { ThemePicker() }
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 32)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .toggleThemePicker)) { _ in
+            showThemePicker.toggle()
         }
     }
 }


### PR DESCRIPTION
- Move project-open action into the sidebar toolbar and move theme picker into a new footer.
- Add a sidebar footer with version text and retained theme-picker shortcut support.
- Improve modifier-key state refresh on app activation and icon button hit testing.