### PR TITLE
Add drag reordering for tabs and projects

### DIFF
--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -115,6 +115,10 @@ final class TabArea: Identifiable {
         selectTab(tabs[previous].id)
     }
 
+    func reorderTab(fromOffsets source: IndexSet, toOffset destination: Int) {
+        tabs.move(fromOffsets: source, toOffset: destination)
+    }
+
     func togglePin(_ tabID: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         let tab = tabs[index]

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -110,6 +110,7 @@ struct WindowConfigurator: NSViewRepresentable {
             w.titlebarAppearsTransparent = true
             w.titleVisibility = .hidden
             w.styleMask.insert(.fullSizeContentView)
+            w.isMovable = false
             w.isMovableByWindowBackground = false
             Self.applyWindowBackground(w)
             Self.repositionTrafficLights(in: w)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -91,7 +91,7 @@ struct MainWindow: View {
                 }
                 Spacer(minLength: 0)
             }
-            .background(WindowDragRepresentable())
+            .background(WindowDragRepresentable(alwaysEnabled: true))
         }
     }
 

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -73,6 +73,7 @@ struct SidebarToolbar: View {
 struct Sidebar: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
+    @State private var dragState = ProjectDragState()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -83,20 +84,75 @@ struct Sidebar: View {
                         ProjectItem(
                             project: project,
                             selected: project.id == appState.activeProjectID,
+                            isAnyDragging: dragState.draggedID != nil,
                             shortcutIndex: index < 9 ? index + 1 : nil,
-                            onSelect: { appState.selectProject(project) },
                             onRemove: {
                                 appState.removeProject(project.id)
                                 projectStore.remove(id: project.id)
                             },
                             onRename: { projectStore.rename(id: project.id, to: $0) }
                         )
+                        .background(GeometryReader { geo in
+                            Color.clear.preference(
+                                key: ItemFramePreferenceKey.self,
+                                value: [project.id: geo.frame(in: .named("sidebar"))]
+                            )
+                        })
+                        .gesture(
+                            DragGesture(minimumDistance: 4, coordinateSpace: .named("sidebar"))
+                                .onChanged { value in
+                                    if dragState.draggedID == nil {
+                                        dragState.draggedID = project.id
+                                    }
+                                    reorderIfNeeded(at: value.location)
+                                }
+                                .onEnded { _ in
+                                    withAnimation(.easeInOut(duration: 0.15)) {
+                                        dragState.draggedID = nil
+                                    }
+                                }
+                        )
+                        .onTapGesture {
+                            guard dragState.draggedID == nil else { return }
+                            appState.selectProject(project)
+                        }
                     }
                 }
                 .padding(6)
+                .onPreferenceChange(ItemFramePreferenceKey.self) { dragState.frames = $0 }
             }
+            .coordinateSpace(name: "sidebar")
             SidebarFooter()
         }
+    }
+
+    private func reorderIfNeeded(at location: CGPoint) {
+        guard let draggedID = dragState.draggedID else { return }
+        for (id, frame) in dragState.frames where id != draggedID {
+            guard frame.contains(location) else { continue }
+            guard let sourceIndex = projectStore.projects.firstIndex(where: { $0.id == draggedID }),
+                  let destIndex = projectStore.projects.firstIndex(where: { $0.id == id })
+            else { return }
+            let offset = destIndex > sourceIndex ? destIndex + 1 : destIndex
+            withAnimation(.easeInOut(duration: 0.15)) {
+                projectStore.reorder(
+                    fromOffsets: IndexSet(integer: sourceIndex), toOffset: offset
+                )
+            }
+            return
+        }
+    }
+}
+
+private struct ProjectDragState {
+    var draggedID: UUID?
+    var frames: [UUID: CGRect] = [:]
+}
+
+private struct ItemFramePreferenceKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: [UUID: CGRect] = [:]
+    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
+        value.merge(nextValue()) { $1 }
     }
 }
 
@@ -130,8 +186,8 @@ struct SidebarFooter: View {
 private struct ProjectItem: View {
     let project: Project
     let selected: Bool
+    var isAnyDragging: Bool = false
     var shortcutIndex: Int?
-    let onSelect: () -> Void
     let onRemove: () -> Void
     let onRename: (String) -> Void
     @State private var hovered = false
@@ -178,8 +234,13 @@ private struct ProjectItem: View {
                     .padding(.trailing, 6)
             }
         }
-        .onTapGesture(perform: onSelect)
-        .onHover { hovered = $0 }
+        .onHover { hovering in
+            guard !isAnyDragging else { return }
+            hovered = hovering
+        }
+        .onChange(of: isAnyDragging) { _, dragging in
+            if dragging { hovered = false }
+        }
         .contextMenu {
             Button("Rename Project") { startRename() }
             Divider()

--- a/Muxy/Views/TabStrip.swift
+++ b/Muxy/Views/TabStrip.swift
@@ -10,6 +10,7 @@ struct PaneTabStrip: View {
     let onCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
     let onClose: () -> Void
+    @State private var dragState = TabDragState()
 
     var body: some View {
         HStack(spacing: 0) {
@@ -18,6 +19,7 @@ struct PaneTabStrip: View {
                     tab: tab,
                     active: tab.id == area.activeTabID,
                     paneFocused: isFocused,
+                    isAnyDragging: dragState.draggedID != nil,
                     shortcutIndex: index < 9 ? index + 1 : nil,
                     onSelect: {
                         onFocus()
@@ -28,19 +30,75 @@ struct PaneTabStrip: View {
                     onCreateRight: { area.createTabAdjacent(to: tab.id, side: .right) },
                     onTogglePin: { area.togglePin(tab.id) }
                 )
+                .background(GeometryReader { geo in
+                    Color.clear.preference(
+                        key: TabFramePreferenceKey.self,
+                        value: [tab.id: geo.frame(in: .named("tabstrip-\(area.id)"))]
+                    )
+                })
+                .gesture(
+                    DragGesture(
+                        minimumDistance: 4,
+                        coordinateSpace: .named("tabstrip-\(area.id)")
+                    )
+                    .onChanged { value in
+                        if dragState.draggedID == nil {
+                            dragState.draggedID = tab.id
+                        }
+                        reorderIfNeeded(at: value.location)
+                    }
+                    .onEnded { _ in
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            dragState.draggedID = nil
+                        }
+                    }
+                )
+                .onTapGesture {
+                    guard dragState.draggedID == nil else { return }
+                    onFocus()
+                    onSelectTab(tab.id)
+                }
             }
 
-            Spacer(minLength: 0)
-
             HStack(spacing: 0) {
+                Spacer(minLength: 0)
                 IconButton(symbol: "square.split.2x1") { onSplit(.horizontal) }
                 IconButton(symbol: "square.split.1x2") { onSplit(.vertical) }
                 IconButton(symbol: "plus") { onCreateTab() }
             }
             .padding(.trailing, 4)
+            .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
         }
         .frame(height: 32)
-        .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
+        .onPreferenceChange(TabFramePreferenceKey.self) { dragState.frames = $0 }
+        .coordinateSpace(name: "tabstrip-\(area.id)")
+    }
+
+    private func reorderIfNeeded(at location: CGPoint) {
+        guard let draggedID = dragState.draggedID else { return }
+        for (id, frame) in dragState.frames where id != draggedID {
+            guard frame.contains(location) else { continue }
+            guard let sourceIndex = area.tabs.firstIndex(where: { $0.id == draggedID }),
+                  let destIndex = area.tabs.firstIndex(where: { $0.id == id })
+            else { return }
+            let offset = destIndex > sourceIndex ? destIndex + 1 : destIndex
+            withAnimation(.easeInOut(duration: 0.15)) {
+                area.reorderTab(fromOffsets: IndexSet(integer: sourceIndex), toOffset: offset)
+            }
+            return
+        }
+    }
+}
+
+private struct TabDragState {
+    var draggedID: UUID?
+    var frames: [UUID: CGRect] = [:]
+}
+
+private struct TabFramePreferenceKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: [UUID: CGRect] = [:]
+    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
+        value.merge(nextValue()) { $1 }
     }
 }
 
@@ -83,7 +141,22 @@ final class WindowDragView: NSView {
             }
             return
         }
-        window?.performDrag(with: event)
+        let threshold = NSEvent.doubleClickInterval
+        guard let next = window?.nextEvent(
+            matching: [.leftMouseUp, .leftMouseDown, .leftMouseDragged],
+            until: Date(timeIntervalSinceNow: threshold),
+            inMode: .eventTracking,
+            dequeue: true
+        )
+        else {
+            window?.performDrag(with: event)
+            return
+        }
+        if next.type == .leftMouseDragged {
+            window?.performDrag(with: event)
+        } else if next.type == .leftMouseDown {
+            mouseDown(with: next)
+        }
     }
 }
 
@@ -91,6 +164,7 @@ private struct TabCell: View {
     @Bindable var tab: TerminalTab
     let active: Bool
     let paneFocused: Bool
+    var isAnyDragging: Bool = false
     var shortcutIndex: Int?
     let onSelect: () -> Void
     let onClose: () -> Void
@@ -164,8 +238,13 @@ private struct TabCell: View {
             }
             .background(active ? MuxyTheme.surface : .clear)
             .contentShape(Rectangle())
-            .onTapGesture(perform: onSelect)
-            .onHover { hovered = $0 }
+            .onHover { hovering in
+                guard !isAnyDragging else { return }
+                hovered = hovering
+            }
+            .onChange(of: isAnyDragging) { _, dragging in
+                if dragging { hovered = false }
+            }
             .overlay {
                 if !tab.isPinned {
                     MiddleClickView(action: onClose)


### PR DESCRIPTION
## Summary
- add drag-and-drop reordering for sidebar projects to improve workspace organization
- add drag-and-drop tab reordering within a pane for faster tab management
- refine titlebar drag behavior so reordering interactions do not trigger accidental window drags