### PR TITLE
Smooth titlebar zoom animation

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -148,7 +148,6 @@ struct WindowConfigurator: NSViewRepresentable {
         func observe(window: NSWindow) {
             guard observations.isEmpty else { return }
             let names: [Notification.Name] = [
-                NSWindow.didResizeNotification,
                 NSWindow.didEndLiveResizeNotification,
                 NSWindow.didExitFullScreenNotification,
                 NSWindow.didEnterFullScreenNotification,

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -66,12 +66,12 @@ final class GhosttyService {
         self.app = createdApp
         self.config = cfg
 
-        let timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 120.0, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: 1.0 / 120.0, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 self?.tick()
             }
         }
-        RunLoop.main.add(timer, forMode: .common)
+        RunLoop.main.add(timer, forMode: .default)
         tickTimer = timer
     }
 


### PR DESCRIPTION
- Run the Ghostty tick timer in default run loop mode to avoid animation contention during titlebar zoom.
- Stop observing per-frame window resize notifications for traffic light repositioning.
- Preserve live terminal surface resizing behavior while improving maximize smoothness.