### PR TITLE
Add directional pane focus shortcuts

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -157,6 +157,46 @@ struct MuxyCommands: Commands {
                 keyBindings.combo(for: .closePane).swiftUIKeyEquivalent,
                 modifiers: keyBindings.combo(for: .closePane).swiftUIModifiers
             )
+
+            Button("Focus Pane Left") {
+                guard isMainWindowFocused else { return }
+                guard let projectID = appState.activeProjectID else { return }
+                appState.focusPaneLeft(projectID: projectID)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .focusPaneLeft).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .focusPaneLeft).swiftUIModifiers
+            )
+
+            Button("Focus Pane Right") {
+                guard isMainWindowFocused else { return }
+                guard let projectID = appState.activeProjectID else { return }
+                appState.focusPaneRight(projectID: projectID)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .focusPaneRight).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .focusPaneRight).swiftUIModifiers
+            )
+
+            Button("Focus Pane Up") {
+                guard isMainWindowFocused else { return }
+                guard let projectID = appState.activeProjectID else { return }
+                appState.focusPaneUp(projectID: projectID)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .focusPaneUp).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .focusPaneUp).swiftUIModifiers
+            )
+
+            Button("Focus Pane Down") {
+                guard isMainWindowFocused else { return }
+                guard let projectID = appState.activeProjectID else { return }
+                appState.focusPaneDown(projectID: projectID)
+            }
+            .keyboardShortcut(
+                keyBindings.combo(for: .focusPaneDown).swiftUIKeyEquivalent,
+                modifiers: keyBindings.combo(for: .focusPaneDown).swiftUIModifiers
+            )
         }
 
         CommandGroup(after: .windowList) {

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -16,6 +16,10 @@ final class AppState {
         case splitArea(projectID: UUID, areaID: UUID, direction: SplitDirection, projectPath: String)
         case closeArea(projectID: UUID, areaID: UUID)
         case focusArea(projectID: UUID, areaID: UUID)
+        case focusPaneLeft(projectID: UUID)
+        case focusPaneRight(projectID: UUID)
+        case focusPaneUp(projectID: UUID)
+        case focusPaneDown(projectID: UUID)
         case selectNextProject(projects: [Project])
         case selectPreviousProject(projects: [Project])
     }
@@ -163,6 +167,22 @@ final class AppState {
 
     func focusArea(_ areaID: UUID, projectID: UUID) {
         dispatch(.focusArea(projectID: projectID, areaID: areaID))
+    }
+
+    func focusPaneLeft(projectID: UUID) {
+        dispatch(.focusPaneLeft(projectID: projectID))
+    }
+
+    func focusPaneRight(projectID: UUID) {
+        dispatch(.focusPaneRight(projectID: projectID))
+    }
+
+    func focusPaneUp(projectID: UUID) {
+        dispatch(.focusPaneUp(projectID: projectID))
+    }
+
+    func focusPaneDown(projectID: UUID) {
+        dispatch(.focusPaneDown(projectID: projectID))
     }
 
     func selectProjectByIndex(_ index: Int, projects: [Project]) {

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -9,6 +9,10 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case splitRight
     case splitDown
     case closePane
+    case focusPaneLeft
+    case focusPaneRight
+    case focusPaneUp
+    case focusPaneDown
     case nextTab
     case previousTab
     case toggleSidebar
@@ -49,6 +53,10 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .splitRight: "Split Right"
         case .splitDown: "Split Down"
         case .closePane: "Close Pane"
+        case .focusPaneLeft: "Focus Pane Left"
+        case .focusPaneRight: "Focus Pane Right"
+        case .focusPaneUp: "Focus Pane Up"
+        case .focusPaneDown: "Focus Pane Down"
         case .nextTab: "Next Tab"
         case .previousTab: "Previous Tab"
         case .toggleSidebar: "Toggle Sidebar"
@@ -89,7 +97,11 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
             "Tabs"
         case .splitRight,
              .splitDown,
-             .closePane:
+             .closePane,
+             .focusPaneLeft,
+             .focusPaneRight,
+             .focusPaneUp,
+             .focusPaneDown:
             "Panes"
         case .nextTab,
              .previousTab,
@@ -159,6 +171,10 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
              .splitRight,
              .splitDown,
              .closePane,
+             .focusPaneLeft,
+             .focusPaneRight,
+             .focusPaneUp,
+             .focusPaneDown,
              .nextTab,
              .previousTab,
              .toggleSidebar,
@@ -197,19 +213,31 @@ enum ShortcutScope: String, Codable, CaseIterable {
 }
 
 struct KeyCombo: Codable, Equatable, Hashable {
+    static let supportedModifierMask: NSEvent.ModifierFlags = [.command, .shift, .control, .option]
+    static let leftArrowKey = "leftarrow"
+    static let rightArrowKey = "rightarrow"
+    static let upArrowKey = "uparrow"
+    static let downArrowKey = "downarrow"
+    private static let keyCodeLeftBracket = 33
+    private static let keyCodeRightBracket = 30
+    private static let keyCodeLeftArrow = 123
+    private static let keyCodeRightArrow = 124
+    private static let keyCodeDownArrow = 125
+    private static let keyCodeUpArrow = 126
+
     let key: String
     let modifiers: UInt
 
     init(key: String, modifiers: UInt) {
-        self.key = key.lowercased()
-        self.modifiers = modifiers
+        self.key = Self.normalized(key: key)
+        self.modifiers = Self.normalized(modifiers: modifiers)
     }
 
     init(
         key: String, command: Bool = false, shift: Bool = false, control: Bool = false,
         option: Bool = false
     ) {
-        self.key = key.lowercased()
+        self.key = Self.normalized(key: key)
         var flags: UInt = 0
         if command { flags |= NSEvent.ModifierFlags.command.rawValue }
         if shift { flags |= NSEvent.ModifierFlags.shift.rawValue }
@@ -219,7 +247,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
     }
 
     var nsModifierFlags: NSEvent.ModifierFlags {
-        NSEvent.ModifierFlags(rawValue: modifiers).intersection(.deviceIndependentFlagsMask)
+        NSEvent.ModifierFlags(rawValue: modifiers).intersection(Self.supportedModifierMask)
     }
 
     var swiftUIKeyEquivalent: KeyEquivalent {
@@ -227,6 +255,10 @@ struct KeyCombo: Codable, Equatable, Hashable {
         case "[": KeyEquivalent("[")
         case "]": KeyEquivalent("]")
         case ",": KeyEquivalent(",")
+        case Self.leftArrowKey: .leftArrow
+        case Self.rightArrowKey: .rightArrow
+        case Self.upArrowKey: .upArrow
+        case Self.downArrowKey: .downArrow
         default: KeyEquivalent(Character(key))
         }
     }
@@ -248,14 +280,56 @@ struct KeyCombo: Codable, Equatable, Hashable {
         if flags.contains(.option) { parts += "⌥" }
         if flags.contains(.shift) { parts += "⇧" }
         if flags.contains(.command) { parts += "⌘" }
-        parts += key.uppercased()
+        let keyDisplay: String = switch key {
+        case Self.leftArrowKey: "←"
+        case Self.rightArrowKey: "→"
+        case Self.upArrowKey: "↑"
+        case Self.downArrowKey: "↓"
+        default: key.uppercased()
+        }
+        parts += keyDisplay
         return parts
     }
 
     func matches(event: NSEvent) -> Bool {
-        let eventFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask).rawValue
-        let eventKey = event.charactersIgnoringModifiers?.lowercased() ?? ""
+        let eventFlags = event.modifierFlags.intersection(Self.supportedModifierMask).rawValue
+        let eventKey = Self.normalized(key: event.charactersIgnoringModifiers ?? "", keyCode: event.keyCode)
         return eventKey == key && eventFlags == modifiers
+    }
+
+    static func normalized(modifiers: UInt) -> UInt {
+        NSEvent.ModifierFlags(rawValue: modifiers).intersection(supportedModifierMask).rawValue
+    }
+
+    static func normalized(key: String, keyCode: UInt16? = nil) -> String {
+        if let keyCode {
+            switch Int(keyCode) {
+            case keyCodeLeftBracket: return "["
+            case keyCodeRightBracket: return "]"
+            case keyCodeLeftArrow: return leftArrowKey
+            case keyCodeRightArrow: return rightArrowKey
+            case keyCodeUpArrow: return upArrowKey
+            case keyCodeDownArrow: return downArrowKey
+            default: break
+            }
+        }
+
+        let lowercased = key.lowercased()
+        if lowercased == leftArrowKey || lowercased == rightArrowKey || lowercased == upArrowKey || lowercased == downArrowKey {
+            return lowercased
+        }
+
+        guard let scalar = lowercased.unicodeScalars.first, lowercased.unicodeScalars.count == 1 else {
+            return lowercased
+        }
+
+        switch Int(scalar.value) {
+        case NSLeftArrowFunctionKey: return leftArrowKey
+        case NSRightArrowFunctionKey: return rightArrowKey
+        case NSUpArrowFunctionKey: return upArrowKey
+        case NSDownArrowFunctionKey: return downArrowKey
+        default: return lowercased
+        }
     }
 }
 
@@ -273,6 +347,10 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .splitRight, combo: KeyCombo(key: "d", command: true)),
         Self(action: .splitDown, combo: KeyCombo(key: "d", command: true, shift: true)),
         Self(action: .closePane, combo: KeyCombo(key: "w", command: true, shift: true)),
+        Self(action: .focusPaneLeft, combo: KeyCombo(key: KeyCombo.leftArrowKey, command: true, option: true)),
+        Self(action: .focusPaneRight, combo: KeyCombo(key: KeyCombo.rightArrowKey, command: true, option: true)),
+        Self(action: .focusPaneUp, combo: KeyCombo(key: KeyCombo.upArrowKey, command: true, option: true)),
+        Self(action: .focusPaneDown, combo: KeyCombo(key: KeyCombo.downArrowKey, command: true, option: true)),
         Self(action: .toggleSidebar, combo: KeyCombo(key: "b", command: true)),
         Self(action: .toggleThemePicker, combo: KeyCombo(key: "k", command: true)),
         Self(action: .newProject, combo: KeyCombo(key: "n", command: true)),

--- a/Muxy/Models/SplitNode.swift
+++ b/Muxy/Models/SplitNode.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 enum SplitDirection {
@@ -111,6 +112,26 @@ extension SplitNode {
         case let .tabArea(area): area.id == id ? area : nil
         case let .split(branch):
             branch.first.findArea(id: id) ?? branch.second.findArea(id: id)
+        }
+    }
+
+    func areaFrames(in rect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)) -> [UUID: CGRect] {
+        switch self {
+        case let .tabArea(area):
+            return [area.id: rect]
+        case let .split(branch):
+            let ratio = min(max(branch.ratio, 0), 1)
+            if branch.direction == .horizontal {
+                let firstWidth = rect.width * ratio
+                let firstRect = CGRect(x: rect.minX, y: rect.minY, width: firstWidth, height: rect.height)
+                let secondRect = CGRect(x: rect.minX + firstWidth, y: rect.minY, width: rect.width - firstWidth, height: rect.height)
+                return branch.first.areaFrames(in: firstRect).merging(branch.second.areaFrames(in: secondRect)) { current, _ in current }
+            }
+
+            let firstHeight = rect.height * ratio
+            let firstRect = CGRect(x: rect.minX, y: rect.minY, width: rect.width, height: firstHeight)
+            let secondRect = CGRect(x: rect.minX, y: rect.minY + firstHeight, width: rect.width, height: rect.height - firstHeight)
+            return branch.first.areaFrames(in: firstRect).merging(branch.second.areaFrames(in: secondRect)) { current, _ in current }
         }
     }
 }

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -62,6 +62,18 @@ enum WorkspaceReducer {
         case let .focusArea(projectID, areaID):
             focusArea(areaID, projectID: projectID, state: &state)
 
+        case let .focusPaneLeft(projectID):
+            focusPane(projectID: projectID, direction: .left, state: &state)
+
+        case let .focusPaneRight(projectID):
+            focusPane(projectID: projectID, direction: .right, state: &state)
+
+        case let .focusPaneUp(projectID):
+            focusPane(projectID: projectID, direction: .up, state: &state)
+
+        case let .focusPaneDown(projectID):
+            focusPane(projectID: projectID, direction: .down, state: &state)
+
         case let .selectNextProject(projects):
             cycleProject(projects: projects, forward: true, state: &state)
 
@@ -162,6 +174,99 @@ enum WorkspaceReducer {
         let project = projects[next]
         state.activeProjectID = project.id
         ensureWorkspaceExists(projectID: project.id, projectPath: project.path, state: &state)
+    }
+
+    private enum PaneFocusDirection {
+        case left
+        case right
+        case up
+        case down
+    }
+
+    private static func focusPane(projectID: UUID, direction: PaneFocusDirection, state: inout WorkspaceState) {
+        guard let root = state.workspaceRoots[projectID],
+              let focusedID = state.focusedAreaID[projectID]
+        else { return }
+
+        let frames = root.areaFrames()
+        guard let focusedFrame = frames[focusedID] else { return }
+
+        var bestCandidate: UUID?
+        var bestScore: (overlapPenalty: Int, axisGap: CGFloat, crossDistance: CGFloat, centerDistance: CGFloat)?
+
+        for (candidateID, candidateFrame) in frames where candidateID != focusedID {
+            guard isCandidate(candidateFrame, from: focusedFrame, direction: direction) else { continue }
+
+            let score = scoreForCandidate(candidateFrame, from: focusedFrame, direction: direction)
+            if let currentBest = bestScore {
+                if score.overlapPenalty < currentBest.overlapPenalty ||
+                    (score.overlapPenalty == currentBest.overlapPenalty && score.axisGap < currentBest.axisGap) ||
+                    (score.overlapPenalty == currentBest.overlapPenalty && score.axisGap == currentBest.axisGap && score
+                        .crossDistance < currentBest.crossDistance) ||
+                    (score.overlapPenalty == currentBest.overlapPenalty && score.axisGap == currentBest.axisGap && score
+                        .crossDistance == currentBest.crossDistance && score.centerDistance < currentBest.centerDistance)
+                {
+                    bestCandidate = candidateID
+                    bestScore = score
+                }
+            } else {
+                bestCandidate = candidateID
+                bestScore = score
+            }
+        }
+
+        guard let bestCandidate else { return }
+        focusArea(bestCandidate, projectID: projectID, state: &state)
+    }
+
+    private static func isCandidate(_ candidate: CGRect, from focused: CGRect, direction: PaneFocusDirection) -> Bool {
+        switch direction {
+        case .left: candidate.midX < focused.midX
+        case .right: candidate.midX > focused.midX
+        case .up: candidate.midY < focused.midY
+        case .down: candidate.midY > focused.midY
+        }
+    }
+
+    private static func scoreForCandidate(
+        _ candidate: CGRect,
+        from focused: CGRect,
+        direction: PaneFocusDirection
+    ) -> (overlapPenalty: Int, axisGap: CGFloat, crossDistance: CGFloat, centerDistance: CGFloat) {
+        let overlap: CGFloat
+        let axisGap: CGFloat
+        let crossDistance: CGFloat
+        let centerDistance: CGFloat
+
+        switch direction {
+        case .left:
+            overlap = min(focused.maxY, candidate.maxY) - max(focused.minY, candidate.minY)
+            axisGap = max(0, focused.minX - candidate.maxX)
+            crossDistance = abs(focused.midY - candidate.midY)
+            centerDistance = abs(focused.midX - candidate.midX)
+        case .right:
+            overlap = min(focused.maxY, candidate.maxY) - max(focused.minY, candidate.minY)
+            axisGap = max(0, candidate.minX - focused.maxX)
+            crossDistance = abs(focused.midY - candidate.midY)
+            centerDistance = abs(focused.midX - candidate.midX)
+        case .up:
+            overlap = min(focused.maxX, candidate.maxX) - max(focused.minX, candidate.minX)
+            axisGap = max(0, focused.minY - candidate.maxY)
+            crossDistance = abs(focused.midX - candidate.midX)
+            centerDistance = abs(focused.midY - candidate.midY)
+        case .down:
+            overlap = min(focused.maxX, candidate.maxX) - max(focused.minX, candidate.minX)
+            axisGap = max(0, candidate.minY - focused.maxY)
+            crossDistance = abs(focused.midX - candidate.midX)
+            centerDistance = abs(focused.midY - candidate.midY)
+        }
+
+        return (
+            overlapPenalty: overlap > 0 ? 0 : 1,
+            axisGap: axisGap,
+            crossDistance: crossDistance,
+            centerDistance: centerDistance
+        )
     }
 
     private static func removeProject(

--- a/Muxy/Services/KeyBindingStore.swift
+++ b/Muxy/Services/KeyBindingStore.swift
@@ -42,16 +42,16 @@ final class KeyBindingStore {
         updateBinding(action: defaultBinding.action, combo: defaultBinding.combo)
     }
 
-    func isRegisteredShortcut(
-        key: String,
-        modifiers: NSEvent.ModifierFlags,
-        scopes: Set<ShortcutScope>
-    ) -> Bool {
-        let flags = modifiers.intersection(.deviceIndependentFlagsMask).rawValue
-        return bindings.contains {
-            $0.combo.key == key &&
-                $0.combo.modifiers == flags &&
-                scopes.contains($0.action.scope)
+    func isRegisteredShortcut(event: NSEvent, scopes: Set<ShortcutScope>) -> Bool {
+        let normalizedKey = KeyCombo.normalized(
+            key: event.charactersIgnoringModifiers ?? "",
+            keyCode: event.keyCode
+        )
+        let flags = event.modifierFlags.intersection(KeyCombo.supportedModifierMask).rawValue
+        return ShortcutAction.allCases.contains { action in
+            guard scopes.contains(action.scope) else { return false }
+            let combo = combo(for: action)
+            return combo.key == normalizedKey && combo.modifiers == flags
         }
     }
 

--- a/Muxy/Views/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/GhosttyTerminalNSView.swift
@@ -155,17 +155,13 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private func isAppShortcut(_ event: NSEvent) -> Bool {
-        let key = event.charactersIgnoringModifiers?.lowercased() ?? ""
-        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let key = KeyCombo.normalized(key: event.charactersIgnoringModifiers ?? "", keyCode: event.keyCode)
+        let modifiers = event.modifierFlags.intersection(KeyCombo.supportedModifierMask)
         if modifiers == .command, Self.systemShortcutKeys.contains(key) {
             return true
         }
         let scopes = ShortcutContext.activeScopes(for: window)
-        return KeyBindingStore.shared.isRegisteredShortcut(
-            key: key,
-            modifiers: modifiers,
-            scopes: scopes
-        )
+        return KeyBindingStore.shared.isRegisteredShortcut(event: event, scopes: scopes)
     }
 
     private static let systemShortcutKeys: Set<String> = ["q", "h", "m", ","]

--- a/Muxy/Views/ShortcutRecorderView.swift
+++ b/Muxy/Views/ShortcutRecorderView.swift
@@ -43,11 +43,11 @@ final class ShortcutRecorderNSView: NSView {
             return true
         }
 
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let flags = event.modifierFlags.intersection(KeyCombo.supportedModifierMask)
         let hasModifier = flags.contains(.command) || flags.contains(.control) || flags.contains(.option)
         guard hasModifier else { return false }
 
-        let key = event.charactersIgnoringModifiers?.lowercased() ?? ""
+        let key = KeyCombo.normalized(key: event.charactersIgnoringModifiers ?? "", keyCode: event.keyCode)
         guard !key.isEmpty else { return false }
 
         onRecord?(KeyCombo(key: key, modifiers: flags.rawValue))

--- a/Muxy/Views/TerminalPane.swift
+++ b/Muxy/Views/TerminalPane.swift
@@ -82,7 +82,7 @@ struct TerminalBridge: NSViewRepresentable {
             DispatchQueue.main.async {
                 nsView.window?.makeFirstResponder(nsView)
             }
-        } else if !focused, wasFocused {
+        } else if !focused {
             nsView.notifySurfaceUnfocused()
         }
     }


### PR DESCRIPTION
- add directional pane focus actions (left/right/up/down) with default arrow-key shortcuts
- wire pane focus commands through AppState, reducer, and command menu
- normalize shortcut matching by keycode/modifiers and fix pane unfocus behavior