### PR TITLE
Fix titlebar drag hit testing

### DIFF
--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -93,16 +93,19 @@ struct MainWindow: View {
                 }
             )
         } else {
-            HStack {
-                if let project = activeProject {
-                    Text(project.name)
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(MuxyTheme.fgMuted)
-                        .padding(.leading, 12)
+            WindowDragRepresentable(alwaysEnabled: true)
+                .overlay {
+                    HStack {
+                        if let project = activeProject {
+                            Text(project.name)
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(MuxyTheme.fgMuted)
+                                .padding(.leading, 12)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .allowsHitTesting(false)
                 }
-                Spacer(minLength: 0)
-            }
-            .background(WindowDragRepresentable(alwaysEnabled: true))
         }
     }
 


### PR DESCRIPTION
- Wrap the fallback titlebar in a drag-enabled host view.
- Move the project name row into an overlay and disable hit testing there.
- Keep drag behavior while preserving header text visibility.