### PR TITLE
Show branch and PR info in VCS tab

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -36,9 +36,12 @@ final class VCSTabState {
     var diffsByPath: [String: LoadedDiff] = [:]
     var loadingDiffPaths: Set<String> = []
     var diffErrorsByPath: [String: String] = [:]
+    var branchName: String?
+    var pullRequestInfo: GitRepositoryService.PRInfo?
 
     @ObservationIgnored private let git = GitRepositoryService()
     @ObservationIgnored private var loadFilesTask: Task<Void, Never>?
+    @ObservationIgnored private var branchTask: Task<Void, Never>?
     @ObservationIgnored private var loadDiffTasks: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var watcher: GitDirectoryWatcher?
     @ObservationIgnored private var isRefreshing = false
@@ -51,6 +54,7 @@ final class VCSTabState {
 
     deinit {
         loadFilesTask?.cancel()
+        branchTask?.cancel()
         loadDiffTasks.values.forEach { $0.cancel() }
     }
 
@@ -82,6 +86,23 @@ final class VCSTabState {
         isRefreshing = true
         pendingRefresh = false
         errorMessage = nil
+
+        branchTask?.cancel()
+        branchTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let branch = try await git.currentBranch(repoPath: projectPath)
+                guard !Task.isCancelled else { return }
+                branchName = branch
+                let prInfo = await git.pullRequestInfo(repoPath: projectPath, branch: branch)
+                guard !Task.isCancelled else { return }
+                pullRequestInfo = prInfo
+            } catch {
+                guard !Task.isCancelled else { return }
+                branchName = nil
+                pullRequestInfo = nil
+            }
+        }
 
         loadFilesTask = Task { [weak self] in
             guard let self else { return }

--- a/Muxy/Services/GitRepositoryService.swift
+++ b/Muxy/Services/GitRepositoryService.swift
@@ -83,6 +83,79 @@ actor GitRepositoryService {
         }
     }
 
+    func currentBranch(repoPath: String) async throws -> String {
+        let result = try runGit(repoPath: repoPath, arguments: ["rev-parse", "--abbrev-ref", "HEAD"])
+        guard result.status == 0 else {
+            throw GitError.commandFailed("Failed to get current branch.")
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    struct PRInfo {
+        let url: String
+        let number: Int
+    }
+
+    func pullRequestInfo(repoPath: String, branch: String) async -> PRInfo? {
+        guard let ghPath = resolveExecutable("gh") else { return nil }
+        let result = try? runCommand(
+            executable: ghPath,
+            arguments: ["pr", "view", branch, "--json", "url,number", "-q", ".url + \"\\n\" + (.number | tostring)"],
+            workingDirectory: repoPath
+        )
+        guard let result, result.status == 0 else { return nil }
+        let lines = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "\n")
+        guard lines.count >= 2,
+              let number = Int(lines[1])
+        else { return nil }
+        return PRInfo(url: String(lines[0]), number: number)
+    }
+
+    nonisolated private func resolveExecutable(_ name: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = [name]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return path?.isEmpty == false ? path : nil
+        } catch {
+            return nil
+        }
+    }
+
+    nonisolated private func runCommand(
+        executable: String,
+        arguments: [String],
+        workingDirectory: String
+    ) throws -> GitRunResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+        return GitRunResult(status: process.terminationStatus, stdout: stdout, stdoutData: stdoutData, stderr: stderr, truncated: false)
+    }
+
     func changedFiles(repoPath: String, ignoreWhitespace: Bool = false) async throws -> [GitStatusFile] {
         let result = try runGit(repoPath: repoPath, arguments: ["rev-parse", "--is-inside-work-tree"])
         guard result.status == 0, result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true" else {

--- a/Muxy/Views/VCSTabView.swift
+++ b/Muxy/Views/VCSTabView.swift
@@ -24,6 +24,26 @@ struct VCSTabView: View {
 
     private var header: some View {
         HStack(spacing: 0) {
+            if let branch = state.branchName {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+
+                    Text(branch)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    if let prInfo = state.pullRequestInfo {
+                        PRBadge(info: prInfo)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
             HStack(spacing: 0) {
                 ForEach(VCSTabState.ViewMode.allCases) { mode in
                     Button {
@@ -42,8 +62,7 @@ struct VCSTabView: View {
                     .buttonStyle(.plain)
                 }
             }
-
-            Spacer(minLength: 0)
+            .padding(.trailing, 6)
 
             Button {
                 if state.expandedFilePaths.isEmpty {
@@ -650,5 +669,36 @@ private final class DiffHighlightCache {
         }
 
         return result
+    }
+}
+
+private struct PRBadge: View {
+    let info: GitRepositoryService.PRInfo
+    @State private var hovered = false
+
+    var body: some View {
+        Button {
+            NSWorkspace.shared.open(URL(string: info.url)!)
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.triangle.pull")
+                    .font(.system(size: 9, weight: .bold))
+                Text("#\(info.number)")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+            }
+            .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(MuxyTheme.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(MuxyTheme.border, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
     }
 }


### PR DESCRIPTION
- Fetch and store the current branch name in VCS tab state.
- Query GitHub CLI for PR URL/number for that branch when available.
- Render branch context and a clickable PR badge in the VCS header.