### PR TITLE
Remove window identity reset

### DIFF
--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -10,7 +10,7 @@ final class GhosttyService {
     static let shared = GhosttyService()
 
     @ObservationIgnored private(set) var app: ghostty_app_t?
-    @ObservationIgnored private(set) var config: ghostty_config_t?
+    private(set) var config: ghostty_config_t?
     private(set) var configVersion = 0
     @ObservationIgnored private var tickTimer: Timer?
     @ObservationIgnored private let runtimeEvents: any GhosttyRuntimeEventHandling = GhosttyRuntimeEventAdapter()

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -48,7 +48,6 @@ struct MainWindow: View {
             }
         }
         .environment(dragCoordinator)
-        .id(ghostty.configVersion)
         .background(WindowConfigurator(configVersion: ghostty.configVersion))
         .edgesIgnoringSafeArea(.top)
         .onAppear {


### PR DESCRIPTION
- Stop recreating the main window when Ghostty config changes\n- Keep config observable so updates still propagate