### PR TITLE
Keep tab terminal views mounted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,12 @@ The xcframework is built via GitHub Actions on the [muxy-app/ghostty](https://gi
 - **Ghostty config:** `~/.config/ghostty/config`
 - **Terminal state (tabs, splits):** in-memory only, lost on app close
 
+## NSViewRepresentable Pitfalls
+
+- Never return a cached/reused NSView from `makeNSView`. SwiftUI assumes it gets a fresh view and breaks silently when it doesn't (blank views, lost input).
+- To keep an NSView alive across tab switches, keep the `NSViewRepresentable` mounted in the view tree (e.g. all tabs in a ZStack with `opacity(0)` + `allowsHitTesting(false)` for inactive ones) rather than conditionally removing it and relying on a registry cache.
+- When debugging blank/empty NSView issues, first check whether the NSView is being re-mounted from a detached state — that's the most common cause.
+
 ## Top Level Rules
 
 - Security first

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -35,14 +35,16 @@ struct TabAreaView: View {
                 Rectangle().fill(MuxyTheme.border).frame(height: 1)
             }
             ZStack {
-                if let tab = area.activeTab {
+                ForEach(area.tabs) { tab in
                     TabContentView(
                         tab: tab,
-                        focused: isFocused && isActiveProject,
+                        focused: tab.id == area.activeTabID && isFocused && isActiveProject,
                         onFocus: onFocus,
                         onProcessExit: { onCloseTab(tab.id) }
                     )
-                    .id(tab.id)
+                    .zIndex(tab.id == area.activeTabID ? 1 : 0)
+                    .opacity(tab.id == area.activeTabID ? 1 : 0)
+                    .allowsHitTesting(tab.id == area.activeTabID)
                 }
             }
             .overlay {


### PR DESCRIPTION
- Keep every tab's terminal view mounted inside the tab area ZStack.
- Show only the active tab with opacity and hit-testing instead of conditional view removal.
- Document NSViewRepresentable lifecycle pitfalls to prevent blank terminal regressions.