### PR TITLE
Move VCS button for split panes

### DIFF
--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -135,6 +135,7 @@ struct MainWindow: View {
                 area: area,
                 isFocused: true,
                 isWindowTitleBar: true,
+                showVCSButton: true,
                 projectID: project.id,
                 onFocus: {},
                 onSelectTab: { tabID in
@@ -144,14 +145,7 @@ struct MainWindow: View {
                     appState.dispatch(.createTab(projectID: project.id, areaID: area.id))
                 },
                 onCreateVCSTab: {
-                    VCSDisplayMode.current.route(
-                        tab: { appState.dispatch(.createVCSTab(projectID: project.id, areaID: area.id)) },
-                        window: { openWindow(id: "vcs") },
-                        attached: {
-                            ensureVCSState(for: project)
-                            vcsPanelVisible.toggle()
-                        }
-                    )
+                    openVCS(for: project, preferredAreaID: area.id)
                 },
                 onCloseTab: { tabID in
                     appState.dispatch(.closeTab(projectID: project.id, areaID: area.id, tabID: tabID))
@@ -182,6 +176,14 @@ struct MainWindow: View {
                     }
                     .allowsHitTesting(false)
                 }
+                .overlay(alignment: .trailing) {
+                    if let project = activeProject, activeProjectHasSplitWorkspace {
+                        FileDiffIconButton {
+                            openVCS(for: project)
+                        }
+                        .padding(.trailing, 4)
+                    }
+                }
         }
     }
 
@@ -197,6 +199,14 @@ struct MainWindow: View {
         return project
     }
 
+    private var activeProjectHasSplitWorkspace: Bool {
+        guard let project = activeProject,
+              let root = appState.workspaceRoot(for: project.id)
+        else { return false }
+        if case .split = root { return true }
+        return false
+    }
+
     private var projectsWithWorkspaces: [Project] {
         projectStore.projects.filter { appState.workspaceRoots[$0.id] != nil }
     }
@@ -209,6 +219,23 @@ struct MainWindow: View {
     private func ensureVCSState(for project: Project) {
         guard vcsStates[project.id] == nil else { return }
         vcsStates[project.id] = VCSTabState(projectPath: project.path)
+    }
+
+    private func openVCS(for project: Project, preferredAreaID: UUID? = nil) {
+        VCSDisplayMode.current.route(
+            tab: {
+                let areaID = preferredAreaID
+                    ?? appState.focusedAreaID[project.id]
+                    ?? appState.workspaceRoot(for: project.id)?.allAreas().first?.id
+                guard let areaID else { return }
+                appState.dispatch(.createVCSTab(projectID: project.id, areaID: areaID))
+            },
+            window: { openWindow(id: "vcs") },
+            attached: {
+                ensureVCSState(for: project)
+                vcsPanelVisible.toggle()
+            }
+        )
     }
 
     private func pruneVCSStates(validProjectIDs: Set<UUID>) {

--- a/Muxy/Views/Workspace/PaneNode.swift
+++ b/Muxy/Views/Workspace/PaneNode.swift
@@ -5,6 +5,7 @@ struct PaneNode: View {
     let focusedAreaID: UUID?
     let isActiveProject: Bool
     var showTabStrip = true
+    var showVCSButton = true
     let projectID: UUID
     let onFocusArea: (UUID) -> Void
     let onSelectTab: (UUID, UUID) -> Void
@@ -23,6 +24,7 @@ struct PaneNode: View {
                 isFocused: focusedAreaID == area.id,
                 isActiveProject: isActiveProject,
                 showTabStrip: showTabStrip,
+                showVCSButton: showVCSButton,
                 projectID: projectID,
                 onFocus: { onFocusArea(area.id) },
                 onSelectTab: { tabID in onSelectTab(area.id, tabID) },
@@ -38,6 +40,7 @@ struct PaneNode: View {
                 branch: branch,
                 focusedAreaID: focusedAreaID,
                 isActiveProject: isActiveProject,
+                showVCSButton: showVCSButton,
                 projectID: projectID,
                 onFocusArea: onFocusArea,
                 onSelectTab: onSelectTab,

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -5,6 +5,7 @@ struct SplitContainer: View {
     let branch: SplitBranch
     let focusedAreaID: UUID?
     let isActiveProject: Bool
+    let showVCSButton: Bool
     let projectID: UUID
     let onFocusArea: (UUID) -> Void
     let onSelectTab: (UUID, UUID) -> Void
@@ -61,6 +62,7 @@ struct SplitContainer: View {
             node: node,
             focusedAreaID: focusedAreaID,
             isActiveProject: isActiveProject,
+            showVCSButton: showVCSButton,
             projectID: projectID,
             onFocusArea: onFocusArea,
             onSelectTab: onSelectTab,

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -5,6 +5,7 @@ struct TabAreaView: View {
     let isFocused: Bool
     let isActiveProject: Bool
     let showTabStrip: Bool
+    let showVCSButton: Bool
     let projectID: UUID
     let onFocus: () -> Void
     let onSelectTab: (UUID) -> Void
@@ -22,6 +23,7 @@ struct TabAreaView: View {
                 PaneTabStrip(
                     area: area,
                     isFocused: isFocused,
+                    showVCSButton: showVCSButton,
                     projectID: projectID,
                     onFocus: onFocus,
                     onSelectTab: onSelectTab,

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -4,6 +4,7 @@ struct PaneTabStrip: View {
     let area: TabArea
     let isFocused: Bool
     var isWindowTitleBar: Bool = false
+    var showVCSButton = true
     let projectID: UUID
     let onFocus: () -> Void
     let onSelectTab: (UUID) -> Void
@@ -65,7 +66,9 @@ struct PaneTabStrip: View {
                 IconButton(symbol: "square.split.2x1") { onSplit(.horizontal) }
                 IconButton(symbol: "square.split.1x2") { onSplit(.vertical) }
                 IconButton(symbol: "plus") { onCreateTab() }
-                FileDiffIconButton(action: onCreateVCSTab)
+                if showVCSButton {
+                    FileDiffIconButton(action: onCreateVCSTab)
+                }
             }
             .padding(.trailing, 4)
             .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -20,6 +20,7 @@ struct TerminalArea: View {
                 focusedAreaID: appState.focusedAreaID[project.id],
                 isActiveProject: isActiveProject,
                 showTabStrip: !rootIsTabArea,
+                showVCSButton: false,
                 projectID: project.id,
                 onFocusArea: { areaID in
                     appState.dispatch(.focusArea(projectID: project.id, areaID: areaID))


### PR DESCRIPTION
- Keep the VCS button on the tab strip when the window has a single tab strip.
- Move the VCS button to the title bar area when split panes are present.
- Reuse shared VCS-open routing so the title bar action targets the focused pane.