### PR TITLE
Remove New Project shortcut and UI entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,4 @@ The xcframework is built via GitHub Actions on the [muxy-app/ghostty](https://gi
 - Don't patch symptoms, fix root causes
 - For every task, Consider how it will impact the architecture and code quality, not just the immediate problem
 - Follow the existing code's pattern but offer refactors if they improve code quality and maintainability.
+- Treat the request as end-to-end behavior, not partial UI edits—verify every trigger path before saying it’s done.

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -56,11 +56,6 @@ struct MuxyCommands: Commands {
         }
 
         CommandGroup(replacing: .newItem) {
-            Button("New Project") {
-                newProject()
-            }
-            .shortcut(for: .newProject, store: keyBindings)
-
             Button("Open Project...") {
                 openProject()
             }
@@ -236,17 +231,6 @@ struct MuxyCommands: Commands {
             }
             .shortcut(for: .toggleThemePicker, store: keyBindings)
         }
-    }
-
-    private func newProject() {
-        let url = FileManager.default.homeDirectoryForCurrentUser
-        let project = Project(
-            name: url.lastPathComponent,
-            path: url.path(percentEncoded: false),
-            sortOrder: projectStore.projects.count
-        )
-        projectStore.add(project)
-        appState.selectProject(project)
     }
 
     private func openProject() {

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -49,6 +49,48 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case findInTerminal
     case openVCSTab
 
+    static let allCases: [Self] = [
+        .newTab,
+        .closeTab,
+        .renameTab,
+        .pinUnpinTab,
+        .splitRight,
+        .splitDown,
+        .closePane,
+        .focusPaneLeft,
+        .focusPaneRight,
+        .focusPaneUp,
+        .focusPaneDown,
+        .nextTab,
+        .previousTab,
+        .toggleSidebar,
+        .toggleThemePicker,
+        .openProject,
+        .reloadConfig,
+        .selectTab1,
+        .selectTab2,
+        .selectTab3,
+        .selectTab4,
+        .selectTab5,
+        .selectTab6,
+        .selectTab7,
+        .selectTab8,
+        .selectTab9,
+        .nextProject,
+        .previousProject,
+        .selectProject1,
+        .selectProject2,
+        .selectProject3,
+        .selectProject4,
+        .selectProject5,
+        .selectProject6,
+        .selectProject7,
+        .selectProject8,
+        .selectProject9,
+        .findInTerminal,
+        .openVCSTab,
+    ]
+
     var id: String { rawValue }
 
     private var metadata: ShortcutMetadata {
@@ -144,7 +186,6 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .toggleSidebar, combo: KeyCombo(key: "b", command: true)),
         Self(action: .toggleThemePicker, combo: KeyCombo(key: "k", command: true, shift: true)),
         Self(action: .openVCSTab, combo: KeyCombo(key: "k", command: true)),
-        Self(action: .newProject, combo: KeyCombo(key: "n", command: true)),
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),
         Self(action: .reloadConfig, combo: KeyCombo(key: "r", command: true, shift: true)),
         Self(action: .nextTab, combo: KeyCombo(key: "]", command: true)),

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -11,7 +11,6 @@ struct SidebarToolbar: View {
         HStack(spacing: 4) {
             Spacer()
             IconButton(symbol: "folder") { openProject() }
-            IconButton(symbol: "plus") { addProject() }
             IconButton(symbol: "sidebar.left") {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     appState.sidebarVisible.toggle()
@@ -25,10 +24,6 @@ struct SidebarToolbar: View {
                 HStack(spacing: 3) {
                     ShortcutBadge(
                         label: KeyBindingStore.shared.combo(for: .openProject).displayString,
-                        compact: true
-                    )
-                    ShortcutBadge(
-                        label: KeyBindingStore.shared.combo(for: .newProject).displayString,
                         compact: true
                     )
                     ShortcutBadge(
@@ -59,16 +54,6 @@ struct SidebarToolbar: View {
         appState.selectProject(project)
     }
 
-    private func addProject() {
-        let url = FileManager.default.homeDirectoryForCurrentUser
-        let project = Project(
-            name: url.lastPathComponent,
-            path: url.path(percentEncoded: false),
-            sortOrder: projectStore.projects.count
-        )
-        projectStore.add(project)
-        appState.selectProject(project)
-    }
 }
 
 struct Sidebar: View {


### PR DESCRIPTION
- Remove the sidebar plus action and Cmd+N hint badge from the top bar.
- Remove the New Project command entry and its handler from the New menu group.
- Drop the default Cmd+N key binding so the shortcut no longer triggers.