### PR TITLE
Confirm before closing last project tab

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -35,9 +35,16 @@ final class AppState {
         didSet { saveSelection() }
     }
 
+    struct PendingTabClose: Equatable {
+        let projectID: UUID
+        let areaID: UUID
+        let tabID: UUID
+    }
+
     var sidebarVisible = true
     var workspaceRoots: [UUID: SplitNode] = [:]
     var focusedAreaID: [UUID: UUID] = [:]
+    var pendingLastTabClose: PendingTabClose?
     private var focusHistory: [UUID: [UUID]] = [:]
 
     init(
@@ -120,7 +127,32 @@ final class AppState {
 
     func closeTab(_ tabID: UUID, projectID: UUID) {
         guard let area = focusedArea(for: projectID) else { return }
-        dispatch(.closeTab(projectID: projectID, areaID: area.id, tabID: tabID))
+        closeTab(tabID, areaID: area.id, projectID: projectID)
+    }
+
+    func closeTab(_ tabID: UUID, areaID: UUID, projectID: UUID) {
+        if isLastTabInProject(tabID, areaID: areaID, projectID: projectID) {
+            pendingLastTabClose = PendingTabClose(projectID: projectID, areaID: areaID, tabID: tabID)
+            return
+        }
+        dispatch(.closeTab(projectID: projectID, areaID: areaID, tabID: tabID))
+    }
+
+    func confirmCloseLastTab() {
+        guard let pending = pendingLastTabClose else { return }
+        pendingLastTabClose = nil
+        dispatch(.closeTab(projectID: pending.projectID, areaID: pending.areaID, tabID: pending.tabID))
+    }
+
+    func cancelCloseLastTab() {
+        pendingLastTabClose = nil
+    }
+
+    private func isLastTabInProject(_ tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
+        guard let root = workspaceRoots[projectID] else { return false }
+        let allAreas = root.allAreas()
+        let totalTabs = allAreas.reduce(0) { $0 + $1.tabs.count }
+        return totalTabs <= 1
     }
 
     func selectTabByIndex(_ index: Int, projectID: UUID) {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -123,6 +123,18 @@ struct MainWindow: View {
             else { return }
             ensureVCSState(for: project)
         }
+        .alert(
+            "Close Project",
+            isPresented: Binding(
+                get: { appState.pendingLastTabClose != nil },
+                set: { if !$0 { appState.cancelCloseLastTab() } }
+            )
+        ) {
+            Button("Close", role: .destructive) { appState.confirmCloseLastTab() }
+            Button("Cancel", role: .cancel) { appState.cancelCloseLastTab() }
+        } message: {
+            Text("This is the last tab. Closing it will remove the project from the sidebar.")
+        }
     }
 
     @ViewBuilder
@@ -148,7 +160,7 @@ struct MainWindow: View {
                     openVCS(for: project, preferredAreaID: area.id)
                 },
                 onCloseTab: { tabID in
-                    appState.dispatch(.closeTab(projectID: project.id, areaID: area.id, tabID: tabID))
+                    appState.closeTab(tabID, areaID: area.id, projectID: project.id)
                 },
                 onSplit: { dir in
                     appState.dispatch(.splitArea(

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -39,7 +39,7 @@ struct TerminalArea: View {
                     )
                 },
                 onCloseTab: { areaID, tabID in
-                    appState.dispatch(.closeTab(projectID: project.id, areaID: areaID, tabID: tabID))
+                    appState.closeTab(tabID, areaID: areaID, projectID: project.id)
                 },
                 onSplit: { areaID, dir in
                     appState.dispatch(.splitArea(


### PR DESCRIPTION
- add pending last-tab close state in `AppState` to gate destructive close actions
- show a confirmation alert before closing the final tab that removes a project
- route workspace and main window tab-close actions through the new close flow