### PR TITLE
Adjust diff line number spacing

### DIFF
--- a/Muxy/Views/VCS/DiffComponents.swift
+++ b/Muxy/Views/VCS/DiffComponents.swift
@@ -69,6 +69,17 @@ func hunkLabel(_ raw: String) -> String {
     return after.isEmpty ? raw : after
 }
 
+func lineNumberWidth(for maxLineNumber: Int) -> CGFloat {
+    let digitCount = max(String(maxLineNumber).count, 1)
+    return CGFloat(digitCount) * 7 + 6
+}
+
+func maxLineNumber(in rows: [DiffDisplayRow]) -> Int {
+    rows.reduce(0) { result, row in
+        max(result, row.oldLineNumber ?? 0, row.newLineNumber ?? 0)
+    }
+}
+
 enum DiffBackgroundSide {
     case left
     case right

--- a/Muxy/Views/VCS/SplitDiffView.swift
+++ b/Muxy/Views/VCS/SplitDiffView.swift
@@ -5,6 +5,10 @@ struct SplitDiffView: View {
     let filePath: String
     let pairedRows: [SplitDiffPairedRow]
 
+    private var numberColumnWidth: CGFloat {
+        lineNumberWidth(for: maxLineNumber(in: rows))
+    }
+
     init(rows: [DiffDisplayRow], filePath: String) {
         self.rows = rows
         self.filePath = filePath
@@ -73,8 +77,8 @@ struct SplitDiffView: View {
             Text(number.map(String.init) ?? "")
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundStyle(MuxyTheme.fgDim)
-                .frame(width: 42, alignment: .trailing)
-                .padding(.trailing, 6)
+                .frame(width: numberColumnWidth, alignment: .trailing)
+                .padding(.trailing, 4)
                 .background(.clear)
                 .overlay(alignment: .trailing) {
                     Rectangle().fill(MuxyTheme.border).frame(width: 1)
@@ -82,7 +86,7 @@ struct SplitDiffView: View {
 
             CodeHighlightedText(text: text ?? "", kind: highlightKind)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 8)
+                .padding(.horizontal, 6)
                 .padding(.vertical, 2)
         }
         .background(rowBackground(bgKind, side: isLeft ? .left : .right))

--- a/Muxy/Views/VCS/UnifiedDiffView.swift
+++ b/Muxy/Views/VCS/UnifiedDiffView.swift
@@ -4,6 +4,10 @@ struct UnifiedDiffView: View {
     let rows: [DiffDisplayRow]
     let filePath: String
 
+    private var numberColumnWidth: CGFloat {
+        lineNumberWidth(for: maxLineNumber(in: rows))
+    }
+
     var body: some View {
         LazyVStack(spacing: 0) {
             ForEach(rows) { row in
@@ -16,7 +20,7 @@ struct UnifiedDiffView: View {
                             numberCell(row.newLineNumber)
                             lineContent(row)
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, 8)
+                                .padding(.horizontal, 6)
                         }
                         .frame(minHeight: 24)
                         .background(rowBackground(row.kind, side: .both))
@@ -31,8 +35,8 @@ struct UnifiedDiffView: View {
         Text(number.map(String.init) ?? "")
             .font(.system(size: 11, design: .monospaced))
             .foregroundStyle(MuxyTheme.fgDim)
-            .frame(width: 42, alignment: .trailing)
-            .padding(.trailing, 6)
+            .frame(width: numberColumnWidth, alignment: .trailing)
+            .padding(.trailing, 4)
             .background(.clear)
             .overlay(alignment: .trailing) {
                 Rectangle().fill(MuxyTheme.border).frame(width: 1)


### PR DESCRIPTION
- Compute line-number column width from actual max line number in each diff.
- Apply dynamic number column width in split and unified diff views.
- Tighten horizontal padding to improve diff readability.