### PR TITLE
Add update badge for available releases

### DIFF
--- a/Muxy/Services/UpdateService.swift
+++ b/Muxy/Services/UpdateService.swift
@@ -13,6 +13,7 @@ final class UpdateService: NSObject {
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
 
     private(set) var canCheckForUpdates = false
+    private(set) var availableUpdateVersion: String?
 
     private var updater: SPUUpdater {
         controller.updater
@@ -28,6 +29,8 @@ final class UpdateService: NSObject {
         controller.updater.publisher(for: \.canCheckForUpdates)
             .assign(to: \.canCheckForUpdates, on: self)
             .store(in: &cancellables)
+        observeUpdateNotifications()
+        applyFeatureFlags()
     }
 
     func start() {
@@ -40,5 +43,30 @@ final class UpdateService: NSObject {
 
     func checkForUpdates() {
         controller.checkForUpdates(nil)
+    }
+
+    private func applyFeatureFlags() {
+        #if DEBUG
+        if ProcessInfo.processInfo.environment["FF_UPDATE_AVAILABLE"] != nil {
+            availableUpdateVersion = "0.0.0-dev"
+        }
+        #endif
+    }
+
+    private func observeUpdateNotifications() {
+        NotificationCenter.default.publisher(for: .SUUpdaterDidFindValidUpdate)
+            .compactMap { $0.userInfo?[SUUpdaterAppcastItemNotificationKey] as? SUAppcastItem }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] item in
+                self?.availableUpdateVersion = item.displayVersionString
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .SUUpdaterDidNotFindUpdate)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.availableUpdateVersion = nil
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Muxy/Views/Components/UpdateBadge.swift
+++ b/Muxy/Views/Components/UpdateBadge.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct UpdateBadge: View {
+    let version: String
+    let action: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.system(size: 9, weight: .bold))
+                Text("Update \(version)")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(MuxyTheme.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(MuxyTheme.border, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -213,12 +213,20 @@ struct MainWindow: View {
                     .allowsHitTesting(false)
                 }
                 .overlay(alignment: .trailing) {
-                    if let project = activeProject, activeProjectHasSplitWorkspace {
-                        FileDiffIconButton {
-                            openVCS(for: project)
+                    HStack(spacing: 0) {
+                        if let version = UpdateService.shared.availableUpdateVersion {
+                            UpdateBadge(version: version) {
+                                UpdateService.shared.checkForUpdates()
+                            }
+                            .padding(.trailing, 4)
                         }
-                        .padding(.trailing, 4)
+                        if let project = activeProject, activeProjectHasSplitWorkspace {
+                            FileDiffIconButton {
+                                openVCS(for: project)
+                            }
+                        }
                     }
+                    .padding(.trailing, 4)
                 }
         }
     }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -63,6 +63,12 @@ struct PaneTabStrip: View {
 
             HStack(spacing: 0) {
                 Spacer(minLength: 0)
+                if isWindowTitleBar, let version = UpdateService.shared.availableUpdateVersion {
+                    UpdateBadge(version: version) {
+                        UpdateService.shared.checkForUpdates()
+                    }
+                    .padding(.trailing, 4)
+                }
                 IconButton(symbol: "square.split.2x1") { onSplit(.horizontal) }
                 IconButton(symbol: "square.split.1x2") { onSplit(.vertical) }
                 IconButton(symbol: "plus") { onCreateTab() }


### PR DESCRIPTION
- Track available Sparkle updates in `UpdateService` using updater notifications.
- Show an `UpdateBadge` in the title bar controls and tab strip when an update is available.
- Add a debug feature flag to simulate an available update during development.