### PR TITLE
Fix terminal lifecycle and state cleanup

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -214,6 +214,7 @@ final class VCSTabState {
     func toggleExpanded(filePath: String) {
         if expandedFilePaths.contains(filePath) {
             expandedFilePaths.remove(filePath)
+            evictDiff(filePath: filePath)
             return
         }
 
@@ -225,6 +226,19 @@ final class VCSTabState {
 
     func collapseAll() {
         expandedFilePaths.removeAll()
+        diffsByPath.removeAll()
+        diffErrorsByPath.removeAll()
+        loadDiffTasks.values.forEach { $0.cancel() }
+        loadDiffTasks.removeAll()
+        loadingDiffPaths.removeAll()
+    }
+
+    private func evictDiff(filePath: String) {
+        diffsByPath.removeValue(forKey: filePath)
+        diffErrorsByPath.removeValue(forKey: filePath)
+        loadDiffTasks[filePath]?.cancel()
+        loadDiffTasks.removeValue(forKey: filePath)
+        loadingDiffPaths.remove(filePath)
     }
 
     func expandAll() {

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -107,10 +107,7 @@ enum WorkspaceReducer {
         )
         state.workspaceRoots[request.projectID] = newRoot
         guard let newAreaID else { return }
-        if let current = state.focusedAreaID[request.projectID] {
-            state.focusHistory[request.projectID, default: []].append(current)
-        }
-        state.focusedAreaID[request.projectID] = newAreaID
+        focusArea(newAreaID, projectID: request.projectID, state: &state)
     }
 
     private static func closeArea(
@@ -243,9 +240,16 @@ enum WorkspaceReducer {
         effects.projectIDsToRemove.append(projectID)
     }
 
+    private static let focusHistoryLimit = 20
+
     private static func focusArea(_ areaID: UUID, projectID: UUID, state: inout WorkspaceState) {
         if let current = state.focusedAreaID[projectID], current != areaID {
-            state.focusHistory[projectID, default: []].append(current)
+            var history = state.focusHistory[projectID, default: []]
+            history.append(current)
+            if history.count > focusHistoryLimit {
+                history.removeFirst(history.count - focusHistoryLimit)
+            }
+            state.focusHistory[projectID] = history
         }
         state.focusedAreaID[projectID] = areaID
     }

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -12,7 +12,6 @@ final class GhosttyService {
     @ObservationIgnored private(set) var app: ghostty_app_t?
     private(set) var config: ghostty_config_t?
     private(set) var configVersion = 0
-    @ObservationIgnored private var tickTimer: Timer?
     @ObservationIgnored private let runtimeEvents: any GhosttyRuntimeEventHandling = GhosttyRuntimeEventAdapter()
     @ObservationIgnored private let muxyConfig: MuxyConfig
 
@@ -65,14 +64,6 @@ final class GhosttyService {
 
         self.app = createdApp
         self.config = cfg
-
-        let timer = Timer(timeInterval: 1.0 / 120.0, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.tick()
-            }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        tickTimer = timer
     }
 
     var backgroundOpacity: Double {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1,6 +1,5 @@
 import AppKit
 import GhosttyKit
-import QuartzCore
 
 final class GhosttyTerminalNSView: NSView {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
@@ -34,19 +33,6 @@ final class GhosttyTerminalNSView: NSView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
     }
-
-    override func makeBackingLayer() -> CALayer {
-        let metalLayer = CAMetalLayer()
-        metalLayer.pixelFormat = .bgra8Unorm
-        metalLayer.isOpaque = false
-        metalLayer.framebufferOnly = false
-        metalLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-        metalLayer.needsDisplayOnBoundsChange = true
-        metalLayer.presentsWithTransaction = false
-        return metalLayer
-    }
-
-    override var wantsUpdateLayer: Bool { true }
 
     private var pendingSurfaceCreation = false
 
@@ -100,6 +86,23 @@ final class GhosttyTerminalNSView: NSView {
             ghostty_surface_free(surface)
         }
         surface = nil
+    }
+
+    func tearDown() {
+        onTitleChange = nil
+        onFocus = nil
+        onProcessExit = nil
+        onSplitRequest = nil
+        onSearchStart = nil
+        onSearchEnd = nil
+        onSearchTotal = nil
+        onSearchSelected = nil
+        if let observer = screenChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            screenChangeObserver = nil
+        }
+        destroySurface()
+        removeFromSuperview()
     }
 
     deinit {
@@ -163,13 +166,6 @@ final class GhosttyTerminalNSView: NSView {
         guard scaledSize.width > 0, scaledSize.height > 0 else { return }
 
         let scale = Double(window.backingScaleFactor)
-
-        if let metalLayer = layer as? CAMetalLayer {
-            CATransaction.begin()
-            CATransaction.setDisableActions(true)
-            metalLayer.contentsScale = CGFloat(scale)
-            CATransaction.commit()
-        }
 
         ghostty_surface_set_content_scale(surface, scale, scale)
 

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct TerminalPane: View {
     let state: TerminalPaneState
     let focused: Bool
+    let visible: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
@@ -13,6 +14,7 @@ struct TerminalPane: View {
             TerminalBridge(
                 state: state,
                 focused: focused,
+                visible: visible,
                 onFocus: onFocus,
                 onProcessExit: onProcessExit,
                 onSplitRequest: onSplitRequest
@@ -43,6 +45,7 @@ struct TerminalPane: View {
 struct TerminalBridge: NSViewRepresentable {
     let state: TerminalPaneState
     let focused: Bool
+    let visible: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
@@ -60,6 +63,7 @@ struct TerminalBridge: NSViewRepresentable {
         let registry = TerminalViewRegistry.shared
         let view = registry.view(for: state.id, workingDirectory: state.projectPath)
         view.isFocused = focused
+        view.isHidden = !visible
         view.onFocus = onFocus
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
@@ -78,6 +82,7 @@ struct TerminalBridge: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: GhosttyTerminalNSView, context: Context) {
+        nsView.isHidden = !visible
         nsView.onFocus = onFocus
         nsView.onProcessExit = onProcessExit
         nsView.onSplitRequest = onSplitRequest

--- a/Muxy/Views/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Views/Terminal/TerminalViewRegistry.swift
@@ -22,7 +22,8 @@ final class TerminalViewRegistry {
     }
 
     func removeView(for paneID: UUID) {
-        views.removeValue(forKey: paneID)
+        guard let view = views.removeValue(forKey: paneID) else { return }
+        view.tearDown()
     }
 
     func needsConfirmQuit(for paneID: UUID) -> Bool {

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -44,6 +44,7 @@ struct TabAreaView: View {
                     TabContentView(
                         tab: tab,
                         focused: isActive && isFocused && isActiveProject,
+                        visible: isActive,
                         onFocus: onFocus,
                         onProcessExit: { onForceCloseTab(tab.id) },
                         onSplitRequest: { direction, position in
@@ -96,6 +97,7 @@ struct TabAreaView: View {
 private struct TabContentView: View {
     let tab: TerminalTab
     let focused: Bool
+    let visible: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
@@ -106,6 +108,7 @@ private struct TabContentView: View {
             TerminalPane(
                 state: pane,
                 focused: focused,
+                visible: visible,
                 onFocus: onFocus,
                 onProcessExit: onProcessExit,
                 onSplitRequest: onSplitRequest


### PR DESCRIPTION
## Summary
- Fix terminal view lifecycle cleanup so removed panes tear down surfaces and callbacks.
- Keep inactive terminal panes mounted but hidden to avoid remount-related rendering/input issues.
- Clear cached VCS diffs on collapse and cap focus history growth to prevent stale state.