### PR TITLE
Remove unused editor invisibles setting

### DIFF
--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -13,7 +13,6 @@ final class EditorSettings {
     var wordWrap: Bool = true { didSet { save() } }
     var showLineNumbers: Bool = true { didSet { save() } }
     var tabSize: Int = 4 { didSet { save() } }
-    var showInvisibles: Bool = false { didSet { save() } }
 
     @ObservationIgnored private let fileURL: URL
     @ObservationIgnored private var isBatchLoading = false
@@ -50,7 +49,6 @@ final class EditorSettings {
         wordWrap = true
         showLineNumbers = true
         tabSize = 4
-        showInvisibles = false
         isBatchLoading = false
         save()
     }
@@ -66,7 +64,6 @@ final class EditorSettings {
             wordWrap = snapshot.wordWrap ?? true
             showLineNumbers = snapshot.showLineNumbers ?? true
             tabSize = snapshot.tabSize ?? 4
-            showInvisibles = snapshot.showInvisibles ?? false
             isBatchLoading = false
         } catch {
             logger.error("Failed to load editor settings: \(error.localizedDescription)")
@@ -81,8 +78,7 @@ final class EditorSettings {
                 fontFamily: fontFamily,
                 wordWrap: wordWrap,
                 showLineNumbers: showLineNumbers,
-                tabSize: tabSize,
-                showInvisibles: showInvisibles
+                tabSize: tabSize
             )
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -104,5 +100,4 @@ private struct Snapshot: Codable {
     let wordWrap: Bool?
     let showLineNumbers: Bool?
     let tabSize: Int?
-    let showInvisibles: Bool?
 }

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -193,7 +193,6 @@ struct CodeEditorView: NSViewRepresentable {
         }
 
         coordinator.tabSize = editorSettings.tabSize
-        coordinator.showInvisibles = editorSettings.showInvisibles
 
         if contentChanged {
             coordinator.resetHighlightedRange()
@@ -269,7 +268,6 @@ struct CodeEditorView: NSViewRepresentable {
         var lastHighlightedRange: NSRange = .init(location: 0, length: 0)
         private static let highlightBuffer = 2000
         var tabSize = 4
-        var showInvisibles = false
         var onLineLayoutChange: ([LineLayoutInfo]) -> Void = { _ in }
         private weak var observedContentView: NSClipView?
         private weak var observedTextView: NSTextView?
@@ -299,7 +297,6 @@ struct CodeEditorView: NSViewRepresentable {
             self.editorSettings = editorSettings
             self.lastWordWrap = editorSettings.wordWrap
             self.tabSize = editorSettings.tabSize
-            self.showInvisibles = editorSettings.showInvisibles
             super.init()
         }
 

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -57,7 +57,6 @@ struct EditorSettingsView: View {
 
             toggleRow("Word Wrap", isOn: $settings.wordWrap)
             toggleRow("Show Line Numbers", isOn: $settings.showLineNumbers)
-            toggleRow("Show Invisibles", isOn: $settings.showInvisibles)
 
             Spacer()
 


### PR DESCRIPTION
- Remove the Show Invisibles setting from the editor preferences UI.
- Drop persisted showInvisibles state from editor settings snapshots.
- Remove unused coordinator wiring tied to that setting.

Fixes #72