### PR TITLE
Add worktree-aware project workflows

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct MuxyCommands: Commands {
     let appState: AppState
     let projectStore: ProjectStore
+    let worktreeStore: WorktreeStore
     let keyBindings: KeyBindingStore
     let config: MuxyConfig
     let ghostty: GhosttyService
@@ -141,7 +142,7 @@ struct MuxyCommands: Commands {
             Button("Close Pane") {
                 guard isMainWindowFocused else { return }
                 guard let projectID = appState.activeProjectID,
-                      let areaID = appState.focusedAreaID[projectID]
+                      let areaID = appState.focusedAreaID(for: projectID)
                 else { return }
                 appState.closeArea(areaID, projectID: projectID)
             }
@@ -224,7 +225,11 @@ struct MuxyCommands: Commands {
                 if let action = ShortcutAction.projectAction(for: index) {
                     Button("Project \(index)") {
                         guard isMainWindowFocused else { return }
-                        appState.selectProjectByIndex(index - 1, projects: projectStore.projects)
+                        appState.selectProjectByIndex(
+                            index - 1,
+                            projects: projectStore.projects,
+                            worktrees: worktreeStore.worktrees
+                        )
                     }
                     .shortcut(for: action, store: keyBindings)
                 }
@@ -261,6 +266,8 @@ struct MuxyCommands: Commands {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
-        appState.selectProject(project)
+        worktreeStore.ensurePrimary(for: project)
+        guard let primary = worktreeStore.primary(for: project.id) else { return }
+        appState.selectProject(project, worktree: primary)
     }
 }

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -209,13 +209,19 @@ struct MuxyCommands: Commands {
         CommandGroup(after: .sidebar) {
             Button("Next Project") {
                 guard isMainWindowFocused else { return }
-                appState.selectNextProject(projects: projectStore.projects)
+                appState.selectNextProject(
+                    projects: projectStore.projects,
+                    worktrees: worktreeStore.worktrees
+                )
             }
             .shortcut(for: .nextProject, store: keyBindings)
 
             Button("Previous Project") {
                 guard isMainWindowFocused else { return }
-                appState.selectPreviousProject(projects: projectStore.projects)
+                appState.selectPreviousProject(
+                    projects: projectStore.projects,
+                    worktrees: worktreeStore.worktrees
+                )
             }
             .shortcut(for: .previousProject, store: keyBindings)
 

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -58,7 +58,11 @@ struct MuxyCommands: Commands {
 
         CommandGroup(replacing: .newItem) {
             Button("Open Project...") {
-                openProject()
+                ProjectOpenService.openProject(
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore
+                )
             }
             .shortcut(for: .openProject, store: keyBindings)
 
@@ -257,23 +261,5 @@ struct MuxyCommands: Commands {
             }
             .shortcut(for: .toggleThemePicker, store: keyBindings)
         }
-    }
-
-    private func openProject() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.message = "Select a project folder"
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        let project = Project(
-            name: url.lastPathComponent,
-            path: url.path(percentEncoded: false),
-            sortOrder: projectStore.projects.count
-        )
-        projectStore.add(project)
-        worktreeStore.ensurePrimary(for: project)
-        guard let primary = worktreeStore.primary(for: project.id) else { return }
-        appState.selectProject(project, worktree: primary)
     }
 }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -16,7 +16,12 @@ final class AppState {
         case selectProject(projectID: UUID, worktreeID: UUID, worktreePath: String)
         case selectWorktree(projectID: UUID, worktreeID: UUID, worktreePath: String)
         case removeProject(projectID: UUID)
-        case removeWorktree(projectID: UUID, worktreeID: UUID)
+        case removeWorktree(
+            projectID: UUID,
+            worktreeID: UUID,
+            replacementWorktreeID: UUID?,
+            replacementWorktreePath: String?
+        )
         case createTab(projectID: UUID, areaID: UUID?)
         case createVCSTab(projectID: UUID, areaID: UUID?)
         case createEditorTab(projectID: UUID, areaID: UUID?, filePath: String)
@@ -446,8 +451,13 @@ final class AppState {
         dispatch(.removeProject(projectID: projectID))
     }
 
-    func removeWorktree(projectID: UUID, worktree: Worktree) {
+    func removeWorktree(projectID: UUID, worktree: Worktree, replacement: Worktree?) {
         guard !worktree.isPrimary else { return }
-        dispatch(.removeWorktree(projectID: projectID, worktreeID: worktree.id))
+        dispatch(.removeWorktree(
+            projectID: projectID,
+            worktreeID: worktree.id,
+            replacementWorktreeID: replacement?.id,
+            replacementWorktreePath: replacement?.path
+        ))
     }
 }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -13,8 +13,10 @@ final class AppState {
     }
 
     enum Action {
-        case selectProject(projectID: UUID, projectPath: String)
+        case selectProject(projectID: UUID, worktreeID: UUID, worktreePath: String)
+        case selectWorktree(projectID: UUID, worktreeID: UUID, worktreePath: String)
         case removeProject(projectID: UUID)
+        case removeWorktree(projectID: UUID, worktreeID: UUID)
         case createTab(projectID: UUID, areaID: UUID?)
         case createVCSTab(projectID: UUID, areaID: UUID?)
         case createEditorTab(projectID: UUID, areaID: UUID?, filePath: String)
@@ -44,6 +46,8 @@ final class AppState {
         didSet { saveSelection() }
     }
 
+    var activeWorktreeID: [UUID: UUID] = [:]
+
     struct PendingTabClose: Equatable {
         let projectID: UUID
         let areaID: UUID
@@ -51,13 +55,13 @@ final class AppState {
     }
 
     var sidebarVisible = true
-    var workspaceRoots: [UUID: SplitNode] = [:]
-    var focusedAreaID: [UUID: UUID] = [:]
+    var workspaceRoots: [WorktreeKey: SplitNode] = [:]
+    var focusedAreaID: [WorktreeKey: UUID] = [:]
     var pendingLastTabClose: PendingTabClose?
     var pendingUnsavedEditorTabClose: PendingTabClose?
     var pendingProcessTabClose: PendingTabClose?
     var pendingSaveErrorMessage: String?
-    private var focusHistory: [UUID: [UUID]] = [:]
+    private var focusHistory: [WorktreeKey: [UUID]] = [:]
 
     init(
         selectionStore: any ActiveProjectSelectionStoring,
@@ -69,19 +73,23 @@ final class AppState {
         self.workspacePersistence = workspacePersistence
     }
 
-    func restoreSelection(projects: [Project]) {
+    func restoreSelection(projects: [Project], worktrees: [UUID: [Worktree]]) {
         let restored = WorkspaceRestorer.restoreAll(
             from: workspacePersistence.loadWorkspaces(),
-            validProjectIDs: Set(projects.map(\.id))
+            projects: projects,
+            worktrees: worktrees
         )
         for entry in restored {
-            workspaceRoots[entry.projectID] = entry.root
-            focusedAreaID[entry.projectID] = entry.focusedAreaID
+            workspaceRoots[entry.key] = entry.root
+            focusedAreaID[entry.key] = entry.focusedAreaID
         }
         guard let id = selectionStore.loadActiveProjectID(),
               let project = projects.first(where: { $0.id == id })
         else { return }
-        selectProject(project)
+        let worktreeList = worktrees[project.id] ?? []
+        let primary = worktreeList.first(where: { $0.isPrimary }) ?? worktreeList.first
+        guard let worktree = primary else { return }
+        selectProject(project, worktree: worktree)
     }
 
     func saveWorkspaces() {
@@ -96,23 +104,48 @@ final class AppState {
         selectionStore.saveActiveProjectID(activeProjectID)
     }
 
-    func workspaceRoot(for projectID: UUID) -> SplitNode? {
-        workspaceRoots[projectID]
+    func activeWorktreeKey(for projectID: UUID) -> WorktreeKey? {
+        guard let worktreeID = activeWorktreeID[projectID] else { return nil }
+        return WorktreeKey(projectID: projectID, worktreeID: worktreeID)
     }
 
-    func selectProject(_ project: Project) {
-        dispatch(.selectProject(projectID: project.id, projectPath: project.path))
+    func workspaceRoot(for projectID: UUID) -> SplitNode? {
+        guard let key = activeWorktreeKey(for: projectID) else { return nil }
+        return workspaceRoots[key]
+    }
+
+    func focusedAreaID(for projectID: UUID) -> UUID? {
+        guard let key = activeWorktreeKey(for: projectID) else { return nil }
+        return focusedAreaID[key]
+    }
+
+    func selectProject(_ project: Project, worktree: Worktree) {
+        dispatch(.selectProject(
+            projectID: project.id,
+            worktreeID: worktree.id,
+            worktreePath: worktree.path
+        ))
+    }
+
+    func selectWorktree(projectID: UUID, worktree: Worktree) {
+        dispatch(.selectWorktree(
+            projectID: projectID,
+            worktreeID: worktree.id,
+            worktreePath: worktree.path
+        ))
     }
 
     func focusedArea(for projectID: UUID) -> TabArea? {
-        guard let root = workspaceRoots[projectID],
-              let areaID = focusedAreaID[projectID]
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key],
+              let areaID = focusedAreaID[key]
         else { return nil }
         return root.findArea(id: areaID)
     }
 
     func allAreas(for projectID: UUID) -> [TabArea] {
-        workspaceRoots[projectID]?.allAreas() ?? []
+        guard let key = activeWorktreeKey(for: projectID) else { return [] }
+        return workspaceRoots[key]?.allAreas() ?? []
     }
 
     func splitFocusedArea(direction: SplitDirection, projectID: UUID) {
@@ -189,7 +222,8 @@ final class AppState {
 
     func saveAndCloseUnsavedEditorTab() {
         guard let pending = pendingUnsavedEditorTabClose else { return }
-        guard let root = workspaceRoots[pending.projectID],
+        guard let key = activeWorktreeKey(for: pending.projectID),
+              let root = workspaceRoots[key],
               let area = root.findArea(id: pending.areaID),
               let tab = area.tabs.first(where: { $0.id == pending.tabID }),
               let editorState = tab.content.editorState
@@ -232,7 +266,8 @@ final class AppState {
     }
 
     private func unpinTabIfNeeded(_ tabID: UUID, areaID: UUID, projectID: UUID) {
-        guard let root = workspaceRoots[projectID],
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key],
               let area = root.findArea(id: areaID),
               let tab = area.tabs.first(where: { $0.id == tabID }),
               tab.isPinned
@@ -241,7 +276,9 @@ final class AppState {
     }
 
     private func isLastTabInProject(_ tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
-        guard let root = workspaceRoots[projectID] else { return false }
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key]
+        else { return false }
         let allAreas = root.allAreas()
         let totalTabs = allAreas.reduce(0) { $0 + $1.tabs.count }
         return totalTabs <= 1
@@ -262,7 +299,8 @@ final class AppState {
     }
 
     private func needsUnsavedEditorConfirmation(tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
-        guard let root = workspaceRoots[projectID],
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key],
               let area = root.findArea(id: areaID),
               let tab = area.tabs.first(where: { $0.id == tabID }),
               let editorState = tab.content.editorState
@@ -271,7 +309,8 @@ final class AppState {
     }
 
     private func needsProcessConfirmation(tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
-        guard let root = workspaceRoots[projectID],
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key],
               let area = root.findArea(id: areaID),
               let tab = area.tabs.first(where: { $0.id == tabID }),
               let paneID = tab.content.pane?.id
@@ -306,12 +345,14 @@ final class AppState {
     func dispatch(_ action: Action) {
         var workspace = WorkspaceState(
             activeProjectID: activeProjectID,
+            activeWorktreeID: activeWorktreeID,
             workspaceRoots: workspaceRoots,
             focusedAreaID: focusedAreaID,
             focusHistory: focusHistory
         )
         let effects = WorkspaceReducer.reduce(action: action, state: &workspace)
         activeProjectID = workspace.activeProjectID
+        activeWorktreeID = workspace.activeWorktreeID
         workspaceRoots = workspace.workspaceRoots
         focusedAreaID = workspace.focusedAreaID
         focusHistory = workspace.focusHistory
@@ -358,7 +399,8 @@ final class AppState {
     }
 
     private func tabExists(tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
-        guard let root = workspaceRoots[projectID],
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key],
               let area = root.findArea(id: areaID)
         else { return false }
         return area.tabs.contains(where: { $0.id == tabID })
@@ -384,9 +426,12 @@ final class AppState {
         dispatch(.focusPaneDown(projectID: projectID))
     }
 
-    func selectProjectByIndex(_ index: Int, projects: [Project]) {
+    func selectProjectByIndex(_ index: Int, projects: [Project], worktrees: [UUID: [Worktree]]) {
         guard index >= 0, index < projects.count else { return }
-        selectProject(projects[index])
+        let project = projects[index]
+        let list = worktrees[project.id] ?? []
+        guard let target = list.first(where: { $0.isPrimary }) ?? list.first else { return }
+        selectProject(project, worktree: target)
     }
 
     func selectNextProject(projects: [Project]) {
@@ -399,5 +444,9 @@ final class AppState {
 
     func removeProject(_ projectID: UUID) {
         dispatch(.removeProject(projectID: projectID))
+    }
+
+    func removeWorktree(projectID: UUID, worktreeID: UUID) {
+        dispatch(.removeWorktree(projectID: projectID, worktreeID: worktreeID))
     }
 }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -33,8 +33,8 @@ final class AppState {
         case focusPaneUp(projectID: UUID)
         case focusPaneDown(projectID: UUID)
         case moveTab(projectID: UUID, request: TabMoveRequest)
-        case selectNextProject(projects: [Project])
-        case selectPreviousProject(projects: [Project])
+        case selectNextProject(projects: [Project], worktrees: [UUID: [Worktree]])
+        case selectPreviousProject(projects: [Project], worktrees: [UUID: [Worktree]])
     }
 
     private let selectionStore: any ActiveProjectSelectionStoring
@@ -434,19 +434,20 @@ final class AppState {
         selectProject(project, worktree: target)
     }
 
-    func selectNextProject(projects: [Project]) {
-        dispatch(.selectNextProject(projects: projects))
+    func selectNextProject(projects: [Project], worktrees: [UUID: [Worktree]]) {
+        dispatch(.selectNextProject(projects: projects, worktrees: worktrees))
     }
 
-    func selectPreviousProject(projects: [Project]) {
-        dispatch(.selectPreviousProject(projects: projects))
+    func selectPreviousProject(projects: [Project], worktrees: [UUID: [Worktree]]) {
+        dispatch(.selectPreviousProject(projects: projects, worktrees: worktrees))
     }
 
     func removeProject(_ projectID: UUID) {
         dispatch(.removeProject(projectID: projectID))
     }
 
-    func removeWorktree(projectID: UUID, worktreeID: UUID) {
-        dispatch(.removeWorktree(projectID: projectID, worktreeID: worktreeID))
+    func removeWorktree(projectID: UUID, worktree: Worktree) {
+        guard !worktree.isPrimary else { return }
+        dispatch(.removeWorktree(projectID: projectID, worktreeID: worktree.id))
     }
 }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -9,7 +9,6 @@ final class AppState {
         let areaID: UUID
         let direction: SplitDirection
         let position: SplitPosition
-        let projectPath: String
     }
 
     enum Action {
@@ -159,8 +158,7 @@ final class AppState {
             projectID: projectID,
             areaID: area.id,
             direction: direction,
-            position: .second,
-            projectPath: area.projectPath
+            position: .second
         )))
     }
 

--- a/Muxy/Models/SplitNode.swift
+++ b/Muxy/Models/SplitNode.swift
@@ -49,12 +49,11 @@ extension SplitNode {
     func splitting(
         areaID: UUID,
         direction: SplitDirection,
-        position: SplitPosition,
-        projectPath: String
+        position: SplitPosition
     ) -> (node: SplitNode, newAreaID: UUID?) {
         switch self {
         case let .tabArea(area) where area.id == areaID:
-            let newArea = TabArea(projectPath: projectPath)
+            let newArea = TabArea(projectPath: area.projectPath)
             let first: SplitNode = position == .first ? .tabArea(newArea) : .tabArea(area)
             let second: SplitNode = position == .first ? .tabArea(area) : .tabArea(newArea)
             let node = SplitNode.split(SplitBranch(
@@ -69,16 +68,14 @@ extension SplitNode {
             let (newFirst, id1) = branch.first.splitting(
                 areaID: areaID,
                 direction: direction,
-                position: position,
-                projectPath: projectPath
+                position: position
             )
             branch.first = newFirst
             if id1 != nil { return (.split(branch), id1) }
             let (newSecond, id2) = branch.second.splitting(
                 areaID: areaID,
                 direction: direction,
-                position: position,
-                projectPath: projectPath
+                position: position
             )
             branch.second = newSecond
             return (.split(branch), id2)
@@ -89,12 +86,11 @@ extension SplitNode {
         areaID: UUID,
         direction: SplitDirection,
         position: SplitPosition,
-        tab: TerminalTab,
-        projectPath: String
+        tab: TerminalTab
     ) -> (node: SplitNode, newAreaID: UUID?) {
         switch self {
         case let .tabArea(area) where area.id == areaID:
-            let newArea = TabArea(projectPath: projectPath, existingTab: tab)
+            let newArea = TabArea(projectPath: area.projectPath, existingTab: tab)
             let first: SplitNode = position == .first ? .tabArea(newArea) : .tabArea(area)
             let second: SplitNode = position == .first ? .tabArea(area) : .tabArea(newArea)
             let node = SplitNode.split(SplitBranch(direction: direction, first: first, second: second))
@@ -103,12 +99,12 @@ extension SplitNode {
             return (self, nil)
         case let .split(branch):
             let (newFirst, id1) = branch.first.splittingWithTab(
-                areaID: areaID, direction: direction, position: position, tab: tab, projectPath: projectPath
+                areaID: areaID, direction: direction, position: position, tab: tab
             )
             branch.first = newFirst
             if id1 != nil { return (.split(branch), id1) }
             let (newSecond, id2) = branch.second.splittingWithTab(
-                areaID: areaID, direction: direction, position: position, tab: tab, projectPath: projectPath
+                areaID: areaID, direction: direction, position: position, tab: tab
             )
             branch.second = newSecond
             return (.split(branch), id2)

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -169,8 +169,7 @@ enum WorkspaceReducer {
         let (newRoot, newAreaID) = root.splitting(
             areaID: request.areaID,
             direction: request.direction,
-            position: request.position,
-            projectPath: request.projectPath
+            position: request.position
         )
         state.workspaceRoots[key] = newRoot
         guard let newAreaID else { return }
@@ -246,8 +245,7 @@ enum WorkspaceReducer {
                 areaID: targetAreaID,
                 direction: split.direction,
                 position: split.position,
-                tab: tab,
-                projectPath: sourceArea.projectPath
+                tab: tab
             )
             state.workspaceRoots[key] = newRoot
 

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -3,9 +3,10 @@ import Foundation
 @MainActor
 struct WorkspaceState {
     var activeProjectID: UUID?
-    var workspaceRoots: [UUID: SplitNode]
-    var focusedAreaID: [UUID: UUID]
-    var focusHistory: [UUID: [UUID]]
+    var activeWorktreeID: [UUID: UUID]
+    var workspaceRoots: [WorktreeKey: SplitNode]
+    var focusedAreaID: [WorktreeKey: UUID]
+    var focusHistory: [WorktreeKey: [UUID]]
 }
 
 @MainActor
@@ -20,72 +21,113 @@ enum WorkspaceReducer {
         var effects = WorkspaceSideEffects()
 
         switch action {
-        case let .selectProject(projectID, projectPath):
+        case let .selectProject(projectID, worktreeID, worktreePath):
             state.activeProjectID = projectID
-            ensureWorkspaceExists(projectID: projectID, projectPath: projectPath, state: &state)
+            state.activeWorktreeID[projectID] = worktreeID
+            ensureWorkspaceExists(
+                projectID: projectID,
+                worktreeID: worktreeID,
+                worktreePath: worktreePath,
+                state: &state
+            )
+
+        case let .selectWorktree(projectID, worktreeID, worktreePath):
+            state.activeProjectID = projectID
+            state.activeWorktreeID[projectID] = worktreeID
+            ensureWorkspaceExists(
+                projectID: projectID,
+                worktreeID: worktreeID,
+                worktreePath: worktreePath,
+                state: &state
+            )
 
         case let .removeProject(projectID):
             removeProject(projectID: projectID, state: &state, effects: &effects)
 
+        case let .removeWorktree(projectID, worktreeID):
+            removeWorktree(projectID: projectID, worktreeID: worktreeID, state: &state, effects: &effects)
+
         case let .createTab(projectID, areaID):
-            guard let area = resolveArea(projectID: projectID, areaID: areaID, state: state) else { break }
-            focusArea(area.id, projectID: projectID, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: areaID, state: state)
+            else { break }
+            focusArea(area.id, key: key, state: &state)
             area.createTab()
 
         case let .createVCSTab(projectID, areaID):
-            guard let area = resolveArea(projectID: projectID, areaID: areaID, state: state) else { break }
-            focusArea(area.id, projectID: projectID, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: areaID, state: state)
+            else { break }
+            focusArea(area.id, key: key, state: &state)
             area.createVCSTab()
 
         case let .createEditorTab(projectID, areaID, filePath):
-            guard let area = resolveArea(projectID: projectID, areaID: areaID, state: state) else { break }
-            focusArea(area.id, projectID: projectID, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: areaID, state: state)
+            else { break }
+            focusArea(area.id, key: key, state: &state)
             area.createEditorTab(filePath: filePath)
 
         case let .closeTab(projectID, areaID, tabID):
-            closeTab(tabID, areaID: areaID, projectID: projectID, state: &state, effects: &effects)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)
 
         case let .selectTab(projectID, areaID, tabID):
-            guard let area = resolveArea(projectID: projectID, areaID: areaID, state: state) else { break }
-            focusArea(area.id, projectID: projectID, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: areaID, state: state)
+            else { break }
+            focusArea(area.id, key: key, state: &state)
             area.selectTab(tabID)
 
         case let .selectTabByIndex(projectID, areaID, index):
-            guard let area = resolveArea(projectID: projectID, areaID: areaID, state: state) else { break }
-            focusArea(area.id, projectID: projectID, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: areaID, state: state)
+            else { break }
+            focusArea(area.id, key: key, state: &state)
             area.selectTabByIndex(index)
 
         case let .selectNextTab(projectID):
-            guard let area = resolveArea(projectID: projectID, areaID: nil, state: state) else { break }
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: nil, state: state)
+            else { break }
             area.selectNextTab()
 
         case let .selectPreviousTab(projectID):
-            guard let area = resolveArea(projectID: projectID, areaID: nil, state: state) else { break }
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: nil, state: state)
+            else { break }
             area.selectPreviousTab()
 
         case let .splitArea(request):
             splitArea(request, state: &state)
 
         case let .closeArea(projectID, areaID):
-            closeArea(areaID, projectID: projectID, state: &state, effects: &effects)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            closeArea(areaID, key: key, state: &state, effects: &effects)
 
         case let .moveTab(projectID, request):
-            moveTab(request, projectID: projectID, state: &state, effects: &effects)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            moveTab(request, key: key, state: &state, effects: &effects)
 
         case let .focusArea(projectID, areaID):
-            focusArea(areaID, projectID: projectID, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            focusArea(areaID, key: key, state: &state)
 
         case let .focusPaneLeft(projectID):
-            focusPane(projectID: projectID, direction: .left, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            focusPane(key: key, direction: .left, state: &state)
 
         case let .focusPaneRight(projectID):
-            focusPane(projectID: projectID, direction: .right, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            focusPane(key: key, direction: .right, state: &state)
 
         case let .focusPaneUp(projectID):
-            focusPane(projectID: projectID, direction: .up, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            focusPane(key: key, direction: .up, state: &state)
 
         case let .focusPaneDown(projectID):
-            focusPane(projectID: projectID, direction: .down, state: &state)
+            guard let key = activeKey(projectID: projectID, state: state) else { break }
+            focusPane(key: key, direction: .down, state: &state)
 
         case let .selectNextProject(projects):
             cycleProject(projects: projects, forward: true, state: &state)
@@ -97,67 +139,91 @@ enum WorkspaceReducer {
         return effects
     }
 
+    private static func activeKey(projectID: UUID, state: WorkspaceState) -> WorktreeKey? {
+        guard let worktreeID = state.activeWorktreeID[projectID] else { return nil }
+        return WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+    }
+
     private static func splitArea(_ request: AppState.SplitAreaRequest, state: inout WorkspaceState) {
-        guard let root = state.workspaceRoots[request.projectID] else { return }
+        guard let key = activeKey(projectID: request.projectID, state: state),
+              let root = state.workspaceRoots[key]
+        else { return }
         let (newRoot, newAreaID) = root.splitting(
             areaID: request.areaID,
             direction: request.direction,
             position: request.position,
             projectPath: request.projectPath
         )
-        state.workspaceRoots[request.projectID] = newRoot
+        state.workspaceRoots[key] = newRoot
         guard let newAreaID else { return }
-        focusArea(newAreaID, projectID: request.projectID, state: &state)
+        focusArea(newAreaID, key: key, state: &state)
     }
 
     private static func closeArea(
         _ areaID: UUID,
+        key: WorktreeKey,
+        state: inout WorkspaceState,
+        effects: inout WorkspaceSideEffects
+    ) {
+        let removed = removeAreaFromTree(areaID, key: key, state: &state, effects: &effects)
+        guard !removed else { return }
+        clearWorkspace(key: key, state: &state)
+        handleProjectEmptiedIfNeeded(projectID: key.projectID, state: &state, effects: &effects)
+    }
+
+    private static func clearWorkspace(key: WorktreeKey, state: inout WorkspaceState) {
+        state.workspaceRoots.removeValue(forKey: key)
+        state.focusedAreaID.removeValue(forKey: key)
+        state.focusHistory.removeValue(forKey: key)
+    }
+
+    private static func handleProjectEmptiedIfNeeded(
         projectID: UUID,
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) {
-        let removed = removeAreaFromTree(areaID, projectID: projectID, state: &state, effects: &effects)
-        guard !removed else { return }
-        state.workspaceRoots.removeValue(forKey: projectID)
-        state.focusedAreaID.removeValue(forKey: projectID)
-        state.focusHistory.removeValue(forKey: projectID)
-        state.activeProjectID = nil
+        let hasAnyWorkspace = state.workspaceRoots.keys.contains { $0.projectID == projectID }
+        guard !hasAnyWorkspace else { return }
+        state.activeWorktreeID.removeValue(forKey: projectID)
+        if state.activeProjectID == projectID {
+            state.activeProjectID = nil
+        }
         effects.projectIDsToRemove.append(projectID)
     }
 
     private static func moveTab(
         _ request: TabMoveRequest,
-        projectID: UUID,
+        key: WorktreeKey,
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) {
         switch request {
         case let .toArea(tabID, sourceAreaID, destinationAreaID):
             guard sourceAreaID != destinationAreaID else { return }
-            guard let root = state.workspaceRoots[projectID],
+            guard let root = state.workspaceRoots[key],
                   let sourceArea = root.findArea(id: sourceAreaID),
                   let destArea = root.findArea(id: destinationAreaID),
                   let tab = sourceArea.removeTab(tabID)
             else { return }
 
             destArea.insertExistingTab(tab)
-            focusArea(destinationAreaID, projectID: projectID, state: &state)
+            focusArea(destinationAreaID, key: key, state: &state)
 
             guard sourceArea.tabs.isEmpty else { return }
-            collapseEmptyArea(sourceAreaID, projectID: projectID, state: &state, effects: &effects)
+            collapseEmptyArea(sourceAreaID, key: key, state: &state, effects: &effects)
 
         case let .toNewSplit(tabID, sourceAreaID, targetAreaID, split):
-            guard let root = state.workspaceRoots[projectID],
+            guard let root = state.workspaceRoots[key],
                   let sourceArea = root.findArea(id: sourceAreaID),
                   let tab = sourceArea.removeTab(tabID)
             else { return }
 
             let shouldCollapseSource = sourceArea.tabs.isEmpty
             if shouldCollapseSource, sourceAreaID != targetAreaID {
-                collapseEmptyArea(sourceAreaID, projectID: projectID, state: &state, effects: &effects)
+                collapseEmptyArea(sourceAreaID, key: key, state: &state, effects: &effects)
             }
 
-            guard let currentRoot = state.workspaceRoots[projectID] else { return }
+            guard let currentRoot = state.workspaceRoots[key] else { return }
             let (newRoot, newAreaID) = currentRoot.splittingWithTab(
                 areaID: targetAreaID,
                 direction: split.direction,
@@ -165,66 +231,66 @@ enum WorkspaceReducer {
                 tab: tab,
                 projectPath: sourceArea.projectPath
             )
-            state.workspaceRoots[projectID] = newRoot
+            state.workspaceRoots[key] = newRoot
 
             if let newAreaID {
-                focusArea(newAreaID, projectID: projectID, state: &state)
+                focusArea(newAreaID, key: key, state: &state)
             }
 
             guard shouldCollapseSource, sourceAreaID == targetAreaID else { return }
-            if let updatedRoot = state.workspaceRoots[projectID],
+            if let updatedRoot = state.workspaceRoots[key],
                let emptyArea = updatedRoot.findArea(id: targetAreaID),
                emptyArea.tabs.isEmpty
             {
-                collapseEmptyArea(targetAreaID, projectID: projectID, state: &state, effects: &effects)
+                collapseEmptyArea(targetAreaID, key: key, state: &state, effects: &effects)
             }
         }
     }
 
     private static func collapseEmptyArea(
         _ areaID: UUID,
-        projectID: UUID,
+        key: WorktreeKey,
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) {
-        _ = removeAreaFromTree(areaID, projectID: projectID, state: &state, effects: &effects)
+        _ = removeAreaFromTree(areaID, key: key, state: &state, effects: &effects)
     }
 
     @discardableResult
     private static func removeAreaFromTree(
         _ areaID: UUID,
-        projectID: UUID,
+        key: WorktreeKey,
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) -> Bool {
-        guard let root = state.workspaceRoots[projectID] else { return false }
+        guard let root = state.workspaceRoots[key] else { return false }
         if let area = root.findArea(id: areaID) {
             effects.paneIDsToRemove.append(contentsOf: area.tabs.compactMap { $0.content.pane?.id })
         }
         guard let newRoot = root.removing(areaID: areaID) else { return false }
-        state.workspaceRoots[projectID] = newRoot
-        state.focusHistory[projectID]?.removeAll { $0 == areaID }
-        guard state.focusedAreaID[projectID] == areaID else { return true }
+        state.workspaceRoots[key] = newRoot
+        state.focusHistory[key]?.removeAll { $0 == areaID }
+        guard state.focusedAreaID[key] == areaID else { return true }
         let remaining = newRoot.allAreas()
-        let previousID = popFocusHistory(projectID: projectID, validAreas: remaining, state: &state)
-        state.focusedAreaID[projectID] = previousID ?? remaining.first?.id
+        let previousID = popFocusHistory(key: key, validAreas: remaining, state: &state)
+        state.focusedAreaID[key] = previousID ?? remaining.first?.id
         return true
     }
 
     private static func closeTab(
         _ tabID: UUID,
         areaID: UUID,
-        projectID: UUID,
+        key: WorktreeKey,
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) {
-        guard let root = state.workspaceRoots[projectID],
+        guard let root = state.workspaceRoots[key],
               let area = root.findArea(id: areaID)
         else { return }
 
         let areaCount = root.allAreas().count
         if area.tabs.count <= 1, areaCount > 1 {
-            closeArea(areaID, projectID: projectID, state: &state, effects: &effects)
+            closeArea(areaID, key: key, state: &state, effects: &effects)
             return
         }
 
@@ -233,25 +299,22 @@ enum WorkspaceReducer {
         }
 
         guard area.tabs.isEmpty else { return }
-        state.workspaceRoots.removeValue(forKey: projectID)
-        state.focusedAreaID.removeValue(forKey: projectID)
-        state.focusHistory.removeValue(forKey: projectID)
-        state.activeProjectID = nil
-        effects.projectIDsToRemove.append(projectID)
+        clearWorkspace(key: key, state: &state)
+        handleProjectEmptiedIfNeeded(projectID: key.projectID, state: &state, effects: &effects)
     }
 
     private static let focusHistoryLimit = 20
 
-    private static func focusArea(_ areaID: UUID, projectID: UUID, state: inout WorkspaceState) {
-        if let current = state.focusedAreaID[projectID], current != areaID {
-            var history = state.focusHistory[projectID, default: []]
+    private static func focusArea(_ areaID: UUID, key: WorktreeKey, state: inout WorkspaceState) {
+        if let current = state.focusedAreaID[key], current != areaID {
+            var history = state.focusHistory[key, default: []]
             history.append(current)
             if history.count > focusHistoryLimit {
                 history.removeFirst(history.count - focusHistoryLimit)
             }
-            state.focusHistory[projectID] = history
+            state.focusHistory[key] = history
         }
-        state.focusedAreaID[projectID] = areaID
+        state.focusedAreaID[key] = areaID
     }
 
     private static func cycleProject(projects: [Project], forward: Bool, state: inout WorkspaceState) {
@@ -262,7 +325,14 @@ enum WorkspaceReducer {
         let next = forward ? (index + 1) % projects.count : (index - 1 + projects.count) % projects.count
         let project = projects[next]
         state.activeProjectID = project.id
-        ensureWorkspaceExists(projectID: project.id, projectPath: project.path, state: &state)
+        let worktreeID = state.activeWorktreeID[project.id] ?? project.id
+        state.activeWorktreeID[project.id] = worktreeID
+        ensureWorkspaceExists(
+            projectID: project.id,
+            worktreeID: worktreeID,
+            worktreePath: project.path,
+            state: &state
+        )
     }
 
     private struct PaneFocusScore: Comparable {
@@ -286,9 +356,9 @@ enum WorkspaceReducer {
         case down
     }
 
-    private static func focusPane(projectID: UUID, direction: PaneFocusDirection, state: inout WorkspaceState) {
-        guard let root = state.workspaceRoots[projectID],
-              let focusedID = state.focusedAreaID[projectID]
+    private static func focusPane(key: WorktreeKey, direction: PaneFocusDirection, state: inout WorkspaceState) {
+        guard let root = state.workspaceRoots[key],
+              let focusedID = state.focusedAreaID[key]
         else { return }
 
         let frames = root.areaFrames()
@@ -308,7 +378,7 @@ enum WorkspaceReducer {
         }
 
         guard let bestCandidate else { return }
-        focusArea(bestCandidate, projectID: projectID, state: &state)
+        focusArea(bestCandidate, key: key, state: &state)
     }
 
     private static func isCandidate(_ candidate: CGRect, from focused: CGRect, direction: PaneFocusDirection) -> Bool {
@@ -366,37 +436,75 @@ enum WorkspaceReducer {
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) {
-        if let root = state.workspaceRoots[projectID] {
-            let paneIDs = root.allAreas().flatMap { area in area.tabs.compactMap { $0.content.pane?.id } }
-            effects.paneIDsToRemove.append(contentsOf: paneIDs)
+        let keysToRemove = state.workspaceRoots.keys.filter { $0.projectID == projectID }
+        for key in keysToRemove {
+            if let root = state.workspaceRoots[key] {
+                let paneIDs = root.allAreas().flatMap { area in area.tabs.compactMap { $0.content.pane?.id } }
+                effects.paneIDsToRemove.append(contentsOf: paneIDs)
+            }
+            state.workspaceRoots.removeValue(forKey: key)
+            state.focusedAreaID.removeValue(forKey: key)
+            state.focusHistory.removeValue(forKey: key)
         }
-        state.workspaceRoots.removeValue(forKey: projectID)
-        state.focusedAreaID.removeValue(forKey: projectID)
-        state.focusHistory.removeValue(forKey: projectID)
+        state.activeWorktreeID.removeValue(forKey: projectID)
         if state.activeProjectID == projectID {
             state.activeProjectID = nil
         }
     }
 
-    private static func ensureWorkspaceExists(projectID: UUID, projectPath: String, state: inout WorkspaceState) {
-        guard state.workspaceRoots[projectID] == nil else { return }
-        let area = TabArea(projectPath: projectPath)
-        state.workspaceRoots[projectID] = .tabArea(area)
-        state.focusedAreaID[projectID] = area.id
+    private static func removeWorktree(
+        projectID: UUID,
+        worktreeID: UUID,
+        state: inout WorkspaceState,
+        effects: inout WorkspaceSideEffects
+    ) {
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        if let root = state.workspaceRoots[key] {
+            let paneIDs = root.allAreas().flatMap { area in area.tabs.compactMap { $0.content.pane?.id } }
+            effects.paneIDsToRemove.append(contentsOf: paneIDs)
+        }
+        state.workspaceRoots.removeValue(forKey: key)
+        state.focusedAreaID.removeValue(forKey: key)
+        state.focusHistory.removeValue(forKey: key)
+
+        guard state.activeWorktreeID[projectID] == worktreeID else { return }
+        let remainingKey = state.workspaceRoots.keys.first { $0.projectID == projectID }
+        if let remainingKey {
+            state.activeWorktreeID[projectID] = remainingKey.worktreeID
+        } else {
+            state.activeWorktreeID.removeValue(forKey: projectID)
+            if state.activeProjectID == projectID {
+                state.activeProjectID = nil
+            }
+            effects.projectIDsToRemove.append(projectID)
+        }
     }
 
-    private static func resolveArea(projectID: UUID, areaID: UUID?, state: WorkspaceState) -> TabArea? {
-        guard let root = state.workspaceRoots[projectID] else { return nil }
+    private static func ensureWorkspaceExists(
+        projectID: UUID,
+        worktreeID: UUID,
+        worktreePath: String,
+        state: inout WorkspaceState
+    ) {
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        guard state.workspaceRoots[key] == nil else { return }
+        let area = TabArea(projectPath: worktreePath)
+        state.workspaceRoots[key] = .tabArea(area)
+        state.focusedAreaID[key] = area.id
+    }
+
+    private static func resolveArea(key: WorktreeKey, areaID: UUID?, state: WorkspaceState) -> TabArea? {
+        guard let root = state.workspaceRoots[key] else { return nil }
         if let areaID {
             return root.findArea(id: areaID)
         }
-        guard let focusedID = state.focusedAreaID[projectID] else { return nil }
+        guard let focusedID = state.focusedAreaID[key] else { return nil }
         return root.findArea(id: focusedID)
     }
 
-    private static func popFocusHistory(projectID: UUID, validAreas: [TabArea], state: inout WorkspaceState) -> UUID? {
+    private static func popFocusHistory(key: WorktreeKey, validAreas: [TabArea], state: inout WorkspaceState) -> UUID? {
         let validIDs = Set(validAreas.map(\.id))
-        while let last = state.focusHistory[projectID]?.popLast() {
+        while let last = state.focusHistory[key]?.popLast() {
             if validIDs.contains(last) {
                 return last
             }

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -129,11 +129,11 @@ enum WorkspaceReducer {
             guard let key = activeKey(projectID: projectID, state: state) else { break }
             focusPane(key: key, direction: .down, state: &state)
 
-        case let .selectNextProject(projects):
-            cycleProject(projects: projects, forward: true, state: &state)
+        case let .selectNextProject(projects, worktrees):
+            cycleProject(projects: projects, worktrees: worktrees, forward: true, state: &state)
 
-        case let .selectPreviousProject(projects):
-            cycleProject(projects: projects, forward: false, state: &state)
+        case let .selectPreviousProject(projects, worktrees):
+            cycleProject(projects: projects, worktrees: worktrees, forward: false, state: &state)
         }
 
         return effects
@@ -317,20 +317,30 @@ enum WorkspaceReducer {
         state.focusedAreaID[key] = areaID
     }
 
-    private static func cycleProject(projects: [Project], forward: Bool, state: inout WorkspaceState) {
+    private static func cycleProject(
+        projects: [Project],
+        worktrees: [UUID: [Worktree]],
+        forward: Bool,
+        state: inout WorkspaceState
+    ) {
         guard projects.count > 1,
               let currentID = state.activeProjectID,
               let index = projects.firstIndex(where: { $0.id == currentID })
         else { return }
         let next = forward ? (index + 1) % projects.count : (index - 1 + projects.count) % projects.count
         let project = projects[next]
+        let list = worktrees[project.id] ?? []
+        let existingID = state.activeWorktreeID[project.id]
+        let target = list.first(where: { $0.id == existingID })
+            ?? list.first(where: { $0.isPrimary })
+            ?? list.first
+        guard let worktree = target else { return }
         state.activeProjectID = project.id
-        let worktreeID = state.activeWorktreeID[project.id] ?? project.id
-        state.activeWorktreeID[project.id] = worktreeID
+        state.activeWorktreeID[project.id] = worktree.id
         ensureWorkspaceExists(
             projectID: project.id,
-            worktreeID: worktreeID,
-            worktreePath: project.path,
+            worktreeID: worktree.id,
+            worktreePath: worktree.path,
             state: &state
         )
     }

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -17,6 +17,11 @@ struct WorkspaceSideEffects {
 
 @MainActor
 enum WorkspaceReducer {
+    private struct WorktreeReplacement {
+        let id: UUID
+        let path: String
+    }
+
     static func reduce(action: AppState.Action, state: inout WorkspaceState) -> WorkspaceSideEffects {
         var effects = WorkspaceSideEffects()
 
@@ -44,8 +49,21 @@ enum WorkspaceReducer {
         case let .removeProject(projectID):
             removeProject(projectID: projectID, state: &state, effects: &effects)
 
-        case let .removeWorktree(projectID, worktreeID):
-            removeWorktree(projectID: projectID, worktreeID: worktreeID, state: &state, effects: &effects)
+        case let .removeWorktree(projectID, worktreeID, replacementWorktreeID, replacementWorktreePath):
+            let replacement: WorktreeReplacement? = if let replacementWorktreeID,
+                                                       let replacementWorktreePath
+            {
+                WorktreeReplacement(id: replacementWorktreeID, path: replacementWorktreePath)
+            } else {
+                nil
+            }
+            removeWorktree(
+                projectID: projectID,
+                worktreeID: worktreeID,
+                replacement: replacement,
+                state: &state,
+                effects: &effects
+            )
 
         case let .createTab(projectID, areaID):
             guard let key = activeKey(projectID: projectID, state: state),
@@ -465,6 +483,7 @@ enum WorkspaceReducer {
     private static func removeWorktree(
         projectID: UUID,
         worktreeID: UUID,
+        replacement: WorktreeReplacement?,
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) {
@@ -478,15 +497,30 @@ enum WorkspaceReducer {
         state.focusHistory.removeValue(forKey: key)
 
         guard state.activeWorktreeID[projectID] == worktreeID else { return }
-        let remainingKey = state.workspaceRoots.keys.first { $0.projectID == projectID }
-        if let remainingKey {
-            state.activeWorktreeID[projectID] = remainingKey.worktreeID
-        } else {
-            state.activeWorktreeID.removeValue(forKey: projectID)
-            if state.activeProjectID == projectID {
-                state.activeProjectID = nil
-            }
-            effects.projectIDsToRemove.append(projectID)
+        if let replacement {
+            state.activeWorktreeID[projectID] = replacement.id
+            ensureWorkspaceExists(
+                projectID: projectID,
+                worktreeID: replacement.id,
+                worktreePath: replacement.path,
+                state: &state
+            )
+            return
+        }
+
+        let hasProjectWorkspace = state.workspaceRoots.keys.contains { $0.projectID == projectID }
+        if hasProjectWorkspace,
+           let fallback = state.workspaceRoots.keys
+           .filter({ $0.projectID == projectID })
+           .min(by: { $0.worktreeID.uuidString < $1.worktreeID.uuidString })
+        {
+            state.activeWorktreeID[projectID] = fallback.worktreeID
+            return
+        }
+
+        state.activeWorktreeID.removeValue(forKey: projectID)
+        if state.activeProjectID == projectID {
+            state.activeProjectID = nil
         }
     }
 

--- a/Muxy/Models/WorkspaceSnapshot.swift
+++ b/Muxy/Models/WorkspaceSnapshot.swift
@@ -2,8 +2,41 @@ import Foundation
 
 struct WorkspaceSnapshot: Codable {
     let projectID: UUID
+    let worktreeID: UUID?
+    let worktreePath: String?
     let focusedAreaID: UUID?
     let root: SplitNodeSnapshot
+
+    init(
+        projectID: UUID,
+        worktreeID: UUID?,
+        worktreePath: String?,
+        focusedAreaID: UUID?,
+        root: SplitNodeSnapshot
+    ) {
+        self.projectID = projectID
+        self.worktreeID = worktreeID
+        self.worktreePath = worktreePath
+        self.focusedAreaID = focusedAreaID
+        self.root = root
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case projectID
+        case worktreeID
+        case worktreePath
+        case focusedAreaID
+        case root
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        projectID = try container.decode(UUID.self, forKey: .projectID)
+        worktreeID = try container.decodeIfPresent(UUID.self, forKey: .worktreeID)
+        worktreePath = try container.decodeIfPresent(String.self, forKey: .worktreePath)
+        focusedAreaID = try container.decodeIfPresent(UUID.self, forKey: .focusedAreaID)
+        root = try container.decode(SplitNodeSnapshot.self, forKey: .root)
+    }
 }
 
 indirect enum SplitNodeSnapshot: Codable {
@@ -109,7 +142,7 @@ struct TerminalTabSnapshot: Codable {
 }
 
 struct RestoredWorkspace {
-    let projectID: UUID
+    let key: WorktreeKey
     let root: SplitNode
     let focusedAreaID: UUID
 }
@@ -118,11 +151,15 @@ struct RestoredWorkspace {
 enum WorkspaceRestorer {
     static func restoreAll(
         from snapshots: [WorkspaceSnapshot],
-        validProjectIDs: Set<UUID>
+        projects: [Project],
+        worktrees: [UUID: [Worktree]]
     ) -> [RestoredWorkspace] {
+        let projectByID = Dictionary(uniqueKeysWithValues: projects.map { ($0.id, $0) })
         var results: [RestoredWorkspace] = []
         for snapshot in snapshots {
-            guard validProjectIDs.contains(snapshot.projectID) else { continue }
+            guard projectByID[snapshot.projectID] != nil else { continue }
+            let worktreeList = worktrees[snapshot.projectID] ?? []
+            guard let targetWorktree = resolveWorktree(for: snapshot, in: worktreeList) else { continue }
             let root = restoreSplitNode(from: snapshot.root)
             let areas = root.allAreas()
             guard !areas.isEmpty else { continue }
@@ -131,20 +168,36 @@ enum WorkspaceRestorer {
             } else {
                 areas[0].id
             }
-            results.append(RestoredWorkspace(projectID: snapshot.projectID, root: root, focusedAreaID: focusedID))
+            let key = WorktreeKey(projectID: snapshot.projectID, worktreeID: targetWorktree.id)
+            results.append(RestoredWorkspace(key: key, root: root, focusedAreaID: focusedID))
         }
         return results
     }
 
+    private static func resolveWorktree(for snapshot: WorkspaceSnapshot, in worktrees: [Worktree]) -> Worktree? {
+        if let worktreeID = snapshot.worktreeID,
+           let match = worktrees.first(where: { $0.id == worktreeID })
+        {
+            return match
+        }
+        return worktrees.first(where: { $0.isPrimary }) ?? worktrees.first
+    }
+
     static func snapshotAll(
-        workspaceRoots: [UUID: SplitNode],
-        focusedAreaID: [UUID: UUID]
+        workspaceRoots: [WorktreeKey: SplitNode],
+        focusedAreaID: [WorktreeKey: UUID]
     ) -> [WorkspaceSnapshot] {
         var snapshots: [WorkspaceSnapshot] = []
-        for (projectID, root) in workspaceRoots {
+        for (key, root) in workspaceRoots {
+            let path: String? = {
+                if case let .tabArea(area) = root { return area.projectPath }
+                return root.allAreas().first?.projectPath
+            }()
             snapshots.append(WorkspaceSnapshot(
-                projectID: projectID,
-                focusedAreaID: focusedAreaID[projectID],
+                projectID: key.projectID,
+                worktreeID: key.worktreeID,
+                worktreePath: path,
+                focusedAreaID: focusedAreaID[key],
                 root: snapshotSplitNode(root)
             ))
         }

--- a/Muxy/Models/Worktree.swift
+++ b/Muxy/Models/Worktree.swift
@@ -5,6 +5,7 @@ struct Worktree: Identifiable, Codable, Hashable {
     var name: String
     var path: String
     var branch: String?
+    var ownsBranch: Bool
     var isPrimary: Bool
     var createdAt: Date
 
@@ -13,6 +14,7 @@ struct Worktree: Identifiable, Codable, Hashable {
         name: String,
         path: String,
         branch: String? = nil,
+        ownsBranch: Bool = false,
         isPrimary: Bool,
         createdAt: Date = Date()
     ) {
@@ -20,7 +22,29 @@ struct Worktree: Identifiable, Codable, Hashable {
         self.name = name
         self.path = path
         self.branch = branch
+        self.ownsBranch = ownsBranch
         self.isPrimary = isPrimary
         self.createdAt = createdAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case path
+        case branch
+        case ownsBranch
+        case isPrimary
+        case createdAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        path = try container.decode(String.self, forKey: .path)
+        branch = try container.decodeIfPresent(String.self, forKey: .branch)
+        ownsBranch = try container.decodeIfPresent(Bool.self, forKey: .ownsBranch) ?? false
+        isPrimary = try container.decode(Bool.self, forKey: .isPrimary)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
     }
 }

--- a/Muxy/Models/Worktree.swift
+++ b/Muxy/Models/Worktree.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct Worktree: Identifiable, Codable, Hashable {
+    let id: UUID
+    var name: String
+    var path: String
+    var branch: String?
+    var isPrimary: Bool
+    var createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        path: String,
+        branch: String? = nil,
+        isPrimary: Bool,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.path = path
+        self.branch = branch
+        self.isPrimary = isPrimary
+        self.createdAt = createdAt
+    }
+}

--- a/Muxy/Models/WorktreeConfig.swift
+++ b/Muxy/Models/WorktreeConfig.swift
@@ -4,9 +4,35 @@ struct WorktreeConfig: Codable {
     struct SetupCommand: Codable {
         let command: String
         let name: String?
+
+        init(command: String, name: String? = nil) {
+            self.command = command
+            self.name = name
+        }
     }
 
     let setup: [SetupCommand]
+
+    private enum CodingKeys: String, CodingKey {
+        case setup
+    }
+
+    init(setup: [SetupCommand]) {
+        self.setup = setup
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let objectEntries = try? container.decode([SetupCommand].self, forKey: .setup) {
+            setup = objectEntries
+            return
+        }
+        if let stringEntries = try? container.decode([String].self, forKey: .setup) {
+            setup = stringEntries.map { SetupCommand(command: $0) }
+            return
+        }
+        setup = []
+    }
 
     static func load(fromProjectPath projectPath: String) -> WorktreeConfig? {
         let url = URL(fileURLWithPath: projectPath)

--- a/Muxy/Models/WorktreeConfig.swift
+++ b/Muxy/Models/WorktreeConfig.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct WorktreeConfig: Codable {
+    struct SetupCommand: Codable {
+        let command: String
+        let name: String?
+    }
+
+    let setup: [SetupCommand]
+
+    static func load(fromProjectPath projectPath: String) -> WorktreeConfig? {
+        let url = URL(fileURLWithPath: projectPath)
+            .appendingPathComponent(".muxy")
+            .appendingPathComponent("worktree.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(WorktreeConfig.self, from: data)
+    }
+}

--- a/Muxy/Models/WorktreeKey.swift
+++ b/Muxy/Models/WorktreeKey.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct WorktreeKey: Hashable {
+    let projectID: UUID
+    let worktreeID: UUID
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -6,6 +6,7 @@ struct MuxyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @State private var appState: AppState
     @State private var projectStore: ProjectStore
+    @State private var worktreeStore: WorktreeStore
     private let updateService = UpdateService.shared
 
     init() {
@@ -22,6 +23,9 @@ struct MuxyApp: App {
                 persistence: environment.projectPersistence
             )
         )
+        _worktreeStore = State(
+            initialValue: WorktreeStore(persistence: environment.worktreePersistence)
+        )
     }
 
     var body: some Scene {
@@ -29,20 +33,28 @@ struct MuxyApp: App {
             MainWindow()
                 .environment(appState)
                 .environment(projectStore)
+                .environment(worktreeStore)
                 .environment(GhosttyService.shared)
                 .environment(MuxyConfig.shared)
                 .environment(ThemeService.shared)
                 .preferredColorScheme(MuxyTheme.colorScheme)
                 .onAppear {
+                    worktreeStore.loadAll(projects: projectStore.projects)
                     appDelegate.onTerminate = { [appState] in
                         appState.saveWorkspaces()
                     }
                     appDelegate.hasUnsavedEditorTabs = { [appState] in
                         appState.unsavedEditorTabs()
                     }
-                    appState.onProjectsEmptied = { [projectStore] projectIDs in
+                    appState.onProjectsEmptied = { [projectStore, worktreeStore] projectIDs in
                         for id in projectIDs {
+                            if let project = projectStore.projects.first(where: { $0.id == id }) {
+                                Task.detached {
+                                    await WorktreeStore.cleanupOnDisk(for: project)
+                                }
+                            }
                             projectStore.remove(id: id)
+                            worktreeStore.removeProject(id)
                         }
                     }
                 }
@@ -53,6 +65,7 @@ struct MuxyApp: App {
             MuxyCommands(
                 appState: appState,
                 projectStore: projectStore,
+                worktreeStore: worktreeStore,
                 keyBindings: .shared,
                 config: .shared,
                 ghostty: .shared,
@@ -64,6 +77,7 @@ struct MuxyApp: App {
             VCSWindowView()
                 .environment(appState)
                 .environment(projectStore)
+                .environment(worktreeStore)
                 .environment(GhosttyService.shared)
                 .preferredColorScheme(MuxyTheme.colorScheme)
         }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -49,8 +49,12 @@ struct MuxyApp: App {
                     appState.onProjectsEmptied = { [projectStore, worktreeStore] projectIDs in
                         for id in projectIDs {
                             if let project = projectStore.projects.first(where: { $0.id == id }) {
+                                let knownWorktrees = worktreeStore.list(for: id)
                                 Task.detached {
-                                    await WorktreeStore.cleanupOnDisk(for: project)
+                                    await WorktreeStore.cleanupOnDisk(
+                                        for: project,
+                                        knownWorktrees: knownWorktrees
+                                    )
                                 }
                             }
                             projectStore.remove(id: id)

--- a/Muxy/Services/AppEnvironment.swift
+++ b/Muxy/Services/AppEnvironment.swift
@@ -6,11 +6,15 @@ struct AppEnvironment {
     let terminalViews: any TerminalViewRemoving
     let projectPersistence: any ProjectPersisting
     let workspacePersistence: any WorkspacePersisting
+    let worktreePersistence: any WorktreePersisting
+    let gitWorktreeService: GitWorktreeService
 
     static let live = Self(
         selectionStore: UserDefaultsActiveProjectSelectionStore(),
         terminalViews: TerminalViewRegistry.shared,
         projectPersistence: FileProjectPersistence(),
-        workspacePersistence: FileWorkspacePersistence()
+        workspacePersistence: FileWorkspacePersistence(),
+        worktreePersistence: FileWorktreePersistence(),
+        gitWorktreeService: GitWorktreeService()
     )
 }

--- a/Muxy/Services/AppEnvironment.swift
+++ b/Muxy/Services/AppEnvironment.swift
@@ -7,14 +7,12 @@ struct AppEnvironment {
     let projectPersistence: any ProjectPersisting
     let workspacePersistence: any WorkspacePersisting
     let worktreePersistence: any WorktreePersisting
-    let gitWorktreeService: GitWorktreeService
 
     static let live = Self(
         selectionStore: UserDefaultsActiveProjectSelectionStore(),
         terminalViews: TerminalViewRegistry.shared,
         projectPersistence: FileProjectPersistence(),
         workspacePersistence: FileWorkspacePersistence(),
-        worktreePersistence: FileWorktreePersistence(),
-        gitWorktreeService: GitWorktreeService()
+        worktreePersistence: FileWorktreePersistence()
     )
 }

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -72,6 +72,18 @@ actor GitWorktreeService {
         }
     }
 
+    func deleteBranch(repoPath: String, branch: String, force: Bool = true) async throws {
+        var args = ["branch"]
+        args.append(force ? "-D" : "-d")
+        args.append(branch)
+        let result = try runGit(repoPath: repoPath, arguments: args)
+        guard result.status == 0 else {
+            throw GitWorktreeError.commandFailed(
+                result.stderr.isEmpty ? "Failed to delete branch \(branch)." : result.stderr
+            )
+        }
+    }
+
     private func parsePorcelain(_ raw: String) -> [GitWorktreeRecord] {
         var records: [GitWorktreeRecord] = []
         var currentPath: String?

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+struct GitWorktreeRecord: Hashable {
+    let path: String
+    let branch: String?
+    let head: String?
+    let isBare: Bool
+    let isDetached: Bool
+}
+
+actor GitWorktreeService {
+    static let shared = GitWorktreeService()
+
+    enum GitWorktreeError: LocalizedError {
+        case notGitRepository
+        case commandFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notGitRepository:
+                "This folder is not a Git repository."
+            case let .commandFailed(message):
+                message
+            }
+        }
+    }
+
+    func isGitRepository(_ path: String) async -> Bool {
+        guard let result = try? runGit(repoPath: path, arguments: ["rev-parse", "--is-inside-work-tree"]) else {
+            return false
+        }
+        return result.status == 0 && result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true"
+    }
+
+    func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
+        let result = try runGit(repoPath: repoPath, arguments: ["worktree", "list", "--porcelain"])
+        guard result.status == 0 else {
+            throw GitWorktreeError.commandFailed(
+                result.stderr.isEmpty ? "Failed to list worktrees." : result.stderr
+            )
+        }
+        return parsePorcelain(result.stdout)
+    }
+
+    func addWorktree(repoPath: String, path: String, branch: String, createBranch: Bool) async throws {
+        guard !branch.isEmpty else {
+            throw GitWorktreeError.commandFailed("Branch name is required.")
+        }
+        var args: [String] = ["worktree", "add"]
+        if createBranch {
+            args += ["-b", branch, path]
+        } else {
+            args += [path, branch]
+        }
+        let result = try runGit(repoPath: repoPath, arguments: args)
+        guard result.status == 0 else {
+            throw GitWorktreeError.commandFailed(
+                result.stderr.isEmpty ? "Failed to add worktree." : result.stderr
+            )
+        }
+    }
+
+    func removeWorktree(repoPath: String, path: String, force: Bool = false) async throws {
+        var args: [String] = ["worktree", "remove"]
+        if force { args.append("--force") }
+        args.append(path)
+        let result = try runGit(repoPath: repoPath, arguments: args)
+        guard result.status == 0 else {
+            throw GitWorktreeError.commandFailed(
+                result.stderr.isEmpty ? "Failed to remove worktree." : result.stderr
+            )
+        }
+    }
+
+    private func parsePorcelain(_ raw: String) -> [GitWorktreeRecord] {
+        var records: [GitWorktreeRecord] = []
+        var currentPath: String?
+        var currentBranch: String?
+        var currentHead: String?
+        var isBare = false
+        var isDetached = false
+
+        func flush() {
+            guard let path = currentPath else { return }
+            records.append(GitWorktreeRecord(
+                path: path,
+                branch: currentBranch,
+                head: currentHead,
+                isBare: isBare,
+                isDetached: isDetached
+            ))
+            currentPath = nil
+            currentBranch = nil
+            currentHead = nil
+            isBare = false
+            isDetached = false
+        }
+
+        for line in raw.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = String(line)
+            if trimmed.isEmpty {
+                flush()
+                continue
+            }
+            if trimmed.hasPrefix("worktree ") {
+                currentPath = String(trimmed.dropFirst("worktree ".count))
+            } else if trimmed.hasPrefix("HEAD ") {
+                currentHead = String(trimmed.dropFirst("HEAD ".count))
+            } else if trimmed.hasPrefix("branch ") {
+                let full = String(trimmed.dropFirst("branch ".count))
+                currentBranch = full.hasPrefix("refs/heads/")
+                    ? String(full.dropFirst("refs/heads/".count))
+                    : full
+            } else if trimmed == "bare" {
+                isBare = true
+            } else if trimmed == "detached" {
+                isDetached = true
+            }
+        }
+        flush()
+        return records
+    }
+
+    private struct GitRunResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+    }
+
+    private func runGit(repoPath: String, arguments: [String]) throws -> GitRunResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", repoPath] + arguments
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+        return GitRunResult(status: process.terminationStatus, stdout: stdout, stderr: stderr)
+    }
+}

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -32,6 +32,18 @@ actor GitWorktreeService {
         return result.status == 0 && result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true"
     }
 
+    func hasUncommittedChanges(worktreePath: String) async -> Bool {
+        guard let result = try? runGit(
+            repoPath: worktreePath,
+            arguments: ["status", "--porcelain=1", "--untracked-files=all"]
+        )
+        else {
+            return false
+        }
+        guard result.status == 0 else { return false }
+        return !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
         let result = try runGit(repoPath: repoPath, arguments: ["worktree", "list", "--porcelain"])
         guard result.status == 0 else {
@@ -42,15 +54,25 @@ actor GitWorktreeService {
         return parsePorcelain(result.stdout)
     }
 
-    func addWorktree(repoPath: String, path: String, branch: String, createBranch: Bool) async throws {
-        guard !branch.isEmpty else {
-            throw GitWorktreeError.commandFailed("Branch name is required.")
+    static let allowedBranchCharacters = CharacterSet.alphanumerics
+        .union(CharacterSet(charactersIn: "._/-"))
+
+    private static func validateBranchName(_ branch: String) throws {
+        guard !branch.isEmpty,
+              !branch.hasPrefix("-"),
+              branch.unicodeScalars.allSatisfy({ Self.allowedBranchCharacters.contains($0) })
+        else {
+            throw GitWorktreeError.commandFailed("Invalid branch name.")
         }
+    }
+
+    func addWorktree(repoPath: String, path: String, branch: String, createBranch: Bool) async throws {
+        try Self.validateBranchName(branch)
         var args: [String] = ["worktree", "add"]
         if createBranch {
-            args += ["-b", branch, path]
+            args += ["-b", branch, "--", path]
         } else {
-            args += [path, branch]
+            args += ["--", path, branch]
         }
         let result = try runGit(repoPath: repoPath, arguments: args)
         guard result.status == 0 else {
@@ -63,7 +85,7 @@ actor GitWorktreeService {
     func removeWorktree(repoPath: String, path: String, force: Bool = false) async throws {
         var args: [String] = ["worktree", "remove"]
         if force { args.append("--force") }
-        args.append(path)
+        args += ["--", path]
         let result = try runGit(repoPath: repoPath, arguments: args)
         guard result.status == 0 else {
             throw GitWorktreeError.commandFailed(
@@ -73,9 +95,8 @@ actor GitWorktreeService {
     }
 
     func deleteBranch(repoPath: String, branch: String, force: Bool = true) async throws {
-        var args = ["branch"]
-        args.append(force ? "-D" : "-d")
-        args.append(branch)
+        try Self.validateBranchName(branch)
+        let args = ["branch", force ? "-D" : "-d", "--", branch]
         let result = try runGit(repoPath: repoPath, arguments: args)
         guard result.status == 0 else {
             throw GitWorktreeError.commandFailed(

--- a/Muxy/Services/GitDirectoryWatcher.swift
+++ b/Muxy/Services/GitDirectoryWatcher.swift
@@ -8,11 +8,8 @@ final class GitDirectoryWatcher: @unchecked Sendable {
     private var handler: (@Sendable () -> Void)?
 
     init?(directoryPath: String, handler: @escaping @Sendable () -> Void) {
-        let gitDir = (directoryPath as NSString).appendingPathComponent(".git")
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: gitDir, isDirectory: &isDirectory),
-              isDirectory.boolValue
-        else { return nil }
+        let gitPath = (directoryPath as NSString).appendingPathComponent(".git")
+        guard FileManager.default.fileExists(atPath: gitPath) else { return nil }
 
         self.handler = handler
 

--- a/Muxy/Services/JSONFilePersistence.swift
+++ b/Muxy/Services/JSONFilePersistence.swift
@@ -22,4 +22,20 @@ enum MuxyFileStorage {
         )
         return dir
     }
+
+    static func worktreeRoot(forProjectID projectID: UUID) -> URL {
+        let dir = appSupportDirectory()
+            .appendingPathComponent("worktree-checkouts", isDirectory: true)
+            .appendingPathComponent(projectID.uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return dir
+    }
+
+    static func worktreeDirectory(forProjectID projectID: UUID, name: String) -> URL {
+        worktreeRoot(forProjectID: projectID).appendingPathComponent(name, isDirectory: true)
+    }
 }

--- a/Muxy/Services/ProjectOpenService.swift
+++ b/Muxy/Services/ProjectOpenService.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+@MainActor
+enum ProjectOpenService {
+    static func openProject(
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Select a project folder"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let project = Project(
+            name: url.lastPathComponent,
+            path: url.path(percentEncoded: false),
+            sortOrder: projectStore.projects.count
+        )
+        projectStore.add(project)
+        worktreeStore.ensurePrimary(for: project)
+        guard let primary = worktreeStore.primary(for: project.id) else { return }
+        appState.selectProject(project, worktree: primary)
+    }
+}

--- a/Muxy/Services/WorktreePersistence.swift
+++ b/Muxy/Services/WorktreePersistence.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+protocol WorktreePersisting {
+    func loadWorktrees(projectID: UUID) throws -> [Worktree]
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws
+    func removeWorktrees(projectID: UUID) throws
+}
+
+final class FileWorktreePersistence: WorktreePersisting {
+    private let directory: URL
+
+    init(directory: URL = MuxyFileStorage.appSupportDirectory().appendingPathComponent("worktrees", isDirectory: true)) {
+        self.directory = directory
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+    }
+
+    func loadWorktrees(projectID: UUID) throws -> [Worktree] {
+        let url = fileURL(for: projectID)
+        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode([Worktree].self, from: data)
+    }
+
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try encoder.encode(worktrees)
+        try data.write(to: fileURL(for: projectID), options: .atomic)
+    }
+
+    func removeWorktrees(projectID: UUID) throws {
+        let url = fileURL(for: projectID)
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        try FileManager.default.removeItem(at: url)
+    }
+
+    private func fileURL(for projectID: UUID) -> URL {
+        directory.appendingPathComponent("\(projectID.uuidString).json")
+    }
+}

--- a/Muxy/Services/WorktreeSetupRunner.swift
+++ b/Muxy/Services/WorktreeSetupRunner.swift
@@ -10,14 +10,18 @@ enum WorktreeSetupRunner {
               !config.setup.isEmpty
         else { return }
 
-        let commands = config.setup.map(\.command).joined(separator: " && ")
+        let commands = config.setup
+            .map(\.command)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " && ")
         guard !commands.isEmpty else { return }
-        let input = commands + "\n"
 
         for _ in 0 ..< 50 {
             try? await Task.sleep(nanoseconds: 100_000_000)
             if let view = TerminalViewRegistry.shared.view(for: paneID), view.hasLiveSurface {
-                view.sendText(input)
+                view.sendText(commands)
+                view.sendReturnKey()
                 return
             }
         }

--- a/Muxy/Services/WorktreeSetupRunner.swift
+++ b/Muxy/Services/WorktreeSetupRunner.swift
@@ -1,0 +1,26 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "WorktreeSetupRunner")
+
+@MainActor
+enum WorktreeSetupRunner {
+    static func run(sourceProjectPath: String, paneID: UUID) async {
+        guard let config = WorktreeConfig.load(fromProjectPath: sourceProjectPath),
+              !config.setup.isEmpty
+        else { return }
+
+        let commands = config.setup.map(\.command).joined(separator: " && ")
+        guard !commands.isEmpty else { return }
+        let input = commands + "\n"
+
+        for _ in 0 ..< 50 {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            if let view = TerminalViewRegistry.shared.view(for: paneID), view.hasLiveSurface {
+                view.sendText(input)
+                return
+            }
+        }
+        logger.error("Timed out waiting for pane \(paneID.uuidString) before sending setup commands")
+    }
+}

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -1,0 +1,149 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "WorktreeStore")
+
+@MainActor
+@Observable
+final class WorktreeStore {
+    private(set) var worktrees: [UUID: [Worktree]] = [:]
+    private let persistence: any WorktreePersisting
+
+    init(persistence: any WorktreePersisting) {
+        self.persistence = persistence
+    }
+
+    func loadAll(projects: [Project]) {
+        for project in projects {
+            do {
+                var loaded = try persistence.loadWorktrees(projectID: project.id)
+                if !loaded.contains(where: \.isPrimary) {
+                    loaded.insert(makePrimary(for: project), at: 0)
+                    try? persistence.saveWorktrees(loaded, projectID: project.id)
+                }
+                worktrees[project.id] = sortPrimaryFirst(loaded)
+            } catch {
+                logger.error("Failed to load worktrees for project \(project.id): \(error)")
+                worktrees[project.id] = [makePrimary(for: project)]
+                save(projectID: project.id)
+            }
+        }
+    }
+
+    func ensurePrimary(for project: Project) {
+        var list = worktrees[project.id] ?? []
+        if list.contains(where: \.isPrimary) { return }
+        list.insert(makePrimary(for: project), at: 0)
+        worktrees[project.id] = sortPrimaryFirst(list)
+        save(projectID: project.id)
+    }
+
+    func list(for projectID: UUID) -> [Worktree] {
+        worktrees[projectID] ?? []
+    }
+
+    func primary(for projectID: UUID) -> Worktree? {
+        list(for: projectID).first(where: { $0.isPrimary })
+    }
+
+    func worktree(projectID: UUID, worktreeID: UUID) -> Worktree? {
+        list(for: projectID).first(where: { $0.id == worktreeID })
+    }
+
+    func add(_ worktree: Worktree, to projectID: UUID) {
+        var list = worktrees[projectID] ?? []
+        list.append(worktree)
+        worktrees[projectID] = sortPrimaryFirst(list)
+        save(projectID: projectID)
+    }
+
+    func remove(worktreeID: UUID, from projectID: UUID) {
+        guard var list = worktrees[projectID] else { return }
+        list.removeAll { $0.id == worktreeID && !$0.isPrimary }
+        worktrees[projectID] = list
+        save(projectID: projectID)
+    }
+
+    static func cleanupOnDisk(
+        worktree: Worktree,
+        repoPath: String
+    ) async {
+        guard !worktree.isPrimary else { return }
+        do {
+            try await GitWorktreeService.shared.removeWorktree(
+                repoPath: repoPath,
+                path: worktree.path,
+                force: true
+            )
+        } catch {
+            try? FileManager.default.removeItem(atPath: worktree.path)
+        }
+    }
+
+    static func cleanupOnDisk(for project: Project) async {
+        let root = MuxyFileStorage.worktreeRoot(forProjectID: project.id)
+        guard FileManager.default.fileExists(atPath: root.path) else { return }
+        let children = (try? FileManager.default.contentsOfDirectory(atPath: root.path)) ?? []
+        for child in children {
+            let childPath = root.appendingPathComponent(child).path
+            try? await GitWorktreeService.shared.removeWorktree(
+                repoPath: project.path,
+                path: childPath,
+                force: true
+            )
+            try? FileManager.default.removeItem(atPath: childPath)
+        }
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func rename(worktreeID: UUID, in projectID: UUID, to newName: String) {
+        guard var list = worktrees[projectID],
+              let index = list.firstIndex(where: { $0.id == worktreeID })
+        else { return }
+        list[index].name = newName
+        worktrees[projectID] = list
+        save(projectID: projectID)
+    }
+
+    func updateBranch(worktreeID: UUID, in projectID: UUID, branch: String?) {
+        guard var list = worktrees[projectID],
+              let index = list.firstIndex(where: { $0.id == worktreeID })
+        else { return }
+        list[index].branch = branch
+        worktrees[projectID] = list
+        save(projectID: projectID)
+    }
+
+    func removeProject(_ projectID: UUID) {
+        worktrees.removeValue(forKey: projectID)
+        do {
+            try persistence.removeWorktrees(projectID: projectID)
+        } catch {
+            logger.error("Failed to remove worktrees file for project \(projectID): \(error)")
+        }
+    }
+
+    private func makePrimary(for project: Project) -> Worktree {
+        Worktree(
+            name: project.name,
+            path: project.path,
+            branch: nil,
+            isPrimary: true
+        )
+    }
+
+    private func sortPrimaryFirst(_ list: [Worktree]) -> [Worktree] {
+        let primary = list.filter(\.isPrimary)
+        let others = list.filter { !$0.isPrimary }.sorted { $0.createdAt < $1.createdAt }
+        return primary + others
+    }
+
+    private func save(projectID: UUID) {
+        guard let list = worktrees[projectID] else { return }
+        do {
+            try persistence.saveWorktrees(list, projectID: projectID)
+        } catch {
+            logger.error("Failed to save worktrees for project \(projectID): \(error)")
+        }
+    }
+}

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -76,11 +76,30 @@ final class WorktreeStore {
                 force: true
             )
         } catch {
-            try? FileManager.default.removeItem(atPath: worktree.path)
+            logger.error("Failed to remove git worktree at \(worktree.path): \(error)")
         }
+
+        if worktree.ownsBranch,
+           let branch = worktree.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !branch.isEmpty
+        {
+            do {
+                try await GitWorktreeService.shared.deleteBranch(repoPath: repoPath, branch: branch)
+            } catch {
+                logger.error("Failed to delete branch \(branch) for worktree \(worktree.path): \(error)")
+            }
+        }
+
+        try? FileManager.default.removeItem(atPath: worktree.path)
+        removeParentDirectoryIfEmpty(for: worktree.path)
     }
 
-    static func cleanupOnDisk(for project: Project) async {
+    static func cleanupOnDisk(for project: Project, knownWorktrees: [Worktree]) async {
+        let secondaryWorktrees = knownWorktrees.filter { !$0.isPrimary }
+        for worktree in secondaryWorktrees {
+            await cleanupOnDisk(worktree: worktree, repoPath: project.path)
+        }
+
         let root = MuxyFileStorage.worktreeRoot(forProjectID: project.id)
         guard FileManager.default.fileExists(atPath: root.path) else { return }
         let children = (try? FileManager.default.contentsOfDirectory(atPath: root.path)) ?? []
@@ -94,6 +113,13 @@ final class WorktreeStore {
             try? FileManager.default.removeItem(atPath: childPath)
         }
         try? FileManager.default.removeItem(at: root)
+    }
+
+    private static func removeParentDirectoryIfEmpty(for path: String) {
+        let parent = URL(fileURLWithPath: path).deletingLastPathComponent()
+        let children = (try? FileManager.default.contentsOfDirectory(atPath: parent.path)) ?? []
+        guard children.isEmpty else { return }
+        try? FileManager.default.removeItem(at: parent)
     }
 
     func rename(worktreeID: UUID, in projectID: UUID, to newName: String) {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct MainWindow: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(GhosttyService.self) private var ghostty
     @Environment(\.openWindow) private var openWindow
     @State private var dragCoordinator = TabDragCoordinator()
@@ -43,9 +44,9 @@ struct MainWindow: View {
 
     @State private var vcsPanelVisible = false
     @State private var vcsPanelWidth: CGFloat = AttachedVCSLayout.defaultWidth
-    @State private var vcsStates: [UUID: VCSTabState] = [:]
+    @State private var vcsStates: [WorktreeKey: VCSTabState] = [:]
     @State private var showQuickOpen = false
-    private let sidebarWidth: CGFloat = 160
+    private let sidebarWidth: CGFloat = 180
 
     var body: some View {
         VStack(spacing: 0) {
@@ -75,9 +76,19 @@ struct MainWindow: View {
                     MuxyTheme.terminalBg
                     if projectsWithWorkspaces.isEmpty {
                         WelcomeView()
-                    } else if let project = activeProjectWithWorkspace {
-                        TerminalArea(project: project, isActiveProject: true)
-                            .id(project.id)
+                    } else if let project = activeProjectWithWorkspace,
+                              let activeKey = appState.activeWorktreeKey(for: project.id)
+                    {
+                        ForEach(mountedWorktreeKeys(for: project), id: \.self) { key in
+                            TerminalArea(
+                                project: project,
+                                worktreeKey: key,
+                                isActiveProject: key == activeKey
+                            )
+                            .opacity(key == activeKey ? 1 : 0)
+                            .allowsHitTesting(key == activeKey)
+                            .zIndex(key == activeKey ? 1 : 0)
+                        }
                     }
                 }
 
@@ -147,7 +158,10 @@ struct MainWindow: View {
         .background(WindowConfigurator(configVersion: ghostty.configVersion))
         .edgesIgnoringSafeArea(.top)
         .onAppear {
-            appState.restoreSelection(projects: projectStore.projects)
+            appState.restoreSelection(
+                projects: projectStore.projects,
+                worktrees: worktreeStore.worktrees
+            )
         }
         .onReceive(NotificationCenter.default.publisher(for: .quickOpen)) { _ in
             showQuickOpen.toggle()
@@ -161,10 +175,10 @@ struct MainWindow: View {
             }
             vcsPanelVisible.toggle()
         }
-        .onChange(of: projectStore.projects.map(\.id)) {
-            pruneVCSStates(validProjectIDs: Set(projectStore.projects.map(\.id)))
+        .onChange(of: vcsPruneSignature) {
+            pruneVCSStates()
         }
-        .onChange(of: appState.activeProjectID) {
+        .onChange(of: vcsEnsureSignature) {
             guard let project = activeProject else { return }
             guard vcsPanelVisible, VCSDisplayMode.current == .attached else { return }
             ensureVCSState(for: project)
@@ -273,6 +287,12 @@ struct MainWindow: View {
         return project
     }
 
+    private func mountedWorktreeKeys(for project: Project) -> [WorktreeKey] {
+        appState.workspaceRoots.keys
+            .filter { $0.projectID == project.id }
+            .sorted { $0.worktreeID.uuidString < $1.worktreeID.uuidString }
+    }
+
     private var activeProjectHasSplitWorkspace: Bool {
         guard let project = activeProject,
               let root = appState.workspaceRoot(for: project.id)
@@ -282,24 +302,30 @@ struct MainWindow: View {
     }
 
     private var projectsWithWorkspaces: [Project] {
-        projectStore.projects.filter { appState.workspaceRoots[$0.id] != nil }
+        projectStore.projects.filter { appState.workspaceRoot(for: $0.id) != nil }
     }
 
     private var activeVCSState: VCSTabState? {
-        guard let project = activeProject else { return nil }
-        return vcsStates[project.id]
+        guard let project = activeProject,
+              let key = appState.activeWorktreeKey(for: project.id)
+        else { return nil }
+        return vcsStates[key]
     }
 
     private func ensureVCSState(for project: Project) {
-        guard vcsStates[project.id] == nil else { return }
-        vcsStates[project.id] = VCSTabState(projectPath: project.path)
+        guard let key = appState.activeWorktreeKey(for: project.id) else { return }
+        guard vcsStates[key] == nil else { return }
+        let worktreePath = worktreeStore
+            .worktree(projectID: project.id, worktreeID: key.worktreeID)?
+            .path ?? project.path
+        vcsStates[key] = VCSTabState(projectPath: worktreePath)
     }
 
     private func openVCS(for project: Project, preferredAreaID: UUID? = nil) {
         VCSDisplayMode.current.route(
             tab: {
                 let areaID = preferredAreaID
-                    ?? appState.focusedAreaID[project.id]
+                    ?? appState.focusedAreaID(for: project.id)
                     ?? appState.workspaceRoot(for: project.id)?.allAreas().first?.id
                 guard let areaID else { return }
                 appState.dispatch(.createVCSTab(projectID: project.id, areaID: areaID))
@@ -312,8 +338,36 @@ struct MainWindow: View {
         )
     }
 
-    private func pruneVCSStates(validProjectIDs: Set<UUID>) {
-        vcsStates = vcsStates.filter { validProjectIDs.contains($0.key) }
+    private func pruneVCSStates() {
+        let validKeys = validVCSKeys()
+        vcsStates = vcsStates.filter { validKeys.contains($0.key) }
+    }
+
+    private func validVCSKeys() -> Set<WorktreeKey> {
+        var keys: Set<WorktreeKey> = []
+        for project in projectStore.projects {
+            for worktree in worktreeStore.list(for: project.id) {
+                keys.insert(WorktreeKey(projectID: project.id, worktreeID: worktree.id))
+            }
+        }
+        return keys
+    }
+
+    private var vcsPruneSignature: [String] {
+        var result: [String] = []
+        for project in projectStore.projects {
+            result.append(project.id.uuidString)
+            for worktree in worktreeStore.list(for: project.id) {
+                result.append(worktree.id.uuidString)
+            }
+        }
+        return result
+    }
+
+    private var vcsEnsureSignature: String {
+        let projectID = appState.activeProjectID?.uuidString ?? ""
+        let worktreeID = appState.activeProjectID.flatMap { appState.activeWorktreeID[$0] }?.uuidString ?? ""
+        return "\(projectID):\(worktreeID)"
     }
 
     private func presentCloseConfirmation(_ kind: CloseConfirmationKind) {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -141,7 +141,7 @@ struct MainWindow: View {
         .overlay {
             if showQuickOpen, let project = activeProject {
                 QuickOpenOverlay(
-                    projectPath: project.path,
+                    projectPath: activeWorktreePath(for: project),
                     onSelect: { filePath in
                         showQuickOpen = false
                         appState.openFile(filePath, projectID: project.id)
@@ -231,8 +231,7 @@ struct MainWindow: View {
                         projectID: project.id,
                         areaID: area.id,
                         direction: dir,
-                        position: .second,
-                        projectPath: project.path
+                        position: .second
                     )))
                 },
                 onClose: {
@@ -315,10 +314,14 @@ struct MainWindow: View {
     private func ensureVCSState(for project: Project) {
         guard let key = appState.activeWorktreeKey(for: project.id) else { return }
         guard vcsStates[key] == nil else { return }
-        let worktreePath = worktreeStore
+        vcsStates[key] = VCSTabState(projectPath: activeWorktreePath(for: project))
+    }
+
+    private func activeWorktreePath(for project: Project) -> String {
+        guard let key = appState.activeWorktreeKey(for: project.id) else { return project.path }
+        return worktreeStore
             .worktree(projectID: project.id, worktreeID: key.worktreeID)?
             .path ?? project.path
-        vcsStates[key] = VCSTabState(projectPath: worktreePath)
     }
 
     private func openVCS(for project: Project, preferredAreaID: UUID? = nil) {

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct SidebarToolbar: View {
@@ -9,8 +8,14 @@ struct SidebarToolbar: View {
     var body: some View {
         HStack(spacing: 4) {
             Spacer()
-            IconButton(symbol: "folder") { openProject() }
-                .help(shortcutTooltip("Open Project", for: .openProject))
+            IconButton(symbol: "folder") {
+                ProjectOpenService.openProject(
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore
+                )
+            }
+            .help(shortcutTooltip("Open Project", for: .openProject))
             IconButton(symbol: "sidebar.left") {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     appState.sidebarVisible.toggle()
@@ -25,24 +30,6 @@ struct SidebarToolbar: View {
 
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {
         "\(name) (\(KeyBindingStore.shared.combo(for: action).displayString))"
-    }
-
-    private func openProject() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.message = "Select a project folder"
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        let project = Project(
-            name: url.lastPathComponent,
-            path: url.path(percentEncoded: false),
-            sortOrder: projectStore.projects.count
-        )
-        projectStore.add(project)
-        worktreeStore.ensurePrimary(for: project)
-        guard let primary = worktreeStore.primary(for: project.id) else { return }
-        appState.selectProject(project, worktree: primary)
     }
 }
 
@@ -148,8 +135,9 @@ struct Sidebar: View {
 
     private func remove(_ project: Project) {
         let capturedProject = project
+        let knownWorktrees = worktreeStore.list(for: project.id)
         Task.detached {
-            await WorktreeStore.cleanupOnDisk(for: capturedProject)
+            await WorktreeStore.cleanupOnDisk(for: capturedProject, knownWorktrees: knownWorktrees)
         }
         appState.removeProject(project.id)
         projectStore.remove(id: project.id)

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SidebarToolbar: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
 
     var body: some View {
         HStack(spacing: 4) {
@@ -39,74 +40,120 @@ struct SidebarToolbar: View {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
-        appState.selectProject(project)
+        worktreeStore.ensurePrimary(for: project)
+        guard let primary = worktreeStore.primary(for: project.id) else { return }
+        appState.selectProject(project, worktree: primary)
     }
 }
 
 struct Sidebar: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
     @State private var dragState = ProjectDragState()
 
     var body: some View {
         VStack(spacing: 0) {
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 2) {
-                    ForEach(Array(projectStore.projects.enumerated()), id: \.element.id) {
-                        index, project in
-                        ProjectItem(
-                            project: project,
-                            selected: project.id == appState.activeProjectID,
-                            isAnyDragging: dragState.draggedID != nil,
-                            shortcutIndex: index < 9 ? index + 1 : nil,
-                            onRemove: {
-                                appState.removeProject(project.id)
-                                projectStore.remove(id: project.id)
-                            },
-                            onRename: { projectStore.rename(id: project.id, to: $0) }
-                        )
-                        .background {
-                            if dragState.draggedID != nil {
-                                GeometryReader { geo in
-                                    Color.clear.preference(
-                                        key: UUIDFramePreferenceKey<SidebarFrameTag>.self,
-                                        value: [project.id: geo.frame(in: .named("sidebar"))]
-                                    )
-                                }
-                            }
-                        }
-                        .gesture(
-                            DragGesture(minimumDistance: 4, coordinateSpace: .named("sidebar"))
-                                .onChanged { value in
-                                    if dragState.draggedID == nil {
-                                        dragState.draggedID = project.id
-                                        dragState.lastReorderTargetID = nil
-                                    }
-                                    reorderIfNeeded(at: value.location)
-                                }
-                                .onEnded { _ in
-                                    withAnimation(.easeInOut(duration: 0.15)) {
-                                        dragState.draggedID = nil
-                                        dragState.frames = [:]
-                                        dragState.lastReorderTargetID = nil
-                                    }
-                                }
-                        )
-                        .onTapGesture {
-                            guard dragState.draggedID == nil else { return }
-                            appState.selectProject(project)
-                        }
-                    }
-                }
-                .padding(6)
-                .onPreferenceChange(UUIDFramePreferenceKey<SidebarFrameTag>.self) { frames in
-                    guard dragState.draggedID != nil else { return }
-                    dragState.frames = frames
-                }
+            if projectStore.projects.isEmpty {
+                emptyState
+            } else {
+                projectList
             }
-            .coordinateSpace(name: "sidebar")
+            Spacer(minLength: 0)
             SidebarFooter()
         }
+    }
+
+    private var projectList: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(spacing: 2) {
+                ForEach(Array(projectStore.projects.enumerated()), id: \.element.id) { index, project in
+                    ProjectRow(
+                        project: project,
+                        shortcutIndex: index < 9 ? index + 1 : nil,
+                        isAnyDragging: dragState.draggedID != nil,
+                        onSelect: { select(project) },
+                        onRemove: { remove(project) },
+                        onRename: { projectStore.rename(id: project.id, to: $0) }
+                    )
+                    .background {
+                        if dragState.draggedID != nil {
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: UUIDFramePreferenceKey<SidebarFrameTag>.self,
+                                    value: [project.id: geo.frame(in: .named("sidebar"))]
+                                )
+                            }
+                        }
+                    }
+                    .gesture(projectDragGesture(for: project))
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 10)
+            .onPreferenceChange(UUIDFramePreferenceKey<SidebarFrameTag>.self) { frames in
+                guard dragState.draggedID != nil else { return }
+                dragState.frames = frames
+            }
+        }
+        .coordinateSpace(name: "sidebar")
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "folder.badge.plus")
+                .font(.system(size: 26, weight: .regular))
+                .foregroundStyle(MuxyTheme.fgDim)
+            Text("No projects yet")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MuxyTheme.fgMuted)
+            Text("Click \(Image(systemName: "folder")) above to open one")
+                .font(.system(size: 10))
+                .foregroundStyle(MuxyTheme.fgDim)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 32)
+    }
+
+    private func projectDragGesture(for project: Project) -> some Gesture {
+        DragGesture(minimumDistance: 6, coordinateSpace: .named("sidebar"))
+            .onChanged { value in
+                if dragState.draggedID == nil {
+                    dragState.draggedID = project.id
+                    dragState.lastReorderTargetID = nil
+                }
+                reorderIfNeeded(at: value.location)
+            }
+            .onEnded { _ in
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    dragState.draggedID = nil
+                    dragState.frames = [:]
+                    dragState.lastReorderTargetID = nil
+                }
+            }
+    }
+
+    private func select(_ project: Project) {
+        worktreeStore.ensurePrimary(for: project)
+        let list = worktreeStore.list(for: project.id)
+        let existingID = appState.activeWorktreeID[project.id]
+        let worktree = list.first(where: { $0.id == existingID })
+            ?? list.first(where: { $0.isPrimary })
+            ?? list.first
+        guard let worktree else { return }
+        appState.selectProject(project, worktree: worktree)
+    }
+
+    private func remove(_ project: Project) {
+        let capturedProject = project
+        Task.detached {
+            await WorktreeStore.cleanupOnDisk(for: capturedProject)
+        }
+        appState.removeProject(project.id)
+        projectStore.remove(id: project.id)
+        worktreeStore.removeProject(project.id)
     }
 
     private func reorderIfNeeded(at location: CGPoint) {
@@ -169,95 +216,5 @@ struct SidebarFooter: View {
         .onReceive(NotificationCenter.default.publisher(for: .toggleThemePicker)) { _ in
             showThemePicker.toggle()
         }
-    }
-}
-
-private struct ProjectItem: View {
-    let project: Project
-    let selected: Bool
-    var isAnyDragging: Bool = false
-    var shortcutIndex: Int?
-    let onRemove: () -> Void
-    let onRename: (String) -> Void
-    @State private var hovered = false
-    @State private var isRenaming = false
-    @State private var renameText = ""
-    @FocusState private var renameFieldFocused: Bool
-
-    private var showBadge: Bool {
-        guard let shortcutIndex,
-              let action = ShortcutAction.projectAction(for: shortcutIndex)
-        else { return false }
-        return ModifierKeyMonitor.shared.isHolding(
-            modifiers: KeyBindingStore.shared.combo(for: action).modifiers
-        )
-    }
-
-    var body: some View {
-        Group {
-            if isRenaming {
-                TextField("", text: $renameText)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 12))
-                    .foregroundStyle(MuxyTheme.fg)
-                    .focused($renameFieldFocused)
-                    .onSubmit { commitRename() }
-                    .onExitCommand { cancelRename() }
-            } else {
-                Text(project.name)
-                    .font(.system(size: 12))
-                    .foregroundStyle(selected ? MuxyTheme.accent : MuxyTheme.fgMuted)
-            }
-        }
-        .lineLimit(1)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(background, in: RoundedRectangle(cornerRadius: 6))
-        .contentShape(RoundedRectangle(cornerRadius: 6))
-        .overlay(alignment: .trailing) {
-            if showBadge, let shortcutIndex,
-               let action = ShortcutAction.projectAction(for: shortcutIndex)
-            {
-                ShortcutBadge(label: KeyBindingStore.shared.combo(for: action).displayString)
-                    .padding(.trailing, 6)
-            }
-        }
-        .onHover { hovering in
-            guard !isAnyDragging else { return }
-            hovered = hovering
-        }
-        .onChange(of: isAnyDragging) { _, dragging in
-            if dragging { hovered = false }
-        }
-        .contextMenu {
-            Button("Rename Project") { startRename() }
-            Divider()
-            Button("Remove Project", role: .destructive, action: onRemove)
-        }
-    }
-
-    private var background: some ShapeStyle {
-        if selected { return AnyShapeStyle(MuxyTheme.accentSoft) }
-        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
-        return AnyShapeStyle(.clear)
-    }
-
-    private func startRename() {
-        renameText = project.name
-        isRenaming = true
-        renameFieldFocused = true
-    }
-
-    private func commitRename() {
-        let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty {
-            onRename(trimmed)
-        }
-        isRenaming = false
-    }
-
-    private func cancelRename() {
-        isRenaming = false
     }
 }

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+enum CreateWorktreeResult {
+    case created(Worktree, runSetup: Bool)
+    case cancelled
+    case failed(String)
+}
+
+struct CreateWorktreeSheet: View {
+    let project: Project
+    let onFinish: (CreateWorktreeResult) -> Void
+
+    @Environment(WorktreeStore.self) private var worktreeStore
+    @State private var name: String = ""
+    @State private var branchName: String = ""
+    @State private var createNewBranch = true
+    @State private var selectedExistingBranch: String = ""
+    @State private var availableBranches: [String] = []
+    @State private var runSetup = true
+    @State private var inProgress = false
+    @State private var errorMessage: String?
+
+    private let gitRepository = GitRepositoryService()
+    private let gitWorktree = GitWorktreeService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("New Worktree")
+                .font(.system(size: 14, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Name").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
+                TextField("feature-x", text: $name)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            Picker("", selection: $createNewBranch) {
+                Text("Create new branch").tag(true)
+                Text("Use existing branch").tag(false)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            if createNewBranch {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Branch Name").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
+                    TextField("feature-x", text: $branchName)
+                        .textFieldStyle(.roundedBorder)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Branch").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
+                    Picker("", selection: $selectedExistingBranch) {
+                        ForEach(availableBranches, id: \.self) { branch in
+                            Text(branch).tag(branch)
+                        }
+                    }
+                    .labelsHidden()
+                }
+            }
+
+            Toggle("Run setup commands from .muxy/worktree.json", isOn: $runSetup)
+                .font(.system(size: 11))
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.diffRemoveFg)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { onFinish(.cancelled) }
+                    .keyboardShortcut(.cancelAction)
+                Button("Create") { Task { await create() } }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canCreate || inProgress)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+        .task { await loadBranches() }
+        .onChange(of: name) { _, newValue in
+            if createNewBranch, branchName.isEmpty || branchName == oldNameToBranch {
+                branchName = newValue
+            }
+            oldNameToBranch = branchName
+        }
+    }
+
+    @State private var oldNameToBranch: String = ""
+
+    private var canCreate: Bool {
+        guard !name.trimmingCharacters(in: .whitespaces).isEmpty else { return false }
+        if createNewBranch {
+            return !branchName.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+        return !selectedExistingBranch.isEmpty
+    }
+
+    private func loadBranches() async {
+        do {
+            let branches = try await gitRepository.listBranches(repoPath: project.path)
+            await MainActor.run {
+                availableBranches = branches
+                if selectedExistingBranch.isEmpty {
+                    selectedExistingBranch = branches.first ?? ""
+                }
+            }
+        } catch {
+            await MainActor.run {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func create() async {
+        inProgress = true
+        errorMessage = nil
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let branch = createNewBranch
+            ? branchName.trimmingCharacters(in: .whitespaces)
+            : selectedExistingBranch
+
+        let slug = Self.slug(from: trimmedName)
+        let worktreeDirectory = MuxyFileStorage
+            .worktreeDirectory(forProjectID: project.id, name: slug)
+            .path(percentEncoded: false)
+
+        if FileManager.default.fileExists(atPath: worktreeDirectory) {
+            await MainActor.run {
+                inProgress = false
+                errorMessage = "A worktree with this name already exists on disk."
+            }
+            return
+        }
+
+        do {
+            try await gitWorktree.addWorktree(
+                repoPath: project.path,
+                path: worktreeDirectory,
+                branch: branch,
+                createBranch: createNewBranch
+            )
+        } catch {
+            await MainActor.run {
+                inProgress = false
+                errorMessage = error.localizedDescription
+            }
+            return
+        }
+
+        let worktree = Worktree(
+            name: trimmedName,
+            path: worktreeDirectory,
+            branch: branch,
+            isPrimary: false
+        )
+        await MainActor.run {
+            worktreeStore.add(worktree, to: project.id)
+            inProgress = false
+            onFinish(.created(worktree, runSetup: runSetup))
+        }
+    }
+
+    private static func slug(from name: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = name.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let collapsed = String(scalars)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+        return collapsed.isEmpty ? UUID().uuidString : collapsed
+    }
+}

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -3,7 +3,6 @@ import SwiftUI
 enum CreateWorktreeResult {
     case created(Worktree, runSetup: Bool)
     case cancelled
-    case failed(String)
 }
 
 struct CreateWorktreeSheet: View {
@@ -13,10 +12,12 @@ struct CreateWorktreeSheet: View {
     @Environment(WorktreeStore.self) private var worktreeStore
     @State private var name: String = ""
     @State private var branchName: String = ""
+    @State private var branchNameEdited = false
     @State private var createNewBranch = true
     @State private var selectedExistingBranch: String = ""
     @State private var availableBranches: [String] = []
-    @State private var runSetup = true
+    @State private var setupCommands: [String] = []
+    @State private var runSetup = false
     @State private var inProgress = false
     @State private var errorMessage: String?
 
@@ -46,6 +47,7 @@ struct CreateWorktreeSheet: View {
                     Text("Branch Name").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
                     TextField("feature-x", text: $branchName)
                         .textFieldStyle(.roundedBorder)
+                        .onChange(of: branchName) { _, _ in branchNameEdited = true }
                 }
             } else {
                 VStack(alignment: .leading, spacing: 6) {
@@ -59,8 +61,9 @@ struct CreateWorktreeSheet: View {
                 }
             }
 
-            Toggle("Run setup commands from .muxy/worktree.json", isOn: $runSetup)
-                .font(.system(size: 11))
+            if !setupCommands.isEmpty {
+                setupCommandsSection
+            }
 
             if let errorMessage {
                 Text(errorMessage)
@@ -79,17 +82,56 @@ struct CreateWorktreeSheet: View {
             }
         }
         .padding(20)
-        .frame(width: 420)
-        .task { await loadBranches() }
+        .frame(width: 460)
+        .task {
+            await loadBranches()
+            loadSetupCommands()
+        }
         .onChange(of: name) { _, newValue in
-            if createNewBranch, branchName.isEmpty || branchName == oldNameToBranch {
-                branchName = newValue
-            }
-            oldNameToBranch = branchName
+            guard createNewBranch, !branchNameEdited else { return }
+            branchName = newValue
         }
     }
 
-    @State private var oldNameToBranch: String = ""
+    private var setupCommandsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MuxyTheme.diffRemoveFg)
+                Text("Setup commands from .muxy/worktree.json")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fg)
+            }
+            Text("These commands will run in the new worktree's terminal. Only enable this if you trust this repository.")
+                .font(.system(size: 10))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(setupCommands, id: \.self) { command in
+                    Text(command)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(8)
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
+            Toggle("Run these commands after creating the worktree", isOn: $runSetup)
+                .font(.system(size: 11))
+        }
+        .padding(10)
+        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func loadSetupCommands() {
+        guard let config = WorktreeConfig.load(fromProjectPath: project.path) else {
+            setupCommands = []
+            return
+        }
+        setupCommands = config.setup.map(\.command).filter { !$0.isEmpty }
+    }
 
     private var canCreate: Bool {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else { return false }

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -47,7 +47,9 @@ struct CreateWorktreeSheet: View {
                     Text("Branch Name").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
                     TextField("feature-x", text: $branchName)
                         .textFieldStyle(.roundedBorder)
-                        .onChange(of: branchName) { _, _ in branchNameEdited = true }
+                        .onChange(of: branchName) { _, newValue in
+                            branchNameEdited = newValue != name
+                        }
                 }
             } else {
                 VStack(alignment: .leading, spacing: 6) {
@@ -61,7 +63,9 @@ struct CreateWorktreeSheet: View {
                 }
             }
 
-            if !setupCommands.isEmpty {
+            if setupCommands.isEmpty {
+                setupCommandsGuideSection
+            } else {
                 setupCommandsSection
             }
 
@@ -90,6 +94,10 @@ struct CreateWorktreeSheet: View {
         .onChange(of: name) { _, newValue in
             guard createNewBranch, !branchNameEdited else { return }
             branchName = newValue
+        }
+        .onChange(of: createNewBranch) { _, isCreatingNewBranch in
+            guard isCreatingNewBranch, !branchNameEdited else { return }
+            branchName = name
         }
     }
 
@@ -120,6 +128,36 @@ struct CreateWorktreeSheet: View {
             .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
             Toggle("Run these commands after creating the worktree", isOn: $runSetup)
                 .font(.system(size: 11))
+        }
+        .padding(10)
+        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var setupCommandsGuideSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MuxyTheme.fgDim)
+                Text("Optional setup commands")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fg)
+            }
+            Text("To run setup commands after creating a worktree, add .muxy/worktree.json in this repository.")
+                .font(.system(size: 10))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("\(project.path)/.muxy/worktree.json")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(MuxyTheme.fg)
+                .textSelection(.enabled)
+            Text("{\n  \"setup\": [\n    \"pnpm install\",\n    \"pnpm dev\"\n  ]\n}")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(MuxyTheme.fg)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
         }
         .padding(10)
         .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: 6))
@@ -197,6 +235,7 @@ struct CreateWorktreeSheet: View {
             name: trimmedName,
             path: worktreeDirectory,
             branch: branch,
+            ownsBranch: createNewBranch,
             isPrimary: false
         )
         await MainActor.run {

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+
+struct ProjectRow: View {
+    let project: Project
+    let shortcutIndex: Int?
+    let isAnyDragging: Bool
+    let onSelect: () -> Void
+    let onRemove: () -> Void
+    let onRename: (String) -> Void
+
+    @Environment(AppState.self) private var appState
+    @Environment(WorktreeStore.self) private var worktreeStore
+
+    @State private var hovered = false
+    @State private var isRenaming = false
+    @State private var renameText = ""
+    @FocusState private var renameFieldFocused: Bool
+    @State private var showWorktreePopover = false
+    @State private var isGitRepo = false
+    @State private var showCreateWorktreeSheet = false
+    @State private var createError: String?
+
+    private var isActive: Bool {
+        appState.activeProjectID == project.id
+    }
+
+    private var worktrees: [Worktree] {
+        worktreeStore.list(for: project.id)
+    }
+
+    private var activeWorktree: Worktree? {
+        guard isActive, let id = appState.activeWorktreeID[project.id] else { return nil }
+        return worktrees.first { $0.id == id }
+    }
+
+    private var showWorktreeTrigger: Bool {
+        isActive
+    }
+
+    private var triggerLabel: String {
+        guard let activeWorktree else { return "main" }
+        if activeWorktree.isPrimary {
+            if let branch = activeWorktree.branch, !branch.isEmpty { return branch }
+            return "main"
+        }
+        return activeWorktree.name
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            label
+            Spacer(minLength: 0)
+            trailingAccessory
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .background(background, in: RoundedRectangle(cornerRadius: 6))
+        .overlay(alignment: .leading) {
+            if isActive {
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 6,
+                    bottomLeadingRadius: 6,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: 0
+                )
+                .fill(MuxyTheme.accent)
+                .frame(width: 3)
+            }
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 6))
+        .onHover { hovering in
+            guard !isAnyDragging else { return }
+            hovered = hovering
+        }
+        .onChange(of: isAnyDragging) { _, dragging in
+            if dragging { hovered = false }
+        }
+        .onTapGesture {
+            guard !isAnyDragging, !isRenaming else { return }
+            onSelect()
+        }
+        .task(id: project.path) {
+            isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path)
+        }
+        .contextMenu {
+            Button("Rename Project") { startRename() }
+            if isGitRepo {
+                Divider()
+                Button("New Worktree…") { showCreateWorktreeSheet = true }
+                if worktrees.count > 1 {
+                    Button("Switch Worktree…") { showWorktreePopover = true }
+                }
+            }
+            Divider()
+            Button("Remove Project", role: .destructive, action: onRemove)
+        }
+        .sheet(isPresented: $showCreateWorktreeSheet) {
+            CreateWorktreeSheet(project: project) { result in
+                showCreateWorktreeSheet = false
+                handleCreateWorktreeResult(result)
+            }
+        }
+        .alert(
+            "Failed to Add Worktree",
+            isPresented: Binding(
+                get: { createError != nil },
+                set: { if !$0 { createError = nil } }
+            ),
+            actions: { Button("OK") { createError = nil } },
+            message: { Text(createError ?? "") }
+        )
+    }
+
+    @ViewBuilder
+    private var label: some View {
+        if isRenaming {
+            TextField("", text: $renameText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+                .focused($renameFieldFocused)
+                .onSubmit { commitRename() }
+                .onExitCommand { cancelRename() }
+        } else {
+            Text(project.name)
+                .font(.system(size: 12, weight: isActive ? .semibold : .medium))
+                .foregroundStyle(nameColor)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    @ViewBuilder
+    private var trailingAccessory: some View {
+        if showShortcutBadge, let shortcutIndex,
+           let action = ShortcutAction.projectAction(for: shortcutIndex)
+        {
+            ShortcutBadge(label: KeyBindingStore.shared.combo(for: action).displayString)
+        } else if showWorktreeTrigger, !isRenaming {
+            Button {
+                showWorktreePopover = true
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.system(size: 9, weight: .semibold))
+                    Text(triggerLabel)
+                        .font(.system(size: 10, weight: .medium))
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(MuxyTheme.fgDim)
+                }
+                .foregroundStyle(MuxyTheme.fg.opacity(0.85))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
+                .contentShape(RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+            .help("Switch Worktree")
+            .popover(isPresented: $showWorktreePopover, arrowEdge: .trailing) {
+                WorktreePopover(
+                    project: project,
+                    isGitRepo: isGitRepo,
+                    onDismiss: { showWorktreePopover = false },
+                    onRequestCreate: {
+                        showWorktreePopover = false
+                        showCreateWorktreeSheet = true
+                    }
+                )
+                .environment(appState)
+                .environment(worktreeStore)
+            }
+        }
+    }
+
+    private var background: AnyShapeStyle {
+        if isActive { return AnyShapeStyle(MuxyTheme.accentSoft) }
+        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        return AnyShapeStyle(Color.clear)
+    }
+
+    private var nameColor: Color {
+        if isActive { return MuxyTheme.fg }
+        if hovered { return MuxyTheme.fg }
+        return MuxyTheme.fgMuted
+    }
+
+    private var showShortcutBadge: Bool {
+        guard let shortcutIndex,
+              let action = ShortcutAction.projectAction(for: shortcutIndex)
+        else { return false }
+        return ModifierKeyMonitor.shared.isHolding(
+            modifiers: KeyBindingStore.shared.combo(for: action).modifiers
+        )
+    }
+
+    private func handleCreateWorktreeResult(_ result: CreateWorktreeResult) {
+        switch result {
+        case let .created(worktree, runSetup):
+            appState.selectWorktree(projectID: project.id, worktree: worktree)
+            if runSetup,
+               let paneID = appState.focusedArea(for: project.id)?.activeTab?.content.pane?.id
+            {
+                Task {
+                    await WorktreeSetupRunner.run(
+                        sourceProjectPath: project.path,
+                        paneID: paneID
+                    )
+                }
+            }
+        case let .failed(message):
+            createError = message
+        case .cancelled:
+            break
+        }
+    }
+
+    private func startRename() {
+        renameText = project.name
+        isRenaming = true
+        renameFieldFocused = true
+    }
+
+    private func commitRename() {
+        let trimmed = renameText.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            onRename(trimmed)
+        }
+        isRenaming = false
+    }
+
+    private func cancelRename() {
+        isRenaming = false
+    }
+}

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -18,7 +18,6 @@ struct ProjectRow: View {
     @State private var showWorktreePopover = false
     @State private var isGitRepo = false
     @State private var showCreateWorktreeSheet = false
-    @State private var createError: String?
 
     private var isActive: Bool {
         appState.activeProjectID == project.id
@@ -100,15 +99,6 @@ struct ProjectRow: View {
                 handleCreateWorktreeResult(result)
             }
         }
-        .alert(
-            "Failed to Add Worktree",
-            isPresented: Binding(
-                get: { createError != nil },
-                set: { if !$0 { createError = nil } }
-            ),
-            actions: { Button("OK") { createError = nil } },
-            message: { Text(createError ?? "") }
-        )
     }
 
     @ViewBuilder
@@ -210,8 +200,6 @@ struct ProjectRow: View {
                     )
                 }
             }
-        case let .failed(message):
-            createError = message
         case .cancelled:
             break
         }

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -120,7 +120,15 @@ struct WorktreePopover: View {
                         onRemove: worktree.isPrimary ? nil : {
                             let capturedWorktree = worktree
                             let repoPath = project.path
-                            appState.removeWorktree(projectID: project.id, worktree: capturedWorktree)
+                            let remaining = worktrees.filter { $0.id != capturedWorktree.id }
+                            let replacement = remaining.first(where: { $0.id == activeWorktreeID })
+                                ?? remaining.first(where: { $0.isPrimary })
+                                ?? remaining.first
+                            appState.removeWorktree(
+                                projectID: project.id,
+                                worktree: capturedWorktree,
+                                replacement: replacement
+                            )
                             worktreeStore.remove(worktreeID: capturedWorktree.id, from: project.id)
                             Task.detached {
                                 await WorktreeStore.cleanupOnDisk(

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -1,0 +1,270 @@
+import SwiftUI
+
+struct WorktreePopover: View {
+    let project: Project
+    let isGitRepo: Bool
+    let onDismiss: () -> Void
+    let onRequestCreate: () -> Void
+
+    @Environment(AppState.self) private var appState
+    @Environment(WorktreeStore.self) private var worktreeStore
+    @State private var searchText = ""
+
+    private var worktrees: [Worktree] {
+        worktreeStore.list(for: project.id)
+    }
+
+    private var filteredWorktrees: [Worktree] {
+        guard !searchText.isEmpty else { return worktrees }
+        return worktrees.filter { worktree in
+            worktree.name.localizedCaseInsensitiveContains(searchText)
+                || (worktree.branch?.localizedCaseInsensitiveContains(searchText) ?? false)
+        }
+    }
+
+    private var activeWorktreeID: UUID? {
+        appState.activeWorktreeID[project.id]
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(MuxyTheme.border)
+            if worktrees.count > 4 {
+                searchField
+                Divider().overlay(MuxyTheme.border)
+            }
+            if filteredWorktrees.isEmpty {
+                emptyResults
+            } else {
+                worktreeList
+            }
+            if isGitRepo {
+                Divider().overlay(MuxyTheme.border)
+                newWorktreeButton
+            }
+        }
+        .frame(width: 300)
+        .frame(maxHeight: 420)
+        .background(MuxyTheme.bg)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Text("WORKTREES")
+                .font(.system(size: 10, weight: .bold))
+                .tracking(0.6)
+                .foregroundStyle(MuxyTheme.fgDim)
+            Text("·")
+                .font(.system(size: 10))
+                .foregroundStyle(MuxyTheme.fgDim)
+            Text(project.name)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundStyle(MuxyTheme.fgMuted)
+            ZStack(alignment: .leading) {
+                if searchText.isEmpty {
+                    Text("Search worktrees…")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuxyTheme.fgDim)
+                }
+                TextField("", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                    .foregroundStyle(MuxyTheme.fg)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var emptyResults: some View {
+        Text("No matches")
+            .font(.system(size: 12))
+            .foregroundStyle(MuxyTheme.fgMuted)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+    }
+
+    private var worktreeList: some View {
+        ScrollView {
+            LazyVStack(spacing: 2) {
+                ForEach(filteredWorktrees) { worktree in
+                    WorktreePopoverRow(
+                        worktree: worktree,
+                        selected: worktree.id == activeWorktreeID,
+                        onSelect: {
+                            appState.selectWorktree(projectID: project.id, worktree: worktree)
+                            onDismiss()
+                        },
+                        onRename: { newName in
+                            worktreeStore.rename(
+                                worktreeID: worktree.id,
+                                in: project.id,
+                                to: newName
+                            )
+                        },
+                        onRemove: worktree.isPrimary ? nil : {
+                            let capturedWorktree = worktree
+                            let repoPath = project.path
+                            appState.removeWorktree(projectID: project.id, worktreeID: worktree.id)
+                            worktreeStore.remove(worktreeID: capturedWorktree.id, from: project.id)
+                            Task.detached {
+                                await WorktreeStore.cleanupOnDisk(
+                                    worktree: capturedWorktree,
+                                    repoPath: repoPath
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 6)
+        }
+    }
+
+    private var newWorktreeButton: some View {
+        Button(action: onRequestCreate) {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.square.dashed")
+                    .font(.system(size: 12))
+                Text("New Worktree…")
+                    .font(.system(size: 12, weight: .medium))
+                Spacer()
+            }
+            .foregroundStyle(MuxyTheme.fg)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct WorktreePopoverRow: View {
+    let worktree: Worktree
+    let selected: Bool
+    let onSelect: () -> Void
+    let onRename: (String) -> Void
+    let onRemove: (() -> Void)?
+
+    @State private var hovered = false
+    @State private var isRenaming = false
+    @State private var renameText = ""
+    @FocusState private var renameFieldFocused: Bool
+
+    private var displayName: String {
+        if worktree.isPrimary, worktree.name.isEmpty { return "main" }
+        return worktree.name
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            indicator
+            VStack(alignment: .leading, spacing: 1) {
+                if isRenaming {
+                    TextField("", text: $renameText)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .focused($renameFieldFocused)
+                        .onSubmit { commitRename() }
+                        .onExitCommand { cancelRename() }
+                } else {
+                    HStack(spacing: 6) {
+                        Text(displayName)
+                            .font(.system(size: 12, weight: selected ? .semibold : .medium))
+                            .foregroundStyle(selected ? MuxyTheme.fg : MuxyTheme.fg.opacity(0.9))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        if worktree.isPrimary {
+                            Text("PRIMARY")
+                                .font(.system(size: 8, weight: .bold))
+                                .tracking(0.5)
+                                .foregroundStyle(MuxyTheme.fgDim)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 1)
+                                .background(MuxyTheme.surface, in: Capsule())
+                        }
+                    }
+                }
+                if let branch = worktree.branch, !branch.isEmpty, !isRenaming {
+                    Text(branch)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(MuxyTheme.fgDim)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            Spacer(minLength: 4)
+            if selected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(MuxyTheme.accent)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: 6))
+        .contentShape(RoundedRectangle(cornerRadius: 6))
+        .onHover { hovered = $0 }
+        .onTapGesture {
+            guard !isRenaming else { return }
+            onSelect()
+        }
+        .contextMenu {
+            if let onRemove {
+                Button("Rename") { startRename() }
+                Divider()
+                Button("Remove", role: .destructive, action: onRemove)
+            } else {
+                Text("Primary worktree").font(.system(size: 11))
+            }
+        }
+    }
+
+    private var indicator: some View {
+        ZStack {
+            Circle()
+                .fill(selected ? MuxyTheme.accent : MuxyTheme.fgDim.opacity(0.35))
+                .frame(width: 7, height: 7)
+        }
+        .frame(width: 10)
+    }
+
+    private var rowBackground: AnyShapeStyle {
+        if selected { return AnyShapeStyle(MuxyTheme.accentSoft) }
+        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        return AnyShapeStyle(Color.clear)
+    }
+
+    private func startRename() {
+        renameText = worktree.name
+        isRenaming = true
+        renameFieldFocused = true
+    }
+
+    private func commitRename() {
+        let trimmed = renameText.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty { onRename(trimmed) }
+        isRenaming = false
+    }
+
+    private func cancelRename() {
+        isRenaming = false
+    }
+}

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -29,10 +29,10 @@ struct WorktreePopover: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider().overlay(MuxyTheme.border)
+            Divider().overlay(MuxyTheme.border.opacity(0.55))
             if worktrees.count > 4 {
                 searchField
-                Divider().overlay(MuxyTheme.border)
+                Divider().overlay(MuxyTheme.border.opacity(0.55))
             }
             if filteredWorktrees.isEmpty {
                 emptyResults
@@ -40,7 +40,7 @@ struct WorktreePopover: View {
                 worktreeList
             }
             if isGitRepo {
-                Divider().overlay(MuxyTheme.border)
+                Divider().overlay(MuxyTheme.border.opacity(0.55))
                 newWorktreeButton
             }
         }

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct WorktreePopover: View {
@@ -118,30 +119,63 @@ struct WorktreePopover: View {
                             )
                         },
                         onRemove: worktree.isPrimary ? nil : {
-                            let capturedWorktree = worktree
-                            let repoPath = project.path
-                            let remaining = worktrees.filter { $0.id != capturedWorktree.id }
-                            let replacement = remaining.first(where: { $0.id == activeWorktreeID })
-                                ?? remaining.first(where: { $0.isPrimary })
-                                ?? remaining.first
-                            appState.removeWorktree(
-                                projectID: project.id,
-                                worktree: capturedWorktree,
-                                replacement: replacement
-                            )
-                            worktreeStore.remove(worktreeID: capturedWorktree.id, from: project.id)
-                            Task.detached {
-                                await WorktreeStore.cleanupOnDisk(
-                                    worktree: capturedWorktree,
-                                    repoPath: repoPath
-                                )
-                            }
+                            Task { await requestRemove(worktree: worktree) }
                         }
                     )
                 }
             }
             .padding(.horizontal, 6)
             .padding(.vertical, 6)
+        }
+    }
+
+    private func requestRemove(worktree: Worktree) async {
+        let hasChanges = await GitWorktreeService.shared.hasUncommittedChanges(worktreePath: worktree.path)
+        if !hasChanges {
+            performRemove(worktree: worktree)
+            return
+        }
+        presentRemoveConfirmation(worktree: worktree)
+    }
+
+    private func presentRemoveConfirmation(worktree: Worktree) {
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
+              window.attachedSheet == nil
+        else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "Remove worktree \"\(worktree.name)\"?"
+        alert.informativeText = "This worktree has uncommitted changes. Removing it will permanently discard them."
+        alert.alertStyle = .warning
+        alert.icon = NSApp.applicationIconImage
+        alert.addButton(withTitle: "Remove")
+        alert.addButton(withTitle: "Cancel")
+        alert.buttons[0].keyEquivalent = "\r"
+        alert.buttons[1].keyEquivalent = "\u{1b}"
+
+        alert.beginSheetModal(for: window) { response in
+            guard response == .alertFirstButtonReturn else { return }
+            performRemove(worktree: worktree)
+        }
+    }
+
+    private func performRemove(worktree: Worktree) {
+        let repoPath = project.path
+        let remaining = worktrees.filter { $0.id != worktree.id }
+        let replacement = remaining.first(where: { $0.id == activeWorktreeID })
+            ?? remaining.first(where: { $0.isPrimary })
+            ?? remaining.first
+        appState.removeWorktree(
+            projectID: project.id,
+            worktree: worktree,
+            replacement: replacement
+        )
+        worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+        Task.detached {
+            await WorktreeStore.cleanupOnDisk(
+                worktree: worktree,
+                repoPath: repoPath
+            )
         }
     }
 

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -120,7 +120,7 @@ struct WorktreePopover: View {
                         onRemove: worktree.isPrimary ? nil : {
                             let capturedWorktree = worktree
                             let repoPath = project.path
-                            appState.removeWorktree(projectID: project.id, worktreeID: worktree.id)
+                            appState.removeWorktree(projectID: project.id, worktree: capturedWorktree)
                             worktreeStore.remove(worktreeID: capturedWorktree.id, from: project.id)
                             Task.detached {
                                 await WorktreeStore.cleanupOnDisk(

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -553,6 +553,17 @@ final class GhosttyTerminalNSView: NSView {
         ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
     }
 
+    func sendText(_ text: String) {
+        guard let surface else { return }
+        text.withCString { ptr in
+            ghostty_surface_text(surface, ptr, UInt(text.utf8.count))
+        }
+    }
+
+    var hasLiveSurface: Bool {
+        surface != nil
+    }
+
     enum SearchDirection: String {
         case next
         case previous

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -560,6 +560,23 @@ final class GhosttyTerminalNSView: NSView {
         }
     }
 
+    func sendReturnKey() {
+        guard let surface else { return }
+        var press = ghostty_input_key_s()
+        press.action = GHOSTTY_ACTION_PRESS
+        press.keycode = 36
+        press.mods = GHOSTTY_MODS_NONE
+        press.consumed_mods = GHOSTTY_MODS_NONE
+        press.composing = false
+        press.text = nil
+        press.unshifted_codepoint = 13
+        _ = ghostty_surface_key(surface, press)
+
+        var release = press
+        release.action = GHOSTTY_ACTION_RELEASE
+        _ = ghostty_surface_key(surface, release)
+    }
+
     var hasLiveSurface: Bool {
         surface != nil
     }

--- a/Muxy/Views/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Views/Terminal/TerminalViewRegistry.swift
@@ -29,6 +29,10 @@ final class TerminalViewRegistry {
     func needsConfirmQuit(for paneID: UUID) -> Bool {
         views[paneID]?.needsConfirmQuit() ?? false
     }
+
+    func view(for paneID: UUID) -> GhosttyTerminalNSView? {
+        views[paneID]
+    }
 }
 
 extension TerminalViewRegistry: TerminalViewRemoving {}

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -27,6 +27,11 @@ struct VCSTabView: View {
                 state.refresh()
             }
         }
+        .onChange(of: state.projectPath) {
+            if !state.hasCompletedInitialLoad, !state.isLoadingFiles {
+                state.refresh()
+            }
+        }
         .onChange(of: state.showPushUpstreamConfirmation) { _, show in
             guard show else { return }
             state.showPushUpstreamConfirmation = false

--- a/Muxy/Views/VCS/VCSWindowView.swift
+++ b/Muxy/Views/VCS/VCSWindowView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 struct VCSWindowView: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
-    @State private var vcsStates: [UUID: VCSTabState] = [:]
+    @Environment(WorktreeStore.self) private var worktreeStore
+    @State private var vcsStates: [WorktreeKey: VCSTabState] = [:]
     @State private var activeState: VCSTabState?
 
     private var activeProject: Project? {
@@ -30,27 +31,40 @@ struct VCSWindowView: View {
         .onChange(of: appState.activeProjectID) {
             synchronizeState()
         }
+        .onChange(of: appState.activeWorktreeID) {
+            synchronizeState()
+        }
         .onChange(of: projectStore.projects.map(\.id)) {
+            synchronizeState()
+        }
+        .onChange(of: worktreeStore.worktrees.mapValues { $0.map(\.id) }) {
             synchronizeState()
         }
     }
 
     private func synchronizeState() {
-        let validProjectIDs = Set(projectStore.projects.map(\.id))
-        vcsStates = vcsStates.filter { validProjectIDs.contains($0.key) }
+        vcsStates = vcsStates.filter { entry in
+            worktreeStore.list(for: entry.key.projectID)
+                .contains(where: { $0.id == entry.key.worktreeID })
+        }
 
-        guard let project = activeProject else {
+        guard let project = activeProject,
+              let key = appState.activeWorktreeKey(for: project.id)
+        else {
             activeState = nil
             return
         }
 
-        if let existing = vcsStates[project.id] {
+        if let existing = vcsStates[key] {
             activeState = existing
             return
         }
 
-        let state = VCSTabState(projectPath: project.path)
-        vcsStates[project.id] = state
+        let worktreePath = worktreeStore
+            .worktree(projectID: project.id, worktreeID: key.worktreeID)?
+            .path ?? project.path
+        let state = VCSTabState(projectPath: worktreePath)
+        vcsStates[key] = state
         activeState = state
     }
 }

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -53,8 +53,7 @@ struct TabAreaView: View {
                                     projectID: projectID,
                                     areaID: area.id,
                                     direction: direction,
-                                    position: position,
-                                    projectPath: area.projectPath
+                                    position: position
                                 )))
                             }
                         )

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -2,22 +2,31 @@ import SwiftUI
 
 struct TerminalArea: View {
     let project: Project
+    let worktreeKey: WorktreeKey
     let isActiveProject: Bool
     @Environment(AppState.self) private var appState
     @Environment(TabDragCoordinator.self) private var dragCoordinator
     @Environment(\.openWindow) private var openWindow
 
+    private var root: SplitNode? {
+        appState.workspaceRoots[worktreeKey]
+    }
+
+    private var focusedAreaID: UUID? {
+        appState.focusedAreaID[worktreeKey]
+    }
+
     private var rootIsTabArea: Bool {
-        guard let root = appState.workspaceRoot(for: project.id) else { return false }
+        guard let root else { return false }
         if case .tabArea = root { return true }
         return false
     }
 
     var body: some View {
-        if let root = appState.workspaceRoot(for: project.id) {
+        if let root {
             PaneNode(
                 node: root,
-                focusedAreaID: appState.focusedAreaID[project.id],
+                focusedAreaID: focusedAreaID,
                 isActiveProject: isActiveProject,
                 showTabStrip: !rootIsTabArea,
                 showVCSButton: false,
@@ -61,6 +70,7 @@ struct TerminalArea: View {
                 }
             )
             .onPreferenceChange(AreaFramePreferenceKey.self) { frames in
+                guard isActiveProject else { return }
                 dragCoordinator.setAreaFrames(frames, forProject: project.id)
             }
         }

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -58,8 +58,7 @@ struct TerminalArea: View {
                         projectID: project.id,
                         areaID: areaID,
                         direction: dir,
-                        position: .second,
-                        projectPath: project.path
+                        position: .second
                     )))
                 },
                 onCloseArea: { areaID in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ Muxy/
     ProjectPersistence.swift  JSON persistence for projects
     WorktreeStore.swift       @Observable store for per-project worktrees
     WorktreePersistence.swift JSON persistence for worktrees (one file per project)
+    ProjectOpenService.swift  Shared open-project flow used by commands and sidebar
     WorktreeSetupRunner.swift Dispatches .muxy/worktree.json setup commands to a new tab
     WorkspacePersistence.swift JSON persistence for workspaces
     JSONFilePersistence.swift Shared App Support directory helper

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,9 @@ Muxy/
     EditorTabState.swift      Code editor tab state (file content, cursor, save)
     EditorSettings.swift      @Observable editor preferences (font, word wrap, tab size)
     Project.swift             Project folder metadata
+    Worktree.swift            Per-project worktree slot (primary or git worktree)
+    WorktreeKey.swift         Hashable (projectID, worktreeID) key for workspace maps
+    WorktreeConfig.swift      Decoder for .muxy/worktree.json setup commands
     TerminalPaneState.swift   Per-pane terminal state
     TerminalSearchState.swift Terminal find-in-page state
   Services/
@@ -34,6 +37,7 @@ Muxy/
     GhosttyRuntimeEventAdapter.swift  C callback bridge from libghostty
     Git/
       GitRepositoryService.swift  Git command execution (actor)
+      GitWorktreeService.swift    git worktree list/add/remove (actor)
       GitDiffParser.swift         Diff patch parsing, context collapsing
       GitStatusParser.swift       Porcelain + numstat output parsing
       GitModels.swift             GitStatusFile, DiffDisplayRow, NumstatEntry
@@ -45,6 +49,9 @@ Muxy/
     KeyBindingPersistence.swift  JSON persistence for shortcuts
     ProjectStore.swift        @Observable store for projects list
     ProjectPersistence.swift  JSON persistence for projects
+    WorktreeStore.swift       @Observable store for per-project worktrees
+    WorktreePersistence.swift JSON persistence for worktrees (one file per project)
+    WorktreeSetupRunner.swift Dispatches .muxy/worktree.json setup commands to a new tab
     WorkspacePersistence.swift JSON persistence for workspaces
     JSONFilePersistence.swift Shared App Support directory helper
     ModifierKeyMonitor.swift  Global modifier key state tracking
@@ -57,6 +64,10 @@ Muxy/
   Views/
     MainWindow.swift          Main window layout (sidebar + workspace)
     Sidebar.swift             Project list sidebar
+    Sidebar/
+      ProjectRow.swift          Avatar + label row, worktree-chevron trigger on active row, ProjectAvatar
+      WorktreePopover.swift     Worktree picker popover triggered from the active project row
+      CreateWorktreeSheet.swift Sheet for creating a new git worktree
     ThemePicker.swift         Theme selection popover
     WelcomeView.swift         Empty state view
     Components/
@@ -100,6 +111,19 @@ Muxy/
       ShortcutBadge.swift     Shortcut label display
 ```
 
+## Hierarchy
+
+```
+Project → Worktree → SplitNode (splits/tab areas) → TerminalTab → Pane
+```
+
+Each project has at least one **primary** worktree pointing at `Project.path`. Git
+projects may add more worktrees via `git worktree add`, each with their own split
+tree, tabs, focus state, and working directory. Workspace state is keyed by
+`WorktreeKey(projectID, worktreeID)` in `AppState` so every per-project map is
+actually per-worktree. `AppState.activeWorktreeID[projectID]` tracks which
+worktree is currently visible for each project.
+
 ## Data Flow
 
 ```
@@ -115,6 +139,6 @@ User action → AppState.dispatch() → WorkspaceReducer.reduce()
 ## Key Integration Points
 
 - **GhosttyKit**: C module wrapping `ghostty.h`. Precompiled xcframework from `muxy-app/ghostty` fork. Surfaces created/destroyed via `TerminalViewRegistry`.
-- **Persistence**: All files in `~/Library/Application Support/Muxy/`. Shared directory helper: `MuxyFileStorage`.
+- **Persistence**: All files in `~/Library/Application Support/Muxy/`. Shared directory helper: `MuxyFileStorage`. Worktrees are persisted per-project at `worktrees/{projectID}.json`. Worktree setup commands live in-repo at `{Project.path}/.muxy/worktree.json`.
 - **Ghostty Config**: Managed by `MuxyConfig`, stored at `~/Library/Application Support/Muxy/ghostty.conf`. Seeded from `~/.config/ghostty/config` on first run.
 - **Updates**: Sparkle framework via `UpdateService`.


### PR DESCRIPTION
## Summary
- Add persistent worktree models, storage, and git worktree orchestration so each project can manage multiple worktrees.
- Refactor workspace state/reducer to key tabs and focus by project+worktree, preserving independent layouts per worktree.
- Update app wiring, commands, and sidebar UI to create/select/remove worktrees and keep project cleanup consistent.