### PR TITLE
Use opaque app backgrounds

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -215,14 +215,8 @@ struct WindowConfigurator: NSViewRepresentable {
     }
 
     private static func applyWindowBackground(_ window: NSWindow) {
-        let opacity = GhosttyService.shared.backgroundOpacity
-        if opacity < 1.0 {
-            window.isOpaque = false
-            window.backgroundColor = .clear
-        } else {
-            window.isOpaque = true
-            window.backgroundColor = MuxyTheme.nsBg
-        }
+        window.isOpaque = true
+        window.backgroundColor = MuxyTheme.nsBg
     }
 
     static let trafficLightY: CGFloat = 3.5

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -66,15 +66,6 @@ final class GhosttyService {
         self.config = cfg
     }
 
-    var backgroundOpacity: Double {
-        guard let config else { return 1.0 }
-        var value = 1.0
-        if ghostty_config_get(config, &value, "background-opacity", 18) {
-            return max(0, min(1, value))
-        }
-        return 1.0
-    }
-
     var backgroundColor: NSColor {
         configColor("background") ?? NSColor(srgbRed: 0.11, green: 0.11, blue: 0.14, alpha: 1)
     }

--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -16,10 +16,6 @@ enum MuxyTheme {
         Color(nsColor: GhosttyService.shared.accentColor.withAlphaComponent(0.1))
     }
 
-    @MainActor static var terminalBg: Color {
-        Color(nsColor: GhosttyService.shared.backgroundColor.withAlphaComponent(GhosttyService.shared.backgroundOpacity))
-    }
-
     @MainActor static var diffAddFg: Color { Color(nsColor: nsDiffAdd) }
     @MainActor static var diffRemoveFg: Color { Color(nsColor: nsDiffRemove) }
     @MainActor static var diffHunkFg: Color { Color(nsColor: nsDiffHunk) }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -73,7 +73,7 @@ struct MainWindow: View {
                 }
 
                 ZStack {
-                    MuxyTheme.terminalBg
+                    MuxyTheme.bg
                     if projectsWithWorkspaces.isEmpty {
                         WelcomeView()
                     } else if let project = activeProjectWithWorkspace,

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -19,7 +19,7 @@ struct VCSTabView: View {
             Rectangle().fill(MuxyTheme.border).frame(height: 1)
             content
         }
-        .background(MuxyTheme.terminalBg)
+        .background(MuxyTheme.bg)
         .contentShape(Rectangle())
         .onTapGesture(perform: onFocus)
         .onAppear {
@@ -654,14 +654,14 @@ private struct SectionSplitLayout: View {
             ProgressView()
                 .frame(maxWidth: .infinity)
                 .padding(14)
-                .background(MuxyTheme.terminalBg)
+                .background(MuxyTheme.bg)
         } else if let error = state.diffErrorsByPath[file.path] {
             Text(error)
                 .font(.system(size: 12))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
-                .background(MuxyTheme.terminalBg)
+                .background(MuxyTheme.bg)
         } else if let diff = state.diffsByPath[file.path] {
             VStack(spacing: 0) {
                 if diff.truncated {
@@ -691,14 +691,14 @@ private struct SectionSplitLayout: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(MuxyTheme.terminalBg)
+            .background(MuxyTheme.bg)
         } else {
             Text("No diff output")
                 .font(.system(size: 12))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
-                .background(MuxyTheme.terminalBg)
+                .background(MuxyTheme.bg)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove dynamic background opacity handling and always use opaque window/theme backgrounds.
- Replace terminal-specific translucent background usage in main and VCS views with the standard app background.
- Prevent transparency-related rendering issues by keeping the app window opaque.