### PR TITLE
Refresh editor highlight after edits

### DIFF
--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -551,6 +551,8 @@ struct CodeEditorView: NSViewRepresentable {
             resetPendingEditState()
             state.markModified()
             isUpdating = false
+            resetHighlightedRange()
+            highlightVisibleRange(force: true)
         }
 
         func textView(


### PR DESCRIPTION
- Reset stale highlighted range after text changes.
- Force highlight recomputation for the currently visible range.
- Keep syntax highlighting in sync immediately after edits.