### PR TITLE
Fix editor viewport click

### DIFF
--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -107,6 +107,40 @@ private final class CodeEditorLayoutManager: NSLayoutManager {
 
 final class ViewportContainerView: NSView {
     override var isFlipped: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let textView = subviews.first as? NSTextView else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        let pointInContainer = convert(event.locationInWindow, from: nil)
+        if textView.frame.contains(pointInContainer) {
+            super.mouseDown(with: event)
+            return
+        }
+
+        let clampedX = min(pointInContainer.x, textView.frame.maxX - 1)
+        let clampedY = min(max(pointInContainer.y, textView.frame.minY), textView.frame.maxY - 1)
+        let pointInTextView = NSPoint(x: clampedX, y: clampedY - textView.frame.origin.y)
+        let charIndex = textView.characterIndexForInsertion(at: pointInTextView)
+
+        textView.window?.makeFirstResponder(textView)
+
+        guard event.modifierFlags.contains(.shift) else {
+            textView.setSelectedRange(NSRange(location: charIndex, length: 0))
+            return
+        }
+
+        let current = textView.selectedRange()
+        let anchor = current.location
+        let newRange = if charIndex >= anchor {
+            NSRange(location: anchor, length: charIndex - anchor)
+        } else {
+            NSRange(location: charIndex, length: anchor - charIndex)
+        }
+        textView.setSelectedRange(newRange)
+    }
 }
 
 struct CodeEditorView: NSViewRepresentable {

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -101,7 +101,7 @@ struct EditorPane: View {
         }
         .background(MuxyTheme.bg)
         .contentShape(Rectangle())
-        .onTapGesture(perform: onFocus)
+        .simultaneousGesture(TapGesture().onEnded { onFocus() })
         .onReceive(NotificationCenter.default.publisher(for: .findInTerminal)) { _ in
             guard focused else { return }
             if !state.currentSelection.isEmpty {


### PR DESCRIPTION
Fix the editor’s viewport issue that when clicking on empty space it wasnt activating the row