### PR TITLE
Fix AttributeGraph cycle spam on tab switching

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -356,6 +356,24 @@ final class AppState {
     }
 
     func dispatch(_ action: Action) {
+        if case let .focusArea(projectID, areaID) = action,
+           let key = activeWorktreeKey(for: projectID),
+           focusedAreaID[key] == areaID
+        {
+            return
+        }
+
+        if case let .selectTab(projectID, areaID, tabID) = action,
+           let key = activeWorktreeKey(for: projectID),
+           let root = workspaceRoots[key],
+           let area = root.findArea(id: areaID),
+           area.activeTabID == tabID,
+           focusedAreaID[key] == areaID
+        {
+            return
+        }
+
+        let currentWorkspaceRootSignature = workspaceRootSignature(workspaceRoots)
         var workspace = WorkspaceState(
             activeProjectID: activeProjectID,
             activeWorktreeID: activeWorktreeID,
@@ -364,11 +382,21 @@ final class AppState {
             focusHistory: focusHistory
         )
         let effects = WorkspaceReducer.reduce(action: action, state: &workspace)
-        activeProjectID = workspace.activeProjectID
-        activeWorktreeID = workspace.activeWorktreeID
-        workspaceRoots = workspace.workspaceRoots
-        focusedAreaID = workspace.focusedAreaID
-        focusHistory = workspace.focusHistory
+        if activeProjectID != workspace.activeProjectID {
+            activeProjectID = workspace.activeProjectID
+        }
+        if activeWorktreeID != workspace.activeWorktreeID {
+            activeWorktreeID = workspace.activeWorktreeID
+        }
+        if currentWorkspaceRootSignature != workspaceRootSignature(workspace.workspaceRoots) {
+            workspaceRoots = workspace.workspaceRoots
+        }
+        if focusedAreaID != workspace.focusedAreaID {
+            focusedAreaID = workspace.focusedAreaID
+        }
+        if focusHistory != workspace.focusHistory {
+            focusHistory = workspace.focusHistory
+        }
         reconcilePendingClosures()
 
         for paneID in effects.paneIDsToRemove {
@@ -381,6 +409,10 @@ final class AppState {
 
         saveWorkspaces()
         saveSelection()
+    }
+
+    private func workspaceRootSignature(_ roots: [WorktreeKey: SplitNode]) -> [WorktreeKey: UUID] {
+        roots.mapValues(\.id)
     }
 
     private func clearPendingProcessCloseIfMatching(tabID: UUID, areaID: UUID, projectID: UUID) {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -98,6 +98,7 @@ final class TabArea: Identifiable {
     }
 
     func selectTab(_ tabID: UUID) {
+        guard activeTabID != tabID else { return }
         if let current = activeTabID, current != tabID {
             tabHistory.append(current)
         }

--- a/Muxy/Models/TabDragCoordinator.swift
+++ b/Muxy/Models/TabDragCoordinator.swift
@@ -39,13 +39,15 @@ final class TabDragCoordinator {
     }
 
     var activeDrag: DragInfo?
-    var globalPosition: CGPoint = .zero
-    var areaFramesByProject: [UUID: [UUID: CGRect]] = [:]
+    @ObservationIgnored var globalPosition: CGPoint = .zero
+    @ObservationIgnored var areaFramesByProject: [UUID: [UUID: CGRect]] = [:]
     private(set) var hoveredAreaID: UUID?
     private(set) var hoveredZone: DropZone?
 
     func setAreaFrames(_ frames: [UUID: CGRect], forProject projectID: UUID) {
+        guard areaFramesByProject[projectID] != frames else { return }
         areaFramesByProject[projectID] = frames
+        computeHover()
     }
 
     func beginDrag(tabID: UUID, sourceAreaID: UUID, projectID: UUID) {
@@ -109,12 +111,15 @@ final class TabDragCoordinator {
     }
 
     private func computeHover() {
-        hoveredAreaID = nil
-        hoveredZone = nil
+        var nextHoveredAreaID: UUID?
+        var nextHoveredZone: DropZone?
 
         guard let projectID = activeDrag?.projectID,
               let frames = areaFramesByProject[projectID]
-        else { return }
+        else {
+            updateHover(areaID: nil, zone: nil)
+            return
+        }
 
         var containingMatch: HoverMatch?
         for (areaID, frame) in frames {
@@ -130,8 +135,9 @@ final class TabDragCoordinator {
         }
 
         if let containingMatch {
-            hoveredAreaID = containingMatch.areaID
-            hoveredZone = zone(for: globalPosition, in: containingMatch.frame)
+            nextHoveredAreaID = containingMatch.areaID
+            nextHoveredZone = zone(for: globalPosition, in: containingMatch.frame)
+            updateHover(areaID: nextHoveredAreaID, zone: nextHoveredZone)
             return
         }
 
@@ -148,10 +154,23 @@ final class TabDragCoordinator {
             nearestMatch = HoverMatch(areaID: areaID, frame: frame, metric: distance)
         }
 
-        guard let nearestMatch else { return }
+        guard let nearestMatch else {
+            updateHover(areaID: nil, zone: nil)
+            return
+        }
         let clampedPosition = clamped(globalPosition, to: nearestMatch.frame)
-        hoveredAreaID = nearestMatch.areaID
-        hoveredZone = zone(for: clampedPosition, in: nearestMatch.frame)
+        nextHoveredAreaID = nearestMatch.areaID
+        nextHoveredZone = zone(for: clampedPosition, in: nearestMatch.frame)
+        updateHover(areaID: nextHoveredAreaID, zone: nextHoveredZone)
+    }
+
+    private func updateHover(areaID: UUID?, zone: DropZone?) {
+        if hoveredAreaID != areaID {
+            hoveredAreaID = areaID
+        }
+        if hoveredZone != zone {
+            hoveredZone = zone
+        }
     }
 
     private func distance(from point: CGPoint, to rect: CGRect) -> CGFloat {

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -5,15 +5,26 @@ import Foundation
 final class TerminalPaneState: Identifiable {
     let id = UUID()
     let projectPath: String
-    var title: String = "Terminal"
+    var title: String
     let searchState = TerminalSearchState()
+    @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
 
     init(projectPath: String) {
         self.projectPath = projectPath
+        self.title = "Terminal"
     }
 
     init(projectPath: String, title: String) {
         self.projectPath = projectPath
         self.title = title
+    }
+
+    func setTitle(_ newTitle: String) {
+        titleDebounceTask?.cancel()
+        titleDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled, let self, self.title != newTitle else { return }
+            self.title = newTitle
+        }
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -240,12 +240,13 @@ struct MainWindow: View {
            case let .tabArea(area) = root
         {
             PaneTabStrip(
-                area: area,
+                areaID: area.id,
+                tabs: PaneTabStrip.snapshots(from: area.tabs),
+                activeTabID: area.activeTabID,
                 isFocused: true,
                 isWindowTitleBar: true,
                 showVCSButton: true,
                 projectID: project.id,
-                onFocus: {},
                 onSelectTab: { tabID in
                     appState.dispatch(.selectTab(projectID: project.id, areaID: area.id, tabID: tabID))
                 },
@@ -266,11 +267,21 @@ struct MainWindow: View {
                         position: .second
                     )))
                 },
-                onClose: {
-                    appState.dispatch(.closeArea(projectID: project.id, areaID: area.id))
-                },
                 onDropAction: { result in
                     appState.dispatch(result.action(projectID: project.id))
+                },
+                onCreateTabAdjacent: { tabID, side in
+                    area.createTabAdjacent(to: tabID, side: side)
+                },
+                onTogglePin: { tabID in
+                    area.togglePin(tabID)
+                },
+                onSetCustomTitle: { tabID, title in
+                    guard let tab = area.tabs.first(where: { $0.id == tabID }) else { return }
+                    tab.customTitle = title
+                },
+                onReorderTab: { fromOffsets, toOffset in
+                    area.reorderTab(fromOffsets: fromOffsets, toOffset: toOffset)
                 }
             )
         } else {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -215,7 +215,9 @@ final class GhosttyTerminalNSView: NSView {
         let result = super.becomeFirstResponder()
         if result {
             ghostty_surface_set_focus(surface, true)
-            onFocus?()
+            DispatchQueue.main.async { [weak self] in
+                self?.onFocus?()
+            }
         }
         return result
     }
@@ -369,7 +371,9 @@ final class GhosttyTerminalNSView: NSView {
         window?.makeFirstResponder(self)
         if alreadyFirstResponder {
             ghostty_surface_set_focus(surface, true)
-            onFocus?()
+            DispatchQueue.main.async { [weak self] in
+                self?.onFocus?()
+            }
         }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -14,7 +14,6 @@ struct TerminalPane: View {
             TerminalBridge(
                 state: state,
                 focused: focused,
-                visible: visible,
                 onFocus: onFocus,
                 onProcessExit: onProcessExit,
                 onSplitRequest: onSplitRequest
@@ -48,7 +47,6 @@ struct TerminalPane: View {
 struct TerminalBridge: NSViewRepresentable {
     let state: TerminalPaneState
     let focused: Bool
-    let visible: Bool
     let onFocus: () -> Void
     let onProcessExit: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
@@ -57,7 +55,6 @@ struct TerminalBridge: NSViewRepresentable {
     final class Coordinator {
         var wasFocused = false
         var wasOverlayActive = false
-        var paneID: UUID?
     }
 
     func makeCoordinator() -> Coordinator {
@@ -69,16 +66,17 @@ struct TerminalBridge: NSViewRepresentable {
         let view = registry.view(for: state.id, workingDirectory: state.projectPath)
         view.isFocused = focused
         view.overlayActive = overlayActive
-        view.isHidden = !visible
         view.onFocus = onFocus
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
         view.onTitleChange = { [weak state] title in
-            state?.title = title
+            DispatchQueue.main.async {
+                guard let state, state.title != title else { return }
+                state.title = title
+            }
         }
         configureSearchCallbacks(view)
         context.coordinator.wasFocused = focused
-        context.coordinator.paneID = state.id
         if focused, !overlayActive {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 view.window?.makeFirstResponder(view)
@@ -88,13 +86,15 @@ struct TerminalBridge: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: GhosttyTerminalNSView, context: Context) {
-        nsView.isHidden = !visible
         nsView.overlayActive = overlayActive
         nsView.onFocus = onFocus
         nsView.onProcessExit = onProcessExit
         nsView.onSplitRequest = onSplitRequest
         nsView.onTitleChange = { [weak state] title in
-            state?.title = title
+            DispatchQueue.main.async {
+                guard let state, state.title != title else { return }
+                state.title = title
+            }
         }
         configureSearchCallbacks(nsView)
         let wasFocused = context.coordinator.wasFocused
@@ -107,13 +107,15 @@ struct TerminalBridge: NSViewRepresentable {
             if nsView.window?.firstResponder === nsView || nsView.window?.firstResponder === nsView.inputContext {
                 nsView.window?.makeFirstResponder(nil)
             }
-            nsView.notifySurfaceUnfocused()
+            if !wasOverlayActive {
+                nsView.notifySurfaceUnfocused()
+            }
         } else if focused, !wasFocused || wasOverlayActive {
             nsView.notifySurfaceFocused()
             DispatchQueue.main.async {
                 nsView.window?.makeFirstResponder(nsView)
             }
-        } else if !focused {
+        } else if !focused, wasFocused {
             nsView.notifySurfaceUnfocused()
         }
     }

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -71,8 +71,7 @@ struct TerminalBridge: NSViewRepresentable {
         view.onSplitRequest = onSplitRequest
         view.onTitleChange = { [weak state] title in
             DispatchQueue.main.async {
-                guard let state, state.title != title else { return }
-                state.title = title
+                state?.setTitle(title)
             }
         }
         configureSearchCallbacks(view)
@@ -92,8 +91,7 @@ struct TerminalBridge: NSViewRepresentable {
         nsView.onSplitRequest = onSplitRequest
         nsView.onTitleChange = { [weak state] title in
             DispatchQueue.main.async {
-                guard let state, state.title != title else { return }
-                state.title = title
+                state?.setTitle(title)
             }
         }
         configureSearchCallbacks(nsView)

--- a/Muxy/Views/Workspace/PaneNode.swift
+++ b/Muxy/Views/Workspace/PaneNode.swift
@@ -34,7 +34,6 @@ struct PaneNode: View {
                 onCloseTab: { tabID in onCloseTab(area.id, tabID) },
                 onForceCloseTab: { tabID in onForceCloseTab(area.id, tabID) },
                 onSplit: { dir in onSplit(area.id, dir) },
-                onClose: { onCloseArea(area.id) },
                 onDropAction: onDropAction
             )
         case let .split(branch):

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -14,7 +14,6 @@ struct TabAreaView: View {
     let onCloseTab: (UUID) -> Void
     let onForceCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
-    let onClose: () -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
     @Environment(TabDragCoordinator.self) private var dragCoordinator
     @Environment(AppState.self) private var appState
@@ -23,44 +22,55 @@ struct TabAreaView: View {
         VStack(spacing: 0) {
             if showTabStrip {
                 PaneTabStrip(
-                    area: area,
+                    areaID: area.id,
+                    tabs: PaneTabStrip.snapshots(from: area.tabs),
+                    activeTabID: area.activeTabID,
                     isFocused: isFocused,
                     showVCSButton: showVCSButton,
                     projectID: projectID,
-                    onFocus: onFocus,
                     onSelectTab: onSelectTab,
                     onCreateTab: onCreateTab,
                     onCreateVCSTab: onCreateVCSTab,
                     onCloseTab: onCloseTab,
                     onSplit: onSplit,
-                    onClose: onClose,
-                    onDropAction: onDropAction
+                    onDropAction: onDropAction,
+                    onCreateTabAdjacent: { tabID, side in
+                        area.createTabAdjacent(to: tabID, side: side)
+                    },
+                    onTogglePin: { tabID in
+                        area.togglePin(tabID)
+                    },
+                    onSetCustomTitle: { tabID, title in
+                        guard let tab = area.tabs.first(where: { $0.id == tabID }) else { return }
+                        tab.customTitle = title
+                    },
+                    onReorderTab: { fromOffsets, toOffset in
+                        area.reorderTab(fromOffsets: fromOffsets, toOffset: toOffset)
+                    }
                 )
                 Rectangle().fill(MuxyTheme.border).frame(height: 1)
             }
             ZStack {
                 ForEach(area.tabs) { tab in
                     let isActive = tab.id == area.activeTabID
-                    if shouldMount(tab: tab, isActive: isActive) {
-                        TabContentView(
-                            tab: tab,
-                            focused: isActive && isFocused && isActiveProject,
-                            visible: isActive,
-                            onFocus: onFocus,
-                            onProcessExit: { onForceCloseTab(tab.id) },
-                            onSplitRequest: { direction, position in
-                                appState.dispatch(.splitArea(.init(
-                                    projectID: projectID,
-                                    areaID: area.id,
-                                    direction: direction,
-                                    position: position
-                                )))
-                            }
-                        )
-                        .zIndex(isActive ? 1 : 0)
-                        .opacity(isActive ? 1 : 0)
-                        .allowsHitTesting(isActive)
-                    }
+                    TabContentView(
+                        tab: tab,
+                        focused: isActive && isFocused && isActiveProject,
+                        visible: isActive,
+                        onFocus: onFocus,
+                        onProcessExit: { onForceCloseTab(tab.id) },
+                        onSplitRequest: { direction, position in
+                            appState.dispatch(.splitArea(.init(
+                                projectID: projectID,
+                                areaID: area.id,
+                                direction: direction,
+                                position: position
+                            )))
+                        }
+                    )
+                    .zIndex(isActive ? 1 : 0)
+                    .opacity(isActive ? 1 : 0)
+                    .allowsHitTesting(isActive)
                 }
             }
             .overlay {
@@ -71,12 +81,16 @@ struct TabAreaView: View {
                 }
             }
         }
-        .background(GeometryReader { geo in
-            Color.clear.preference(
-                key: AreaFramePreferenceKey.self,
-                value: [area.id: geo.frame(in: .named(DragCoordinateSpace.mainWindow))]
-            )
-        })
+        .background {
+            if dragCoordinator.activeDrag != nil {
+                GeometryReader { geo in
+                    Color.clear.preference(
+                        key: AreaFramePreferenceKey.self,
+                        value: [area.id: geo.frame(in: .named(DragCoordinateSpace.mainWindow))]
+                    )
+                }
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .findInTerminal)) { _ in
             guard isFocused, isActiveProject else { return }
             guard let tabID = area.activeTabID,
@@ -98,16 +112,6 @@ struct TabAreaView: View {
                     appState.pendingSaveErrorMessage = error.localizedDescription
                 }
             }
-        }
-    }
-
-    private func shouldMount(tab: TerminalTab, isActive: Bool) -> Bool {
-        switch tab.content {
-        case .terminal:
-            true
-        case .vcs,
-             .editor:
-            isActive
         }
     }
 }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -31,22 +31,9 @@ struct PaneTabStrip: View {
 
     static func snapshots(from tabs: [TerminalTab]) -> [TabSnapshot] {
         tabs.map { tab in
-            let title: String = if let customTitle = tab.customTitle {
-                customTitle
-            } else {
-                switch tab.kind {
-                case .terminal:
-                    "Terminal"
-                case .vcs:
-                    "Git Diff"
-                case .editor:
-                    tab.content.editorState?.displayTitle ?? "Editor"
-                }
-            }
-
-            return TabSnapshot(
+            TabSnapshot(
                 id: tab.id,
-                title: title,
+                title: tab.title,
                 kind: tab.kind,
                 isPinned: tab.isPinned,
                 hasCustomTitle: tab.customTitle != nil

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -1,46 +1,83 @@
 import SwiftUI
 
 struct PaneTabStrip: View {
-    let area: TabArea
+    struct TabSnapshot: Identifiable {
+        let id: UUID
+        let title: String
+        let kind: TerminalTab.Kind
+        let isPinned: Bool
+        let hasCustomTitle: Bool
+    }
+
+    let areaID: UUID
+    let tabs: [TabSnapshot]
+    let activeTabID: UUID?
     let isFocused: Bool
     var isWindowTitleBar: Bool = false
     var showVCSButton = true
     let projectID: UUID
-    let onFocus: () -> Void
     let onSelectTab: (UUID) -> Void
     let onCreateTab: () -> Void
     let onCreateVCSTab: () -> Void
     let onCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
-    let onClose: () -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    let onCreateTabAdjacent: (UUID, TabArea.InsertSide) -> Void
+    let onTogglePin: (UUID) -> Void
+    let onSetCustomTitle: (UUID, String?) -> Void
+    let onReorderTab: (IndexSet, Int) -> Void
     @Environment(TabDragCoordinator.self) private var dragCoordinator
     @State private var dragState = TabDragState()
 
+    static func snapshots(from tabs: [TerminalTab]) -> [TabSnapshot] {
+        tabs.map { tab in
+            let title: String = if let customTitle = tab.customTitle {
+                customTitle
+            } else {
+                switch tab.kind {
+                case .terminal:
+                    "Terminal"
+                case .vcs:
+                    "Git Diff"
+                case .editor:
+                    tab.content.editorState?.displayTitle ?? "Editor"
+                }
+            }
+
+            return TabSnapshot(
+                id: tab.id,
+                title: title,
+                kind: tab.kind,
+                isPinned: tab.isPinned,
+                hasCustomTitle: tab.customTitle != nil
+            )
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(Array(area.tabs.enumerated()), id: \.element.id) { index, tab in
+            ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
                 TabCell(
                     tab: tab,
-                    active: tab.id == area.activeTabID,
+                    active: tab.id == activeTabID,
                     paneFocused: isFocused,
                     isAnyDragging: dragState.draggedID != nil,
                     shortcutIndex: index < 9 ? index + 1 : nil,
                     onSelect: {
-                        onFocus()
                         onSelectTab(tab.id)
                     },
                     onClose: { onCloseTab(tab.id) },
-                    onCreateLeft: { area.createTabAdjacent(to: tab.id, side: .left) },
-                    onCreateRight: { area.createTabAdjacent(to: tab.id, side: .right) },
-                    onTogglePin: { area.togglePin(tab.id) }
+                    onCreateLeft: { onCreateTabAdjacent(tab.id, .left) },
+                    onCreateRight: { onCreateTabAdjacent(tab.id, .right) },
+                    onTogglePin: { onTogglePin(tab.id) },
+                    onSetCustomTitle: { onSetCustomTitle(tab.id, $0) }
                 )
                 .background {
                     if dragState.draggedID != nil {
                         GeometryReader { geo in
                             Color.clear.preference(
                                 key: TabFramePreferenceKey.self,
-                                value: [tab.id: geo.frame(in: .named("tabstrip-\(area.id)"))]
+                                value: [tab.id: geo.frame(in: .named(DragCoordinateSpace.mainWindow))]
                             )
                         }
                     }
@@ -48,7 +85,11 @@ struct PaneTabStrip: View {
                 .gesture(
                     DragGesture(minimumDistance: 4, coordinateSpace: .named(DragCoordinateSpace.mainWindow))
                         .onChanged { value in
-                            handleDragChanged(tab: tab, globalLocation: value.location)
+                            handleDragChanged(
+                                tab: tab,
+                                globalLocation: value.location,
+                                dragStartGlobalLocation: value.startLocation
+                            )
                         }
                         .onEnded { _ in
                             handleDragEnded()
@@ -56,7 +97,6 @@ struct PaneTabStrip: View {
                 )
                 .onTapGesture {
                     guard dragState.draggedID == nil else { return }
-                    onFocus()
                     onSelectTab(tab.id)
                 }
             }
@@ -88,25 +128,21 @@ struct PaneTabStrip: View {
             .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
         }
         .frame(height: 32)
-        .background(GeometryReader { geo in
-            Color.clear
-                .onAppear { dragState.stripFrameGlobal = geo.frame(in: .named(DragCoordinateSpace.mainWindow)) }
-                .onChange(of: geo.frame(in: .named(DragCoordinateSpace.mainWindow))) { _, newFrame in
-                    dragState.stripFrameGlobal = newFrame
-                }
-        })
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
             guard dragState.draggedID != nil else { return }
             dragState.frames = frames
         }
-        .coordinateSpace(name: "tabstrip-\(area.id)")
     }
 
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {
         "\(name) (\(KeyBindingStore.shared.combo(for: action).displayString))"
     }
 
-    private func handleDragChanged(tab: TerminalTab, globalLocation: CGPoint) {
+    private func handleDragChanged(
+        tab: TabSnapshot,
+        globalLocation: CGPoint,
+        dragStartGlobalLocation: CGPoint
+    ) {
         if dragState.draggedID == nil {
             dragState.draggedID = tab.id
             dragState.lastReorderTargetID = nil
@@ -117,20 +153,16 @@ struct PaneTabStrip: View {
             return
         }
 
-        let stripFrame = dragState.stripFrameGlobal
-        let verticalEscape = globalLocation.y < stripFrame.minY - 20
-            || globalLocation.y > stripFrame.maxY + 20
+        let verticalEscape = abs(globalLocation.y - dragStartGlobalLocation.y) > 24
 
         if verticalEscape, !tab.isPinned {
             dragState.isInSplitMode = true
-            dragCoordinator.beginDrag(tabID: tab.id, sourceAreaID: area.id, projectID: projectID)
+            dragCoordinator.beginDrag(tabID: tab.id, sourceAreaID: areaID, projectID: projectID)
             dragCoordinator.updatePosition(globalLocation)
             return
         }
 
-        let localX = globalLocation.x - stripFrame.minX
-        let localY = globalLocation.y - stripFrame.minY
-        reorderIfNeeded(at: CGPoint(x: localX, y: localY))
+        reorderIfNeeded(at: globalLocation)
     }
 
     private func handleDragEnded() {
@@ -156,14 +188,14 @@ struct PaneTabStrip: View {
             hoveredTargetID = id
             guard dragState.lastReorderTargetID != id else { return }
 
-            guard let sourceIndex = area.tabs.firstIndex(where: { $0.id == draggedID }),
-                  let destIndex = area.tabs.firstIndex(where: { $0.id == id })
+            guard let sourceIndex = tabs.firstIndex(where: { $0.id == draggedID }),
+                  let destIndex = tabs.firstIndex(where: { $0.id == id })
             else { return }
 
             dragState.lastReorderTargetID = id
             let offset = destIndex > sourceIndex ? destIndex + 1 : destIndex
             withAnimation(.easeInOut(duration: 0.15)) {
-                area.reorderTab(fromOffsets: IndexSet(integer: sourceIndex), toOffset: offset)
+                onReorderTab(IndexSet(integer: sourceIndex), offset)
             }
             return
         }
@@ -178,14 +210,13 @@ private struct TabDragState {
     var draggedID: UUID?
     var frames: [UUID: CGRect] = [:]
     var isInSplitMode = false
-    var stripFrameGlobal: CGRect = .zero
     var lastReorderTargetID: UUID?
 }
 
 private typealias TabFramePreferenceKey = UUIDFramePreferenceKey<TabFrameTag>
 
 private struct TabCell: View {
-    @Bindable var tab: TerminalTab
+    let tab: PaneTabStrip.TabSnapshot
     let active: Bool
     let paneFocused: Bool
     var isAnyDragging: Bool = false
@@ -195,6 +226,7 @@ private struct TabCell: View {
     let onCreateLeft: () -> Void
     let onCreateRight: () -> Void
     let onTogglePin: () -> Void
+    let onSetCustomTitle: (String?) -> Void
     @State private var hovered = false
     @State private var isRenaming = false
     @State private var renameText = ""
@@ -278,8 +310,8 @@ private struct TabCell: View {
                 Button("New Tab to the Right") { onCreateRight() }
                 Divider()
                 Button("Rename Tab") { startRename() }
-                if tab.customTitle != nil {
-                    Button("Reset Title") { tab.customTitle = nil }
+                if tab.hasCustomTitle {
+                    Button("Reset Title") { onSetCustomTitle(nil) }
                 }
                 Divider()
                 Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
@@ -307,7 +339,7 @@ private struct TabCell: View {
 
     private func commitRename() {
         let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-        tab.customTitle = trimmed.isEmpty ? nil : trimmed
+        onSetCustomTitle(trimmed.isEmpty ? nil : trimmed)
         isRenaming = false
     }
 

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -69,7 +69,7 @@ struct TerminalArea: View {
                 }
             )
             .onPreferenceChange(AreaFramePreferenceKey.self) { frames in
-                guard isActiveProject else { return }
+                guard isActiveProject, dragCoordinator.activeDrag != nil else { return }
                 dragCoordinator.setAreaFrames(frames, forProject: project.id)
             }
         }


### PR DESCRIPTION
## Summary
- Eliminate re-entrant focus and tab-selection updates that were repeatedly invalidating SwiftUI state.
- Decouple tab strip rendering from live observable tab models and simplify tab actions to reduce observation feedback loops.
- Gate drag frame preference updates to active drags and keep tab content mounted to avoid mount/unmount churn during tab switches.