### PR TITLE
Add configurable quick-open editor

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -24,6 +24,7 @@ final class AppState {
         case createTab(projectID: UUID, areaID: UUID?)
         case createVCSTab(projectID: UUID, areaID: UUID?)
         case createEditorTab(projectID: UUID, areaID: UUID?, filePath: String)
+        case createExternalEditorTab(projectID: UUID, areaID: UUID?, filePath: String, command: String)
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTabByIndex(projectID: UUID, areaID: UUID?, index: Int)
@@ -185,6 +186,14 @@ final class AppState {
     }
 
     func openFile(_ filePath: String, projectID: UUID) {
+        let settings = EditorSettings.shared
+        if settings.quickOpenEditor == .terminalCommand {
+            let command = settings.externalEditorCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !command.isEmpty {
+                openFileInExternalEditor(filePath, projectID: projectID, command: command)
+                return
+            }
+        }
         for area in allAreas(for: projectID) {
             if let tab = area.tabs.first(where: { $0.content.editorState?.filePath == filePath }) {
                 dispatch(.selectTab(projectID: projectID, areaID: area.id, tabID: tab.id))
@@ -192,6 +201,16 @@ final class AppState {
             }
         }
         dispatch(.createEditorTab(projectID: projectID, areaID: nil, filePath: filePath))
+    }
+
+    private func openFileInExternalEditor(_ filePath: String, projectID: UUID, command: String) {
+        for area in allAreas(for: projectID) {
+            if let tab = area.tabs.first(where: { $0.content.pane?.externalEditorFilePath == filePath }) {
+                dispatch(.selectTab(projectID: projectID, areaID: area.id, tabID: tab.id))
+                return
+            }
+        }
+        dispatch(.createExternalEditorTab(projectID: projectID, areaID: nil, filePath: filePath, command: command))
     }
 
     func closeTab(_ tabID: UUID, projectID: UUID) {

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -187,7 +187,7 @@ final class AppState {
 
     func openFile(_ filePath: String, projectID: UUID) {
         let settings = EditorSettings.shared
-        if settings.quickOpenEditor == .terminalCommand {
+        if settings.defaultEditor == .terminalCommand {
             let command = settings.externalEditorCommand.trimmingCharacters(in: .whitespacesAndNewlines)
             if !command.isEmpty {
                 openFileInExternalEditor(filePath, projectID: projectID, command: command)

--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -8,7 +8,7 @@ private let logger = Logger(subsystem: "app.muxy", category: "EditorSettings")
 final class EditorSettings {
     static let shared = EditorSettings()
 
-    enum QuickOpenEditor: String, Codable, CaseIterable, Identifiable {
+    enum DefaultEditor: String, Codable, CaseIterable, Identifiable {
         case builtIn
         case terminalCommand
 
@@ -32,7 +32,7 @@ final class EditorSettings {
     var syntaxHighlighting: Bool = true { didSet { save() } }
     var bracketMatching: Bool = true { didSet { save() } }
     var currentLineHighlight: Bool = true { didSet { save() } }
-    var quickOpenEditor: QuickOpenEditor = .builtIn { didSet { save() } }
+    var defaultEditor: DefaultEditor = .builtIn { didSet { save() } }
     var externalEditorCommand: String = "vim" { didSet { save() } }
 
     @ObservationIgnored private let fileURL: URL
@@ -73,7 +73,7 @@ final class EditorSettings {
         syntaxHighlighting = true
         bracketMatching = true
         currentLineHighlight = true
-        quickOpenEditor = .builtIn
+        defaultEditor = .builtIn
         externalEditorCommand = "vim"
         isBatchLoading = false
         save()
@@ -93,7 +93,7 @@ final class EditorSettings {
             syntaxHighlighting = snapshot.syntaxHighlighting ?? true
             bracketMatching = snapshot.bracketMatching ?? true
             currentLineHighlight = snapshot.currentLineHighlight ?? true
-            quickOpenEditor = snapshot.quickOpenEditor ?? .builtIn
+            defaultEditor = snapshot.defaultEditor ?? snapshot.quickOpenEditor ?? .builtIn
             externalEditorCommand = snapshot.externalEditorCommand ?? "vim"
             isBatchLoading = false
         } catch {
@@ -113,7 +113,8 @@ final class EditorSettings {
                 syntaxHighlighting: syntaxHighlighting,
                 bracketMatching: bracketMatching,
                 currentLineHighlight: currentLineHighlight,
-                quickOpenEditor: quickOpenEditor,
+                defaultEditor: defaultEditor,
+                quickOpenEditor: nil,
                 externalEditorCommand: externalEditorCommand
             )
             let encoder = JSONEncoder()
@@ -139,6 +140,7 @@ private struct Snapshot: Codable {
     let syntaxHighlighting: Bool?
     let bracketMatching: Bool?
     let currentLineHighlight: Bool?
-    let quickOpenEditor: EditorSettings.QuickOpenEditor?
+    let defaultEditor: EditorSettings.DefaultEditor?
+    let quickOpenEditor: EditorSettings.DefaultEditor?
     let externalEditorCommand: String?
 }

--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -8,6 +8,22 @@ private let logger = Logger(subsystem: "app.muxy", category: "EditorSettings")
 final class EditorSettings {
     static let shared = EditorSettings()
 
+    enum QuickOpenEditor: String, Codable, CaseIterable, Identifiable {
+        case builtIn
+        case terminalCommand
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .builtIn:
+                "Built-in Editor"
+            case .terminalCommand:
+                "Terminal Command"
+            }
+        }
+    }
+
     var fontSize: CGFloat = 13 { didSet { save() } }
     var fontFamily: String = "SF Mono" { didSet { save() } }
     var wordWrap: Bool = true { didSet { save() } }
@@ -16,6 +32,8 @@ final class EditorSettings {
     var syntaxHighlighting: Bool = true { didSet { save() } }
     var bracketMatching: Bool = true { didSet { save() } }
     var currentLineHighlight: Bool = true { didSet { save() } }
+    var quickOpenEditor: QuickOpenEditor = .builtIn { didSet { save() } }
+    var externalEditorCommand: String = "vim" { didSet { save() } }
 
     @ObservationIgnored private let fileURL: URL
     @ObservationIgnored private var isBatchLoading = false
@@ -55,6 +73,8 @@ final class EditorSettings {
         syntaxHighlighting = true
         bracketMatching = true
         currentLineHighlight = true
+        quickOpenEditor = .builtIn
+        externalEditorCommand = "vim"
         isBatchLoading = false
         save()
     }
@@ -73,6 +93,8 @@ final class EditorSettings {
             syntaxHighlighting = snapshot.syntaxHighlighting ?? true
             bracketMatching = snapshot.bracketMatching ?? true
             currentLineHighlight = snapshot.currentLineHighlight ?? true
+            quickOpenEditor = snapshot.quickOpenEditor ?? .builtIn
+            externalEditorCommand = snapshot.externalEditorCommand ?? "vim"
             isBatchLoading = false
         } catch {
             logger.error("Failed to load editor settings: \(error.localizedDescription)")
@@ -90,7 +112,9 @@ final class EditorSettings {
                 tabSize: tabSize,
                 syntaxHighlighting: syntaxHighlighting,
                 bracketMatching: bracketMatching,
-                currentLineHighlight: currentLineHighlight
+                currentLineHighlight: currentLineHighlight,
+                quickOpenEditor: quickOpenEditor,
+                externalEditorCommand: externalEditorCommand
             )
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -115,4 +139,6 @@ private struct Snapshot: Codable {
     let syntaxHighlighting: Bool?
     let bracketMatching: Bool?
     let currentLineHighlight: Bool?
+    let quickOpenEditor: EditorSettings.QuickOpenEditor?
+    let externalEditorCommand: String?
 }

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -70,6 +70,43 @@ final class TabArea: Identifiable {
         insertTab(TerminalTab(editorState: EditorTabState(projectPath: projectPath, filePath: filePath)))
     }
 
+    func createExternalEditorTab(filePath: String, command: String) {
+        if let existing = tabs.first(where: { $0.content.pane?.externalEditorFilePath == filePath }) {
+            selectTab(existing.id)
+            return
+        }
+        let title = "\(commandTitle(command)) \(URL(fileURLWithPath: filePath).lastPathComponent)"
+        let pane = TerminalPaneState(
+            projectPath: projectPath,
+            title: title,
+            startupCommand: Self.editorLaunchCommand(command: command, filePath: filePath),
+            externalEditorFilePath: filePath
+        )
+        insertTab(TerminalTab(pane: pane))
+    }
+
+    private static func editorLaunchCommand(command: String, filePath: String) -> String {
+        let escapedPath = shellEscapedPath(filePath)
+        if command.contains("{file}") {
+            return command.replacingOccurrences(of: "{file}", with: escapedPath)
+        }
+        return command + " " + escapedPath
+    }
+
+    private func commandTitle(_ command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.split(separator: " ").first else { return "Editor" }
+        return String(first)
+    }
+
+    private static func shellEscapedPath(_ path: String) -> String {
+        let needsQuoting = path.contains { character in
+            character.isWhitespace || "'\"\\&|;$`!()[]{}<>*?".contains(character)
+        }
+        guard needsQuoting else { return path }
+        return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
     private func insertTab(_ tab: TerminalTab) {
         tabs.append(tab)
         if let current = activeTabID {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -75,7 +75,7 @@ final class TabArea: Identifiable {
             selectTab(existing.id)
             return
         }
-        let title = "\(commandTitle(command)) \(URL(fileURLWithPath: filePath).lastPathComponent)"
+        let title = "\(Self.commandTitle(command)) \(URL(fileURLWithPath: filePath).lastPathComponent)"
         let pane = TerminalPaneState(
             projectPath: projectPath,
             title: title,
@@ -85,15 +85,14 @@ final class TabArea: Identifiable {
         insertTab(TerminalTab(pane: pane))
     }
 
-    private static func editorLaunchCommand(command: String, filePath: String) -> String {
-        let escapedPath = shellEscapedPath(filePath)
+    static func editorLaunchCommand(command: String, filePath: String) -> String {
         if command.contains("{file}") {
-            return command.replacingOccurrences(of: "{file}", with: escapedPath)
+            return command.replacingOccurrences(of: "{file}", with: filePath)
         }
-        return command + " " + escapedPath
+        return command + " " + shellEscapedPath(filePath)
     }
 
-    private func commandTitle(_ command: String) -> String {
+    private static func commandTitle(_ command: String) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let first = trimmed.split(separator: " ").first else { return "Editor" }
         return String(first)

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -6,17 +6,30 @@ final class TerminalPaneState: Identifiable {
     let id = UUID()
     let projectPath: String
     var title: String
+    let startupCommand: String?
+    let externalEditorFilePath: String?
     let searchState = TerminalSearchState()
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
 
     init(projectPath: String) {
         self.projectPath = projectPath
         self.title = "Terminal"
+        self.startupCommand = nil
+        self.externalEditorFilePath = nil
     }
 
     init(projectPath: String, title: String) {
         self.projectPath = projectPath
         self.title = title
+        self.startupCommand = nil
+        self.externalEditorFilePath = nil
+    }
+
+    init(projectPath: String, title: String, startupCommand: String, externalEditorFilePath: String) {
+        self.projectPath = projectPath
+        self.title = title
+        self.startupCommand = startupCommand
+        self.externalEditorFilePath = externalEditorFilePath
     }
 
     func setTitle(_ newTitle: String) {

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -11,21 +11,12 @@ final class TerminalPaneState: Identifiable {
     let searchState = TerminalSearchState()
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
 
-    init(projectPath: String) {
-        self.projectPath = projectPath
-        self.title = "Terminal"
-        self.startupCommand = nil
-        self.externalEditorFilePath = nil
-    }
-
-    init(projectPath: String, title: String) {
-        self.projectPath = projectPath
-        self.title = title
-        self.startupCommand = nil
-        self.externalEditorFilePath = nil
-    }
-
-    init(projectPath: String, title: String, startupCommand: String, externalEditorFilePath: String) {
+    init(
+        projectPath: String,
+        title: String = "Terminal",
+        startupCommand: String? = nil,
+        externalEditorFilePath: String? = nil
+    ) {
         self.projectPath = projectPath
         self.title = title
         self.startupCommand = startupCommand

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -86,6 +86,13 @@ enum WorkspaceReducer {
             focusArea(area.id, key: key, state: &state)
             area.createEditorTab(filePath: filePath)
 
+        case let .createExternalEditorTab(projectID, areaID, filePath, command):
+            guard let key = activeKey(projectID: projectID, state: state),
+                  let area = resolveArea(key: key, areaID: areaID, state: state)
+            else { break }
+            focusArea(area.id, key: key, state: &state)
+            area.createExternalEditorTab(filePath: filePath, command: command)
+
         case let .closeTab(projectID, areaID, tabID):
             guard let key = activeKey(projectID: projectID, state: state) else { break }
             closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)

--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -102,6 +102,8 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         guard let userdata else { return }
         let view = Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
         DispatchQueue.main.async {
+            guard !view.processExitHandled else { return }
+            view.processExitHandled = true
             view.onProcessExit?()
         }
     }
@@ -109,6 +111,8 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
     private func handleCommandExit(target: ghostty_target_s) {
         guard let view = surfaceView(from: target), view.closesOnCommandExit else { return }
         DispatchQueue.main.async {
+            guard !view.processExitHandled else { return }
+            view.processExitHandled = true
             view.onProcessExit?()
         }
     }

--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -42,6 +42,10 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         case GHOSTTY_ACTION_SEARCH_SELECTED:
             handleSearchSelected(target: target, selected: action.action.search_selected)
             return true
+        case GHOSTTY_ACTION_COMMAND_FINISHED,
+             GHOSTTY_ACTION_SHOW_CHILD_EXITED:
+            handleCommandExit(target: target)
+            return true
         default:
             return false
         }
@@ -97,6 +101,13 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
     func closeSurface(userdata: UnsafeMutableRawPointer?, needsConfirm: Bool) {
         guard let userdata else { return }
         let view = Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
+        DispatchQueue.main.async {
+            view.onProcessExit?()
+        }
+    }
+
+    private func handleCommandExit(target: ghostty_target_s) {
+        guard let view = surfaceView(from: target), view.closesOnCommandExit else { return }
         DispatchQueue.main.async {
             view.onProcessExit?()
         }

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -6,16 +6,17 @@ struct EditorSettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            settingRow("Quick Open Editor") {
-                Picker("", selection: $settings.quickOpenEditor) {
-                    ForEach(EditorSettings.QuickOpenEditor.allCases) { editor in
+            settingRow("Default Editor") {
+                Picker("", selection: $settings.defaultEditor) {
+                    ForEach(EditorSettings.DefaultEditor.allCases) { editor in
                         Text(editor.displayName).tag(editor)
                     }
                 }
-                .frame(width: 210)
+                .labelsHidden()
+                .frame(width: 210, alignment: .trailing)
             }
 
-            if settings.quickOpenEditor == .terminalCommand {
+            if settings.defaultEditor == .terminalCommand {
                 settingRow("Editor Command") {
                     TextField("vim", text: $settings.externalEditorCommand)
                         .textFieldStyle(.roundedBorder)
@@ -34,7 +35,8 @@ struct EditorSettingsView: View {
                                 .tag(family)
                         }
                     }
-                    .frame(width: 210)
+                    .labelsHidden()
+                    .frame(width: 210, alignment: .trailing)
                 }
 
                 settingRow("Font Size") {
@@ -71,8 +73,9 @@ struct EditorSettingsView: View {
                         Text("4").tag(4)
                         Text("8").tag(8)
                     }
+                    .labelsHidden()
                     .pickerStyle(.segmented)
-                    .frame(width: 140)
+                    .frame(width: 140, alignment: .trailing)
                 }
 
                 toggleRow("Word Wrap", isOn: $settings.wordWrap)

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -6,60 +6,81 @@ struct EditorSettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            settingRow("Font Family") {
-                Picker("", selection: $settings.fontFamily) {
-                    ForEach(monoFonts, id: \.self) { family in
-                        Text(family)
-                            .font(.custom(family, size: 12))
-                            .tag(family)
+            settingRow("Quick Open Editor") {
+                Picker("", selection: $settings.quickOpenEditor) {
+                    ForEach(EditorSettings.QuickOpenEditor.allCases) { editor in
+                        Text(editor.displayName).tag(editor)
                     }
                 }
                 .frame(width: 210)
             }
 
-            settingRow("Font Size") {
-                HStack(spacing: 8) {
-                    Button {
-                        guard settings.fontSize > 8 else { return }
-                        settings.fontSize -= 1
-                    } label: {
-                        Image(systemName: "minus")
-                            .font(.system(size: 10, weight: .medium))
-                            .frame(width: 20, height: 20)
-                    }
-                    .buttonStyle(.borderless)
-
-                    Text("\(Int(settings.fontSize)) pt")
+            if settings.quickOpenEditor == .terminalCommand {
+                settingRow("Editor Command") {
+                    TextField("vim", text: $settings.externalEditorCommand)
+                        .textFieldStyle(.roundedBorder)
                         .font(.system(size: 12, design: .monospaced))
-                        .frame(width: 44)
+                        .frame(width: 210)
+                }
+            } else {
+                Divider()
+                    .padding(.vertical, 4)
 
-                    Button {
-                        guard settings.fontSize < 36 else { return }
-                        settings.fontSize += 1
-                    } label: {
-                        Image(systemName: "plus")
-                            .font(.system(size: 10, weight: .medium))
-                            .frame(width: 20, height: 20)
+                settingRow("Font Family") {
+                    Picker("", selection: $settings.fontFamily) {
+                        ForEach(monoFonts, id: \.self) { family in
+                            Text(family)
+                                .font(.custom(family, size: 12))
+                                .tag(family)
+                        }
                     }
-                    .buttonStyle(.borderless)
+                    .frame(width: 210)
                 }
-            }
 
-            settingRow("Tab Size") {
-                Picker("", selection: $settings.tabSize) {
-                    Text("2").tag(2)
-                    Text("4").tag(4)
-                    Text("8").tag(8)
+                settingRow("Font Size") {
+                    HStack(spacing: 8) {
+                        Button {
+                            guard settings.fontSize > 8 else { return }
+                            settings.fontSize -= 1
+                        } label: {
+                            Image(systemName: "minus")
+                                .font(.system(size: 10, weight: .medium))
+                                .frame(width: 20, height: 20)
+                        }
+                        .buttonStyle(.borderless)
+
+                        Text("\(Int(settings.fontSize)) pt")
+                            .font(.system(size: 12, design: .monospaced))
+                            .frame(width: 44)
+
+                        Button {
+                            guard settings.fontSize < 36 else { return }
+                            settings.fontSize += 1
+                        } label: {
+                            Image(systemName: "plus")
+                                .font(.system(size: 10, weight: .medium))
+                                .frame(width: 20, height: 20)
+                        }
+                        .buttonStyle(.borderless)
+                    }
                 }
-                .pickerStyle(.segmented)
-                .frame(width: 140)
-            }
 
-            toggleRow("Word Wrap", isOn: $settings.wordWrap)
-            toggleRow("Show Line Numbers", isOn: $settings.showLineNumbers)
-            toggleRow("Syntax Highlighting", isOn: $settings.syntaxHighlighting)
-            toggleRow("Bracket Matching", isOn: $settings.bracketMatching)
-            toggleRow("Current Line Highlight", isOn: $settings.currentLineHighlight)
+                settingRow("Tab Size") {
+                    Picker("", selection: $settings.tabSize) {
+                        Text("2").tag(2)
+                        Text("4").tag(4)
+                        Text("8").tag(8)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 140)
+                }
+
+                toggleRow("Word Wrap", isOn: $settings.wordWrap)
+                toggleRow("Show Line Numbers", isOn: $settings.showLineNumbers)
+                toggleRow("Syntax Highlighting", isOn: $settings.syntaxHighlighting)
+                toggleRow("Bracket Matching", isOn: $settings.bracketMatching)
+                toggleRow("Current Line Highlight", isOn: $settings.currentLineHighlight)
+            }
 
             Spacer()
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -17,6 +17,8 @@ final class GhosttyTerminalNSView: NSView {
     var isFocused: Bool = false
     var overlayActive: Bool = false
 
+    var processExitHandled = false
+
     var closesOnCommandExit: Bool {
         command != nil
     }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -4,6 +4,7 @@ import GhosttyKit
 final class GhosttyTerminalNSView: NSView {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
     private let workingDirectory: String
+    private let command: String?
     var envVars: [(key: String, value: String)] = []
     var onTitleChange: ((String) -> Void)?
     var onFocus: (() -> Void)?
@@ -16,6 +17,10 @@ final class GhosttyTerminalNSView: NSView {
     var isFocused: Bool = false
     var overlayActive: Bool = false
 
+    var closesOnCommandExit: Bool {
+        command != nil
+    }
+
     private var _markedText: String = ""
     private var _markedRange: NSRange = .init(location: NSNotFound, length: 0)
     private var _selectedRange: NSRange = .init(location: NSNotFound, length: 0)
@@ -24,8 +29,9 @@ final class GhosttyTerminalNSView: NSView {
     private var currentKeyEvent: NSEvent?
     private var commandSelectorCalled = false
 
-    init(workingDirectory: String) {
+    init(workingDirectory: String, command: String? = nil) {
         self.workingDirectory = workingDirectory
+        self.command = command
         super.init(frame: .zero)
         wantsLayer = true
         setupTrackingArea()
@@ -60,6 +66,12 @@ final class GhosttyTerminalNSView: NSView {
 
         var cStrings: [UnsafeMutablePointer<CChar>] = []
         defer { cStrings.forEach { free($0) } }
+
+        if let command, let cCommand = strdup(command) {
+            cStrings.append(cCommand)
+            config.command = UnsafePointer(cCommand)
+            config.wait_after_command = false
+        }
 
         var cEnvVars: [ghostty_env_var_s] = []
         for pair in envVars {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -64,7 +64,11 @@ struct TerminalBridge: NSViewRepresentable {
 
     func makeNSView(context: Context) -> GhosttyTerminalNSView {
         let registry = TerminalViewRegistry.shared
-        let view = registry.view(for: state.id, workingDirectory: state.projectPath)
+        let view = registry.view(
+            for: state.id,
+            workingDirectory: state.projectPath,
+            command: state.startupCommand
+        )
         if view.envVars.isEmpty, let key = worktreeKey {
             view.envVars = Self.buildEnvVars(paneID: state.id, worktreeKey: key)
         }

--- a/Muxy/Views/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Views/Terminal/TerminalViewRegistry.swift
@@ -9,11 +9,11 @@ final class TerminalViewRegistry {
 
     private init() {}
 
-    func view(for paneID: UUID, workingDirectory: String) -> GhosttyTerminalNSView {
+    func view(for paneID: UUID, workingDirectory: String, command: String? = nil) -> GhosttyTerminalNSView {
         if let existing = views[paneID] {
             return existing
         }
-        let view = GhosttyTerminalNSView(workingDirectory: workingDirectory)
+        let view = GhosttyTerminalNSView(workingDirectory: workingDirectory, command: command)
         views[paneID] = view
         paneIDs[ObjectIdentifier(view)] = paneID
         return view

--- a/Tests/MuxyTests/Models/TabAreaTests.swift
+++ b/Tests/MuxyTests/Models/TabAreaTests.swift
@@ -87,6 +87,30 @@ struct TabAreaTests {
         #expect(area.activeTab?.content.pane?.startupCommand == "vim +10 /tmp/test/file.swift")
     }
 
+    @Test("shellEscapedPath does not escape simple paths")
+    func shellEscapedPathSimple() {
+        let command = TabArea.editorLaunchCommand(command: "vim", filePath: "/tmp/test/file.swift")
+        #expect(command == "vim /tmp/test/file.swift")
+    }
+
+    @Test("shellEscapedPath escapes paths with spaces")
+    func shellEscapedPathSpaces() {
+        let command = TabArea.editorLaunchCommand(command: "vim", filePath: "/tmp/test/my file.swift")
+        #expect(command == "vim '/tmp/test/my file.swift'")
+    }
+
+    @Test("shellEscapedPath escapes paths with single quotes")
+    func shellEscapedPathSingleQuotes() {
+        let command = TabArea.editorLaunchCommand(command: "vim", filePath: "/tmp/test/it's a file.swift")
+        #expect(command == "vim '/tmp/test/it'\\''s a file.swift'")
+    }
+
+    @Test("file placeholder uses raw path for user-controlled quoting")
+    func filePlaceholderRawPath() {
+        let command = TabArea.editorLaunchCommand(command: "vim \"{file}\"", filePath: "/tmp/test/my file.swift")
+        #expect(command == "vim \"/tmp/test/my file.swift\"")
+    }
+
     @Test("createExternalEditorTab reuses matching external editor tab")
     func createExternalEditorTabReuse() {
         let area = TabArea(projectPath: testPath)

--- a/Tests/MuxyTests/Models/TabAreaTests.swift
+++ b/Tests/MuxyTests/Models/TabAreaTests.swift
@@ -67,6 +67,41 @@ struct TabAreaTests {
         #expect(area.activeTabID == editorTabID)
     }
 
+    @Test("createExternalEditorTab adds terminal tab with launch command")
+    func createExternalEditorTab() {
+        let area = TabArea(projectPath: testPath)
+        let filePath = "/tmp/test/file name.swift"
+        area.createExternalEditorTab(filePath: filePath, command: "vim")
+
+        let pane = area.activeTab?.content.pane
+        #expect(area.activeTab?.kind == .terminal)
+        #expect(pane?.externalEditorFilePath == filePath)
+        #expect(pane?.startupCommand == "vim '/tmp/test/file name.swift'")
+    }
+
+    @Test("createExternalEditorTab supports file placeholder")
+    func createExternalEditorTabPlaceholder() {
+        let area = TabArea(projectPath: testPath)
+        area.createExternalEditorTab(filePath: "/tmp/test/file.swift", command: "vim +10 {file}")
+
+        #expect(area.activeTab?.content.pane?.startupCommand == "vim +10 /tmp/test/file.swift")
+    }
+
+    @Test("createExternalEditorTab reuses matching external editor tab")
+    func createExternalEditorTabReuse() {
+        let area = TabArea(projectPath: testPath)
+        let filePath = "/tmp/test/file.swift"
+        area.createExternalEditorTab(filePath: filePath, command: "vim -n")
+        let editorTabID = area.activeTabID
+
+        area.createTab()
+        #expect(area.activeTabID != editorTabID)
+
+        area.createExternalEditorTab(filePath: filePath, command: "vim")
+        #expect(area.tabs.count == 3)
+        #expect(area.activeTabID == editorTabID)
+    }
+
     @Test("closeTab removes tab and returns paneID for terminal")
     func closeTabTerminal() {
         let area = TabArea(projectPath: testPath)

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -189,6 +189,25 @@ struct WorkspaceReducerTests {
         #expect(area?.activeTab?.kind == .editor)
     }
 
+    @Test("createExternalEditorTab adds terminal editor tab")
+    func createExternalEditorTab() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+
+        let action = AppState.Action.createExternalEditorTab(
+            projectID: projectID,
+            areaID: nil,
+            filePath: "/tmp/test/file.swift",
+            command: "vim"
+        )
+        _ = WorkspaceReducer.reduce(action: action, state: &state)
+
+        let area = focusedArea(in: state, projectID: projectID)
+        #expect(area?.activeTab?.kind == .terminal)
+        #expect(area?.activeTab?.content.pane?.externalEditorFilePath == "/tmp/test/file.swift")
+    }
+
     @Test("closeTab removes tab and populates paneIDsToRemove")
     func closeTab() {
         let projectID = UUID()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ Muxy/
     KeyCombo.swift            Key combo encoding, display, matching
     VCSTabState.swift         Git diff viewer state + loading orchestration
     EditorTabState.swift      Code editor tab state (backing store, cursor, search, save)
-    EditorSettings.swift      @Observable editor preferences (quick-open editor, font, wrap, tab size, feature toggles)
+    EditorSettings.swift      @Observable editor preferences (default editor, font, wrap, tab size, feature toggles)
     TextBackingStore.swift    Line-array backing store for editor documents
     ViewportState.swift       Viewport window computation and line mapping for editor documents
     Project.swift             Project folder metadata
@@ -149,7 +149,7 @@ User action → AppState.dispatch() → WorkspaceReducer.reduce()
 
 ## Key Integration Points
 
-- **Editor Pipeline**: Quick-open routes through `AppState.openFile`. `EditorSettings.quickOpenEditor`
+- **Editor Pipeline**: File opening routes through `AppState.openFile`. `EditorSettings.defaultEditor`
   chooses either the built-in editor or a configured terminal command. Built-in editor tabs load files into
   `TextBackingStore` and render through `CodeEditorRepresentable`; terminal editor tabs create a normal
   terminal pane with the configured Ghostty startup command. The size thresholds in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,14 +26,14 @@ Muxy/
     KeyCombo.swift            Key combo encoding, display, matching
     VCSTabState.swift         Git diff viewer state + loading orchestration
     EditorTabState.swift      Code editor tab state (backing store, cursor, search, save)
-    EditorSettings.swift      @Observable editor preferences (font, wrap, tab size, feature toggles)
+    EditorSettings.swift      @Observable editor preferences (quick-open editor, font, wrap, tab size, feature toggles)
     TextBackingStore.swift    Line-array backing store for editor documents
     ViewportState.swift       Viewport window computation and line mapping for editor documents
     Project.swift             Project folder metadata
     Worktree.swift            Per-project worktree slot (primary or git worktree)
     WorktreeKey.swift         Hashable (projectID, worktreeID) key for workspace maps
     WorktreeConfig.swift      Decoder for .muxy/worktree.json setup commands
-    TerminalPaneState.swift   Per-pane terminal state
+    TerminalPaneState.swift   Per-pane terminal state, including startup commands for terminal editors
     TerminalSearchState.swift Terminal find-in-page state
   Services/
     GhosttyService.swift      Singleton managing ghostty_app_t lifecycle
@@ -149,7 +149,11 @@ User action → AppState.dispatch() → WorkspaceReducer.reduce()
 
 ## Key Integration Points
 
-- **Editor Pipeline**: All opened files are loaded into `TextBackingStore` and rendered through the viewport pipeline in `CodeEditorRepresentable`. The size thresholds in `EditorTabState` control only large-file warning/refusal UX, not editor mode selection.
+- **Editor Pipeline**: Quick-open routes through `AppState.openFile`. `EditorSettings.quickOpenEditor`
+  chooses either the built-in editor or a configured terminal command. Built-in editor tabs load files into
+  `TextBackingStore` and render through `CodeEditorRepresentable`; terminal editor tabs create a normal
+  terminal pane with the configured Ghostty startup command. The size thresholds in
+  `EditorTabState` apply only to the built-in editor path.
 - **GhosttyKit**: C module wrapping `ghostty.h`. Precompiled xcframework from `muxy-app/ghostty` fork. Surfaces created/destroyed via `TerminalViewRegistry`.
 - **Persistence**: All files in `~/Library/Application Support/Muxy/`. Shared directory helper: `MuxyFileStorage`. Worktrees are persisted per-project at `worktrees/{projectID}.json`. Worktree setup commands live in-repo at `{Project.path}/.muxy/worktree.json`.
 - **Ghostty Config**: Managed by `MuxyConfig`, stored at `~/Library/Application Support/Muxy/ghostty.conf`. Seeded from `~/.config/ghostty/config` on first run.


### PR DESCRIPTION
## Summary
- add a quick-open editor preference with built-in editor and terminal command modes
- launch terminal editor tabs directly through Ghostty startup commands and close them when the editor exits
- hide built-in editor-only settings when terminal command mode is selected

Closes #139

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer mise exec -- scripts/checks.sh --fix`