### PR TITLE
Add terminal quick select

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -54,6 +54,12 @@ struct MuxyCommands: Commands {
                 NotificationCenter.default.post(name: .findInTerminal, object: nil)
             }
             .shortcut(for: .findInTerminal, store: keyBindings)
+
+            Button("Quick Select") {
+                guard isMainWindowFocused else { return }
+                NotificationCenter.default.post(name: .quickSelect, object: nil)
+            }
+            .shortcut(for: .quickSelect, store: keyBindings)
         }
 
         CommandGroup(replacing: .newItem) {

--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -5,6 +5,7 @@ extension Notification.Name {
     static let toggleThemePicker = Notification.Name("MuxyToggleThemePicker")
     static let themeDidChange = Notification.Name("MuxyThemeDidChange")
     static let findInTerminal = Notification.Name("MuxyFindInTerminal")
+    static let quickSelect = Notification.Name("MuxyQuickSelect")
     static let openVCSWindow = Notification.Name("MuxyOpenVCSWindow")
     static let toggleAttachedVCS = Notification.Name("MuxyToggleAttachedVCS")
     static let quickOpen = Notification.Name("MuxyQuickOpen")

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -46,6 +46,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case selectProject8
     case selectProject9
     case findInTerminal
+    case quickSelect
     case openVCSTab
     case quickOpen
     case switchWorktree
@@ -90,6 +91,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .selectProject8,
         .selectProject9,
         .findInTerminal,
+        .quickSelect,
         .openVCSTab,
         .quickOpen,
         .switchWorktree,
@@ -135,6 +137,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .selectProject8: ShortcutMetadata(displayName: "Project 8", category: "Project Navigation", scope: .mainWindow)
         case .selectProject9: ShortcutMetadata(displayName: "Project 9", category: "Project Navigation", scope: .mainWindow)
         case .findInTerminal: ShortcutMetadata(displayName: "Find", category: "Terminal", scope: .mainWindow)
+        case .quickSelect: ShortcutMetadata(displayName: "Quick Select", category: "Terminal", scope: .mainWindow)
         case .openVCSTab: ShortcutMetadata(displayName: "Source Control", category: "App", scope: .mainWindow)
         case .quickOpen: ShortcutMetadata(displayName: "Quick Open", category: "App", scope: .mainWindow)
         case .switchWorktree: ShortcutMetadata(displayName: "Switch Worktree", category: "Project Navigation", scope: .mainWindow)
@@ -219,6 +222,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .selectProject8, combo: KeyCombo(key: "8", control: true)),
         Self(action: .selectProject9, combo: KeyCombo(key: "9", control: true)),
         Self(action: .findInTerminal, combo: KeyCombo(key: "f", command: true)),
+        Self(action: .quickSelect, combo: KeyCombo(key: KeyCombo.spaceKey, shift: true, control: true)),
         Self(action: .quickOpen, combo: KeyCombo(key: "p", command: true)),
         Self(action: .switchWorktree, combo: KeyCombo(key: "o", command: true, shift: true)),
         Self(action: .saveFile, combo: KeyCombo(key: "s", command: true)),

--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -12,12 +12,14 @@ struct KeyCombo: Codable, Equatable, Hashable {
     static let rightArrowKey = "rightarrow"
     static let upArrowKey = "uparrow"
     static let downArrowKey = "downarrow"
+    static let spaceKey = "space"
     private static let keyCodeLeftBracket = 33
     private static let keyCodeRightBracket = 30
     private static let keyCodeLeftArrow = 123
     private static let keyCodeRightArrow = 124
     private static let keyCodeDownArrow = 125
     private static let keyCodeUpArrow = 126
+    private static let keyCodeSpace = 49
 
     let key: String
     let modifiers: UInt
@@ -46,6 +48,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
 
     var swiftUIKeyEquivalent: KeyEquivalent {
         switch key {
+        case Self.spaceKey: .space
         case "[": KeyEquivalent("[")
         case "]": KeyEquivalent("]")
         case ",": KeyEquivalent(",")
@@ -79,6 +82,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
         case Self.rightArrowKey: "→"
         case Self.upArrowKey: "↑"
         case Self.downArrowKey: "↓"
+        case Self.spaceKey: "Space"
         default: key.uppercased()
         }
         parts += keyDisplay
@@ -104,12 +108,15 @@ struct KeyCombo: Codable, Equatable, Hashable {
             case keyCodeRightArrow: return rightArrowKey
             case keyCodeUpArrow: return upArrowKey
             case keyCodeDownArrow: return downArrowKey
+            case keyCodeSpace: return spaceKey
             default: break
             }
         }
 
         let lowercased = key.lowercased()
-        if lowercased == leftArrowKey || lowercased == rightArrowKey || lowercased == upArrowKey || lowercased == downArrowKey {
+        if lowercased == leftArrowKey || lowercased == rightArrowKey || lowercased == upArrowKey || lowercased == downArrowKey ||
+            lowercased == spaceKey
+        {
             return lowercased
         }
 

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -9,6 +9,7 @@ final class TerminalPaneState: Identifiable {
     let startupCommand: String?
     let externalEditorFilePath: String?
     let searchState = TerminalSearchState()
+    let quickSelectState = TerminalQuickSelectState()
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
 
     init(

--- a/Muxy/Models/TerminalQuickSelectState.swift
+++ b/Muxy/Models/TerminalQuickSelectState.swift
@@ -1,0 +1,201 @@
+import AppKit
+import Foundation
+
+struct TerminalTextSnapshot {
+    let text: String
+    let viewSize: CGSize
+    let cellSize: CGSize?
+}
+
+struct TerminalQuickSelectMatch: Identifiable {
+    let id = UUID()
+    let text: String
+    let label: String
+    let frame: CGRect
+}
+
+enum TerminalQuickSelectInput {
+    case character(String, shifted: Bool)
+    case delete
+    case escape
+}
+
+enum TerminalQuickSelectResult: Equatable {
+    case none
+    case copy(String, paste: Bool)
+    case dismiss
+}
+
+@MainActor
+@Observable
+final class TerminalQuickSelectState {
+    var isVisible = false
+    var matches: [TerminalQuickSelectMatch] = []
+    var prefix = ""
+    var status = ""
+
+    func activate(snapshot: TerminalTextSnapshot?) {
+        guard let snapshot else {
+            status = "No terminal text available"
+            isVisible = true
+            matches = []
+            prefix = ""
+            return
+        }
+
+        let found = Self.matches(in: snapshot)
+        matches = found
+        prefix = ""
+        status = found.isEmpty ? "No matches" : "Type a label to copy, Shift-label to paste"
+        isVisible = true
+    }
+
+    func dismiss() {
+        isVisible = false
+        matches = []
+        prefix = ""
+        status = ""
+    }
+
+    func handle(_ input: TerminalQuickSelectInput) -> TerminalQuickSelectResult {
+        switch input {
+        case .escape:
+            dismiss()
+            return .dismiss
+        case .delete:
+            guard !prefix.isEmpty else { return .none }
+            prefix.removeLast()
+            return .none
+        case let .character(value, shifted):
+            let next = prefix + value.lowercased()
+            let candidates = matches.filter { $0.label.hasPrefix(next) }
+            guard !candidates.isEmpty else {
+                NSSound.beep()
+                return .none
+            }
+
+            prefix = next
+            if let exact = candidates.first(where: { $0.label == next }) {
+                let text = exact.text
+                let shouldPaste = shifted
+                dismiss()
+                return .copy(text, paste: shouldPaste)
+            }
+
+            return .none
+        }
+    }
+
+    private static func matches(in snapshot: TerminalTextSnapshot) -> [TerminalQuickSelectMatch] {
+        let lines = snapshot.text.components(separatedBy: .newlines)
+        let candidates = matchCandidates(lines: lines)
+        let labels = labels(count: candidates.count)
+        let fallbackLineCount = max(lines.count, 1)
+        let fallbackColumnCount = max(lines.map(\.count).max() ?? 1, 1)
+        let cellWidth = snapshot.cellSize?.width ?? snapshot.viewSize.width / CGFloat(fallbackColumnCount)
+        let cellHeight = snapshot.cellSize?.height ?? snapshot.viewSize.height / CGFloat(fallbackLineCount)
+
+        return zip(candidates, labels).map { candidate, label in
+            TerminalQuickSelectMatch(
+                text: candidate.text,
+                label: label,
+                frame: CGRect(
+                    x: CGFloat(candidate.column) * cellWidth,
+                    y: CGFloat(candidate.line) * cellHeight,
+                    width: max(CGFloat(candidate.length) * cellWidth, cellWidth),
+                    height: cellHeight
+                )
+            )
+        }
+    }
+
+    private static func matchCandidates(lines: [String]) -> [TerminalQuickSelectCandidate] {
+        var result: [TerminalQuickSelectCandidate] = []
+        var seen = Set<String>()
+        var occupiedRanges: [Int: [Range<String.Index>]] = [:]
+        for lineIndex in lines.indices {
+            let line = lines[lineIndex]
+            for pattern in patterns {
+                for range in ranges(matching: pattern, in: line) {
+                    if occupiedRanges[lineIndex, default: []].contains(where: { $0.overlaps(range) }) {
+                        continue
+                    }
+                    let text = String(line[range]).trimmedQuickSelectText
+                    guard !text.isEmpty else { continue }
+                    let column = line.distance(from: line.startIndex, to: range.lowerBound)
+                    let length = text.count
+                    let key = "\(lineIndex):\(column):\(length)"
+                    guard seen.insert(key).inserted else { continue }
+                    result.append(TerminalQuickSelectCandidate(
+                        text: text,
+                        line: lineIndex,
+                        column: column,
+                        length: length
+                    ))
+                    occupiedRanges[lineIndex, default: []].append(range)
+                }
+            }
+        }
+        return Array(result.prefix(702))
+    }
+
+    private static func ranges(matching pattern: NSRegularExpression, in line: String) -> [Range<String.Index>] {
+        let fullRange = NSRange(line.startIndex ..< line.endIndex, in: line)
+        return pattern.matches(in: line, range: fullRange).compactMap { match in
+            Range(match.range, in: line)
+        }
+    }
+
+    private static func labels(count: Int) -> [String] {
+        let alphabet = TerminalSettings.quickSelectLabels
+        guard count > alphabet.count else { return Array(alphabet.prefix(count)) }
+        var length = 2
+        while Int(pow(Double(alphabet.count), Double(length))) < count {
+            length += 1
+        }
+        return Array(labelCombinations(alphabet: alphabet, length: length).prefix(count))
+    }
+
+    private static func labelCombinations(alphabet: [String], length: Int) -> [String] {
+        guard length > 1 else { return alphabet }
+        let tails = labelCombinations(alphabet: alphabet, length: length - 1)
+        return alphabet.flatMap { first in
+            tails.map { first + $0 }
+        }
+    }
+
+    private static let patterns: [NSRegularExpression] = [
+        regex(#"https?://[^\s<>"']+"#),
+        regex(#"(?<![\w.-])(?:~|\.{1,2}|/)[A-Za-z0-9_@%+=:,./~#-]+(?::[0-9]+)?"#),
+        regex(#"\b[0-9a-fA-F]{7,40}\b"#),
+        regex(#"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"#),
+        regex(#"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]+)?\b"#),
+        regex(#"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"#),
+    ]
+
+    private static func regex(_ pattern: String) -> NSRegularExpression {
+        do {
+            return try NSRegularExpression(pattern: pattern)
+        } catch {
+            fatalError("Invalid quick select pattern: \(pattern)")
+        }
+    }
+}
+
+private struct TerminalQuickSelectCandidate {
+    let text: String
+    let line: Int
+    let column: Int
+    let length: Int
+}
+
+private extension String {
+    var trimmedQuickSelectText: String {
+        var value = self
+        let trailing = CharacterSet(charactersIn: ".,;:)]}>\"'")
+        while let scalar = value.unicodeScalars.last, trailing.contains(scalar) {
+            value.removeLast()
+        }
+        return value
+    }
+}

--- a/Muxy/Models/TerminalSettings.swift
+++ b/Muxy/Models/TerminalSettings.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+enum QuickSelectKeyboardLayout: String, CaseIterable, Identifiable {
+    case qwerty
+    case colemak
+    case colemakDH
+    case dvorak
+    case workman
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .qwerty:
+            "QWERTY"
+        case .colemak:
+            "Colemak"
+        case .colemakDH:
+            "Colemak-DH"
+        case .dvorak:
+            "Dvorak"
+        case .workman:
+            "Workman"
+        case .custom:
+            "Custom"
+        }
+    }
+
+    var defaultLabels: String {
+        switch self {
+        case .qwerty:
+            "asdfghjkl"
+        case .colemak:
+            "arstdhneio"
+        case .colemakDH:
+            "arstgmneio"
+        case .dvorak:
+            "aoeuidhtns"
+        case .workman:
+            "ashtgyneoi"
+        case .custom:
+            ""
+        }
+    }
+}
+
+enum TerminalSettings {
+    static let quickSelectLayoutKey = "muxy.terminal.quickSelectLayout"
+    static let quickSelectCustomLabelsKey = "muxy.terminal.quickSelectCustomLabels"
+
+    static var quickSelectLabels: [String] {
+        let rawLayout = UserDefaults.standard.string(forKey: quickSelectLayoutKey)
+        let layout = rawLayout.flatMap(QuickSelectKeyboardLayout.init(rawValue:)) ?? .qwerty
+        let rawLabels = switch layout {
+        case .qwerty,
+             .colemak,
+             .colemakDH,
+             .dvorak,
+             .workman:
+            layout.defaultLabels
+        case .custom:
+            UserDefaults.standard.string(forKey: quickSelectCustomLabelsKey) ?? layout.defaultLabels
+        }
+        return quickSelectLabels(for: rawLabels)
+    }
+
+    static func sanitizeQuickSelectLabelString(_ value: String) -> String {
+        sanitizeQuickSelectLabels(value).joined()
+    }
+
+    static func quickSelectLabels(for value: String) -> [String] {
+        let labels = sanitizeQuickSelectLabels(value)
+        guard !labels.isEmpty else {
+            return sanitizeQuickSelectLabels(QuickSelectKeyboardLayout.qwerty.defaultLabels)
+        }
+        return labels
+    }
+
+    private static func sanitizeQuickSelectLabels(_ value: String) -> [String] {
+        var seen = Set<Character>()
+        var result: [String] = []
+        for character in value.lowercased() where character.isLetter {
+            guard seen.insert(character).inserted else { continue }
+            result.append(String(character))
+        }
+        return result
+    }
+}

--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -42,6 +42,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         case GHOSTTY_ACTION_SEARCH_SELECTED:
             handleSearchSelected(target: target, selected: action.action.search_selected)
             return true
+        case GHOSTTY_ACTION_CELL_SIZE:
+            handleCellSize(target: target, size: action.action.cell_size)
+            return true
         case GHOSTTY_ACTION_COMMAND_FINISHED,
              GHOSTTY_ACTION_SHOW_CHILD_EXITED:
             handleCommandExit(target: target)
@@ -145,6 +148,13 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         let value = selected.selected >= 0 ? Int(selected.selected) : nil
         DispatchQueue.main.async {
             view.onSearchSelected?(value)
+        }
+    }
+
+    private func handleCellSize(target: ghostty_target_s, size: ghostty_action_cell_size_s) {
+        guard let view = surfaceView(from: target) else { return }
+        DispatchQueue.main.async {
+            view.cellSize = CGSize(width: Int(size.width), height: Int(size.height))
         }
     }
 

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -5,6 +5,8 @@ struct SettingsView: View {
         TabView {
             AppearanceSettingsView()
                 .tabItem { Label("Appearance", systemImage: "paintbrush") }
+            TerminalSettingsView()
+                .tabItem { Label("Terminal", systemImage: "terminal") }
             EditorSettingsView()
                 .tabItem { Label("Editor", systemImage: "pencil.line") }
             KeyboardShortcutsSettingsView()

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct TerminalSettingsView: View {
+    @AppStorage(TerminalSettings.quickSelectLayoutKey) private var quickSelectLayout = QuickSelectKeyboardLayout.qwerty.rawValue
+    @AppStorage(TerminalSettings.quickSelectCustomLabelsKey) private var customLabels = QuickSelectKeyboardLayout.colemakDH.defaultLabels
+
+    var body: some View {
+        VStack(spacing: 0) {
+            section("Quick Select") {
+                pickerRow("Label Layout", selection: $quickSelectLayout, options: QuickSelectKeyboardLayout.allCases) {
+                    $0.displayName
+                }
+
+                if quickSelectLayout == QuickSelectKeyboardLayout.custom.rawValue {
+                    customLabelsRow
+                } else {
+                    previewRow
+                }
+            }
+
+            Spacer()
+        }
+    }
+
+    private var customLabelsRow: some View {
+        HStack {
+            Text("Custom Labels")
+                .font(.system(size: 12))
+            Spacer()
+            TextField("", text: customLabelsBinding)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 12, design: .monospaced))
+                .frame(width: 250)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    private var previewRow: some View {
+        HStack {
+            Text("Label Order")
+                .font(.system(size: 12))
+            Spacer()
+            Text(activeLayout.defaultLabels)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    private var customLabelsBinding: Binding<String> {
+        Binding(
+            get: { customLabels },
+            set: { customLabels = TerminalSettings.sanitizeQuickSelectLabelString($0) }
+        )
+    }
+
+    private var activeLayout: QuickSelectKeyboardLayout {
+        QuickSelectKeyboardLayout(rawValue: quickSelectLayout) ?? .qwerty
+    }
+
+    private func section(_ title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                .padding(.bottom, 4)
+            content()
+        }
+    }
+
+    private func pickerRow<T: Identifiable & RawRepresentable<String>>(
+        _ label: String,
+        selection: Binding<String>,
+        options: [T],
+        displayValue: @escaping (T) -> String
+    ) -> some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 12))
+            Spacer()
+            Picker("", selection: selection) {
+                ForEach(options) { option in
+                    Text(displayValue(option)).tag(option.rawValue)
+                }
+            }
+            .frame(width: 160)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+}

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -14,8 +14,11 @@ final class GhosttyTerminalNSView: NSView {
     var onSearchEnd: (() -> Void)?
     var onSearchTotal: ((Int?) -> Void)?
     var onSearchSelected: ((Int?) -> Void)?
+    var onQuickSelectInput: ((TerminalQuickSelectInput) -> Void)?
     var isFocused: Bool = false
     var overlayActive: Bool = false
+    var quickSelectActive: Bool = false
+    var cellSize: CGSize?
 
     var processExitHandled = false
 
@@ -132,6 +135,7 @@ final class GhosttyTerminalNSView: NSView {
         onSearchEnd = nil
         onSearchTotal = nil
         onSearchSelected = nil
+        onQuickSelectInput = nil
         if let observer = screenChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             screenChangeObserver = nil
@@ -242,7 +246,7 @@ final class GhosttyTerminalNSView: NSView {
         ghostty_surface_set_focus(surface, false)
     }
 
-    override var acceptsFirstResponder: Bool { !overlayActive }
+    override var acceptsFirstResponder: Bool { !overlayActive || quickSelectActive }
 
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
@@ -282,6 +286,8 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
+        if handleQuickSelectKey(event) { return }
+
         guard let surface else { super.keyDown(with: event)
             return
         }
@@ -361,6 +367,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func keyUp(with event: NSEvent) {
+        if quickSelectActive { return }
         guard let surface else { return }
         var keyEvent = buildKeyEvent(from: event, action: GHOSTTY_ACTION_RELEASE)
         keyEvent.text = nil
@@ -368,6 +375,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func flagsChanged(with event: NSEvent) {
+        if quickSelectActive { return }
         guard let surface else { return }
         if hasMarkedText() { return }
         var keyEvent = buildKeyEvent(from: event, action: isFlagPress(event) ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE)
@@ -376,6 +384,8 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if handleQuickSelectKey(event) { return true }
+
         if isAppShortcut(event) { return false }
         guard window?.firstResponder === self || window?.firstResponder === inputContext else { return false }
         guard event.type == .keyDown, let surface else { return false }
@@ -525,6 +535,26 @@ final class GhosttyTerminalNSView: NSView {
         return keyEvent
     }
 
+    private func handleQuickSelectKey(_ event: NSEvent) -> Bool {
+        guard quickSelectActive, event.type == .keyDown else { return false }
+        if event.keyCode == 53 {
+            onQuickSelectInput?(.escape)
+            return true
+        }
+        if event.keyCode == 51 {
+            onQuickSelectInput?(.delete)
+            return true
+        }
+        let flags = event.modifierFlags.intersection(KeyCombo.supportedModifierMask)
+        guard flags.subtracting([.shift]).isEmpty else { return true }
+        guard let character = event.charactersIgnoringModifiers?.lowercased(), character.count == 1 else {
+            return true
+        }
+        guard character.rangeOfCharacter(from: .letters) != nil else { return true }
+        onQuickSelectInput?(.character(character, shifted: flags.contains(.shift)))
+        return true
+    }
+
     private func consumedModsFromFlags(_ flags: NSEvent.ModifierFlags) -> ghostty_input_mods_e {
         var mods = GHOSTTY_MODS_NONE.rawValue
         if flags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
@@ -615,6 +645,65 @@ final class GhosttyTerminalNSView: NSView {
         text.withCString { ptr in
             ghostty_surface_text(surface, ptr, UInt(text.utf8.count))
         }
+    }
+
+    func quickSelectSnapshot() -> TerminalTextSnapshot? {
+        guard let surface, bounds.width > 0, bounds.height > 0 else { return nil }
+        let backingSize = convertToBacking(bounds).size
+        let scale = window?.backingScaleFactor ?? 1
+        let logicalCellSize = cellSize.map { CGSize(width: $0.width / scale, height: $0.height / scale) }
+        let selections = quickSelectSelections(backingSize: backingSize, cellSize: logicalCellSize)
+        for selection in selections {
+            if let text = readText(selection: selection, surface: surface) {
+                return TerminalTextSnapshot(text: text, viewSize: bounds.size, cellSize: logicalCellSize)
+            }
+        }
+        return nil
+    }
+
+    private func quickSelectSelections(backingSize: CGSize, cellSize: CGSize?) -> [ghostty_selection_s] {
+        var selections = [
+            quickSelectSelection(
+                tag: GHOSTTY_POINT_SURFACE,
+                width: UInt32(max(bounds.width - 1, 0)),
+                height: UInt32(max(bounds.height - 1, 0))
+            ),
+            quickSelectSelection(
+                tag: GHOSTTY_POINT_SURFACE,
+                width: UInt32(max(backingSize.width - 1, 0)),
+                height: UInt32(max(backingSize.height - 1, 0))
+            ),
+        ]
+        if let cellSize, cellSize.width > 0, cellSize.height > 0 {
+            selections.append(quickSelectSelection(
+                tag: GHOSTTY_POINT_VIEWPORT,
+                width: UInt32(max(floor(bounds.width / cellSize.width) - 1, 0)),
+                height: UInt32(max(floor(bounds.height / cellSize.height) - 1, 0))
+            ))
+        }
+        return selections
+    }
+
+    private func quickSelectSelection(
+        tag: ghostty_point_tag_e,
+        width: UInt32,
+        height: UInt32
+    ) -> ghostty_selection_s {
+        ghostty_selection_s(
+            top_left: ghostty_point_s(tag: tag, coord: GHOSTTY_POINT_COORD_TOP_LEFT, x: 0, y: 0),
+            bottom_right: ghostty_point_s(tag: tag, coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT, x: width, y: height),
+            rectangle: true
+        )
+    }
+
+    private func readText(selection: ghostty_selection_s, surface: ghostty_surface_t) -> String? {
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, selection, &text), let ptr = text.text else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        let bytes = UnsafeRawPointer(ptr).assumingMemoryBound(to: UInt8.self)
+        let buffer = UnsafeBufferPointer(start: bytes, count: Int(text.text_len))
+        guard let value = String(bytes: buffer, encoding: .utf8), !value.isEmpty else { return nil }
+        return value
     }
 
     func sendReturnKey() {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -40,6 +40,16 @@ struct TerminalPane: View {
                 )
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
+
+            if state.quickSelectState.isVisible {
+                TerminalQuickSelectOverlay(state: state.quickSelectState)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .quickSelect)) { _ in
+            guard focused else { return }
+            let view = TerminalViewRegistry.shared.existingView(for: state.id)
+            state.quickSelectState.activate(snapshot: view?.quickSelectSnapshot())
+            view?.window?.makeFirstResponder(view)
         }
     }
 }
@@ -74,9 +84,13 @@ struct TerminalBridge: NSViewRepresentable {
         }
         view.isFocused = focused
         view.overlayActive = overlayActive
+        view.quickSelectActive = state.quickSelectState.isVisible
         view.onFocus = onFocus
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
+        view.onQuickSelectInput = { [weak state, weak view] input in
+            Self.handleQuickSelectInput(input, state: state, view: view)
+        }
         view.onTitleChange = { [weak state] title in
             DispatchQueue.main.async {
                 state?.setTitle(title)
@@ -100,6 +114,10 @@ struct TerminalBridge: NSViewRepresentable {
         nsView.onFocus = onFocus
         nsView.onProcessExit = onProcessExit
         nsView.onSplitRequest = onSplitRequest
+        nsView.quickSelectActive = state.quickSelectState.isVisible
+        nsView.onQuickSelectInput = { [weak state, weak nsView] input in
+            Self.handleQuickSelectInput(input, state: state, view: nsView)
+        }
         nsView.onTitleChange = { [weak state] title in
             DispatchQueue.main.async {
                 state?.setTitle(title)
@@ -172,5 +190,65 @@ struct TerminalBridge: NSViewRepresentable {
         view.onSearchSelected = { [weak state] selected in
             state?.searchState.selected = selected
         }
+    }
+
+    private static func handleQuickSelectInput(
+        _ input: TerminalQuickSelectInput,
+        state: TerminalPaneState?,
+        view: GhosttyTerminalNSView?
+    ) {
+        guard let state else { return }
+        switch state.quickSelectState.handle(input) {
+        case .none,
+             .dismiss:
+            break
+        case let .copy(text, paste):
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+            if paste {
+                view?.sendText(text)
+            }
+            DispatchQueue.main.async {
+                view?.window?.makeFirstResponder(view)
+            }
+        }
+    }
+}
+
+private struct TerminalQuickSelectOverlay: View {
+    let state: TerminalQuickSelectState
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color.black.opacity(0.08)
+                .ignoresSafeArea()
+
+            ForEach(state.matches) { match in
+                Text(match.label.uppercased())
+                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(MuxyTheme.accent, in: RoundedRectangle(cornerRadius: 4))
+                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(.black.opacity(0.35), lineWidth: 1))
+                    .position(x: match.frame.minX + 12, y: match.frame.minY + 8)
+            }
+
+            HStack(spacing: 8) {
+                Text(state.prefix.isEmpty ? state.status : "\(state.status): \(state.prefix.uppercased())")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fg)
+                Text("Esc")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(MuxyTheme.bg.opacity(0.92), in: RoundedRectangle(cornerRadius: 6))
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+            .padding(8)
+        }
+        .allowsHitTesting(false)
+        .transition(.opacity)
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,9 +26,16 @@
 - **Customizable shortcuts** — 40+ configurable keyboard shortcuts with conflict detection
 - **Workspace persistence** — Tabs, splits, and focus state are saved and restored per project
 - **In-terminal search** — Find text in terminal output with match navigation
+- **Keyboard quick select** — Label URLs, paths, commits, and addresses in the visible terminal for keyboard copy or paste
 - **Drag and drop** — Reorder tabs and projects, drag tabs between panes to create splits
 - **Auto-updates** — Built-in update checking via Sparkle
 - **Text Editor** - Native, Lightweight Text (not code) Editor with code highlight support for most of the programming languages
+
+## Keyboard Quick Select
+
+Press `Ctrl+Shift+Space` in a terminal pane to label detected URLs, file paths, git SHAs, IP addresses, and email addresses. Type a label to copy the match, or hold Shift on the final label key to copy and paste it.
+
+Label layouts are configurable in Settings → Terminal. Muxy includes QWERTY, Colemak, Colemak-DH, Dvorak, Workman, and custom home-row labels.
 
 ## Requirements
 

--- a/Tests/MuxyTests/Models/KeyComboTests.swift
+++ b/Tests/MuxyTests/Models/KeyComboTests.swift
@@ -46,6 +46,11 @@ struct KeyComboTests {
         #expect(KeyCombo(key: "downarrow", command: true).displayString == "⌘↓")
     }
 
+    @Test("displayString for space key")
+    func displayStringSpaceKey() {
+        #expect(KeyCombo(key: "space", shift: true, control: true).displayString == "⌃⇧Space")
+    }
+
     @Test("displayString for letter key is uppercased")
     func displayStringLetter() {
         let combo = KeyCombo(key: "t", command: true)
@@ -64,6 +69,11 @@ struct KeyComboTests {
         #expect(KeyCombo.normalized(key: "", keyCode: 124) == "rightarrow")
         #expect(KeyCombo.normalized(key: "", keyCode: 125) == "downarrow")
         #expect(KeyCombo.normalized(key: "", keyCode: 126) == "uparrow")
+    }
+
+    @Test("normalized key with space keyCode")
+    func normalizedSpaceKeyCode() {
+        #expect(KeyCombo.normalized(key: "", keyCode: 49) == "space")
     }
 
     @Test("normalized key with function key scalars")

--- a/Tests/MuxyTests/Models/TerminalQuickSelectStateTests.swift
+++ b/Tests/MuxyTests/Models/TerminalQuickSelectStateTests.swift
@@ -1,0 +1,57 @@
+import CoreGraphics
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("TerminalQuickSelectState")
+struct TerminalQuickSelectStateTests {
+    @Test("matches common terminal tokens")
+    func matchesCommonTerminalTokens() {
+        let state = TerminalQuickSelectState()
+        state.activate(snapshot: TerminalTextSnapshot(
+            text: "open https://example.com, then ./Sources/App.swift:12 and 127.0.0.1:8080",
+            viewSize: CGSize(width: 800, height: 200),
+            cellSize: CGSize(width: 10, height: 20)
+        ))
+
+        #expect(state.matches.map(\.text).contains("https://example.com"))
+        #expect(state.matches.map(\.text).contains("./Sources/App.swift:12"))
+        #expect(state.matches.map(\.text).contains("127.0.0.1:8080"))
+    }
+
+    @Test("uses non-ambiguous labels when more than one key is required")
+    func usesNonAmbiguousLabels() {
+        let lines = (0 ..< 27).map { "https://example.com/\($0)" }.joined(separator: "\n")
+        let state = TerminalQuickSelectState()
+        state.activate(snapshot: TerminalTextSnapshot(
+            text: lines,
+            viewSize: CGSize(width: 800, height: 800),
+            cellSize: CGSize(width: 10, height: 20)
+        ))
+
+        #expect(state.matches.count == 27)
+        #expect(Set(state.matches.map(\.label)).count == 27)
+        #expect(state.matches.allSatisfy { $0.label.count > 1 })
+    }
+
+    @Test("shifted final label key requests paste")
+    func shiftedFinalLabelKeyRequestsPaste() {
+        let lines = (0 ..< 27).map { "https://example.com/\($0)" }.joined(separator: "\n")
+        let state = TerminalQuickSelectState()
+        state.activate(snapshot: TerminalTextSnapshot(
+            text: lines,
+            viewSize: CGSize(width: 800, height: 800),
+            cellSize: CGSize(width: 10, height: 20)
+        ))
+
+        let label = state.matches[0].label
+        let keys = label.map(String.init)
+
+        for key in keys.dropLast() {
+            #expect(state.handle(.character(key, shifted: false)) == .none)
+        }
+        #expect(state.handle(.character(keys.last!, shifted: true)) == .copy("https://example.com/0", paste: true))
+        #expect(!state.isVisible)
+    }
+}

--- a/Tests/MuxyTests/Models/TerminalSettingsTests.swift
+++ b/Tests/MuxyTests/Models/TerminalSettingsTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalSettings")
+struct TerminalSettingsTests {
+    @Test("custom labels are lowercased letters with duplicates removed")
+    func customLabelsAreSanitized() {
+        #expect(TerminalSettings.sanitizeQuickSelectLabelString("AARs-12T") == "arst")
+    }
+
+    @Test("custom labels use only configured keys")
+    func customLabelsUseOnlyConfiguredKeys() {
+        let labels = TerminalSettings.quickSelectLabels(for: "arst")
+        #expect(labels == ["a", "r", "s", "t"])
+    }
+
+    @Test("empty custom labels fall back to qwerty home row")
+    func emptyCustomLabelsFallBackToQwertyHomeRow() {
+        #expect(TerminalSettings.quickSelectLabels(for: "").joined() == "asdfghjkl")
+    }
+
+    @Test("built-in layouts use home row keys")
+    func builtInLayoutsUseHomeRowKeys() {
+        #expect(QuickSelectKeyboardLayout.qwerty.defaultLabels == "asdfghjkl")
+        #expect(QuickSelectKeyboardLayout.colemak.defaultLabels == "arstdhneio")
+        #expect(QuickSelectKeyboardLayout.colemakDH.defaultLabels == "arstgmneio")
+        #expect(QuickSelectKeyboardLayout.dvorak.defaultLabels == "aoeuidhtns")
+        #expect(QuickSelectKeyboardLayout.workman.defaultLabels == "ashtgyneoi")
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,12 +29,14 @@ Muxy/
     EditorSettings.swift      @Observable editor preferences (default editor, font, wrap, tab size, feature toggles)
     TextBackingStore.swift    Line-array backing store for editor documents
     ViewportState.swift       Viewport window computation and line mapping for editor documents
+    TerminalSettings.swift    Terminal preference keys and quick-select label layout helpers
     Project.swift             Project folder metadata
     Worktree.swift            Per-project worktree slot (primary or git worktree)
     WorktreeKey.swift         Hashable (projectID, worktreeID) key for workspace maps
     WorktreeConfig.swift      Decoder for .muxy/worktree.json setup commands
     TerminalPaneState.swift   Per-pane terminal state, including startup commands for terminal editors
     TerminalSearchState.swift Terminal find-in-page state
+    TerminalQuickSelectState.swift Keyboard quick-select match state and label generation
   Services/
     GhosttyService.swift      Singleton managing ghostty_app_t lifecycle
     GhosttyRuntimeEventAdapter.swift  C callback bridge from libghostty (OSC + command finished → notifications)
@@ -90,7 +92,7 @@ Muxy/
       QuickOpenOverlay.swift  Cmd+P file search overlay (name substring match via find)
     Terminal/
       GhosttyTerminalNSView.swift       AppKit view wrapping ghostty_surface_t + NSTextInputClient
-      TerminalPane.swift      SwiftUI wrapper for terminal + search
+      TerminalPane.swift      SwiftUI wrapper for terminal, search, and quick-select overlays
       TerminalSearchBar.swift Find-in-terminal UI
       TerminalViewRegistry.swift  Terminal view lifecycle management
     Editor/
@@ -116,6 +118,7 @@ Muxy/
     Settings/
       SettingsView.swift      Settings window layout
       AppearanceSettingsView.swift  Theme settings tab
+      TerminalSettingsView.swift  Terminal preferences tab, including quick-select label layout
       EditorSettingsView.swift  Editor preferences tab (font, wrap, tab size, feature toggles)
       KeyboardShortcutsSettingsView.swift  Shortcut config tab
       ShortcutRecorderView.swift  Shortcut capture field


### PR DESCRIPTION
## Summary

Adds keyboard-driven Quick Select for terminal panes.

- Detects URLs, paths, git SHAs, UUIDs, IP addresses, and email addresses in visible terminal text
- Labels matches so typing the label copies the match, with Shift on the final label key copying and pasting
- Adds QWERTY, Colemak, Colemak-DH, Dvorak, Workman, and custom home-row label layouts in Terminal settings
- Adds Quick Select to the configurable shortcut system with a default `Ctrl+Shift+Space` binding
- Documents the feature in the README and architecture map

## Motivation

The goal is a keyboard-first selection flow for terminal text. The interaction is inspired by Vim/Vimari-style hint labels: enter a mode, type a short label, and act on the target without reaching for the mouse. WezTerm has a similar quick-select workflow for URLs and other terminal text, and this brings that kind of terminal-native affordance into Muxy.

This is intentionally a first step toward richer keyboard-driven terminal selection. Quick Select handles the high-value case first: copying or pasting visible URLs, paths, commits, and addresses directly from the terminal using only the keyboard.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer scripts/checks.sh --fix`
