### PR TITLE
Fix mobile app on Tailscale network

### DIFF
--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -17,7 +17,7 @@ struct MobileSettingsView: View {
             } header: {
                 Text("Mobile")
             } footer: {
-                Text("When enabled, Muxy listens on port 4865 for the Muxy iOS app on the same network.")
+                Text("Muxy listens on port 4865 for the iOS app over your local network or a private VPN such as Tailscale.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/MuxyMobile/ConnectView.swift
+++ b/MuxyMobile/ConnectView.swift
@@ -104,6 +104,8 @@ struct AddDeviceSheet: View {
                         .keyboardType(.numberPad)
                 } header: {
                     Text("Connection")
+                } footer: {
+                    Text("Use the Mac's LAN IP (e.g. 192.168.1.10) or a VPN IP such as a Tailscale address (100.x.x.x).")
                 }
             }
             .navigationTitle("Add Device")

--- a/MuxyMobile/Info.plist
+++ b/MuxyMobile/Info.plist
@@ -46,9 +46,11 @@
 		<string>JetBrainsMonoNerdFontMono-Bold.ttf</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Muxy connects to your Mac on the local network to share terminals.</string>
+	<string>Muxy connects to your Mac on the local network or over a private VPN (such as Tailscale) to share terminals.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>


### PR DESCRIPTION
This PR fixes the issue that the mobile app can only connect to the Desktop when both on the same LAN network but not able to connect via Tailscale network