### PR TITLE
Fix terminal tab switch issue on mobile

### DIFF
--- a/Muxy/Services/PairingRequestCoordinator.swift
+++ b/Muxy/Services/PairingRequestCoordinator.swift
@@ -71,5 +71,31 @@ final class PairingRequestCoordinator {
     private func present(_ request: PairingRequest) {
         pendingRequest = request
         NSApp.activate(ignoringOtherApps: true)
+        DispatchQueue.main.async { [weak self] in
+            self?.runAlert(for: request)
+        }
+    }
+
+    private func runAlert(for request: PairingRequest) {
+        guard pendingRequest?.id == request.id else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "Allow \(request.deviceName) to connect?"
+        alert.informativeText = "This device is requesting access to Muxy. Only approve devices you recognize."
+        alert.alertStyle = .warning
+        alert.icon = NSApp.applicationIconImage
+        alert.addButton(withTitle: "Approve")
+        alert.addButton(withTitle: "Deny")
+        alert.buttons[0].keyEquivalent = "\r"
+        alert.buttons[1].keyEquivalent = "\u{1b}"
+
+        let response = alert.runModal()
+        guard pendingRequest?.id == request.id else { return }
+
+        if response == .alertFirstButtonReturn {
+            approve(request)
+        } else {
+            deny(request)
+        }
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -237,12 +237,6 @@ struct MainWindow: View {
             guard isPresented, let message = appState.pendingSaveErrorMessage else { return }
             presentSaveErrorAlert(message: message)
         }
-        .onChange(of: PairingRequestCoordinator.shared.pendingRequest?.id) { _, _ in
-            presentPairingRequestIfNeeded()
-        }
-        .onAppear {
-            presentPairingRequestIfNeeded()
-        }
     }
 
     @ViewBuilder
@@ -542,31 +536,6 @@ struct MainWindow: View {
                 } else {
                     appState.cancelCloseRunningTab()
                 }
-            }
-        }
-    }
-
-    private func presentPairingRequestIfNeeded() {
-        guard let request = PairingRequestCoordinator.shared.pendingRequest else { return }
-        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
-              window.attachedSheet == nil
-        else { return }
-
-        let alert = NSAlert()
-        alert.messageText = "Allow \(request.deviceName) to connect?"
-        alert.informativeText = "This device is requesting access to Muxy. Only approve devices you recognize."
-        alert.alertStyle = .warning
-        alert.icon = NSApp.applicationIconImage
-        alert.addButton(withTitle: "Approve")
-        alert.addButton(withTitle: "Deny")
-        alert.buttons[0].keyEquivalent = "\r"
-        alert.buttons[1].keyEquivalent = "\u{1b}"
-
-        alert.beginSheetModal(for: window) { response in
-            if response == .alertFirstButtonReturn {
-                PairingRequestCoordinator.shared.approve(request)
-            } else {
-                PairingRequestCoordinator.shared.deny(request)
             }
         }
     }

--- a/MuxyMobile/TerminalView.swift
+++ b/MuxyMobile/TerminalView.swift
@@ -100,9 +100,7 @@ struct TerminalView: View {
         }
         .background(themeBg)
         .onAppear {
-            inputCoordinator.onSend = { text in
-                Task { await connection.sendTerminalInput(paneID: paneID, text: text) }
-            }
+            bindInput()
             startPolling()
             if isOwnedBySelf {
                 Task { @MainActor in
@@ -117,6 +115,7 @@ struct TerminalView: View {
         .onChange(of: paneID) { _, _ in
             cells = nil
             stopPolling()
+            bindInput()
             startPolling()
         }
         .onChange(of: isOwnedBySelf) { _, newValue in
@@ -176,6 +175,12 @@ struct TerminalView: View {
         .onTapGesture {
             guard isOwnedBySelf else { return }
             inputCoordinator.becomeFirstResponder()
+        }
+    }
+
+    private func bindInput() {
+        inputCoordinator.onSend = { text in
+            Task { await connection.sendTerminalInput(paneID: paneID, text: text) }
         }
     }
 


### PR DESCRIPTION
This PR fixes the issue that on terminal switching tab was still interacting with the first taken over tab