### PR TITLE
Fix terminal content cutoff when moving window between displays

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -309,6 +309,8 @@ struct WindowConfigurator: NSViewRepresentable {
             let names: [Notification.Name] = [
                 NSWindow.didResizeNotification,
                 NSWindow.didEndLiveResizeNotification,
+                NSWindow.didChangeScreenNotification,
+                NSWindow.didChangeBackingPropertiesNotification,
                 NSWindow.didExitFullScreenNotification,
                 NSWindow.didEnterFullScreenNotification,
             ]
@@ -322,6 +324,11 @@ struct WindowConfigurator: NSViewRepresentable {
                     MainActor.assumeIsolated {
                         WindowConfigurator.repositionTrafficLights(in: w)
                         WindowConfigurator.hideTitlebarDecorationView(in: w)
+                        if name == NSWindow.didChangeScreenNotification
+                            || name == NSWindow.didChangeBackingPropertiesNotification
+                        {
+                            WindowConfigurator.neutralizeSafeAreaInsets(in: w)
+                        }
                         if name == NSWindow.didEnterFullScreenNotification
                             || name == NSWindow.didExitFullScreenNotification
                         {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -158,10 +158,6 @@ final class GhosttyTerminalNSView: NSView {
             NotificationCenter.default.removeObserver(observer)
             screenChangeObserver = nil
         }
-        if let observer = backingPropertiesChangeObserver {
-            NotificationCenter.default.removeObserver(observer)
-            backingPropertiesChangeObserver = nil
-        }
         delayedResizeWorkItem?.cancel()
         delayedResizeWorkItem = nil
         destroySurface()
@@ -170,7 +166,6 @@ final class GhosttyTerminalNSView: NSView {
 
     deinit {
         screenChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
-        backingPropertiesChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
         delayedResizeWorkItem?.cancel()
         if let surface {
             ghostty_surface_free(surface)
@@ -178,7 +173,6 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     nonisolated(unsafe) private var screenChangeObserver: NSObjectProtocol?
-    nonisolated(unsafe) private var backingPropertiesChangeObserver: NSObjectProtocol?
     nonisolated(unsafe) private var delayedResizeWorkItem: DispatchWorkItem?
 
     override func viewDidMoveToWindow() {
@@ -186,8 +180,6 @@ final class GhosttyTerminalNSView: NSView {
 
         screenChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
         screenChangeObserver = nil
-        backingPropertiesChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
-        backingPropertiesChangeObserver = nil
         delayedResizeWorkItem?.cancel()
         delayedResizeWorkItem = nil
 
@@ -199,16 +191,6 @@ final class GhosttyTerminalNSView: NSView {
 
         screenChangeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didChangeScreenNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.updateMetalLayerSize(deferred: true)
-            }
-        }
-
-        backingPropertiesChangeObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didChangeBackingPropertiesNotification,
             object: window,
             queue: .main
         ) { [weak self] _ in

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -75,8 +75,7 @@ final class GhosttyTerminalNSView: NSView {
     func createSurface() {
         guard surface == nil, let app = GhosttyService.shared.app else { return }
 
-        let backingSize = convertToBacking(bounds).size
-        guard backingSize.width > 0, backingSize.height > 0 else {
+        guard let backingSize = backingPixelSize() else {
             pendingSurfaceCreation = true
             return
         }
@@ -125,9 +124,7 @@ final class GhosttyTerminalNSView: NSView {
         let scale = Double(window?.backingScaleFactor ?? 2.0)
         ghostty_surface_set_content_scale(surface, scale, scale)
 
-        let w = UInt32(backingSize.width)
-        let h = UInt32(backingSize.height)
-        ghostty_surface_set_size(surface, w, h)
+        ghostty_surface_set_size(surface, backingSize.width, backingSize.height)
 
         let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
@@ -161,24 +158,38 @@ final class GhosttyTerminalNSView: NSView {
             NotificationCenter.default.removeObserver(observer)
             screenChangeObserver = nil
         }
+        if let observer = backingPropertiesChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            backingPropertiesChangeObserver = nil
+        }
+        delayedResizeWorkItem?.cancel()
+        delayedResizeWorkItem = nil
         destroySurface()
         removeFromSuperview()
     }
 
     deinit {
         screenChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
+        backingPropertiesChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
+        delayedResizeWorkItem?.cancel()
         if let surface {
             ghostty_surface_free(surface)
         }
     }
 
     nonisolated(unsafe) private var screenChangeObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var backingPropertiesChangeObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var delayedResizeWorkItem: DispatchWorkItem?
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
 
         screenChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
         screenChangeObserver = nil
+        backingPropertiesChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
+        backingPropertiesChangeObserver = nil
+        delayedResizeWorkItem?.cancel()
+        delayedResizeWorkItem = nil
 
         guard let window else { return }
 
@@ -192,11 +203,21 @@ final class GhosttyTerminalNSView: NSView {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.updateMetalLayerSize()
+                self?.updateMetalLayerSize(deferred: true)
             }
         }
 
-        updateMetalLayerSize()
+        backingPropertiesChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeBackingPropertiesNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.updateMetalLayerSize(deferred: true)
+            }
+        }
+
+        updateMetalLayerSize(deferred: true)
     }
 
     override func setFrameSize(_ newSize: NSSize) {
@@ -204,12 +225,12 @@ final class GhosttyTerminalNSView: NSView {
         if pendingSurfaceCreation {
             createSurface()
         }
-        updateMetalLayerSize()
+        updateMetalLayerSize(deferred: false)
     }
 
     override func viewDidChangeBackingProperties() {
         super.viewDidChangeBackingProperties()
-        updateMetalLayerSize()
+        updateMetalLayerSize(deferred: true)
     }
 
     override func viewDidChangeEffectiveAppearance() {
@@ -219,11 +240,25 @@ final class GhosttyTerminalNSView: NSView {
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
     }
 
-    private func updateMetalLayerSize() {
-        guard let surface, let window else { return }
+    private func updateMetalLayerSize(deferred: Bool) {
+        if deferred {
+            delayedResizeWorkItem?.cancel()
+            DispatchQueue.main.async { [weak self] in
+                self?.updateMetalLayerSize(deferred: false)
+            }
+            let workItem = DispatchWorkItem { [weak self] in
+                self?.updateMetalLayerSize(deferred: false)
+            }
+            delayedResizeWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
+            return
+        }
 
-        let scaledSize = convertToBacking(bounds).size
-        guard scaledSize.width > 0, scaledSize.height > 0 else { return }
+        guard let surface, let window else { return }
+        layer?.contentsScale = window.backingScaleFactor
+        layoutSubtreeIfNeeded()
+
+        guard let backingSize = backingPixelSize() else { return }
 
         let scale = Double(window.backingScaleFactor)
 
@@ -241,13 +276,19 @@ final class GhosttyTerminalNSView: NSView {
             return
         }
 
-        let w = UInt32(scaledSize.width)
-        let h = UInt32(scaledSize.height)
-        ghostty_surface_set_size(surface, w, h)
+        ghostty_surface_set_size(surface, backingSize.width, backingSize.height)
     }
 
     func remoteOwnershipDidChange() {
-        updateMetalLayerSize()
+        updateMetalLayerSize(deferred: false)
+    }
+
+    private func backingPixelSize() -> (width: UInt32, height: UInt32)? {
+        let size = convertToBacking(bounds).size
+        let width = Int(floor(size.width))
+        let height = Int(floor(size.height))
+        guard width > 0, height > 0 else { return nil }
+        return (UInt32(width), UInt32(height))
     }
 
     private func isAppShortcut(_ event: NSEvent) -> Bool {


### PR DESCRIPTION
## Summary
This PR fixes issue #164. Terminal content was not showing properly when window was moved between different displays.

## Changes

- Added a small delayed resize to let AppKit settle when the window moves between displays
- Updated the view/layer scaling step to match the new display first, then resize the Ghosty surface
- Hooked into screen/backing change notifications to re-apply safe-area neutralization, which was getting out of sync after moving between monitors.
- Switched backing pixel rounding from `ceil` to `floor` to avoid occasional off-by-one sizing that could clip the bottom row.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS