### PR TITLE
Extract DiffCache from VCSTabState

### DIFF
--- a/Muxy/Models/DiffCache.swift
+++ b/Muxy/Models/DiffCache.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+@MainActor
+@Observable
+final class DiffCache {
+    struct LoadedDiff {
+        let rows: [DiffDisplayRow]
+        let additions: Int
+        let deletions: Int
+        let truncated: Bool
+    }
+
+    private(set) var diffsByPath: [String: LoadedDiff] = [:]
+    private(set) var loadingPaths: Set<String> = []
+    private(set) var errorsByPath: [String: String] = [:]
+
+    @ObservationIgnored private var accessOrder: [String] = []
+    @ObservationIgnored nonisolated(unsafe) private var tasks: [String: Task<Void, Never>] = [:]
+    @ObservationIgnored private let cap: Int
+
+    init(cap: Int = 50) {
+        self.cap = cap
+    }
+
+    func diff(for filePath: String) -> LoadedDiff? {
+        diffsByPath[filePath]
+    }
+
+    func isLoading(_ filePath: String) -> Bool {
+        loadingPaths.contains(filePath)
+    }
+
+    func error(for filePath: String) -> String? {
+        errorsByPath[filePath]
+    }
+
+    func hasDiff(for filePath: String) -> Bool {
+        diffsByPath[filePath] != nil
+    }
+
+    func markLoading(_ filePath: String) {
+        loadingPaths.insert(filePath)
+        errorsByPath[filePath] = nil
+    }
+
+    func store(_ diff: LoadedDiff, for filePath: String, pinnedPaths: Set<String>) {
+        diffsByPath[filePath] = diff
+        touch(filePath)
+        loadingPaths.remove(filePath)
+        tasks.removeValue(forKey: filePath)
+        enforceCap(pinnedPaths: pinnedPaths)
+    }
+
+    func storeError(_ message: String, for filePath: String) {
+        errorsByPath[filePath] = message
+        loadingPaths.remove(filePath)
+        tasks.removeValue(forKey: filePath)
+    }
+
+    func touch(_ filePath: String) {
+        accessOrder.removeAll { $0 == filePath }
+        accessOrder.append(filePath)
+    }
+
+    func evict(_ filePath: String) {
+        diffsByPath.removeValue(forKey: filePath)
+        errorsByPath.removeValue(forKey: filePath)
+        tasks[filePath]?.cancel()
+        tasks.removeValue(forKey: filePath)
+        loadingPaths.remove(filePath)
+        accessOrder.removeAll { $0 == filePath }
+    }
+
+    func cancelLoad(for filePath: String) {
+        tasks[filePath]?.cancel()
+        tasks.removeValue(forKey: filePath)
+        loadingPaths.remove(filePath)
+    }
+
+    func registerTask(_ task: Task<Void, Never>, for filePath: String) {
+        tasks[filePath]?.cancel()
+        tasks[filePath] = task
+    }
+
+    func collapseAll() {
+        tasks.values.forEach { $0.cancel() }
+        tasks.removeAll()
+        loadingPaths.removeAll()
+        errorsByPath.removeAll()
+    }
+
+    func clearAll() {
+        tasks.values.forEach { $0.cancel() }
+        tasks.removeAll()
+        diffsByPath.removeAll()
+        loadingPaths.removeAll()
+        errorsByPath.removeAll()
+        accessOrder.removeAll()
+    }
+
+    nonisolated func cancelAll() {
+        tasks.values.forEach { $0.cancel() }
+    }
+
+    private func enforceCap(pinnedPaths: Set<String>) {
+        while accessOrder.count > cap {
+            let oldest = accessOrder.removeFirst()
+            if pinnedPaths.contains(oldest) { continue }
+            diffsByPath.removeValue(forKey: oldest)
+            errorsByPath.removeValue(forKey: oldest)
+        }
+    }
+}

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -19,12 +19,7 @@ final class VCSTabState {
         }
     }
 
-    struct LoadedDiff {
-        let rows: [DiffDisplayRow]
-        let additions: Int
-        let deletions: Int
-        let truncated: Bool
-    }
+    typealias LoadedDiff = DiffCache.LoadedDiff
 
     enum PRLaunchState: Equatable {
         case hidden
@@ -59,9 +54,7 @@ final class VCSTabState {
     var expandedFilePaths: Set<String> = []
     var isLoadingFiles = false
     var errorMessage: String?
-    var diffsByPath: [String: LoadedDiff] = [:]
-    var loadingDiffPaths: Set<String> = []
-    var diffErrorsByPath: [String: String] = [:]
+    let diffCache = DiffCache()
     var branchName: String?
     var pullRequestInfo: GitRepositoryService.PRInfo?
     var defaultBranch: String?
@@ -136,17 +129,14 @@ final class VCSTabState {
     @ObservationIgnored private var branchTask: Task<Void, Never>?
     @ObservationIgnored private var prInfoTask: Task<Void, Never>?
     @ObservationIgnored private var loadBranchesTask: Task<Void, Never>?
-    @ObservationIgnored private var loadDiffTasks: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var commitLogTask: Task<Void, Never>?
     @ObservationIgnored private var watcher: GitDirectoryWatcher?
     @ObservationIgnored nonisolated(unsafe) private var remoteChangeObserver: NSObjectProtocol?
     @ObservationIgnored private var isRefreshing = false
     @ObservationIgnored private var pendingRefresh = false
-    @ObservationIgnored private var diffAccessOrder: [String] = []
     @ObservationIgnored private var lastFetchedHeadSha: String?
     private(set) var hasCompletedInitialLoad = false
     @ObservationIgnored private static let commitsPerPage = 100
-    @ObservationIgnored private static let diffCacheCap = 50
 
     init(projectPath: String) {
         self.projectPath = projectPath
@@ -160,7 +150,7 @@ final class VCSTabState {
         prInfoTask?.cancel()
         loadBranchesTask?.cancel()
         commitLogTask?.cancel()
-        loadDiffTasks.values.forEach { $0.cancel() }
+        diffCache.cancelAll()
         if let remoteChangeObserver {
             NotificationCenter.default.removeObserver(remoteChangeObserver)
         }
@@ -279,7 +269,7 @@ final class VCSTabState {
                 if !removedPaths.isEmpty {
                     expandedFilePaths = expandedFilePaths.intersection(validPaths)
                     for path in removedPaths {
-                        evictDiff(filePath: path)
+                        diffCache.evict(path)
                     }
                 }
 
@@ -291,7 +281,7 @@ final class VCSTabState {
                     }
                     if Self.stagingStateChanged(old: old, new: file) {
                         changedPaths.insert(file.path)
-                        evictDiff(filePath: file.path)
+                        diffCache.evict(file.path)
                     }
                 }
 
@@ -315,12 +305,7 @@ final class VCSTabState {
                 guard !Task.isCancelled else { return }
                 files = []
                 expandedFilePaths = []
-                diffsByPath = [:]
-                loadingDiffPaths = []
-                diffErrorsByPath = [:]
-                loadDiffTasks.values.forEach { $0.cancel() }
-                loadDiffTasks = [:]
-                diffAccessOrder = []
+                diffCache.clearAll()
                 errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
                 isLoadingFiles = false
             }
@@ -337,59 +322,21 @@ final class VCSTabState {
     func toggleExpanded(filePath: String) {
         if expandedFilePaths.contains(filePath) {
             expandedFilePaths.remove(filePath)
-            loadDiffTasks[filePath]?.cancel()
-            loadDiffTasks.removeValue(forKey: filePath)
-            loadingDiffPaths.remove(filePath)
+            diffCache.cancelLoad(for: filePath)
             return
         }
 
         expandedFilePaths.insert(filePath)
-        if needsDiffReload(filePath: filePath) {
-            loadDiff(filePath: filePath, forceFull: false)
+        if diffCache.hasDiff(for: filePath) {
+            diffCache.touch(filePath)
         } else {
-            touchCache(filePath: filePath)
+            loadDiff(filePath: filePath, forceFull: false)
         }
     }
 
     func collapseAll() {
         expandedFilePaths.removeAll()
-        loadDiffTasks.values.forEach { $0.cancel() }
-        loadDiffTasks.removeAll()
-        loadingDiffPaths.removeAll()
-        diffErrorsByPath.removeAll()
-    }
-
-    private func evictDiff(filePath: String) {
-        diffsByPath.removeValue(forKey: filePath)
-        diffErrorsByPath.removeValue(forKey: filePath)
-        loadDiffTasks[filePath]?.cancel()
-        loadDiffTasks.removeValue(forKey: filePath)
-        loadingDiffPaths.remove(filePath)
-        diffAccessOrder.removeAll { $0 == filePath }
-    }
-
-    private func needsDiffReload(filePath: String) -> Bool {
-        diffsByPath[filePath] == nil
-    }
-
-    private func touchCache(filePath: String) {
-        diffAccessOrder.removeAll { $0 == filePath }
-        diffAccessOrder.append(filePath)
-    }
-
-    private func storeDiff(_ diff: LoadedDiff, for filePath: String) {
-        diffsByPath[filePath] = diff
-        touchCache(filePath: filePath)
-        enforceDiffCacheCap()
-    }
-
-    private func enforceDiffCacheCap() {
-        while diffAccessOrder.count > Self.diffCacheCap {
-            let oldest = diffAccessOrder.removeFirst()
-            if expandedFilePaths.contains(oldest) { continue }
-            diffsByPath.removeValue(forKey: oldest)
-            diffErrorsByPath.removeValue(forKey: oldest)
-        }
+        diffCache.collapseAll()
     }
 
     func expandAll() {
@@ -402,10 +349,10 @@ final class VCSTabState {
             var toLoad: [String] = []
             for file in files where !updated.contains(file.path) {
                 updated.insert(file.path)
-                if needsDiffReload(filePath: file.path) {
-                    toLoad.append(file.path)
+                if diffCache.hasDiff(for: file.path) {
+                    diffCache.touch(file.path)
                 } else {
-                    touchCache(filePath: file.path)
+                    toLoad.append(file.path)
                 }
             }
             expandedFilePaths = updated
@@ -418,9 +365,7 @@ final class VCSTabState {
         var updated = expandedFilePaths
         for file in files where updated.contains(file.path) {
             updated.remove(file.path)
-            loadDiffTasks[file.path]?.cancel()
-            loadDiffTasks.removeValue(forKey: file.path)
-            loadingDiffPaths.remove(file.path)
+            diffCache.cancelLoad(for: file.path)
         }
         expandedFilePaths = updated
     }
@@ -436,7 +381,7 @@ final class VCSTabState {
     }
 
     func displayedStats(for file: GitStatusFile) -> FileStats {
-        if let loaded = diffsByPath[file.path] {
+        if let loaded = diffCache.diff(for: file.path) {
             return FileStats(additions: loaded.additions, deletions: loaded.deletions, binary: false)
         }
         return FileStats(additions: file.additions, deletions: file.deletions, binary: file.isBinary)
@@ -1039,14 +984,12 @@ final class VCSTabState {
     }
 
     private func loadDiff(filePath: String, forceFull: Bool) {
-        loadDiffTasks[filePath]?.cancel()
-        loadingDiffPaths.insert(filePath)
-        diffErrorsByPath[filePath] = nil
+        diffCache.markLoading(filePath)
 
         let lineLimit = forceFull ? nil : 20000
         let hints = diffHints(for: filePath)
 
-        loadDiffTasks[filePath] = Task { [weak self] in
+        let task = Task { [weak self] in
             guard let self else { return }
             do {
                 let result = try await git.patchAndCompare(
@@ -1057,23 +1000,22 @@ final class VCSTabState {
                 )
                 guard !Task.isCancelled else { return }
 
-                storeDiff(
+                diffCache.store(
                     LoadedDiff(
                         rows: result.rows,
                         additions: result.additions,
                         deletions: result.deletions,
                         truncated: result.truncated
                     ),
-                    for: filePath
+                    for: filePath,
+                    pinnedPaths: expandedFilePaths
                 )
-                loadingDiffPaths.remove(filePath)
-                loadDiffTasks.removeValue(forKey: filePath)
             } catch {
                 guard !Task.isCancelled else { return }
-                diffErrorsByPath[filePath] = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-                loadingDiffPaths.remove(filePath)
-                loadDiffTasks.removeValue(forKey: filePath)
+                let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                diffCache.storeError(message, for: filePath)
             }
         }
+        diffCache.registerTask(task, for: filePath)
     }
 }

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1392,19 +1392,19 @@ private struct SectionSplitLayout: View {
 
     @ViewBuilder
     private func expandedDiff(for file: GitStatusFile) -> some View {
-        if state.loadingDiffPaths.contains(file.path) {
+        if state.diffCache.isLoading(file.path) {
             ProgressView()
                 .frame(maxWidth: .infinity)
                 .padding(14)
                 .background(MuxyTheme.bg)
-        } else if let error = state.diffErrorsByPath[file.path] {
+        } else if let error = state.diffCache.error(for: file.path) {
             Text(error)
                 .font(.system(size: 12))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
                 .background(MuxyTheme.bg)
-        } else if let diff = state.diffsByPath[file.path] {
+        } else if let diff = state.diffCache.diff(for: file.path) {
             VStack(spacing: 0) {
                 if diff.truncated {
                     HStack {

--- a/Tests/MuxyTests/Models/DiffCacheTests.swift
+++ b/Tests/MuxyTests/Models/DiffCacheTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("DiffCache")
+@MainActor
+struct DiffCacheTests {
+    private func makeDiff(additions: Int = 1, deletions: Int = 0, truncated: Bool = false) -> DiffCache.LoadedDiff {
+        DiffCache.LoadedDiff(rows: [], additions: additions, deletions: deletions, truncated: truncated)
+    }
+
+    @Test("store makes diff retrievable")
+    func storeMakesDiffRetrievable() {
+        let cache = DiffCache()
+        let diff = makeDiff()
+        cache.store(diff, for: "a.swift", pinnedPaths: [])
+        #expect(cache.hasDiff(for: "a.swift"))
+        #expect(cache.diff(for: "a.swift")?.additions == 1)
+    }
+
+    @Test("markLoading reports loading and clears prior error")
+    func markLoadingClearsError() {
+        let cache = DiffCache()
+        cache.storeError("boom", for: "a.swift")
+        #expect(cache.error(for: "a.swift") == "boom")
+        cache.markLoading("a.swift")
+        #expect(cache.isLoading("a.swift"))
+        #expect(cache.error(for: "a.swift") == nil)
+    }
+
+    @Test("store clears loading state for that path")
+    func storeClearsLoading() {
+        let cache = DiffCache()
+        cache.markLoading("a.swift")
+        #expect(cache.isLoading("a.swift"))
+        cache.store(makeDiff(), for: "a.swift", pinnedPaths: [])
+        #expect(!cache.isLoading("a.swift"))
+    }
+
+    @Test("storeError clears loading state")
+    func storeErrorClearsLoading() {
+        let cache = DiffCache()
+        cache.markLoading("a.swift")
+        cache.storeError("oops", for: "a.swift")
+        #expect(!cache.isLoading("a.swift"))
+        #expect(cache.error(for: "a.swift") == "oops")
+    }
+
+    @Test("evict removes diff, error, loading, and access order entry")
+    func evictRemovesAll() {
+        let cache = DiffCache()
+        cache.store(makeDiff(), for: "a.swift", pinnedPaths: [])
+        cache.storeError("e", for: "a.swift")
+        cache.markLoading("a.swift")
+        cache.evict("a.swift")
+        #expect(!cache.hasDiff(for: "a.swift"))
+        #expect(cache.error(for: "a.swift") == nil)
+        #expect(!cache.isLoading("a.swift"))
+    }
+
+    @Test("LRU evicts oldest unpinned entry when cap exceeded")
+    func lruEvictsOldestUnpinned() {
+        let cache = DiffCache(cap: 2)
+        cache.store(makeDiff(), for: "a.swift", pinnedPaths: [])
+        cache.store(makeDiff(), for: "b.swift", pinnedPaths: [])
+        cache.store(makeDiff(), for: "c.swift", pinnedPaths: [])
+        #expect(!cache.hasDiff(for: "a.swift"))
+        #expect(cache.hasDiff(for: "b.swift"))
+        #expect(cache.hasDiff(for: "c.swift"))
+    }
+
+    @Test("LRU keeps pinned entries even when they are oldest")
+    func lruRespectsPinned() {
+        let cache = DiffCache(cap: 2)
+        cache.store(makeDiff(), for: "a.swift", pinnedPaths: ["a.swift"])
+        cache.store(makeDiff(), for: "b.swift", pinnedPaths: ["a.swift"])
+        cache.store(makeDiff(), for: "c.swift", pinnedPaths: ["a.swift"])
+        #expect(cache.hasDiff(for: "a.swift"))
+        #expect(cache.hasDiff(for: "b.swift"))
+        #expect(cache.hasDiff(for: "c.swift"))
+    }
+
+    @Test("touch moves entry to newest in LRU")
+    func touchMovesToNewest() {
+        let cache = DiffCache(cap: 2)
+        cache.store(makeDiff(), for: "a.swift", pinnedPaths: [])
+        cache.store(makeDiff(), for: "b.swift", pinnedPaths: [])
+        cache.touch("a.swift")
+        cache.store(makeDiff(), for: "c.swift", pinnedPaths: [])
+        #expect(cache.hasDiff(for: "a.swift"))
+        #expect(!cache.hasDiff(for: "b.swift"))
+        #expect(cache.hasDiff(for: "c.swift"))
+    }
+
+    @Test("collapseAll clears loading and errors but keeps diffs")
+    func collapseAllKeepsDiffs() {
+        let cache = DiffCache()
+        cache.store(makeDiff(), for: "a.swift", pinnedPaths: [])
+        cache.markLoading("b.swift")
+        cache.storeError("e", for: "c.swift")
+        cache.collapseAll()
+        #expect(cache.hasDiff(for: "a.swift"))
+        #expect(!cache.isLoading("b.swift"))
+        #expect(cache.error(for: "c.swift") == nil)
+    }
+
+    @Test("clearAll removes everything")
+    func clearAllRemovesEverything() {
+        let cache = DiffCache()
+        cache.store(makeDiff(), for: "a.swift", pinnedPaths: [])
+        cache.markLoading("b.swift")
+        cache.storeError("e", for: "c.swift")
+        cache.clearAll()
+        #expect(!cache.hasDiff(for: "a.swift"))
+        #expect(!cache.isLoading("b.swift"))
+        #expect(cache.error(for: "c.swift") == nil)
+    }
+
+    @Test("cancelLoad clears loading flag for path")
+    func cancelLoadClearsLoading() {
+        let cache = DiffCache()
+        cache.markLoading("a.swift")
+        cache.cancelLoad(for: "a.swift")
+        #expect(!cache.isLoading("a.swift"))
+    }
+}


### PR DESCRIPTION
  - Pulled the diff cache out of `VCSTabState` into a standalone `DiffCache` class that owns diffs, loading flags, errors,
  LRU access order, per-path tasks, and the cache cap.
  - `VCSTabState` now holds `let diffCache = DiffCache()` and delegates all cache operations through it. Views read via
  `state.diffCache.isLoading(_:) / .error(for:) / .diff(for:)`.
  - Pinning is now explicit: callers pass `pinnedPaths: expandedFilePaths` into `store()`, so the cache can't silently
  evict what the user has open.
  - Added 11 unit tests covering store/retrieve, loading/error transitions, LRU eviction with pinned paths, `touch`
  reordering, `collapseAll`, and `clearAll`.