### PR TITLE
Extract GitPRParser and GitCommitLogParser from GitRepositoryService

### DIFF
--- a/Muxy/Services/Git/GitCommitLogParser.swift
+++ b/Muxy/Services/Git/GitCommitLogParser.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum GitCommitLogParser {
+    static let fieldSeparator = "\u{1F}"
+    static let recordSeparator = "\u{1E}"
+
+    static let logFormat = [
+        "%H", "%h", "%s", "%an", "%aI", "%D", "%P",
+    ].joined(separator: fieldSeparator) + recordSeparator
+
+    static func parseCommitLog(_ raw: String) -> [GitCommit] {
+        let records = raw.split(separator: Character(recordSeparator), omittingEmptySubsequences: true)
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime]
+
+        return records.compactMap { record in
+            let fields = record.trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(separator: Character(fieldSeparator), maxSplits: 6, omittingEmptySubsequences: false)
+            guard fields.count >= 7 else { return nil }
+
+            let hash = String(fields[0])
+            let shortHash = String(fields[1])
+            let subject = String(fields[2])
+            let authorName = String(fields[3])
+            let dateString = String(fields[4])
+            let refsRaw = String(fields[5])
+            let parentsRaw = String(fields[6])
+
+            let date = dateFormatter.date(from: dateString) ?? Date.distantPast
+            let refs = parseRefs(refsRaw)
+            let parents = parentsRaw.split(separator: " ").map(String.init)
+
+            return GitCommit(
+                hash: hash,
+                shortHash: shortHash,
+                subject: subject,
+                authorName: authorName,
+                authorDate: date,
+                refs: refs,
+                parentHashes: parents
+            )
+        }
+    }
+
+    static func parseRefs(_ raw: String) -> [GitRef] {
+        guard !raw.isEmpty else { return [] }
+        return raw.split(separator: ",").compactMap { segment in
+            let trimmed = segment.trimmingCharacters(in: .whitespaces)
+            if trimmed == "HEAD" {
+                return GitRef(name: "HEAD", kind: .head)
+            }
+            if trimmed.hasPrefix("HEAD -> ") {
+                let branch = String(trimmed.dropFirst("HEAD -> ".count))
+                    .replacingOccurrences(of: "refs/heads/", with: "")
+                return GitRef(name: branch, kind: .localBranch)
+            }
+            if trimmed.hasPrefix("tag: ") {
+                let tag = String(trimmed.dropFirst("tag: ".count))
+                    .replacingOccurrences(of: "refs/tags/", with: "")
+                return GitRef(name: tag, kind: .tag)
+            }
+            if trimmed.hasPrefix("refs/heads/") {
+                let name = String(trimmed.dropFirst("refs/heads/".count))
+                return GitRef(name: name, kind: .localBranch)
+            }
+            if trimmed.hasPrefix("refs/remotes/") {
+                let name = String(trimmed.dropFirst("refs/remotes/".count))
+                return GitRef(name: name, kind: .remoteBranch)
+            }
+            if trimmed.hasPrefix("refs/tags/") {
+                let name = String(trimmed.dropFirst("refs/tags/".count))
+                return GitRef(name: name, kind: .tag)
+            }
+            return GitRef(name: trimmed, kind: .localBranch)
+        }
+    }
+}

--- a/Muxy/Services/Git/GitPRParser.swift
+++ b/Muxy/Services/Git/GitPRParser.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+enum GitPRParser {
+    static func parsePRInfo(_ json: String) -> GitRepositoryService.PRInfo? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return parsePRInfo(object)
+    }
+
+    static func parsePRInfo(_ json: [String: Any]) -> GitRepositoryService.PRInfo? {
+        guard let url = json["url"] as? String,
+              let number = json["number"] as? Int,
+              let stateRaw = json["state"] as? String
+        else { return nil }
+
+        let state = GitRepositoryService.PRState(rawValue: stateRaw) ?? .open
+        let isDraft = json["isDraft"] as? Bool ?? false
+        let baseBranch = json["baseRefName"] as? String ?? ""
+        let mergeable: Bool? = switch json["mergeable"] as? String {
+        case "MERGEABLE": true
+        case "CONFLICTING": false
+        default: nil
+        }
+        let rollup = json["statusCheckRollup"] as? [[String: Any]] ?? []
+
+        return GitRepositoryService.PRInfo(
+            url: url,
+            number: number,
+            state: state,
+            isDraft: isDraft,
+            baseBranch: baseBranch,
+            mergeable: mergeable,
+            checks: parseStatusChecks(rollup)
+        )
+    }
+
+    static func parseStatusChecks(_ rollup: [[String: Any]]) -> GitRepositoryService.PRChecks {
+        if rollup.isEmpty {
+            return GitRepositoryService.PRChecks(status: .none, passing: 0, failing: 0, pending: 0, total: 0)
+        }
+
+        var passing = 0
+        var failing = 0
+        var pending = 0
+
+        for entry in rollup {
+            switch classifyOutcome(entry) {
+            case .passing: passing += 1
+            case .failing: failing += 1
+            case .pending: pending += 1
+            }
+        }
+
+        let total = passing + failing + pending
+        let status: GitRepositoryService.PRChecksStatus = if failing > 0 {
+            .failure
+        } else if pending > 0 {
+            .pending
+        } else if passing > 0 {
+            .success
+        } else {
+            .none
+        }
+        return GitRepositoryService.PRChecks(
+            status: status,
+            passing: passing,
+            failing: failing,
+            pending: pending,
+            total: total
+        )
+    }
+
+    static func parseAheadBehind(counts: String, hasUpstream: Bool) -> GitRepositoryService.AheadBehind {
+        guard hasUpstream else {
+            return GitRepositoryService.AheadBehind(ahead: 0, behind: 0, hasUpstream: false)
+        }
+        let parts = counts
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0 == "\t" || $0 == " " })
+        guard parts.count == 2,
+              let ahead = Int(parts[0]),
+              let behind = Int(parts[1])
+        else {
+            return GitRepositoryService.AheadBehind(ahead: 0, behind: 0, hasUpstream: true)
+        }
+        return GitRepositoryService.AheadBehind(ahead: ahead, behind: behind, hasUpstream: true)
+    }
+
+    private enum Outcome {
+        case passing
+        case failing
+        case pending
+    }
+
+    private static func classifyOutcome(_ entry: [String: Any]) -> Outcome {
+        let typename = entry["__typename"] as? String ?? ""
+        let raw: String = if typename == "CheckRun" {
+            if (entry["status"] as? String ?? "").uppercased() != "COMPLETED" {
+                "PENDING"
+            } else {
+                (entry["conclusion"] as? String ?? "").uppercased()
+            }
+        } else {
+            (entry["state"] as? String ?? "").uppercased()
+        }
+
+        switch raw {
+        case "SUCCESS",
+             "NEUTRAL",
+             "SKIPPED":
+            return .passing
+        case "FAILURE",
+             "ERROR",
+             "CANCELLED",
+             "TIMED_OUT",
+             "ACTION_REQUIRED",
+             "STARTUP_FAILURE":
+            return .failing
+        default:
+            return .pending
+        }
+    }
+}

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -193,99 +193,8 @@ struct GitRepositoryService {
             arguments: arguments,
             workingDirectory: repoPath
         )
-        guard let result, result.status == 0,
-              let data = result.stdout.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return nil }
-
-        guard let url = json["url"] as? String,
-              let number = json["number"] as? Int,
-              let stateRaw = json["state"] as? String
-        else { return nil }
-
-        let state = PRState(rawValue: stateRaw) ?? .open
-        let isDraft = json["isDraft"] as? Bool ?? false
-        let baseBranch = json["baseRefName"] as? String ?? ""
-        let mergeableRaw = json["mergeable"] as? String
-        let mergeable: Bool? = switch mergeableRaw {
-        case "MERGEABLE": true
-        case "CONFLICTING": false
-        default: nil
-        }
-
-        let rollup = json["statusCheckRollup"] as? [[String: Any]] ?? []
-        let checks = Self.parseStatusChecks(rollup)
-
-        return PRInfo(
-            url: url,
-            number: number,
-            state: state,
-            isDraft: isDraft,
-            baseBranch: baseBranch,
-            mergeable: mergeable,
-            checks: checks
-        )
-    }
-
-    private static func parseStatusChecks(_ rollup: [[String: Any]]) -> PRChecks {
-        if rollup.isEmpty {
-            return PRChecks(status: .none, passing: 0, failing: 0, pending: 0, total: 0)
-        }
-
-        var passing = 0
-        var failing = 0
-        var pending = 0
-
-        for entry in rollup {
-            let typename = entry["__typename"] as? String ?? ""
-            let outcome: String
-            if typename == "CheckRun" {
-                let status = (entry["status"] as? String ?? "").uppercased()
-                let conclusion = (entry["conclusion"] as? String ?? "").uppercased()
-                if status != "COMPLETED" {
-                    outcome = "PENDING"
-                } else {
-                    outcome = conclusion
-                }
-            } else {
-                outcome = (entry["state"] as? String ?? "").uppercased()
-            }
-
-            switch outcome {
-            case "SUCCESS",
-                 "NEUTRAL",
-                 "SKIPPED":
-                passing += 1
-            case "FAILURE",
-                 "ERROR",
-                 "CANCELLED",
-                 "TIMED_OUT",
-                 "ACTION_REQUIRED",
-                 "STARTUP_FAILURE":
-                failing += 1
-            case "PENDING",
-                 "QUEUED",
-                 "IN_PROGRESS",
-                 "WAITING",
-                 "REQUESTED",
-                 "EXPECTED":
-                pending += 1
-            default:
-                pending += 1
-            }
-        }
-
-        let total = passing + failing + pending
-        let status: PRChecksStatus = if failing > 0 {
-            .failure
-        } else if pending > 0 {
-            .pending
-        } else if passing > 0 {
-            .success
-        } else {
-            .none
-        }
-        return PRChecks(status: status, passing: passing, failing: failing, pending: pending, total: total)
+        guard let result, result.status == 0 else { return nil }
+        return GitPRParser.parsePRInfo(result.stdout)
     }
 
     func aheadBehind(repoPath: String, branch: String) async -> AheadBehind {
@@ -307,16 +216,7 @@ struct GitRepositoryService {
         guard let countsResult = try? await countsTask, countsResult.status == 0 else {
             return AheadBehind(ahead: 0, behind: 0, hasUpstream: true)
         }
-        let parts = countsResult.stdout
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: { $0 == "\t" || $0 == " " })
-        guard parts.count == 2,
-              let ahead = Int(parts[0]),
-              let behind = Int(parts[1])
-        else {
-            return AheadBehind(ahead: 0, behind: 0, hasUpstream: true)
-        }
-        return AheadBehind(ahead: ahead, behind: behind, hasUpstream: true)
+        return GitPRParser.parseAheadBehind(counts: countsResult.stdout, hasUpstream: true)
     }
 
     func hasRemoteBranch(repoPath: String, branch: String) async -> Bool {
@@ -888,20 +788,13 @@ struct GitRepositoryService {
         }
     }
 
-    private static let commitFieldSeparator = "\u{1F}"
-    private static let commitRecordSeparator = "\u{1E}"
-
-    private static let logFormat = [
-        "%H", "%h", "%s", "%an", "%aI", "%D", "%P",
-    ].joined(separator: commitFieldSeparator) + commitRecordSeparator
-
     func commitLog(repoPath: String, maxCount: Int = 100, skip: Int = 0) async throws -> [GitCommit] {
         let result = try await GitProcessRunner.runGit(
             repoPath: repoPath,
             arguments: [
                 "log",
                 "--decorate=full",
-                "--format=\(Self.logFormat)",
+                "--format=\(GitCommitLogParser.logFormat)",
                 "--max-count=\(maxCount)",
                 "--skip=\(skip)",
             ]
@@ -909,74 +802,7 @@ struct GitRepositoryService {
         guard result.status == 0 else {
             throw GitError.commandFailed(result.stderr.isEmpty ? "Failed to load commit history." : result.stderr)
         }
-        return Self.parseCommitLog(result.stdout)
-    }
-
-    private static func parseCommitLog(_ raw: String) -> [GitCommit] {
-        let records = raw.split(separator: Character(commitRecordSeparator), omittingEmptySubsequences: true)
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime]
-
-        return records.compactMap { record in
-            let fields = record.trimmingCharacters(in: .whitespacesAndNewlines)
-                .split(separator: Character(commitFieldSeparator), maxSplits: 6, omittingEmptySubsequences: false)
-            guard fields.count >= 7 else { return nil }
-
-            let hash = String(fields[0])
-            let shortHash = String(fields[1])
-            let subject = String(fields[2])
-            let authorName = String(fields[3])
-            let dateString = String(fields[4])
-            let refsRaw = String(fields[5])
-            let parentsRaw = String(fields[6])
-
-            let date = dateFormatter.date(from: dateString) ?? Date.distantPast
-            let refs = parseRefs(refsRaw)
-            let parents = parentsRaw.split(separator: " ").map(String.init)
-
-            return GitCommit(
-                hash: hash,
-                shortHash: shortHash,
-                subject: subject,
-                authorName: authorName,
-                authorDate: date,
-                refs: refs,
-                parentHashes: parents
-            )
-        }
-    }
-
-    private static func parseRefs(_ raw: String) -> [GitRef] {
-        guard !raw.isEmpty else { return [] }
-        return raw.split(separator: ",").compactMap { segment in
-            let trimmed = segment.trimmingCharacters(in: .whitespaces)
-            if trimmed == "HEAD" {
-                return GitRef(name: "HEAD", kind: .head)
-            }
-            if trimmed.hasPrefix("HEAD -> ") {
-                let branch = String(trimmed.dropFirst("HEAD -> ".count))
-                    .replacingOccurrences(of: "refs/heads/", with: "")
-                return GitRef(name: branch, kind: .localBranch)
-            }
-            if trimmed.hasPrefix("tag: ") {
-                let tag = String(trimmed.dropFirst("tag: ".count))
-                    .replacingOccurrences(of: "refs/tags/", with: "")
-                return GitRef(name: tag, kind: .tag)
-            }
-            if trimmed.hasPrefix("refs/heads/") {
-                let name = String(trimmed.dropFirst("refs/heads/".count))
-                return GitRef(name: name, kind: .localBranch)
-            }
-            if trimmed.hasPrefix("refs/remotes/") {
-                let name = String(trimmed.dropFirst("refs/remotes/".count))
-                return GitRef(name: name, kind: .remoteBranch)
-            }
-            if trimmed.hasPrefix("refs/tags/") {
-                let name = String(trimmed.dropFirst("refs/tags/".count))
-                return GitRef(name: name, kind: .tag)
-            }
-            return GitRef(name: trimmed, kind: .localBranch)
-        }
+        return GitCommitLogParser.parseCommitLog(result.stdout)
     }
 
     func cherryPick(repoPath: String, hash: String) async throws {

--- a/Tests/MuxyTests/Git/GitCommitLogParserTests.swift
+++ b/Tests/MuxyTests/Git/GitCommitLogParserTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitCommitLogParser")
+struct GitCommitLogParserTests {
+    private static let field = GitCommitLogParser.fieldSeparator
+    private static let record = GitCommitLogParser.recordSeparator
+
+    private func makeRecord(
+        hash: String = "abcdef1234567890abcdef1234567890abcdef12",
+        shortHash: String = "abcdef1",
+        subject: String = "Initial commit",
+        author: String = "Alice",
+        date: String = "2025-01-15T10:30:00Z",
+        refs: String = "",
+        parents: String = ""
+    ) -> String {
+        [hash, shortHash, subject, author, date, refs, parents]
+            .joined(separator: Self.field) + Self.record
+    }
+
+    @Test("empty input returns empty array")
+    func empty() {
+        #expect(GitCommitLogParser.parseCommitLog("").isEmpty)
+    }
+
+    @Test("single record parses all fields")
+    func singleRecord() {
+        let raw = makeRecord(
+            hash: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            shortHash: "a1b2c3d",
+            subject: "Fix bug",
+            author: "Bob Builder",
+            date: "2025-03-10T08:00:00Z",
+            refs: "",
+            parents: "parent1hash parent2hash"
+        )
+        let commits = GitCommitLogParser.parseCommitLog(raw)
+        #expect(commits.count == 1)
+        let c = commits[0]
+        #expect(c.hash == "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0")
+        #expect(c.shortHash == "a1b2c3d")
+        #expect(c.subject == "Fix bug")
+        #expect(c.authorName == "Bob Builder")
+        #expect(c.parentHashes == ["parent1hash", "parent2hash"])
+        #expect(c.isMerge == true)
+    }
+
+    @Test("multiple records parse in order")
+    func multipleRecords() {
+        let raw = makeRecord(hash: "aaa", shortHash: "aaa", subject: "First")
+            + makeRecord(hash: "bbb", shortHash: "bbb", subject: "Second")
+            + makeRecord(hash: "ccc", shortHash: "ccc", subject: "Third")
+        let commits = GitCommitLogParser.parseCommitLog(raw)
+        #expect(commits.count == 3)
+        #expect(commits.map(\.subject) == ["First", "Second", "Third"])
+    }
+
+    @Test("malformed record with too few fields is dropped")
+    func malformedDropped() {
+        let raw = "only\(Self.field)two\(Self.record)" + makeRecord(subject: "Good one")
+        let commits = GitCommitLogParser.parseCommitLog(raw)
+        #expect(commits.count == 1)
+        #expect(commits[0].subject == "Good one")
+    }
+
+    @Test("single parent is non-merge")
+    func singleParentNotMerge() {
+        let raw = makeRecord(parents: "onlyone")
+        let commits = GitCommitLogParser.parseCommitLog(raw)
+        #expect(commits[0].isMerge == false)
+        #expect(commits[0].parentHashes == ["onlyone"])
+    }
+
+    @Test("parseRefs handles empty string")
+    func parseRefsEmpty() {
+        #expect(GitCommitLogParser.parseRefs("").isEmpty)
+    }
+
+    @Test("parseRefs handles HEAD")
+    func parseRefsHead() {
+        let refs = GitCommitLogParser.parseRefs("HEAD")
+        #expect(refs.count == 1)
+        #expect(refs[0].name == "HEAD")
+        #expect(refs[0].kind == .head)
+    }
+
+    @Test("parseRefs handles HEAD -> branch")
+    func parseRefsHeadArrow() {
+        let refs = GitCommitLogParser.parseRefs("HEAD -> refs/heads/main")
+        #expect(refs.count == 1)
+        #expect(refs[0].name == "main")
+        #expect(refs[0].kind == .localBranch)
+    }
+
+    @Test("parseRefs handles tag prefix")
+    func parseRefsTagPrefix() {
+        let refs = GitCommitLogParser.parseRefs("tag: refs/tags/v1.0")
+        #expect(refs.count == 1)
+        #expect(refs[0].name == "v1.0")
+        #expect(refs[0].kind == .tag)
+    }
+
+    @Test("parseRefs handles refs/heads prefix")
+    func parseRefsLocalBranch() {
+        let refs = GitCommitLogParser.parseRefs("refs/heads/feature")
+        #expect(refs.count == 1)
+        #expect(refs[0].name == "feature")
+        #expect(refs[0].kind == .localBranch)
+    }
+
+    @Test("parseRefs handles refs/remotes prefix")
+    func parseRefsRemoteBranch() {
+        let refs = GitCommitLogParser.parseRefs("refs/remotes/origin/main")
+        #expect(refs.count == 1)
+        #expect(refs[0].name == "origin/main")
+        #expect(refs[0].kind == .remoteBranch)
+    }
+
+    @Test("parseRefs handles multiple comma-separated refs")
+    func parseRefsMultiple() {
+        let refs = GitCommitLogParser.parseRefs("HEAD -> refs/heads/main, refs/remotes/origin/main, tag: refs/tags/v2.0")
+        #expect(refs.count == 3)
+        #expect(refs[0].kind == .localBranch)
+        #expect(refs[1].kind == .remoteBranch)
+        #expect(refs[2].kind == .tag)
+        #expect(refs[0].name == "main")
+        #expect(refs[1].name == "origin/main")
+        #expect(refs[2].name == "v2.0")
+    }
+
+    @Test("parseRefs treats bare name as local branch")
+    func parseRefsBareName() {
+        let refs = GitCommitLogParser.parseRefs("develop")
+        #expect(refs.count == 1)
+        #expect(refs[0].name == "develop")
+        #expect(refs[0].kind == .localBranch)
+    }
+
+    @Test("logFormat matches expected git format string")
+    func logFormatShape() {
+        #expect(GitCommitLogParser.logFormat.contains("%H"))
+        #expect(GitCommitLogParser.logFormat.contains("%h"))
+        #expect(GitCommitLogParser.logFormat.contains("%s"))
+        #expect(GitCommitLogParser.logFormat.contains("%an"))
+        #expect(GitCommitLogParser.logFormat.contains("%aI"))
+        #expect(GitCommitLogParser.logFormat.contains("%D"))
+        #expect(GitCommitLogParser.logFormat.contains("%P"))
+        #expect(GitCommitLogParser.logFormat.hasSuffix(GitCommitLogParser.recordSeparator))
+    }
+}

--- a/Tests/MuxyTests/Git/GitPRParserTests.swift
+++ b/Tests/MuxyTests/Git/GitPRParserTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitPRParser")
+struct GitPRParserTests {
+    @Suite("parseStatusChecks")
+    struct StatusChecks {
+        @Test("empty rollup returns none status")
+        func emptyRollup() {
+            let result = GitPRParser.parseStatusChecks([])
+            #expect(result.status == .none)
+            #expect(result.total == 0)
+        }
+
+        @Test("all successful check runs report success")
+        func allSuccess() {
+            let rollup: [[String: Any]] = [
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"],
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": "NEUTRAL"],
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SKIPPED"],
+            ]
+            let result = GitPRParser.parseStatusChecks(rollup)
+            #expect(result.status == .success)
+            #expect(result.passing == 3)
+            #expect(result.failing == 0)
+            #expect(result.pending == 0)
+        }
+
+        @Test("any failure dominates status")
+        func anyFailure() {
+            let rollup: [[String: Any]] = [
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"],
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": "FAILURE"],
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"],
+            ]
+            let result = GitPRParser.parseStatusChecks(rollup)
+            #expect(result.status == .failure)
+            #expect(result.passing == 2)
+            #expect(result.failing == 1)
+        }
+
+        @Test("pending only reports pending status")
+        func pendingOnly() {
+            let rollup: [[String: Any]] = [
+                ["__typename": "CheckRun", "status": "IN_PROGRESS"],
+                ["__typename": "CheckRun", "status": "QUEUED"],
+            ]
+            let result = GitPRParser.parseStatusChecks(rollup)
+            #expect(result.status == .pending)
+            #expect(result.pending == 2)
+        }
+
+        @Test("StatusContext entries use state field")
+        func statusContextUsesStateField() {
+            let rollup: [[String: Any]] = [
+                ["__typename": "StatusContext", "state": "SUCCESS"],
+                ["__typename": "StatusContext", "state": "FAILURE"],
+                ["__typename": "StatusContext", "state": "PENDING"],
+            ]
+            let result = GitPRParser.parseStatusChecks(rollup)
+            #expect(result.passing == 1)
+            #expect(result.failing == 1)
+            #expect(result.pending == 1)
+            #expect(result.status == .failure)
+        }
+
+        @Test("all failure-class conclusions classify as failing")
+        func allFailureConclusions() {
+            let conclusions = ["FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"]
+            let rollup = conclusions.map { c -> [String: Any] in
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": c]
+            }
+            let result = GitPRParser.parseStatusChecks(rollup)
+            #expect(result.failing == conclusions.count)
+            #expect(result.passing == 0)
+        }
+
+        @Test("unknown conclusion falls into pending bucket")
+        func unknownConclusion() {
+            let rollup: [[String: Any]] = [
+                ["__typename": "CheckRun", "status": "COMPLETED", "conclusion": "MYSTERY"],
+            ]
+            let result = GitPRParser.parseStatusChecks(rollup)
+            #expect(result.pending == 1)
+        }
+    }
+
+    @Suite("parsePRInfo")
+    struct PRInfoParsing {
+        @Test("full JSON parses all fields")
+        func fullJSON() {
+            let json = """
+            {
+              "url": "https://github.com/a/b/pull/42",
+              "number": 42,
+              "state": "OPEN",
+              "isDraft": true,
+              "baseRefName": "main",
+              "mergeable": "MERGEABLE",
+              "statusCheckRollup": []
+            }
+            """
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.url == "https://github.com/a/b/pull/42")
+            #expect(info?.number == 42)
+            #expect(info?.state == .open)
+            #expect(info?.isDraft == true)
+            #expect(info?.baseBranch == "main")
+            #expect(info?.mergeable == true)
+            #expect(info?.checks.status == GitRepositoryService.PRChecksStatus.none)
+        }
+
+        @Test("CONFLICTING mergeable maps to false")
+        func conflictingMergeable() {
+            let json = """
+            {"url":"u","number":1,"state":"OPEN","mergeable":"CONFLICTING"}
+            """
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.mergeable == false)
+        }
+
+        @Test("unknown mergeable maps to nil")
+        func unknownMergeable() {
+            let json = """
+            {"url":"u","number":1,"state":"OPEN","mergeable":"UNKNOWN"}
+            """
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.mergeable == nil)
+        }
+
+        @Test("missing required fields returns nil")
+        func missingRequired() {
+            #expect(GitPRParser.parsePRInfo("{}") == nil)
+            #expect(GitPRParser.parsePRInfo(#"{"url":"u"}"#) == nil)
+            #expect(GitPRParser.parsePRInfo(#"{"url":"u","number":1}"#) == nil)
+        }
+
+        @Test("invalid JSON returns nil")
+        func invalidJSON() {
+            #expect(GitPRParser.parsePRInfo("not json") == nil)
+        }
+
+        @Test("unknown state defaults to open")
+        func unknownStateDefaults() {
+            let json = #"{"url":"u","number":1,"state":"WAT"}"#
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.state == .open)
+        }
+    }
+
+    @Suite("parseAheadBehind")
+    struct AheadBehindParsing {
+        @Test("no upstream returns zeros")
+        func noUpstream() {
+            let result = GitPRParser.parseAheadBehind(counts: "", hasUpstream: false)
+            #expect(result.hasUpstream == false)
+            #expect(result.ahead == 0)
+            #expect(result.behind == 0)
+        }
+
+        @Test("tab-separated counts parse")
+        func tabSeparated() {
+            let result = GitPRParser.parseAheadBehind(counts: "3\t5\n", hasUpstream: true)
+            #expect(result.hasUpstream == true)
+            #expect(result.ahead == 3)
+            #expect(result.behind == 5)
+        }
+
+        @Test("space-separated counts parse")
+        func spaceSeparated() {
+            let result = GitPRParser.parseAheadBehind(counts: "7 2", hasUpstream: true)
+            #expect(result.ahead == 7)
+            #expect(result.behind == 2)
+        }
+
+        @Test("malformed counts fall back to zeros with upstream")
+        func malformed() {
+            let result = GitPRParser.parseAheadBehind(counts: "abc", hasUpstream: true)
+            #expect(result.hasUpstream == true)
+            #expect(result.ahead == 0)
+            #expect(result.behind == 0)
+        }
+    }
+}


### PR DESCRIPTION
  - Pulled pure parsing logic out of `GitRepositoryService` into sibling parsers, matching the existing `GitDiffParser` /
  `GitStatusParser` pattern.
  - `GitPRParser` — PR JSON → `PRInfo`, status-check rollup → `PRChecks` (including the pass/fail/pending bucketing), and
  rev-list count → `AheadBehind`.
  - `GitCommitLogParser` — commit log output → `[GitCommit]`, ref string → `[GitRef]`, plus the ASCII field/record
  separators and the `git log --format=...` string.
  - `GitRepositoryService` now only spawns processes and wires results through these parsers.