### PR TITLE
Unify persistence layer behind CodableFileStore

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import SwiftUI
+
+private let logger = Logger(subsystem: "app.muxy", category: "AppState")
 
 @MainActor
 @Observable
@@ -76,8 +79,15 @@ final class AppState {
     }
 
     func restoreSelection(projects: [Project], worktrees: [UUID: [Worktree]]) {
+        let snapshots: [WorkspaceSnapshot]
+        do {
+            snapshots = try workspacePersistence.loadWorkspaces()
+        } catch {
+            logger.error("Failed to load workspaces: \(error)")
+            snapshots = []
+        }
         let restored = WorkspaceRestorer.restoreAll(
-            from: workspacePersistence.loadWorkspaces(),
+            from: snapshots,
             projects: projects,
             worktrees: worktrees
         )
@@ -111,7 +121,11 @@ final class AppState {
             workspaceRoots: workspaceRoots,
             focusedAreaID: focusedAreaID
         )
-        workspacePersistence.saveWorkspaces(snapshots)
+        do {
+            try workspacePersistence.saveWorkspaces(snapshots)
+        } catch {
+            logger.error("Failed to save workspaces: \(error)")
+        }
     }
 
     private func saveSelection() {

--- a/Muxy/Services/CodableFileStore.swift
+++ b/Muxy/Services/CodableFileStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct CodableFileStoreOptions {
+    var prettyPrinted: Bool = false
+    var sortedKeys: Bool = false
+    var filePermissions: Int?
+
+    static let standard = Self()
+    static let pretty = Self(prettyPrinted: true)
+    static let prettySorted = Self(prettyPrinted: true, sortedKeys: true)
+}
+
+struct CodableFileStore<Value: Codable> {
+    let fileURL: URL
+    let options: CodableFileStoreOptions
+
+    init(fileURL: URL, options: CodableFileStoreOptions = .standard) {
+        self.fileURL = fileURL
+        self.options = options
+    }
+
+    func load() throws -> Value? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode(Value.self, from: data)
+    }
+
+    func save(_ value: Value) throws {
+        let encoder = JSONEncoder()
+        var formatting: JSONEncoder.OutputFormatting = []
+        if options.prettyPrinted { formatting.insert(.prettyPrinted) }
+        if options.sortedKeys { formatting.insert(.sortedKeys) }
+        encoder.outputFormatting = formatting
+
+        let data = try encoder.encode(value)
+        try data.write(to: fileURL, options: .atomic)
+
+        if let permissions = options.filePermissions {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: permissions],
+                ofItemAtPath: fileURL.path
+            )
+        }
+    }
+
+    func remove() throws {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        try FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/Muxy/Services/KeyBindingPersistence.swift
+++ b/Muxy/Services/KeyBindingPersistence.swift
@@ -6,31 +6,28 @@ protocol KeyBindingPersisting {
 }
 
 final class FileKeyBindingPersistence: KeyBindingPersisting {
-    private let fileURL: URL
+    private let reader: CodableFileStore<[SafeKeyBinding]>
+    private let writer: CodableFileStore<[KeyBinding]>
 
     init(fileURL: URL = MuxyFileStorage.fileURL(filename: "keybindings.json")) {
-        self.fileURL = fileURL
+        reader = CodableFileStore(fileURL: fileURL)
+        writer = CodableFileStore(
+            fileURL: fileURL,
+            options: CodableFileStoreOptions(
+                prettyPrinted: true,
+                sortedKeys: true,
+                filePermissions: 0o600
+            )
+        )
     }
 
     func loadBindings() throws -> [KeyBinding] {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return KeyBinding.defaults
-        }
-        let data = try Data(contentsOf: fileURL)
-        let containers = try JSONDecoder().decode([SafeKeyBinding].self, from: data)
-        let saved = containers.compactMap(\.binding)
-        return Self.mergeWithDefaults(saved)
+        guard let containers = try reader.load() else { return KeyBinding.defaults }
+        return Self.mergeWithDefaults(containers.compactMap(\.binding))
     }
 
     func saveBindings(_ bindings: [KeyBinding]) throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(bindings)
-        try data.write(to: fileURL, options: .atomic)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: fileURL.path
-        )
+        try writer.save(bindings)
     }
 
     private static func mergeWithDefaults(_ saved: [KeyBinding]) -> [KeyBinding] {
@@ -40,11 +37,15 @@ final class FileKeyBindingPersistence: KeyBindingPersisting {
         }
     }
 
-    private struct SafeKeyBinding: Decodable {
+    private struct SafeKeyBinding: Codable {
         let binding: KeyBinding?
 
         init(from decoder: Decoder) throws {
             binding = try? KeyBinding(from: decoder)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try binding?.encode(to: encoder)
         }
     }
 }

--- a/Muxy/Services/ProjectPersistence.swift
+++ b/Muxy/Services/ProjectPersistence.swift
@@ -6,20 +6,17 @@ protocol ProjectPersisting {
 }
 
 final class FileProjectPersistence: ProjectPersisting {
-    private let fileURL: URL
+    private let store: CodableFileStore<[Project]>
 
     init(fileURL: URL = MuxyFileStorage.fileURL(filename: "projects.json")) {
-        self.fileURL = fileURL
+        store = CodableFileStore(fileURL: fileURL)
     }
 
     func loadProjects() throws -> [Project] {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
-        let data = try Data(contentsOf: fileURL)
-        return try JSONDecoder().decode([Project].self, from: data)
+        try store.load() ?? []
     }
 
     func saveProjects(_ projects: [Project]) throws {
-        let data = try JSONEncoder().encode(projects)
-        try data.write(to: fileURL, options: .atomic)
+        try store.save(projects)
     }
 }

--- a/Muxy/Services/WorkspacePersistence.swift
+++ b/Muxy/Services/WorkspacePersistence.swift
@@ -1,39 +1,22 @@
 import Foundation
-import os
-
-private let logger = Logger(subsystem: "app.muxy", category: "WorkspacePersistence")
 
 protocol WorkspacePersisting {
-    func loadWorkspaces() -> [WorkspaceSnapshot]
-    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot])
+    func loadWorkspaces() throws -> [WorkspaceSnapshot]
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws
 }
 
 final class FileWorkspacePersistence: WorkspacePersisting {
-    private let fileURL: URL
+    private let store: CodableFileStore<[WorkspaceSnapshot]>
 
     init(fileURL: URL = MuxyFileStorage.fileURL(filename: "workspaces.json")) {
-        self.fileURL = fileURL
+        store = CodableFileStore(fileURL: fileURL, options: .pretty)
     }
 
-    func loadWorkspaces() -> [WorkspaceSnapshot] {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
-        do {
-            let data = try Data(contentsOf: fileURL)
-            return try JSONDecoder().decode([WorkspaceSnapshot].self, from: data)
-        } catch {
-            logger.error("Failed to load workspaces: \(error)")
-            return []
-        }
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] {
+        try store.load() ?? []
     }
 
-    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) {
-        do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(workspaces)
-            try data.write(to: fileURL, options: .atomic)
-        } catch {
-            logger.error("Failed to save workspaces: \(error)")
-        }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws {
+        try store.save(workspaces)
     }
 }

--- a/Muxy/Services/WorktreePersistence.swift
+++ b/Muxy/Services/WorktreePersistence.swift
@@ -19,26 +19,21 @@ final class FileWorktreePersistence: WorktreePersisting {
     }
 
     func loadWorktrees(projectID: UUID) throws -> [Worktree] {
-        let url = fileURL(for: projectID)
-        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
-        let data = try Data(contentsOf: url)
-        return try JSONDecoder().decode([Worktree].self, from: data)
+        try store(for: projectID).load() ?? []
     }
 
     func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        let data = try encoder.encode(worktrees)
-        try data.write(to: fileURL(for: projectID), options: .atomic)
+        try store(for: projectID).save(worktrees)
     }
 
     func removeWorktrees(projectID: UUID) throws {
-        let url = fileURL(for: projectID)
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        try FileManager.default.removeItem(at: url)
+        try store(for: projectID).remove()
     }
 
-    private func fileURL(for projectID: UUID) -> URL {
-        directory.appendingPathComponent("\(projectID.uuidString).json")
+    private func store(for projectID: UUID) -> CodableFileStore<[Worktree]> {
+        CodableFileStore(
+            fileURL: directory.appendingPathComponent("\(projectID.uuidString).json"),
+            options: .pretty
+        )
     }
 }

--- a/Tests/MuxyTests/Services/CodableFileStoreTests.swift
+++ b/Tests/MuxyTests/Services/CodableFileStoreTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("CodableFileStore")
+struct CodableFileStoreTests {
+    private struct Fixture: Codable, Equatable {
+        let name: String
+        let count: Int
+    }
+
+    private func tempURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodableFileStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("value.json")
+    }
+
+    @Test("load returns nil when file does not exist")
+    func loadMissingReturnsNil() throws {
+        let store = CodableFileStore<Fixture>(fileURL: tempURL())
+        #expect(try store.load() == nil)
+    }
+
+    @Test("save then load round-trips value")
+    func roundTrip() throws {
+        let url = tempURL()
+        let store = CodableFileStore<Fixture>(fileURL: url)
+        let original = Fixture(name: "thing", count: 7)
+        try store.save(original)
+        #expect(try store.load() == original)
+    }
+
+    @Test("save overwrites existing file atomically")
+    func saveOverwrites() throws {
+        let url = tempURL()
+        let store = CodableFileStore<Fixture>(fileURL: url)
+        try store.save(Fixture(name: "first", count: 1))
+        try store.save(Fixture(name: "second", count: 2))
+        #expect(try store.load() == Fixture(name: "second", count: 2))
+    }
+
+    @Test("pretty-printed option produces multi-line JSON")
+    func prettyPrinted() throws {
+        let url = tempURL()
+        let store = CodableFileStore<Fixture>(fileURL: url, options: .pretty)
+        try store.save(Fixture(name: "a", count: 1))
+        let text = try String(contentsOf: url, encoding: .utf8)
+        #expect(text.contains("\n"))
+    }
+
+    @Test("sortedKeys option orders keys alphabetically")
+    func sortedKeys() throws {
+        let url = tempURL()
+        let store = CodableFileStore<Fixture>(fileURL: url, options: .prettySorted)
+        try store.save(Fixture(name: "a", count: 1))
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let countIndex = text.range(of: "\"count\"")?.lowerBound
+        let nameIndex = text.range(of: "\"name\"")?.lowerBound
+        #expect(countIndex != nil && nameIndex != nil)
+        if let countIndex, let nameIndex {
+            #expect(countIndex < nameIndex)
+        }
+    }
+
+    @Test("filePermissions option applies to saved file")
+    func filePermissions() throws {
+        let url = tempURL()
+        let store = CodableFileStore<Fixture>(
+            fileURL: url,
+            options: CodableFileStoreOptions(filePermissions: 0o600)
+        )
+        try store.save(Fixture(name: "a", count: 1))
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let perms = attrs[.posixPermissions] as? NSNumber
+        #expect(perms?.intValue == 0o600)
+    }
+
+    @Test("remove deletes existing file")
+    func removeExisting() throws {
+        let url = tempURL()
+        let store = CodableFileStore<Fixture>(fileURL: url)
+        try store.save(Fixture(name: "a", count: 1))
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        try store.remove()
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("remove on missing file is a no-op")
+    func removeMissing() throws {
+        let store = CodableFileStore<Fixture>(fileURL: tempURL())
+        try store.remove()
+    }
+
+    @Test("load throws on corrupt JSON")
+    func loadCorrupt() throws {
+        let url = tempURL()
+        try "not json".data(using: .utf8)!.write(to: url)
+        let store = CodableFileStore<Fixture>(fileURL: url)
+        #expect(throws: (any Error).self) {
+            _ = try store.load()
+        }
+    }
+}


### PR DESCRIPTION
  - Added `CodableFileStore<Value: Codable>` — a single generic that owns JSON load/save/remove, atomic writes, and
  pretty/sortedKeys/permissions options.
  - Migrated all four persistences (`Project`, `Workspace`, `Worktree`, `KeyBinding`) to delegate through it. Each is now
  ~20–40 lines of wiring instead of hand-rolled JSON plumbing.
  - `WorkspacePersisting` now throws consistently with the other three (previously it silently swallowed load/save errors
  and logged them internally). `AppState.restoreSelection` and `saveWorkspaces` now catch + log via a new `os.Logger`,
  matching the pattern already in `ProjectStore` / `WorktreeStore`.