### PR TITLE
Escape dropped paths

### DIFF
--- a/Muxy/Services/ShellEscaper.swift
+++ b/Muxy/Services/ShellEscaper.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum ShellEscaper {
+    private static let metaCharacters: Set<Character> = [
+        " ", "(", ")", "'", "\"", "\\", "&", "|", ";", "$", "`", "!",
+    ]
+
+    static func escape(_ path: String) -> String {
+        guard path.contains(where: metaCharacters.contains) else { return path }
+        return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -815,19 +815,10 @@ extension GhosttyTerminalNSView {
               !urls.isEmpty
         else { return false }
 
-        let paths = urls.map { Self.shellEscapedPath($0.path) }
+        let paths = urls.map { ShellEscaper.escape($0.path) }
         let text = paths.joined(separator: " ")
         insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
         return true
-    }
-
-    private static func shellEscapedPath(_ path: String) -> String {
-        let needsQuoting = path.contains(" ") || path.contains("(") || path.contains(")")
-            || path.contains("'") || path.contains("\"") || path.contains("\\")
-            || path.contains("&") || path.contains("|") || path.contains(";")
-            || path.contains("$") || path.contains("`") || path.contains("!")
-        guard needsQuoting else { return path }
-        return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }
 

--- a/Tests/MuxyTests/Services/ShellEscaperTests.swift
+++ b/Tests/MuxyTests/Services/ShellEscaperTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ShellEscaper")
+struct ShellEscaperTests {
+    @Test("plain path is returned unchanged")
+    func plainPath() {
+        #expect(ShellEscaper.escape("/Users/alice/file.txt") == "/Users/alice/file.txt")
+    }
+
+    @Test("empty string is returned unchanged")
+    func empty() {
+        #expect(ShellEscaper.escape("") == "")
+    }
+
+    @Test("path with space is single-quoted")
+    func withSpace() {
+        #expect(ShellEscaper.escape("/tmp/my file.txt") == "'/tmp/my file.txt'")
+    }
+
+    @Test("path with parentheses is single-quoted")
+    func withParens() {
+        #expect(ShellEscaper.escape("/tmp/Dir (copy)/x") == "'/tmp/Dir (copy)/x'")
+    }
+
+    @Test("path with double quote is single-quoted")
+    func withDoubleQuote() {
+        #expect(ShellEscaper.escape("/tmp/\"x\".txt") == "'/tmp/\"x\".txt'")
+    }
+
+    @Test("path with backslash is single-quoted")
+    func withBackslash() {
+        #expect(ShellEscaper.escape("/tmp/a\\b") == "'/tmp/a\\b'")
+    }
+
+    @Test("path with shell metacharacters is single-quoted")
+    func withShellMeta() {
+        #expect(ShellEscaper.escape("/tmp/a$b") == "'/tmp/a$b'")
+        #expect(ShellEscaper.escape("/tmp/a`b`") == "'/tmp/a`b`'")
+        #expect(ShellEscaper.escape("/tmp/a!b") == "'/tmp/a!b'")
+        #expect(ShellEscaper.escape("/tmp/a&b") == "'/tmp/a&b'")
+        #expect(ShellEscaper.escape("/tmp/a|b") == "'/tmp/a|b'")
+        #expect(ShellEscaper.escape("/tmp/a;b") == "'/tmp/a;b'")
+    }
+
+    @Test("single quote in path is escaped using close-escape-open pattern")
+    func withSingleQuote() {
+        #expect(ShellEscaper.escape("/tmp/it's.txt") == "'/tmp/it'\\''s.txt'")
+    }
+
+    @Test("multiple single quotes each get escaped")
+    func withMultipleSingleQuotes() {
+        #expect(ShellEscaper.escape("a'b'c") == "'a'\\''b'\\''c'")
+    }
+
+    @Test("path with space and single quote combines escapes")
+    func withSpaceAndSingleQuote() {
+        #expect(ShellEscaper.escape("it's my file") == "'it'\\''s my file'")
+    }
+
+    @Test("path with only alphanumerics and safe punctuation stays plain")
+    func safePunctuation() {
+        #expect(ShellEscaper.escape("/Users/a/b-c_d.1.txt") == "/Users/a/b-c_d.1.txt")
+    }
+}


### PR DESCRIPTION
## Summary
- Extract path shell-escaping into `ShellEscaper` so dropped file paths are quoted consistently.
- Reuse the helper from `GhosttyTerminalNSView` to avoid duplicating shell-escaping logic.
- Add focused tests for spaces, quotes, and shell metacharacters to prevent regressions.