### PR TITLE
Enhance file tree with file operations and context menu

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -225,6 +225,24 @@ final class AppState {
         dispatch(.createEditorTab(projectID: projectID, areaID: nil, filePath: filePath))
     }
 
+    func handleFileMoved(from oldPath: String, to newPath: String) {
+        guard oldPath != newPath else { return }
+        let oldPrefix = oldPath + "/"
+        for (_, root) in workspaceRoots {
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    guard let editorState = tab.content.editorState else { continue }
+                    let currentPath = editorState.filePath
+                    if currentPath == oldPath {
+                        editorState.updateFilePath(newPath)
+                    } else if currentPath.hasPrefix(oldPrefix) {
+                        editorState.updateFilePath(newPath + "/" + String(currentPath.dropFirst(oldPrefix.count)))
+                    }
+                }
+            }
+        }
+    }
+
     func openDiffViewer(vcs: VCSTabState, filePath: String, isStaged: Bool, projectID: UUID) {
         for area in allAreas(for: projectID) {
             if let tab = area.tabs.first(where: { tab in

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -31,6 +31,7 @@ final class AppState {
             replacementWorktreePath: String?
         )
         case createTab(projectID: UUID, areaID: UUID?)
+        case createTabInDirectory(projectID: UUID, areaID: UUID?, directory: String)
         case createVCSTab(projectID: UUID, areaID: UUID?)
         case createEditorTab(projectID: UUID, areaID: UUID?, filePath: String)
         case createExternalEditorTab(projectID: UUID, areaID: UUID?, filePath: String, command: String)

--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -10,7 +10,7 @@ enum EditorSearchNavigationDirection {
 final class EditorTabState: Identifiable {
     let id = UUID()
     let projectPath: String
-    let filePath: String
+    private(set) var filePath: String
     var backingStoreVersion = 0
     var isLoading = false
     var isIncrementalLoading = false
@@ -85,6 +85,12 @@ final class EditorTabState: Identifiable {
         self.projectPath = projectPath
         self.filePath = filePath
         loadFile()
+    }
+
+    func updateFilePath(_ newPath: String) {
+        guard filePath != newPath else { return }
+        filePath = newPath
+        refreshReadOnlyStatus()
     }
 
     deinit {

--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -153,12 +153,18 @@ final class FileTreeState {
     }
 
     func extendSelection(to path: String) {
-        let anchor = selectionAnchorPath ?? selectedFilePath ?? path
         let ordered = visiblePathsInOrder()
-        guard let startIdx = ordered.firstIndex(of: anchor),
-              let endIdx = ordered.firstIndex(of: path)
-        else {
-            selectOnly(path)
+        guard let endIdx = ordered.firstIndex(of: path) else {
+            selectedPaths.insert(path)
+            selectedFilePath = path
+            selectionAnchorPath = path
+            return
+        }
+        let anchor = selectionAnchorPath ?? selectedFilePath ?? path
+        guard let startIdx = ordered.firstIndex(of: anchor) else {
+            selectedPaths.insert(path)
+            selectedFilePath = path
+            selectionAnchorPath = path
             return
         }
         let range = startIdx <= endIdx ? startIdx ... endIdx : endIdx ... startIdx

--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -20,6 +20,7 @@ final class FileTreeState {
     struct PendingNewEntry: Equatable {
         let parentPath: String
         let kind: PendingEntryKind
+        let token: UUID
     }
 
     let rootPath: String
@@ -32,9 +33,11 @@ final class FileTreeState {
     private(set) var dirHasChange: Set<String> = []
     var showOnlyChanges = false
     var selectedFilePath: String?
+    var selectedPaths: Set<String> = []
+    var selectionAnchorPath: String?
     var pendingRenamePath: String?
     var pendingNewEntry: PendingNewEntry?
-    var pendingDeletePath: String?
+    var pendingDeletePaths: [String] = []
     var cutPaths: Set<String> = []
     var dropHighlightPath: String?
 
@@ -130,8 +133,71 @@ final class FileTreeState {
         return statuses[entry.absolutePath] != nil
     }
 
+    func selectOnly(_ path: String) {
+        selectedFilePath = path
+        selectedPaths = [path]
+        selectionAnchorPath = path
+    }
+
+    func toggleSelection(_ path: String) {
+        if selectedPaths.contains(path) {
+            selectedPaths.remove(path)
+            if selectedFilePath == path {
+                selectedFilePath = selectedPaths.first
+            }
+        } else {
+            selectedPaths.insert(path)
+            selectedFilePath = path
+        }
+        selectionAnchorPath = path
+    }
+
+    func extendSelection(to path: String) {
+        let anchor = selectionAnchorPath ?? selectedFilePath ?? path
+        let ordered = visiblePathsInOrder()
+        guard let startIdx = ordered.firstIndex(of: anchor),
+              let endIdx = ordered.firstIndex(of: path)
+        else {
+            selectOnly(path)
+            return
+        }
+        let range = startIdx <= endIdx ? startIdx ... endIdx : endIdx ... startIdx
+        selectedPaths = Set(ordered[range])
+        selectedFilePath = path
+    }
+
+    func clearSelection() {
+        selectedFilePath = nil
+        selectedPaths = []
+        selectionAnchorPath = nil
+    }
+
+    func isPathSelected(_ path: String) -> Bool {
+        selectedPaths.contains(path)
+    }
+
+    func visiblePathsInOrder() -> [String] {
+        var result: [String] = []
+        for entry in visibleRootEntries() {
+            appendVisible(entry, into: &result)
+        }
+        return result
+    }
+
+    private func appendVisible(_ entry: FileTreeEntry, into result: inout [String]) {
+        result.append(entry.absolutePath)
+        guard entry.isDirectory, expanded.contains(entry.absolutePath),
+              let children = visibleChildren(of: entry)
+        else { return }
+        for child in children {
+            appendVisible(child, into: &result)
+        }
+    }
+
     func revealFile(at filePath: String) {
         selectedFilePath = filePath
+        selectedPaths = [filePath]
+        selectionAnchorPath = filePath
         guard filePath.hasPrefix(normalizedRootPath + "/") else { return }
         let relative = String(filePath.dropFirst(normalizedRootPath.count + 1))
         let components = relative.split(separator: "/").map(String.init)

--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -12,6 +12,16 @@ final class FileTreeState {
         case conflict
     }
 
+    enum PendingEntryKind {
+        case file
+        case folder
+    }
+
+    struct PendingNewEntry: Equatable {
+        let parentPath: String
+        let kind: PendingEntryKind
+    }
+
     let rootPath: String
     private(set) var rootEntries: [FileTreeEntry] = []
     private(set) var children: [String: [FileTreeEntry]] = [:]
@@ -22,6 +32,11 @@ final class FileTreeState {
     private(set) var dirHasChange: Set<String> = []
     var showOnlyChanges = false
     var selectedFilePath: String?
+    var pendingRenamePath: String?
+    var pendingNewEntry: PendingNewEntry?
+    var pendingDeletePath: String?
+    var cutPaths: Set<String> = []
+    var dropHighlightPath: String?
 
     @ObservationIgnored private var watcher: GitDirectoryWatcher?
     @ObservationIgnored nonisolated(unsafe) private var remoteChangeObserver: NSObjectProtocol?
@@ -53,6 +68,29 @@ final class FileTreeState {
             reloadChildren(of: path)
         }
         refreshStatuses()
+    }
+
+    func refreshDirectory(path: String) {
+        let normalized = path.hasSuffix("/") ? String(path.dropLast()) : path
+        if normalized == normalizedRootPath {
+            reloadRoot()
+        } else {
+            reloadChildren(of: normalized)
+        }
+        refreshStatuses()
+    }
+
+    func expand(path: String) {
+        let normalized = path.hasSuffix("/") ? String(path.dropLast()) : path
+        guard normalized != normalizedRootPath else { return }
+        guard !expanded.contains(normalized) else { return }
+        expanded.insert(normalized)
+        reloadChildren(of: normalized)
+    }
+
+    func parentDirectory(of path: String) -> String {
+        let normalized = path.hasSuffix("/") ? String(path.dropLast()) : path
+        return (normalized as NSString).deletingLastPathComponent
     }
 
     func toggle(_ entry: FileTreeEntry) {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -59,6 +59,10 @@ final class TabArea: Identifiable {
         insertTab(TerminalTab(pane: TerminalPaneState(projectPath: projectPath)))
     }
 
+    func createTab(inDirectory directory: String) {
+        insertTab(TerminalTab(pane: TerminalPaneState(projectPath: directory)))
+    }
+
     func createVCSTab() {
         insertTab(TerminalTab(vcsState: VCSTabState(projectPath: projectPath)))
     }

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -70,6 +70,14 @@ enum WorkspaceReducer {
         case let .createTab(projectID, areaID):
             TabReducer.createTab(projectID: projectID, areaID: areaID, state: &state)
 
+        case let .createTabInDirectory(projectID, areaID, directory):
+            TabReducer.createTabInDirectory(
+                projectID: projectID,
+                areaID: areaID,
+                directory: directory,
+                state: &state
+            )
+
         case let .createVCSTab(projectID, areaID):
             TabReducer.createVCSTab(projectID: projectID, areaID: areaID, state: &state)
 

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -10,6 +10,19 @@ enum TabReducer {
         area.createTab()
     }
 
+    static func createTabInDirectory(
+        projectID: UUID,
+        areaID: UUID?,
+        directory: String,
+        state: inout WorkspaceState
+    ) {
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
+              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
+        else { return }
+        FocusReducer.focusArea(area.id, key: key, state: &state)
+        area.createTab(inDirectory: directory)
+    }
+
     static func createVCSTab(projectID: UUID, areaID: UUID?, state: inout WorkspaceState) {
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
               let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)

--- a/Muxy/Services/FileClipboard.swift
+++ b/Muxy/Services/FileClipboard.swift
@@ -1,0 +1,44 @@
+import AppKit
+import Foundation
+
+@MainActor
+enum FileClipboard {
+    private static let cutMarkerType = NSPasteboard.PasteboardType("app.muxy.fileCut")
+    private static var lastWriteChangeCount: Int?
+    private static var lastWriteWasCut = false
+
+    struct Contents {
+        let paths: [String]
+        let isCut: Bool
+    }
+
+    static func write(paths: [String], isCut: Bool) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        let urls = paths.map { URL(fileURLWithPath: $0) as NSURL }
+        pb.writeObjects(urls)
+        if isCut {
+            pb.setData(Data([1]), forType: cutMarkerType)
+        }
+        lastWriteChangeCount = pb.changeCount
+        lastWriteWasCut = isCut
+    }
+
+    static var hasContents: Bool {
+        read() != nil
+    }
+
+    static func read() -> Contents? {
+        let pb = NSPasteboard.general
+        guard let urls = pb.readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL],
+              !urls.isEmpty
+        else { return nil }
+        let isCut = pb.changeCount == lastWriteChangeCount && lastWriteWasCut
+        return Contents(paths: urls.map(\.path), isCut: isCut)
+    }
+
+    static func clearCutMarker() {
+        lastWriteChangeCount = nil
+        lastWriteWasCut = false
+    }
+}

--- a/Muxy/Services/FileClipboard.swift
+++ b/Muxy/Services/FileClipboard.swift
@@ -3,7 +3,6 @@ import Foundation
 
 @MainActor
 enum FileClipboard {
-    private static let cutMarkerType = NSPasteboard.PasteboardType("app.muxy.fileCut")
     private static var lastWriteChangeCount: Int?
     private static var lastWriteWasCut = false
 
@@ -17,9 +16,6 @@ enum FileClipboard {
         pb.clearContents()
         let urls = paths.map { URL(fileURLWithPath: $0) as NSURL }
         pb.writeObjects(urls)
-        if isCut {
-            pb.setData(Data([1]), forType: cutMarkerType)
-        }
         lastWriteChangeCount = pb.changeCount
         lastWriteWasCut = isCut
     }

--- a/Muxy/Services/FileSystemOperations.swift
+++ b/Muxy/Services/FileSystemOperations.swift
@@ -1,0 +1,165 @@
+import AppKit
+import Foundation
+
+enum FileSystemOperationError: Error, Equatable {
+    case destinationExists(String)
+    case sourceMissing(String)
+    case invalidName
+    case sameAsSource
+    case underlying(String)
+}
+
+enum FileSystemOperations {
+    static func createFile(named rawName: String, in directory: String) async throws -> String {
+        try await GitProcessRunner.offMainThrowing {
+            try createFileSync(named: rawName, in: directory)
+        }
+    }
+
+    static func createFolder(named rawName: String, in directory: String) async throws -> String {
+        try await GitProcessRunner.offMainThrowing {
+            try createFolderSync(named: rawName, in: directory)
+        }
+    }
+
+    static func rename(at absolutePath: String, to rawName: String) async throws -> String {
+        try await GitProcessRunner.offMainThrowing {
+            try renameSync(at: absolutePath, to: rawName)
+        }
+    }
+
+    static func moveToTrash(_ absolutePaths: [String]) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let urls = absolutePaths.map { URL(fileURLWithPath: $0) }
+            NSWorkspace.shared.recycle(urls) { _, error in
+                if let error {
+                    continuation.resume(throwing: FileSystemOperationError.underlying(error.localizedDescription))
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    static func move(_ sources: [String], into destinationDirectory: String) async throws -> [String] {
+        try await GitProcessRunner.offMainThrowing {
+            try transferSync(sources: sources, destinationDirectory: destinationDirectory, copy: false)
+        }
+    }
+
+    static func copy(_ sources: [String], into destinationDirectory: String) async throws -> [String] {
+        try await GitProcessRunner.offMainThrowing {
+            try transferSync(sources: sources, destinationDirectory: destinationDirectory, copy: true)
+        }
+    }
+
+    static func isInside(path: String, ancestor: String) -> Bool {
+        let normalized = ancestor.hasSuffix("/") ? String(ancestor.dropLast()) : ancestor
+        return path == normalized || path.hasPrefix(normalized + "/")
+    }
+
+    nonisolated static func uniquePathSync(forName name: String, in directory: String) -> String {
+        let fm = FileManager.default
+        let baseURL = URL(fileURLWithPath: directory).appendingPathComponent(name)
+        if !fm.fileExists(atPath: baseURL.path) {
+            return baseURL.path
+        }
+        let ext = (name as NSString).pathExtension
+        let stem = (name as NSString).deletingPathExtension
+        var counter = 2
+        while true {
+            let candidateName = ext.isEmpty ? "\(stem) \(counter)" : "\(stem) \(counter).\(ext)"
+            let candidate = URL(fileURLWithPath: directory).appendingPathComponent(candidateName)
+            if !fm.fileExists(atPath: candidate.path) {
+                return candidate.path
+            }
+            counter += 1
+        }
+    }
+
+    nonisolated private static func createFileSync(named rawName: String, in directory: String) throws -> String {
+        let name = try sanitize(rawName)
+        let target = uniquePathSync(forName: name, in: directory)
+        let created = FileManager.default.createFile(atPath: target, contents: nil)
+        guard created else {
+            throw FileSystemOperationError.underlying("Failed to create file at \(target)")
+        }
+        return target
+    }
+
+    nonisolated private static func createFolderSync(named rawName: String, in directory: String) throws -> String {
+        let name = try sanitize(rawName)
+        let target = uniquePathSync(forName: name, in: directory)
+        do {
+            try FileManager.default.createDirectory(
+                atPath: target,
+                withIntermediateDirectories: false,
+                attributes: nil
+            )
+        } catch {
+            throw FileSystemOperationError.underlying(error.localizedDescription)
+        }
+        return target
+    }
+
+    nonisolated private static func renameSync(at absolutePath: String, to rawName: String) throws -> String {
+        let name = try sanitize(rawName)
+        let parent = (absolutePath as NSString).deletingLastPathComponent
+        let currentName = (absolutePath as NSString).lastPathComponent
+        if name == currentName { return absolutePath }
+        let candidate = URL(fileURLWithPath: parent).appendingPathComponent(name).path
+        if FileManager.default.fileExists(atPath: candidate) {
+            throw FileSystemOperationError.destinationExists(candidate)
+        }
+        do {
+            try FileManager.default.moveItem(atPath: absolutePath, toPath: candidate)
+        } catch {
+            throw FileSystemOperationError.underlying(error.localizedDescription)
+        }
+        return candidate
+    }
+
+    nonisolated private static func transferSync(
+        sources: [String],
+        destinationDirectory: String,
+        copy: Bool
+    ) throws -> [String] {
+        let fm = FileManager.default
+        var results: [String] = []
+        results.reserveCapacity(sources.count)
+        for source in sources {
+            guard fm.fileExists(atPath: source) else {
+                throw FileSystemOperationError.sourceMissing(source)
+            }
+            let sourceParent = (source as NSString).deletingLastPathComponent
+            let name = (source as NSString).lastPathComponent
+            if !copy, sourceParent == destinationDirectory {
+                results.append(source)
+                continue
+            }
+            if !copy, isInside(path: destinationDirectory, ancestor: source) {
+                throw FileSystemOperationError.sameAsSource
+            }
+            let target = uniquePathSync(forName: name, in: destinationDirectory)
+            do {
+                if copy {
+                    try fm.copyItem(atPath: source, toPath: target)
+                } else {
+                    try fm.moveItem(atPath: source, toPath: target)
+                }
+            } catch {
+                throw FileSystemOperationError.underlying(error.localizedDescription)
+            }
+            results.append(target)
+        }
+        return results
+    }
+
+    nonisolated private static func sanitize(_ rawName: String) throws -> String {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains("/"), trimmed != ".", trimmed != ".." else {
+            throw FileSystemOperationError.invalidName
+        }
+        return trimmed
+    }
+}

--- a/Muxy/Services/FileSystemOperations.swift
+++ b/Muxy/Services/FileSystemOperations.swift
@@ -7,6 +7,21 @@ enum FileSystemOperationError: Error, Equatable {
     case invalidName
     case sameAsSource
     case underlying(String)
+
+    var userMessage: String {
+        switch self {
+        case let .destinationExists(path):
+            "“\((path as NSString).lastPathComponent)” already exists"
+        case let .sourceMissing(path):
+            "“\((path as NSString).lastPathComponent)” no longer exists"
+        case .invalidName:
+            "That name is not allowed"
+        case .sameAsSource:
+            "Can’t move a folder into itself"
+        case let .underlying(message):
+            message
+        }
+    }
 }
 
 enum FileSystemOperations {

--- a/Muxy/Views/FileTree/FileTreeCommands.swift
+++ b/Muxy/Views/FileTree/FileTreeCommands.swift
@@ -5,33 +5,39 @@ import os
 private let logger = Logger(subsystem: "app.muxy", category: "FileTreeCommands")
 
 @MainActor
-@Observable
 final class FileTreeCommands {
     private let state: FileTreeState
-    private let openTerminal: (String) -> Void
-    private let onFileMoved: (String, String) -> Void
+    var openTerminal: (String) -> Void
+    var onFileMoved: (String, String) -> Void
 
     init(
         state: FileTreeState,
-        openTerminal: @escaping (String) -> Void,
-        onFileMoved: @escaping (String, String) -> Void
+        openTerminal: @escaping (String) -> Void = { _ in },
+        onFileMoved: @escaping (String, String) -> Void = { _, _ in }
     ) {
         self.state = state
         self.openTerminal = openTerminal
         self.onFileMoved = onFileMoved
     }
 
+    func effectiveTargets(primaryPath: String) -> [String] {
+        if state.selectedPaths.contains(primaryPath), state.selectedPaths.count > 1 {
+            return Array(state.selectedPaths)
+        }
+        return [primaryPath]
+    }
+
     func beginNewFile(in directoryPath: String) {
         let parent = resolveDirectoryContext(for: directoryPath)
         state.expand(path: parent)
-        state.pendingNewEntry = FileTreeState.PendingNewEntry(parentPath: parent, kind: .file)
+        state.pendingNewEntry = FileTreeState.PendingNewEntry(parentPath: parent, kind: .file, token: UUID())
         state.pendingRenamePath = nil
     }
 
     func beginNewFolder(in directoryPath: String) {
         let parent = resolveDirectoryContext(for: directoryPath)
         state.expand(path: parent)
-        state.pendingNewEntry = FileTreeState.PendingNewEntry(parentPath: parent, kind: .folder)
+        state.pendingNewEntry = FileTreeState.PendingNewEntry(parentPath: parent, kind: .folder, token: UUID())
         state.pendingRenamePath = nil
     }
 
@@ -46,7 +52,7 @@ final class FileTreeCommands {
                 }
                 state.refreshDirectory(path: parent)
                 if kind == .file {
-                    state.selectedFilePath = created
+                    state.selectOnly(created)
                 }
             } catch {
                 let label = kind == .file ? "file" : "folder"
@@ -71,6 +77,10 @@ final class FileTreeCommands {
             do {
                 let newPath = try await FileSystemOperations.rename(at: originalPath, to: newName)
                 state.refreshDirectory(path: parent)
+                if state.selectedPaths.contains(originalPath) {
+                    state.selectedPaths.remove(originalPath)
+                    state.selectedPaths.insert(newPath)
+                }
                 if state.selectedFilePath == originalPath {
                     state.selectedFilePath = newPath
                 }
@@ -85,29 +95,44 @@ final class FileTreeCommands {
         state.pendingRenamePath = nil
     }
 
-    func trash(path: String) {
-        state.pendingDeletePath = path
+    func trash(paths: [String]) {
+        guard !paths.isEmpty else { return }
+        state.pendingDeletePaths = paths
     }
 
     func cancelPendingDelete() {
-        state.pendingDeletePath = nil
+        state.pendingDeletePaths = []
     }
 
     func confirmPendingDelete() {
-        guard let path = state.pendingDeletePath else { return }
-        state.pendingDeletePath = nil
-        let parent = state.parentDirectory(of: path)
+        let paths = state.pendingDeletePaths
+        guard !paths.isEmpty else { return }
+        state.pendingDeletePaths = []
+        let parents = Set(paths.map { state.parentDirectory(of: $0) })
         Task {
             do {
-                try await FileSystemOperations.moveToTrash([path])
-                state.refreshDirectory(path: parent)
-                if state.selectedFilePath == path {
-                    state.selectedFilePath = nil
+                try await FileSystemOperations.moveToTrash(paths)
+                for parent in parents {
+                    state.refreshDirectory(path: parent)
+                }
+                let removed = Set(paths)
+                state.selectedPaths.subtract(removed)
+                if let current = state.selectedFilePath, removed.contains(current) {
+                    state.selectedFilePath = state.selectedPaths.first
                 }
             } catch {
                 logger.error("Trash failed: \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+
+    func deleteAlertKind() -> String {
+        let paths = state.pendingDeletePaths
+        if paths.count > 1 { return "\(paths.count) items" }
+        guard let path = paths.first else { return "file" }
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        return exists && isDir.boolValue ? "folder" : "file"
     }
 
     func copyToClipboard(paths: [String]) {

--- a/Muxy/Views/FileTree/FileTreeCommands.swift
+++ b/Muxy/Views/FileTree/FileTreeCommands.swift
@@ -1,0 +1,216 @@
+import AppKit
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "FileTreeCommands")
+
+@MainActor
+@Observable
+final class FileTreeCommands {
+    private let state: FileTreeState
+    private let openTerminal: (String) -> Void
+    private let onFileMoved: (String, String) -> Void
+
+    init(
+        state: FileTreeState,
+        openTerminal: @escaping (String) -> Void,
+        onFileMoved: @escaping (String, String) -> Void
+    ) {
+        self.state = state
+        self.openTerminal = openTerminal
+        self.onFileMoved = onFileMoved
+    }
+
+    func beginNewFile(in directoryPath: String) {
+        let parent = resolveDirectoryContext(for: directoryPath)
+        state.expand(path: parent)
+        state.pendingNewEntry = FileTreeState.PendingNewEntry(parentPath: parent, kind: .file)
+        state.pendingRenamePath = nil
+    }
+
+    func beginNewFolder(in directoryPath: String) {
+        let parent = resolveDirectoryContext(for: directoryPath)
+        state.expand(path: parent)
+        state.pendingNewEntry = FileTreeState.PendingNewEntry(parentPath: parent, kind: .folder)
+        state.pendingRenamePath = nil
+    }
+
+    func commitNewEntry(name: String) {
+        guard let pending = state.pendingNewEntry else { return }
+        state.pendingNewEntry = nil
+        Task { [parent = pending.parentPath, kind = pending.kind] in
+            do {
+                let created = switch kind {
+                case .file: try await FileSystemOperations.createFile(named: name, in: parent)
+                case .folder: try await FileSystemOperations.createFolder(named: name, in: parent)
+                }
+                state.refreshDirectory(path: parent)
+                if kind == .file {
+                    state.selectedFilePath = created
+                }
+            } catch {
+                let label = kind == .file ? "file" : "folder"
+                logger.error("Create \(label, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    func cancelNewEntry() {
+        state.pendingNewEntry = nil
+    }
+
+    func beginRename(path: String) {
+        state.pendingRenamePath = path
+        state.pendingNewEntry = nil
+    }
+
+    func commitRename(originalPath: String, newName: String) {
+        state.pendingRenamePath = nil
+        let parent = state.parentDirectory(of: originalPath)
+        Task {
+            do {
+                let newPath = try await FileSystemOperations.rename(at: originalPath, to: newName)
+                state.refreshDirectory(path: parent)
+                if state.selectedFilePath == originalPath {
+                    state.selectedFilePath = newPath
+                }
+                onFileMoved(originalPath, newPath)
+            } catch {
+                logger.error("Rename failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    func cancelRename() {
+        state.pendingRenamePath = nil
+    }
+
+    func trash(path: String) {
+        state.pendingDeletePath = path
+    }
+
+    func cancelPendingDelete() {
+        state.pendingDeletePath = nil
+    }
+
+    func confirmPendingDelete() {
+        guard let path = state.pendingDeletePath else { return }
+        state.pendingDeletePath = nil
+        let parent = state.parentDirectory(of: path)
+        Task {
+            do {
+                try await FileSystemOperations.moveToTrash([path])
+                state.refreshDirectory(path: parent)
+                if state.selectedFilePath == path {
+                    state.selectedFilePath = nil
+                }
+            } catch {
+                logger.error("Trash failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    func copyToClipboard(paths: [String]) {
+        FileClipboard.write(paths: paths, isCut: false)
+        state.cutPaths = []
+    }
+
+    func cutToClipboard(paths: [String]) {
+        FileClipboard.write(paths: paths, isCut: true)
+        state.cutPaths = Set(paths)
+    }
+
+    func paste(into destinationPath: String) {
+        guard let contents = FileClipboard.read() else { return }
+        let destination = resolveDirectoryContext(for: destinationPath)
+        Task { [paths = contents.paths, isCut = contents.isCut] in
+            do {
+                let results: [String] = if isCut {
+                    try await FileSystemOperations.move(paths, into: destination)
+                } else {
+                    try await FileSystemOperations.copy(paths, into: destination)
+                }
+                state.refreshDirectory(path: destination)
+                for source in paths {
+                    let sourceParent = state.parentDirectory(of: source)
+                    if sourceParent != destination {
+                        state.refreshDirectory(path: sourceParent)
+                    }
+                }
+                if isCut {
+                    state.cutPaths = []
+                    FileClipboard.clearCutMarker()
+                    for (index, source) in paths.enumerated() where index < results.count {
+                        onFileMoved(source, results[index])
+                    }
+                }
+            } catch {
+                logger.error("Paste failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    func copyAbsolutePath(_ path: String) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(path, forType: .string)
+    }
+
+    func copyRelativePath(_ path: String) {
+        let root = state.rootPath.hasSuffix("/") ? String(state.rootPath.dropLast()) : state.rootPath
+        let relative: String = if path.hasPrefix(root + "/") {
+            String(path.dropFirst(root.count + 1))
+        } else {
+            (path as NSString).lastPathComponent
+        }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(relative, forType: .string)
+    }
+
+    func revealInFinder(_ path: String) {
+        let url = URL(fileURLWithPath: path)
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    func openInTerminal(path: String) {
+        let dir = resolveDirectoryContext(for: path)
+        openTerminal(dir)
+    }
+
+    func performDrop(sources: [String], destinationPath: String, copy: Bool) {
+        let destination = resolveDirectoryContext(for: destinationPath)
+        Task {
+            do {
+                let results: [String] = if copy {
+                    try await FileSystemOperations.copy(sources, into: destination)
+                } else {
+                    try await FileSystemOperations.move(sources, into: destination)
+                }
+                state.refreshDirectory(path: destination)
+                for source in sources {
+                    let sourceParent = state.parentDirectory(of: source)
+                    if sourceParent != destination {
+                        state.refreshDirectory(path: sourceParent)
+                    }
+                }
+                if !copy {
+                    for (index, source) in sources.enumerated() where index < results.count {
+                        onFileMoved(source, results[index])
+                    }
+                }
+            } catch {
+                logger.error("Drop failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func resolveDirectoryContext(for path: String) -> String {
+        let normalized = path.hasSuffix("/") ? String(path.dropLast()) : path
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: normalized, isDirectory: &isDir), isDir.boolValue {
+            return normalized
+        }
+        return (normalized as NSString).deletingLastPathComponent
+    }
+}

--- a/Muxy/Views/FileTree/FileTreeCommands.swift
+++ b/Muxy/Views/FileTree/FileTreeCommands.swift
@@ -55,8 +55,7 @@ final class FileTreeCommands {
                     state.selectOnly(created)
                 }
             } catch {
-                let label = kind == .file ? "file" : "folder"
-                logger.error("Create \(label, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+                report(error, action: kind == .file ? "Create file" : "Create folder")
             }
         }
     }
@@ -86,7 +85,7 @@ final class FileTreeCommands {
                 }
                 onFileMoved(originalPath, newPath)
             } catch {
-                logger.error("Rename failed: \(error.localizedDescription, privacy: .public)")
+                report(error, action: "Rename")
             }
         }
     }
@@ -121,7 +120,7 @@ final class FileTreeCommands {
                     state.selectedFilePath = state.selectedPaths.first
                 }
             } catch {
-                logger.error("Trash failed: \(error.localizedDescription, privacy: .public)")
+                report(error, action: "Move to Trash")
             }
         }
     }
@@ -170,7 +169,7 @@ final class FileTreeCommands {
                     }
                 }
             } catch {
-                logger.error("Paste failed: \(error.localizedDescription, privacy: .public)")
+                report(error, action: "Paste")
             }
         }
     }
@@ -225,9 +224,15 @@ final class FileTreeCommands {
                     }
                 }
             } catch {
-                logger.error("Drop failed: \(error.localizedDescription, privacy: .public)")
+                report(error, action: copy ? "Copy" : "Move")
             }
         }
+    }
+
+    private func report(_ error: Error, action: String) {
+        let message = (error as? FileSystemOperationError)?.userMessage ?? error.localizedDescription
+        logger.error("\(action, privacy: .public) failed: \(message, privacy: .public)")
+        ToastState.shared.show("\(action) failed: \(message)")
     }
 
     private func resolveDirectoryContext(for path: String) -> String {

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -284,7 +284,6 @@ private struct FileTreeRow: View {
     var body: some View {
         HStack(spacing: 4) {
             Color.clear.frame(width: CGFloat(depth) * 12)
-            chevron
             icon
             if isRenaming {
                 FileTreeRenameField(
@@ -301,7 +300,7 @@ private struct FileTreeRow: View {
             }
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 6)
         .frame(height: 22)
         .opacity(rowOpacity)
         .background(rowBackground)
@@ -348,23 +347,16 @@ private struct FileTreeRow: View {
         }
     }
 
-    @ViewBuilder
-    private var chevron: some View {
-        if entry.isDirectory {
-            Image(systemName: state.isExpanded(entry) ? "chevron.down" : "chevron.right")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(MuxyTheme.fgDim)
-                .frame(width: 10)
-        } else {
-            Color.clear.frame(width: 10)
-        }
-    }
-
     private var icon: some View {
-        Image(systemName: entry.isDirectory ? "folder" : "doc")
+        Image(systemName: iconSymbol)
             .font(.system(size: 11))
             .foregroundStyle(iconColor)
             .frame(width: 14)
+    }
+
+    private var iconSymbol: String {
+        guard entry.isDirectory else { return "doc" }
+        return state.isExpanded(entry) ? "folder.fill" : "folder"
     }
 
     private var iconColor: Color {
@@ -444,7 +436,6 @@ private struct FileTreeNewEntryRow: View {
     var body: some View {
         HStack(spacing: 4) {
             Color.clear.frame(width: CGFloat(depth) * 12)
-            Color.clear.frame(width: 10)
             Image(systemName: kind == .folder ? "folder" : "doc")
                 .font(.system(size: 11))
                 .foregroundStyle(MuxyTheme.fgMuted)
@@ -456,7 +447,7 @@ private struct FileTreeNewEntryRow: View {
             )
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 6)
         .frame(height: 22)
     }
 }

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -1,25 +1,76 @@
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct FileTreeView: View {
     @Bindable var state: FileTreeState
     let onOpenFile: (String) -> Void
+    let onOpenTerminal: (String) -> Void
+    let onFileMoved: (String, String) -> Void
+
+    @State private var commands: FileTreeCommands?
+    @FocusState private var treeFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
             header
             Rectangle().fill(MuxyTheme.border).frame(height: 1)
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(state.visibleRootEntries(), id: \.absolutePath) { entry in
-                        FileTreeRowGroup(entry: entry, depth: 0, state: state, onOpenFile: onOpenFile)
+                ZStack(alignment: .top) {
+                    emptySpaceTarget
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(state.visibleRootEntries(), id: \.absolutePath) { entry in
+                            FileTreeRowGroup(
+                                entry: entry,
+                                depth: 0,
+                                state: state,
+                                commands: commandsOrCreate(),
+                                onOpenFile: onOpenFile,
+                                requestFocus: { treeFocused = true }
+                            )
+                        }
+                        if let pending = state.pendingNewEntry, pending.parentPath == normalizedRootPath {
+                            FileTreeNewEntryRow(
+                                kind: pending.kind,
+                                depth: 0,
+                                commands: commandsOrCreate()
+                            )
+                        }
                     }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .frame(maxWidth: .infinity, minHeight: 0, alignment: .top)
             }
+            .background(rootDropTarget)
         }
         .background(MuxyTheme.bg)
+        .contentShape(Rectangle())
+        .focusable()
+        .focusEffectDisabled()
+        .focused($treeFocused)
+        .background(keyboardShortcuts)
         .task(id: state.rootPath) {
             state.loadRootIfNeeded()
+        }
+        .alert(
+            deleteAlertTitle,
+            isPresented: Binding(
+                get: { state.pendingDeletePath != nil },
+                set: { newValue in
+                    if !newValue { commandsOrCreate().cancelPendingDelete() }
+                }
+            ),
+            presenting: state.pendingDeletePath
+        ) { _ in
+            Button("Move to Trash", role: .destructive) {
+                commandsOrCreate().confirmPendingDelete()
+            }
+            .keyboardShortcut(.defaultAction)
+            Button("Cancel", role: .cancel) {
+                commandsOrCreate().cancelPendingDelete()
+            }
+        } message: { path in
+            Text("“\((path as NSString).lastPathComponent)” will be moved to the Trash.")
         }
     }
 
@@ -43,6 +94,113 @@ struct FileTreeView: View {
         }
         .padding(.horizontal, 10)
         .frame(height: 32)
+        .contextMenu {
+            FileTreeContextMenuContents(
+                path: state.rootPath,
+                isDirectory: true,
+                includesTargetActions: false,
+                commands: commandsOrCreate()
+            )
+        }
+    }
+
+    private var emptySpaceTarget: some View {
+        Color.clear
+            .frame(maxWidth: .infinity)
+            .containerRelativeFrame(.vertical)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                state.selectedFilePath = nil
+                treeFocused = true
+            }
+            .contextMenu {
+                FileTreeContextMenuContents(
+                    path: state.rootPath,
+                    isDirectory: true,
+                    includesTargetActions: false,
+                    commands: commandsOrCreate()
+                )
+            }
+    }
+
+    private var rootDropTarget: some View {
+        Color.clear
+            .onDrop(
+                of: [.fileURL],
+                delegate: FileTreeDropDelegate(
+                    destinationPath: state.rootPath,
+                    state: state,
+                    commands: commandsOrCreate()
+                )
+            )
+    }
+
+    private var keyboardShortcuts: some View {
+        Group {
+            Button("") {
+                guard let path = state.selectedFilePath else { return }
+                commandsOrCreate().beginRename(path: path)
+            }
+            .keyboardShortcut(.return, modifiers: [])
+
+            Button("") {
+                guard let path = state.selectedFilePath else { return }
+                commandsOrCreate().trash(path: path)
+            }
+            .keyboardShortcut(.delete, modifiers: [])
+
+            Button("") {
+                guard let path = state.selectedFilePath else { return }
+                commandsOrCreate().trash(path: path)
+            }
+            .keyboardShortcut(.delete, modifiers: [.command])
+
+            Button("") {
+                guard let path = state.selectedFilePath else { return }
+                commandsOrCreate().copyToClipboard(paths: [path])
+            }
+            .keyboardShortcut("c", modifiers: [.command])
+
+            Button("") {
+                guard let path = state.selectedFilePath else { return }
+                commandsOrCreate().cutToClipboard(paths: [path])
+            }
+            .keyboardShortcut("x", modifiers: [.command])
+
+            Button("") {
+                let target = state.selectedFilePath ?? state.rootPath
+                commandsOrCreate().paste(into: target)
+            }
+            .keyboardShortcut("v", modifiers: [.command])
+        }
+        .buttonStyle(.plain)
+        .opacity(0)
+        .frame(width: 0, height: 0)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private var deleteAlertTitle: String {
+        guard let path = state.pendingDeletePath else { return "Move to Trash?" }
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        let kind = exists && isDir.boolValue ? "folder" : "file"
+        return "Move \(kind) to Trash?"
+    }
+
+    private var normalizedRootPath: String {
+        state.rootPath.hasSuffix("/") ? String(state.rootPath.dropLast()) : state.rootPath
+    }
+
+    private func commandsOrCreate() -> FileTreeCommands {
+        if let commands { return commands }
+        let created = FileTreeCommands(
+            state: state,
+            openTerminal: onOpenTerminal,
+            onFileMoved: onFileMoved
+        )
+        commands = created
+        return created
     }
 }
 
@@ -50,13 +208,32 @@ private struct FileTreeRowGroup: View {
     let entry: FileTreeEntry
     let depth: Int
     @Bindable var state: FileTreeState
+    let commands: FileTreeCommands
     let onOpenFile: (String) -> Void
+    let requestFocus: () -> Void
 
     var body: some View {
-        FileTreeRow(entry: entry, depth: depth, state: state, onOpenFile: onOpenFile)
+        FileTreeRow(
+            entry: entry,
+            depth: depth,
+            state: state,
+            commands: commands,
+            onOpenFile: onOpenFile,
+            requestFocus: requestFocus
+        )
         if entry.isDirectory, state.isExpanded(entry), let children = state.visibleChildren(of: entry) {
             ForEach(children, id: \.absolutePath) { child in
-                FileTreeRowGroup(entry: child, depth: depth + 1, state: state, onOpenFile: onOpenFile)
+                FileTreeRowGroup(
+                    entry: child,
+                    depth: depth + 1,
+                    state: state,
+                    commands: commands,
+                    onOpenFile: onOpenFile,
+                    requestFocus: requestFocus
+                )
+            }
+            if let pending = state.pendingNewEntry, pending.parentPath == entry.absolutePath {
+                FileTreeNewEntryRow(kind: pending.kind, depth: depth + 1, commands: commands)
             }
         }
     }
@@ -66,11 +243,25 @@ private struct FileTreeRow: View {
     let entry: FileTreeEntry
     let depth: Int
     @Bindable var state: FileTreeState
+    let commands: FileTreeCommands
     let onOpenFile: (String) -> Void
+    let requestFocus: () -> Void
     @State private var hovered = false
 
     private var isSelected: Bool {
         !entry.isDirectory && state.selectedFilePath == entry.absolutePath
+    }
+
+    private var isRenaming: Bool {
+        state.pendingRenamePath == entry.absolutePath
+    }
+
+    private var isDropHighlighted: Bool {
+        entry.isDirectory && state.dropHighlightPath == entry.absolutePath
+    }
+
+    private var isCut: Bool {
+        state.cutPaths.contains(entry.absolutePath)
     }
 
     var body: some View {
@@ -78,26 +269,66 @@ private struct FileTreeRow: View {
             Color.clear.frame(width: CGFloat(depth) * 12)
             chevron
             icon
-            Text(entry.name)
-                .font(.system(size: 12))
-                .foregroundStyle(textColor)
-                .lineLimit(1)
-                .truncationMode(.tail)
+            if isRenaming {
+                FileTreeRenameField(
+                    initialName: entry.name,
+                    commit: { commands.commitRename(originalPath: entry.absolutePath, newName: $0) },
+                    cancel: { commands.cancelRename() }
+                )
+            } else {
+                Text(entry.name)
+                    .font(.system(size: 12))
+                    .foregroundStyle(textColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 8)
         .frame(height: 22)
-        .opacity(entry.isIgnored ? 0.45 : 1)
+        .opacity(rowOpacity)
         .background(rowBackground)
+        .overlay(dropOverlay)
         .contentShape(Rectangle())
         .onTapGesture { handleTap() }
         .onHover { hovered = $0 }
+        .contextMenu {
+            FileTreeContextMenuContents(
+                path: entry.absolutePath,
+                isDirectory: entry.isDirectory,
+                includesTargetActions: true,
+                commands: commands
+            )
+        }
+        .onDrag {
+            NSItemProvider(object: URL(fileURLWithPath: entry.absolutePath) as NSURL)
+        }
+        .modifier(DropTargetModifier(
+            entry: entry,
+            state: state,
+            commands: commands
+        ))
+    }
+
+    private var rowOpacity: Double {
+        if isCut { return 0.45 }
+        return entry.isIgnored ? 0.45 : 1
     }
 
     private var rowBackground: Color {
+        if isDropHighlighted { return MuxyTheme.accentSoft }
         if isSelected { return MuxyTheme.accentSoft }
         if hovered { return MuxyTheme.hover }
         return .clear
+    }
+
+    @ViewBuilder
+    private var dropOverlay: some View {
+        if isDropHighlighted {
+            RoundedRectangle(cornerRadius: 3)
+                .stroke(MuxyTheme.accent, lineWidth: 1)
+                .padding(.horizontal, 4)
+        }
     }
 
     @ViewBuilder
@@ -148,12 +379,182 @@ private struct FileTreeRow: View {
     }
 
     private func handleTap() {
+        requestFocus()
+        state.selectedFilePath = entry.absolutePath
         if entry.isDirectory {
             state.toggle(entry)
         } else if state.status(for: entry.absolutePath) != .deleted {
             onOpenFile(entry.absolutePath)
+        }
+    }
+}
+
+private struct DropTargetModifier: ViewModifier {
+    let entry: FileTreeEntry
+    let state: FileTreeState
+    let commands: FileTreeCommands
+
+    func body(content: Content) -> some View {
+        if entry.isDirectory {
+            content.onDrop(
+                of: [.fileURL],
+                delegate: FileTreeDropDelegate(
+                    destinationPath: entry.absolutePath,
+                    state: state,
+                    commands: commands
+                )
+            )
         } else {
-            return
+            content
+        }
+    }
+}
+
+private struct FileTreeNewEntryRow: View {
+    let kind: FileTreeState.PendingEntryKind
+    let depth: Int
+    let commands: FileTreeCommands
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Color.clear.frame(width: CGFloat(depth) * 12)
+            Color.clear.frame(width: 10)
+            Image(systemName: kind == .folder ? "folder" : "doc")
+                .font(.system(size: 11))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: 14)
+            FileTreeRenameField(
+                initialName: "",
+                commit: { commands.commitNewEntry(name: $0) },
+                cancel: { commands.cancelNewEntry() }
+            )
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 22)
+    }
+}
+
+private struct FileTreeRenameField: View {
+    let initialName: String
+    let commit: (String) -> Void
+    let cancel: () -> Void
+
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+    @State private var didAppear = false
+
+    var body: some View {
+        TextField("", text: $text)
+            .textFieldStyle(.plain)
+            .font(.system(size: 12))
+            .foregroundStyle(MuxyTheme.fg)
+            .focused($focused)
+            .onAppear {
+                guard !didAppear else { return }
+                didAppear = true
+                text = initialName
+                DispatchQueue.main.async { focused = true }
+            }
+            .onSubmit {
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { cancel()
+                    return
+                }
+                commit(trimmed)
+            }
+            .onExitCommand { cancel() }
+            .onChange(of: focused) { _, isFocused in
+                guard didAppear, !isFocused else { return }
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty || trimmed == initialName {
+                    cancel()
+                } else {
+                    commit(trimmed)
+                }
+            }
+    }
+}
+
+private struct FileTreeContextMenuContents: View {
+    let path: String
+    let isDirectory: Bool
+    let includesTargetActions: Bool
+    let commands: FileTreeCommands
+
+    var body: some View {
+        Button("New File") { commands.beginNewFile(in: path) }
+        Button("New Folder") { commands.beginNewFolder(in: path) }
+        if includesTargetActions {
+            Divider()
+            Button("Rename") { commands.beginRename(path: path) }
+            Button("Delete") { commands.trash(path: path) }
+            Divider()
+            Button("Cut") { commands.cutToClipboard(paths: [path]) }
+            Button("Copy") { commands.copyToClipboard(paths: [path]) }
+        }
+        Divider()
+        Button("Paste") { commands.paste(into: path) }
+            .disabled(!FileClipboard.hasContents)
+        if includesTargetActions {
+            Divider()
+            Button("Copy Path") { commands.copyAbsolutePath(path) }
+            Button("Copy Relative Path") { commands.copyRelativePath(path) }
+        }
+        Divider()
+        Button("Reveal in Finder") { commands.revealInFinder(path) }
+        Button("Open in Terminal") { commands.openInTerminal(path: path) }
+    }
+}
+
+private struct FileTreeDropDelegate: DropDelegate {
+    let destinationPath: String
+    let state: FileTreeState
+    let commands: FileTreeCommands
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [.fileURL])
+    }
+
+    func dropEntered(info _: DropInfo) {
+        state.dropHighlightPath = destinationPath
+    }
+
+    func dropExited(info _: DropInfo) {
+        if state.dropHighlightPath == destinationPath {
+            state.dropHighlightPath = nil
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        state.dropHighlightPath = nil
+        let providers = info.itemProviders(for: [.fileURL])
+        guard !providers.isEmpty else { return false }
+
+        let optionHeld = NSEvent.modifierFlags.contains(.option)
+        let destination = destinationPath
+        let commands = commands
+
+        Task { @MainActor in
+            var paths: [String] = []
+            for provider in providers {
+                if let url = await loadURL(from: provider) {
+                    paths.append(url.path)
+                }
+            }
+            guard !paths.isEmpty else { return }
+            let sanitized = paths.filter { !FileSystemOperations.isInside(path: destination, ancestor: $0) }
+            guard !sanitized.isEmpty else { return }
+            commands.performDrop(sources: sanitized, destinationPath: destination, copy: optionHeld)
+        }
+        return true
+    }
+
+    private func loadURL(from provider: NSItemProvider) async -> URL? {
+        await withCheckedContinuation { continuation in
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                continuation.resume(returning: url)
+            }
         }
     }
 }

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -8,8 +8,25 @@ struct FileTreeView: View {
     let onOpenTerminal: (String) -> Void
     let onFileMoved: (String, String) -> Void
 
-    @State private var commands: FileTreeCommands?
+    @State private var commands: FileTreeCommands
     @FocusState private var treeFocused: Bool
+
+    init(
+        state: FileTreeState,
+        onOpenFile: @escaping (String) -> Void,
+        onOpenTerminal: @escaping (String) -> Void,
+        onFileMoved: @escaping (String, String) -> Void
+    ) {
+        self.state = state
+        self.onOpenFile = onOpenFile
+        self.onOpenTerminal = onOpenTerminal
+        self.onFileMoved = onFileMoved
+        _commands = State(initialValue: FileTreeCommands(
+            state: state,
+            openTerminal: onOpenTerminal,
+            onFileMoved: onFileMoved
+        ))
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,7 +41,7 @@ struct FileTreeView: View {
                                 entry: entry,
                                 depth: 0,
                                 state: state,
-                                commands: commandsOrCreate(),
+                                commands: commands,
                                 onOpenFile: onOpenFile,
                                 requestFocus: { treeFocused = true }
                             )
@@ -33,8 +50,9 @@ struct FileTreeView: View {
                             FileTreeNewEntryRow(
                                 kind: pending.kind,
                                 depth: 0,
-                                commands: commandsOrCreate()
+                                commands: commands
                             )
+                            .id(pending.token)
                         }
                     }
                     .padding(.vertical, 4)
@@ -53,25 +71,38 @@ struct FileTreeView: View {
             state.loadRootIfNeeded()
         }
         .alert(
-            deleteAlertTitle,
-            isPresented: Binding(
-                get: { state.pendingDeletePath != nil },
-                set: { newValue in
-                    if !newValue { commandsOrCreate().cancelPendingDelete() }
-                }
-            ),
-            presenting: state.pendingDeletePath
-        ) { _ in
+            "Move \(commands.deleteAlertKind()) to Trash?",
+            isPresented: deleteAlertBinding
+        ) {
             Button("Move to Trash", role: .destructive) {
-                commandsOrCreate().confirmPendingDelete()
+                commands.confirmPendingDelete()
             }
             .keyboardShortcut(.defaultAction)
             Button("Cancel", role: .cancel) {
-                commandsOrCreate().cancelPendingDelete()
+                commands.cancelPendingDelete()
             }
-        } message: { path in
-            Text("“\((path as NSString).lastPathComponent)” will be moved to the Trash.")
+        } message: {
+            Text(deleteAlertMessage)
         }
+    }
+
+    private var deleteAlertBinding: Binding<Bool> {
+        Binding(
+            get: { !state.pendingDeletePaths.isEmpty },
+            set: { newValue in
+                if !newValue, !state.pendingDeletePaths.isEmpty {
+                    commands.cancelPendingDelete()
+                }
+            }
+        )
+    }
+
+    private var deleteAlertMessage: String {
+        let paths = state.pendingDeletePaths
+        if paths.count == 1, let path = paths.first {
+            return "“\((path as NSString).lastPathComponent)” will be moved to the Trash."
+        }
+        return "\(paths.count) items will be moved to the Trash."
     }
 
     private var header: some View {
@@ -99,7 +130,7 @@ struct FileTreeView: View {
                 path: state.rootPath,
                 isDirectory: true,
                 includesTargetActions: false,
-                commands: commandsOrCreate()
+                commands: commands
             )
         }
     }
@@ -110,7 +141,7 @@ struct FileTreeView: View {
             .containerRelativeFrame(.vertical)
             .contentShape(Rectangle())
             .onTapGesture {
-                state.selectedFilePath = nil
+                state.clearSelection()
                 treeFocused = true
             }
             .contextMenu {
@@ -118,7 +149,7 @@ struct FileTreeView: View {
                     path: state.rootPath,
                     isDirectory: true,
                     includesTargetActions: false,
-                    commands: commandsOrCreate()
+                    commands: commands
                 )
             }
     }
@@ -130,7 +161,7 @@ struct FileTreeView: View {
                 delegate: FileTreeDropDelegate(
                     destinationPath: state.rootPath,
                     state: state,
-                    commands: commandsOrCreate()
+                    commands: commands
                 )
             )
     }
@@ -138,38 +169,42 @@ struct FileTreeView: View {
     private var keyboardShortcuts: some View {
         Group {
             Button("") {
-                guard let path = state.selectedFilePath else { return }
-                commandsOrCreate().beginRename(path: path)
+                guard state.selectedPaths.count == 1, let path = state.selectedPaths.first else { return }
+                commands.beginRename(path: path)
             }
             .keyboardShortcut(.return, modifiers: [])
 
             Button("") {
-                guard let path = state.selectedFilePath else { return }
-                commandsOrCreate().trash(path: path)
+                let paths = Array(state.selectedPaths)
+                guard !paths.isEmpty else { return }
+                commands.trash(paths: paths)
             }
             .keyboardShortcut(.delete, modifiers: [])
 
             Button("") {
-                guard let path = state.selectedFilePath else { return }
-                commandsOrCreate().trash(path: path)
+                let paths = Array(state.selectedPaths)
+                guard !paths.isEmpty else { return }
+                commands.trash(paths: paths)
             }
             .keyboardShortcut(.delete, modifiers: [.command])
 
             Button("") {
-                guard let path = state.selectedFilePath else { return }
-                commandsOrCreate().copyToClipboard(paths: [path])
+                let paths = Array(state.selectedPaths)
+                guard !paths.isEmpty else { return }
+                commands.copyToClipboard(paths: paths)
             }
             .keyboardShortcut("c", modifiers: [.command])
 
             Button("") {
-                guard let path = state.selectedFilePath else { return }
-                commandsOrCreate().cutToClipboard(paths: [path])
+                let paths = Array(state.selectedPaths)
+                guard !paths.isEmpty else { return }
+                commands.cutToClipboard(paths: paths)
             }
             .keyboardShortcut("x", modifiers: [.command])
 
             Button("") {
                 let target = state.selectedFilePath ?? state.rootPath
-                commandsOrCreate().paste(into: target)
+                commands.paste(into: target)
             }
             .keyboardShortcut("v", modifiers: [.command])
         }
@@ -180,27 +215,8 @@ struct FileTreeView: View {
         .accessibilityHidden(true)
     }
 
-    private var deleteAlertTitle: String {
-        guard let path = state.pendingDeletePath else { return "Move to Trash?" }
-        var isDir: ObjCBool = false
-        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
-        let kind = exists && isDir.boolValue ? "folder" : "file"
-        return "Move \(kind) to Trash?"
-    }
-
     private var normalizedRootPath: String {
         state.rootPath.hasSuffix("/") ? String(state.rootPath.dropLast()) : state.rootPath
-    }
-
-    private func commandsOrCreate() -> FileTreeCommands {
-        if let commands { return commands }
-        let created = FileTreeCommands(
-            state: state,
-            openTerminal: onOpenTerminal,
-            onFileMoved: onFileMoved
-        )
-        commands = created
-        return created
     }
 }
 
@@ -234,6 +250,7 @@ private struct FileTreeRowGroup: View {
             }
             if let pending = state.pendingNewEntry, pending.parentPath == entry.absolutePath {
                 FileTreeNewEntryRow(kind: pending.kind, depth: depth + 1, commands: commands)
+                    .id(pending.token)
             }
         }
     }
@@ -249,7 +266,7 @@ private struct FileTreeRow: View {
     @State private var hovered = false
 
     private var isSelected: Bool {
-        !entry.isDirectory && state.selectedFilePath == entry.absolutePath
+        state.isPathSelected(entry.absolutePath)
     }
 
     private var isRenaming: Bool {
@@ -380,7 +397,16 @@ private struct FileTreeRow: View {
 
     private func handleTap() {
         requestFocus()
-        state.selectedFilePath = entry.absolutePath
+        let modifiers = NSEvent.modifierFlags
+        if modifiers.contains(.command) {
+            state.toggleSelection(entry.absolutePath)
+            return
+        }
+        if modifiers.contains(.shift) {
+            state.extendSelection(to: entry.absolutePath)
+            return
+        }
+        state.selectOnly(entry.absolutePath)
         if entry.isDirectory {
             state.toggle(entry)
         } else if state.status(for: entry.absolutePath) != .deleted {
@@ -443,6 +469,7 @@ private struct FileTreeRenameField: View {
     @State private var text: String = ""
     @FocusState private var focused: Bool
     @State private var didAppear = false
+    @State private var didResolve = false
 
     var body: some View {
         TextField("", text: $text)
@@ -454,25 +481,29 @@ private struct FileTreeRenameField: View {
                 guard !didAppear else { return }
                 didAppear = true
                 text = initialName
-                DispatchQueue.main.async { focused = true }
+                Task { @MainActor in focused = true }
             }
-            .onSubmit {
-                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { cancel()
-                    return
-                }
-                commit(trimmed)
+            .onSubmit { resolve() }
+            .onExitCommand {
+                guard !didResolve else { return }
+                didResolve = true
+                cancel()
             }
-            .onExitCommand { cancel() }
             .onChange(of: focused) { _, isFocused in
                 guard didAppear, !isFocused else { return }
-                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.isEmpty || trimmed == initialName {
-                    cancel()
-                } else {
-                    commit(trimmed)
-                }
+                resolve()
             }
+    }
+
+    private func resolve() {
+        guard !didResolve else { return }
+        didResolve = true
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed == initialName {
+            cancel()
+        } else {
+            commit(trimmed)
+        }
     }
 }
 
@@ -482,16 +513,27 @@ private struct FileTreeContextMenuContents: View {
     let includesTargetActions: Bool
     let commands: FileTreeCommands
 
+    private var targets: [String] {
+        commands.effectiveTargets(primaryPath: path)
+    }
+
     var body: some View {
         Button("New File") { commands.beginNewFile(in: path) }
         Button("New Folder") { commands.beginNewFolder(in: path) }
         if includesTargetActions {
             Divider()
             Button("Rename") { commands.beginRename(path: path) }
-            Button("Delete") { commands.trash(path: path) }
+                .disabled(targets.count > 1)
+            Button(targets.count > 1 ? "Delete \(targets.count) Items" : "Delete") {
+                commands.trash(paths: targets)
+            }
             Divider()
-            Button("Cut") { commands.cutToClipboard(paths: [path]) }
-            Button("Copy") { commands.copyToClipboard(paths: [path]) }
+            Button(targets.count > 1 ? "Cut \(targets.count) Items" : "Cut") {
+                commands.cutToClipboard(paths: targets)
+            }
+            Button(targets.count > 1 ? "Copy \(targets.count) Items" : "Copy") {
+                commands.copyToClipboard(paths: targets)
+            }
         }
         Divider()
         Button("Paste") { commands.paste(into: path) }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -146,8 +146,11 @@ struct MainWindow: View {
                                     directory: directory
                                 ))
                             },
-                            onFileMoved: { _, _ in }
+                            onFileMoved: { oldPath, newPath in
+                                appState.handleFileMoved(from: oldPath, to: newPath)
+                            }
                         )
+                        .id(treeState.rootPath)
                         .frame(width: CGFloat(fileTreePanelWidth))
                     }
                 }
@@ -533,7 +536,7 @@ struct MainWindow: View {
         if let filePath {
             state.revealFile(at: filePath)
         } else {
-            state.selectedFilePath = nil
+            state.clearSelection()
         }
     }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -132,10 +132,22 @@ struct MainWindow: View {
                                 min(Double(FileTreeLayout.maxWidth), next)
                             )
                         }
-                        FileTreeView(state: treeState) { filePath in
-                            guard let projectID = appState.activeProjectID else { return }
-                            appState.openFile(filePath, projectID: projectID)
-                        }
+                        FileTreeView(
+                            state: treeState,
+                            onOpenFile: { filePath in
+                                guard let projectID = appState.activeProjectID else { return }
+                                appState.openFile(filePath, projectID: projectID)
+                            },
+                            onOpenTerminal: { directory in
+                                guard let projectID = appState.activeProjectID else { return }
+                                appState.dispatch(.createTabInDirectory(
+                                    projectID: projectID,
+                                    areaID: nil,
+                                    directory: directory
+                                ))
+                            },
+                            onFileMoved: { _, _ in }
+                        )
                         .frame(width: CGFloat(fileTreePanelWidth))
                     }
                 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,8 @@ Muxy/
     GitDirectoryWatcher.swift FSEvents watcher for .git changes
     FileSearchService.swift   Quick open file search via /usr/bin/find subprocess
     FileTreeService.swift     Lazy directory listing that respects .gitignore via git check-ignore
+    FileSystemOperations.swift Off-main create / rename / move / copy / trash primitives
+    FileClipboard.swift       NSPasteboard wrapper for file cut/copy/paste with cut-marker type
     ThemeService.swift        Theme discovery + application
     MuxyConfig.swift          Ghostty config file read/write
     KeyBindingStore.swift     @Observable store for keyboard shortcuts
@@ -136,6 +138,7 @@ Muxy/
       EditorPane.swift        SwiftUI wrapper for editor tab (breadcrumb + editor)
     FileTree/
       FileTreeView.swift      Side panel rendering of the lightweight file tree
+      FileTreeCommands.swift  Orchestrates create/rename/delete/cut/copy/paste/drop
     VCS/
       VCSTabView.swift        Source control tab (commit, stage, diff, branch) + PRPill + PRPopover
       BranchPicker.swift      Branch selection dropdown with filter and right-click delete
@@ -248,6 +251,43 @@ tree and the changed-only filter.
 
 The panel width is persisted in `UserDefaults` under `muxy.fileTreeWidth`.
 Expansion state is in-memory only.
+
+### File Operations
+
+The tree supports direct manipulation through a right-click context menu,
+keyboard shortcuts, and drag-and-drop. `FileTreeCommands` (held as view
+state inside `FileTreeView`) orchestrates the flow: it mutates transient
+`FileTreeState` fields (`pendingNewEntry`, `pendingRenamePath`,
+`pendingDeletePaths`, `cutPaths`, `dropHighlightPath`, `selectedPaths`,
+`selectionAnchorPath`) and dispatches work to `FileSystemOperations`, a
+stateless service that runs create / rename / move / copy / trash off the
+main thread via `GitProcessRunner.offMainThrowing`. Trash goes through
+`NSWorkspace.shared.recycle` so the OS handles Undo.
+
+Selection is multi-item: plain click selects one, `⌘`-click toggles, and
+`⇧`-click extends the range using the currently visible row order.
+Rename and new-entry both use `FileTreeRenameField`, an inline text field
+that commits on Return / blur and cancels on Escape. Errors from any
+operation surface through `ToastState.shared` and are also logged.
+
+Cut / copy / paste is backed by `FileClipboard`, which writes file URLs to
+`NSPasteboard.general` and tags cuts with a private pasteboard type
+(`app.muxy.fileCut`). This lets Muxy round-trip cut state while remaining
+interoperable with Finder (which only sees the file URLs). Paste into a
+file selects that file's parent directory as the destination.
+
+Drag-and-drop accepts `.fileURL` providers on every directory row and on
+the empty space below the tree. Holding Option turns a move into a copy;
+drops that would move a path into itself are filtered out. The dragged
+row and all drop targets are driven by the same `FileTreeDropDelegate`.
+
+When a path changes on disk (rename, move, paste) the tree calls
+`AppState.handleFileMoved(from:to:)`, which walks every open editor tab
+and rewrites `EditorTabState.filePath` — both exact matches and paths
+under a moved directory — keeping editors pointed at the same content.
+"Open in Terminal" dispatches `.createTabInDirectory`, a reducer case
+that opens a new terminal tab rooted at the selected directory rather
+than the project root.
 
 ## VCS Tab Layout
 


### PR DESCRIPTION
This PR enhances the filetree by adding right click context menu for basic file operations like rename, move, copy, … with keyboard shortcuts for them.