### PR TITLE
Add "Don't ask again" option for running-process close confirmation

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -398,6 +398,7 @@ final class AppState {
     }
 
     private func needsProcessConfirmation(tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
+        guard TabCloseConfirmationPreferences.confirmRunningProcess else { return false }
         guard let key = activeWorktreeKey(for: projectID),
               let root = workspaceRoots[key],
               let area = root.findArea(id: areaID),

--- a/Muxy/Models/TabCloseConfirmationPreferences.swift
+++ b/Muxy/Models/TabCloseConfirmationPreferences.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum TabCloseConfirmationPreferences {
+    static let confirmRunningProcessKey = "muxy.tabs.confirmCloseRunningProcess"
+
+    static var confirmRunningProcess: Bool {
+        get {
+            let defaults = UserDefaults.standard
+            if defaults.object(forKey: confirmRunningProcessKey) == nil { return true }
+            return defaults.bool(forKey: confirmRunningProcessKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: confirmRunningProcessKey)
+        }
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -673,6 +673,11 @@ struct MainWindow: View {
             alert.buttons[1].keyEquivalent = "\u{1b}"
         }
 
+        if kind == .runningProcess {
+            alert.showsSuppressionButton = true
+            alert.suppressionButton?.title = "Don't ask again"
+        }
+
         alert.beginSheetModal(for: window) { response in
             switch kind {
             case .lastTab:
@@ -692,6 +697,9 @@ struct MainWindow: View {
                 }
             case .runningProcess:
                 if response == .alertFirstButtonReturn {
+                    if alert.suppressionButton?.state == .on {
+                        TabCloseConfirmationPreferences.confirmRunningProcess = false
+                    }
                     appState.confirmCloseRunningTab()
                 } else {
                     appState.cancelCloseRunningTab()

--- a/Muxy/Views/Settings/AppearanceSettingsView.swift
+++ b/Muxy/Views/Settings/AppearanceSettingsView.swift
@@ -5,6 +5,7 @@ struct AppearanceSettingsView: View {
     @State private var showThemePicker = false
     @State private var currentTheme: String?
     @AppStorage("muxy.vcsDisplayMode") private var vcsDisplayMode = VCSDisplayMode.tab.rawValue
+    @AppStorage(TabCloseConfirmationPreferences.confirmRunningProcessKey) private var confirmRunningProcess = true
 
     var body: some View {
         SettingsContainer {
@@ -32,7 +33,7 @@ struct AppearanceSettingsView: View {
                 }
             }
 
-            SettingsSection("Source Control", showsDivider: false) {
+            SettingsSection("Source Control") {
                 SettingsRow("Display Mode") {
                     Picker("", selection: $vcsDisplayMode) {
                         ForEach(VCSDisplayMode.allCases) { mode in
@@ -43,6 +44,13 @@ struct AppearanceSettingsView: View {
                     .pickerStyle(.segmented)
                     .frame(width: SettingsMetrics.controlWidth)
                 }
+            }
+
+            SettingsSection("Tabs", showsDivider: false) {
+                SettingsToggleRow(
+                    label: "Confirm before closing a tab with a running process",
+                    isOn: $confirmRunningProcess
+                )
             }
         }
         .task {

--- a/Muxy/Views/Settings/AppearanceSettingsView.swift
+++ b/Muxy/Views/Settings/AppearanceSettingsView.swift
@@ -5,7 +5,6 @@ struct AppearanceSettingsView: View {
     @State private var showThemePicker = false
     @State private var currentTheme: String?
     @AppStorage("muxy.vcsDisplayMode") private var vcsDisplayMode = VCSDisplayMode.tab.rawValue
-    @AppStorage(TabCloseConfirmationPreferences.confirmRunningProcessKey) private var confirmRunningProcess = true
 
     var body: some View {
         SettingsContainer {
@@ -33,7 +32,7 @@ struct AppearanceSettingsView: View {
                 }
             }
 
-            SettingsSection("Source Control") {
+            SettingsSection("Source Control", showsDivider: false) {
                 SettingsRow("Display Mode") {
                     Picker("", selection: $vcsDisplayMode) {
                         ForEach(VCSDisplayMode.allCases) { mode in
@@ -44,13 +43,6 @@ struct AppearanceSettingsView: View {
                     .pickerStyle(.segmented)
                     .frame(width: SettingsMetrics.controlWidth)
                 }
-            }
-
-            SettingsSection("Tabs", showsDivider: false) {
-                SettingsToggleRow(
-                    label: "Confirm before closing a tab with a running process",
-                    isOn: $confirmRunningProcess
-                )
             }
         }
         .task {

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -7,17 +7,25 @@ enum GeneralSettingsKeys {
 struct GeneralSettingsView: View {
     @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
     private var autoExpandWorktrees = false
+    @AppStorage(TabCloseConfirmationPreferences.confirmRunningProcessKey)
+    private var confirmRunningProcess = true
 
     var body: some View {
         SettingsContainer {
             SettingsSection(
                 "Sidebar",
-                footer: "Automatically reveal worktrees when you switch to a project.",
-                showsDivider: false
+                footer: "Automatically reveal worktrees when you switch to a project."
             ) {
                 SettingsToggleRow(
                     label: "Auto-expand worktrees on project switch",
                     isOn: $autoExpandWorktrees
+                )
+            }
+
+            SettingsSection("Tabs", showsDivider: false) {
+                SettingsToggleRow(
+                    label: "Confirm before closing a tab with a running process",
+                    isOn: $confirmRunningProcess
                 )
             }
         }


### PR DESCRIPTION
## Summary

So boring every time when I close some tab inside of project asking me are you sure to close so I add some future to don't ask again



## Testing

 

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

 