### PR TITLE
Remove `setAppIcon()` dock icon override

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -114,7 +114,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
-        setAppIcon()
         _ = GhosttyService.shared
         ThemeService.shared.applyDefaultThemeIfNeeded()
         UpdateService.shared.start()
@@ -188,16 +187,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         MainActor.assumeIsolated {
             MobileServerService.shared.stopForTermination()
         }
-    }
-
-    @MainActor
-    private func setAppIcon() {
-        guard let url = Bundle.appResources.url(forResource: "AppIcon", withExtension: "png") else {
-            return
-        }
-        guard let image = NSImage(contentsOf: url) else { return }
-        image.size = NSSize(width: 512, height: 512)
-        NSApp.applicationIconImage = image
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {


### PR DESCRIPTION
## Summary

In a early commit, I believe `setAppIcon()` was added to handle icon problem at that time, but now it's causing an issue where after app launches, the icon is programmatically replaced and user's custom icon (whether applied through Finder Inspect, an app like Pictogram, or even direct replacement of `AppIcon.icns` inside .app bundle) is not respected, and icon always changes to default Muxy icon.

There is an `setAppIcon()` method that does this, in there the runtime `applicationIconImage` prop always takes precedence over what macOS reads from .icns bundle resource, which destroys icon customization I have made, which is bad UX.
  
Since macOS automatically uses `AppIcon.icns` from the app bundle as the dock icon, I removed the `setAppIcon()` call completely, and I've made sure same icon is still shown, just that user now have the freedom to set what they want!

## Changes

- removed `setAppIcon()` in `MuxyApp.swift`

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

<img width="327" height="155" alt="image" src="https://github.com/user-attachments/assets/a331efb3-7df8-46f8-bb64-412d5b709b77" />
