### PR TITLE
Auto expand the project tab and remember the state

### DIFF
--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+enum GeneralSettingsKeys {
+    static let autoExpandWorktreesOnProjectSwitch = "muxy.general.autoExpandWorktreesOnProjectSwitch"
+}
+
+struct GeneralSettingsView: View {
+    @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
+    private var autoExpandWorktrees = true
+
+    var body: some View {
+        SettingsContainer {
+            SettingsSection(
+                "Sidebar",
+                footer: "Automatically reveal worktrees when you switch to a project.",
+                showsDivider: false
+            ) {
+                SettingsToggleRow(
+                    label: "Auto-expand worktrees on project switch",
+                    isOn: $autoExpandWorktrees
+                )
+            }
+        }
+    }
+}

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -6,7 +6,7 @@ enum GeneralSettingsKeys {
 
 struct GeneralSettingsView: View {
     @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
-    private var autoExpandWorktrees = true
+    private var autoExpandWorktrees = false
 
     var body: some View {
         SettingsContainer {

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct SettingsView: View {
     var body: some View {
         TabView {
+            GeneralSettingsView()
+                .tabItem { Label("General", systemImage: "gearshape") }
             AppearanceSettingsView()
                 .tabItem { Label("Appearance", systemImage: "paintbrush") }
             EditorSettingsView()

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -16,7 +16,7 @@ struct ExpandedProjectRow: View {
     @Environment(WorktreeStore.self) private var worktreeStore
 
     @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
-    private var autoExpandWorktrees = true
+    private var autoExpandWorktrees = false
 
     @State private var hovered = false
     @State private var isRenaming = false

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -15,6 +15,9 @@ struct ExpandedProjectRow: View {
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
 
+    @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
+    private var autoExpandWorktrees = true
+
     @State private var hovered = false
     @State private var isRenaming = false
     @State private var renameText = ""
@@ -54,12 +57,14 @@ struct ExpandedProjectRow: View {
         }
         .task(id: project.path) {
             isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path)
+            if autoExpandWorktrees, isActive, isGitRepo {
+                worktreesExpanded = true
+            }
         }
         .onChange(of: isActive) { _, active in
-            if !active {
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    worktreesExpanded = false
-                }
+            guard autoExpandWorktrees, active, isGitRepo else { return }
+            withAnimation(.easeInOut(duration: 0.15)) {
+                worktreesExpanded = true
             }
         }
         .contextMenu {


### PR DESCRIPTION
This PR adds auto expand feature to the project items in the sidebar and keeps the state.

It also adds a general tab in the settings where this behaviour can be configured

Closes #194