### PR TITLE
Fix laggy scrolling and sidebar re-renders

### DIFF
--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -1280,15 +1280,15 @@ struct CodeEditorView: NSViewRepresentable {
                 lastObservedClipSize = size
             }
             updateMarkdownEditorScrollMetrics()
-            if isMarkdownSplitActive {
-                if isApplyingMarkdownScroll {
-                    isApplyingMarkdownScroll = false
-                } else {
-                    if state.markdownScrollDriver != .editor {
-                        state.markdownScrollDriver = .editor
-                    }
-                    updateMarkdownPreviewSyncPointFromEditorScroll()
+            if !isMarkdownSplitActive {
+                isApplyingMarkdownScroll = false
+            } else if isApplyingMarkdownScroll {
+                isApplyingMarkdownScroll = false
+            } else {
+                if state.markdownScrollDriver != .editor {
+                    state.markdownScrollDriver = .editor
                 }
+                updateMarkdownPreviewSyncPointFromEditorScroll()
             }
             if !isEditingViewport {
                 refreshViewport(force: false)

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -1280,11 +1280,15 @@ struct CodeEditorView: NSViewRepresentable {
                 lastObservedClipSize = size
             }
             updateMarkdownEditorScrollMetrics()
-            if isApplyingMarkdownScroll {
-                isApplyingMarkdownScroll = false
-            } else {
-                state.markdownScrollDriver = .editor
-                updateMarkdownPreviewSyncPointFromEditorScroll()
+            if isMarkdownSplitActive {
+                if isApplyingMarkdownScroll {
+                    isApplyingMarkdownScroll = false
+                } else {
+                    if state.markdownScrollDriver != .editor {
+                        state.markdownScrollDriver = .editor
+                    }
+                    updateMarkdownPreviewSyncPointFromEditorScroll()
+                }
             }
             if !isEditingViewport {
                 refreshViewport(force: false)
@@ -1307,10 +1311,12 @@ struct CodeEditorView: NSViewRepresentable {
             }
         }
 
+        private var isMarkdownSplitActive: Bool {
+            state.isMarkdownFile && state.markdownViewMode == .split && state.markdownScrollSyncEnabled
+        }
+
         func updateMarkdownEditorScrollMetrics() {
-            guard state.isMarkdownFile,
-                  state.markdownViewMode == .split,
-                  state.markdownScrollSyncEnabled,
+            guard isMarkdownSplitActive,
                   let scrollView,
                   let viewport = viewportState
             else { return }

--- a/Muxy/Views/Sidebar/AIUsagePanel.swift
+++ b/Muxy/Views/Sidebar/AIUsagePanel.swift
@@ -127,6 +127,8 @@ struct AIUsagePanel: View {
 struct AIProviderUsageView: View {
     let snapshot: AIProviderUsageSnapshot
 
+    @AppStorage(AIUsageSettingsStore.sidebarPreviewProviderIDKey) private var pinnedRawValue: String = ""
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
@@ -144,7 +146,12 @@ struct AIProviderUsageView: View {
                         AIUsageMetricRowView(
                             row: row,
                             fetchedAt: snapshot.fetchedAt,
-                            providerID: snapshot.providerID
+                            providerID: snapshot.providerID,
+                            isPinned: AIUsageSettingsStore.isSidebarPinned(
+                                providerID: snapshot.providerID,
+                                rowLabel: row.label,
+                                pinnedRawValue: pinnedRawValue
+                            )
                         )
                     }
                 }
@@ -162,21 +169,13 @@ struct AIUsageMetricRowView: View {
     let row: AIUsageMetricRow
     let fetchedAt: Date
     let providerID: String
+    let isPinned: Bool
 
     @AppStorage(AIUsageSettingsStore.usageDisplayModeKey) private var usageDisplayModeRaw = AIUsageSettingsStore.defaultUsageDisplayMode
         .rawValue
-    @AppStorage(AIUsageSettingsStore.sidebarPreviewProviderIDKey) private var pinnedRawValue: String = ""
     @State private var pinHovered = false
 
     private var canPin: Bool { row.percent != nil }
-
-    private var isPinned: Bool {
-        AIUsageSettingsStore.isSidebarPinned(
-            providerID: providerID,
-            rowLabel: row.label,
-            pinnedRawValue: pinnedRawValue
-        )
-    }
 
     private func togglePin() {
         if isPinned {


### PR DESCRIPTION
  Editor scroll notifications wrote `markdownScrollDriver` on every tick for every file, churning the `@Observable`
  graph even on plain code scrolling. Now gated to active markdown splits.

  AI usage rows each subscribed to `@AppStorage` for the pinned provider; hoisted to the parent so snapshot ticks
  don't re-render every row.