### PR TITLE
Fix PR detection for fork checkouts in VCS

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -925,6 +925,7 @@ final class VCSTabState {
             guard let self else { return }
             defer { isMergingPullRequest = false }
             do {
+                let skipDeleteForFork = deleteBranch && info.isCrossRepository
                 try await git.mergePullRequest(
                     repoPath: projectPath,
                     number: info.number,
@@ -933,6 +934,9 @@ final class VCSTabState {
                 )
                 guard !Task.isCancelled else { return }
                 pullRequestInfo = nil
+                if skipDeleteForFork {
+                    ToastState.shared.show("Branch lives on a fork — left intact.")
+                }
                 onSuccess(info, branch)
             } catch {
                 guard !Task.isCancelled else { return }

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -929,7 +929,7 @@ final class VCSTabState {
                     repoPath: projectPath,
                     number: info.number,
                     method: method,
-                    deleteBranch: deleteBranch
+                    deleteBranch: deleteBranch && !info.isCrossRepository
                 )
                 guard !Task.isCancelled else { return }
                 pullRequestInfo = nil

--- a/Muxy/Services/Git/GitPRParser.swift
+++ b/Muxy/Services/Git/GitPRParser.swift
@@ -26,6 +26,7 @@ enum GitPRParser {
             rawValue: (json["mergeStateStatus"] as? String) ?? ""
         ) ?? .unknown
         let rollup = json["statusCheckRollup"] as? [[String: Any]] ?? []
+        let isCrossRepository = json["isCrossRepository"] as? Bool ?? false
 
         return GitRepositoryService.PRInfo(
             url: url,
@@ -35,7 +36,8 @@ enum GitPRParser {
             baseBranch: baseBranch,
             mergeable: mergeable,
             mergeStateStatus: mergeStateStatus,
-            checks: parseStatusChecks(rollup)
+            checks: parseStatusChecks(rollup),
+            isCrossRepository: isCrossRepository
         )
     }
 

--- a/Muxy/Services/Git/GitPRParser.swift
+++ b/Muxy/Services/Git/GitPRParser.swift
@@ -75,6 +75,18 @@ enum GitPRParser {
         )
     }
 
+    static func parsePRInfoMatchingHeadSha(_ json: String, headSha: String) -> GitRepositoryService.PRInfo? {
+        guard let data = json.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return nil }
+        let normalized = headSha.lowercased()
+        let match = array.first { entry in
+            (entry["headRefOid"] as? String)?.lowercased() == normalized
+        }
+        guard let match else { return nil }
+        return parsePRInfo(match)
+    }
+
     static func parsePRList(_ json: String) -> [GitRepositoryService.PRListItem] {
         guard let data = json.data(using: .utf8),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
@@ -90,6 +102,7 @@ enum GitPRParser {
             else { return nil }
             let author = (entry["author"] as? [String: Any])?["login"] as? String ?? ""
             let headBranch = entry["headRefName"] as? String ?? ""
+            let headRefOid = entry["headRefOid"] as? String ?? ""
             let baseBranch = entry["baseRefName"] as? String ?? ""
             let stateRaw = (entry["state"] as? String) ?? "OPEN"
             let state = GitRepositoryService.PRState(rawValue: stateRaw) ?? .open
@@ -100,17 +113,28 @@ enum GitPRParser {
                 updatedAt = formatter.date(from: raw) ?? fallbackFormatter.date(from: raw)
             }
             let rollup = entry["statusCheckRollup"] as? [[String: Any]] ?? []
+            let mergeable: Bool? = switch entry["mergeable"] as? String {
+            case "MERGEABLE": true
+            case "CONFLICTING": false
+            default: nil
+            }
+            let mergeStateStatus = GitRepositoryService.PRMergeStateStatus(
+                rawValue: (entry["mergeStateStatus"] as? String) ?? ""
+            ) ?? .unknown
             return GitRepositoryService.PRListItem(
                 number: number,
                 title: title,
                 author: author,
                 headBranch: headBranch,
+                headRefOid: headRefOid,
                 baseBranch: baseBranch,
                 state: state,
                 isDraft: isDraft,
                 url: url,
                 updatedAt: updatedAt,
-                checks: parseStatusChecks(rollup)
+                checks: parseStatusChecks(rollup),
+                mergeable: mergeable,
+                mergeStateStatus: mergeStateStatus
             )
         }
     }

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -195,25 +195,29 @@ struct GitRepositoryService {
         return info
     }
 
+    private static let prInfoJSONFields =
+        "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository"
+    private static let prInfoJSONFieldsWithHeadRefOid = prInfoJSONFields + ",headRefOid"
+
     func pullRequestInfo(repoPath: String, branch: String, headSha: String? = nil) async -> PRInfo? {
         guard let ghPath = GitProcessRunner.resolveExecutable("gh") else { return nil }
 
-        let resolvedSha: String? = if let headSha { headSha } else { await self.headSha(repoPath: repoPath) }
-        if let resolvedSha,
-           let info = await pullRequestInfoByHeadSha(
-               ghPath: ghPath, repoPath: repoPath, headSha: resolvedSha
-           )
-        {
+        if let info = await ghPRView(ghPath: ghPath, repoPath: repoPath, jsonFields: Self.prInfoJSONFields) {
+            return info
+        }
+        if let info = await ghPRView(
+            ghPath: ghPath, repoPath: repoPath, argument: branch, jsonFields: Self.prInfoJSONFields
+        ) {
             return info
         }
 
-        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository"
-        if let info = await ghPRView(ghPath: ghPath, repoPath: repoPath, jsonFields: jsonFields) {
-            return info
+        let resolvedSha: String? = if let headSha { headSha } else { await self.headSha(repoPath: repoPath) }
+        if let resolvedSha {
+            return await pullRequestInfoByHeadSha(
+                ghPath: ghPath, repoPath: repoPath, headSha: resolvedSha
+            )
         }
-        return await ghPRView(
-            ghPath: ghPath, repoPath: repoPath, branch: branch, jsonFields: jsonFields
-        )
+        return nil
     }
 
     private func pullRequestInfoByHeadSha(
@@ -221,12 +225,11 @@ struct GitRepositoryService {
         repoPath: String,
         headSha: String
     ) async -> PRInfo? {
-        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,headRefOid,isCrossRepository"
         let arguments = [
             "pr", "list",
             "--state", "all",
             "--limit", "100",
-            "--json", jsonFields,
+            "--json", Self.prInfoJSONFieldsWithHeadRefOid,
         ]
         let result = try? await GitProcessRunner.runCommand(
             executable: ghPath,
@@ -240,15 +243,12 @@ struct GitRepositoryService {
     private func ghPRView(
         ghPath: String,
         repoPath: String,
-        branch: String? = nil,
-        selector: String? = nil,
+        argument: String? = nil,
         jsonFields: String
     ) async -> PRInfo? {
         var arguments = ["pr", "view"]
-        if let selector {
-            arguments.append(selector)
-        } else if let branch {
-            arguments.append(branch)
+        if let argument {
+            arguments.append(argument)
         }
         arguments += ["--json", jsonFields]
 
@@ -459,12 +459,11 @@ struct GitRepositoryService {
             .map(String.init)
             .first(where: { $0.hasPrefix("https://") }) ?? ""
 
-        let viewFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository"
         if !createdURL.isEmpty, let info = await ghPRView(
             ghPath: ghPath,
             repoPath: repoPath,
-            selector: createdURL,
-            jsonFields: viewFields
+            argument: createdURL,
+            jsonFields: Self.prInfoJSONFields
         ) {
             return info
         }

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -41,12 +41,15 @@ struct GitRepositoryService {
         let title: String
         let author: String
         let headBranch: String
+        let headRefOid: String
         let baseBranch: String
         let state: PRState
         let isDraft: Bool
         let url: String
         let updatedAt: Date?
         let checks: PRChecks
+        let mergeable: Bool?
+        let mergeStateStatus: PRMergeStateStatus
 
         var id: Int { number }
     }
@@ -186,15 +189,24 @@ struct GitRepositoryService {
         ) {
             return cached
         }
-        let info = await pullRequestInfo(repoPath: repoPath, branch: branch)
+        let info = await pullRequestInfo(repoPath: repoPath, branch: branch, headSha: headSha)
         GitMetadataCache.shared.storePRInfo(info, repoPath: repoPath, branch: branch, headSha: headSha)
         return info
     }
 
-    func pullRequestInfo(repoPath: String, branch: String) async -> PRInfo? {
+    func pullRequestInfo(repoPath: String, branch: String, headSha: String? = nil) async -> PRInfo? {
         guard let ghPath = GitProcessRunner.resolveExecutable("gh") else { return nil }
-        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup"
 
+        let resolvedSha: String? = if let headSha { headSha } else { await self.headSha(repoPath: repoPath) }
+        if let resolvedSha,
+           let info = await pullRequestInfoByHeadSha(
+               ghPath: ghPath, repoPath: repoPath, headSha: resolvedSha
+           )
+        {
+            return info
+        }
+
+        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup"
         if let info = await ghPRView(ghPath: ghPath, repoPath: repoPath, jsonFields: jsonFields) {
             return info
         }
@@ -203,14 +215,38 @@ struct GitRepositoryService {
         )
     }
 
+    private func pullRequestInfoByHeadSha(
+        ghPath: String,
+        repoPath: String,
+        headSha: String
+    ) async -> PRInfo? {
+        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,headRefOid"
+        let arguments = [
+            "pr", "list",
+            "--state", "all",
+            "--limit", "100",
+            "--json", jsonFields,
+        ]
+        let result = try? await GitProcessRunner.runCommand(
+            executable: ghPath,
+            arguments: arguments,
+            workingDirectory: repoPath
+        )
+        guard let result, result.status == 0 else { return nil }
+        return GitPRParser.parsePRInfoMatchingHeadSha(result.stdout, headSha: headSha)
+    }
+
     private func ghPRView(
         ghPath: String,
         repoPath: String,
         branch: String? = nil,
+        selector: String? = nil,
         jsonFields: String
     ) async -> PRInfo? {
         var arguments = ["pr", "view"]
-        if let branch {
+        if let selector {
+            arguments.append(selector)
+        } else if let branch {
             arguments.append(branch)
         }
         arguments += ["--json", jsonFields]
@@ -239,7 +275,12 @@ struct GitRepositoryService {
         guard let ghPath = GitProcessRunner.resolveExecutable("gh") else {
             throw PRCreateError.ghNotInstalled
         }
-        let jsonFields = "number,title,author,headRefName,baseRefName,state,isDraft,url,updatedAt,statusCheckRollup"
+        let jsonFields = [
+            "number", "title", "author",
+            "headRefName", "headRefOid", "baseRefName",
+            "state", "isDraft", "url", "updatedAt",
+            "statusCheckRollup", "mergeable", "mergeStateStatus",
+        ].joined(separator: ",")
         let arguments = [
             "pr", "list",
             "--state", filter.rawValue,
@@ -412,15 +453,29 @@ struct GitRepositoryService {
 
         GitMetadataCache.shared.invalidatePRInfo(repoPath: repoPath, branch: branch)
 
+        let createdURL = createResult.stdout
+            .split(whereSeparator: { $0.isNewline || $0.isWhitespace })
+            .map(String.init)
+            .first(where: { $0.hasPrefix("https://") }) ?? ""
+
+        let viewFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup"
+        if !createdURL.isEmpty, let info = await ghPRView(
+            ghPath: ghPath,
+            repoPath: repoPath,
+            selector: createdURL,
+            jsonFields: viewFields
+        ) {
+            return info
+        }
+
         if let info = await pullRequestInfo(repoPath: repoPath, branch: branch) {
             return info
         }
 
-        let fallbackURL = createResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         throw PRCreateError.commandFailed(
-            fallbackURL.isEmpty
+            createdURL.isEmpty
                 ? "Pull request created but could not be read back."
-                : "Pull request created at \(fallbackURL) but could not be read back."
+                : "Pull request created at \(createdURL) but could not be read back."
         )
     }
 

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -34,6 +34,7 @@ struct GitRepositoryService {
         let mergeable: Bool?
         let mergeStateStatus: PRMergeStateStatus
         let checks: PRChecks
+        let isCrossRepository: Bool
     }
 
     struct PRListItem: Equatable, Identifiable {
@@ -206,7 +207,7 @@ struct GitRepositoryService {
             return info
         }
 
-        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup"
+        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository"
         if let info = await ghPRView(ghPath: ghPath, repoPath: repoPath, jsonFields: jsonFields) {
             return info
         }
@@ -220,7 +221,7 @@ struct GitRepositoryService {
         repoPath: String,
         headSha: String
     ) async -> PRInfo? {
-        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,headRefOid"
+        let jsonFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,headRefOid,isCrossRepository"
         let arguments = [
             "pr", "list",
             "--state", "all",
@@ -458,7 +459,7 @@ struct GitRepositoryService {
             .map(String.init)
             .first(where: { $0.hasPrefix("https://") }) ?? ""
 
-        let viewFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup"
+        let viewFields = "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository"
         if !createdURL.isEmpty, let info = await ghPRView(
             ghPath: ghPath,
             repoPath: repoPath,

--- a/Tests/MuxyTests/Git/GitPRParserTests.swift
+++ b/Tests/MuxyTests/Git/GitPRParserTests.swift
@@ -167,6 +167,27 @@ struct GitPRParserTests {
             let info = GitPRParser.parsePRInfo(json)
             #expect(info?.state == .open)
         }
+
+        @Test("isCrossRepository true parses")
+        func isCrossRepositoryTrue() {
+            let json = #"{"url":"u","number":1,"state":"OPEN","isCrossRepository":true}"#
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.isCrossRepository == true)
+        }
+
+        @Test("isCrossRepository false parses")
+        func isCrossRepositoryFalse() {
+            let json = #"{"url":"u","number":1,"state":"OPEN","isCrossRepository":false}"#
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.isCrossRepository == false)
+        }
+
+        @Test("missing isCrossRepository defaults to false")
+        func isCrossRepositoryMissing() {
+            let json = #"{"url":"u","number":1,"state":"OPEN"}"#
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.isCrossRepository == false)
+        }
     }
 
     @Suite("parsePRInfoMatchingHeadSha")

--- a/Tests/MuxyTests/Git/GitPRParserTests.swift
+++ b/Tests/MuxyTests/Git/GitPRParserTests.swift
@@ -169,6 +169,51 @@ struct GitPRParserTests {
         }
     }
 
+    @Suite("parsePRInfoMatchingHeadSha")
+    struct PRInfoMatchingHeadSha {
+        @Test("matches PR by head SHA case-insensitively")
+        func matches() {
+            let json = """
+            [
+              {
+                "url": "https://github.com/o/r/pull/1",
+                "number": 1,
+                "state": "OPEN",
+                "baseRefName": "main",
+                "statusCheckRollup": [],
+                "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              },
+              {
+                "url": "https://github.com/o/r/pull/2",
+                "number": 2,
+                "state": "OPEN",
+                "baseRefName": "main",
+                "statusCheckRollup": [],
+                "headRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+              }
+            ]
+            """
+            let info = GitPRParser.parsePRInfoMatchingHeadSha(
+                json,
+                headSha: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+            )
+            #expect(info?.number == 2)
+        }
+
+        @Test("returns nil when no PR matches")
+        func noMatch() {
+            let json = """
+            [{"url":"u","number":1,"state":"OPEN","statusCheckRollup":[],"headRefOid":"aa"}]
+            """
+            #expect(GitPRParser.parsePRInfoMatchingHeadSha(json, headSha: "deadbeef") == nil)
+        }
+
+        @Test("returns nil for invalid JSON")
+        func invalid() {
+            #expect(GitPRParser.parsePRInfoMatchingHeadSha("not-json", headSha: "x") == nil)
+        }
+    }
+
     @Suite("parseAheadBehind")
     struct AheadBehindParsing {
         @Test("no upstream returns zeros")
@@ -309,6 +354,30 @@ struct GitPRParserTests {
             let items = GitPRParser.parsePRList(json)
             #expect(items[0].state == .merged)
             #expect(items[1].state == .closed)
+        }
+
+        @Test("headRefOid and merge fields parse")
+        func headRefOidAndMergeFields() {
+            let json = """
+            [
+              {
+                "number": 7,
+                "title": "Hello",
+                "author": {"login": "alice"},
+                "headRefName": "feature",
+                "headRefOid": "cccccccccccccccccccccccccccccccccccccccc",
+                "baseRefName": "main",
+                "state": "OPEN",
+                "mergeable": "CONFLICTING",
+                "mergeStateStatus": "DIRTY"
+              }
+            ]
+            """
+            let items = GitPRParser.parsePRList(json)
+            #expect(items.count == 1)
+            #expect(items[0].headRefOid == "cccccccccccccccccccccccccccccccccccccccc")
+            #expect(items[0].mergeable == false)
+            #expect(items[0].mergeStateStatus == .dirty)
         }
 
         @Test("updatedAt parses with and without fractional seconds")


### PR DESCRIPTION
  Summary:
  - Resolve the current branch's PR by matching HEAD SHA against gh pr list --json …,headRefOid, so cross-repo (fork) PRs checked out
   via gh pr checkout are correctly associated.
  - Read back newly created PRs by URL instead of branch name — fixes the same lookup gap right after gh pr create.
  - Downstream merge / close / status popover inherit the fix (all keyed on PR num