### PR TITLE
add select menu to open terminal with a cli

### DIFF
--- a/Muxy/Extensions/DTOConversions.swift
+++ b/Muxy/Extensions/DTOConversions.swift
@@ -87,6 +87,21 @@ extension TerminalTab.Kind {
         case .vcs: .vcs
         case .editor: .editor
         case .diffViewer: .diffViewer
+        case .claude: .claude
+        case .gemini: .gemini
+        }
+    }
+}
+
+extension TabKindDTO {
+    func toKind() -> TerminalTab.Kind {
+        switch self {
+        case .terminal: .terminal
+        case .vcs: .vcs
+        case .editor: .editor
+        case .diffViewer: .diffViewer
+        case .claude: .claude
+        case .gemini: .gemini
         }
     }
 }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -30,7 +30,7 @@ final class AppState {
             replacementWorktreeID: UUID?,
             replacementWorktreePath: String?
         )
-        case createTab(projectID: UUID, areaID: UUID?)
+        case createTab(projectID: UUID, areaID: UUID?, kind: TerminalTab.Kind = .terminal)
         case createTabInDirectory(projectID: UUID, areaID: UUID?, directory: String)
         case createVCSTab(projectID: UUID, areaID: UUID?)
         case createEditorTab(projectID: UUID, areaID: UUID?, filePath: String)
@@ -202,8 +202,8 @@ final class AppState {
         dispatch(.closeArea(projectID: projectID, areaID: areaID))
     }
 
-    func createTab(projectID: UUID) {
-        dispatch(.createTab(projectID: projectID, areaID: nil))
+    func createTab(projectID: UUID, kind: TerminalTab.Kind = .terminal) {
+        dispatch(.createTab(projectID: projectID, areaID: nil, kind: kind))
     }
 
     func createVCSTab(projectID: UUID) {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -55,8 +55,19 @@ final class TabArea: Identifiable {
         tabs.firstIndex(where: { !$0.isPinned }) ?? tabs.count
     }
 
-    func createTab() {
-        insertTab(TerminalTab(pane: TerminalPaneState(projectPath: projectPath)))
+    func createTab(kind: TerminalTab.Kind = .terminal) {
+        let command: String? = switch kind {
+        case .claude: "claude"
+        case .gemini: "gemini"
+        default: nil
+        }
+        let title = switch kind {
+        case .claude: "Claude Code"
+        case .gemini: "Gemini"
+        default: "Terminal"
+        }
+        let pane = TerminalPaneState(projectPath: projectPath, title: title, startupCommand: command)
+        insertTab(TerminalTab(pane: pane, kind: kind))
     }
 
     func createTab(inDirectory directory: String) {

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -8,6 +8,8 @@ final class TerminalTab: Identifiable {
         case vcs
         case editor
         case diffViewer
+        case claude
+        case gemini
     }
 
     enum Content {
@@ -15,6 +17,8 @@ final class TerminalTab: Identifiable {
         case vcs(VCSTabState)
         case editor(EditorTabState)
         case diffViewer(DiffViewerTabState)
+        case claude(TerminalPaneState)
+        case gemini(TerminalPaneState)
 
         var kind: Kind {
             switch self {
@@ -22,12 +26,18 @@ final class TerminalTab: Identifiable {
             case .vcs: .vcs
             case .editor: .editor
             case .diffViewer: .diffViewer
+            case .claude: .claude
+            case .gemini: .gemini
             }
         }
 
         var pane: TerminalPaneState? {
-            guard case let .terminal(pane) = self else { return nil }
-            return pane
+            switch self {
+            case let .terminal(pane): pane
+            case let .claude(pane): pane
+            case let .gemini(pane): pane
+            default: nil
+            }
         }
 
         var vcsState: VCSTabState? {
@@ -51,6 +61,8 @@ final class TerminalTab: Identifiable {
             case let .vcs(state): state.projectPath
             case let .editor(state): state.projectPath
             case let .diffViewer(state): state.projectPath
+            case let .claude(pane): pane.projectPath
+            case let .gemini(pane): pane.projectPath
             }
         }
     }
@@ -76,11 +88,19 @@ final class TerminalTab: Identifiable {
             return state.displayTitle
         case let .diffViewer(state):
             return state.displayTitle
+        case let .claude(pane):
+            return pane.title
+        case let .gemini(pane):
+            return pane.title
         }
     }
 
-    init(pane: TerminalPaneState) {
-        content = .terminal(pane)
+    init(pane: TerminalPaneState, kind: Kind = .terminal) {
+        switch kind {
+        case .claude: content = .claude(pane)
+        case .gemini: content = .gemini(pane)
+        default: content = .terminal(pane)
+        }
     }
 
     init(vcsState: VCSTabState) {
@@ -99,19 +119,24 @@ final class TerminalTab: Identifiable {
         customTitle = snapshot.customTitle
         colorID = snapshot.colorID
         isPinned = snapshot.isPinned
+        let pane = TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle)
         switch snapshot.kind {
         case .terminal:
-            content = .terminal(TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle))
+            content = .terminal(pane)
         case .vcs:
             content = .vcs(VCSTabState(projectPath: snapshot.projectPath))
         case .editor:
             if let filePath = snapshot.filePath {
                 content = .editor(EditorTabState(projectPath: snapshot.projectPath, filePath: filePath))
             } else {
-                content = .terminal(TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle))
+                content = .terminal(pane)
             }
         case .diffViewer:
-            content = .terminal(TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle))
+            content = .terminal(pane)
+        case .claude:
+            content = .claude(pane)
+        case .gemini:
+            content = .gemini(pane)
         }
     }
 

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -68,8 +68,8 @@ enum WorkspaceReducer {
                 state: &state
             )
 
-        case let .createTab(projectID, areaID):
-            TabReducer.createTab(projectID: projectID, areaID: areaID, state: &state)
+        case let .createTab(projectID, areaID, kind):
+            TabReducer.createTab(projectID: projectID, areaID: areaID, kind: kind, state: &state)
 
         case let .createTabInDirectory(projectID, areaID, directory):
             TabReducer.createTabInDirectory(

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -2,12 +2,12 @@ import Foundation
 
 @MainActor
 enum TabReducer {
-    static func createTab(projectID: UUID, areaID: UUID?, state: inout WorkspaceState) {
+    static func createTab(projectID: UUID, areaID: UUID?, kind: TerminalTab.Kind, state: inout WorkspaceState) {
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
               let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
         else { return }
         FocusReducer.focusArea(area.id, key: key, state: &state)
-        area.createTab()
+        area.createTab(kind: kind)
     }
 
     static func createTabInDirectory(

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -80,15 +80,10 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     }
 
     func createTab(projectID: UUID, areaID: UUID?, kind: TabKindDTO) -> TabDTO? {
-        switch kind {
-        case .terminal:
-            appState.dispatch(.createTab(projectID: projectID, areaID: areaID))
-        case .vcs:
+        if kind == .vcs {
             appState.dispatch(.createVCSTab(projectID: projectID, areaID: areaID))
-        case .editor:
-            appState.dispatch(.createTab(projectID: projectID, areaID: areaID))
-        case .diffViewer:
-            appState.dispatch(.createTab(projectID: projectID, areaID: areaID))
+        } else {
+            appState.dispatch(.createTab(projectID: projectID, areaID: areaID, kind: kind.toKind()))
         }
 
         guard let area = appState.focusedArea(for: projectID),

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -2,12 +2,18 @@ import AppKit
 import SwiftUI
 
 struct MainWindow: View {
-    @Environment(AppState.self) private var appState
-    @Environment(ProjectStore.self) private var projectStore
-    @Environment(WorktreeStore.self) private var worktreeStore
-    @Environment(GhosttyService.self) private var ghostty
-    @Environment(\.openWindow) private var openWindow
-    @State private var dragCoordinator = TabDragCoordinator()
+    @Environment(AppState.self)
+    private var appState
+    @Environment(ProjectStore.self)
+    private var projectStore
+    @Environment(WorktreeStore.self)
+    private var worktreeStore
+    @Environment(GhosttyService.self)
+    private var ghostty
+    @Environment(\.openWindow)
+    private var openWindow
+    @State
+    private var dragCoordinator = TabDragCoordinator()
     private enum AttachedVCSLayout {
         static let minWidth: CGFloat = 200
         static let defaultWidth: CGFloat = 400
@@ -48,17 +54,28 @@ struct MainWindow: View {
         }
     }
 
-    @State private var vcsPanelVisible = false
-    @State private var vcsPanelWidth: CGFloat = AttachedVCSLayout.defaultWidth
-    @State private var vcsStates: [WorktreeKey: VCSTabState] = [:]
-    @State private var fileTreePanelVisible = false
-    @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
-    @State private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
-    @State private var showQuickOpen = false
-    @State private var showWorktreeSwitcher = false
-    @State private var isFullScreen = false
-    @State private var sidebarExpanded = UserDefaults.standard.bool(forKey: "muxy.sidebarExpanded")
-    @AppStorage("muxy.notifications.toastPosition") private var toastPositionRaw = ToastPosition.topCenter.rawValue
+    @State
+    private var vcsPanelVisible = false
+    @State
+    private var vcsPanelWidth: CGFloat = AttachedVCSLayout.defaultWidth
+    @State
+    private var vcsStates: [WorktreeKey: VCSTabState] = [:]
+    @State
+    private var fileTreePanelVisible = false
+    @AppStorage("muxy.fileTreeWidth")
+    private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
+    @State
+    private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
+    @State
+    private var showQuickOpen = false
+    @State
+    private var showWorktreeSwitcher = false
+    @State
+    private var isFullScreen = false
+    @State
+    private var sidebarExpanded = UserDefaults.standard.bool(forKey: "muxy.sidebarExpanded")
+    @AppStorage("muxy.notifications.toastPosition")
+    private var toastPositionRaw = ToastPosition.topCenter.rawValue
     private let trafficLightWidth: CGFloat = 75
 
     var body: some View {
@@ -330,8 +347,8 @@ struct MainWindow: View {
                 onSelectTab: { tabID in
                     appState.dispatch(.selectTab(projectID: project.id, areaID: area.id, tabID: tabID))
                 },
-                onCreateTab: {
-                    appState.dispatch(.createTab(projectID: project.id, areaID: area.id))
+                onCreateTab: { kind in
+                    appState.dispatch(.createTab(projectID: project.id, areaID: area.id, kind: kind))
                 },
                 onCreateVCSTab: {
                     openVCS(for: project, preferredAreaID: area.id)
@@ -805,7 +822,8 @@ private struct NavigationArrowButton: View {
     let isEnabled: Bool
     let label: String
     let action: () -> Void
-    @State private var hovered = false
+    @State
+    private var hovered = false
 
     var body: some View {
         Button(action: action) {

--- a/Muxy/Views/Workspace/PaneNode.swift
+++ b/Muxy/Views/Workspace/PaneNode.swift
@@ -9,7 +9,7 @@ struct PaneNode: View {
     let projectID: UUID
     let onFocusArea: (UUID) -> Void
     let onSelectTab: (UUID, UUID) -> Void
-    let onCreateTab: (UUID) -> Void
+    let onCreateTab: (UUID, TerminalTab.Kind) -> Void
     let onCreateVCSTab: (UUID) -> Void
     let onCloseTab: (UUID, UUID) -> Void
     let onForceCloseTab: (UUID, UUID) -> Void
@@ -29,7 +29,7 @@ struct PaneNode: View {
                 projectID: projectID,
                 onFocus: { onFocusArea(area.id) },
                 onSelectTab: { tabID in onSelectTab(area.id, tabID) },
-                onCreateTab: { onCreateTab(area.id) },
+                onCreateTab: { kind in onCreateTab(area.id, kind) },
                 onCreateVCSTab: { onCreateVCSTab(area.id) },
                 onCloseTab: { tabID in onCloseTab(area.id, tabID) },
                 onForceCloseTab: { tabID in onForceCloseTab(area.id, tabID) },

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -9,7 +9,7 @@ struct SplitContainer: View {
     let projectID: UUID
     let onFocusArea: (UUID) -> Void
     let onSelectTab: (UUID, UUID) -> Void
-    let onCreateTab: (UUID) -> Void
+    let onCreateTab: (UUID, TerminalTab.Kind) -> Void
     let onCreateVCSTab: (UUID) -> Void
     let onCloseTab: (UUID, UUID) -> Void
     let onForceCloseTab: (UUID, UUID) -> Void

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -9,14 +9,16 @@ struct TabAreaView: View {
     let projectID: UUID
     let onFocus: () -> Void
     let onSelectTab: (UUID) -> Void
-    let onCreateTab: () -> Void
+    let onCreateTab: (TerminalTab.Kind) -> Void
     let onCreateVCSTab: () -> Void
     let onCloseTab: (UUID) -> Void
     let onForceCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
-    @Environment(TabDragCoordinator.self) private var dragCoordinator
-    @Environment(AppState.self) private var appState
+    @Environment(TabDragCoordinator.self)
+    private var dragCoordinator
+    @Environment(AppState.self)
+    private var appState
 
     var body: some View {
         VStack(spacing: 0) {
@@ -130,7 +132,9 @@ private struct TabContentView: View {
 
     var body: some View {
         switch tab.content {
-        case let .terminal(pane):
+        case let .terminal(pane),
+             let .claude(pane),
+             let .gemini(pane):
             TerminalPane(
                 state: pane,
                 focused: focused,

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -20,7 +20,7 @@ struct PaneTabStrip: View {
     var showDevelopmentBadge = false
     let projectID: UUID
     let onSelectTab: (UUID) -> Void
-    let onCreateTab: () -> Void
+    let onCreateTab: (TerminalTab.Kind) -> Void
     let onCreateVCSTab: () -> Void
     let onCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
@@ -30,8 +30,10 @@ struct PaneTabStrip: View {
     let onSetCustomTitle: (UUID, String?) -> Void
     let onSetColorID: (UUID, String?) -> Void
     let onReorderTab: (IndexSet, Int) -> Void
-    @Environment(TabDragCoordinator.self) private var dragCoordinator
-    @State private var dragState = TabDragState()
+    @Environment(TabDragCoordinator.self)
+    private var dragCoordinator
+    @State
+    private var dragState = TabDragState()
 
     static func snapshots(from tabs: [TerminalTab]) -> [TabSnapshot] {
         tabs.map { tab in
@@ -73,8 +75,29 @@ struct PaneTabStrip: View {
                     .help(shortcutTooltip("Split Right", for: .splitRight))
                 IconButton(symbol: "square.split.1x2", accessibilityLabel: "Split Down") { onSplit(.vertical) }
                     .help(shortcutTooltip("Split Down", for: .splitDown))
-                IconButton(symbol: "plus", accessibilityLabel: "New Tab") { onCreateTab() }
-                    .help(shortcutTooltip("New Tab", for: .newTab))
+
+                Menu {
+                    Button { onCreateTab(.claude) } label: {
+                        Label("Claude Code", systemImage: "sparkles")
+                    }
+                    Button { onCreateTab(.gemini) } label: {
+                        Label("Gemini", systemImage: "wand.and.stars")
+                    }
+                    Divider()
+                    Button { onCreateTab(.terminal) } label: {
+                        Label("Terminal", systemImage: "terminal")
+                    }
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.button)
+                .buttonStyle(.plain)
+                .help(shortcutTooltip("New Tab", for: .newTab))
+
                 if showVCSButton {
                     IconButton(symbol: "doc.text", size: 12, accessibilityLabel: "Quick Open") {
                         NotificationCenter.default.post(name: .quickOpen, object: nil)
@@ -283,12 +306,18 @@ private struct TabCell: View {
     let onTogglePin: () -> Void
     let onSetCustomTitle: (String?) -> Void
     let onSetColorID: (String?) -> Void
-    @State private var hovered = false
-    @State private var isRenaming = false
-    @State private var renameText = ""
-    @State private var showColorPicker = false
-    @State private var measuredWidth: CGFloat = TabCell.maxWidth
-    @FocusState private var renameFieldFocused: Bool
+    @State
+    private var hovered = false
+    @State
+    private var isRenaming = false
+    @State
+    private var renameText = ""
+    @State
+    private var showColorPicker = false
+    @State
+    private var measuredWidth: CGFloat = TabCell.maxWidth
+    @FocusState
+    private var renameFieldFocused: Bool
 
     private var titleHidden: Bool {
         measuredWidth < Self.titleHideThreshold
@@ -472,6 +501,8 @@ private struct TabCell: View {
         case .vcs: label += ", Source Control"
         case .editor: label += ", Editor"
         case .diffViewer: label += ", Diff Viewer"
+        case .claude: label += ", Claude Code"
+        case .gemini: label += ", Gemini"
         }
         if tab.isPinned { label += ", Pinned" }
         if hasUnread { label += ", Unread" }
@@ -493,6 +524,12 @@ private struct TabCell: View {
         } else if tab.kind == .diffViewer {
             Image(systemName: "rectangle.split.2x1")
                 .font(.system(size: 11, weight: .semibold))
+        } else if tab.kind == .claude {
+            Image(systemName: "sparkles")
+                .font(.system(size: 12, weight: .semibold))
+        } else if tab.kind == .gemini {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 12, weight: .semibold))
         } else {
             Image(systemName: "terminal")
                 .font(.system(size: 12, weight: .semibold))

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -4,9 +4,12 @@ struct TerminalArea: View {
     let project: Project
     let worktreeKey: WorktreeKey
     let isActiveProject: Bool
-    @Environment(AppState.self) private var appState
-    @Environment(TabDragCoordinator.self) private var dragCoordinator
-    @Environment(\.openWindow) private var openWindow
+    @Environment(AppState.self)
+    private var appState
+    @Environment(TabDragCoordinator.self)
+    private var dragCoordinator
+    @Environment(\.openWindow)
+    private var openWindow
 
     private var root: SplitNode? {
         appState.workspaceRoots[worktreeKey]
@@ -37,8 +40,8 @@ struct TerminalArea: View {
                 onSelectTab: { areaID, tabID in
                     appState.dispatch(.selectTab(projectID: project.id, areaID: areaID, tabID: tabID))
                 },
-                onCreateTab: { areaID in
-                    appState.dispatch(.createTab(projectID: project.id, areaID: areaID))
+                onCreateTab: { areaID, kind in
+                    appState.dispatch(.createTab(projectID: project.id, areaID: areaID, kind: kind))
                 },
                 onCreateVCSTab: { areaID in
                     VCSDisplayMode.current.route(

--- a/MuxyMobile/RemoteWorkspaceView.swift
+++ b/MuxyMobile/RemoteWorkspaceView.swift
@@ -2,8 +2,10 @@ import MuxyShared
 import SwiftUI
 
 struct WorkspaceContentWrapper: View {
-    @Environment(ConnectionManager.self) private var connection
-    @State private var showingVCS = false
+    @Environment(ConnectionManager.self)
+    private var connection
+    @State
+    private var showingVCS = false
 
     private var activeProject: ProjectDTO? {
         guard let id = connection.activeProjectID else { return nil }
@@ -146,6 +148,8 @@ struct WorkspaceContentWrapper: View {
         case .vcs: "arrow.triangle.branch"
         case .editor: "doc.text"
         case .diffViewer: "rectangle.split.2x1"
+        case .claude: "sparkles"
+        case .gemini: "wand.and.stars"
         }
     }
 }
@@ -153,12 +157,15 @@ struct WorkspaceContentWrapper: View {
 struct TabDetailView: View {
     let area: TabAreaDTO
     let tab: TabDTO
-    @Environment(ConnectionManager.self) private var connection
+    @Environment(ConnectionManager.self)
+    private var connection
 
     var body: some View {
         VStack(spacing: 0) {
             switch tab.kind {
-            case .terminal:
+            case .terminal,
+                 .claude,
+                 .gemini:
                 terminalPlaceholder
             case .vcs:
                 vcsPlaceholder

--- a/MuxyShared/WorkspaceDTO.swift
+++ b/MuxyShared/WorkspaceDTO.swift
@@ -131,4 +131,6 @@ public enum TabKindDTO: String, Codable, Sendable {
     case vcs
     case editor
     case diffViewer
+    case claude
+    case gemini
 }


### PR DESCRIPTION
add select menu to open terminal with a cli, cause it's annoying to write command everytime we open the terminal


## Summary

this PR does add select menu to choose either gemini cli, claude code, or normal terminal


## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

<img width="225" height="200" alt="image" src="https://github.com/user-attachments/assets/8e5aa440-fcd8-49bf-858a-c9ee1d3670f1" />
