### PR TITLE
Fix editor search leaving current match without syntax color after close

### DIFF
--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -1020,16 +1020,19 @@ struct CodeEditorView: NSViewRepresentable {
         private var appliedCurrentSearchMatchRange: NSRange?
 
         private func clearAppliedSearchHighlights(layoutManager: NSLayoutManager, storageLength: Int) {
+            let hadCurrentMatchOverride = appliedCurrentSearchMatchRange != nil
             for range in appliedSearchHighlightRanges {
                 guard NSMaxRange(range) <= storageLength else { continue }
                 layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: range)
-                layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: range)
             }
             if let range = appliedCurrentSearchMatchRange, NSMaxRange(range) <= storageLength {
                 layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: range)
             }
             appliedSearchHighlightRanges.removeAll(keepingCapacity: true)
             appliedCurrentSearchMatchRange = nil
+            if hadCurrentMatchOverride {
+                reapplySyntaxHighlights()
+            }
         }
 
         func performSearchViewport(_ needle: String, caseSensitive: Bool, useRegex: Bool) {


### PR DESCRIPTION
The current search match overrode foreground via a temporary attribute; clearing it on close wiped the syntax color too since
  syntax highlights use the same attribute layer. Now we re-apply syntax highlights after clearing the search override.