### PR TITLE
Add open repo button to the VCS header

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -69,6 +69,7 @@ final class VCSTabState {
     var isRefreshingPullRequest = false
     var hasFetchedPullRequestInfo = false
     private(set) var isGitRepo = false
+    private(set) var remoteWebURL: URL?
 
     var commitMessage = ""
     var branches: [String] = []
@@ -230,16 +231,22 @@ final class VCSTabState {
         branchTask?.cancel()
         prInfoTask?.cancel()
         let shouldForcePR = forcePRFetch || !incremental
+        if shouldForcePR {
+            isRefreshingPullRequest = true
+        }
         branchTask = Task { [weak self] in
             guard let self else { return }
             do {
                 async let branchValue = git.currentBranch(repoPath: projectPath)
                 async let headValue = git.headSha(repoPath: projectPath)
+                async let remoteURLValue = git.remoteWebURL(repoPath: projectPath)
                 let branch = try await branchValue
                 let head = await headValue
+                let remoteURL = await remoteURLValue
                 guard !Task.isCancelled else { return }
 
                 isGitRepo = true
+                remoteWebURL = remoteURL
                 let branchChanged = branchName != branch
                 if branchChanged {
                     hasFetchedPullRequestInfo = false
@@ -264,6 +271,7 @@ final class VCSTabState {
                 hasFetchedPullRequestInfo = false
                 lastFetchedHeadSha = nil
                 aheadBehind = .init(ahead: 0, behind: 0, hasUpstream: false)
+                isRefreshingPullRequest = false
             }
         }
 

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -386,6 +386,43 @@ struct GitRepositoryService {
         return resolved
     }
 
+    func remoteWebURL(repoPath: String, remote: String = "origin") async -> URL? {
+        let result = try? await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["remote", "get-url", remote]
+        )
+        guard let result, result.status == 0 else { return nil }
+        let raw = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return Self.webURL(fromRemoteURL: raw)
+    }
+
+    static func webURL(fromRemoteURL raw: String) -> URL? {
+        guard !raw.isEmpty else { return nil }
+        var value = raw
+        if value.hasSuffix(".git") { value = String(value.dropLast(4)) }
+
+        if value.hasPrefix("http://") || value.hasPrefix("https://") {
+            return URL(string: value)
+        }
+
+        if value.hasPrefix("ssh://") {
+            guard var components = URLComponents(string: value) else { return nil }
+            components.scheme = "https"
+            components.user = nil
+            components.password = nil
+            components.port = nil
+            return components.url
+        }
+
+        if let atIndex = value.firstIndex(of: "@"), let colonIndex = value[atIndex...].firstIndex(of: ":") {
+            let host = String(value[value.index(after: atIndex) ..< colonIndex])
+            let path = String(value[value.index(after: colonIndex)...])
+            return URL(string: "https://\(host)/\(path)")
+        }
+
+        return nil
+    }
+
     private func resolveDefaultBranch(repoPath: String) async -> String? {
         let symbolic = try? await GitProcessRunner.runGit(
             repoPath: repoPath,

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -129,8 +129,14 @@ struct VCSTabView: View {
 
             VCSSectionVisibilityMenu(state: state)
 
-            IconButton(symbol: "arrow.clockwise", accessibilityLabel: "Refresh") {
-                state.refresh()
+            if state.isRefreshingPullRequest {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 24, height: 24)
+            } else {
+                IconButton(symbol: "arrow.clockwise", accessibilityLabel: "Refresh") {
+                    state.refresh()
+                }
             }
         }
         .padding(.horizontal, 8)
@@ -756,15 +762,40 @@ struct PRPill: View {
     @State private var showPRPopover = false
 
     var body: some View {
-        switch state.prLaunchState {
-        case .hidden:
+        if !state.hasFetchedPullRequestInfo {
             EmptyView()
-        case .ghMissing:
-            ghMissingPill
-        case .canCreate:
-            createPRPill
-        case let .hasPR(info):
-            hasPRPill(info: info)
+        } else {
+            switch state.prLaunchState {
+            case .hidden:
+                openRepoButton
+            case .ghMissing:
+                HStack(spacing: 4) {
+                    ghMissingPill
+                    openRepoButton
+                }
+            case .canCreate:
+                createPRPill
+            case let .hasPR(info):
+                HStack(spacing: 4) {
+                    hasPRPill(info: info)
+                    openRepoButton
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var openRepoButton: some View {
+        if let url = state.remoteWebURL {
+            pillContainer(
+                icon: "globe",
+                text: "Open Repo",
+                tint: MuxyTheme.fg.opacity(0.85),
+                disabled: false
+            ) {
+                NSWorkspace.shared.open(url)
+            }
+            .help("Open repository on web")
         }
     }
 
@@ -779,14 +810,49 @@ struct PRPill: View {
     }
 
     private var createPRPill: some View {
-        pillContainer(
-            icon: "arrow.triangle.pull",
-            text: "Create PR",
-            tint: MuxyTheme.accent,
-            disabled: state.isOpeningPullRequest,
-            action: onRequestCreate
-        )
-        .help("Create a pull request")
+        HStack(spacing: 0) {
+            Button(action: onRequestCreate) {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.triangle.pull")
+                        .font(.system(size: 9, weight: .bold))
+                    Text("Create PR")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                .foregroundStyle(MuxyTheme.accent)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(state.isOpeningPullRequest)
+            .help("Create a pull request")
+
+            if state.remoteWebURL != nil {
+                Rectangle()
+                    .fill(MuxyTheme.accent.opacity(0.35))
+                    .frame(width: 1, height: 14)
+                Menu {
+                    if let url = state.remoteWebURL {
+                        Button("Open Repository on Web") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(MuxyTheme.accent)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 5)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.button)
+                .menuIndicator(.hidden)
+                .buttonStyle(.plain)
+                .fixedSize()
+            }
+        }
+        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
+        .overlay(RoundedRectangle(cornerRadius: 5).stroke(MuxyTheme.accent.opacity(0.35), lineWidth: 1))
     }
 
     private func hasPRPill(info: GitRepositoryService.PRInfo) -> some View {

--- a/Tests/MuxyTests/Git/GitRemoteWebURLTests.swift
+++ b/Tests/MuxyTests/Git/GitRemoteWebURLTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitRepositoryService.webURL(fromRemoteURL:)")
+struct GitRemoteWebURLTests {
+    @Test("https URL passes through and strips .git")
+    func httpsURL() {
+        let url = GitRepositoryService.webURL(fromRemoteURL: "https://github.com/foo/bar.git")
+        #expect(url?.absoluteString == "https://github.com/foo/bar")
+    }
+
+    @Test("scp-style ssh URL converts to https")
+    func scpStyle() {
+        let url = GitRepositoryService.webURL(fromRemoteURL: "git@github.com:foo/bar.git")
+        #expect(url?.absoluteString == "https://github.com/foo/bar")
+    }
+
+    @Test("ssh:// URL converts to https and drops user/port")
+    func sshURL() {
+        let url = GitRepositoryService.webURL(fromRemoteURL: "ssh://git@github.com:22/foo/bar.git")
+        #expect(url?.absoluteString == "https://github.com/foo/bar")
+    }
+
+    @Test("empty string returns nil")
+    func empty() {
+        #expect(GitRepositoryService.webURL(fromRemoteURL: "") == nil)
+    }
+
+    @Test("gitlab https without .git is preserved")
+    func gitlab() {
+        let url = GitRepositoryService.webURL(fromRemoteURL: "https://gitlab.com/group/sub/proj")
+        #expect(url?.absoluteString == "https://gitlab.com/group/sub/proj")
+    }
+}


### PR DESCRIPTION
Adds a button in the VCS header to open the repository in a browser. When the "Create PR" pill is hidden, it shows as a standalone
  "Open Repo" pill; when "Create PR" or a PR pill is visible, it appears as a chevron menu / globe icon next to it. The PR slot now
  stays empty until the async PR check completes, and the header refresh icon turns into a spinner while loading.