### PR TITLE
ios: Fix iOS sheet crashes from missing ConnectionManager environment

### DIFF
--- a/MuxyMobile/ConnectView.swift
+++ b/MuxyMobile/ConnectView.swift
@@ -70,6 +70,7 @@ struct ConnectView: View {
             }
             .sheet(isPresented: $showAddSheet) {
                 AddDeviceSheet()
+                    .environment(connection)
             }
             .sheet(isPresented: $showSettings) {
                 SettingsSheet()

--- a/MuxyMobile/VCSView.swift
+++ b/MuxyMobile/VCSView.swift
@@ -57,9 +57,11 @@ struct VCSView: View {
             }
             .sheet(isPresented: $showingBranches) {
                 BranchesSheet(projectID: projectID) { await refresh() }
+                    .environment(connection)
             }
             .sheet(isPresented: $showingWorktrees) {
                 WorktreesSheet(projectID: projectID) { await refresh() }
+                    .environment(connection)
             }
             .sheet(isPresented: $showingCreatePR) {
                 CreatePRSheet(
@@ -67,6 +69,7 @@ struct VCSView: View {
                     defaultBase: status?.defaultBranch,
                     currentBranch: status?.branch ?? ""
                 ) { await refresh() }
+                    .environment(connection)
             }
         }
         .task { await refresh() }

--- a/MuxyMobile/WorktreesSheet.swift
+++ b/MuxyMobile/WorktreesSheet.swift
@@ -37,6 +37,7 @@ struct WorktreesSheet: View {
             }
             .sheet(isPresented: $showingAdd) {
                 AddWorktreeSheet(projectID: projectID)
+                    .environment(connection)
             }
         }
     }


### PR DESCRIPTION
Re-inject ConnectionManager into MuxyMobile sheets that read it via @Environment, matching the existing workaround in
  RemoteWorkspaceView. Fixes a SwiftUI EnvironmentValues assertion crash reported via TestFlight.