### PR TITLE
Fix white flash when opening markdown preview

### DIFF
--- a/Muxy/Views/Markdown/MarkdownTabView.swift
+++ b/Muxy/Views/Markdown/MarkdownTabView.swift
@@ -77,9 +77,10 @@ struct MarkdownWebView: NSViewRepresentable {
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
-        webView.setValue(false, forKey: "drawsBackground")
         webView.wantsLayer = true
         webView.layer?.backgroundColor = palette.background.cgColor
+        webView.setValue(false, forKey: "drawsBackground")
+        webView.underPageBackgroundColor = palette.background
         context.coordinator.configure(with: configuration)
         if scrollSyncEnabled {
             context.coordinator.applyPreferredScroll(
@@ -254,6 +255,7 @@ struct MarkdownWebView: NSViewRepresentable {
             if let lastAppliedPalette, lastAppliedPalette == palette { return }
             lastAppliedPalette = palette
             webView.layer?.backgroundColor = palette.background.cgColor
+            webView.underPageBackgroundColor = palette.background
             let script = MarkdownRenderer.themeApplyScript(palette: palette)
             webView.evaluateJavaScript(script) { _, error in
                 if let error {


### PR DESCRIPTION
  The WKWebView briefly painted its default white background before the themed HTML loaded. Setting the layer background before
  disabling drawsBackground and using underPageBackgroundColor keeps the preview on the terminal theme color from the first paint.