### PR TITLE
Fix branch-name field losing user edits in Create PR sheet

### DIFF
--- a/Muxy/Views/VCS/CreatePRSheet.swift
+++ b/Muxy/Views/VCS/CreatePRSheet.swift
@@ -28,7 +28,6 @@ struct CreatePRSheet: View {
     @State private var bodyText: String = ""
     @State private var newBranchName: String = ""
     @State private var userEditedBranchName = false
-    @State private var isProgrammaticBranchNameChange = false
     @State private var includeAll = true
     @State private var draft = false
     @State private var didApplyDefaults = false
@@ -96,7 +95,6 @@ struct CreatePRSheet: View {
         .onChange(of: context.availableBaseBranches) { _, _ in applyDefaults() }
         .onChange(of: title) { _, newValue in
             guard !userEditedBranchName else { return }
-            isProgrammaticBranchNameChange = true
             newBranchName = Self.slugify(newValue)
         }
     }
@@ -175,12 +173,11 @@ struct CreatePRSheet: View {
             TextField("branch-name", text: $newBranchName)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(size: 11, design: .monospaced))
-                .onChange(of: newBranchName) { _, _ in
-                    if isProgrammaticBranchNameChange {
-                        isProgrammaticBranchNameChange = false
-                        return
+                .onChange(of: newBranchName) { _, newValue in
+                    guard !userEditedBranchName else { return }
+                    if newValue != Self.slugify(title) {
+                        userEditedBranchName = true
                     }
-                    userEditedBranchName = true
                 }
             Text("A new branch will be created from \(currentBranchSnapshot) for this pull request.")
                 .font(.system(size: 11))

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -776,10 +776,7 @@ struct PRPill: View {
             case .canCreate:
                 createPRPill
             case let .hasPR(info):
-                HStack(spacing: 4) {
-                    hasPRPill(info: info)
-                    openRepoButton
-                }
+                hasPRPill(info: info)
             }
         }
     }


### PR DESCRIPTION
The auto-slug-from-title flag had a race when the slug equalled the current branch name, causing the next manual edit to be
  silently ignored. Replaced the flag with a value comparison so any divergence from the title's slug locks the branch field.