### PR TITLE
Inline Create PR form + merged worktree/branch picker

### DIFF
--- a/Muxy/Views/Components/PopoverPicker.swift
+++ b/Muxy/Views/Components/PopoverPicker.swift
@@ -28,6 +28,7 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
     let searchPlaceholder: String
     let emptyLabel: String
     let footerActions: [PopoverFooterAction]
+    let fixedSize: Bool
     let onSelect: (Item) -> Void
     @ViewBuilder let row: (Item, Bool) -> RowContent
 
@@ -37,6 +38,7 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
         searchPlaceholder: String,
         emptyLabel: String,
         footerActions: [PopoverFooterAction] = [],
+        fixedSize: Bool = true,
         onSelect: @escaping (Item) -> Void,
         @ViewBuilder row: @escaping (Item, Bool) -> RowContent
     ) {
@@ -45,6 +47,7 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
         self.searchPlaceholder = searchPlaceholder
         self.emptyLabel = emptyLabel
         self.footerActions = footerActions
+        self.fixedSize = fixedSize
         self.onSelect = onSelect
         self.row = row
     }
@@ -73,7 +76,8 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
                 }
             }
         }
-        .frame(width: 300, height: 420)
+        .frame(width: fixedSize ? 300 : nil, height: fixedSize ? 420 : nil)
+        .frame(maxWidth: fixedSize ? nil : .infinity, maxHeight: fixedSize ? nil : .infinity)
         .background(MuxyTheme.bg)
     }
 

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -6,6 +6,7 @@ struct WorktreePopover: View {
     let isGitRepo: Bool
     let onDismiss: () -> Void
     let onRequestCreate: () -> Void
+    var fixedSize: Bool = true
 
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -29,6 +30,7 @@ struct WorktreePopover: View {
             searchPlaceholder: "Search worktrees…",
             emptyLabel: "No matches",
             footerActions: footerActions,
+            fixedSize: fixedSize,
             onSelect: { worktree in
                 appState.selectWorktree(projectID: project.id, worktree: worktree)
                 onDismiss()

--- a/Muxy/Views/VCS/BranchPicker.swift
+++ b/Muxy/Views/VCS/BranchPicker.swift
@@ -42,46 +42,77 @@ struct BranchPicker: View {
         .accessibilityLabel("Branch: \(currentBranch ?? "detached")")
         .accessibilityHint("Opens branch picker")
         .popover(isPresented: $showPopover, arrowEdge: .top) {
-            PopoverPicker(
-                items: branchItems,
-                filterKey: \.name,
-                searchPlaceholder: "Search branches…",
-                emptyLabel: isLoading ? "Loading…" : "No branches found",
-                footerActions: onCreateBranch.map { action in
-                    [
-                        PopoverFooterAction(
-                            title: "New Branch…",
-                            icon: "plus.square.dashed",
-                            action: {
-                                showPopover = false
-                                action()
-                            }
-                        ),
-                    ]
-                } ?? [],
-                onSelect: { item in
+            BranchPickerContent(
+                currentBranch: currentBranch,
+                branches: branches,
+                isLoading: isLoading,
+                fixedSize: true,
+                onSelect: { name in
                     showPopover = false
-                    onSelect(item.name)
+                    onSelect(name)
                 },
-                row: { item, isHighlighted in
-                    BranchRow(
-                        name: item.name,
-                        isActive: item.name == currentBranch,
-                        isHighlighted: isHighlighted
-                    )
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .contextMenu {
-                        if let onDeleteBranch, item.name != currentBranch {
-                            Button("Delete Branch", role: .destructive) {
-                                showPopover = false
-                                onDeleteBranch(item.name)
-                            }
-                        }
+                onCreateBranch: onCreateBranch.map { action in
+                    {
+                        showPopover = false
+                        action()
+                    }
+                },
+                onDeleteBranch: onDeleteBranch.map { action in
+                    { name in
+                        showPopover = false
+                        action(name)
                     }
                 }
             )
         }
+    }
+}
+
+struct BranchPickerContent: View {
+    let currentBranch: String?
+    let branches: [String]
+    let isLoading: Bool
+    var fixedSize: Bool = false
+    let onSelect: (String) -> Void
+    let onCreateBranch: (() -> Void)?
+    let onDeleteBranch: ((String) -> Void)?
+
+    private var items: [BranchItem] { branches.map { BranchItem(name: $0) } }
+
+    var body: some View {
+        PopoverPicker(
+            items: items,
+            filterKey: \.name,
+            searchPlaceholder: "Search branches…",
+            emptyLabel: isLoading ? "Loading…" : "No branches found",
+            footerActions: onCreateBranch.map { action in
+                [
+                    PopoverFooterAction(
+                        title: "New Branch…",
+                        icon: "plus.square.dashed",
+                        action: action
+                    ),
+                ]
+            } ?? [],
+            fixedSize: fixedSize,
+            onSelect: { item in onSelect(item.name) },
+            row: { item, isHighlighted in
+                BranchRow(
+                    name: item.name,
+                    isActive: item.name == currentBranch,
+                    isHighlighted: isHighlighted
+                )
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .contextMenu {
+                    if let onDeleteBranch, item.name != currentBranch {
+                        Button("Delete Branch", role: .destructive) {
+                            onDeleteBranch(item.name)
+                        }
+                    }
+                }
+            }
+        )
     }
 }
 

--- a/Muxy/Views/VCS/CreatePRSheet.swift
+++ b/Muxy/Views/VCS/CreatePRSheet.swift
@@ -28,8 +28,11 @@ struct CreatePRForm: View {
     @State private var didLoadRemoteBranches = false
 
     private var availableBaseBranches: [String] {
-        if didLoadRemoteBranches || !context.remoteBranches.isEmpty {
+        if !context.remoteBranches.isEmpty {
             return context.remoteBranches
+        }
+        if didLoadRemoteBranches, context.isLoadingRemoteBranches {
+            return []
         }
         return context.localBranches
     }
@@ -110,7 +113,12 @@ struct CreatePRForm: View {
         .padding(10)
         .background(MuxyTheme.bg)
         .onAppear(perform: applyDefaults)
-        .onChange(of: availableBaseBranches) { _, _ in applyDefaults() }
+        .onChange(of: availableBaseBranches) { _, newList in
+            if !baseBranch.isEmpty, !newList.contains(baseBranch) {
+                baseBranch = ""
+            }
+            applyDefaults()
+        }
         .onChange(of: title) { _, newValue in
             guard !userEditedBranchName else { return }
             newBranchName = Self.slugify(newValue)
@@ -131,7 +139,6 @@ struct CreatePRForm: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .keyboardShortcut(.cancelAction)
             .help("Back to commit")
 
             Image(systemName: "arrow.triangle.pull")

--- a/Muxy/Views/VCS/CreatePRSheet.swift
+++ b/Muxy/Views/VCS/CreatePRSheet.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
-struct CreatePRSheet: View {
+struct CreatePRForm: View {
     struct Context {
         let currentBranch: String
         let defaultBranch: String?
-        let availableBaseBranches: [String]
-        let isLoadingBranches: Bool
+        let localBranches: [String]
+        let remoteBranches: [String]
+        let isLoadingRemoteBranches: Bool
         let hasStagedChanges: Bool
         let hasUnstagedChanges: Bool
     }
@@ -13,6 +14,7 @@ struct CreatePRSheet: View {
     let context: Context
     let inProgress: Bool
     let errorMessage: String?
+    let onLoadRemoteBranches: () -> Void
     let onSubmit: (
         _ baseBranch: String,
         _ title: String,
@@ -23,6 +25,15 @@ struct CreatePRSheet: View {
     ) -> Void
     let onCancel: () -> Void
 
+    @State private var didLoadRemoteBranches = false
+
+    private var availableBaseBranches: [String] {
+        if didLoadRemoteBranches || !context.remoteBranches.isEmpty {
+            return context.remoteBranches
+        }
+        return context.localBranches
+    }
+
     @State private var baseBranch: String = ""
     @State private var title: String = ""
     @State private var bodyText: String = ""
@@ -32,6 +43,7 @@ struct CreatePRSheet: View {
     @State private var draft = false
     @State private var didApplyDefaults = false
     @State private var initialCurrentBranch: String?
+    @State private var advanced = false
     @FocusState private var titleFocused: Bool
 
     private var currentBranchSnapshot: String {
@@ -67,32 +79,38 @@ struct CreatePRSheet: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 10) {
             header
-            targetBranchField
             titleField
             descriptionField
 
-            if needsNewBranch {
-                newBranchField
+            if advanced {
+                targetBranchField
+                if needsNewBranch {
+                    newBranchField
+                }
+                if hasAnyChanges, context.hasStagedChanges, context.hasUnstagedChanges {
+                    includeSection
+                }
             }
 
-            if hasAnyChanges, context.hasStagedChanges, context.hasUnstagedChanges {
-                includeSection
+            HStack(spacing: 10) {
+                advancedToggle
+                if advanced {
+                    draftToggle
+                }
+                Spacer(minLength: 0)
+                footerButtons
             }
-
-            draftToggle
 
             if let errorMessage {
                 warning(errorMessage)
             }
-
-            footer
         }
-        .padding(20)
-        .frame(width: 500)
+        .padding(10)
+        .background(MuxyTheme.bg)
         .onAppear(perform: applyDefaults)
-        .onChange(of: context.availableBaseBranches) { _, _ in applyDefaults() }
+        .onChange(of: availableBaseBranches) { _, _ in applyDefaults() }
         .onChange(of: title) { _, newValue in
             guard !userEditedBranchName else { return }
             newBranchName = Self.slugify(newValue)
@@ -101,84 +119,137 @@ struct CreatePRSheet: View {
 
     private var header: some View {
         HStack(spacing: 8) {
+            Button(action: onCancel) {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 10, weight: .bold))
+                    Text("Back")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .padding(.vertical, 3)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .help("Back to commit")
+
             Image(systemName: "arrow.triangle.pull")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(MuxyTheme.accent)
-            Text("Create Pull Request")
-                .font(.system(size: 14, weight: .semibold))
+            Text("New Pull Request")
+                .font(.system(size: 12, weight: .semibold))
             Spacer(minLength: 0)
         }
     }
 
     private var targetBranchField: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Target Branch")
-                .font(.system(size: 11))
-                .foregroundStyle(MuxyTheme.fgMuted)
-            if context.isLoadingBranches, context.availableBaseBranches.isEmpty {
-                HStack(spacing: 6) {
-                    ProgressView().controlSize(.small)
-                    Text("Loading remote branches…")
-                        .font(.system(size: 11))
-                        .foregroundStyle(MuxyTheme.fgMuted)
-                }
-            } else if context.availableBaseBranches.isEmpty {
-                Text("No remote branches found. Push at least one branch to origin first.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(MuxyTheme.diffRemoveFg)
-            } else {
-                Picker("", selection: $baseBranch) {
-                    ForEach(context.availableBaseBranches, id: \.self) { branch in
-                        Text(branch).tag(branch)
+        VStack(alignment: .leading, spacing: 4) {
+            fieldLabel("Target Branch")
+            if availableBaseBranches.isEmpty {
+                if context.isLoadingRemoteBranches {
+                    HStack(spacing: 6) {
+                        ProgressView().controlSize(.small)
+                        Text("Loading remote branches…")
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuxyTheme.fgMuted)
                     }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 7)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .themedFieldBackground()
+                } else {
+                    Text("No branches found.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuxyTheme.diffRemoveFg)
                 }
-                .labelsHidden()
+            } else {
+                Menu {
+                    ForEach(availableBaseBranches, id: \.self) { branch in
+                        Button(branch) { baseBranch = branch }
+                    }
+                    Divider()
+                    Button {
+                        didLoadRemoteBranches = true
+                        onLoadRemoteBranches()
+                    } label: {
+                        if context.isLoadingRemoteBranches {
+                            Text("Loading remote branches…")
+                        } else if didLoadRemoteBranches || !context.remoteBranches.isEmpty {
+                            Text("Refresh remote branches")
+                        } else {
+                            Text("Load remote branches")
+                        }
+                    }
+                    .disabled(context.isLoadingRemoteBranches)
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.triangle.branch")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(MuxyTheme.fgDim)
+                        Text(baseBranch.isEmpty ? "Select branch" : baseBranch)
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(MuxyTheme.fg)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer(minLength: 4)
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(MuxyTheme.fgDim)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 7)
+                    .contentShape(Rectangle())
+                }
+                .menuStyle(.button)
+                .menuIndicator(.hidden)
+                .buttonStyle(.plain)
+                .themedFieldBackground()
             }
         }
     }
 
     private var titleField: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Title")
-                .font(.system(size: 11))
-                .foregroundStyle(MuxyTheme.fgMuted)
-            TextField("Short summary of the change", text: $title)
-                .textFieldStyle(.roundedBorder)
-                .focused($titleFocused)
-                .onSubmit { if canSubmit, !inProgress { submit() } }
+        VStack(alignment: .leading, spacing: 4) {
+            fieldLabel("Title")
+            ThemedTextField(
+                text: $title,
+                placeholder: "Short summary of the change",
+                monospaced: false,
+                onSubmit: { if canSubmit, !inProgress { submit() } }
+            )
+            .focused($titleFocused)
         }
     }
 
     private var descriptionField: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Description")
-                .font(.system(size: 11))
-                .foregroundStyle(MuxyTheme.fgMuted)
+        VStack(alignment: .leading, spacing: 4) {
+            fieldLabel("Description")
             TextEditor(text: $bodyText)
                 .font(.system(size: 12))
                 .foregroundStyle(MuxyTheme.fg)
                 .scrollContentBackground(.hidden)
-                .padding(6)
-                .frame(minHeight: 100, maxHeight: 160)
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 3)
+                .frame(height: 100)
+                .themedFieldBackground()
         }
     }
 
     private var newBranchField: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("New Branch")
-                .font(.system(size: 11))
-                .foregroundStyle(MuxyTheme.fgMuted)
-            TextField("branch-name", text: $newBranchName)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 11, design: .monospaced))
-                .onChange(of: newBranchName) { _, newValue in
-                    guard !userEditedBranchName else { return }
-                    if newValue != Self.slugify(title) {
-                        userEditedBranchName = true
-                    }
+        VStack(alignment: .leading, spacing: 4) {
+            fieldLabel("New Branch")
+            ThemedTextField(
+                text: $newBranchName,
+                placeholder: "branch-name",
+                monospaced: true
+            )
+            .onChange(of: newBranchName) { _, newValue in
+                guard !userEditedBranchName else { return }
+                if newValue != Self.slugify(title) {
+                    userEditedBranchName = true
                 }
+            }
             Text("A new branch will be created from \(currentBranchSnapshot) for this pull request.")
                 .font(.system(size: 11))
                 .foregroundStyle(MuxyTheme.fgDim)
@@ -188,16 +259,46 @@ struct CreatePRSheet: View {
 
     private var includeSection: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Include")
-                .font(.system(size: 11))
-                .foregroundStyle(MuxyTheme.fgMuted)
-            Picker("", selection: $includeAll) {
-                Text("All changes (staged + unstaged)").tag(true)
-                Text("Only staged changes").tag(false)
+            fieldLabel("Include")
+            VStack(alignment: .leading, spacing: 4) {
+                includeRadio(label: "All changes (staged + unstaged)", value: true)
+                includeRadio(label: "Only staged changes", value: false)
             }
-            .pickerStyle(.radioGroup)
-            .labelsHidden()
         }
+    }
+
+    private func includeRadio(label: String, value: Bool) -> some View {
+        Button {
+            includeAll = value
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: includeAll == value ? "largecircle.fill.circle" : "circle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(includeAll == value ? MuxyTheme.accent : MuxyTheme.fgDim)
+                Text(label)
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fg)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var advancedToggle: some View {
+        Button {
+            advanced.toggle()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: advanced ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .bold))
+                Text("Advanced")
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundStyle(MuxyTheme.fgMuted)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Show target branch, include and draft options")
     }
 
     private var draftToggle: some View {
@@ -216,25 +317,53 @@ struct CreatePRSheet: View {
             .fixedSize(horizontal: false, vertical: true)
     }
 
-    private var footer: some View {
-        HStack {
-            Spacer()
-            Button("Cancel", action: onCancel)
-                .keyboardShortcut(.cancelAction)
-                .disabled(inProgress)
-            Button {
-                submit()
-            } label: {
+    private var footerButtons: some View {
+        HStack(spacing: 6) {
+            Button(action: onCancel) {
+                Text("Cancel")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
+                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(inProgress)
+
+            let submitEnabled = canSubmit && !inProgress
+            Button(action: submit) {
                 HStack(spacing: 4) {
                     if inProgress {
                         ProgressView().controlSize(.mini)
                     }
                     Text("Create PR")
+                        .font(.system(size: 11, weight: .semibold))
                 }
+                .foregroundStyle(submitEnabled ? MuxyTheme.bg : MuxyTheme.fgDim)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    submitEnabled ? MuxyTheme.accent : MuxyTheme.surface,
+                    in: RoundedRectangle(cornerRadius: 6)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(MuxyTheme.border, lineWidth: submitEnabled ? 0 : 1)
+                )
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
             .keyboardShortcut(.defaultAction)
-            .disabled(!canSubmit || inProgress)
+            .disabled(!submitEnabled)
         }
+    }
+
+    private func fieldLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11))
+            .foregroundStyle(MuxyTheme.fgMuted)
     }
 
     private func applyDefaults() {
@@ -243,8 +372,8 @@ struct CreatePRSheet: View {
         }
         if baseBranch.isEmpty {
             baseBranch = context.defaultBranch
-                ?? context.availableBaseBranches.first(where: { $0 != currentBranchSnapshot })
-                ?? context.availableBaseBranches.first
+                ?? availableBaseBranches.first(where: { $0 != currentBranchSnapshot })
+                ?? availableBaseBranches.first
                 ?? ""
         }
         if !didApplyDefaults {
@@ -268,5 +397,31 @@ struct CreatePRSheet: View {
             .split(separator: "-", omittingEmptySubsequences: true)
             .joined(separator: "-")
         return String(collapsed.prefix(20))
+    }
+}
+
+private struct ThemedTextField: View {
+    @Binding var text: String
+    let placeholder: String
+    var monospaced: Bool = false
+    var onSubmit: (() -> Void)?
+
+    var body: some View {
+        TextField(placeholder, text: $text)
+            .textFieldStyle(.plain)
+            .font(.system(size: 12, design: monospaced ? .monospaced : .default))
+            .foregroundStyle(MuxyTheme.fg)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 7)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .themedFieldBackground()
+            .onSubmit { onSubmit?() }
+    }
+}
+
+private extension View {
+    func themedFieldBackground() -> some View {
+        background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
     }
 }

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -12,8 +12,7 @@ struct VCSTabView: View {
     @State private var pendingDiscardPath: String?
     @State private var showCreateWorktreeSheet = false
     @State private var showCreateBranchSheet = false
-    @State private var showCreatePRSheet = false
-    @State private var showWorktreePopover = false
+    @State private var showInlinePRForm = false
     @State private var pendingClosePR: GitRepositoryService.PRInfo?
     @State private var pendingCheckoutPR: GitRepositoryService.PRListItem?
     private var commitEnabled: Bool {
@@ -106,17 +105,7 @@ struct VCSTabView: View {
 
     private var header: some View {
         HStack(spacing: 6) {
-            worktreeTrigger
-
-            BranchPicker(
-                currentBranch: state.branchName,
-                branches: state.branches,
-                isLoading: state.isLoadingBranches,
-                onSelect: { state.switchBranch($0) },
-                onRefresh: { state.loadBranches() },
-                onCreateBranch: { showCreateBranchSheet = true },
-                onDeleteBranch: { branch in presentDeleteBranchConfirmation(branch) }
-            )
+            worktreeBranchPicker
 
             PRPill(
                 state: state,
@@ -126,6 +115,13 @@ struct VCSTabView: View {
             )
 
             Spacer(minLength: 0)
+
+            if let url = state.remoteWebURL {
+                IconButton(symbol: "globe", accessibilityLabel: "Open Repository on Web") {
+                    NSWorkspace.shared.open(url)
+                }
+                .help("Open repository on web")
+            }
 
             VCSSectionVisibilityMenu(state: state)
 
@@ -160,97 +156,37 @@ struct VCSTabView: View {
                 onCancel: { showCreateBranchSheet = false }
             )
         }
-        .sheet(isPresented: $showCreatePRSheet) {
-            CreatePRSheet(
-                context: CreatePRSheet.Context(
-                    currentBranch: state.branchName ?? "",
-                    defaultBranch: state.defaultBranch,
-                    availableBaseBranches: state.remoteBranches,
-                    isLoadingBranches: state.isLoadingRemoteBranches,
-                    hasStagedChanges: state.hasStagedChanges,
-                    hasUnstagedChanges: !state.unstagedFiles.isEmpty
-                ),
-                inProgress: state.isOpeningPullRequest,
-                errorMessage: state.openPullRequestError,
-                onSubmit: { base, title, body, branchStrategy, includeMode, draft in
-                    ToastState.shared.show("Creating pull request…")
-                    state.openPullRequest(
-                        VCSTabState.PRCreateRequest(
-                            baseBranch: base,
-                            title: title,
-                            body: body,
-                            branchStrategy: branchStrategy,
-                            includeMode: includeMode,
-                            draft: draft
-                        )
-                    )
-                },
-                onCancel: {
-                    state.openPullRequestError = nil
-                    showCreatePRSheet = false
-                }
-            )
-        }
         .onChange(of: state.pullRequestInfo?.number) { _, number in
-            guard number != nil, showCreatePRSheet else { return }
-            showCreatePRSheet = false
+            guard number != nil, showInlinePRForm else { return }
+            showInlinePRForm = false
         }
     }
 
     private func requestOpenPR() {
         state.openPullRequestError = nil
-        state.loadRemoteBranches()
-        showCreatePRSheet = true
+        state.loadBranches()
+        showInlinePRForm = true
     }
 
     @ViewBuilder
-    private var worktreeTrigger: some View {
+    private var worktreeBranchPicker: some View {
         if let project = owningProject {
-            Button {
-                showWorktreePopover = true
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "square.stack.3d.up")
-                        .font(.system(size: 9, weight: .semibold))
-                    Text(worktreeTriggerLabel)
-                        .font(.system(size: 10, weight: .medium))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .frame(maxWidth: 120, alignment: .leading)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 8, weight: .bold))
-                        .foregroundStyle(MuxyTheme.fgDim)
-                }
-                .foregroundStyle(MuxyTheme.fg.opacity(0.85))
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
-                .contentShape(RoundedRectangle(cornerRadius: 5))
-            }
-            .buttonStyle(.plain)
-            .help(worktreeTriggerLabel)
-            .popover(isPresented: $showWorktreePopover, arrowEdge: .top) {
-                WorktreePopover(
-                    project: project,
-                    isGitRepo: state.isGitRepo,
-                    onDismiss: { showWorktreePopover = false },
-                    onRequestCreate: {
-                        showWorktreePopover = false
-                        showCreateWorktreeSheet = true
-                    }
-                )
-                .environment(appState)
-                .environment(worktreeStore)
-            }
+            WorktreeBranchPicker(
+                project: project,
+                isGitRepo: state.isGitRepo,
+                currentBranch: state.branchName,
+                branches: state.branches,
+                isLoadingBranches: state.isLoadingBranches,
+                activeWorktree: activeWorktreeForTab,
+                onSelectBranch: { state.switchBranch($0) },
+                onRefreshBranches: { state.loadBranches() },
+                onCreateBranch: { showCreateBranchSheet = true },
+                onDeleteBranch: { branch in presentDeleteBranchConfirmation(branch) },
+                onRequestCreateWorktree: { showCreateWorktreeSheet = true }
+            )
+            .environment(appState)
+            .environment(worktreeStore)
         }
-    }
-
-    private var worktreeTriggerLabel: String {
-        guard let worktree = activeWorktreeForTab else { return "default" }
-        if worktree.isPrimary {
-            return worktree.name.isEmpty ? "default" : worktree.name
-        }
-        return worktree.name
     }
 
     private func performMerge(prInfo: GitRepositoryService.PRInfo, method: GitRepositoryService.PRMergeMethod) {
@@ -439,7 +375,11 @@ struct VCSTabView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             VStack(spacing: 0) {
-                commitArea
+                if showInlinePRForm {
+                    createPRForm
+                } else {
+                    commitArea
+                }
                 SectionSplitLayout(
                     state: state,
                     onFocus: onFocus,
@@ -451,6 +391,40 @@ struct VCSTabView: View {
                 )
             }
         }
+    }
+
+    private var createPRForm: some View {
+        CreatePRForm(
+            context: CreatePRForm.Context(
+                currentBranch: state.branchName ?? "",
+                defaultBranch: state.defaultBranch,
+                localBranches: state.branches,
+                remoteBranches: state.remoteBranches,
+                isLoadingRemoteBranches: state.isLoadingRemoteBranches,
+                hasStagedChanges: state.hasStagedChanges,
+                hasUnstagedChanges: !state.unstagedFiles.isEmpty
+            ),
+            inProgress: state.isOpeningPullRequest,
+            errorMessage: state.openPullRequestError,
+            onLoadRemoteBranches: { state.loadRemoteBranches() },
+            onSubmit: { base, title, body, branchStrategy, includeMode, draft in
+                ToastState.shared.show("Creating pull request…")
+                state.openPullRequest(
+                    VCSTabState.PRCreateRequest(
+                        baseBranch: base,
+                        title: title,
+                        body: body,
+                        branchStrategy: branchStrategy,
+                        includeMode: includeMode,
+                        draft: draft
+                    )
+                )
+            },
+            onCancel: {
+                state.openPullRequestError = nil
+                showInlinePRForm = false
+            }
+        )
     }
 
     private var commitArea: some View {
@@ -767,32 +741,14 @@ struct PRPill: View {
         } else {
             switch state.prLaunchState {
             case .hidden:
-                openRepoButton
+                EmptyView()
             case .ghMissing:
-                HStack(spacing: 4) {
-                    ghMissingPill
-                    openRepoButton
-                }
+                ghMissingPill
             case .canCreate:
                 createPRPill
             case let .hasPR(info):
                 hasPRPill(info: info)
             }
-        }
-    }
-
-    @ViewBuilder
-    private var openRepoButton: some View {
-        if let url = state.remoteWebURL {
-            pillContainer(
-                icon: "globe",
-                text: "Open Repo",
-                tint: MuxyTheme.fg.opacity(0.85),
-                disabled: false
-            ) {
-                NSWorkspace.shared.open(url)
-            }
-            .help("Open repository on web")
         }
     }
 
@@ -807,47 +763,21 @@ struct PRPill: View {
     }
 
     private var createPRPill: some View {
-        HStack(spacing: 0) {
-            Button(action: onRequestCreate) {
-                HStack(spacing: 4) {
-                    Image(systemName: "arrow.triangle.pull")
-                        .font(.system(size: 9, weight: .bold))
-                    Text("Create PR")
-                        .font(.system(size: 10, weight: .semibold))
-                }
-                .foregroundStyle(MuxyTheme.accent)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .contentShape(Rectangle())
+        Button(action: onRequestCreate) {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.triangle.pull")
+                    .font(.system(size: 9, weight: .bold))
+                Text("Create PR")
+                    .font(.system(size: 10, weight: .semibold))
             }
-            .buttonStyle(.plain)
-            .disabled(state.isOpeningPullRequest)
-            .help("Create a pull request")
-
-            if state.remoteWebURL != nil {
-                Rectangle()
-                    .fill(MuxyTheme.accent.opacity(0.35))
-                    .frame(width: 1, height: 14)
-                Menu {
-                    if let url = state.remoteWebURL {
-                        Button("Open Repository on Web") {
-                            NSWorkspace.shared.open(url)
-                        }
-                    }
-                } label: {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 8, weight: .bold))
-                        .foregroundStyle(MuxyTheme.accent)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 5)
-                        .contentShape(Rectangle())
-                }
-                .menuStyle(.button)
-                .menuIndicator(.hidden)
-                .buttonStyle(.plain)
-                .fixedSize()
-            }
+            .foregroundStyle(MuxyTheme.accent)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .disabled(state.isOpeningPullRequest)
+        .help("Create a pull request")
         .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
         .overlay(RoundedRectangle(cornerRadius: 5).stroke(MuxyTheme.accent.opacity(0.35), lineWidth: 1))
     }

--- a/Muxy/Views/VCS/WorktreeBranchPicker.swift
+++ b/Muxy/Views/VCS/WorktreeBranchPicker.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+struct WorktreeBranchPicker: View {
+    let project: Project
+    let isGitRepo: Bool
+    let currentBranch: String?
+    let branches: [String]
+    let isLoadingBranches: Bool
+    let activeWorktree: Worktree?
+    let onSelectBranch: (String) -> Void
+    let onRefreshBranches: () -> Void
+    let onCreateBranch: () -> Void
+    let onDeleteBranch: (String) -> Void
+    let onRequestCreateWorktree: () -> Void
+
+    @Environment(AppState.self) private var appState
+    @Environment(WorktreeStore.self) private var worktreeStore
+
+    @State private var showPopover = false
+    @State private var segment: Segment = .worktrees
+
+    enum Segment: String, CaseIterable, Identifiable {
+        case worktrees
+        case branches
+        var id: String { rawValue }
+        var title: String {
+            switch self {
+            case .worktrees: "Worktrees"
+            case .branches: "Branches"
+            }
+        }
+    }
+
+    private var worktreeLabel: String {
+        guard let worktree = activeWorktree else { return "default" }
+        if worktree.isPrimary {
+            return worktree.name.isEmpty ? "default" : worktree.name
+        }
+        return worktree.name
+    }
+
+    private var branchLabel: String {
+        currentBranch ?? "detached"
+    }
+
+    var body: some View {
+        Button(action: open) {
+            HStack(spacing: 4) {
+                Image(systemName: "square.stack.3d.up")
+                    .font(.system(size: 9, weight: .semibold))
+                Text(worktreeLabel)
+                    .font(.system(size: 10, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(MuxyTheme.fgDim)
+                Image(systemName: "arrow.triangle.branch")
+                    .font(.system(size: 9, weight: .semibold))
+                Text(branchLabel)
+                    .font(.system(size: 10, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(MuxyTheme.fgDim)
+            }
+            .frame(maxWidth: 160, alignment: .leading)
+            .foregroundStyle(MuxyTheme.fg.opacity(0.85))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
+            .contentShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .help("\(worktreeLabel) › \(branchLabel)")
+        .accessibilityLabel("Worktree \(worktreeLabel), Branch \(branchLabel)")
+        .accessibilityHint("Opens worktree and branch picker")
+        .popover(isPresented: $showPopover, arrowEdge: .top) {
+            popoverContent
+        }
+    }
+
+    private func open() {
+        onRefreshBranches()
+        showPopover = true
+    }
+
+    private var segmentedHeader: some View {
+        HStack(spacing: 0) {
+            ForEach(Segment.allCases) { item in
+                segmentButton(item)
+            }
+        }
+        .frame(height: 32)
+    }
+
+    private func segmentButton(_ item: Segment) -> some View {
+        let isActive = segment == item
+        return Button {
+            segment = item
+        } label: {
+            Text(item.title)
+                .font(.system(size: 11, weight: isActive ? .semibold : .medium))
+                .foregroundStyle(isActive ? MuxyTheme.fg : MuxyTheme.fgDim)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(isActive ? MuxyTheme.accent : Color.clear)
+                        .frame(height: 2)
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var popoverContent: some View {
+        VStack(spacing: 0) {
+            segmentedHeader
+            Divider().overlay(MuxyTheme.border.opacity(0.55))
+
+            Group {
+                switch segment {
+                case .worktrees:
+                    WorktreePopover(
+                        project: project,
+                        isGitRepo: isGitRepo,
+                        onDismiss: { showPopover = false },
+                        onRequestCreate: {
+                            showPopover = false
+                            onRequestCreateWorktree()
+                        },
+                        fixedSize: false
+                    )
+                case .branches:
+                    BranchPickerContent(
+                        currentBranch: currentBranch,
+                        branches: branches,
+                        isLoading: isLoadingBranches,
+                        fixedSize: false,
+                        onSelect: { branch in
+                            showPopover = false
+                            onSelectBranch(branch)
+                        },
+                        onCreateBranch: {
+                            showPopover = false
+                            onCreateBranch()
+                        },
+                        onDeleteBranch: { branch in
+                            showPopover = false
+                            onDeleteBranch(branch)
+                        }
+                    )
+                }
+            }
+        }
+        .frame(width: 320, height: 460)
+        .background(MuxyTheme.bg)
+    }
+}

--- a/Muxy/Views/VCS/WorktreeBranchPicker.swift
+++ b/Muxy/Views/VCS/WorktreeBranchPicker.swift
@@ -82,7 +82,9 @@ struct WorktreeBranchPicker: View {
     }
 
     private func open() {
-        onRefreshBranches()
+        if segment == .branches {
+            onRefreshBranches()
+        }
         showPopover = true
     }
 
@@ -99,6 +101,9 @@ struct WorktreeBranchPicker: View {
         let isActive = segment == item
         return Button {
             segment = item
+            if item == .branches {
+                onRefreshBranches()
+            }
         } label: {
             Text(item.title)
                 .font(.system(size: 11, weight: isActive ? .semibold : .medium))


### PR DESCRIPTION
  - Merged worktree and branch popovers into one segmented picker on the VCS topbar; pulled the Open Repo button out
  as a small icon on the right.
  - Replaced the Create PR sheet with an inline form in the commit area: quick mode (title + description) with an
  Advanced section for target branch, include selector and draft.
  - Target branch loads from local first; remote branches load on demand from a menu item.