### PR TITLE
Cmd+click file paths in terminal to open in Muxy editor

### DIFF
--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -46,6 +46,11 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
              GHOSTTY_ACTION_SHOW_CHILD_EXITED:
             handleCommandExit(target: target)
             return true
+        case GHOSTTY_ACTION_MOUSE_OVER_LINK:
+            handleMouseOverLink(target: target, link: action.action.mouse_over_link)
+            return true
+        case GHOSTTY_ACTION_OPEN_URL:
+            return handleOpenURL(target: target, openURL: action.action.open_url)
         default:
             return false
         }
@@ -105,6 +110,24 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
             guard !view.processExitHandled else { return }
             view.processExitHandled = true
             view.onProcessExit?()
+        }
+    }
+
+    private func handleOpenURL(target: ghostty_target_s, openURL: ghostty_action_open_url_s) -> Bool {
+        guard let view = surfaceView(from: target) else { return false }
+        guard let urlPtr = openURL.url, openURL.len > 0 else { return false }
+        let urlString = urlPtr.withMemoryRebound(to: UInt8.self, capacity: Int(openURL.len)) { rawPtr in
+            String(bytes: UnsafeBufferPointer(start: rawPtr, count: Int(openURL.len)), encoding: .utf8)
+        }
+        guard let urlString, let url = URL(string: urlString) else { return false }
+        return view.onOpenURL?(url) ?? false
+    }
+
+    private func handleMouseOverLink(target: ghostty_target_s, link: ghostty_action_mouse_over_link_s) {
+        guard let view = surfaceView(from: target) else { return }
+        let hasLink = link.len > 0 && link.url != nil
+        DispatchQueue.main.async {
+            view.hasOSC8LinkUnderCursor = hasLink
         }
     }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -14,6 +14,11 @@ final class GhosttyTerminalNSView: NSView {
     var onSearchEnd: (() -> Void)?
     var onSearchTotal: ((Int?) -> Void)?
     var onSearchSelected: ((Int?) -> Void)?
+    var onCmdClickFile: ((String) -> Void)?
+    var resolveCmdHoverFile: ((String) -> Bool)?
+    var onOpenURL: ((URL) -> Bool)?
+    private var isShowingHandCursor = false
+    var hasOSC8LinkUnderCursor: Bool = false
     var isFocused: Bool = false
     var overlayActive: Bool = false
 
@@ -153,6 +158,10 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     func tearDown() {
+        setHandCursor(false)
+        onOpenURL = nil
+        onCmdClickFile = nil
+        resolveCmdHoverFile = nil
         onTitleChange = nil
         onFocus = nil
         onProcessExit = nil
@@ -438,6 +447,7 @@ final class GhosttyTerminalNSView: NSView {
         var keyEvent = buildKeyEvent(from: event, action: isFlagPress(event) ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE)
         keyEvent.text = nil
         _ = ghostty_surface_key(surface, keyEvent)
+        updateCmdHoverCursor(modifierFlags: event.modifierFlags)
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -480,7 +490,21 @@ final class GhosttyTerminalNSView: NSView {
         }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
+        if event.modifierFlags.contains(.command), !hasOSC8LinkUnderCursor, let word = readWordUnderMouse() {
+            onCmdClickFile?(word)
+            return
+        }
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
+    }
+
+    private func readWordUnderMouse() -> String? {
+        guard let surface else { return nil }
+        var text = ghostty_text_s()
+        guard ghostty_surface_quicklook_word(surface, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let value = extractString(from: text) else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -506,6 +530,36 @@ final class GhosttyTerminalNSView: NSView {
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
+        updateCmdHoverCursor(modifierFlags: event.modifierFlags)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        setHandCursor(false)
+    }
+
+    private func updateCmdHoverCursor(modifierFlags: NSEvent.ModifierFlags) {
+        guard modifierFlags.contains(.command), !hasOSC8LinkUnderCursor else {
+            setHandCursor(false)
+            return
+        }
+        guard let word = readWordUnderMouse(), resolveCmdHoverFile?(word) == true else {
+            setHandCursor(false)
+            return
+        }
+        setHandCursor(true)
+    }
+
+    private func setHandCursor(_ on: Bool) {
+        guard on != isShowingHandCursor else { return }
+        isShowingHandCursor = on
+        if on {
+            NSCursor.pointingHand.push()
+            NSCursor.pointingHand.set()
+        } else {
+            NSCursor.pop()
+            NSCursor.arrow.set()
+        }
     }
 
     override func rightMouseDown(with event: NSEvent) {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -555,10 +555,8 @@ final class GhosttyTerminalNSView: NSView {
         isShowingHandCursor = on
         if on {
             NSCursor.pointingHand.push()
-            NSCursor.pointingHand.set()
         } else {
             NSCursor.pop()
-            NSCursor.arrow.set()
         }
     }
 

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -230,7 +230,7 @@ struct TerminalBridge: NSViewRepresentable {
         }
     }
 
-    private static func resolveFilePath(_ token: String, projectPath: String) -> String? {
+    static func resolveFilePath(_ token: String, projectPath: String) -> String? {
         let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: "\"' \t\n\r()[]<>"))
         guard !cleaned.isEmpty else { return nil }
         let expanded = (cleaned as NSString).expandingTildeInPath

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -145,6 +145,7 @@ struct TerminalBridge: NSViewRepresentable {
             }
         }
         configureSearchCallbacks(view)
+        configureFileOpenCallback(view)
         context.coordinator.wasFocused = focused
         if focused, !overlayActive {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -168,6 +169,7 @@ struct TerminalBridge: NSViewRepresentable {
             }
         }
         configureSearchCallbacks(nsView)
+        configureFileOpenCallback(nsView)
         let wasFocused = context.coordinator.wasFocused
         let wasOverlayActive = context.coordinator.wasOverlayActive
         context.coordinator.wasFocused = focused
@@ -202,6 +204,45 @@ struct TerminalBridge: NSViewRepresentable {
             vars.append((key: "MUXY_HOOK_SCRIPT", value: hookPath))
         }
         return vars
+    }
+
+    private func configureFileOpenCallback(_ view: GhosttyTerminalNSView) {
+        let projectID = worktreeKey?.projectID
+        let projectPath = state.projectPath
+        view.onCmdClickFile = { token in
+            guard let projectID else { return }
+            guard let resolved = Self.resolveFilePath(token, projectPath: projectPath) else { return }
+            Task { @MainActor in
+                NotificationStore.shared.appState?.openFile(resolved, projectID: projectID, preserveFocus: true)
+            }
+        }
+        view.resolveCmdHoverFile = { token in
+            Self.resolveFilePath(token, projectPath: projectPath) != nil
+        }
+        view.onOpenURL = { url in
+            guard let projectID, url.isFileURL else { return false }
+            let path = url.path
+            guard !path.isEmpty, FileManager.default.fileExists(atPath: path) else { return false }
+            Task { @MainActor in
+                NotificationStore.shared.appState?.openFile(path, projectID: projectID, preserveFocus: true)
+            }
+            return true
+        }
+    }
+
+    private static func resolveFilePath(_ token: String, projectPath: String) -> String? {
+        let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: "\"' \t\n\r()[]<>"))
+        guard !cleaned.isEmpty else { return nil }
+        let expanded = (cleaned as NSString).expandingTildeInPath
+        let candidate: String = if expanded.hasPrefix("/") {
+            expanded
+        } else {
+            (projectPath as NSString).appendingPathComponent(expanded)
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory) else { return nil }
+        guard !isDirectory.boolValue else { return nil }
+        return candidate
     }
 
     private func configureSearchCallbacks(_ view: GhosttyTerminalNSView) {

--- a/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
+++ b/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import Muxy
+
+@Suite("TerminalBridge.resolveFilePath")
+struct TerminalBridgeResolveFilePathTests {
+    private func makeTempDir() -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("muxy-resolve-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeFile(_ url: URL, name: String) -> String {
+        let path = url.appendingPathComponent(name).path
+        FileManager.default.createFile(atPath: path, contents: Data())
+        return path
+    }
+
+    @Test func resolvesAbsolutePath() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "a.txt")
+        #expect(TerminalBridge.resolveFilePath(file, projectPath: "/unused") == file)
+    }
+
+    @Test func resolvesRelativeToProject() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        _ = writeFile(dir, name: "b.txt")
+        let resolved = TerminalBridge.resolveFilePath("b.txt", projectPath: dir.path)
+        #expect(resolved == dir.appendingPathComponent("b.txt").path)
+    }
+
+    @Test func stripsQuotesAndBrackets() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        _ = writeFile(dir, name: "c.txt")
+        #expect(TerminalBridge.resolveFilePath("\"c.txt\"", projectPath: dir.path) != nil)
+        #expect(TerminalBridge.resolveFilePath("(c.txt)", projectPath: dir.path) != nil)
+        #expect(TerminalBridge.resolveFilePath("<c.txt>", projectPath: dir.path) != nil)
+    }
+
+    @Test func rejectsDirectory() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sub = dir.appendingPathComponent("sub")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        #expect(TerminalBridge.resolveFilePath("sub", projectPath: dir.path) == nil)
+    }
+
+    @Test func rejectsMissingPath() {
+        #expect(TerminalBridge.resolveFilePath("does-not-exist.xyz", projectPath: "/tmp") == nil)
+    }
+
+    @Test func rejectsEmptyAndWhitespace() {
+        #expect(TerminalBridge.resolveFilePath("", projectPath: "/tmp") == nil)
+        #expect(TerminalBridge.resolveFilePath("   \t", projectPath: "/tmp") == nil)
+    }
+
+    @Test func expandsTilde() throws {
+        let home = NSString(string: "~").expandingTildeInPath
+        let name = "muxy-tilde-\(UUID().uuidString).txt"
+        let path = (home as NSString).appendingPathComponent(name)
+        FileManager.default.createFile(atPath: path, contents: Data())
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let resolved = TerminalBridge.resolveFilePath("~/\(name)", projectPath: "/unused")
+        #expect(resolved == path)
+    }
+}


### PR DESCRIPTION
  - Cmd+click on file paths or OSC 8 hyperlinks in the terminal opens the file in Muxy's default editor (built-in or
  external command).
  - Hand cursor while ⌘ is held over a resolvable file.

Closes #259 