### PR TITLE
Fix markdown preview white flash at the source

### DIFF
--- a/Muxy/Models/MarkdownRenderer.swift
+++ b/Muxy/Models/MarkdownRenderer.swift
@@ -104,7 +104,6 @@ enum MarkdownRenderer {
             <style id="muxy-base-style">
                 :root {
                     color-scheme: light;
-                    --bg: #FFFFFF;
                     --fg: #1F2328;
                     --accent: #0969DA;
                     --border: #D0D7DE;
@@ -115,7 +114,7 @@ enum MarkdownRenderer {
                 }
                 * { box-sizing: border-box; margin: 0; padding: 0; }
                 html, body {
-                    background: var(--bg);
+                    background: transparent;
                     color: var(--fg);
                     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
                     font-size: 14px;

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -157,7 +157,7 @@ struct EditorPane: View {
                 )
             }
         }
-        .background(MuxyTheme.bg)
+        .background(Color(nsColor: markdownPalette.background))
         .focusable(focused)
         .focusEffectDisabled()
         .focused($markdownPreviewFocused)


### PR DESCRIPTION
  Previous fixes patched the WKWebView wrapper (layer bg, underPageBackgroundColor, drawsBackground), but the HTML template itself
  declared `html, body { background: #FFFFFF }` until JS swapped the theme variable — so the page painted white from inside.