### PR TITLE
Persist VCS section collapse states and resize ratios

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -85,14 +85,33 @@ final class VCSTabState {
     var commits: [GitCommit] = []
     var isLoadingCommits = false
     var hasMoreCommits = true
-    var stagedCollapsed = false
-    var changesCollapsed = false
-    var historyCollapsed = false
-    var pullRequestsCollapsed = true
+    var stagedCollapsed = false {
+        didSet { persistCollapseIfChanged(oldValue, stagedCollapsed) }
+    }
+
+    var changesCollapsed = false {
+        didSet { persistCollapseIfChanged(oldValue, changesCollapsed) }
+    }
+
+    var historyCollapsed = false {
+        didSet { persistCollapseIfChanged(oldValue, historyCollapsed) }
+    }
+
+    var pullRequestsCollapsed = true {
+        didSet { persistCollapseIfChanged(oldValue, pullRequestsCollapsed) }
+    }
+
     var changesVisible = true
     var historyVisible = true
     var pullRequestsVisible = true
-    var sectionRatios: [CGFloat] = [0.25, 0.25, 0.25, 0.25]
+    var sectionRatios: [CGFloat] = [0.25, 0.25, 0.25, 0.25] {
+        didSet {
+            guard isLoaded, sectionRatios != oldValue else { return }
+            VCSPersistedSettings.storeSectionRatios(sectionRatios, repoPath: projectPath)
+        }
+    }
+
+    @ObservationIgnored private var isLoaded = false
 
     var pullRequests: [GitRepositoryService.PRListItem] = []
     var isLoadingPullRequests = false
@@ -162,6 +181,16 @@ final class VCSTabState {
         changesVisible = visibility.changes
         historyVisible = visibility.history
         pullRequestsVisible = visibility.pullRequests
+        let collapse = VCSPersistedSettings.loadSectionCollapse(repoPath: projectPath)
+        stagedCollapsed = collapse.staged
+        changesCollapsed = collapse.changes
+        historyCollapsed = collapse.history
+        pullRequestsCollapsed = collapse.pullRequests
+        let storedRatios = VCSPersistedSettings.loadSectionRatios(repoPath: projectPath)
+        if storedRatios.count == sectionRatios.count {
+            sectionRatios = storedRatios
+        }
+        isLoaded = true
         startWatching()
         observeRemoteChanges()
         rescheduleAutoSync()
@@ -1142,6 +1171,20 @@ final class VCSTabState {
         guard pullRequestsVisible != visible else { return }
         pullRequestsVisible = visible
         VCSPersistedSettings.storeSectionVisibility(currentVisibility, repoPath: projectPath)
+    }
+
+    private func persistCollapseIfChanged(_ oldValue: Bool, _ newValue: Bool) {
+        guard isLoaded, oldValue != newValue else { return }
+        VCSPersistedSettings.storeSectionCollapse(currentCollapse, repoPath: projectPath)
+    }
+
+    private var currentCollapse: VCSPersistedSettings.SectionCollapse {
+        VCSPersistedSettings.SectionCollapse(
+            staged: stagedCollapsed,
+            changes: changesCollapsed,
+            history: historyCollapsed,
+            pullRequests: pullRequestsCollapsed
+        )
     }
 
     private var currentVisibility: VCSPersistedSettings.SectionVisibility {

--- a/Muxy/Services/Git/VCSPersistedSettings.swift
+++ b/Muxy/Services/Git/VCSPersistedSettings.swift
@@ -1,9 +1,21 @@
+import CoreGraphics
 import CryptoKit
 import Foundation
 
 enum VCSPersistedSettings {
     private static let visibilityPrefix = "vcs.sectionVisibility."
     private static let autoSyncPrefix = "vcs.prAutoSyncMinutes."
+    private static let collapsePrefix = "vcs.sectionCollapsed."
+    private static let ratiosPrefix = "vcs.sectionRatios."
+
+    struct SectionCollapse: Equatable {
+        var staged: Bool
+        var changes: Bool
+        var history: Bool
+        var pullRequests: Bool
+
+        static let defaults = SectionCollapse(staged: false, changes: false, history: false, pullRequests: true)
+    }
 
     struct SectionVisibility: Equatable {
         var changes: Bool
@@ -59,8 +71,46 @@ enum VCSPersistedSettings {
         let token = token(for: repoPath)
         defaults.removeObject(forKey: visibilityPrefix + token)
         defaults.removeObject(forKey: autoSyncPrefix + token)
+        defaults.removeObject(forKey: collapsePrefix + token)
+        defaults.removeObject(forKey: ratiosPrefix + token)
         defaults.removeObject(forKey: visibilityPrefix + repoPath)
         defaults.removeObject(forKey: autoSyncPrefix + repoPath)
+    }
+
+    static func loadSectionCollapse(repoPath: String) -> SectionCollapse {
+        let defaults = UserDefaults.standard
+        guard let dict = defaults.dictionary(forKey: collapsePrefix + token(for: repoPath)) as? [String: Bool] else {
+            return .defaults
+        }
+        return SectionCollapse(
+            staged: dict["staged"] ?? false,
+            changes: dict["changes"] ?? false,
+            history: dict["history"] ?? false,
+            pullRequests: dict["pullRequests"] ?? true
+        )
+    }
+
+    static func storeSectionCollapse(_ collapse: SectionCollapse, repoPath: String) {
+        let raw: [String: Bool] = [
+            "staged": collapse.staged,
+            "changes": collapse.changes,
+            "history": collapse.history,
+            "pullRequests": collapse.pullRequests,
+        ]
+        UserDefaults.standard.set(raw, forKey: collapsePrefix + token(for: repoPath))
+    }
+
+    static func loadSectionRatios(repoPath: String) -> [CGFloat] {
+        let defaults = UserDefaults.standard
+        guard let raw = defaults.array(forKey: ratiosPrefix + token(for: repoPath)) as? [Double] else {
+            return []
+        }
+        return raw.map { CGFloat($0) }
+    }
+
+    static func storeSectionRatios(_ ratios: [CGFloat], repoPath: String) {
+        let raw = ratios.map { Double($0) }
+        UserDefaults.standard.set(raw, forKey: ratiosPrefix + token(for: repoPath))
     }
 
     private static func migrateLegacy(prefix: String, repoPath: String) -> Any? {


### PR DESCRIPTION
Section collapse states and resize ratios in the VCS area now persist per repo via UserDefaults, alongside the
  existing visibility settings, so the layout survives app restarts.