### PR TITLE
Prevent Muxy from acquiring git index.lock during background status polling

### DIFF
--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -371,6 +371,10 @@ final class FileTreeState {
         process.executableURL = URL(fileURLWithPath: gitPath)
         process.arguments = ["-C", repoRoot, "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=normal"]
 
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_OPTIONAL_LOCKS"] = "0"
+        process.environment = environment
+
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         process.standardOutput = stdoutPipe

--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -119,6 +119,11 @@ enum GitProcessRunner {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_OPTIONAL_LOCKS"] = "0"
+        process.environment = environment
+
         if let workingDirectory {
             process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
         }


### PR DESCRIPTION
<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

When trying to work with git in the command line, i was getting continuous errors with git lock file taken.

Investigating the processes i saw that the index.lock file was being created/removed when Muxy was open.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS
