### PR TITLE
Add font family and zoom controls for markdown preview

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -64,6 +64,19 @@ struct MuxyCommands: Commands {
         }
     }
 
+    private var isMarkdownPreviewActive: Bool {
+        guard let state = activeEditorState, state.isMarkdownFile else { return false }
+        return state.markdownViewMode == .preview || state.markdownViewMode == .split
+    }
+
+    private func adjustMarkdownPreviewZoom(by delta: CGFloat) {
+        let next = EditorSettings.shared.markdownPreviewFontScale + delta
+        EditorSettings.shared.markdownPreviewFontScale = min(
+            EditorSettings.maxMarkdownPreviewFontScale,
+            max(EditorSettings.minMarkdownPreviewFontScale, next)
+        )
+    }
+
     private func performCommandShortcut(_ shortcut: CommandShortcut) {
         guard isMainWindowFocused,
               let projectID = appState.activeProjectID,
@@ -277,6 +290,29 @@ struct MuxyCommands: Commands {
                 performShortcutAction(.focusPaneDown)
             }
             .shortcut(for: .focusPaneDown, store: keyBindings)
+        }
+
+        CommandGroup(after: .toolbar) {
+            Button("Zoom In Markdown Preview") {
+                guard isMainWindowFocused, isMarkdownPreviewActive else { return }
+                adjustMarkdownPreviewZoom(by: 0.1)
+            }
+            .keyboardShortcut("+", modifiers: .command)
+            .disabled(!isMarkdownPreviewActive)
+
+            Button("Zoom Out Markdown Preview") {
+                guard isMainWindowFocused, isMarkdownPreviewActive else { return }
+                adjustMarkdownPreviewZoom(by: -0.1)
+            }
+            .keyboardShortcut("-", modifiers: .command)
+            .disabled(!isMarkdownPreviewActive)
+
+            Button("Reset Markdown Preview Zoom") {
+                guard isMainWindowFocused, isMarkdownPreviewActive else { return }
+                EditorSettings.shared.markdownPreviewFontScale = EditorSettings.defaultMarkdownPreviewFontScale
+            }
+            .keyboardShortcut("0", modifiers: .command)
+            .disabled(!isMarkdownPreviewActive)
         }
 
         CommandGroup(after: .windowList) {

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -70,11 +70,7 @@ struct MuxyCommands: Commands {
     }
 
     private func adjustMarkdownPreviewZoom(by delta: CGFloat) {
-        let next = EditorSettings.shared.markdownPreviewFontScale + delta
-        EditorSettings.shared.markdownPreviewFontScale = min(
-            EditorSettings.maxMarkdownPreviewFontScale,
-            max(EditorSettings.minMarkdownPreviewFontScale, next)
-        )
+        EditorSettings.shared.adjustMarkdownPreviewFontScale(by: delta)
     }
 
     private func performCommandShortcut(_ shortcut: CommandShortcut) {
@@ -295,14 +291,14 @@ struct MuxyCommands: Commands {
         CommandGroup(after: .toolbar) {
             Button("Zoom In Markdown Preview") {
                 guard isMainWindowFocused, isMarkdownPreviewActive else { return }
-                adjustMarkdownPreviewZoom(by: 0.1)
+                adjustMarkdownPreviewZoom(by: EditorSettings.markdownPreviewZoomStep)
             }
-            .keyboardShortcut("+", modifiers: .command)
+            .keyboardShortcut("=", modifiers: .command)
             .disabled(!isMarkdownPreviewActive)
 
             Button("Zoom Out Markdown Preview") {
                 guard isMainWindowFocused, isMarkdownPreviewActive else { return }
-                adjustMarkdownPreviewZoom(by: -0.1)
+                adjustMarkdownPreviewZoom(by: -EditorSettings.markdownPreviewZoomStep)
             }
             .keyboardShortcut("-", modifiers: .command)
             .disabled(!isMarkdownPreviewActive)

--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -24,10 +24,18 @@ final class EditorSettings {
         }
     }
 
+    static let systemFontFamilyToken = "System Default"
+    static let defaultMarkdownPreviewFontFamily = systemFontFamilyToken
+    static let defaultMarkdownPreviewFontScale: CGFloat = 1.0
+    static let minMarkdownPreviewFontScale: CGFloat = 0.6
+    static let maxMarkdownPreviewFontScale: CGFloat = 2.5
+
     var fontSize: CGFloat = 13 { didSet { save() } }
     var fontFamily: String = "SF Mono" { didSet { save() } }
     var defaultEditor: DefaultEditor = .builtIn { didSet { save() } }
     var externalEditorCommand: String = "vim" { didSet { save() } }
+    var markdownPreviewFontFamily: String = EditorSettings.defaultMarkdownPreviewFontFamily { didSet { save() } }
+    var markdownPreviewFontScale: CGFloat = EditorSettings.defaultMarkdownPreviewFontScale { didSet { save() } }
 
     @ObservationIgnored private let fileURL: URL
     @ObservationIgnored private var isBatchLoading = false
@@ -37,6 +45,22 @@ final class EditorSettings {
             return font
         }
         return NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+    }
+
+    var resolvedMarkdownPreviewFontFamilyCSS: String {
+        if markdownPreviewFontFamily == Self.systemFontFamilyToken {
+            return Self.systemFontFamilyCSSStack
+        }
+        let escaped = markdownPreviewFontFamily.replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\", \(Self.systemFontFamilyCSSStack)"
+    }
+
+    static let systemFontFamilyCSSStack =
+        "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Arial, sans-serif"
+
+    static var availableMarkdownPreviewFonts: [String] {
+        let families = NSFontManager.shared.availableFontFamilies.sorted()
+        return [systemFontFamilyToken] + families
     }
 
     static var availableMonospacedFonts: [String] {
@@ -63,6 +87,8 @@ final class EditorSettings {
         fontFamily = "SF Mono"
         defaultEditor = .builtIn
         externalEditorCommand = "vim"
+        markdownPreviewFontFamily = Self.defaultMarkdownPreviewFontFamily
+        markdownPreviewFontScale = Self.defaultMarkdownPreviewFontScale
         isBatchLoading = false
         save()
     }
@@ -77,6 +103,12 @@ final class EditorSettings {
             fontFamily = snapshot.fontFamily ?? "SF Mono"
             defaultEditor = snapshot.defaultEditor ?? snapshot.quickOpenEditor ?? .builtIn
             externalEditorCommand = snapshot.externalEditorCommand ?? "vim"
+            markdownPreviewFontFamily = snapshot.markdownPreviewFontFamily ?? Self.defaultMarkdownPreviewFontFamily
+            let loadedScale = snapshot.markdownPreviewFontScale ?? Self.defaultMarkdownPreviewFontScale
+            markdownPreviewFontScale = min(
+                max(loadedScale, Self.minMarkdownPreviewFontScale),
+                Self.maxMarkdownPreviewFontScale
+            )
             isBatchLoading = false
         } catch {
             logger.error("Failed to load editor settings: \(error.localizedDescription)")
@@ -91,7 +123,9 @@ final class EditorSettings {
                 fontFamily: fontFamily,
                 defaultEditor: defaultEditor,
                 quickOpenEditor: nil,
-                externalEditorCommand: externalEditorCommand
+                externalEditorCommand: externalEditorCommand,
+                markdownPreviewFontFamily: markdownPreviewFontFamily,
+                markdownPreviewFontScale: markdownPreviewFontScale
             )
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -113,4 +147,6 @@ private struct Snapshot: Codable {
     let defaultEditor: EditorSettings.DefaultEditor?
     let quickOpenEditor: EditorSettings.DefaultEditor?
     let externalEditorCommand: String?
+    let markdownPreviewFontFamily: String?
+    let markdownPreviewFontScale: CGFloat?
 }

--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -29,6 +29,8 @@ final class EditorSettings {
     static let defaultMarkdownPreviewFontScale: CGFloat = 1.0
     static let minMarkdownPreviewFontScale: CGFloat = 0.6
     static let maxMarkdownPreviewFontScale: CGFloat = 2.5
+    static let markdownPreviewBaseFontSize: CGFloat = 14
+    static let markdownPreviewZoomStep: CGFloat = 0.1
 
     var fontSize: CGFloat = 13 { didSet { save() } }
     var fontFamily: String = "SF Mono" { didSet { save() } }
@@ -51,8 +53,18 @@ final class EditorSettings {
         if markdownPreviewFontFamily == Self.systemFontFamilyToken {
             return Self.systemFontFamilyCSSStack
         }
-        let escaped = markdownPreviewFontFamily.replacingOccurrences(of: "\"", with: "\\\"")
+        let escaped = markdownPreviewFontFamily
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
         return "\"\(escaped)\", \(Self.systemFontFamilyCSSStack)"
+    }
+
+    func adjustMarkdownPreviewFontScale(by delta: CGFloat) {
+        let next = markdownPreviewFontScale + delta
+        markdownPreviewFontScale = min(
+            Self.maxMarkdownPreviewFontScale,
+            max(Self.minMarkdownPreviewFontScale, next)
+        )
     }
 
     static let systemFontFamilyCSSStack =

--- a/Muxy/Models/MarkdownRenderer.swift
+++ b/Muxy/Models/MarkdownRenderer.swift
@@ -380,7 +380,7 @@ enum MarkdownRenderer {
         let fontFamilyCSS = palette.fontFamilyCSS
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "'", with: "\\'")
-        let fontSizePixels = max(6, 14 * palette.fontScale)
+        let fontSizePixels = max(6, EditorSettings.markdownPreviewBaseFontSize * palette.fontScale)
         let isDarkPreview = isDarkColor(palette.background)
         let mermaidBaseTheme = isDarkPreview ? "dark" : "default"
         let colorScheme = isDarkPreview ? "dark" : "light"

--- a/Muxy/Models/MarkdownRenderer.swift
+++ b/Muxy/Models/MarkdownRenderer.swift
@@ -87,6 +87,8 @@ enum MarkdownRenderer {
         let background: NSColor
         let foreground: NSColor
         let accent: NSColor
+        let fontFamilyCSS: String
+        let fontScale: CGFloat
     }
 
     @MainActor
@@ -111,13 +113,15 @@ enum MarkdownRenderer {
                     --code-bg: #F6F8FA;
                     --blockquote-border: #D0D7DE;
                     --row-alt: #F6F8FA;
+                    --md-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+                    --md-font-size: 14px;
                 }
                 * { box-sizing: border-box; margin: 0; padding: 0; }
                 html, body {
                     background: transparent;
                     color: var(--fg);
-                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-                    font-size: 14px;
+                    font-family: var(--md-font-family);
+                    font-size: var(--md-font-size);
                     line-height: 1.6;
                     padding: 0;
                     margin: 0;
@@ -373,6 +377,10 @@ enum MarkdownRenderer {
             pie12: "#\(mermaidTertiaryHex)"
         )
         let mermaidThemeJSON = mermaidThemeVariables.jsObjectLiteral
+        let fontFamilyCSS = palette.fontFamilyCSS
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+        let fontSizePixels = max(6, 14 * palette.fontScale)
         let isDarkPreview = isDarkColor(palette.background)
         let mermaidBaseTheme = isDarkPreview ? "dark" : "default"
         let colorScheme = isDarkPreview ? "dark" : "light"
@@ -395,6 +403,8 @@ enum MarkdownRenderer {
             root.style.setProperty('--code-bg', '#\(codeBgHex)');
             root.style.setProperty('--blockquote-border', '#\(borderHex)');
             root.style.setProperty('--row-alt', '#\(rowAltHex)');
+            root.style.setProperty('--md-font-family', '\(fontFamilyCSS)');
+            root.style.setProperty('--md-font-size', '\(String(format: "%.2f", fontSizePixels))px');
             const syntaxStyle = document.getElementById('muxy-syntax-style');
             if (syntaxStyle) {
                 syntaxStyle.textContent = `\(escapedSyntaxCSS)`;

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -195,7 +195,9 @@ struct EditorPane: View {
         MarkdownRenderer.Palette(
             background: ghostty.backgroundColor,
             foreground: ghostty.foregroundColor,
-            accent: ghostty.accentColor
+            accent: ghostty.accentColor,
+            fontFamilyCSS: editorSettings.resolvedMarkdownPreviewFontFamilyCSS,
+            fontScale: editorSettings.markdownPreviewFontScale
         )
     }
 

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -60,9 +60,7 @@ struct EditorSettingsView: View {
                 SettingsRow("Zoom") {
                     HStack(spacing: 8) {
                         Button {
-                            let next = settings.markdownPreviewFontScale - 0.1
-                            guard next >= EditorSettings.minMarkdownPreviewFontScale - 0.0001 else { return }
-                            settings.markdownPreviewFontScale = max(EditorSettings.minMarkdownPreviewFontScale, next)
+                            settings.adjustMarkdownPreviewFontScale(by: -EditorSettings.markdownPreviewZoomStep)
                         } label: {
                             Image(systemName: "minus")
                                 .font(.system(size: 10, weight: .medium))
@@ -75,9 +73,7 @@ struct EditorSettingsView: View {
                             .frame(width: 44)
 
                         Button {
-                            let next = settings.markdownPreviewFontScale + 0.1
-                            guard next <= EditorSettings.maxMarkdownPreviewFontScale + 0.0001 else { return }
-                            settings.markdownPreviewFontScale = min(EditorSettings.maxMarkdownPreviewFontScale, next)
+                            settings.adjustMarkdownPreviewFontScale(by: EditorSettings.markdownPreviewZoomStep)
                         } label: {
                             Image(systemName: "plus")
                                 .font(.system(size: 10, weight: .medium))

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct EditorSettingsView: View {
     @State private var settings = EditorSettings.shared
     @State private var monoFonts: [String] = []
+    @State private var markdownFonts: [String] = []
     @State private var allowMarkdownRemoteImages = MarkdownPreviewPreferences.allowRemoteImages
 
     private var showsAppearanceSection: Bool { settings.defaultEditor == .builtIn }
@@ -39,6 +40,52 @@ struct EditorSettingsView: View {
                     .onChange(of: allowMarkdownRemoteImages) { _, newValue in
                         MarkdownPreviewPreferences.allowRemoteImages = newValue
                     }
+
+                SettingsRow("Font Family") {
+                    Picker("", selection: $settings.markdownPreviewFontFamily) {
+                        ForEach(markdownFonts, id: \.self) { family in
+                            if family == EditorSettings.systemFontFamilyToken {
+                                Text(family).tag(family)
+                            } else {
+                                Text(family)
+                                    .font(.custom(family, size: 12))
+                                    .tag(family)
+                            }
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
+                }
+
+                SettingsRow("Zoom") {
+                    HStack(spacing: 8) {
+                        Button {
+                            let next = settings.markdownPreviewFontScale - 0.1
+                            guard next >= EditorSettings.minMarkdownPreviewFontScale - 0.0001 else { return }
+                            settings.markdownPreviewFontScale = max(EditorSettings.minMarkdownPreviewFontScale, next)
+                        } label: {
+                            Image(systemName: "minus")
+                                .font(.system(size: 10, weight: .medium))
+                                .frame(width: 20, height: 20)
+                        }
+                        .buttonStyle(.borderless)
+
+                        Text("\(Int((settings.markdownPreviewFontScale * 100).rounded()))%")
+                            .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
+                            .frame(width: 44)
+
+                        Button {
+                            let next = settings.markdownPreviewFontScale + 0.1
+                            guard next <= EditorSettings.maxMarkdownPreviewFontScale + 0.0001 else { return }
+                            settings.markdownPreviewFontScale = min(EditorSettings.maxMarkdownPreviewFontScale, next)
+                        } label: {
+                            Image(systemName: "plus")
+                                .font(.system(size: 10, weight: .medium))
+                                .frame(width: 20, height: 20)
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
             }
 
             if showsAppearanceSection {
@@ -101,6 +148,7 @@ struct EditorSettingsView: View {
         }
         .task {
             monoFonts = EditorSettings.availableMonospacedFonts
+            markdownFonts = EditorSettings.availableMarkdownPreviewFonts
         }
     }
 }

--- a/Tests/MuxyTests/Models/MermaidCodeBlockNormalizerTests.swift
+++ b/Tests/MuxyTests/Models/MermaidCodeBlockNormalizerTests.swift
@@ -90,7 +90,9 @@ struct MermaidCodeBlockNormalizerTests {
             palette: MarkdownRenderer.Palette(
                 background: NSColor.black,
                 foreground: NSColor.white,
-                accent: NSColor.systemBlue
+                accent: NSColor.systemBlue,
+                fontFamilyCSS: EditorSettings.systemFontFamilyCSSStack,
+                fontScale: 1.0
             )
         )
 


### PR DESCRIPTION
Adds Font Family picker and Zoom stepper under Settings → Editor → Markdown Preview, applied live via CSS variables
   in the preview WebView. Choices persist in editor-settings.json and reset with "Reset to Defaults".