### PR TITLE
Refresh git history on pull, push, and manual refresh

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -304,7 +304,7 @@ final class VCSTabState {
             }
         }
 
-        if !historyCollapsed, commits.isEmpty {
+        if !historyCollapsed, !incremental || commits.isEmpty {
             loadCommits()
         }
 


### PR DESCRIPTION
Pull/Push/Refresh now reload the commit history. Previously performRefresh only loaded
  commits when the list was empty, so the history pane went stale after pushing or pulling.