### PR TITLE
Refactor: adopt CodableFileStore in stores and extract FilePermissions

### DIFF
--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -39,7 +39,7 @@ final class EditorSettings {
     var markdownPreviewFontFamily: String = EditorSettings.defaultMarkdownPreviewFontFamily { didSet { save() } }
     var markdownPreviewFontScale: CGFloat = EditorSettings.defaultMarkdownPreviewFontScale { didSet { save() } }
 
-    @ObservationIgnored private let fileURL: URL
+    @ObservationIgnored private let store: CodableFileStore<Snapshot>
     @ObservationIgnored private var isBatchLoading = false
 
     var resolvedFont: NSFont {
@@ -89,7 +89,14 @@ final class EditorSettings {
     }
 
     private init() {
-        fileURL = MuxyFileStorage.fileURL(filename: "editor-settings.json")
+        store = CodableFileStore(
+            fileURL: MuxyFileStorage.fileURL(filename: "editor-settings.json"),
+            options: CodableFileStoreOptions(
+                prettyPrinted: true,
+                sortedKeys: true,
+                filePermissions: FilePermissions.privateFile
+            )
+        )
         load()
     }
 
@@ -106,10 +113,8 @@ final class EditorSettings {
     }
 
     private func load() {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
         do {
-            let data = try Data(contentsOf: fileURL)
-            let snapshot = try JSONDecoder().decode(Snapshot.self, from: data)
+            guard let snapshot = try store.load() else { return }
             isBatchLoading = true
             fontSize = snapshot.fontSize ?? 13
             fontFamily = snapshot.fontFamily ?? "SF Mono"
@@ -130,7 +135,7 @@ final class EditorSettings {
     private func save() {
         guard !isBatchLoading else { return }
         do {
-            let snapshot = Snapshot(
+            try store.save(Snapshot(
                 fontSize: fontSize,
                 fontFamily: fontFamily,
                 defaultEditor: defaultEditor,
@@ -138,15 +143,7 @@ final class EditorSettings {
                 externalEditorCommand: externalEditorCommand,
                 markdownPreviewFontFamily: markdownPreviewFontFamily,
                 markdownPreviewFontScale: markdownPreviewFontScale
-            )
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            let data = try encoder.encode(snapshot)
-            try data.write(to: fileURL, options: .atomic)
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o600],
-                ofItemAtPath: fileURL.path
-            )
+            ))
         } catch {
             logger.error("Failed to save editor settings: \(error.localizedDescription)")
         }

--- a/Muxy/Services/ApprovedDevicesStore.swift
+++ b/Muxy/Services/ApprovedDevicesStore.swift
@@ -17,14 +17,21 @@ struct ApprovedDevice: Codable, Identifiable, Equatable {
 final class ApprovedDevicesStore {
     static let shared = ApprovedDevicesStore()
 
-    private static let fileURL = MuxyFileStorage.fileURL(filename: "approved-devices.json")
+    private static let store = CodableFileStore<[ApprovedDevice]>(
+        fileURL: MuxyFileStorage.fileURL(filename: "approved-devices.json"),
+        options: CodableFileStoreOptions(filePermissions: FilePermissions.privateFile)
+    )
 
     private(set) var devices: [ApprovedDevice] = []
 
     var onRevoke: ((UUID) -> Void)?
 
     private init() {
-        load()
+        do {
+            devices = try Self.store.load() ?? []
+        } catch {
+            logger.error("Failed to load approved devices: \(error)")
+        }
     }
 
     func approve(deviceID: UUID, name: String, token: String) {
@@ -93,24 +100,9 @@ final class ApprovedDevicesStore {
 
     private func save() {
         do {
-            let data = try JSONEncoder().encode(devices)
-            try data.write(to: Self.fileURL, options: .atomic)
-            try? FileManager.default.setAttributes(
-                [.posixPermissions: 0o600],
-                ofItemAtPath: Self.fileURL.path
-            )
+            try Self.store.save(devices)
         } catch {
             logger.error("Failed to save approved devices: \(error)")
-        }
-    }
-
-    private func load() {
-        guard FileManager.default.fileExists(atPath: Self.fileURL.path) else { return }
-        do {
-            let data = try Data(contentsOf: Self.fileURL)
-            devices = try JSONDecoder().decode([ApprovedDevice].self, from: data)
-        } catch {
-            logger.error("Failed to load approved devices: \(error)")
         }
     }
 }

--- a/Muxy/Services/CLIAccessor.swift
+++ b/Muxy/Services/CLIAccessor.swift
@@ -93,7 +93,7 @@ enum CLIAccessor {
         do {
             try FileManager.default.copyItem(at: resourceURL, to: target)
             try FileManager.default.setAttributes(
-                [.posixPermissions: 0o755],
+                [.posixPermissions: FilePermissions.executable],
                 ofItemAtPath: target.path
             )
             return true

--- a/Muxy/Services/CommandShortcutStore.swift
+++ b/Muxy/Services/CommandShortcutStore.swift
@@ -17,7 +17,7 @@ final class FileCommandShortcutPersistence: CommandShortcutPersisting {
             options: CodableFileStoreOptions(
                 prettyPrinted: true,
                 sortedKeys: true,
-                filePermissions: 0o600
+                filePermissions: FilePermissions.privateFile
             )
         )
     }

--- a/Muxy/Services/FilePermissions.swift
+++ b/Muxy/Services/FilePermissions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum FilePermissions {
+    static let privateFile = 0o600
+    static let privateDirectory = 0o700
+    static let executable = 0o755
+}

--- a/Muxy/Services/JSONFilePersistence.swift
+++ b/Muxy/Services/JSONFilePersistence.swift
@@ -18,7 +18,7 @@ enum MuxyFileStorage {
         try? FileManager.default.createDirectory(
             at: dir,
             withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
         )
         return dir
     }
@@ -30,7 +30,7 @@ enum MuxyFileStorage {
         try? FileManager.default.createDirectory(
             at: dir,
             withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
         )
         return dir
     }

--- a/Muxy/Services/KeyBindingPersistence.swift
+++ b/Muxy/Services/KeyBindingPersistence.swift
@@ -16,7 +16,7 @@ final class FileKeyBindingPersistence: KeyBindingPersisting {
             options: CodableFileStoreOptions(
                 prettyPrinted: true,
                 sortedKeys: true,
-                filePermissions: 0o600
+                filePermissions: FilePermissions.privateFile
             )
         )
     }

--- a/Muxy/Services/MuxyConfig.swift
+++ b/Muxy/Services/MuxyConfig.swift
@@ -77,6 +77,9 @@ final class MuxyConfig {
     }
 
     private static func restrictFilePermissions(_ url: URL) {
-        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.privateFile],
+            ofItemAtPath: url.path
+        )
     }
 }

--- a/Muxy/Services/MuxyNotificationHooks.swift
+++ b/Muxy/Services/MuxyNotificationHooks.swift
@@ -42,7 +42,10 @@ enum MuxyNotificationHooks {
 
         if !FileManager.default.isExecutableFile(atPath: path) {
             do {
-                try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: FilePermissions.executable],
+                    ofItemAtPath: path
+                )
             } catch {
                 logger.error("Failed to set executable permission on \(path): \(error.localizedDescription)")
                 return nil

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -60,7 +60,7 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
 
-        chmod(path, 0o600)
+        chmod(path, mode_t(FilePermissions.privateFile))
 
         guard listen(serverFD, 5) == 0 else {
             logger.error("Failed to listen on socket: \(String(cString: strerror(errno)))")

--- a/Muxy/Services/NotificationStore.swift
+++ b/Muxy/Services/NotificationStore.swift
@@ -17,7 +17,9 @@ final class NotificationStore {
 
     private static let maxNotifications = 200
     private static let defaults = UserDefaults.standard
-    private static let fileURL = MuxyFileStorage.fileURL(filename: "notifications.json")
+    private static let store = CodableFileStore<[MuxyNotification]>(
+        fileURL: MuxyFileStorage.fileURL(filename: "notifications.json")
+    )
     private var saveTask: Task<Void, Never>?
 
     private init() {
@@ -205,18 +207,15 @@ final class NotificationStore {
 
     func saveToDisk() {
         do {
-            let data = try JSONEncoder().encode(notifications)
-            try data.write(to: Self.fileURL, options: .atomic)
+            try Self.store.save(notifications)
         } catch {
             logger.error("Failed to save notifications: \(error.localizedDescription)")
         }
     }
 
     private static func loadFromDisk() -> [MuxyNotification] {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
         do {
-            let data = try Data(contentsOf: fileURL)
-            let loaded = try JSONDecoder().decode([MuxyNotification].self, from: data)
+            let loaded = try store.load() ?? []
             return Array(loaded.prefix(maxNotifications))
         } catch {
             logger.error("Failed to load notifications: \(error.localizedDescription)")

--- a/Muxy/Services/ProjectLogoStorage.swift
+++ b/Muxy/Services/ProjectLogoStorage.swift
@@ -11,7 +11,7 @@ enum ProjectLogoStorage {
         try? FileManager.default.createDirectory(
             at: dir,
             withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
         )
         return dir
     }

--- a/Muxy/Services/Providers/ClaudeCodeProvider.swift
+++ b/Muxy/Services/Providers/ClaudeCodeProvider.swift
@@ -137,7 +137,10 @@ struct ClaudeCodeProvider: AIProviderIntegration, AIUsageProvider {
 
         let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: fileURL, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: settingsPath)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.privateFile],
+            ofItemAtPath: settingsPath
+        )
     }
 
     private static let credentialsKeychainService = "Claude Code-credentials"

--- a/Muxy/Services/WorktreePersistence.swift
+++ b/Muxy/Services/WorktreePersistence.swift
@@ -14,7 +14,7 @@ final class FileWorktreePersistence: WorktreePersisting {
         try? FileManager.default.createDirectory(
             at: directory,
             withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
         )
     }
 

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -291,8 +291,6 @@ struct CodeEditorView: NSViewRepresentable {
         }
     }
 
-    // MARK: - updateNSView
-
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
         let coordinator = context.coordinator
@@ -308,8 +306,6 @@ struct CodeEditorView: NSViewRepresentable {
 
         updateNSViewViewportMode(scrollView: scrollView, textView: textView, coordinator: coordinator)
     }
-
-    // MARK: - Viewport Mode
 
     private func updateNSViewViewportMode(scrollView: NSScrollView, textView: NSTextView, coordinator: Coordinator) {
         guard let viewport = coordinator.viewportState else { return }
@@ -375,8 +371,6 @@ struct CodeEditorView: NSViewRepresentable {
             coordinator.focusEditorPreservingSelection()
         }
     }
-
-    // MARK: - Shared helpers
 
     private func applyThemeAndFont(textView: NSTextView, font: NSFont) {
         let fgColor = GhosttyService.shared.foregroundColor
@@ -453,8 +447,6 @@ struct CodeEditorView: NSViewRepresentable {
             )
         }
     }
-
-    // MARK: - Coordinator
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
@@ -583,8 +575,6 @@ struct CodeEditorView: NSViewRepresentable {
                 )
             }
         }
-
-        // MARK: - Viewport Mode Setup
 
         func enterViewportMode(scrollView: NSScrollView) {
             guard let store = state.backingStore, let textView else { return }
@@ -897,8 +887,6 @@ struct CodeEditorView: NSViewRepresentable {
             }
         }
 
-        // MARK: - Editor Focus
-
         func focusEditorPreservingSelection() {
             guard let textView else { return }
             if let viewport = viewportState, !viewportSearchMatches.isEmpty {
@@ -923,8 +911,6 @@ struct CodeEditorView: NSViewRepresentable {
                 window.makeFirstResponder(textView)
             }
         }
-
-        // MARK: - Search Highlighting
 
         func clearSearchHighlights() {
             viewportSearchMatches = []
@@ -1015,8 +1001,6 @@ struct CodeEditorView: NSViewRepresentable {
             appliedCurrentSearchMatchRange = nextCurrentRange
             textView.needsDisplay = true
         }
-
-        // MARK: - Viewport Search
 
         private var viewportSearchMatches: [TextBackingStore.SearchMatch] = []
         private var appliedSearchHighlightRanges: [NSRange] = []
@@ -1227,8 +1211,6 @@ struct CodeEditorView: NSViewRepresentable {
             )
         }
 
-        // MARK: - Scroll Observer
-
         func setScrollObserver(for scrollView: NSScrollView) {
             guard observedContentView !== scrollView.contentView else { return }
             removeScrollObserver()
@@ -1415,8 +1397,6 @@ struct CodeEditorView: NSViewRepresentable {
             let scrollY = min(max(0, scrollView.contentView.bounds.origin.y), maxScrollY)
             return maxScrollY > 0 ? scrollY / maxScrollY : 0
         }
-
-        // MARK: - NSTextViewDelegate
 
         func textDidChange(_: Notification) {
             guard let textView, !isUpdating else { return }
@@ -1942,8 +1922,6 @@ struct CodeEditorView: NSViewRepresentable {
             }
             state.currentSelection = selected
         }
-
-        // MARK: - Line Start Offsets
 
         private func isValidEditRange(_ range: NSRange, textLength: Int) -> Bool {
             guard range.location != NSNotFound else { return false }


### PR DESCRIPTION
  - Remove 11 // MARK: comments from CodeEditorRepresentable per the no-comments rule.
  - Introduce FilePermissions enum to replace 0o600/0o700/0o755 magic numbers across 13
  sites.
  - Migrate ApprovedDevicesStore, NotificationStore, and EditorSettings onto the existing
  CodableFileStore to drop duplicated JSON encode/decode + chmod boilerplate.