### PR TITLE
Refactor editor into composable extensions; add live markdown styling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,5 @@
 # Muxy
 
-
-## Build & Run
-
-```bash
-scripts/setup.sh         # First-time setup (downloads GhosttyKit.xcframework)
-swift build              # Debug build
-swift build -c release   # Release build
-swift run Muxy            # Run the app
-```
-
 Requires macOS 14+ and Swift 6.0+. No external dependency managers needed — everything is SPM-based.
 
 ## Linting & Formatting

--- a/Muxy/Syntax/MarkdownInlineHighlighter.swift
+++ b/Muxy/Syntax/MarkdownInlineHighlighter.swift
@@ -1,0 +1,303 @@
+import AppKit
+
+struct MarkdownInlineDecoration: Equatable {
+    enum Kind: Equatable {
+        case heading(level: Int)
+        case bold
+        case italic
+        case boldItalic
+        case strikethrough
+        case codeSpan
+        case marker
+        case blockquote
+        case listMarker
+    }
+
+    let range: NSRange
+    let kind: Kind
+}
+
+enum MarkdownInlineHighlighter {
+    static func decorations(line: String, isInsideFencedCode: Bool) -> [MarkdownInlineDecoration] {
+        guard !isInsideFencedCode else { return [] }
+        let ns = line as NSString
+        let length = ns.length
+        guard length > 0 else { return [] }
+
+        var decorations: [MarkdownInlineDecoration] = []
+        let leading = leadingWhitespaceCount(ns: ns, length: length)
+        var contentStart = leading
+
+        if let blockquote = matchBlockquote(ns: ns, length: length, from: leading) {
+            decorations.append(blockquote.decoration)
+            contentStart = blockquote.contentStart
+        } else if let list = matchListMarker(ns: ns, length: length, from: leading) {
+            decorations.append(list.decoration)
+            contentStart = list.contentStart
+        }
+
+        if let heading = matchHeading(ns: ns, length: length, from: contentStart) {
+            decorations.append(contentsOf: heading)
+            return decorations
+        }
+
+        decorations.append(contentsOf: scanInline(ns: ns, length: length, from: contentStart))
+        return decorations
+    }
+
+    private static func leadingWhitespaceCount(ns: NSString, length: Int) -> Int {
+        var index = 0
+        while index < length {
+            let ch = ns.character(at: index)
+            if ch == 0x20 || ch == 0x09 { index += 1 } else { break }
+        }
+        if index > 3 { return 0 }
+        return index
+    }
+
+    private static func matchBlockquote(
+        ns: NSString,
+        length: Int,
+        from start: Int
+    ) -> (decoration: MarkdownInlineDecoration, contentStart: Int)? {
+        guard start < length, ns.character(at: start) == 0x3E else { return nil }
+        var end = start + 1
+        if end < length, ns.character(at: end) == 0x20 { end += 1 }
+        let decoration = MarkdownInlineDecoration(
+            range: NSRange(location: start, length: end - start),
+            kind: .blockquote
+        )
+        return (decoration, end)
+    }
+
+    private static func matchListMarker(
+        ns: NSString,
+        length: Int,
+        from start: Int
+    ) -> (decoration: MarkdownInlineDecoration, contentStart: Int)? {
+        guard start < length else { return nil }
+        let ch = ns.character(at: start)
+        if ch == 0x2D || ch == 0x2A || ch == 0x2B {
+            let next = start + 1
+            guard next < length, ns.character(at: next) == 0x20 else { return nil }
+            return (
+                MarkdownInlineDecoration(range: NSRange(location: start, length: 1), kind: .listMarker),
+                next + 1
+            )
+        }
+        if ch >= 0x30, ch <= 0x39 {
+            var index = start
+            while index < length {
+                let c = ns.character(at: index)
+                if c >= 0x30, c <= 0x39 { index += 1 } else { break }
+            }
+            guard index < length else { return nil }
+            let punct = ns.character(at: index)
+            guard punct == 0x2E || punct == 0x29 else { return nil }
+            let after = index + 1
+            guard after < length, ns.character(at: after) == 0x20 else { return nil }
+            return (
+                MarkdownInlineDecoration(
+                    range: NSRange(location: start, length: after - start),
+                    kind: .listMarker
+                ),
+                after + 1
+            )
+        }
+        return nil
+    }
+
+    private static func matchHeading(
+        ns: NSString,
+        length: Int,
+        from start: Int
+    ) -> [MarkdownInlineDecoration]? {
+        guard start < length, ns.character(at: start) == 0x23 else { return nil }
+        var hashEnd = start
+        while hashEnd < length, ns.character(at: hashEnd) == 0x23 {
+            hashEnd += 1
+        }
+        let level = hashEnd - start
+        guard level >= 1, level <= 6 else { return nil }
+        guard hashEnd == length || ns.character(at: hashEnd) == 0x20 else { return nil }
+        let headingRange = NSRange(location: start, length: length - start)
+        let markerRange = NSRange(location: start, length: level)
+        return [
+            MarkdownInlineDecoration(range: headingRange, kind: .heading(level: level)),
+            MarkdownInlineDecoration(range: markerRange, kind: .marker),
+        ]
+    }
+
+    private static func scanInline(ns: NSString, length: Int, from start: Int) -> [MarkdownInlineDecoration] {
+        var decorations: [MarkdownInlineDecoration] = []
+        var index = start
+        while index < length {
+            let ch = ns.character(at: index)
+            if ch == 0x60 {
+                if let endIndex = findClosing(ns: ns, length: length, from: index + 1, char: 0x60) {
+                    decorations.append(MarkdownInlineDecoration(
+                        range: NSRange(location: index, length: endIndex - index + 1),
+                        kind: .codeSpan
+                    ))
+                    index = endIndex + 1
+                    continue
+                }
+            } else if ch == 0x2A || ch == 0x5F {
+                if let match = matchEmphasis(ns: ns, length: length, from: index, marker: ch) {
+                    decorations.append(match.decoration)
+                    index = match.endIndex
+                    continue
+                }
+            } else if ch == 0x7E {
+                if let match = matchStrikethrough(ns: ns, length: length, from: index) {
+                    decorations.append(match.decoration)
+                    index = match.endIndex
+                    continue
+                }
+            }
+            index += 1
+        }
+        return decorations
+    }
+
+    private static func findClosing(ns: NSString, length: Int, from start: Int, char: unichar) -> Int? {
+        var index = start
+        while index < length {
+            if ns.character(at: index) == char { return index }
+            index += 1
+        }
+        return nil
+    }
+
+    private static func matchEmphasis(
+        ns: NSString,
+        length: Int,
+        from start: Int,
+        marker: unichar
+    ) -> (decoration: MarkdownInlineDecoration, endIndex: Int)? {
+        var openCount = 0
+        var cursor = start
+        while cursor < length, ns.character(at: cursor) == marker, openCount < 3 {
+            openCount += 1
+            cursor += 1
+        }
+        guard openCount >= 1, cursor < length else { return nil }
+        let firstContent = ns.character(at: cursor)
+        if firstContent == 0x20 || firstContent == 0x09 { return nil }
+
+        var search = cursor
+        while search < length {
+            if ns.character(at: search) == marker {
+                var closeCount = 0
+                var probe = search
+                while probe < length, ns.character(at: probe) == marker, closeCount < openCount {
+                    closeCount += 1
+                    probe += 1
+                }
+                if closeCount == openCount, search > cursor {
+                    let prev = ns.character(at: search - 1)
+                    if prev != 0x20, prev != 0x09 {
+                        let kind: MarkdownInlineDecoration.Kind = switch openCount {
+                        case 1: .italic
+                        case 2: .bold
+                        default: .boldItalic
+                        }
+                        let totalLength = (probe - start)
+                        return (
+                            MarkdownInlineDecoration(
+                                range: NSRange(location: start, length: totalLength),
+                                kind: kind
+                            ),
+                            probe
+                        )
+                    }
+                }
+                search = probe
+            } else {
+                search += 1
+            }
+        }
+        return nil
+    }
+
+    private static func matchStrikethrough(
+        ns: NSString,
+        length: Int,
+        from start: Int
+    ) -> (decoration: MarkdownInlineDecoration, endIndex: Int)? {
+        guard start + 1 < length, ns.character(at: start + 1) == 0x7E else { return nil }
+        var index = start + 2
+        while index + 1 < length {
+            if ns.character(at: index) == 0x7E, ns.character(at: index + 1) == 0x7E {
+                let end = index + 2
+                return (
+                    MarkdownInlineDecoration(
+                        range: NSRange(location: start, length: end - start),
+                        kind: .strikethrough
+                    ),
+                    end
+                )
+            }
+            index += 1
+        }
+        return nil
+    }
+}
+
+@MainActor
+enum MarkdownInlineStyle {
+    static let headingScales: [CGFloat] = [1.6, 1.45, 1.3, 1.18, 1.08, 1.0]
+
+    static func headingFontSize(baseSize: CGFloat, level: Int) -> CGFloat {
+        let clamped = max(1, min(level, headingScales.count))
+        return baseSize * headingScales[clamped - 1]
+    }
+
+    static func font(for kind: MarkdownInlineDecoration.Kind, baseFont: NSFont) -> NSFont? {
+        switch kind {
+        case let .heading(level):
+            let size = headingFontSize(baseSize: baseFont.pointSize, level: level)
+            let descriptor = baseFont.fontDescriptor.withSymbolicTraits(.bold)
+            return NSFont(descriptor: descriptor, size: size) ?? baseFont
+        case .bold:
+            return applyTraits(.bold, to: baseFont)
+        case .italic:
+            return applyTraits(.italic, to: baseFont)
+        case .boldItalic:
+            return applyTraits([.bold, .italic], to: baseFont)
+        case .strikethrough,
+             .codeSpan,
+             .marker,
+             .blockquote,
+             .listMarker:
+            return nil
+        }
+    }
+
+    static func foregroundColor(for kind: MarkdownInlineDecoration.Kind) -> NSColor? {
+        switch kind {
+        case .heading:
+            SyntaxTheme.color(for: .heading)
+        case .codeSpan:
+            SyntaxTheme.color(for: .string)
+        case .marker,
+             .blockquote,
+             .listMarker:
+            SyntaxTheme.defaultForeground.withAlphaComponent(0.5)
+        case .bold,
+             .italic,
+             .boldItalic,
+             .strikethrough:
+            nil
+        }
+    }
+
+    static func strikethroughStyle(for kind: MarkdownInlineDecoration.Kind) -> NSUnderlineStyle? {
+        kind == .strikethrough ? .single : nil
+    }
+
+    private static func applyTraits(_ traits: NSFontDescriptor.SymbolicTraits, to font: NSFont) -> NSFont {
+        let descriptor = font.fontDescriptor.withSymbolicTraits(traits)
+        return NSFont(descriptor: descriptor, size: font.pointSize) ?? font
+    }
+}

--- a/Muxy/Syntax/SyntaxHighlighter.swift
+++ b/Muxy/Syntax/SyntaxHighlighter.swift
@@ -44,6 +44,11 @@ final class SyntaxHighlighter {
         return cache[line].tokens
     }
 
+    func lineStartState(at line: Int) -> LineEndState {
+        guard line > 0, line - 1 < cache.count else { return .normal }
+        return cache[line - 1].endState
+    }
+
     func applyEdit(
         startLine: Int,
         oldLineCount: Int,

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -506,10 +506,11 @@ struct CodeEditorView: NSViewRepresentable {
             self.state = state
             self.editorSettings = editorSettings
             super.init()
-            extensions = [
-                SyntaxHighlightExtension(coordinator: self),
-                MarkdownInlineExtension(),
-            ]
+            var loaded: [EditorExtension] = [SyntaxHighlightExtension(coordinator: self)]
+            if state.isMarkdownFile {
+                loaded.append(MarkdownInlineExtension())
+            }
+            extensions = loaded
         }
 
         private func makeRenderContext() -> EditorRenderContext? {

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -449,31 +449,7 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     @MainActor
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        private struct ViewportCursor {
-            let line: Int
-            let column: Int
-        }
-
-        private struct PendingViewportEdit {
-            let startLine: Int
-            let oldLines: [String]
-            let newLines: [String]
-            let selectionBefore: ViewportCursor
-        }
-
-        private struct ViewportEdit {
-            let startLine: Int
-            let oldLines: [String]
-            let newLines: [String]
-            let selectionBefore: ViewportCursor
-            let selectionAfter: ViewportCursor
-        }
-
-        private struct ViewportEditGroup {
-            var edits: [ViewportEdit]
-        }
-
+    final class Coordinator: NSObject, NSTextViewDelegate, SyntaxHighlightCoordinator, SearchControllerHost, ViewportEditHistoryHost {
         let state: EditorTabState
         let editorSettings: EditorSettings
         weak var textView: NSTextView?
@@ -499,8 +475,6 @@ struct CodeEditorView: NSViewRepresentable {
         private static let initialViewportLineLimit = 1100
         private(set) var lineStartOffsets: [Int] = [0]
         private weak var observedContentView: NSClipView?
-        private static let viewportUndoLimit = 200
-        private static let viewportUndoCoalesceInterval: CFTimeInterval = 1.0
         private static let undoCommandSelector = #selector(CodeEditorTextView.undo(_:))
         private static let redoCommandSelector = #selector(CodeEditorTextView.redo(_:))
         private static let previewRefreshDebounceNanos: UInt64 = 500_000_000
@@ -513,27 +487,48 @@ struct CodeEditorView: NSViewRepresentable {
             return UserDefaults.standard.bool(forKey: "MuxyEditorPerf")
         }()
 
-        private var pendingViewportEdit: PendingViewportEdit?
-        private var viewportUndoStack: [ViewportEditGroup] = []
-        private var viewportRedoStack: [ViewportEditGroup] = []
-        private var lastViewportEditTimestamp: CFTimeInterval?
-        private var isApplyingViewportHistory = false
+        private lazy var history = ViewportEditHistory(host: self)
         private var needsViewportTextReload = true
         private var lastRenderedViewportRange: Range<Int>?
         private var lastRenderedBackingStoreVersion = -1
         private var lastObservedClipSize: CGSize = .zero
-        private var isApplyingMarkdownScroll = false
+        private lazy var markdownScrollSync = MarkdownScrollSyncController(state: state)
         private var refreshTimingCount = 0
         private var highlightTimingCount = 0
         private var lastRefreshDurationMs: Double = 0
         private var lastHighlightDurationMs: Double = 0
         private var previewRefreshTask: Task<Void, Never>?
         private var pendingCascadeReapplyGeneration: UInt64 = 0
+        private var extensions: [EditorExtension] = []
+        private lazy var searchController = SearchController(host: self)
 
         init(state: EditorTabState, editorSettings: EditorSettings) {
             self.state = state
             self.editorSettings = editorSettings
             super.init()
+            extensions = [
+                SyntaxHighlightExtension(coordinator: self),
+                MarkdownInlineExtension(),
+            ]
+        }
+
+        private func makeRenderContext() -> EditorRenderContext? {
+            guard let textView,
+                  let storage = textView.textStorage,
+                  let layoutManager = textView.layoutManager,
+                  let viewport = viewportState,
+                  let backingStore = state.backingStore
+            else { return nil }
+            return EditorRenderContext(
+                textView: textView,
+                storage: storage,
+                layoutManager: layoutManager,
+                viewport: viewport,
+                backingStore: backingStore,
+                lineStartOffsets: lineStartOffsets,
+                editorSettings: editorSettings,
+                state: state
+            )
         }
 
         deinit {
@@ -541,7 +536,7 @@ struct CodeEditorView: NSViewRepresentable {
             NotificationCenter.default.removeObserver(self)
         }
 
-        private func beginPerfTiming() -> CFTimeInterval? {
+        func beginPerfTiming() -> CFTimeInterval? {
             guard Self.perfEnabled else { return nil }
             return CACurrentMediaTime()
         }
@@ -563,7 +558,7 @@ struct CodeEditorView: NSViewRepresentable {
             }
         }
 
-        private func recordHighlightTiming(start: CFTimeInterval?, highlightedRangeCount: Int, force: Bool) {
+        func recordHighlightTiming(start: CFTimeInterval?, highlightedRangeCount: Int, force: Bool) {
             guard let start else { return }
             let durationMs = (CACurrentMediaTime() - start) * 1000
             let deltaMs = durationMs - lastHighlightDurationMs
@@ -708,35 +703,11 @@ struct CodeEditorView: NSViewRepresentable {
             applySearchHighlights()
         }
 
-        func applySyntaxHighlights(storage: NSTextStorage, viewport: ViewportState) {
-            guard let highlighter = state.syntaxHighlighter,
-                  let backingStore = state.backingStore,
-                  let textView,
-                  let layoutManager = textView.layoutManager
-            else { return }
-            let storageLength = storage.length
-            guard storageLength > 0 else { return }
-            let range = viewport.viewportStartLine ..< viewport.viewportEndLine
-            guard !range.isEmpty else { return }
-
-            let spans = highlighter.spans(
-                in: range,
-                lineStartOffsets: lineStartOffsets,
-                backingStore: backingStore
-            )
-
-            let fullRange = NSRange(location: 0, length: storageLength)
-            layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: fullRange)
-            for span in spans {
-                let availableLength = storageLength - span.range.location
-                guard span.range.location >= 0, availableLength > 0 else { continue }
-                let clampedLength = min(span.range.length, availableLength)
-                guard clampedLength > 0 else { continue }
-                layoutManager.addTemporaryAttribute(
-                    .foregroundColor,
-                    value: SyntaxTheme.color(for: span.scope),
-                    forCharacterRange: NSRange(location: span.range.location, length: clampedLength)
-                )
+        func applySyntaxHighlights(storage _: NSTextStorage, viewport: ViewportState) {
+            guard let context = makeRenderContext() else { return }
+            let lineRange = viewport.viewportStartLine ..< viewport.viewportEndLine
+            for ext in extensions {
+                ext.renderViewport(context: context, lineRange: lineRange)
             }
         }
 
@@ -745,7 +716,7 @@ struct CodeEditorView: NSViewRepresentable {
         }
 
         func reapplySyntaxHighlights() {
-            guard let textView, let storage = textView.textStorage, let viewport = viewportState else { return }
+            guard let viewport = viewportState, let storage = textView?.textStorage else { return }
             applySyntaxHighlights(storage: storage, viewport: viewport)
         }
 
@@ -754,78 +725,24 @@ struct CodeEditorView: NSViewRepresentable {
             oldLineCount: Int,
             newLineCount: Int
         ) {
-            guard let highlighter = state.syntaxHighlighter,
-                  let backingStore = state.backingStore,
-                  let viewport = viewportState,
-                  let textView,
-                  let storage = textView.textStorage
-            else { return }
-
-            let outcome = highlighter.applyEdit(
+            guard let context = makeRenderContext() else { return }
+            let lineRange = startLine ..< startLine + newLineCount
+            let edit = EditorTextEdit(
                 startLine: startLine,
                 oldLineCount: oldLineCount,
-                newLineCount: newLineCount,
-                backingStore: backingStore
+                newLineCount: newLineCount
             )
-
-            applySyntaxAttributes(
-                storage: storage,
-                viewport: viewport,
-                highlighter: highlighter,
-                lineRange: startLine ..< startLine + newLineCount
-            )
-
-            if case .cascade = outcome {
-                scheduleCascadeReapply()
+            for ext in extensions {
+                ext.applyIncremental(context: context, lineRange: lineRange, edit: edit)
             }
         }
 
-        private func scheduleCascadeReapply() {
+        func scheduleSyntaxCascadeReapply() {
             pendingCascadeReapplyGeneration &+= 1
             let generation = pendingCascadeReapplyGeneration
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(16)) { [weak self] in
                 guard let self, self.pendingCascadeReapplyGeneration == generation else { return }
                 self.reapplySyntaxHighlights()
-            }
-        }
-
-        private func applySyntaxAttributes(
-            storage: NSTextStorage,
-            viewport: ViewportState,
-            highlighter: SyntaxHighlighter,
-            lineRange: Range<Int>
-        ) {
-            guard let textView, let layoutManager = textView.layoutManager else { return }
-            let storageLength = storage.length
-            guard storageLength > 0 else { return }
-
-            let viewportStart = viewport.viewportStartLine
-            let localStart = max(0, lineRange.lowerBound - viewportStart)
-            let localEndRaw = lineRange.upperBound - viewportStart
-            let localEnd = min(localEndRaw, viewport.viewportLineCount)
-            guard localStart < localEnd, localStart < lineStartOffsets.count else { return }
-
-            let charStart = lineStartOffsets[localStart]
-            let charEnd: Int = localEnd < lineStartOffsets.count ? lineStartOffsets[localEnd] : storageLength
-            guard charEnd > charStart, charStart >= 0, charEnd <= storageLength else { return }
-
-            layoutManager.removeTemporaryAttribute(
-                .foregroundColor,
-                forCharacterRange: NSRange(location: charStart, length: charEnd - charStart)
-            )
-            for localIndex in localStart ..< localEnd {
-                let globalLine = viewportStart + localIndex
-                guard let tokens = highlighter.tokens(forLine: globalLine) else { continue }
-                let lineOffset = lineStartOffsets[localIndex]
-                for token in tokens {
-                    let location = lineOffset + token.location
-                    guard location >= 0, location + token.length <= storageLength else { continue }
-                    layoutManager.addTemporaryAttribute(
-                        .foregroundColor,
-                        value: SyntaxTheme.color(for: token.scope),
-                        forCharacterRange: NSRange(location: location, length: token.length)
-                    )
-                }
             }
         }
 
@@ -889,10 +806,11 @@ struct CodeEditorView: NSViewRepresentable {
 
         func focusEditorPreservingSelection() {
             guard let textView else { return }
-            if let viewport = viewportState, !viewportSearchMatches.isEmpty {
+            let matches = searchController.matches
+            if let viewport = viewportState, !matches.isEmpty {
                 let currentIndex = max(0, state.searchCurrentIndex - 1)
-                if currentIndex < viewportSearchMatches.count {
-                    let match = viewportSearchMatches[currentIndex]
+                if currentIndex < matches.count {
+                    let match = matches[currentIndex]
                     if let localLine = viewport.viewportLine(forBackingStoreLine: match.lineIndex) {
                         let localCharOffset = charOffsetForLocalLine(localLine)
                         let selectRange = NSRange(
@@ -913,229 +831,30 @@ struct CodeEditorView: NSViewRepresentable {
         }
 
         func clearSearchHighlights() {
-            viewportSearchMatches = []
-            state.searchMatchCount = 0
-            state.searchCurrentIndex = 0
-            applySearchHighlights()
+            searchController.clearHighlights()
         }
 
         func applySearchHighlights(force: Bool = false) {
-            let perfStart = beginPerfTiming()
-            var highlightedRangeCount = 0
-            defer {
-                recordHighlightTiming(start: perfStart, highlightedRangeCount: highlightedRangeCount, force: force)
-            }
-
-            guard let textView, let layoutManager = textView.layoutManager else { return }
-            let storageLength = textView.textStorage?.length ?? 0
-            guard storageLength > 0 else {
-                appliedSearchHighlightRanges.removeAll(keepingCapacity: true)
-                appliedCurrentSearchMatchRange = nil
-                return
-            }
-
-            guard let viewport = viewportState, !viewportSearchMatches.isEmpty else {
-                guard !appliedSearchHighlightRanges.isEmpty || appliedCurrentSearchMatchRange != nil else { return }
-                clearAppliedSearchHighlights(layoutManager: layoutManager, storageLength: storageLength)
-                textView.needsDisplay = true
-                return
-            }
-
-            var nextRanges: [NSRange] = []
-            nextRanges.reserveCapacity(min(viewportSearchMatches.count, 256))
-
-            let currentIndex = max(0, state.searchCurrentIndex - 1)
-            var nextCurrentRange: NSRange?
-            let visibleStartLine = viewport.viewportStartLine
-            let visibleEndLine = viewport.viewportEndLine
-
-            for (i, match) in viewportSearchMatches.enumerated() {
-                if match.lineIndex < visibleStartLine {
-                    continue
-                }
-                if match.lineIndex >= visibleEndLine {
-                    break
-                }
-                guard let localLine = viewport.viewportLine(forBackingStoreLine: match.lineIndex) else { continue }
-                let localCharOffset = charOffsetForLocalLine(localLine)
-                let highlightRange = NSRange(
-                    location: localCharOffset + match.range.location,
-                    length: match.range.length
-                )
-                guard NSMaxRange(highlightRange) <= storageLength else { continue }
-                nextRanges.append(highlightRange)
-                if i == currentIndex {
-                    nextCurrentRange = highlightRange
-                }
-            }
-
-            if !force,
-               appliedSearchHighlightRanges == nextRanges,
-               appliedCurrentSearchMatchRange == nextCurrentRange
-            {
-                return
-            }
-
-            clearAppliedSearchHighlights(layoutManager: layoutManager, storageLength: storageLength)
-            guard !nextRanges.isEmpty else {
-                textView.needsDisplay = true
-                return
-            }
-
-            let matchBg = GhosttyService.shared.foregroundColor.withAlphaComponent(0.2)
-            let themeYellow = GhosttyService.shared.paletteColor(at: 3) ?? NSColor.systemYellow
-            let currentMatchBg = themeYellow.withAlphaComponent(0.85)
-            let currentMatchFg = GhosttyService.shared.backgroundColor
-
-            for highlightRange in nextRanges {
-                if highlightRange == nextCurrentRange {
-                    layoutManager.addTemporaryAttribute(.backgroundColor, value: currentMatchBg, forCharacterRange: highlightRange)
-                    layoutManager.addTemporaryAttribute(.foregroundColor, value: currentMatchFg, forCharacterRange: highlightRange)
-                } else {
-                    layoutManager.addTemporaryAttribute(.backgroundColor, value: matchBg, forCharacterRange: highlightRange)
-                }
-            }
-
-            highlightedRangeCount = nextRanges.count
-            appliedSearchHighlightRanges = nextRanges
-            appliedCurrentSearchMatchRange = nextCurrentRange
-            textView.needsDisplay = true
-        }
-
-        private var viewportSearchMatches: [TextBackingStore.SearchMatch] = []
-        private var appliedSearchHighlightRanges: [NSRange] = []
-        private var appliedCurrentSearchMatchRange: NSRange?
-
-        private func clearAppliedSearchHighlights(layoutManager: NSLayoutManager, storageLength: Int) {
-            let hadCurrentMatchOverride = appliedCurrentSearchMatchRange != nil
-            for range in appliedSearchHighlightRanges {
-                guard NSMaxRange(range) <= storageLength else { continue }
-                layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: range)
-            }
-            if let range = appliedCurrentSearchMatchRange, NSMaxRange(range) <= storageLength {
-                layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: range)
-            }
-            appliedSearchHighlightRanges.removeAll(keepingCapacity: true)
-            appliedCurrentSearchMatchRange = nil
-            if hadCurrentMatchOverride {
-                reapplySyntaxHighlights()
-            }
+            searchController.applyHighlights(force: force)
         }
 
         func performSearchViewport(_ needle: String, caseSensitive: Bool, useRegex: Bool) {
-            guard let store = state.backingStore else { return }
-            state.searchInvalidRegex = false
-            viewportSearchMatches = []
-            guard !needle.isEmpty else {
-                state.searchMatchCount = 0
-                state.searchCurrentIndex = 0
-                applySearchHighlights()
-                return
-            }
-            if useRegex {
-                if (try? NSRegularExpression(pattern: needle)) == nil {
-                    state.searchInvalidRegex = true
-                    state.searchMatchCount = 0
-                    state.searchCurrentIndex = 0
-                    applySearchHighlights()
-                    return
-                }
-            }
-            viewportSearchMatches = store.search(needle: needle, caseSensitive: caseSensitive, useRegex: useRegex)
-            state.searchMatchCount = viewportSearchMatches.count
-            if !viewportSearchMatches.isEmpty {
-                state.searchCurrentIndex = 1
-                scrollToSearchMatch(at: 0)
-            } else {
-                state.searchCurrentIndex = 0
-                applySearchHighlights()
-            }
+            searchController.performSearch(needle, caseSensitive: caseSensitive, useRegex: useRegex)
         }
 
         func navigateSearchViewport(forward: Bool) {
-            guard !viewportSearchMatches.isEmpty else { return }
-            var idx = state.searchCurrentIndex - 1
-            if forward {
-                idx = (idx + 1) % viewportSearchMatches.count
-            } else {
-                idx = (idx - 1 + viewportSearchMatches.count) % viewportSearchMatches.count
-            }
-            state.searchCurrentIndex = idx + 1
-            scrollToSearchMatch(at: idx)
+            searchController.navigate(forward: forward)
         }
 
         func replaceCurrentViewport(with replacement: String, needle: String, caseSensitive: Bool, useRegex: Bool) {
-            guard let store = state.backingStore, !needle.isEmpty, !viewportSearchMatches.isEmpty else { return }
-            clearViewportHistory()
-            let currentIndex = max(0, state.searchCurrentIndex - 1)
-            guard currentIndex < viewportSearchMatches.count else { return }
-            let match = viewportSearchMatches[currentIndex]
-            let line = store.line(at: match.lineIndex)
-            let nsLine = line as NSString
-            let newLine = nsLine.replacingCharacters(in: match.range, with: replacement)
-            _ = store.replaceLines(in: match.lineIndex ..< match.lineIndex + 1, with: [newLine])
-            state.backingStoreVersion += 1
-            lastSyncedBackingStoreVersion = state.backingStoreVersion
-            state.markModified()
-            invalidateSyntaxHighlightsFromLine(match.lineIndex)
-            invalidateRenderedViewportText()
-            scheduleMarkdownPreviewRefresh(immediate: true)
-            performSearchViewport(needle, caseSensitive: caseSensitive, useRegex: useRegex)
-            refreshViewport(force: true)
+            searchController.replaceCurrent(with: replacement, needle: needle, caseSensitive: caseSensitive, useRegex: useRegex)
         }
 
         func replaceAllViewport(with replacement: String, needle: String, caseSensitive: Bool, useRegex: Bool) {
-            guard let store = state.backingStore, !needle.isEmpty, !viewportSearchMatches.isEmpty else { return }
-            clearViewportHistory()
-            var grouped: [Int: [NSRange]] = [:]
-            for match in viewportSearchMatches {
-                grouped[match.lineIndex, default: []].append(match.range)
-            }
-            var earliestInvalidation = Int.max
-            for lineIndex in grouped.keys.sorted().reversed() {
-                guard let lineRanges = grouped[lineIndex] else { continue }
-                let ranges = lineRanges.sorted { $0.location > $1.location }
-                var nsLine = store.line(at: lineIndex) as NSString
-                for range in ranges {
-                    nsLine = nsLine.replacingCharacters(in: range, with: replacement) as NSString
-                }
-                _ = store.replaceLines(in: lineIndex ..< lineIndex + 1, with: [nsLine as String])
-                earliestInvalidation = min(earliestInvalidation, lineIndex)
-            }
-            if earliestInvalidation != Int.max {
-                invalidateSyntaxHighlightsFromLine(earliestInvalidation)
-            }
-            state.backingStoreVersion += 1
-            lastSyncedBackingStoreVersion = state.backingStoreVersion
-            state.markModified()
-            invalidateRenderedViewportText()
-            scheduleMarkdownPreviewRefresh(immediate: true)
-            performSearchViewport(needle, caseSensitive: caseSensitive, useRegex: useRegex)
-            refreshViewport(force: true)
+            searchController.replaceAll(with: replacement, needle: needle, caseSensitive: caseSensitive, useRegex: useRegex)
         }
 
-        private func scrollToSearchMatch(at index: Int) {
-            guard index >= 0, index < viewportSearchMatches.count,
-                  let viewport = viewportState, let scrollView, let textView
-            else { return }
-            let match = viewportSearchMatches[index]
-            let targetScrollY = viewport.scrollY(forLine: match.lineIndex)
-            let visibleHeight = scrollView.contentView.bounds.height
-            let centeredY = max(0, targetScrollY - visibleHeight / 2)
-            scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: centeredY))
-            scrollView.reflectScrolledClipView(scrollView.contentView)
-            refreshViewport(force: true)
-
-            guard let localLine = viewport.viewportLine(forBackingStoreLine: match.lineIndex) else { return }
-            let localCharOffset = charOffsetForLocalLine(localLine)
-            let matchStart = localCharOffset + match.range.location
-            let content = textView.string as NSString
-            guard matchStart <= content.length else { return }
-            textView.setSelectedRange(NSRange(location: matchStart, length: 0))
-            applySearchHighlights()
-        }
-
-        private func charOffsetForLocalLine(_ localLine: Int) -> Int {
+        func charOffsetForLocalLine(_ localLine: Int) -> Int {
             guard localLine >= 0, localLine < lineStartOffsets.count else { return 0 }
             return lineStartOffsets[localLine]
         }
@@ -1267,17 +986,8 @@ struct CodeEditorView: NSViewRepresentable {
                 }
                 lastObservedClipSize = size
             }
-            updateMarkdownEditorScrollMetrics()
-            if !isMarkdownSplitActive {
-                isApplyingMarkdownScroll = false
-            } else if isApplyingMarkdownScroll {
-                isApplyingMarkdownScroll = false
-            } else {
-                if state.markdownScrollDriver != .editor {
-                    state.markdownScrollDriver = .editor
-                }
-                updateMarkdownPreviewSyncPointFromEditorScroll()
-            }
+            markdownScrollSync.attach(scrollView: scrollView, viewport: viewportState)
+            markdownScrollSync.reconcileScrollBoundsChange()
             if !isEditingViewport {
                 refreshViewport(force: false)
             }
@@ -1299,103 +1009,27 @@ struct CodeEditorView: NSViewRepresentable {
             }
         }
 
-        private var isMarkdownSplitActive: Bool {
-            state.isMarkdownFile && state.markdownViewMode == .split && state.markdownScrollSyncEnabled
-        }
-
         func updateMarkdownEditorScrollMetrics() {
-            guard isMarkdownSplitActive,
-                  let scrollView,
-                  let viewport = viewportState
-            else { return }
-
-            let visibleHeight = scrollView.contentView.bounds.height
-            let documentHeight = scrollView.documentView?.bounds.height ?? 0
-            let maxScrollY = max(0, documentHeight - visibleHeight)
-            let scrollY = min(max(0, scrollView.contentView.bounds.origin.y), maxScrollY)
-
-            state.markdownEditorScrollY = scrollY
-            state.markdownEditorMaxScrollY = maxScrollY
-            state.markdownEditorViewportHeight = visibleHeight
-            state.markdownEditorLineHeight = viewport.estimatedLineHeight
+            markdownScrollSync.attach(scrollView: scrollView, viewport: viewportState)
+            markdownScrollSync.updateEditorScrollMetrics()
         }
 
         func syncMarkdownScrollPositionIfNeeded() {
-            guard state.isMarkdownFile,
-                  state.markdownViewMode == .split,
-                  state.markdownScrollSyncEnabled
-            else { return }
-
-            applyPendingMarkdownEditorScrollRequestIfNeeded()
+            markdownScrollSync.attach(scrollView: scrollView, viewport: viewportState)
+            markdownScrollSync.syncScrollPositionIfNeeded(
+                refreshViewport: { [weak self] in self?.refreshViewport(force: true) },
+                rebuildLineStartOffsets: { [weak self] in self?.rebuildLineStartOffsetsForViewport() }
+            )
         }
 
         func updateMarkdownPreviewSyncPointFromEditorScroll() {
-            guard !isApplyingMarkdownScroll else { return }
-            guard state.markdownScrollDriver != .preview else { return }
-            guard state.isMarkdownFile,
-                  state.markdownViewMode == .split,
-                  state.markdownScrollSyncEnabled
-            else { return }
-
-            let map = state.currentMarkdownSyncMap()
-            let output = state.markdownSyncCoordinator.editorDidScroll(scrollY: state.markdownEditorScrollY, map: map)
-            guard !output.isEmpty else { return }
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.state.applyMarkdownSyncOutput(output)
-            }
-        }
-
-        private var lastAppliedMarkdownEditorScrollRequestVersion: Int {
-            get { _lastAppliedMarkdownEditorScrollRequestVersion }
-            set { _lastAppliedMarkdownEditorScrollRequestVersion = newValue }
-        }
-
-        private var _lastAppliedMarkdownEditorScrollRequestVersion: Int = 0
-
-        private func applyPendingMarkdownEditorScrollRequestIfNeeded() {
-            guard let scrollView, viewportState != nil else { return }
-            guard lastAppliedMarkdownEditorScrollRequestVersion != state.markdownEditorScrollRequestVersion else { return }
-            lastAppliedMarkdownEditorScrollRequestVersion = state.markdownEditorScrollRequestVersion
-
-            guard state.isMarkdownFile,
-                  state.markdownViewMode == .split,
-                  state.markdownScrollSyncEnabled,
-                  let targetY = state.markdownEditorScrollRequestY
-            else { return }
-
-            isApplyingMarkdownScroll = true
-            let visibleHeight = scrollView.contentView.bounds.height
-            let documentHeight = scrollView.documentView?.bounds.height ?? 0
-            let maxScrollY = max(0, documentHeight - visibleHeight)
-            let clamped = min(max(0, targetY), maxScrollY)
-            scrollView.contentView.setBoundsOrigin(NSPoint(x: scrollView.contentView.bounds.origin.x, y: clamped))
-            scrollView.reflectScrolledClipView(scrollView.contentView)
-            refreshViewport(force: true)
-            rebuildLineStartOffsetsForViewport()
+            markdownScrollSync.attach(scrollView: scrollView, viewport: viewportState)
+            markdownScrollSync.updatePreviewSyncPointFromEditorScroll()
         }
 
         private func publishMarkdownProgressIfEditorAutoScrolled(_ work: () -> Void) {
-            guard let scrollView else {
-                work()
-                return
-            }
-
-            let beforeY = scrollView.contentView.bounds.origin.y
-            work()
-            let afterY = scrollView.contentView.bounds.origin.y
-
-            guard abs(afterY - beforeY) > 0.5 else { return }
-            updateMarkdownEditorScrollMetrics()
-            updateMarkdownPreviewSyncPointFromEditorScroll()
-        }
-
-        private func markdownScrollProgress(for scrollView: NSScrollView) -> CGFloat {
-            let visibleHeight = scrollView.contentView.bounds.height
-            let documentHeight = scrollView.documentView?.bounds.height ?? 0
-            let maxScrollY = max(0, documentHeight - visibleHeight)
-            let scrollY = min(max(0, scrollView.contentView.bounds.origin.y), maxScrollY)
-            return maxScrollY > 0 ? scrollY / maxScrollY : 0
+            markdownScrollSync.attach(scrollView: scrollView, viewport: viewportState)
+            markdownScrollSync.publishProgressIfEditorAutoScrolled(work)
         }
 
         func textDidChange(_: Notification) {
@@ -1404,7 +1038,7 @@ struct CodeEditorView: NSViewRepresentable {
             scheduleMarkdownPreviewRefresh()
         }
 
-        private func scheduleMarkdownPreviewRefresh(immediate: Bool = false) {
+        func scheduleMarkdownPreviewRefresh(immediate: Bool = false) {
             guard state.isMarkdownFile else { return }
             previewRefreshTask?.cancel()
             if immediate {
@@ -1422,8 +1056,8 @@ struct CodeEditorView: NSViewRepresentable {
 
         private func handleTextDidChangeViewport(_ textView: NSTextView) {
             guard let viewport = viewportState, let scrollView else { return }
-            let pendingEdit = pendingViewportEdit
-            pendingViewportEdit = nil
+            let pendingEdit = history.pendingEdit
+            history.pendingEdit = nil
             let cursorLocation = textView.selectedRange().location
             let viewportStartLine = viewport.viewportStartLine
             var lineDelta = 0
@@ -1436,7 +1070,7 @@ struct CodeEditorView: NSViewRepresentable {
                 let newViewportEnd = max(viewportStartLine, viewport.viewportEndLine + lineDelta)
                 viewport.applyViewport(viewportStartLine ..< newViewportEnd)
             } else {
-                if !isApplyingViewportHistory {
+                if !history.isApplyingHistory {
                     clearViewportHistory()
                 }
                 let newLocalText = textView.string
@@ -1461,10 +1095,10 @@ struct CodeEditorView: NSViewRepresentable {
             rebuildLineStartOffsetsForViewport()
 
             if let pendingEdit,
-               !isApplyingViewportHistory,
+               !history.isApplyingHistory,
                let selectionAfter = globalCursorFromLocalLocation(cursorLocation)
             {
-                pushViewportEdit(ViewportEdit(
+                history.push(ViewportEdit(
                     startLine: pendingEdit.startLine,
                     oldLines: pendingEdit.oldLines,
                     newLines: pendingEdit.newLines,
@@ -1474,7 +1108,7 @@ struct CodeEditorView: NSViewRepresentable {
                 recordedViewportEdit = true
             }
 
-            if pendingEdit != nil, !recordedViewportEdit, !isApplyingViewportHistory {
+            if pendingEdit != nil, !recordedViewportEdit, !history.isApplyingHistory {
                 clearViewportHistory()
             }
 
@@ -1531,15 +1165,12 @@ struct CodeEditorView: NSViewRepresentable {
         }
 
         func clearViewportHistory() {
-            pendingViewportEdit = nil
-            viewportUndoStack.removeAll(keepingCapacity: false)
-            viewportRedoStack.removeAll(keepingCapacity: false)
-            lastViewportEditTimestamp = nil
+            history.clear()
         }
 
         func performUndoRequest() -> Bool {
             if viewportState != nil {
-                return performViewportUndo()
+                return history.performUndo()
             }
             guard let textView, textView.undoManager?.canUndo == true else { return false }
             textView.undoManager?.undo()
@@ -1548,7 +1179,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         func performRedoRequest() -> Bool {
             if viewportState != nil {
-                return performViewportRedo()
+                return history.performRedo()
             }
             guard let textView, textView.undoManager?.canRedo == true else { return false }
             textView.undoManager?.redo()
@@ -1557,121 +1188,24 @@ struct CodeEditorView: NSViewRepresentable {
 
         func canPerformUndoRequest() -> Bool {
             if viewportState != nil {
-                return !viewportUndoStack.isEmpty
+                return history.canUndo
             }
             return textView?.undoManager?.canUndo ?? false
         }
 
         func canPerformRedoRequest() -> Bool {
             if viewportState != nil {
-                return !viewportRedoStack.isEmpty
+                return history.canRedo
             }
             return textView?.undoManager?.canRedo ?? false
         }
 
-        private func performViewportUndo() -> Bool {
-            guard let viewport = viewportState else { return false }
-            guard let group = viewportUndoStack.popLast(), !group.edits.isEmpty else { return false }
-
-            isApplyingViewportHistory = true
-            defer { isApplyingViewportHistory = false }
-
-            var earliestInvalidation = Int.max
-            for edit in group.edits.reversed() {
-                let replaceRange = edit.startLine ..< edit.startLine + edit.newLines.count
-                _ = viewport.backingStore.replaceLines(in: replaceRange, with: edit.oldLines)
-                adjustViewportRangeForReplacement(
-                    startLine: edit.startLine,
-                    replacedLineCount: edit.newLines.count,
-                    insertedLineCount: edit.oldLines.count
-                )
-                earliestInvalidation = min(earliestInvalidation, edit.startLine)
-            }
-            if earliestInvalidation != Int.max {
-                invalidateSyntaxHighlightsFromLine(earliestInvalidation)
-            }
-            state.backingStoreVersion += 1
-            lastSyncedBackingStoreVersion = state.backingStoreVersion
-            state.markModified()
-            invalidateRenderedViewportText()
-            scheduleMarkdownPreviewRefresh(immediate: true)
-            appendViewportRedo(group)
-            if let selection = group.edits.first?.selectionBefore {
-                applyViewportHistorySelection(selection)
-            }
-            lastViewportEditTimestamp = nil
-            return true
+        func applyHistorySelection(_ selection: ViewportCursor) {
+            updateContainerHeight()
+            scrollToGlobalLine(selection.line, column: selection.column)
         }
 
-        private func performViewportRedo() -> Bool {
-            guard let viewport = viewportState else { return false }
-            guard let group = viewportRedoStack.popLast(), !group.edits.isEmpty else { return false }
-
-            isApplyingViewportHistory = true
-            defer { isApplyingViewportHistory = false }
-
-            var earliestInvalidation = Int.max
-            for edit in group.edits {
-                let replaceRange = edit.startLine ..< edit.startLine + edit.oldLines.count
-                _ = viewport.backingStore.replaceLines(in: replaceRange, with: edit.newLines)
-                adjustViewportRangeForReplacement(
-                    startLine: edit.startLine,
-                    replacedLineCount: edit.oldLines.count,
-                    insertedLineCount: edit.newLines.count
-                )
-                earliestInvalidation = min(earliestInvalidation, edit.startLine)
-            }
-            if earliestInvalidation != Int.max {
-                invalidateSyntaxHighlightsFromLine(earliestInvalidation)
-            }
-            state.backingStoreVersion += 1
-            lastSyncedBackingStoreVersion = state.backingStoreVersion
-            state.markModified()
-            invalidateRenderedViewportText()
-            scheduleMarkdownPreviewRefresh(immediate: true)
-            appendViewportUndo(group)
-            if let selection = group.edits.last?.selectionAfter {
-                applyViewportHistorySelection(selection)
-            }
-            lastViewportEditTimestamp = nil
-            return true
-        }
-
-        private func pushViewportEdit(_ edit: ViewportEdit) {
-            let now = CFAbsoluteTimeGetCurrent()
-            if shouldCoalesceViewportEdit(edit, now: now), var group = viewportUndoStack.popLast() {
-                group.edits.append(edit)
-                viewportUndoStack.append(group)
-            } else {
-                appendViewportUndo(ViewportEditGroup(edits: [edit]))
-            }
-            viewportRedoStack.removeAll(keepingCapacity: false)
-            lastViewportEditTimestamp = now
-        }
-
-        private func appendViewportUndo(_ group: ViewportEditGroup) {
-            viewportUndoStack.append(group)
-            if viewportUndoStack.count > Self.viewportUndoLimit {
-                viewportUndoStack.removeFirst(viewportUndoStack.count - Self.viewportUndoLimit)
-            }
-        }
-
-        private func appendViewportRedo(_ group: ViewportEditGroup) {
-            viewportRedoStack.append(group)
-            if viewportRedoStack.count > Self.viewportUndoLimit {
-                viewportRedoStack.removeFirst(viewportRedoStack.count - Self.viewportUndoLimit)
-            }
-        }
-
-        private func shouldCoalesceViewportEdit(_ edit: ViewportEdit, now: CFAbsoluteTime) -> Bool {
-            guard let lastTimestamp = lastViewportEditTimestamp else { return false }
-            guard now - lastTimestamp <= Self.viewportUndoCoalesceInterval else { return false }
-            guard let lastEdit = viewportUndoStack.last?.edits.last else { return false }
-            return lastEdit.selectionAfter.line == edit.selectionBefore.line
-                && lastEdit.selectionAfter.column == edit.selectionBefore.column
-        }
-
-        private func adjustViewportRangeForReplacement(
+        func adjustViewportRangeForReplacement(
             startLine: Int,
             replacedLineCount: Int,
             insertedLineCount: Int
@@ -1697,17 +1231,12 @@ struct CodeEditorView: NSViewRepresentable {
             viewport.applyViewport(newStart ..< newEnd)
         }
 
-        private func applyViewportHistorySelection(_ selection: ViewportCursor) {
-            updateContainerHeight()
-            scrollToGlobalLine(selection.line, column: selection.column)
-        }
-
         private func captureViewportPendingEdit(
             textView: NSTextView,
             affectedCharRange: NSRange,
             replacementString: String?
         ) {
-            pendingViewportEdit = nil
+            history.pendingEdit = nil
             guard let viewport = viewportState else { return }
 
             let content = textView.string as NSString
@@ -1741,7 +1270,7 @@ struct CodeEditorView: NSViewRepresentable {
             let newBlock = oldBlock.replacingCharacters(in: relativeRange, with: replacement)
             let newLines = newBlock.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
 
-            pendingViewportEdit = PendingViewportEdit(
+            history.pendingEdit = PendingViewportEdit(
                 startLine: globalStartLine,
                 oldLines: oldLines,
                 newLines: newLines,

--- a/Muxy/Views/Editor/EditorSearchBar.swift
+++ b/Muxy/Views/Editor/EditorSearchBar.swift
@@ -65,6 +65,11 @@ struct EditorSearchBar: View {
                     .foregroundStyle(MuxyTheme.fg)
                     .focused($isFieldFocused)
                     .onSubmit { onNext() }
+                    .onKeyPress(.return, phases: .down) { press in
+                        guard press.modifiers.contains(.shift) else { return .ignored }
+                        onPrevious()
+                        return .handled
+                    }
 
                 if !displayText.isEmpty {
                     Text(displayText)

--- a/Muxy/Views/Editor/Extensions/EditorExtension.swift
+++ b/Muxy/Views/Editor/Extensions/EditorExtension.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+@MainActor
+protocol EditorExtension: AnyObject {
+    var identifier: String { get }
+
+    func didMount(context: EditorRenderContext)
+
+    func willUnmount(context: EditorRenderContext)
+
+    func renderViewport(context: EditorRenderContext, lineRange: Range<Int>)
+
+    func applyIncremental(context: EditorRenderContext, lineRange: Range<Int>, edit: EditorTextEdit)
+
+    func textDidChange(context: EditorRenderContext)
+}
+
+extension EditorExtension {
+    func didMount(context _: EditorRenderContext) {}
+    func willUnmount(context _: EditorRenderContext) {}
+    func renderViewport(context _: EditorRenderContext, lineRange _: Range<Int>) {}
+    func applyIncremental(context _: EditorRenderContext, lineRange _: Range<Int>, edit _: EditorTextEdit) {}
+    func textDidChange(context _: EditorRenderContext) {}
+}

--- a/Muxy/Views/Editor/Extensions/EditorRenderContext.swift
+++ b/Muxy/Views/Editor/Extensions/EditorRenderContext.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+@MainActor
+struct EditorRenderContext {
+    let textView: NSTextView
+    let storage: NSTextStorage
+    let layoutManager: NSLayoutManager
+    let viewport: ViewportState
+    let backingStore: TextBackingStore
+    let lineStartOffsets: [Int]
+    let editorSettings: EditorSettings
+    let state: EditorTabState
+}
+
+@MainActor
+struct EditorTextEdit {
+    let startLine: Int
+    let oldLineCount: Int
+    let newLineCount: Int
+}

--- a/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
+++ b/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
@@ -1,0 +1,81 @@
+import AppKit
+
+@MainActor
+final class MarkdownInlineExtension: EditorExtension {
+    let identifier = "markdown-inline"
+
+    func renderViewport(context: EditorRenderContext, lineRange: Range<Int>) {
+        guard context.state.isMarkdownFile else { return }
+        applyDecorations(context: context, lineRange: lineRange)
+    }
+
+    func applyIncremental(context: EditorRenderContext, lineRange: Range<Int>, edit _: EditorTextEdit) {
+        guard context.state.isMarkdownFile else { return }
+        applyDecorations(context: context, lineRange: lineRange)
+    }
+
+    private func applyDecorations(context: EditorRenderContext, lineRange: Range<Int>) {
+        guard let highlighter = context.state.syntaxHighlighter else { return }
+        let storage = context.storage
+        let storageLength = storage.length
+        guard storageLength > 0 else { return }
+
+        let viewportStart = context.viewport.viewportStartLine
+        let localStart = max(0, lineRange.lowerBound - viewportStart)
+        let localEnd = min(lineRange.upperBound - viewportStart, context.viewport.viewportLineCount)
+        guard localStart < localEnd, localStart < context.lineStartOffsets.count else { return }
+
+        let baseFont = context.editorSettings.resolvedFont
+        let charStart = context.lineStartOffsets[localStart]
+        let charEnd: Int = localEnd < context.lineStartOffsets.count
+            ? context.lineStartOffsets[localEnd]
+            : storageLength
+        guard charEnd > charStart, charStart >= 0, charEnd <= storageLength else { return }
+
+        let editedRange = NSRange(location: charStart, length: charEnd - charStart)
+        context.layoutManager.removeTemporaryAttribute(.strikethroughStyle, forCharacterRange: editedRange)
+
+        storage.beginEditing()
+        storage.addAttribute(.font, value: baseFont, range: editedRange)
+        for localIndex in localStart ..< localEnd {
+            let globalLine = viewportStart + localIndex
+            guard globalLine < context.backingStore.lineCount else { break }
+            let lineText = context.backingStore.line(at: globalLine)
+            let isInsideFence = if case .inBlockComment = highlighter.lineStartState(at: globalLine) {
+                true
+            } else {
+                false
+            }
+            let decorations = MarkdownInlineHighlighter.decorations(
+                line: lineText,
+                isInsideFencedCode: isInsideFence
+            )
+            guard !decorations.isEmpty else { continue }
+            let lineOffset = context.lineStartOffsets[localIndex]
+            for decoration in decorations {
+                let location = lineOffset + decoration.range.location
+                let length = decoration.range.length
+                guard location >= 0, length > 0, location + length <= storageLength else { continue }
+                let nsRange = NSRange(location: location, length: length)
+                if let font = MarkdownInlineStyle.font(for: decoration.kind, baseFont: baseFont) {
+                    storage.addAttribute(.font, value: font, range: nsRange)
+                }
+                if let color = MarkdownInlineStyle.foregroundColor(for: decoration.kind) {
+                    context.layoutManager.addTemporaryAttribute(
+                        .foregroundColor,
+                        value: color,
+                        forCharacterRange: nsRange
+                    )
+                }
+                if let strike = MarkdownInlineStyle.strikethroughStyle(for: decoration.kind) {
+                    context.layoutManager.addTemporaryAttribute(
+                        .strikethroughStyle,
+                        value: strike.rawValue,
+                        forCharacterRange: nsRange
+                    )
+                }
+            }
+        }
+        storage.endEditing()
+    }
+}

--- a/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
+++ b/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
@@ -5,12 +5,10 @@ final class MarkdownInlineExtension: EditorExtension {
     let identifier = "markdown-inline"
 
     func renderViewport(context: EditorRenderContext, lineRange: Range<Int>) {
-        guard context.state.isMarkdownFile else { return }
         applyDecorations(context: context, lineRange: lineRange)
     }
 
     func applyIncremental(context: EditorRenderContext, lineRange: Range<Int>, edit _: EditorTextEdit) {
-        guard context.state.isMarkdownFile else { return }
         applyDecorations(context: context, lineRange: lineRange)
     }
 

--- a/Muxy/Views/Editor/Extensions/SyntaxHighlightExtension.swift
+++ b/Muxy/Views/Editor/Extensions/SyntaxHighlightExtension.swift
@@ -1,0 +1,99 @@
+import AppKit
+
+@MainActor
+final class SyntaxHighlightExtension: EditorExtension {
+    let identifier = "syntax-highlight"
+
+    private weak var coordinator: SyntaxHighlightCoordinator?
+
+    init(coordinator: SyntaxHighlightCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    func renderViewport(context: EditorRenderContext, lineRange: Range<Int>) {
+        guard let highlighter = context.state.syntaxHighlighter else { return }
+        let storage = context.storage
+        let storageLength = storage.length
+        guard storageLength > 0, !lineRange.isEmpty else { return }
+
+        let spans = highlighter.spans(
+            in: lineRange,
+            lineStartOffsets: context.lineStartOffsets,
+            backingStore: context.backingStore
+        )
+
+        let fullRange = NSRange(location: 0, length: storageLength)
+        context.layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: fullRange)
+        for span in spans {
+            let availableLength = storageLength - span.range.location
+            guard span.range.location >= 0, availableLength > 0 else { continue }
+            let clampedLength = min(span.range.length, availableLength)
+            guard clampedLength > 0 else { continue }
+            context.layoutManager.addTemporaryAttribute(
+                .foregroundColor,
+                value: SyntaxTheme.color(for: span.scope),
+                forCharacterRange: NSRange(location: span.range.location, length: clampedLength)
+            )
+        }
+    }
+
+    func applyIncremental(context: EditorRenderContext, lineRange: Range<Int>, edit: EditorTextEdit) {
+        guard let highlighter = context.state.syntaxHighlighter else { return }
+        let storage = context.storage
+        let storageLength = storage.length
+        guard storageLength > 0 else { return }
+
+        let outcome = highlighter.applyEdit(
+            startLine: edit.startLine,
+            oldLineCount: edit.oldLineCount,
+            newLineCount: edit.newLineCount,
+            backingStore: context.backingStore
+        )
+
+        let viewportStart = context.viewport.viewportStartLine
+        let localStart = max(0, lineRange.lowerBound - viewportStart)
+        let localEnd = min(lineRange.upperBound - viewportStart, context.viewport.viewportLineCount)
+        guard localStart < localEnd, localStart < context.lineStartOffsets.count else {
+            handleCascade(outcome: outcome)
+            return
+        }
+
+        let charStart = context.lineStartOffsets[localStart]
+        let charEnd: Int = localEnd < context.lineStartOffsets.count
+            ? context.lineStartOffsets[localEnd]
+            : storageLength
+        guard charEnd > charStart, charStart >= 0, charEnd <= storageLength else {
+            handleCascade(outcome: outcome)
+            return
+        }
+
+        let editedRange = NSRange(location: charStart, length: charEnd - charStart)
+        context.layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: editedRange)
+        for localIndex in localStart ..< localEnd {
+            let globalLine = viewportStart + localIndex
+            guard let tokens = highlighter.tokens(forLine: globalLine) else { continue }
+            let lineOffset = context.lineStartOffsets[localIndex]
+            for token in tokens {
+                let location = lineOffset + token.location
+                guard location >= 0, location + token.length <= storageLength else { continue }
+                context.layoutManager.addTemporaryAttribute(
+                    .foregroundColor,
+                    value: SyntaxTheme.color(for: token.scope),
+                    forCharacterRange: NSRange(location: location, length: token.length)
+                )
+            }
+        }
+
+        handleCascade(outcome: outcome)
+    }
+
+    private func handleCascade(outcome: SyntaxHighlighter.EditOutcome) {
+        guard case .cascade = outcome else { return }
+        coordinator?.scheduleSyntaxCascadeReapply()
+    }
+}
+
+@MainActor
+protocol SyntaxHighlightCoordinator: AnyObject {
+    func scheduleSyntaxCascadeReapply()
+}

--- a/Muxy/Views/Editor/History/ViewportEditHistory.swift
+++ b/Muxy/Views/Editor/History/ViewportEditHistory.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+struct ViewportCursor: Equatable {
+    let line: Int
+    let column: Int
+}
+
+struct PendingViewportEdit {
+    let startLine: Int
+    let oldLines: [String]
+    let newLines: [String]
+    let selectionBefore: ViewportCursor
+}
+
+struct ViewportEdit {
+    let startLine: Int
+    let oldLines: [String]
+    let newLines: [String]
+    let selectionBefore: ViewportCursor
+    let selectionAfter: ViewportCursor
+}
+
+struct ViewportEditGroup {
+    var edits: [ViewportEdit]
+}
+
+@MainActor
+protocol ViewportEditHistoryHost: AnyObject {
+    var viewportState: ViewportState? { get }
+    var state: EditorTabState { get }
+    var lastSyncedBackingStoreVersion: Int { get set }
+
+    func adjustViewportRangeForReplacement(startLine: Int, replacedLineCount: Int, insertedLineCount: Int)
+    func invalidateSyntaxHighlightsFromLine(_ line: Int)
+    func invalidateRenderedViewportText()
+    func scheduleMarkdownPreviewRefresh(immediate: Bool)
+    func applyHistorySelection(_ selection: ViewportCursor)
+}
+
+@MainActor
+final class ViewportEditHistory {
+    static let undoLimit = 200
+    static let coalesceInterval: CFTimeInterval = 1.0
+
+    private weak var host: ViewportEditHistoryHost?
+
+    var pendingEdit: PendingViewportEdit?
+    private var undoStack: [ViewportEditGroup] = []
+    private var redoStack: [ViewportEditGroup] = []
+    private var lastEditTimestamp: CFTimeInterval?
+    private(set) var isApplyingHistory = false
+
+    init(host: ViewportEditHistoryHost) {
+        self.host = host
+    }
+
+    var canUndo: Bool { !undoStack.isEmpty }
+    var canRedo: Bool { !redoStack.isEmpty }
+
+    func clear() {
+        pendingEdit = nil
+        undoStack.removeAll(keepingCapacity: false)
+        redoStack.removeAll(keepingCapacity: false)
+        lastEditTimestamp = nil
+    }
+
+    func push(_ edit: ViewportEdit) {
+        let now = CFAbsoluteTimeGetCurrent()
+        if shouldCoalesce(edit, now: now), var group = undoStack.popLast() {
+            group.edits.append(edit)
+            undoStack.append(group)
+        } else {
+            appendUndo(ViewportEditGroup(edits: [edit]))
+        }
+        redoStack.removeAll(keepingCapacity: false)
+        lastEditTimestamp = now
+    }
+
+    func performUndo() -> Bool {
+        guard let host, let viewport = host.viewportState else { return false }
+        guard let group = undoStack.popLast(), !group.edits.isEmpty else { return false }
+
+        isApplyingHistory = true
+        defer { isApplyingHistory = false }
+
+        var earliestInvalidation = Int.max
+        for edit in group.edits.reversed() {
+            let replaceRange = edit.startLine ..< edit.startLine + edit.newLines.count
+            _ = viewport.backingStore.replaceLines(in: replaceRange, with: edit.oldLines)
+            host.adjustViewportRangeForReplacement(
+                startLine: edit.startLine,
+                replacedLineCount: edit.newLines.count,
+                insertedLineCount: edit.oldLines.count
+            )
+            earliestInvalidation = min(earliestInvalidation, edit.startLine)
+        }
+        if earliestInvalidation != Int.max {
+            host.invalidateSyntaxHighlightsFromLine(earliestInvalidation)
+        }
+        host.state.backingStoreVersion += 1
+        host.lastSyncedBackingStoreVersion = host.state.backingStoreVersion
+        host.state.markModified()
+        host.invalidateRenderedViewportText()
+        host.scheduleMarkdownPreviewRefresh(immediate: true)
+        appendRedo(group)
+        if let selection = group.edits.first?.selectionBefore {
+            host.applyHistorySelection(selection)
+        }
+        lastEditTimestamp = nil
+        return true
+    }
+
+    func performRedo() -> Bool {
+        guard let host, let viewport = host.viewportState else { return false }
+        guard let group = redoStack.popLast(), !group.edits.isEmpty else { return false }
+
+        isApplyingHistory = true
+        defer { isApplyingHistory = false }
+
+        var earliestInvalidation = Int.max
+        for edit in group.edits {
+            let replaceRange = edit.startLine ..< edit.startLine + edit.oldLines.count
+            _ = viewport.backingStore.replaceLines(in: replaceRange, with: edit.newLines)
+            host.adjustViewportRangeForReplacement(
+                startLine: edit.startLine,
+                replacedLineCount: edit.oldLines.count,
+                insertedLineCount: edit.newLines.count
+            )
+            earliestInvalidation = min(earliestInvalidation, edit.startLine)
+        }
+        if earliestInvalidation != Int.max {
+            host.invalidateSyntaxHighlightsFromLine(earliestInvalidation)
+        }
+        host.state.backingStoreVersion += 1
+        host.lastSyncedBackingStoreVersion = host.state.backingStoreVersion
+        host.state.markModified()
+        host.invalidateRenderedViewportText()
+        host.scheduleMarkdownPreviewRefresh(immediate: true)
+        appendUndo(group)
+        if let selection = group.edits.last?.selectionAfter {
+            host.applyHistorySelection(selection)
+        }
+        lastEditTimestamp = nil
+        return true
+    }
+
+    private func appendUndo(_ group: ViewportEditGroup) {
+        undoStack.append(group)
+        if undoStack.count > Self.undoLimit {
+            undoStack.removeFirst(undoStack.count - Self.undoLimit)
+        }
+    }
+
+    private func appendRedo(_ group: ViewportEditGroup) {
+        redoStack.append(group)
+        if redoStack.count > Self.undoLimit {
+            redoStack.removeFirst(redoStack.count - Self.undoLimit)
+        }
+    }
+
+    private func shouldCoalesce(_ edit: ViewportEdit, now: CFAbsoluteTime) -> Bool {
+        guard let lastTimestamp = lastEditTimestamp else { return false }
+        guard now - lastTimestamp <= Self.coalesceInterval else { return false }
+        guard let lastEdit = undoStack.last?.edits.last else { return false }
+        return lastEdit.selectionAfter.line == edit.selectionBefore.line
+            && lastEdit.selectionAfter.column == edit.selectionBefore.column
+    }
+}

--- a/Muxy/Views/Editor/Markdown/MarkdownScrollSyncController.swift
+++ b/Muxy/Views/Editor/Markdown/MarkdownScrollSyncController.swift
@@ -1,0 +1,124 @@
+import AppKit
+
+@MainActor
+final class MarkdownScrollSyncController {
+    private let state: EditorTabState
+    private weak var scrollView: NSScrollView?
+    private weak var viewport: ViewportState?
+
+    private var isApplyingScroll = false
+    private var lastAppliedScrollRequestVersion = 0
+
+    init(state: EditorTabState) {
+        self.state = state
+    }
+
+    func attach(scrollView: NSScrollView?, viewport: ViewportState?) {
+        self.scrollView = scrollView
+        self.viewport = viewport
+    }
+
+    var isSplitActive: Bool {
+        state.isMarkdownFile && state.markdownViewMode == .split && state.markdownScrollSyncEnabled
+    }
+
+    func updateEditorScrollMetrics() {
+        guard isSplitActive,
+              let scrollView,
+              let viewport
+        else { return }
+
+        let visibleHeight = scrollView.contentView.bounds.height
+        let documentHeight = scrollView.documentView?.bounds.height ?? 0
+        let maxScrollY = max(0, documentHeight - visibleHeight)
+        let scrollY = min(max(0, scrollView.contentView.bounds.origin.y), maxScrollY)
+
+        state.markdownEditorScrollY = scrollY
+        state.markdownEditorMaxScrollY = maxScrollY
+        state.markdownEditorViewportHeight = visibleHeight
+        state.markdownEditorLineHeight = viewport.estimatedLineHeight
+    }
+
+    func syncScrollPositionIfNeeded(refreshViewport: () -> Void, rebuildLineStartOffsets: () -> Void) {
+        guard state.isMarkdownFile,
+              state.markdownViewMode == .split,
+              state.markdownScrollSyncEnabled
+        else { return }
+
+        applyPendingScrollRequestIfNeeded(
+            refreshViewport: refreshViewport,
+            rebuildLineStartOffsets: rebuildLineStartOffsets
+        )
+    }
+
+    func updatePreviewSyncPointFromEditorScroll() {
+        guard !isApplyingScroll else { return }
+        guard state.markdownScrollDriver != .preview else { return }
+        guard state.isMarkdownFile,
+              state.markdownViewMode == .split,
+              state.markdownScrollSyncEnabled
+        else { return }
+
+        let map = state.currentMarkdownSyncMap()
+        let output = state.markdownSyncCoordinator.editorDidScroll(scrollY: state.markdownEditorScrollY, map: map)
+        guard !output.isEmpty else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.state.applyMarkdownSyncOutput(output)
+        }
+    }
+
+    func reconcileScrollBoundsChange() {
+        updateEditorScrollMetrics()
+        if !isSplitActive {
+            isApplyingScroll = false
+        } else if isApplyingScroll {
+            isApplyingScroll = false
+        } else {
+            if state.markdownScrollDriver != .editor {
+                state.markdownScrollDriver = .editor
+            }
+            updatePreviewSyncPointFromEditorScroll()
+        }
+    }
+
+    func publishProgressIfEditorAutoScrolled(_ work: () -> Void) {
+        guard let scrollView else {
+            work()
+            return
+        }
+
+        let beforeY = scrollView.contentView.bounds.origin.y
+        work()
+        let afterY = scrollView.contentView.bounds.origin.y
+
+        guard abs(afterY - beforeY) > 0.5 else { return }
+        updateEditorScrollMetrics()
+        updatePreviewSyncPointFromEditorScroll()
+    }
+
+    private func applyPendingScrollRequestIfNeeded(
+        refreshViewport: () -> Void,
+        rebuildLineStartOffsets: () -> Void
+    ) {
+        guard let scrollView, viewport != nil else { return }
+        guard lastAppliedScrollRequestVersion != state.markdownEditorScrollRequestVersion else { return }
+        lastAppliedScrollRequestVersion = state.markdownEditorScrollRequestVersion
+
+        guard state.isMarkdownFile,
+              state.markdownViewMode == .split,
+              state.markdownScrollSyncEnabled,
+              let targetY = state.markdownEditorScrollRequestY
+        else { return }
+
+        isApplyingScroll = true
+        let visibleHeight = scrollView.contentView.bounds.height
+        let documentHeight = scrollView.documentView?.bounds.height ?? 0
+        let maxScrollY = max(0, documentHeight - visibleHeight)
+        let clamped = min(max(0, targetY), maxScrollY)
+        scrollView.contentView.setBoundsOrigin(NSPoint(x: scrollView.contentView.bounds.origin.x, y: clamped))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        refreshViewport()
+        rebuildLineStartOffsets()
+    }
+}

--- a/Muxy/Views/Editor/Search/SearchController.swift
+++ b/Muxy/Views/Editor/Search/SearchController.swift
@@ -1,0 +1,252 @@
+import AppKit
+
+@MainActor
+protocol SearchControllerHost: AnyObject {
+    var textView: NSTextView? { get }
+    var scrollView: NSScrollView? { get }
+    var viewportState: ViewportState? { get }
+    var lineStartOffsets: [Int] { get }
+    var state: EditorTabState { get }
+    var lastSyncedBackingStoreVersion: Int { get set }
+
+    func charOffsetForLocalLine(_ localLine: Int) -> Int
+    func refreshViewport(force: Bool)
+    func reapplySyntaxHighlights()
+    func invalidateSyntaxHighlightsFromLine(_ line: Int)
+    func invalidateRenderedViewportText()
+    func clearViewportHistory()
+    func scheduleMarkdownPreviewRefresh(immediate: Bool)
+    func recordHighlightTiming(start: CFTimeInterval?, highlightedRangeCount: Int, force: Bool)
+    func beginPerfTiming() -> CFTimeInterval?
+}
+
+@MainActor
+final class SearchController {
+    private weak var host: SearchControllerHost?
+
+    private(set) var matches: [TextBackingStore.SearchMatch] = []
+    private var appliedRanges: [NSRange] = []
+    private var appliedCurrentRange: NSRange?
+
+    init(host: SearchControllerHost) {
+        self.host = host
+    }
+
+    func clearHighlights() {
+        guard let host else { return }
+        matches = []
+        host.state.searchMatchCount = 0
+        host.state.searchCurrentIndex = 0
+        applyHighlights()
+    }
+
+    func applyHighlights(force: Bool = false) {
+        guard let host else { return }
+        let perfStart = host.beginPerfTiming()
+        var highlightedRangeCount = 0
+        defer {
+            host.recordHighlightTiming(start: perfStart, highlightedRangeCount: highlightedRangeCount, force: force)
+        }
+
+        guard let textView = host.textView, let layoutManager = textView.layoutManager else { return }
+        let storageLength = textView.textStorage?.length ?? 0
+        guard storageLength > 0 else {
+            appliedRanges.removeAll(keepingCapacity: true)
+            appliedCurrentRange = nil
+            return
+        }
+
+        guard let viewport = host.viewportState, !matches.isEmpty else {
+            guard !appliedRanges.isEmpty || appliedCurrentRange != nil else { return }
+            clearAppliedHighlights(layoutManager: layoutManager, storageLength: storageLength)
+            textView.needsDisplay = true
+            return
+        }
+
+        var nextRanges: [NSRange] = []
+        nextRanges.reserveCapacity(min(matches.count, 256))
+
+        let currentIndex = max(0, host.state.searchCurrentIndex - 1)
+        var nextCurrentRange: NSRange?
+        let visibleStartLine = viewport.viewportStartLine
+        let visibleEndLine = viewport.viewportEndLine
+
+        for (i, match) in matches.enumerated() {
+            if match.lineIndex < visibleStartLine { continue }
+            if match.lineIndex >= visibleEndLine { break }
+            guard let localLine = viewport.viewportLine(forBackingStoreLine: match.lineIndex) else { continue }
+            let localCharOffset = host.charOffsetForLocalLine(localLine)
+            let highlightRange = NSRange(
+                location: localCharOffset + match.range.location,
+                length: match.range.length
+            )
+            guard NSMaxRange(highlightRange) <= storageLength else { continue }
+            nextRanges.append(highlightRange)
+            if i == currentIndex {
+                nextCurrentRange = highlightRange
+            }
+        }
+
+        if !force,
+           appliedRanges == nextRanges,
+           appliedCurrentRange == nextCurrentRange
+        {
+            return
+        }
+
+        clearAppliedHighlights(layoutManager: layoutManager, storageLength: storageLength)
+        guard !nextRanges.isEmpty else {
+            textView.needsDisplay = true
+            return
+        }
+
+        let matchBg = GhosttyService.shared.foregroundColor.withAlphaComponent(0.2)
+        let themeYellow = GhosttyService.shared.paletteColor(at: 3) ?? NSColor.systemYellow
+        let currentMatchBg = themeYellow.withAlphaComponent(0.85)
+        let currentMatchFg = GhosttyService.shared.backgroundColor
+
+        for highlightRange in nextRanges {
+            if highlightRange == nextCurrentRange {
+                layoutManager.addTemporaryAttribute(.backgroundColor, value: currentMatchBg, forCharacterRange: highlightRange)
+                layoutManager.addTemporaryAttribute(.foregroundColor, value: currentMatchFg, forCharacterRange: highlightRange)
+            } else {
+                layoutManager.addTemporaryAttribute(.backgroundColor, value: matchBg, forCharacterRange: highlightRange)
+            }
+        }
+
+        highlightedRangeCount = nextRanges.count
+        appliedRanges = nextRanges
+        appliedCurrentRange = nextCurrentRange
+        textView.needsDisplay = true
+    }
+
+    func performSearch(_ needle: String, caseSensitive: Bool, useRegex: Bool) {
+        guard let host, let store = host.state.backingStore else { return }
+        host.state.searchInvalidRegex = false
+        matches = []
+        guard !needle.isEmpty else {
+            host.state.searchMatchCount = 0
+            host.state.searchCurrentIndex = 0
+            applyHighlights()
+            return
+        }
+        if useRegex, (try? NSRegularExpression(pattern: needle)) == nil {
+            host.state.searchInvalidRegex = true
+            host.state.searchMatchCount = 0
+            host.state.searchCurrentIndex = 0
+            applyHighlights()
+            return
+        }
+        matches = store.search(needle: needle, caseSensitive: caseSensitive, useRegex: useRegex)
+        host.state.searchMatchCount = matches.count
+        if !matches.isEmpty {
+            host.state.searchCurrentIndex = 1
+            scrollToMatch(at: 0)
+        } else {
+            host.state.searchCurrentIndex = 0
+            applyHighlights()
+        }
+    }
+
+    func navigate(forward: Bool) {
+        guard let host, !matches.isEmpty else { return }
+        var idx = host.state.searchCurrentIndex - 1
+        if forward {
+            idx = (idx + 1) % matches.count
+        } else {
+            idx = (idx - 1 + matches.count) % matches.count
+        }
+        host.state.searchCurrentIndex = idx + 1
+        scrollToMatch(at: idx)
+    }
+
+    func replaceCurrent(with replacement: String, needle: String, caseSensitive: Bool, useRegex: Bool) {
+        guard let host, let store = host.state.backingStore, !needle.isEmpty, !matches.isEmpty else { return }
+        host.clearViewportHistory()
+        let currentIndex = max(0, host.state.searchCurrentIndex - 1)
+        guard currentIndex < matches.count else { return }
+        let match = matches[currentIndex]
+        let line = store.line(at: match.lineIndex)
+        let nsLine = line as NSString
+        let newLine = nsLine.replacingCharacters(in: match.range, with: replacement)
+        _ = store.replaceLines(in: match.lineIndex ..< match.lineIndex + 1, with: [newLine])
+        host.state.backingStoreVersion += 1
+        host.lastSyncedBackingStoreVersion = host.state.backingStoreVersion
+        host.state.markModified()
+        host.invalidateSyntaxHighlightsFromLine(match.lineIndex)
+        host.invalidateRenderedViewportText()
+        host.scheduleMarkdownPreviewRefresh(immediate: true)
+        performSearch(needle, caseSensitive: caseSensitive, useRegex: useRegex)
+        host.refreshViewport(force: true)
+    }
+
+    func replaceAll(with replacement: String, needle: String, caseSensitive: Bool, useRegex: Bool) {
+        guard let host, let store = host.state.backingStore, !needle.isEmpty, !matches.isEmpty else { return }
+        host.clearViewportHistory()
+        var grouped: [Int: [NSRange]] = [:]
+        for match in matches {
+            grouped[match.lineIndex, default: []].append(match.range)
+        }
+        var earliestInvalidation = Int.max
+        for lineIndex in grouped.keys.sorted().reversed() {
+            guard let lineRanges = grouped[lineIndex] else { continue }
+            let ranges = lineRanges.sorted { $0.location > $1.location }
+            var nsLine = store.line(at: lineIndex) as NSString
+            for range in ranges {
+                nsLine = nsLine.replacingCharacters(in: range, with: replacement) as NSString
+            }
+            _ = store.replaceLines(in: lineIndex ..< lineIndex + 1, with: [nsLine as String])
+            earliestInvalidation = min(earliestInvalidation, lineIndex)
+        }
+        if earliestInvalidation != Int.max {
+            host.invalidateSyntaxHighlightsFromLine(earliestInvalidation)
+        }
+        host.state.backingStoreVersion += 1
+        host.lastSyncedBackingStoreVersion = host.state.backingStoreVersion
+        host.state.markModified()
+        host.invalidateRenderedViewportText()
+        host.scheduleMarkdownPreviewRefresh(immediate: true)
+        performSearch(needle, caseSensitive: caseSensitive, useRegex: useRegex)
+        host.refreshViewport(force: true)
+    }
+
+    private func clearAppliedHighlights(layoutManager: NSLayoutManager, storageLength: Int) {
+        guard let host else { return }
+        let hadCurrentMatchOverride = appliedCurrentRange != nil
+        for range in appliedRanges {
+            guard NSMaxRange(range) <= storageLength else { continue }
+            layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: range)
+        }
+        if let range = appliedCurrentRange, NSMaxRange(range) <= storageLength {
+            layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: range)
+        }
+        appliedRanges.removeAll(keepingCapacity: true)
+        appliedCurrentRange = nil
+        if hadCurrentMatchOverride {
+            host.reapplySyntaxHighlights()
+        }
+    }
+
+    private func scrollToMatch(at index: Int) {
+        guard let host, index >= 0, index < matches.count,
+              let viewport = host.viewportState,
+              let scrollView = host.scrollView,
+              let textView = host.textView
+        else { return }
+        let match = matches[index]
+        let targetScrollY = viewport.scrollY(forLine: match.lineIndex)
+        let visibleHeight = scrollView.contentView.bounds.height
+        let centeredY = max(0, targetScrollY - visibleHeight / 2)
+        scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: centeredY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        host.refreshViewport(force: true)
+
+        guard let localLine = viewport.viewportLine(forBackingStoreLine: match.lineIndex) else { return }
+        let localCharOffset = host.charOffsetForLocalLine(localLine)
+        let matchStart = localCharOffset + match.range.location
+        let content = textView.string as NSString
+        guard matchStart <= content.length else { return }
+        textView.setSelectedRange(NSRange(location: matchStart, length: 0))
+        applyHighlights()
+    }
+}

--- a/Tests/MuxyTests/Models/MarkdownInlineHighlighterTests.swift
+++ b/Tests/MuxyTests/Models/MarkdownInlineHighlighterTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("MarkdownInlineHighlighter")
+struct MarkdownInlineHighlighterTests {
+    @Test("ATX heading produces heading + marker decoration")
+    func heading() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "## Hello world", isInsideFencedCode: false)
+        #expect(decorations.contains { $0.kind == .heading(level: 2) })
+        #expect(decorations.contains { $0.kind == .marker && $0.range.length == 2 })
+    }
+
+    @Test("Six-level headings detected; seven hashes are not headings")
+    func headingLevels() {
+        for level in 1 ... 6 {
+            let line = String(repeating: "#", count: level) + " Title"
+            let decorations = MarkdownInlineHighlighter.decorations(line: line, isInsideFencedCode: false)
+            #expect(decorations.contains { $0.kind == .heading(level: level) })
+        }
+        let invalid = MarkdownInlineHighlighter.decorations(line: "####### nope", isInsideFencedCode: false)
+        #expect(!invalid.contains { if case .heading = $0.kind { true } else { false } })
+    }
+
+    @Test("Bold detected with ** markers")
+    func bold() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "this is **strong** text", isInsideFencedCode: false)
+        let bold = decorations.first { $0.kind == .bold }
+        #expect(bold != nil)
+        #expect(bold?.range.length == "**strong**".count)
+    }
+
+    @Test("Italic detected with single asterisk markers")
+    func italic() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "an *emphasized* word", isInsideFencedCode: false)
+        #expect(decorations.contains { $0.kind == .italic })
+    }
+
+    @Test("Bold italic detected with triple asterisks")
+    func boldItalic() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "***wow***", isInsideFencedCode: false)
+        #expect(decorations.contains { $0.kind == .boldItalic })
+    }
+
+    @Test("Strikethrough detected")
+    func strikethrough() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "~~old~~ news", isInsideFencedCode: false)
+        #expect(decorations.contains { $0.kind == .strikethrough })
+    }
+
+    @Test("Code span detected")
+    func codeSpan() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "use `foo()` here", isInsideFencedCode: false)
+        #expect(decorations.contains { $0.kind == .codeSpan })
+    }
+
+    @Test("Blockquote marker detected")
+    func blockquote() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "> a quote", isInsideFencedCode: false)
+        #expect(decorations.contains { $0.kind == .blockquote })
+    }
+
+    @Test("Unordered and ordered list markers detected")
+    func listMarkers() {
+        let dash = MarkdownInlineHighlighter.decorations(line: "- item", isInsideFencedCode: false)
+        #expect(dash.contains { $0.kind == .listMarker })
+
+        let numbered = MarkdownInlineHighlighter.decorations(line: "1. item", isInsideFencedCode: false)
+        #expect(numbered.contains { $0.kind == .listMarker })
+    }
+
+    @Test("No decorations inside fenced code block")
+    func fencedCode() {
+        let decorations = MarkdownInlineHighlighter.decorations(
+            line: "# not a heading **inside** code",
+            isInsideFencedCode: true
+        )
+        #expect(decorations.isEmpty)
+    }
+
+    @Test("Unmatched markers do not produce emphasis")
+    func unmatched() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "this **never closes", isInsideFencedCode: false)
+        #expect(!decorations.contains { $0.kind == .bold })
+    }
+
+    @Test("Whitespace-flanked markers are not emphasis")
+    func whitespaceFlanked() {
+        let decorations = MarkdownInlineHighlighter.decorations(line: "a ** b ** c", isInsideFencedCode: false)
+        #expect(!decorations.contains { $0.kind == .bold })
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,7 @@ Muxy/
     SyntaxTokenizer.swift     Stateful per-line tokenizer emitting TokenSpans and end state
     SyntaxHighlighter.swift   Per-file line-end-state cache + viewport highlight API
     SyntaxLanguageRegistry.swift  File-extension → grammar lookup
+    MarkdownInlineHighlighter.swift  Pure decorator: scans a markdown line and emits MarkdownInlineDecoration values (heading, bold/italic/strike, code-span, blockquote, list marker). Consumed by MarkdownInlineExtension to apply font and attribute changes in the editor.
     Grammars/
       CFamilyGrammars.swift   Swift, JS, TS, Objective-C, C, C++, C#, Java, Kotlin, Scala, Go, Rust, Dart, PHP
       ScriptGrammars.swift    Python, Ruby, Lua, Shell, Perl, Elixir, Haskell
@@ -169,8 +170,19 @@ Muxy/
       TerminalSearchBar.swift Find-in-terminal UI
       TerminalViewRegistry.swift  Terminal view lifecycle management
     Editor/
-      CodeEditorRepresentable.swift  NSViewRepresentable bridge for code editor (viewport rendering path)
+      CodeEditorRepresentable.swift  NSViewRepresentable bridge for code editor (viewport rendering path); coordinator dispatches render and incremental events to a list of EditorExtensions
       EditorPane.swift        SwiftUI wrapper for editor tab (breadcrumb + editor)
+      Extensions/
+        EditorExtension.swift            Protocol with lifecycle hooks (didMount, willUnmount, renderViewport, applyIncremental, textDidChange) and default no-op implementations
+        EditorRenderContext.swift        Bundle of render-time dependencies (textView, storage, layoutManager, viewport, backingStore, line offsets, settings, state) handed to extensions
+        SyntaxHighlightExtension.swift   Owns .foregroundColor temporary attributes from SyntaxHighlighter spans; schedules cascade reapply via SyntaxHighlightCoordinator
+        MarkdownInlineExtension.swift    Markdown-only: heading sizes, bold/italic/strike font traits, code-span/blockquote/list muted markers; gates on EditorTabState.isMarkdownFile
+      Markdown/
+        MarkdownScrollSyncController.swift  Drives editor↔preview scroll sync for markdown split mode; owns the isApplyingScroll guard and pending-request version tracking
+      Search/
+        SearchController.swift              Owns find/replace state and viewport-anchored search highlights; communicates with the coordinator through SearchControllerHost
+      History/
+        ViewportEditHistory.swift           Owns viewport-mode undo/redo stacks, edit coalescing, and apply logic; ViewportCursor / ViewportEdit / ViewportEditGroup / PendingViewportEdit lifted to file scope; communicates with the coordinator through ViewportEditHistoryHost
     FileTree/
       FileTreeView.swift      Side panel rendering of the lightweight file tree
       FileTreeCommands.swift  Orchestrates create/rename/delete/cut/copy/paste/drop


### PR DESCRIPTION
  Splits the editor coordinator into focused modules (syntax, markdown styling, scroll sync, search, undo/redo)
  behind an EditorExtension protocol. Adds inline markdown rendering (heading sizes, bold/italic/strike) and fixes
  Shift+Enter navigating previous match in search.