### PR TITLE
Bundle ghostty resources to remove Ghostty.app dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ DerivedData/
 .netrc
 GhosttyKit.xcframework
 GhosttyKit/ghostty.h
+Muxy/Resources/ghostty
+Muxy/Resources/terminfo
 /ghostty
 /build
 .agents/

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -132,24 +132,19 @@ final class GhosttyService {
         ghostty_app_tick(app)
     }
 
-    private static let allowedResourceParents = [
-        "/Applications/Ghostty.app/Contents/Resources/ghostty",
-        NSHomeDirectory() + "/Applications/Ghostty.app/Contents/Resources/ghostty",
-    ]
-
     private func resolveGhosttyResources() {
-        if let existing = getenv("GHOSTTY_RESOURCES_DIR").map({ String(cString: $0) }) {
-            guard Self.allowedResourceParents.contains(where: { existing.hasPrefix($0) }) else {
-                unsetenv("GHOSTTY_RESOURCES_DIR")
-                return
-            }
+        guard let bundled = Self.bundledResourcesPath() else {
+            logger.error("bundled ghostty resources not found in app bundle")
+            unsetenv("GHOSTTY_RESOURCES_DIR")
             return
         }
+        setenv("GHOSTTY_RESOURCES_DIR", bundled, 1)
+    }
 
-        for path in Self.allowedResourceParents {
-            guard FileManager.default.fileExists(atPath: path + "/shell-integration") else { continue }
-            setenv("GHOSTTY_RESOURCES_DIR", path, 1)
-            return
-        }
+    static func bundledResourcesPath() -> String? {
+        guard let url = Bundle.appResources.resourceURL?.appendingPathComponent("ghostty"),
+              FileManager.default.fileExists(atPath: url.appendingPathComponent("shell-integration").path)
+        else { return nil }
+        return url.path
     }
 }

--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -109,24 +109,13 @@ final class ThemeService {
 
     nonisolated private static func themeDirectories() -> [String] {
         var dirs: [String] = []
-        if let resourcesDir = getenv("GHOSTTY_RESOURCES_DIR").map({ String(cString: $0) }) {
-            dirs.append(resourcesDir + "/themes")
+        if let bundled = Bundle.appResources.resourceURL?.appendingPathComponent("ghostty/themes").path {
+            dirs.append(bundled)
         }
-
-        let appBundlePaths = [
-            "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
-            NSHomeDirectory() + "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
-        ]
-        for path in appBundlePaths where !dirs.contains(path) {
-            dirs.append(path)
-        }
-
         dirs.append(NSHomeDirectory() + "/.config/ghostty/themes")
-
-        if let bundledThemes = Bundle.appResources.resourceURL?.appendingPathComponent("themes").path {
-            dirs.append(bundledThemes)
+        if let extraThemes = Bundle.appResources.resourceURL?.appendingPathComponent("themes").path {
+            dirs.append(extraThemes)
         }
-
         return dirs
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -41,9 +41,11 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Muxy",
-            exclude: ["Info.plist", "Muxy.entitlements"],
+            exclude: ["Info.plist", "Muxy.entitlements", "Resources/ghostty", "Resources/terminfo"],
             resources: [
                 .process("Resources"),
+                .copy("Resources/ghostty"),
+                .copy("Resources/terminfo"),
             ],
             linkerSettings: [
                 .unsafeFlags([

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,10 +5,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 FORK_REPO="muxy-app/ghostty"
 XCFRAMEWORK_DIR="$PROJECT_ROOT/GhosttyKit.xcframework"
+RESOURCES_DIR="$PROJECT_ROOT/Muxy/Resources/ghostty"
+TERMINFO_DIR="$PROJECT_ROOT/Muxy/Resources/terminfo"
 
-if [[ -d "$XCFRAMEWORK_DIR" ]]; then
-    echo "==> GhosttyKit.xcframework already exists, skipping download"
-    echo "    To re-download, remove it first: rm -rf GhosttyKit.xcframework"
+if [[ -d "$XCFRAMEWORK_DIR" && -d "$RESOURCES_DIR/shell-integration" && -d "$TERMINFO_DIR" ]]; then
+    echo "==> GhosttyKit.xcframework and resources already present, skipping download"
+    echo "    To re-download, remove: rm -rf GhosttyKit.xcframework Muxy/Resources/ghostty Muxy/Resources/terminfo"
     exit 0
 fi
 
@@ -20,16 +22,30 @@ if [[ -z "$LATEST_TAG" ]]; then
 fi
 echo "    Tag: $LATEST_TAG"
 
-echo "==> Downloading GhosttyKit.xcframework"
 cd "$PROJECT_ROOT"
-gh release download "$LATEST_TAG" \
-    --pattern "GhosttyKit.xcframework.tar.gz" \
-    --repo "$FORK_REPO"
-tar xzf GhosttyKit.xcframework.tar.gz
-rm GhosttyKit.xcframework.tar.gz
 
-echo "==> Syncing ghostty.h from xcframework"
-cp "$XCFRAMEWORK_DIR/macos-arm64_x86_64/Headers/ghostty.h" "$PROJECT_ROOT/GhosttyKit/ghostty.h"
+if [[ ! -d "$XCFRAMEWORK_DIR" ]]; then
+    echo "==> Downloading GhosttyKit.xcframework"
+    gh release download "$LATEST_TAG" \
+        --pattern "GhosttyKit.xcframework.tar.gz" \
+        --repo "$FORK_REPO"
+    tar xzf GhosttyKit.xcframework.tar.gz
+    rm GhosttyKit.xcframework.tar.gz
+
+    echo "==> Syncing ghostty.h from xcframework"
+    cp "$XCFRAMEWORK_DIR/macos-arm64_x86_64/Headers/ghostty.h" "$PROJECT_ROOT/GhosttyKit/ghostty.h"
+fi
+
+if [[ ! -d "$RESOURCES_DIR/shell-integration" || ! -d "$TERMINFO_DIR" ]]; then
+    echo "==> Downloading GhosttyKit runtime resources"
+    gh release download "$LATEST_TAG" \
+        --pattern "GhosttyKit-resources.tar.gz" \
+        --repo "$FORK_REPO"
+    rm -rf "$RESOURCES_DIR" "$TERMINFO_DIR"
+    mkdir -p "$(dirname "$RESOURCES_DIR")"
+    tar xzf GhosttyKit-resources.tar.gz -C "$(dirname "$RESOURCES_DIR")"
+    rm GhosttyKit-resources.tar.gz
+fi
 
 echo "==> Done"
 echo "    Run 'swift build' to build the project"


### PR DESCRIPTION
Vendors libghostty's shell-integration, themes, and terminfo into Muxy.app so the terminal works correctly without
  /Applications/Ghostty.app installed. Fixes broken Delete key, Ctrl+L, cursor shape, and spurious tab-close
  confirmations.