### PR TITLE
Fix split panes both showing focused cursor

### DIFF
--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -326,8 +326,10 @@ final class GhosttyTerminalNSView: NSView {
         let result = super.becomeFirstResponder()
         if result {
             ghostty_surface_set_focus(surface, true)
-            DispatchQueue.main.async { [weak self] in
-                self?.onFocus?()
+            if !isFocused {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onFocus?()
+                }
             }
         }
         return result

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -154,8 +154,14 @@ struct TerminalBridge: NSViewRepresentable {
         configureFileOpenCallback(view)
         context.coordinator.wasFocused = focused
         if focused, !overlayActive {
+            view.notifySurfaceFocused()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 view.window?.makeFirstResponder(view)
+            }
+        } else {
+            view.notifySurfaceUnfocused()
+            if view.window?.firstResponder === view {
+                view.window?.makeFirstResponder(nil)
             }
         }
         return view


### PR DESCRIPTION
  Splitting a tab left both panes' terminal cursors blinking because the cached GhosttyTerminalNSView returned from
  TerminalViewRegistry carried stale libghostty focus state into the remounted TerminalBridge, and
  becomeFirstResponder re-dispatched onFocus during SwiftUI-driven focus changes, causing focus to oscillate on
  restore.

  makeNSView now syncs the surface focus to the current focused prop and releases first responder when unfocused;
  becomeFirstResponder only dispatches onFocus when the view isn't already focused.