### PR TITLE
Add support for light & dark theme config

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -132,6 +132,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var openProjectFromPath: ((String) -> Void)?
 
     private var pendingOpenPaths: [String] = []
+    private var systemAppearanceObserver: NSObjectProtocol?
 
     @MainActor
     func handleOpenProjectPath(_ path: String) {
@@ -210,6 +211,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setAppIcon()
         _ = GhosttyService.shared
         ThemeService.shared.applyDefaultThemeIfNeeded()
+        observeSystemAppearanceChanges()
         UpdateService.shared.start()
         ModifierKeyMonitor.shared.start()
         NotificationSocketServer.shared.start()
@@ -291,11 +293,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        if let observer = systemAppearanceObserver {
+            DistributedNotificationCenter.default().removeObserver(observer)
+            systemAppearanceObserver = nil
+        }
         onTerminate?()
         NotificationStore.shared.saveToDisk()
         NotificationSocketServer.shared.stop()
         MainActor.assumeIsolated {
             MobileServerService.shared.stopForTermination()
+        }
+    }
+
+    @MainActor
+    private func observeSystemAppearanceChanges() {
+        if let observer = systemAppearanceObserver {
+            DistributedNotificationCenter.default().removeObserver(observer)
+            systemAppearanceObserver = nil
+        }
+        systemAppearanceObserver = DistributedNotificationCenter.default().addObserver(
+            forName: Notification.Name("AppleInterfaceThemeChangedNotification"),
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                GhosttyService.shared.appearanceDidChange()
+            }
         }
     }
 
@@ -346,8 +369,10 @@ struct WindowConfigurator: NSViewRepresentable {
     }
 
     private static func applyWindowBackground(_ window: NSWindow) {
-        window.isOpaque = true
-        window.backgroundColor = MuxyTheme.nsBg
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.contentView?.wantsLayer = true
+        window.contentView?.layer?.backgroundColor = MuxyTheme.nsBg.cgColor
     }
 
     static func neutralizeSafeAreaInsets(in window: NSWindow) {

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -211,6 +211,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setAppIcon()
         _ = GhosttyService.shared
         ThemeService.shared.applyDefaultThemeIfNeeded()
+        ThemeService.shared.migrateToPairedThemeIfNeeded()
         observeSystemAppearanceChanges()
         UpdateService.shared.start()
         ModifierKeyMonitor.shared.start()

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -210,6 +210,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate()
         setAppIcon()
         _ = GhosttyService.shared
+        GhosttyService.shared.applyInitialColorScheme()
         ThemeService.shared.applyDefaultThemeIfNeeded()
         ThemeService.shared.migrateToPairedThemeIfNeeded()
         observeSystemAppearanceChanges()

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -118,13 +118,7 @@ final class GhosttyService {
     }
 
     private func refreshConfig(postThemeChangeNotification: Bool) {
-        guard let app, let newConfig = loadMuxyGhosttyConfig() else {
-            if postThemeChangeNotification {
-                configVersion += 1
-                NotificationCenter.default.post(name: .themeDidChange, object: nil)
-            }
-            return
-        }
+        guard let app, let newConfig = loadMuxyGhosttyConfig() else { return }
         ghostty_app_update_config(app, newConfig)
         let oldConfig = config
         config = newConfig

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -108,13 +108,31 @@ final class GhosttyService {
     }
 
     func reloadConfig() {
-        guard let app else { return }
-        guard let newConfig = loadMuxyGhosttyConfig() else { return }
+        refreshConfig(postThemeChangeNotification: false)
+    }
+
+    func appearanceDidChange() {
+        let isDark = ThemeService.isCurrentAppearanceDark()
+        TerminalViewRegistry.shared.applyColorSchemeToAllViews(isDark: isDark)
+        refreshConfig(postThemeChangeNotification: true)
+    }
+
+    private func refreshConfig(postThemeChangeNotification: Bool) {
+        guard let app, let newConfig = loadMuxyGhosttyConfig() else {
+            if postThemeChangeNotification {
+                configVersion += 1
+                NotificationCenter.default.post(name: .themeDidChange, object: nil)
+            }
+            return
+        }
         ghostty_app_update_config(app, newConfig)
-        let oldConfig = self.config
-        self.config = newConfig
+        let oldConfig = config
+        config = newConfig
         if let oldConfig { ghostty_config_free(oldConfig) }
         configVersion += 1
+        if postThemeChangeNotification {
+            NotificationCenter.default.post(name: .themeDidChange, object: nil)
+        }
     }
 
     private func loadMuxyGhosttyConfig() -> ghostty_config_t? {

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -66,6 +66,16 @@ final class GhosttyService {
         self.config = cfg
     }
 
+    func applyInitialColorScheme() {
+        guard let app else { return }
+        ghostty_app_set_color_scheme(app, Self.currentColorScheme())
+        refreshConfig(postThemeChangeNotification: false)
+    }
+
+    private static func currentColorScheme() -> ghostty_color_scheme_e {
+        ThemeService.isCurrentAppearanceDark() ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT
+    }
+
     var backgroundColor: NSColor {
         configColor("background") ?? NSColor(srgbRed: 0.098, green: 0.090, blue: 0.122, alpha: 1)
     }
@@ -113,6 +123,9 @@ final class GhosttyService {
 
     func appearanceDidChange() {
         let isDark = ThemeService.isCurrentAppearanceDark()
+        if let app {
+            ghostty_app_set_color_scheme(app, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
+        }
         TerminalViewRegistry.shared.applyColorSchemeToAllViews(isDark: isDark)
         refreshConfig(postThemeChangeNotification: true)
     }

--- a/Muxy/Services/MuxyConfig.swift
+++ b/Muxy/Services/MuxyConfig.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "MuxyConfig")
 
 @MainActor @Observable
 final class MuxyConfig {
@@ -41,7 +44,11 @@ final class MuxyConfig {
         }
 
         content = lines.joined(separator: "\n")
-        try? writeGhosttyConfig(content)
+        do {
+            try writeGhosttyConfig(content)
+        } catch {
+            logger.error("Failed to write config: \(error)")
+        }
     }
 
     func configValue(for key: String) -> String? {

--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -65,6 +65,16 @@ final class ThemeService {
         return Self.parseThemeSelection(value)
     }
 
+    func currentLightThemeName() -> String? {
+        guard let selection = currentThemeSelection() else { return nil }
+        return selection.lightName ?? selection.fallbackName
+    }
+
+    func currentDarkThemeName() -> String? {
+        guard let selection = currentThemeSelection() else { return nil }
+        return selection.darkName ?? selection.fallbackName
+    }
+
     func activeThemeName() -> String? {
         currentThemeSelection()?.resolvedName(isDark: Self.isCurrentAppearanceDark())
     }
@@ -112,6 +122,24 @@ final class ThemeService {
     func applyDefaultThemeIfNeeded() {
         guard currentThemeName() == nil else { return }
         applyTheme(Self.defaultThemeName)
+    }
+
+    func migrateToPairedThemeIfNeeded() {
+        guard let selection = currentThemeSelection() else { return }
+        if selection.darkName != nil, selection.lightName != nil { return }
+        let dark = selection.darkName ?? selection.fallbackName ?? Self.defaultThemeName
+        let light = selection.lightName ?? selection.fallbackName ?? Self.defaultThemeName
+        applyTheme(dark: dark, light: light)
+    }
+
+    func applyLightTheme(_ name: String) {
+        let dark = currentDarkThemeName() ?? name
+        applyTheme(dark: dark, light: name)
+    }
+
+    func applyDarkTheme(_ name: String) {
+        let light = currentLightThemeName() ?? name
+        applyTheme(dark: name, light: light)
     }
 
     func applyTheme(_ name: String) {

--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -10,6 +10,26 @@ struct ThemePreview: Identifiable {
     var id: String { name }
 }
 
+struct ThemeSelection: Equatable {
+    let rawValue: String
+    let darkName: String?
+    let lightName: String?
+    let fallbackName: String?
+
+    var displayName: String {
+        if let darkName, let lightName {
+            return "Dark: \(darkName), Light: \(lightName)"
+        }
+        return fallbackName ?? rawValue
+    }
+
+    func resolvedName(isDark: Bool) -> String? {
+        if isDark, let darkName { return darkName }
+        if !isDark, let lightName { return lightName }
+        return fallbackName ?? darkName ?? lightName
+    }
+}
+
 @MainActor @Observable
 final class ThemeService {
     static let shared = ThemeService()
@@ -37,26 +57,41 @@ final class ThemeService {
     }
 
     func currentThemeName() -> String? {
-        config.configValue(for: "theme")?.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        currentThemeSelection()?.displayName
+    }
+
+    func currentThemeSelection() -> ThemeSelection? {
+        guard let value = config.configValue(for: "theme") else { return nil }
+        return Self.parseThemeSelection(value)
+    }
+
+    func activeThemeName() -> String? {
+        currentThemeSelection()?.resolvedName(isDark: Self.isCurrentAppearanceDark())
+    }
+
+    func activeThemePreview() -> ThemePreview? {
+        guard let name = activeThemeName() else { return nil }
+        return Self.themePreview(named: name)
+    }
+
+    func activeThemePreview(isDark: Bool) -> ThemePreview? {
+        guard let name = currentThemeSelection()?.resolvedName(isDark: isDark) else { return nil }
+        return Self.themePreview(named: name)
     }
 
     func currentThemeColors() -> DeviceThemeEventDTO? {
-        guard let name = currentThemeName() else { return nil }
+        guard let name = activeThemeName() else { return nil }
         if let cached = cachedColors, cached.name == name {
             return DeviceThemeEventDTO(fg: cached.fg, bg: cached.bg, palette: cached.palette)
         }
-        for dir in Self.themeDirectories() {
-            let path = dir + "/" + name
-            guard FileManager.default.fileExists(atPath: path),
-                  let theme = Self.parseThemeFile(atPath: path, name: name)
-            else { continue }
-            let fg = Self.rgb(from: theme.foreground)
-            let bg = Self.rgb(from: theme.background)
-            let palette = currentPalette()
-            cachedColors = CachedThemeColors(name: name, fg: fg, bg: bg, palette: palette)
-            return DeviceThemeEventDTO(fg: fg, bg: bg, palette: palette)
-        }
-        return nil
+        guard let theme = Self.themePreview(named: name) else { return nil }
+        let fg = Self.rgb(from: theme.foreground)
+        let bg = Self.rgb(from: theme.background)
+        let palette = theme.palette.count == 16
+            ? theme.palette.map(Self.rgb(from:))
+            : currentPalette()
+        cachedColors = CachedThemeColors(name: name, fg: fg, bg: bg, palette: palette)
+        return DeviceThemeEventDTO(fg: fg, bg: bg, palette: palette)
     }
 
     private func currentPalette() -> [UInt32] {
@@ -80,11 +115,104 @@ final class ThemeService {
     }
 
     func applyTheme(_ name: String) {
-        let sanitized = name.filter { $0 != "\"" && $0 != "\n" && $0 != "\r" }
+        let sanitized = sanitizedThemeName(name)
         config.updateConfigValue("theme", value: "\"\(sanitized)\"")
         cachedColors = nil
         ghostty.reloadConfig()
         NotificationCenter.default.post(name: .themeDidChange, object: nil)
+    }
+
+    func applyTheme(dark darkName: String, light lightName: String) {
+        let dark = sanitizedThemeName(darkName)
+        let light = sanitizedThemeName(lightName)
+        config.updateConfigValue("theme", value: "dark:\"\(dark)\",light:\"\(light)\"")
+        cachedColors = nil
+        ghostty.reloadConfig()
+        NotificationCenter.default.post(name: .themeDidChange, object: nil)
+    }
+
+    private func sanitizedThemeName(_ name: String) -> String {
+        name.filter { $0 != "\"" && $0 != "\n" && $0 != "\r" }
+    }
+
+    nonisolated static func parseThemeSelection(_ value: String) -> ThemeSelection {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let unquoted = unquote(trimmed)
+        let entries = splitThemeEntries(unquoted)
+        var darkName: String?
+        var lightName: String?
+        var fallbackParts: [String] = []
+
+        for entry in entries {
+            let parts = entry.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else {
+                fallbackParts.append(entry)
+                continue
+            }
+            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let name = unquote(parts[1].trimmingCharacters(in: .whitespacesAndNewlines))
+            if key == "dark" {
+                darkName = name
+            } else if key == "light" {
+                lightName = name
+            } else {
+                fallbackParts.append(entry)
+            }
+        }
+
+        let fallback = fallbackParts.isEmpty
+            ? (darkName == nil && lightName == nil ? unquoted : nil)
+            : fallbackParts.joined(separator: ",")
+        return ThemeSelection(
+            rawValue: trimmed,
+            darkName: darkName,
+            lightName: lightName,
+            fallbackName: fallback
+        )
+    }
+
+    nonisolated private static func splitThemeEntries(_ value: String) -> [String] {
+        var entries: [String] = []
+        var current = ""
+        var isQuoted = false
+        for char in value {
+            if char == "\"" {
+                isQuoted.toggle()
+                current.append(char)
+            } else if char == ",", !isQuoted {
+                let entry = current.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !entry.isEmpty { entries.append(entry) }
+                current = ""
+            } else {
+                current.append(char)
+            }
+        }
+        let entry = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !entry.isEmpty { entries.append(entry) }
+        return entries
+    }
+
+    nonisolated private static func unquote(_ value: String) -> String {
+        guard value.count >= 2, value.first == "\"", value.last == "\"" else { return value }
+        return String(value.dropFirst().dropLast())
+    }
+
+    static func isCurrentAppearanceDark() -> Bool {
+        if let style = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") {
+            return style.localizedCaseInsensitiveCompare("dark") == .orderedSame
+        }
+        return NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    }
+
+    nonisolated private static func themePreview(named name: String) -> ThemePreview? {
+        for dir in themeDirectories() {
+            let path = dir + "/" + name
+            guard FileManager.default.fileExists(atPath: path),
+                  let theme = parseThemeFile(atPath: path, name: name)
+            else { continue }
+            return theme
+        }
+        return nil
     }
 
     nonisolated private static func discoverThemes() -> [ThemePreview] {

--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -127,9 +127,8 @@ final class ThemeService {
     func migrateToPairedThemeIfNeeded() {
         guard let selection = currentThemeSelection() else { return }
         if selection.darkName != nil, selection.lightName != nil { return }
-        let dark = selection.darkName ?? selection.fallbackName ?? Self.defaultThemeName
-        let light = selection.lightName ?? selection.fallbackName ?? Self.defaultThemeName
-        applyTheme(dark: dark, light: light)
+        let unified = selection.darkName ?? selection.lightName ?? selection.fallbackName ?? Self.defaultThemeName
+        applyTheme(dark: selection.darkName ?? unified, light: selection.lightName ?? unified)
     }
 
     func applyLightTheme(_ name: String) {

--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -32,16 +32,19 @@ enum MuxyTheme {
     @MainActor static var colorScheme: ColorScheme { snapshot.colorScheme }
 
     @MainActor private static var cachedVersion: Int = -1
+    @MainActor private static var cachedIsDark = false
     @MainActor private static var cachedSnapshot: Snapshot?
 
     @MainActor private static var snapshot: Snapshot {
         let version = GhosttyService.shared.configVersion
-        if let cached = cachedSnapshot, cachedVersion == version {
-            return cached
+        let isDark = ThemeService.isCurrentAppearanceDark()
+        if let cachedSnapshot, cachedVersion == version, cachedIsDark == isDark {
+            return cachedSnapshot
         }
-        let newSnapshot = Snapshot(from: GhosttyService.shared)
-        cachedSnapshot = newSnapshot
+        let newSnapshot = Snapshot(from: GhosttyService.shared, isDark: isDark)
         cachedVersion = version
+        cachedIsDark = isDark
+        cachedSnapshot = newSnapshot
         return newSnapshot
     }
 }
@@ -74,10 +77,12 @@ extension MuxyTheme {
         let colorScheme: ColorScheme
 
         @MainActor
-        init(from service: GhosttyService) {
-            let bgColor = service.backgroundColor
-            let fgColor = service.foregroundColor
-            let accentColor = service.accentColor
+        init(from service: GhosttyService, isDark: Bool) {
+            let preview = ThemeService.shared.activeThemePreview(isDark: isDark)
+            let bgColor = preview?.background ?? service.backgroundColor
+            let fgColor = preview?.foreground ?? service.foregroundColor
+            let palette = preview?.palette ?? []
+            let accentColor = palette[safe: 4] ?? service.accentColor
 
             nsBg = bgColor
             bg = Color(nsColor: bgColor)
@@ -91,16 +96,16 @@ extension MuxyTheme {
             accentSoft = Color(nsColor: accentColor.withAlphaComponent(0.1))
             warning = Color(nsColor: service.paletteColor(at: 3) ?? NSColor.systemYellow)
 
-            let addColor = service.paletteColor(at: 2) ?? NSColor.systemGreen
-            let removeColor = service.paletteColor(at: 1) ?? NSColor.systemRed
-            let hunkColor = service.paletteColor(at: 6) ?? accentColor
+            let addColor = palette[safe: 2] ?? service.paletteColor(at: 2) ?? NSColor.systemGreen
+            let removeColor = palette[safe: 1] ?? service.paletteColor(at: 1) ?? NSColor.systemRed
+            let hunkColor = palette[safe: 6] ?? service.paletteColor(at: 6) ?? accentColor
 
             nsDiffAdd = addColor
             nsDiffRemove = removeColor
             nsDiffHunk = hunkColor
-            nsDiffString = service.paletteColor(at: 2) ?? NSColor.systemGreen
-            nsDiffNumber = service.paletteColor(at: 3) ?? NSColor.systemYellow
-            nsDiffComment = service.paletteColor(at: 8) ?? fgColor.withAlphaComponent(0.5)
+            nsDiffString = palette[safe: 2] ?? service.paletteColor(at: 2) ?? NSColor.systemGreen
+            nsDiffNumber = palette[safe: 3] ?? service.paletteColor(at: 3) ?? NSColor.systemYellow
+            nsDiffComment = palette[safe: 8] ?? service.paletteColor(at: 8) ?? fgColor.withAlphaComponent(0.5)
 
             diffAddFg = Color(nsColor: addColor)
             diffRemoveFg = Color(nsColor: removeColor)
@@ -117,5 +122,11 @@ extension MuxyTheme {
             }
             colorScheme = luminance > 0.5 ? .light : .dark
         }
+    }
+}
+
+private extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/Muxy/Views/Settings/AppearanceSettingsView.swift
+++ b/Muxy/Views/Settings/AppearanceSettingsView.swift
@@ -2,8 +2,10 @@ import SwiftUI
 
 struct AppearanceSettingsView: View {
     @State private var themeService = ThemeService.shared
-    @State private var showThemePicker = false
-    @State private var currentTheme: String?
+    @State private var showLightThemePicker = false
+    @State private var showDarkThemePicker = false
+    @State private var currentLightTheme: String?
+    @State private var currentDarkTheme: String?
     @AppStorage("muxy.vcsDisplayMode") private var vcsDisplayMode = VCSDisplayMode.attached.rawValue
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyle = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyle = SidebarExpandedStyle.defaultValue.rawValue
@@ -11,26 +13,19 @@ struct AppearanceSettingsView: View {
     var body: some View {
         SettingsContainer {
             SettingsSection("Terminal") {
-                SettingsRow("Theme") {
-                    Button {
-                        showThemePicker.toggle()
-                    } label: {
-                        HStack(spacing: 6) {
-                            Text(currentTheme ?? "Default")
-                                .font(.system(size: SettingsMetrics.labelFontSize))
-                                .lineLimit(1)
-                            Image(systemName: "chevron.up.chevron.down")
-                                .font(.system(size: 10))
-                        }
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
-                    }
-                    .buttonStyle(.plain)
-                    .popover(isPresented: $showThemePicker) {
-                        ThemePicker()
-                            .environment(themeService)
-                    }
+                SettingsRow("Light Theme") {
+                    themeButton(
+                        title: currentLightTheme ?? "Default",
+                        isPresented: $showLightThemePicker,
+                        mode: .light
+                    )
+                }
+                SettingsRow("Dark Theme") {
+                    themeButton(
+                        title: currentDarkTheme ?? "Default",
+                        isPresented: $showDarkThemePicker,
+                        mode: .dark
+                    )
                 }
             }
 
@@ -80,10 +75,41 @@ struct AppearanceSettingsView: View {
             }
         }
         .task {
-            currentTheme = themeService.currentThemeName()
+            refreshThemeNames()
         }
         .onReceive(NotificationCenter.default.publisher(for: .themeDidChange)) { _ in
-            currentTheme = themeService.currentThemeName()
+            refreshThemeNames()
         }
+    }
+
+    private func themeButton(
+        title: String,
+        isPresented: Binding<Bool>,
+        mode: ThemePickerMode
+    ) -> some View {
+        Button {
+            isPresented.wrappedValue.toggle()
+        } label: {
+            HStack(spacing: 6) {
+                Text(title)
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .lineLimit(1)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 10))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: isPresented) {
+            ThemePicker(mode: mode)
+                .environment(themeService)
+        }
+    }
+
+    private func refreshThemeNames() {
+        currentLightTheme = themeService.currentLightThemeName()
+        currentDarkTheme = themeService.currentDarkThemeName()
     }
 }

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -391,7 +391,7 @@ struct SidebarFooter: View {
                 }
             IconButton(symbol: "paintpalette", accessibilityLabel: "Theme Picker") { showThemePicker.toggle() }
                 .help("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
-                .popover(isPresented: $showThemePicker) { ThemePicker() }
+                .popover(isPresented: $showThemePicker) { ThemePicker(mode: .sidebar) }
             IconButton(symbol: sidebarToggleIcon, accessibilityLabel: sidebarToggleLabel) { postToggleSidebar() }
                 .help("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))")
         }
@@ -415,7 +415,7 @@ struct SidebarFooter: View {
                 }
             IconButton(symbol: "paintpalette", accessibilityLabel: "Theme Picker") { showThemePicker.toggle() }
                 .help("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
-                .popover(isPresented: $showThemePicker) { ThemePicker() }
+                .popover(isPresented: $showThemePicker) { ThemePicker(mode: .sidebar) }
         }
         .padding(.horizontal, 10)
         .padding(.bottom, 8)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -134,8 +134,7 @@ final class GhosttyTerminalNSView: NSView {
 
         ghostty_surface_set_size(surface, backingSize.width, backingSize.height)
 
-        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
+        applyColorScheme(isDark: ThemeService.isCurrentAppearanceDark())
 
         if let screen = window?.screen ?? NSScreen.main,
            let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? UInt32
@@ -236,8 +235,11 @@ final class GhosttyTerminalNSView: NSView {
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
+        applyColorScheme(isDark: ThemeService.isCurrentAppearanceDark())
+    }
+
+    func applyColorScheme(isDark: Bool) {
         guard let surface else { return }
-        let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
     }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -233,11 +233,6 @@ final class GhosttyTerminalNSView: NSView {
         updateMetalLayerSize(deferred: true)
     }
 
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        applyColorScheme(isDark: ThemeService.isCurrentAppearanceDark())
-    }
-
     func applyColorScheme(isDark: Bool) {
         guard let surface else { return }
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)

--- a/Muxy/Views/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Views/Terminal/TerminalViewRegistry.swift
@@ -53,6 +53,12 @@ final class TerminalViewRegistry {
     func paneID(for view: GhosttyTerminalNSView) -> UUID? {
         paneIDs[ObjectIdentifier(view)]
     }
+
+    func applyColorSchemeToAllViews(isDark: Bool) {
+        for view in views.values {
+            view.applyColorScheme(isDark: isDark)
+        }
+    }
 }
 
 extension TerminalViewRegistry: TerminalViewRemoving {}

--- a/Muxy/Views/ThemePicker.swift
+++ b/Muxy/Views/ThemePicker.swift
@@ -1,6 +1,15 @@
 import SwiftUI
 
+enum ThemePickerMode {
+    case light
+    case dark
+    case currentAppearance
+
+    static var sidebar: ThemePickerMode { .currentAppearance }
+}
+
 struct ThemePicker: View {
+    var mode: ThemePickerMode = .currentAppearance
     @Environment(ThemeService.self) private var themeService
     @State private var themes: [ThemePreview] = []
     @State private var currentTheme: String?
@@ -23,13 +32,29 @@ struct ThemePicker: View {
         .frame(width: 280, height: 400)
         .task {
             themes = await themeService.loadThemes()
-            currentTheme = themeService.currentThemeName()
+            currentTheme = currentName()
+        }
+    }
+
+    private func currentName() -> String? {
+        isDarkMode() ? themeService.currentDarkThemeName() : themeService.currentLightThemeName()
+    }
+
+    private func isDarkMode() -> Bool {
+        switch mode {
+        case .light: false
+        case .dark: true
+        case .currentAppearance: ThemeService.isCurrentAppearanceDark()
         }
     }
 
     private func selectTheme(_ theme: ThemePreview) {
         currentTheme = theme.name
-        themeService.applyTheme(theme.name)
+        if isDarkMode() {
+            themeService.applyDarkTheme(theme.name)
+        } else {
+            themeService.applyLightTheme(theme.name)
+        }
     }
 }
 

--- a/Tests/MuxyTests/Services/ThemeServiceTests.swift
+++ b/Tests/MuxyTests/Services/ThemeServiceTests.swift
@@ -1,0 +1,41 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("ThemeService")
+struct ThemeServiceTests {
+    @Test("parseThemeSelection preserves single theme names")
+    func parseSingleThemeName() {
+        let selection = ThemeService.parseThemeSelection("\"Muxy\"")
+
+        #expect(selection.displayName == "Muxy")
+        #expect(selection.resolvedName(isDark: true) == "Muxy")
+        #expect(selection.resolvedName(isDark: false) == "Muxy")
+    }
+
+    @Test("parseThemeSelection resolves paired dark and light theme names")
+    func parsePairedThemeNames() {
+        let selection = ThemeService.parseThemeSelection("dark:\"Muxy\",light:\"Muxy Light\"")
+
+        #expect(selection.displayName == "Dark: Muxy, Light: Muxy Light")
+        #expect(selection.resolvedName(isDark: true) == "Muxy")
+        #expect(selection.resolvedName(isDark: false) == "Muxy Light")
+    }
+
+    @Test("parseThemeSelection falls back when one side is missing")
+    func parsePartialThemePair() {
+        let selection = ThemeService.parseThemeSelection("dark:\"Muxy\"")
+
+        #expect(selection.displayName == selection.rawValue)
+        #expect(selection.resolvedName(isDark: true) == "Muxy")
+        #expect(selection.resolvedName(isDark: false) == "Muxy")
+    }
+
+    @Test("parseThemeSelection ignores commas inside quoted names")
+    func parseQuotedCommaThemeName() {
+        let selection = ThemeService.parseThemeSelection("dark:\"Dark, Variant\",light:\"Light\"")
+
+        #expect(selection.resolvedName(isDark: true) == "Dark, Variant")
+        #expect(selection.resolvedName(isDark: false) == "Light")
+    }
+}

--- a/Tests/MuxyTests/Services/ThemeServiceTests.swift
+++ b/Tests/MuxyTests/Services/ThemeServiceTests.swift
@@ -13,6 +13,15 @@ struct ThemeServiceTests {
         #expect(selection.resolvedName(isDark: false) == "Muxy")
     }
 
+    @Test("parseThemeSelection handles unquoted bare name")
+    func parseUnquotedBareName() {
+        let selection = ThemeService.parseThemeSelection("Muxy")
+
+        #expect(selection.displayName == "Muxy")
+        #expect(selection.resolvedName(isDark: true) == "Muxy")
+        #expect(selection.resolvedName(isDark: false) == "Muxy")
+    }
+
     @Test("parseThemeSelection resolves paired dark and light theme names")
     func parsePairedThemeNames() {
         let selection = ThemeService.parseThemeSelection("dark:\"Muxy\",light:\"Muxy Light\"")
@@ -22,13 +31,22 @@ struct ThemeServiceTests {
         #expect(selection.resolvedName(isDark: false) == "Muxy Light")
     }
 
-    @Test("parseThemeSelection falls back when one side is missing")
-    func parsePartialThemePair() {
+    @Test("parseThemeSelection falls back when dark side is missing")
+    func parseDarkOnlyPair() {
         let selection = ThemeService.parseThemeSelection("dark:\"Muxy\"")
 
         #expect(selection.displayName == selection.rawValue)
         #expect(selection.resolvedName(isDark: true) == "Muxy")
         #expect(selection.resolvedName(isDark: false) == "Muxy")
+    }
+
+    @Test("parseThemeSelection falls back when light side is missing")
+    func parseLightOnlyPair() {
+        let selection = ThemeService.parseThemeSelection("light:\"Muxy Light\"")
+
+        #expect(selection.displayName == selection.rawValue)
+        #expect(selection.resolvedName(isDark: true) == "Muxy Light")
+        #expect(selection.resolvedName(isDark: false) == "Muxy Light")
     }
 
     @Test("parseThemeSelection ignores commas inside quoted names")
@@ -37,5 +55,77 @@ struct ThemeServiceTests {
 
         #expect(selection.resolvedName(isDark: true) == "Dark, Variant")
         #expect(selection.resolvedName(isDark: false) == "Light")
+    }
+
+    @Test("parseThemeSelection treats unknown keys as fallback")
+    func parseUnknownKey() {
+        let selection = ThemeService.parseThemeSelection("foo:\"Bar\"")
+
+        #expect(selection.darkName == nil)
+        #expect(selection.lightName == nil)
+        #expect(selection.resolvedName(isDark: true) != nil)
+        #expect(selection.resolvedName(isDark: false) != nil)
+    }
+
+    @Test("parseThemeSelection handles empty string")
+    func parseEmptyString() {
+        let selection = ThemeService.parseThemeSelection("")
+
+        #expect(selection.darkName == nil)
+        #expect(selection.lightName == nil)
+        #expect(selection.resolvedName(isDark: true) == "")
+        #expect(selection.resolvedName(isDark: false) == "")
+    }
+
+    @Suite("Migration math")
+    struct MigrationTests {
+        private func migrationResult(
+            for rawValue: String,
+            defaultTheme: String = "Muxy"
+        ) -> (dark: String, light: String) {
+            let selection = ThemeService.parseThemeSelection(rawValue)
+            let unified = selection.darkName ?? selection.lightName ?? selection.fallbackName ?? defaultTheme
+            return (selection.darkName ?? unified, selection.lightName ?? unified)
+        }
+
+        @Test("single quoted name migrates to identical dark and light")
+        func migrateSingleName() {
+            let result = migrationResult(for: "\"Dracula\"")
+
+            #expect(result.dark == "Dracula")
+            #expect(result.light == "Dracula")
+        }
+
+        @Test("dark-only config mirrors dark theme to light side")
+        func migrateDarkOnly() {
+            let result = migrationResult(for: "dark:\"Dracula\"")
+
+            #expect(result.dark == "Dracula")
+            #expect(result.light == "Dracula")
+        }
+
+        @Test("light-only config mirrors light theme to dark side")
+        func migrateLightOnly() {
+            let result = migrationResult(for: "light:\"Muxy Light\"")
+
+            #expect(result.dark == "Muxy Light")
+            #expect(result.light == "Muxy Light")
+        }
+
+        @Test("already paired config has both sides non-nil, skipping migration")
+        func alreadyPaired() {
+            let selection = ThemeService.parseThemeSelection("dark:\"Dracula\",light:\"Muxy Light\"")
+
+            #expect(selection.darkName != nil)
+            #expect(selection.lightName != nil)
+        }
+
+        @Test("unquoted single name migrates to identical dark and light")
+        func migrateUnquotedName() {
+            let result = migrationResult(for: "Dracula")
+
+            #expect(result.dark == "Dracula")
+            #expect(result.light == "Dracula")
+        }
     }
 }


### PR DESCRIPTION
## Summary

This changeset adds support for setting light and dark themes on macOS matching the Ghostty pair theme syntax: `theme = dark:"Ayu Mirage",light:"Ayu Light"`.

## Changes

- Add light/dark paired theme support: `theme = dark:X,light:Y` config syntax.
- Add separate light/dark theme selectors in the settings Appearance tab.
- Add one-time migration for existing single-theme configs. The existing theme is copied to both light and dark modes on first run.
- The terminal and app chrome follow the macOS mode changes in real time.
- The quick theme picker in the sidebar sets the theme for the current mode (light or dark), leaving the other mode theme unchanged.

## Testing

- [x] `scripts/checks.sh` passes.
- [x] Theme copy to both modes on fresh update works.
- [x] App opens with the dark theme applied in dark mode.
- [x] App opens with the light theme applied in light mode.
- [x] App changes theme when system changes mode.
- [x] Sidebar quick theme picker sets the new theme just for the current mode.

## Screenshots

<img width="612" height="700" alt="light-dark" src="https://github.com/user-attachments/assets/15ee8d1d-16da-48ae-a8b2-aa1717c59ae7" />