### PR TITLE
Fix editor colors in dark mode

### DIFF
--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -225,10 +225,21 @@ final class ThemeService {
     }
 
     static func isCurrentAppearanceDark() -> Bool {
-        if let style = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") {
-            return style.localizedCaseInsensitiveCompare("dark") == .orderedSame
+        isDarkAppearance(
+            userInterfaceStyle: UserDefaults.standard.string(forKey: "AppleInterfaceStyle"),
+            effectiveAppearance: NSApp?.effectiveAppearance
+        )
+    }
+
+    nonisolated static func isDarkAppearance(
+        userInterfaceStyle: String?,
+        effectiveAppearance: NSAppearance?
+    ) -> Bool {
+        if let userInterfaceStyle {
+            return userInterfaceStyle.localizedCaseInsensitiveCompare("dark") == .orderedSame
         }
-        return NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        guard let effectiveAppearance else { return false }
+        return effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     }
 
     nonisolated private static func themePreview(named name: String) -> ThemePreview? {

--- a/Muxy/Syntax/SyntaxScope.swift
+++ b/Muxy/Syntax/SyntaxScope.swift
@@ -47,7 +47,7 @@ enum SyntaxTheme {
         if let cached = cachedDefaultForeground {
             return cached
         }
-        let color = GhosttyService.shared.foregroundColor
+        let color = EditorThemePalette.active.foreground
         cachedDefaultForeground = color
         return color
     }
@@ -61,54 +61,54 @@ enum SyntaxTheme {
     }
 
     private static func resolve(scope: SyntaxScope) -> NSColor {
-        let service = GhosttyService.shared
-        let fg = service.foregroundColor
+        let palette = EditorThemePalette.active
+        let fg = palette.foreground
 
         switch scope {
         case .keyword,
              .storage:
-            return service.paletteColor(at: 5) ?? fg
+            return palette.paletteColor(at: 5) ?? fg
         case .type:
-            return service.paletteColor(at: 6) ?? fg
+            return palette.paletteColor(at: 6) ?? fg
         case .builtin:
-            return service.paletteColor(at: 14) ?? service.paletteColor(at: 6) ?? fg
+            return palette.paletteColor(at: 14) ?? palette.paletteColor(at: 6) ?? fg
         case .constant:
-            return service.paletteColor(at: 3) ?? fg
+            return palette.paletteColor(at: 3) ?? fg
         case .string:
-            return service.paletteColor(at: 2) ?? fg
+            return palette.paletteColor(at: 2) ?? fg
         case .stringEscape:
-            return service.paletteColor(at: 13) ?? service.paletteColor(at: 5) ?? fg
+            return palette.paletteColor(at: 13) ?? palette.paletteColor(at: 5) ?? fg
         case .number:
-            return service.paletteColor(at: 3) ?? fg
+            return palette.paletteColor(at: 3) ?? fg
         case .comment,
              .docComment:
-            return service.paletteColor(at: 8) ?? fg.withAlphaComponent(0.55)
+            return palette.paletteColor(at: 8) ?? fg.withAlphaComponent(0.55)
         case .function:
-            return service.paletteColor(at: 4) ?? fg
+            return palette.paletteColor(at: 4) ?? fg
         case .variable:
-            return service.paletteColor(at: 6) ?? fg
+            return palette.paletteColor(at: 6) ?? fg
         case .attribute:
-            return service.paletteColor(at: 11) ?? service.paletteColor(at: 3) ?? fg
+            return palette.paletteColor(at: 11) ?? palette.paletteColor(at: 3) ?? fg
         case .preprocessor:
-            return service.paletteColor(at: 13) ?? service.paletteColor(at: 5) ?? fg
+            return palette.paletteColor(at: 13) ?? palette.paletteColor(at: 5) ?? fg
         case .op:
             return fg
         case .punctuation:
             return fg.withAlphaComponent(0.75)
         case .tag:
-            return service.paletteColor(at: 1) ?? fg
+            return palette.paletteColor(at: 1) ?? fg
         case .attributeName:
-            return service.paletteColor(at: 3) ?? fg
+            return palette.paletteColor(at: 3) ?? fg
         case .attributeValue:
-            return service.paletteColor(at: 2) ?? fg
+            return palette.paletteColor(at: 2) ?? fg
         case .regex:
-            return service.paletteColor(at: 1) ?? fg
+            return palette.paletteColor(at: 1) ?? fg
         case .heading:
-            return service.paletteColor(at: 4) ?? fg
+            return palette.paletteColor(at: 4) ?? fg
         case .link:
-            return service.paletteColor(at: 6) ?? fg
+            return palette.paletteColor(at: 6) ?? fg
         case .emphasis:
-            return service.paletteColor(at: 3) ?? fg
+            return palette.paletteColor(at: 3) ?? fg
         }
     }
 }

--- a/Muxy/Theme/EditorThemePalette.swift
+++ b/Muxy/Theme/EditorThemePalette.swift
@@ -1,0 +1,54 @@
+import AppKit
+
+struct EditorThemePalette {
+    let background: NSColor
+    let foreground: NSColor
+    let accent: NSColor
+    private let paletteColors: [Int: NSColor]
+
+    @MainActor
+    static var active: EditorThemePalette {
+        let service = GhosttyService.shared
+        let preview = ThemeService.shared.activeThemePreview(isDark: ThemeService.isCurrentAppearanceDark())
+        return resolve(
+            preview: preview,
+            fallbackBackground: service.backgroundColor,
+            fallbackForeground: service.foregroundColor,
+            fallbackAccent: service.accentColor,
+            fallbackPaletteColor: { service.paletteColor(at: $0) }
+        )
+    }
+
+    static func resolve(
+        preview: ThemePreview?,
+        fallbackBackground: NSColor,
+        fallbackForeground: NSColor,
+        fallbackAccent: NSColor,
+        fallbackPaletteColor: (Int) -> NSColor?
+    ) -> EditorThemePalette {
+        let previewPalette = preview?.palette ?? []
+        let paletteCount = max(16, previewPalette.count)
+        var resolvedPalette: [Int: NSColor] = [:]
+        for index in 0 ..< paletteCount {
+            resolvedPalette[index] = previewPalette[safe: index] ?? fallbackPaletteColor(index)
+        }
+        let accent = previewPalette[safe: 4] ?? fallbackPaletteColor(4) ?? fallbackAccent
+        return EditorThemePalette(
+            background: preview?.background ?? fallbackBackground,
+            foreground: preview?.foreground ?? fallbackForeground,
+            accent: accent,
+            paletteColors: resolvedPalette
+        )
+    }
+
+    func paletteColor(at index: Int) -> NSColor? {
+        guard index >= 0 else { return nil }
+        return paletteColors[index]
+    }
+}
+
+private extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -51,6 +51,7 @@ enum MuxyTheme {
 
 extension MuxyTheme {
     struct Snapshot {
+        let palette: EditorThemePalette
         let nsBg: NSColor
         let bg: Color
         let fg: Color
@@ -78,12 +79,18 @@ extension MuxyTheme {
 
         @MainActor
         init(from service: GhosttyService, isDark: Bool) {
-            let preview = ThemeService.shared.activeThemePreview(isDark: isDark)
-            let bgColor = preview?.background ?? service.backgroundColor
-            let fgColor = preview?.foreground ?? service.foregroundColor
-            let palette = preview?.palette ?? []
-            let accentColor = palette[safe: 4] ?? service.accentColor
+            let resolvedPalette = EditorThemePalette.resolve(
+                preview: ThemeService.shared.activeThemePreview(isDark: isDark),
+                fallbackBackground: service.backgroundColor,
+                fallbackForeground: service.foregroundColor,
+                fallbackAccent: service.accentColor,
+                fallbackPaletteColor: { service.paletteColor(at: $0) }
+            )
+            let bgColor = resolvedPalette.background
+            let fgColor = resolvedPalette.foreground
+            let accentColor = resolvedPalette.accent
 
+            palette = resolvedPalette
             nsBg = bgColor
             bg = Color(nsColor: bgColor)
             fg = Color(nsColor: fgColor)
@@ -94,18 +101,18 @@ extension MuxyTheme {
             hover = Color(nsColor: fgColor.withAlphaComponent(0.06))
             accent = Color(nsColor: accentColor)
             accentSoft = Color(nsColor: accentColor.withAlphaComponent(0.1))
-            warning = Color(nsColor: service.paletteColor(at: 3) ?? NSColor.systemYellow)
+            warning = Color(nsColor: resolvedPalette.paletteColor(at: 3) ?? NSColor.systemYellow)
 
-            let addColor = palette[safe: 2] ?? service.paletteColor(at: 2) ?? NSColor.systemGreen
-            let removeColor = palette[safe: 1] ?? service.paletteColor(at: 1) ?? NSColor.systemRed
-            let hunkColor = palette[safe: 6] ?? service.paletteColor(at: 6) ?? accentColor
+            let addColor = resolvedPalette.paletteColor(at: 2) ?? NSColor.systemGreen
+            let removeColor = resolvedPalette.paletteColor(at: 1) ?? NSColor.systemRed
+            let hunkColor = resolvedPalette.paletteColor(at: 6) ?? accentColor
 
             nsDiffAdd = addColor
             nsDiffRemove = removeColor
             nsDiffHunk = hunkColor
-            nsDiffString = palette[safe: 2] ?? service.paletteColor(at: 2) ?? NSColor.systemGreen
-            nsDiffNumber = palette[safe: 3] ?? service.paletteColor(at: 3) ?? NSColor.systemYellow
-            nsDiffComment = palette[safe: 8] ?? service.paletteColor(at: 8) ?? fgColor.withAlphaComponent(0.5)
+            nsDiffString = resolvedPalette.paletteColor(at: 2) ?? NSColor.systemGreen
+            nsDiffNumber = resolvedPalette.paletteColor(at: 3) ?? NSColor.systemYellow
+            nsDiffComment = resolvedPalette.paletteColor(at: 8) ?? fgColor.withAlphaComponent(0.5)
 
             diffAddFg = Color(nsColor: addColor)
             diffRemoveFg = Color(nsColor: removeColor)
@@ -122,11 +129,5 @@ extension MuxyTheme {
             }
             colorScheme = luminance > 0.5 ? .light : .dark
         }
-    }
-}
-
-private extension Collection {
-    subscript(safe index: Index) -> Element? {
-        indices.contains(index) ? self[index] : nil
     }
 }

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -223,20 +223,24 @@ struct CodeEditorView: NSViewRepresentable {
         textView.textContainerInset = NSSize(width: 0, height: 4)
 
         let font = editorSettings.resolvedFont
+        let palette = EditorThemePalette.active
         textView.font = font
-        textView.backgroundColor = GhosttyService.shared.backgroundColor
-        textView.insertionPointColor = GhosttyService.shared.foregroundColor
-        textView.textColor = GhosttyService.shared.foregroundColor
+        textView.backgroundColor = palette.background
+        textView.insertionPointColor = palette.foreground
+        textView.textColor = palette.foreground
         textView.typingAttributes = [
             .font: font,
-            .foregroundColor: GhosttyService.shared.foregroundColor,
+            .foregroundColor: palette.foreground,
         ]
         textView.selectedTextAttributes = [
-            .backgroundColor: GhosttyService.shared.foregroundColor.withAlphaComponent(0.15),
+            .backgroundColor: palette.foreground.withAlphaComponent(0.15),
         ]
 
         scrollView.autohidesScrollers = showsVerticalScroller
-        scrollView.drawsBackground = false
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = palette.background
+        scrollView.contentView.drawsBackground = true
+        scrollView.contentView.backgroundColor = palette.background
         scrollView.borderType = .noBorder
         scrollView.contentView.postsBoundsChangedNotifications = true
         scrollView.contentView.postsFrameChangedNotifications = true
@@ -340,7 +344,7 @@ struct CodeEditorView: NSViewRepresentable {
         let font = editorSettings.resolvedFont
         let fontChanged = textView.font != font
 
-        applyThemeAndFont(textView: textView, font: font)
+        applyThemeAndFont(scrollView: scrollView, textView: textView, font: font)
 
         if fontChanged {
             viewport.updateEstimatedLineHeight(font: font)
@@ -372,10 +376,27 @@ struct CodeEditorView: NSViewRepresentable {
         }
     }
 
-    private func applyThemeAndFont(textView: NSTextView, font: NSFont) {
-        let fgColor = GhosttyService.shared.foregroundColor
-        let bgColor = GhosttyService.shared.backgroundColor
+    private func applyThemeAndFont(scrollView: NSScrollView, textView: NSTextView, font: NSFont) {
+        let palette = EditorThemePalette.active
+        let fgColor = palette.foreground
+        let bgColor = palette.background
 
+        if !scrollView.drawsBackground {
+            scrollView.drawsBackground = true
+        }
+        if scrollView.backgroundColor != bgColor {
+            scrollView.backgroundColor = bgColor
+        }
+        if !scrollView.contentView.drawsBackground {
+            scrollView.contentView.drawsBackground = true
+        }
+        if scrollView.contentView.backgroundColor != bgColor {
+            scrollView.contentView.backgroundColor = bgColor
+        }
+        if let documentView = scrollView.documentView, documentView !== textView {
+            documentView.wantsLayer = true
+            documentView.layer?.backgroundColor = bgColor.cgColor
+        }
         if textView.backgroundColor != bgColor {
             textView.backgroundColor = bgColor
         }
@@ -592,6 +613,7 @@ struct CodeEditorView: NSViewRepresentable {
 
             let container = ViewportContainerView()
             container.wantsLayer = true
+            container.layer?.backgroundColor = EditorThemePalette.active.background.cgColor
             let height = max(viewport.totalDocumentHeight, scrollView.contentView.bounds.height)
             let width = max(scrollView.contentSize.width, textView.frame.width)
             container.frame = NSRect(x: 0, y: 0, width: width, height: height)
@@ -674,6 +696,7 @@ struct CodeEditorView: NSViewRepresentable {
                 let fullRange = NSRange(location: 0, length: storage.length)
                 storage.beginEditing()
                 storage.addAttribute(.font, value: font, range: fullRange)
+                storage.addAttribute(.foregroundColor, value: EditorThemePalette.active.foreground, range: fullRange)
                 storage.endEditing()
                 applySyntaxHighlights(storage: storage, viewport: viewport)
             }

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -192,10 +192,11 @@ struct EditorPane: View {
     }
 
     private var markdownPalette: MarkdownRenderer.Palette {
-        MarkdownRenderer.Palette(
-            background: ghostty.backgroundColor,
-            foreground: ghostty.foregroundColor,
-            accent: ghostty.accentColor,
+        let palette = EditorThemePalette.active
+        return MarkdownRenderer.Palette(
+            background: palette.background,
+            foreground: palette.foreground,
+            accent: palette.accent,
             fontFamilyCSS: editorSettings.resolvedMarkdownPreviewFontFamilyCSS,
             fontScale: editorSettings.markdownPreviewFontScale
         )

--- a/Muxy/Views/Editor/Search/SearchController.swift
+++ b/Muxy/Views/Editor/Search/SearchController.swift
@@ -100,10 +100,11 @@ final class SearchController {
             return
         }
 
-        let matchBg = GhosttyService.shared.foregroundColor.withAlphaComponent(0.2)
-        let themeYellow = GhosttyService.shared.paletteColor(at: 3) ?? NSColor.systemYellow
+        let palette = EditorThemePalette.active
+        let matchBg = palette.foreground.withAlphaComponent(0.2)
+        let themeYellow = palette.paletteColor(at: 3) ?? NSColor.systemYellow
         let currentMatchBg = themeYellow.withAlphaComponent(0.85)
-        let currentMatchFg = GhosttyService.shared.backgroundColor
+        let currentMatchFg = palette.background
 
         for highlightRange in nextRanges {
             if highlightRange == nextCurrentRange {

--- a/Tests/MuxyTests/Services/EditorThemePaletteTests.swift
+++ b/Tests/MuxyTests/Services/EditorThemePaletteTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+struct EditorThemePaletteTests {
+    @Test("resolve prefers preview colors over Ghostty fallbacks")
+    func resolvePrefersPreviewColors() {
+        let previewBackground = NSColor(srgbRed: 0.1, green: 0.2, blue: 0.3, alpha: 1)
+        let previewForeground = NSColor(srgbRed: 0.8, green: 0.7, blue: 0.6, alpha: 1)
+        let previewPalette = (0 ..< 16).map { index in
+            NSColor(srgbRed: CGFloat(index) / 20, green: 0.1, blue: 0.2, alpha: 1)
+        }
+        let preview = ThemePreview(
+            name: "Dark Preview",
+            background: previewBackground,
+            foreground: previewForeground,
+            palette: previewPalette
+        )
+
+        let resolved = EditorThemePalette.resolve(
+            preview: preview,
+            fallbackBackground: .white,
+            fallbackForeground: .black,
+            fallbackAccent: .red,
+            fallbackPaletteColor: { _ in .green }
+        )
+
+        #expect(resolved.background == previewBackground)
+        #expect(resolved.foreground == previewForeground)
+        #expect(resolved.accent == previewPalette[4])
+        #expect(resolved.paletteColor(at: 2) == previewPalette[2])
+    }
+
+    @Test("resolve fills incomplete preview palettes from fallbacks")
+    func resolveFillsIncompletePreviewPalettesFromFallbacks() {
+        let preview = ThemePreview(
+            name: "Partial Preview",
+            background: .black,
+            foreground: .white,
+            palette: [.red]
+        )
+
+        let resolved = EditorThemePalette.resolve(
+            preview: preview,
+            fallbackBackground: .white,
+            fallbackForeground: .black,
+            fallbackAccent: .blue,
+            fallbackPaletteColor: { index in
+                NSColor(srgbRed: CGFloat(index) / 20, green: 0.3, blue: 0.4, alpha: 1)
+            }
+        )
+
+        #expect(resolved.paletteColor(at: 0) == .red)
+        #expect(resolved.paletteColor(at: 3) == NSColor(srgbRed: 0.15, green: 0.3, blue: 0.4, alpha: 1))
+        #expect(resolved.accent == NSColor(srgbRed: 0.2, green: 0.3, blue: 0.4, alpha: 1))
+    }
+
+    @Test("resolve uses fallback colors when no preview exists")
+    func resolveUsesFallbackColorsWithoutPreview() {
+        let fallbackBackground = NSColor(srgbRed: 0.9, green: 0.8, blue: 0.7, alpha: 1)
+        let fallbackForeground = NSColor(srgbRed: 0.1, green: 0.2, blue: 0.3, alpha: 1)
+        let fallbackAccent = NSColor(srgbRed: 0.4, green: 0.5, blue: 0.6, alpha: 1)
+
+        let resolved = EditorThemePalette.resolve(
+            preview: nil,
+            fallbackBackground: fallbackBackground,
+            fallbackForeground: fallbackForeground,
+            fallbackAccent: fallbackAccent,
+            fallbackPaletteColor: { index in
+                index == 4 ? nil : NSColor(srgbRed: CGFloat(index) / 20, green: 0.4, blue: 0.5, alpha: 1)
+            }
+        )
+
+        #expect(resolved.background == fallbackBackground)
+        #expect(resolved.foreground == fallbackForeground)
+        #expect(resolved.accent == fallbackAccent)
+        #expect(resolved.paletteColor(at: 4) == nil)
+        #expect(resolved.paletteColor(at: -1) == nil)
+    }
+}

--- a/Tests/MuxyTests/Services/ThemeServiceTests.swift
+++ b/Tests/MuxyTests/Services/ThemeServiceTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Testing
 
 @testable import Muxy
@@ -75,6 +76,29 @@ struct ThemeServiceTests {
         #expect(selection.lightName == nil)
         #expect(selection.resolvedName(isDark: true) == "")
         #expect(selection.resolvedName(isDark: false) == "")
+    }
+
+    @Test("isDarkAppearance uses user defaults before AppKit appearance")
+    func isDarkAppearanceUsesUserDefaults() throws {
+        let darkAppearance = try #require(NSAppearance(named: .darkAqua))
+        let lightAppearance = try #require(NSAppearance(named: .aqua))
+
+        #expect(ThemeService.isDarkAppearance(userInterfaceStyle: "dark", effectiveAppearance: lightAppearance))
+        #expect(!ThemeService.isDarkAppearance(userInterfaceStyle: "light", effectiveAppearance: darkAppearance))
+    }
+
+    @Test("isDarkAppearance uses effective appearance")
+    func isDarkAppearanceUsesEffectiveAppearance() throws {
+        let darkAppearance = try #require(NSAppearance(named: .darkAqua))
+        let lightAppearance = try #require(NSAppearance(named: .aqua))
+
+        #expect(ThemeService.isDarkAppearance(userInterfaceStyle: nil, effectiveAppearance: darkAppearance))
+        #expect(!ThemeService.isDarkAppearance(userInterfaceStyle: nil, effectiveAppearance: lightAppearance))
+    }
+
+    @Test("isDarkAppearance defaults to light when effective appearance is missing")
+    func isDarkAppearanceDefaultsToLightWhenAppearanceIsMissing() {
+        #expect(!ThemeService.isDarkAppearance(userInterfaceStyle: nil, effectiveAppearance: nil))
     }
 
     @Suite("Migration math")


### PR DESCRIPTION
## Summary

This changeset fixes an issue introduced in PR #301 where having the syatem in dark mode would render the file editor with the light theme.

## Changes

- Updates the editor panel color theme to respect the dark theme set in the config.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Set your system to dark mode and open a file in the built-in editor

## Screenshots

<img width="1624" height="1060" alt="Screenshot 2026-05-01 at 23 27 20" src="https://github.com/user-attachments/assets/cdc5529d-0aad-4e38-adb4-295a680283a3" />
