### PR TITLE
Add project path sync and UI shortcut improvements

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -137,6 +137,24 @@ struct MuxyCommands: Commands {
         }
 
         CommandGroup(replacing: .newItem) {
+            Button("New Project") {
+                performShortcutAction(.newProject)
+            }
+            .shortcut(for: .newProject, store: keyBindings)
+
+            Button("New Window") {
+                performShortcutAction(.newWindow)
+            }
+            .shortcut(for: .newWindow, store: keyBindings)
+
+            Button("Rename Project") {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.renameProject)
+            }
+            .shortcut(for: .renameProject, store: keyBindings)
+
+            Divider()
+
             Button("Open Project...") {
                 performShortcutAction(.openProject)
             }

--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -17,4 +17,6 @@ extension Notification.Name {
     static let toggleNotificationPanel = Notification.Name("MuxyToggleNotificationPanel")
     static let toggleAIUsage = Notification.Name("MuxyToggleAIUsage")
     static let vcsRepoDidChange = Notification.Name("MuxyVCSRepoDidChange")
+    static let openNewMainWindow = Notification.Name("MuxyOpenNewMainWindow")
+    static let renameActiveProject = Notification.Name("MuxyRenameActiveProject")
 }

--- a/Muxy/Extensions/View+KeyboardShortcut.swift
+++ b/Muxy/Extensions/View+KeyboardShortcut.swift
@@ -3,6 +3,9 @@ import SwiftUI
 extension View {
     func shortcut(for action: ShortcutAction, store: KeyBindingStore) -> some View {
         let combo = store.combo(for: action)
-        return keyboardShortcut(combo.swiftUIKeyEquivalent, modifiers: combo.swiftUIModifiers)
+        if let keyEquivalent = combo.swiftUIKeyEquivalent {
+            return AnyView(keyboardShortcut(keyEquivalent, modifiers: combo.swiftUIModifiers))
+        }
+        return AnyView(self)
     }
 }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -189,6 +189,24 @@ final class AppState {
         return workspaceRoots[key]?.allAreas() ?? []
     }
 
+    func terminalCount(for projectID: UUID) -> Int {
+        workspaceRoots.reduce(0) { count, entry in
+            guard entry.key.projectID == projectID else { return count }
+            return count + entry.value.allAreas().reduce(0) { areaCount, area in
+                areaCount + area.tabs.count(where: { $0.kind == .terminal })
+            }
+        }
+    }
+
+    func updateWorkspacePath(projectID: UUID, worktreeID: UUID, to path: String) {
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        guard let root = workspaceRoots[key] else { return }
+        for area in root.allAreas() {
+            area.updateProjectPath(path)
+        }
+        saveWorkspaces()
+    }
+
     func splitFocusedArea(direction: SplitDirection, projectID: UUID) {
         guard let area = focusedArea(for: projectID) else { return }
         dispatch(.splitArea(.init(

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -55,6 +55,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case toggleAIUsage
     case navigateBack
     case navigateForward
+    case newWindow
+    case renameProject
 
     static let allCases: [Self] = [
         .newTab,
@@ -103,6 +105,9 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .toggleAIUsage,
         .navigateBack,
         .navigateForward,
+        .newProject,
+        .newWindow,
+        .renameProject,
     ]
 
     var id: String { rawValue }
@@ -155,6 +160,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .toggleThemePicker: ShortcutMetadata(displayName: "Theme Picker", category: "App", scope: .mainWindow)
         case .newProject: ShortcutMetadata(displayName: "New Project", category: "App", scope: .mainWindow)
         case .openProject: ShortcutMetadata(displayName: "Open Project", category: "App", scope: .mainWindow)
+        case .newWindow: ShortcutMetadata(displayName: "New Window", category: "App", scope: .global)
+        case .renameProject: ShortcutMetadata(displayName: "Rename Project", category: "App", scope: .mainWindow)
         case .reloadConfig: ShortcutMetadata(displayName: "Reload Configuration", category: "App", scope: .global)
         }
     }
@@ -269,5 +276,8 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .toggleAIUsage, combo: KeyCombo(key: "l", command: true)),
         Self(action: .navigateBack, combo: KeyCombo(key: KeyCombo.leftArrowKey, command: true, control: true)),
         Self(action: .navigateForward, combo: KeyCombo(key: KeyCombo.rightArrowKey, command: true, control: true)),
+        Self(action: .newProject, combo: KeyCombo(key: "n", command: true)),
+        Self(action: .newWindow, combo: KeyCombo(key: "n", command: true, shift: true)),
+        Self(action: .renameProject, combo: KeyCombo(key: "", modifiers: 0)),
     ]
 }

--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -78,6 +78,10 @@ struct KeyCombo: Codable, Equatable, Hashable {
         case kVK_ANSI_Keypad7: "7"
         case kVK_ANSI_Keypad8: "8"
         case kVK_ANSI_Keypad9: "9"
+        case kVK_Return: "return"
+        case kVK_Tab: "tab"
+        case kVK_Space: "space"
+        case kVK_Delete: "delete"
         case kVK_LeftArrow: leftArrowKey
         case kVK_RightArrow: rightArrowKey
         case kVK_DownArrow: downArrowKey
@@ -119,16 +123,23 @@ struct KeyCombo: Codable, Equatable, Hashable {
         NSEvent.ModifierFlags(rawValue: modifiers).intersection(Self.supportedModifierMask)
     }
 
-    var swiftUIKeyEquivalent: KeyEquivalent {
+    var swiftUIKeyEquivalent: KeyEquivalent? {
+        guard !key.isEmpty else { return nil }
         switch key {
-        case "[": KeyEquivalent("[")
-        case "]": KeyEquivalent("]")
-        case ",": KeyEquivalent(",")
-        case Self.leftArrowKey: .leftArrow
-        case Self.rightArrowKey: .rightArrow
-        case Self.upArrowKey: .upArrow
-        case Self.downArrowKey: .downArrow
-        default: KeyEquivalent(Character(key))
+        case "[": return KeyEquivalent("[")
+        case "]": return KeyEquivalent("]")
+        case ",": return KeyEquivalent(",")
+        case Self.leftArrowKey: return KeyEquivalent.leftArrow
+        case Self.rightArrowKey: return KeyEquivalent.rightArrow
+        case Self.upArrowKey: return KeyEquivalent.upArrow
+        case Self.downArrowKey: return KeyEquivalent.downArrow
+        case "tab": return KeyEquivalent.tab
+        case "return": return KeyEquivalent.return
+        case "space": return KeyEquivalent.space
+        case "delete": return KeyEquivalent.delete
+        default:
+            guard let scalar = key.unicodeScalars.first, key.unicodeScalars.count == 1 else { return nil }
+            return KeyEquivalent(Character(scalar))
         }
     }
 

--- a/Muxy/Models/Project.swift
+++ b/Muxy/Models/Project.swift
@@ -9,8 +9,9 @@ struct Project: Identifiable, Codable, Hashable {
     var icon: String?
     var logo: String?
     var iconColor: String?
+    var isNameCustomized: Bool
 
-    init(name: String, path: String, sortOrder: Int = 0) {
+    init(name: String, path: String, sortOrder: Int = 0, isNameCustomized: Bool = false) {
         self.id = UUID()
         self.name = name
         self.path = path
@@ -19,6 +20,26 @@ struct Project: Identifiable, Codable, Hashable {
         self.icon = nil
         self.logo = nil
         self.iconColor = nil
+        self.isNameCustomized = isNameCustomized
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, path, sortOrder, createdAt, icon, logo, iconColor, isNameCustomized
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        path = try container.decode(String.self, forKey: .path)
+        sortOrder = try container.decode(Int.self, forKey: .sortOrder)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        logo = try container.decodeIfPresent(String.self, forKey: .logo)
+        iconColor = try container.decodeIfPresent(String.self, forKey: .iconColor)
+        let stored = try container.decodeIfPresent(Bool.self, forKey: .isNameCustomized)
+        let folderName = URL(fileURLWithPath: path).lastPathComponent
+        isNameCustomized = stored ?? (name != folderName)
     }
 
     var pathExists: Bool {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -4,7 +4,7 @@ import Foundation
 @Observable
 final class TabArea: Identifiable {
     let id: UUID
-    let projectPath: String
+    var projectPath: String
     var tabs: [TerminalTab] = []
     var activeTabID: UUID?
     private var tabHistory: [UUID] = []
@@ -57,6 +57,13 @@ final class TabArea: Identifiable {
 
     func createTab() {
         insertTab(TerminalTab(pane: TerminalPaneState(projectPath: projectPath)))
+    }
+
+    func updateProjectPath(_ path: String) {
+        projectPath = path
+        for tab in tabs {
+            tab.updateProjectPath(path)
+        }
     }
 
     func createTab(inDirectory directory: String) {

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -4,7 +4,7 @@ import Foundation
 @Observable
 final class TerminalPaneState: Identifiable {
     let id = UUID()
-    let projectPath: String
+    var projectPath: String
     var title: String
     var currentWorkingDirectory: String?
     let startupCommand: String?
@@ -40,5 +40,9 @@ final class TerminalPaneState: Identifiable {
 
     func setWorkingDirectory(_ path: String) {
         currentWorkingDirectory = path
+    }
+
+    func updateProjectPath(_ path: String) {
+        projectPath = path
     }
 }

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -10,6 +10,7 @@ final class TerminalTab: Identifiable {
         case diffViewer
     }
 
+    @MainActor
     enum Content {
         case terminal(TerminalPaneState)
         case vcs(VCSTabState)
@@ -130,5 +131,9 @@ final class TerminalTab: Identifiable {
             filePath: content.editorState?.filePath,
             currentWorkingDirectory: content.pane?.currentWorkingDirectory
         )
+    }
+
+    func updateProjectPath(_ path: String) {
+        content.pane?.updateProjectPath(path)
     }
 }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -34,7 +34,7 @@ struct MuxyApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: "main") {
             MainWindow()
                 .environment(appState)
                 .environment(projectStore)
@@ -205,6 +205,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
+        UserDefaults.standard.set(200, forKey: "NSInitialToolTipDelay")
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
         setAppIcon()

--- a/Muxy/Services/ProjectOpenService.swift
+++ b/Muxy/Services/ProjectOpenService.swift
@@ -16,11 +16,31 @@ enum ProjectOpenService {
         let project = Project(
             name: url.lastPathComponent,
             path: url.path(percentEncoded: false),
-            sortOrder: projectStore.projects.count
+            sortOrder: 0
         )
-        projectStore.add(project)
+        projectStore.insert(project, afterProjectWithID: appState.activeProjectID)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return }
         appState.selectProject(project, worktree: primary)
+    }
+
+    static func duplicateActiveProject(
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) -> Bool {
+        guard let activeProjectID = appState.activeProjectID,
+              let activeProject = projectStore.projects.first(where: { $0.id == activeProjectID })
+        else { return false }
+        let project = Project(
+            name: activeProject.name,
+            path: activeProject.path,
+            sortOrder: 0
+        )
+        projectStore.insert(project, afterProjectWithID: activeProjectID)
+        worktreeStore.ensurePrimary(for: project)
+        guard let primary = worktreeStore.primary(for: project.id) else { return false }
+        appState.selectProject(project, worktree: primary)
+        return true
     }
 }

--- a/Muxy/Services/ProjectPathSyncService.swift
+++ b/Muxy/Services/ProjectPathSyncService.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@MainActor
+enum ProjectPathSyncService {
+    static func syncFromTerminalWorkingDirectory(
+        projectID: UUID,
+        worktreeID: UUID,
+        path: String,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) {
+        guard appState.terminalCount(for: projectID) == 1 else { return }
+        guard let project = projectStore.updatePath(id: projectID, to: path) else { return }
+        worktreeStore.updatePrimary(projectID: projectID, path: project.path)
+        appState.updateWorkspacePath(projectID: projectID, worktreeID: worktreeID, to: project.path)
+    }
+}

--- a/Muxy/Services/ProjectStore.swift
+++ b/Muxy/Services/ProjectStore.swift
@@ -19,6 +19,24 @@ final class ProjectStore {
         save()
     }
 
+    func insert(_ project: Project, afterProjectWithID projectID: UUID?) {
+        let index: Int
+        if let projectID,
+           let activeIndex = projects.firstIndex(where: { $0.id == projectID })
+        {
+            index = activeIndex + 1
+        } else {
+            index = projects.count
+        }
+        var mutable = project
+        mutable.sortOrder = index
+        projects.insert(mutable, at: min(index, projects.count))
+        for i in 0 ..< projects.count {
+            projects[i].sortOrder = i
+        }
+        save()
+    }
+
     func remove(id: UUID) {
         if let project = projects.first(where: { $0.id == id }) {
             VCSPersistedSettings.clearSettings(repoPath: project.path)

--- a/Muxy/Services/ProjectStore.swift
+++ b/Muxy/Services/ProjectStore.swift
@@ -48,7 +48,21 @@ final class ProjectStore {
     func rename(id: UUID, to newName: String) {
         guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
         projects[index].name = newName
+        projects[index].isNameCustomized = true
         save()
+    }
+
+    @discardableResult
+    func updatePath(id: UUID, to newPath: String) -> Project? {
+        guard let index = projects.firstIndex(where: { $0.id == id }) else { return nil }
+        let standardized = URL(fileURLWithPath: newPath).standardizedFileURL.path
+        guard projects[index].path != standardized else { return projects[index] }
+        projects[index].path = standardized
+        if !projects[index].isNameCustomized {
+            projects[index].name = URL(fileURLWithPath: standardized).lastPathComponent
+        }
+        save()
+        return projects[index]
     }
 
     func setLogo(id: UUID, to logo: String?) {

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -100,7 +100,18 @@ struct ShortcutActionDispatcher {
             notificationCenter.post(name: .toggleThemePicker, object: nil)
             return true
         case .newProject:
-            return false
+            _ = ProjectOpenService.duplicateActiveProject(
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+            return true
+        case .newWindow:
+            notificationCenter.post(name: .openNewMainWindow, object: nil)
+            return true
+        case .renameProject:
+            notificationCenter.post(name: .renameActiveProject, object: nil)
+            return true
         case .openProject:
             ProjectOpenService.openProject(
                 appState: appState,

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -95,7 +95,7 @@ final class WorktreeStore {
 
         if let primaryIndex = list.firstIndex(where: \.isPrimary) {
             list[primaryIndex].path = project.path
-            list[primaryIndex].name = project.name
+            list[primaryIndex].name = Self.primaryName(for: project.path)
         } else {
             list.insert(makePrimary(for: project), at: 0)
         }
@@ -126,7 +126,7 @@ final class WorktreeStore {
             {
                 list[index].branch = record.branch
                 if list[index].isPrimary {
-                    list[index].name = project.name
+                    list[index].name = Self.primaryName(for: project.path)
                     list[index].path = project.path
                 }
                 continue
@@ -229,6 +229,18 @@ final class WorktreeStore {
         save(projectID: projectID)
     }
 
+    func updatePrimary(projectID: UUID, path: String) {
+        guard var list = worktrees[projectID],
+              let index = list.firstIndex(where: \.isPrimary)
+        else { return }
+        let name = Self.primaryName(for: path)
+        guard list[index].path != path || list[index].name != name else { return }
+        list[index].path = path
+        list[index].name = name
+        setWorktrees(list, for: projectID)
+        save(projectID: projectID)
+    }
+
     func removeProject(_ projectID: UUID) {
         if let existing = worktrees[projectID] {
             for worktree in existing where projectIDByPath[worktree.path] == projectID {
@@ -257,12 +269,17 @@ final class WorktreeStore {
 
     private func makePrimary(for project: Project) -> Worktree {
         Worktree(
-            name: project.name,
+            name: Self.primaryName(for: project.path),
             path: project.path,
             branch: nil,
             source: .muxy,
             isPrimary: true
         )
+    }
+
+    private static func primaryName(for path: String) -> String {
+        let folderName = URL(fileURLWithPath: path).lastPathComponent
+        return folderName.isEmpty ? path : folderName
     }
 
     private func sortPrimaryFirst(_ list: [Worktree]) -> [Worktree] {

--- a/Muxy/Views/Components/DebugButton.swift
+++ b/Muxy/Views/Components/DebugButton.swift
@@ -7,6 +7,7 @@ struct DebugButton: View {
 
     var body: some View {
         Button {
+            TooltipState.shared.hideAll()
             showingPopover.toggle()
         } label: {
             Image(systemName: "ladybug.fill")
@@ -18,7 +19,7 @@ struct DebugButton: View {
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
-        .help("Debug Info")
+        .quickTooltip("Debug Info")
         .popover(isPresented: $showingPopover, arrowEdge: .bottom) {
             DebugInfoPopover()
         }

--- a/Muxy/Views/Components/OpenInIDEControl.swift
+++ b/Muxy/Views/Components/OpenInIDEControl.swift
@@ -39,7 +39,7 @@ struct OpenInIDEControl: View {
             .buttonStyle(.plain)
             .disabled(projectPath == nil || defaultIDE == nil)
             .onHover { hoveredPrimary = $0 }
-            .help(helpText)
+            .quickTooltip(helpText)
             .accessibilityLabel(helpText)
 
             menuToggleButton(width: 14)
@@ -70,7 +70,7 @@ struct OpenInIDEControl: View {
             .buttonStyle(.plain)
             .disabled(projectPath == nil || defaultIDE == nil)
             .onHover { hoveredPrimary = $0 }
-            .help(helpText)
+            .quickTooltip(helpText)
             .accessibilityLabel(helpText)
 
             menuToggleButton(width: 18)
@@ -83,6 +83,7 @@ struct OpenInIDEControl: View {
     private func menuToggleButton(width: CGFloat) -> some View {
         Button {
             guard projectPath != nil else { return }
+            TooltipState.shared.hideAll()
             showingMenu.toggle()
         } label: {
             Image(systemName: "chevron.down")
@@ -94,7 +95,7 @@ struct OpenInIDEControl: View {
         .buttonStyle(.plain)
         .disabled(projectPath == nil)
         .onHover { hoveredMenu = $0 }
-        .help(menuHelpText)
+        .quickTooltip(menuHelpText)
     }
 
     private var menuPopoverContent: some View {
@@ -105,6 +106,7 @@ struct OpenInIDEControl: View {
                     fallbackSystemName: "folder",
                     title: "Finder"
                 ) {
+                    TooltipState.shared.hideAll()
                     showingMenu = false
                     _ = ideService.openProject(at: projectPath, in: IDEIntegrationService.finderApplication)
                 }
@@ -217,11 +219,13 @@ struct OpenInIDEControl: View {
 
     private func openDefaultIDE() {
         guard let defaultIDE else { return }
+        TooltipState.shared.hideAll()
         open(defaultIDE)
     }
 
     private func open(_ ide: IDEIntegrationService.IDEApplication) {
         guard let projectPath else { return }
+        TooltipState.shared.hideAll()
         let cursor = cursorProvider()
         _ = ideService.openProject(
             at: projectPath,

--- a/Muxy/Views/Components/QuickTooltipModifier.swift
+++ b/Muxy/Views/Components/QuickTooltipModifier.swift
@@ -1,0 +1,152 @@
+import AppKit
+import SwiftUI
+
+struct TooltipInfo: Equatable {
+    let id: UUID
+    let text: String
+    let frame: CGRect
+}
+
+@MainActor
+@Observable
+final class TooltipState {
+    static let shared = TooltipState()
+    var active: TooltipInfo?
+    @ObservationIgnored
+    private var timers: [UUID: Timer] = [:]
+    @ObservationIgnored
+    private var mouseDownMonitor: Any?
+
+    private init() {
+        mouseDownMonitor = NSEvent.addLocalMonitorForEvents(matching: [
+            .leftMouseDown,
+            .rightMouseDown,
+            .otherMouseDown,
+        ]) { [weak self] event in
+            Task { @MainActor in
+                self?.hideAll()
+            }
+            return event
+        }
+    }
+
+    func show(id: UUID, text: String, frame: CGRect) {
+        timers[id]?.invalidate()
+        timers[id] = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.active = TooltipInfo(id: id, text: text, frame: frame)
+            }
+        }
+    }
+
+    func hide(id: UUID) {
+        timers[id]?.invalidate()
+        timers[id] = nil
+        if active?.id == id { active = nil }
+    }
+
+    func hideAll() {
+        timers.values.forEach { $0.invalidate() }
+        timers.removeAll()
+        active = nil
+    }
+}
+
+struct QuickTooltipModifier: ViewModifier {
+    let text: String
+    @State private var id = UUID()
+    @State private var globalFrame: CGRect = .zero
+
+    func body(content: Content) -> some View {
+        content
+            .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { globalFrame = $0 }
+            .background(TooltipHoverTrackingView { hovering in
+                if hovering { TooltipState.shared.show(id: id, text: text, frame: globalFrame) }
+                else { TooltipState.shared.hide(id: id) }
+            })
+            .simultaneousGesture(TapGesture().onEnded {
+                TooltipState.shared.hide(id: id)
+            })
+            .onDisappear {
+                TooltipState.shared.hide(id: id)
+            }
+    }
+}
+
+private struct TooltipHoverTrackingView: NSViewRepresentable {
+    let onHover: (Bool) -> Void
+
+    func makeNSView(context: Context) -> TooltipTrackingNSView {
+        let view = TooltipTrackingNSView()
+        view.onHover = onHover
+        return view
+    }
+
+    func updateNSView(_ nsView: TooltipTrackingNSView, context: Context) {
+        nsView.onHover = onHover
+    }
+}
+
+private final class TooltipTrackingNSView: NSView {
+    var onHover: ((Bool) -> Void)?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas {
+            removeTrackingArea(area)
+        }
+        addTrackingArea(NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onHover?(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onHover?(false)
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+struct TooltipOverlay: View {
+    @State private var state = TooltipState.shared
+
+    var body: some View {
+        GeometryReader { windowGeo in
+            if let info = state.active {
+                let originX = windowGeo.frame(in: .global).minX
+                let originY = windowGeo.frame(in: .global).minY
+                Text(info.text)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(MuxyTheme.surface)
+                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+                            .shadow(color: Color.black.opacity(0.2), radius: 8, x: 0, y: 4)
+                    )
+                    .position(
+                        x: info.frame.midX - originX,
+                        y: info.frame.maxY - originY + 14
+                    )
+                    .transition(.opacity.animation(.easeInOut(duration: 0.15)))
+            }
+        }
+    }
+}
+
+extension View {
+    func quickTooltip(_ text: String) -> some View {
+        modifier(QuickTooltipModifier(text: text))
+    }
+}

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -301,7 +301,7 @@ private struct EditorMarkdownModePicker: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help(scrollSyncEnabled ? "Disable Scroll Sync" : "Enable Scroll Sync")
+                .quickTooltip(scrollSyncEnabled ? "Disable Scroll Sync" : "Enable Scroll Sync")
                 .accessibilityLabel(scrollSyncEnabled ? "Disable Markdown Scroll Sync" : "Enable Markdown Scroll Sync")
 
                 Rectangle()
@@ -323,7 +323,7 @@ private struct EditorMarkdownModePicker: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help(helpText(for: candidate, currentMode: mode))
+                .quickTooltip(helpText(for: candidate, currentMode: mode))
                 .accessibilityLabel("Markdown \(candidate.title) View")
             }
         }

--- a/Muxy/Views/Editor/EditorSearchBar.swift
+++ b/Muxy/Views/Editor/EditorSearchBar.swift
@@ -27,7 +27,7 @@ struct EditorSearchBar: View {
                         .font(.system(size: 10, weight: .semibold))
                 }
                 .buttonStyle(EditorSearchButtonStyle())
-                .help(state.replaceVisible ? "Hide Replace" : "Show Replace")
+                .quickTooltip(state.replaceVisible ? "Hide Replace" : "Show Replace")
                 .accessibilityLabel(state.replaceVisible ? "Hide Replace" : "Show Replace")
                 .padding(.top, 1)
 
@@ -203,7 +203,7 @@ private struct EditorSearchOptionToggle: View {
                 .clipShape(RoundedRectangle(cornerRadius: 4))
         }
         .buttonStyle(.plain)
-        .help(help)
+        .quickTooltip(help)
         .accessibilityLabel(help)
         .accessibilityValue(isOn ? "Enabled" : "Disabled")
         .accessibilityAddTraits(.isToggle)

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -133,7 +133,7 @@ struct FileTreeView: View {
             ) {
                 state.showOnlyChanges.toggle()
             }
-            .help(state.showOnlyChanges ? "Show All Files" : "Show Only Changed Files")
+            .quickTooltip(state.showOnlyChanges ? "Show All Files" : "Show Only Changed Files")
         }
         .padding(.horizontal, 10)
         .frame(height: 32)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -20,6 +20,11 @@ struct MainWindow: View {
         static let maxWidth: CGFloat = 600
     }
 
+    private enum SidebarDragMode {
+        case collapsed
+        case expanded
+    }
+
     private enum CloseConfirmationKind {
         case lastTab
         case unsavedEditor
@@ -49,7 +54,7 @@ struct MainWindow: View {
     }
 
     @State private var vcsPanelVisible = false
-    @State private var vcsPanelWidth: CGFloat = AttachedVCSLayout.defaultWidth
+    @AppStorage("muxy.vcsPanelWidth") private var vcsPanelWidth: Double = .init(AttachedVCSLayout.defaultWidth)
     @State private var vcsStates: [WorktreeKey: VCSTabState] = [:]
     @State private var fileTreePanelVisible = false
     @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
@@ -61,7 +66,13 @@ struct MainWindow: View {
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage("muxy.notifications.toastPosition") private var toastPositionRaw = ToastPosition.topCenter.rawValue
+    @AppStorage("muxy.sidebarCustomWidth") private var sidebarCustomWidth: Double = SidebarLayout.expandedDefaultWidth
+    @AppStorage(GeneralSettingsKeys.showNavigationArrows) private var showNavigationArrows = true
+    @State private var sidebarDragMode: SidebarDragMode?
+    @State private var sidebarDragWidth: CGFloat?
+    @State private var sidebarDragStartWidth: CGFloat = 0
     private let trafficLightWidth: CGFloat = 75
+    private let sidebarResizeHandleWidth: CGFloat = 5
 
     var body: some View {
         VStack(spacing: 0) {
@@ -72,7 +83,9 @@ struct MainWindow: View {
                         .fixedSize(horizontal: true, vertical: false)
                         .overlay(alignment: .trailing) {
                             HStack(spacing: 0) {
-                                navigationArrows
+                                if showNavigationArrows {
+                                    navigationArrows
+                                }
                                 Rectangle().fill(MuxyTheme.border).frame(width: 1)
                             }
                         }
@@ -88,14 +101,19 @@ struct MainWindow: View {
 
             HStack(spacing: 0) {
                 HStack(spacing: 0) {
-                    Sidebar()
-                    if !SidebarLayout.isHidden(expanded: sidebarExpanded, collapsedStyle: sidebarCollapsedStyle) {
-                        Rectangle().fill(MuxyTheme.border).frame(width: 1)
-                            .accessibilityHidden(true)
-                    }
+                    Sidebar(expanded: sidebarRenderedMode == .expanded, width: sidebarRenderedWidth)
                 }
-                .fixedSize(horizontal: true, vertical: false)
+                .frame(width: sidebarRenderedWidth)
                 .background(MuxyTheme.bg)
+                .clipped()
+
+                if sidebarRenderedWidth > 0 {
+                    if isSidebarResizable {
+                        sidebarResizeHandle
+                    }
+                    Rectangle().fill(MuxyTheme.border).frame(width: 1)
+                        .accessibilityHidden(true)
+                }
 
                 ZStack {
                     MuxyTheme.bg
@@ -127,15 +145,17 @@ struct MainWindow: View {
                 if vcsPanelVisible, VCSDisplayMode.current == .attached, let state = activeVCSState {
                     HStack(spacing: 0) {
                         sidePanelResizeHandle { delta in
+                            let next = vcsPanelWidth - Double(delta)
                             vcsPanelWidth = max(
-                                AttachedVCSLayout.minWidth,
-                                min(AttachedVCSLayout.maxWidth, vcsPanelWidth - delta)
+                                Double(AttachedVCSLayout.minWidth),
+                                min(Double(AttachedVCSLayout.maxWidth), next)
                             )
                         }
                         VCSTabView(state: state, focused: false, onFocus: {})
-                            .frame(width: vcsPanelWidth)
+                            .frame(width: CGFloat(vcsPanelWidth))
                     }
-                } else if fileTreePanelVisible, let treeState = activeFileTreeState {
+                }
+                if fileTreePanelVisible, let treeState = activeFileTreeState {
                     HStack(spacing: 0) {
                         sidePanelResizeHandle { delta in
                             let next = fileTreePanelWidth - Double(delta)
@@ -167,6 +187,7 @@ struct MainWindow: View {
                     }
                 }
             }
+            .coordinateSpace(name: "sidebarResizeSpace")
         }
         .environment(\.overlayActive, showQuickOpen || showWorktreeSwitcher)
         .overlay(alignment: toastAlignment) {
@@ -246,12 +267,16 @@ struct MainWindow: View {
             withAnimation(.easeInOut(duration: 0.2)) {
                 sidebarExpanded.toggle()
             }
+            UserDefaults.standard.set(sidebarExpanded, forKey: "muxy.sidebarExpanded")
         }
         .onReceive(NotificationCenter.default.publisher(for: .windowFullScreenDidChange)) { notification in
             isFullScreen = notification.userInfo?["isFullScreen"] as? Bool ?? false
         }
         .onReceive(NotificationCenter.default.publisher(for: .openVCSWindow)) { _ in
             openWindow(id: "vcs")
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openNewMainWindow)) { _ in
+            openWindow(id: "main")
         }
         .onReceive(NotificationCenter.default.publisher(for: .toggleAttachedVCS)) { _ in
             toggleAttachedVCSPanel()
@@ -293,26 +318,10 @@ struct MainWindow: View {
             guard isPresented, let message = appState.pendingSaveErrorMessage else { return }
             presentSaveErrorAlert(message: message)
         }
-    }
-
-    private var navigationArrows: some View {
-        HStack(spacing: 2) {
-            NavigationArrowButton(
-                symbol: "chevron.left",
-                isEnabled: appState.navigation.canGoBack,
-                label: "Back (\(KeyBindingStore.shared.combo(for: .navigateBack).displayString))"
-            ) {
-                appState.goBack()
-            }
-            NavigationArrowButton(
-                symbol: "chevron.right",
-                isEnabled: appState.navigation.canGoForward,
-                label: "Forward (\(KeyBindingStore.shared.combo(for: .navigateForward).displayString))"
-            ) {
-                appState.goForward()
-            }
+        .overlay(alignment: .topLeading) {
+            TooltipOverlay()
+                .allowsHitTesting(false)
         }
-        .padding(.trailing, 4)
     }
 
     @ViewBuilder
@@ -416,14 +425,14 @@ struct MainWindow: View {
                             IconButton(symbol: "doc.text", size: 12, accessibilityLabel: "Quick Open") {
                                 NotificationCenter.default.post(name: .quickOpen, object: nil)
                             }
-                            .help("Quick Open (\(KeyBindingStore.shared.combo(for: .quickOpen).displayString))")
+                            .quickTooltip("Quick Open (\(KeyBindingStore.shared.combo(for: .quickOpen).displayString))")
                             FileDiffIconButton {
                                 openVCS(for: project)
                             }
                             FileTreeIconButton {
                                 NotificationCenter.default.post(name: .toggleFileTree, object: nil)
                             }
-                            .help("File Tree (\(KeyBindingStore.shared.combo(for: .toggleFileTree).displayString))")
+                            .quickTooltip("File Tree (\(KeyBindingStore.shared.combo(for: .toggleFileTree).displayString))")
                         }
                     }
                     .padding(.trailing, 4)
@@ -482,17 +491,140 @@ struct MainWindow: View {
         SidebarExpandedStyle(rawValue: sidebarExpandedStyleRaw) ?? .defaultValue
     }
 
-    private var topBarLeadingWidth: CGFloat {
-        let sidebarWidth = SidebarLayout.resolvedWidth(
-            expanded: sidebarExpanded,
-            collapsedStyle: sidebarCollapsedStyle,
-            expandedStyle: sidebarExpandedStyle
-        ) + 1
-        let navigationMinimum = trafficLightWidth + navigationArrowsWidth
-        return max(navigationMinimum, sidebarWidth)
+    private var sidebarRenderedMode: SidebarDragMode {
+        sidebarDragMode ?? (sidebarExpanded ? .expanded : .collapsed)
     }
 
-    private var navigationArrowsWidth: CGFloat { 52 }
+    private var sidebarRenderedWidth: CGFloat {
+        if let sidebarDragWidth {
+            return sidebarDragWidth
+        }
+        if sidebarRenderedMode == .expanded, sidebarExpandedStyle == .wide {
+            return sidebarClampedExpandedWidth
+        }
+        return sidebarCollapsedWidth
+    }
+
+    private var sidebarCollapsedWidth: CGFloat {
+        sidebarCollapsedStyle == .hidden ? 0 : SidebarLayout.collapsedWidth
+    }
+
+    private var sidebarClampedExpandedWidth: CGFloat {
+        max(SidebarLayout.minExpandedWidth, min(SidebarLayout.maxExpandedWidth, CGFloat(sidebarCustomWidth)))
+    }
+
+    private var isSidebarResizable: Bool {
+        guard sidebarExpandedStyle == .wide else { return false }
+        if sidebarExpanded { return true }
+        if sidebarCollapsedStyle == .icons { return true }
+        return false
+    }
+
+    private var sidebarResizeGesture: some Gesture {
+        DragGesture(minimumDistance: 1, coordinateSpace: .named("sidebarResizeSpace"))
+            .onChanged { v in
+                beginSidebarDragIfNeeded()
+                let proposed = sidebarDragStartWidth + (v.location.x - v.startLocation.x)
+                updateSidebarDrag(proposedWidth: proposed)
+            }
+            .onEnded { _ in
+                finishSidebarDrag()
+            }
+    }
+
+    private func beginSidebarDragIfNeeded() {
+        guard sidebarDragMode == nil else { return }
+        sidebarDragStartWidth = sidebarRenderedWidth
+        sidebarDragMode = sidebarExpanded ? .expanded : .collapsed
+        sidebarDragWidth = sidebarRenderedWidth
+    }
+
+    private func updateSidebarDrag(proposedWidth: CGFloat) {
+        let width = clampedSidebarDragWidth(proposedWidth)
+        switch sidebarRenderedMode {
+        case .collapsed:
+            if width >= SidebarLayout.autoExpandThreshold {
+                applySidebarDrag(mode: .expanded, width: width)
+            } else {
+                applySidebarDrag(mode: .collapsed, width: width)
+            }
+        case .expanded:
+            if width < SidebarLayout.autoCollapseThreshold {
+                applySidebarDrag(mode: .collapsed, width: width)
+            } else {
+                applySidebarDrag(mode: .expanded, width: width)
+            }
+        }
+    }
+
+    private func applySidebarDrag(mode: SidebarDragMode, width: CGFloat) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            sidebarDragWidth = width
+        }
+        if sidebarDragMode == mode {
+            return
+        }
+        withAnimation(.easeInOut(duration: 0.12)) {
+            sidebarDragMode = mode
+        }
+    }
+
+    private func finishSidebarDrag() {
+        guard let sidebarDragMode else { return }
+        switch sidebarDragMode {
+        case .collapsed:
+            sidebarExpanded = false
+            UserDefaults.standard.set(false, forKey: "muxy.sidebarExpanded")
+        case .expanded:
+            sidebarExpanded = true
+            sidebarCustomWidth = Double(clampedSidebarExpandedWidth(sidebarDragWidth ?? sidebarClampedExpandedWidth))
+            UserDefaults.standard.set(true, forKey: "muxy.sidebarExpanded")
+        }
+        self.sidebarDragMode = nil
+        sidebarDragWidth = nil
+    }
+
+    private func clampedSidebarDragWidth(_ width: CGFloat) -> CGFloat {
+        max(sidebarCollapsedWidth, min(SidebarLayout.maxExpandedWidth, width))
+    }
+
+    private func clampedSidebarExpandedWidth(_ width: CGFloat) -> CGFloat {
+        max(SidebarLayout.minExpandedWidth, min(SidebarLayout.maxExpandedWidth, width))
+    }
+
+    private var topBarLeadingWidth: CGFloat {
+        let actualSidebarWidth = sidebarRenderedWidth + sidebarChromeWidth
+        let navigationMinimum = trafficLightWidth + navigationArrowsWidth
+        return max(navigationMinimum, actualSidebarWidth)
+    }
+
+    private var sidebarChromeWidth: CGFloat {
+        (isSidebarResizable ? sidebarResizeHandleWidth : 0) + 1
+    }
+
+    private var navigationArrowsWidth: CGFloat { showNavigationArrows ? 52 : 0 }
+
+    private var navigationArrows: some View {
+        HStack(spacing: 2) {
+            NavigationArrowButton(
+                symbol: "chevron.left",
+                isEnabled: appState.navigation.canGoBack,
+                label: "Back (\(KeyBindingStore.shared.combo(for: .navigateBack).displayString))"
+            ) {
+                appState.goBack()
+            }
+            NavigationArrowButton(
+                symbol: "chevron.right",
+                isEnabled: appState.navigation.canGoForward,
+                label: "Forward (\(KeyBindingStore.shared.combo(for: .navigateForward).displayString))"
+            ) {
+                appState.goForward()
+            }
+        }
+        .padding(.trailing, 4)
+    }
 
     private var devModeBadge: some View {
         DebugButton()
@@ -588,6 +720,18 @@ struct MainWindow: View {
             }
     }
 
+    private var sidebarResizeHandle: some View {
+        Color.clear
+            .frame(width: sidebarResizeHandleWidth)
+            .contentShape(Rectangle())
+            .gesture(sidebarResizeGesture)
+            .onHover { on in
+                guard isSidebarResizable else { return }
+                if on { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
+            }
+            .accessibilityHidden(true)
+    }
+
     private var activeFileTreeState: FileTreeState? {
         guard let project = activeProject,
               let key = appState.activeWorktreeKey(for: project.id)
@@ -643,11 +787,7 @@ struct MainWindow: View {
         }
 
         ensureVCSState(for: project)
-        let isShowing = !vcsPanelVisible
-        vcsPanelVisible = isShowing
-        if isShowing {
-            fileTreePanelVisible = false
-        }
+        vcsPanelVisible.toggle()
     }
 
     private func toggleFileTreePanel() {
@@ -660,11 +800,8 @@ struct MainWindow: View {
         }
 
         ensureFileTreeState(for: project)
-        let isShowing = !fileTreePanelVisible
-        fileTreePanelVisible = isShowing
-        if isShowing {
-            vcsPanelVisible = false
-        } else {
+        fileTreePanelVisible.toggle()
+        if !fileTreePanelVisible {
             NotificationCenter.default.post(name: .refocusActiveTerminal, object: nil)
         }
     }
@@ -874,7 +1011,7 @@ private struct NavigationArrowButton: View {
         .buttonStyle(.plain)
         .disabled(!isEnabled)
         .onHover { hovered = $0 }
-        .help(label)
+        .quickTooltip(label)
         .accessibilityLabel(label)
     }
 

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum GeneralSettingsKeys {
     static let autoExpandWorktreesOnProjectSwitch = "muxy.general.autoExpandWorktreesOnProjectSwitch"
+    static let showNavigationArrows = "muxy.general.showNavigationArrows"
 }
 
 struct GeneralSettingsView: View {
@@ -11,6 +12,8 @@ struct GeneralSettingsView: View {
     private var confirmRunningProcess = true
     @AppStorage(ProjectLifecyclePreferences.keepOpenWhenNoTabsKey)
     private var keepProjectsOpenWhenNoTabs = false
+    @AppStorage(GeneralSettingsKeys.showNavigationArrows)
+    private var showNavigationArrows = true
 
     var body: some View {
         SettingsContainer {
@@ -21,6 +24,16 @@ struct GeneralSettingsView: View {
                 SettingsToggleRow(
                     label: "Auto-expand worktrees on project switch",
                     isOn: $autoExpandWorktrees
+                )
+            }
+
+            SettingsSection(
+                "Navigation",
+                footer: "Show or hide the back and forward arrow buttons in the top bar."
+            ) {
+                SettingsToggleRow(
+                    label: "Show navigation arrows",
+                    isOn: $showNavigationArrows
                 )
             }
 

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -110,7 +110,7 @@ struct KeyboardShortcutsSettingsView: View {
                         .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
                 }
                 .buttonStyle(.plain)
-                .help("Add Command Shortcut")
+                .quickTooltip("Add Command Shortcut")
                 .accessibilityLabel("Add Command Shortcut")
             }
         }

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -2,16 +2,25 @@ import SwiftUI
 
 enum SidebarLayout {
     static let collapsedWidth: CGFloat = 44
-    static let expandedWidth: CGFloat = 220
+    static let expandedDefaultWidth: CGFloat = 220
     static let width: CGFloat = 44
+    static let minExpandedWidth: CGFloat = 100
+    static let maxExpandedWidth: CGFloat = 500
+    static let autoCollapseThreshold: CGFloat = 80
+
+    static var expandedWidth: CGFloat { expandedDefaultWidth }
+    static var autoExpandThreshold: CGFloat { minExpandedWidth }
 
     static func resolvedWidth(
         expanded: Bool,
         collapsedStyle: SidebarCollapsedStyle,
-        expandedStyle: SidebarExpandedStyle
+        expandedStyle: SidebarExpandedStyle,
+        customWidth: CGFloat = expandedDefaultWidth
     ) -> CGFloat {
         if expanded {
-            return expandedStyle == .wide ? expandedWidth : collapsedWidth
+            return expandedStyle == .wide
+                ? max(minExpandedWidth, min(maxExpandedWidth, customWidth))
+                : collapsedWidth
         }
         return collapsedStyle == .hidden ? 0 : collapsedWidth
     }
@@ -30,9 +39,11 @@ struct Sidebar: View {
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @State private var dragState = ProjectDragState()
-    @State private var expanded = UserDefaults.standard.bool(forKey: "muxy.sidebarExpanded")
     @AppStorage(SidebarCollapsedStyle.storageKey) private var collapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var expandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
+
+    let expanded: Bool
+    let width: CGFloat
 
     private var collapsedStyle: SidebarCollapsedStyle {
         SidebarCollapsedStyle(rawValue: collapsedStyleRaw) ?? .defaultValue
@@ -60,20 +71,10 @@ struct Sidebar: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxHeight: .infinity, alignment: .bottom)
-        .frame(width: isHidden ? 0 : (isWide ? SidebarLayout.expandedWidth : SidebarLayout.collapsedWidth))
+        .frame(width: isHidden ? 0 : (isWide ? width : SidebarLayout.collapsedWidth))
         .opacity(isHidden ? 0 : 1)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Sidebar")
-        .onReceive(NotificationCenter.default.publisher(for: .toggleSidebar)) { _ in
-            toggleExpanded()
-        }
-    }
-
-    private func toggleExpanded() {
-        withAnimation(.easeInOut(duration: 0.2)) {
-            expanded.toggle()
-        }
-        UserDefaults.standard.set(expanded, forKey: "muxy.sidebarExpanded")
     }
 
     private var addButton: some View {
@@ -84,7 +85,7 @@ struct Sidebar: View {
                 worktreeStore: worktreeStore
             )
         }
-        .help(shortcutTooltip("Add Project", for: .openProject))
+        .quickTooltip(shortcutTooltip("Add Project", for: .openProject))
     }
 
     private var projectList: some View {
@@ -376,7 +377,7 @@ struct SidebarFooter: View {
                 onRefresh: refreshUsage
             )
         }
-        .help("AI Usage (\(KeyBindingStore.shared.combo(for: .toggleAIUsage).displayString))")
+        .quickTooltip("AI Usage (\(KeyBindingStore.shared.combo(for: .toggleAIUsage).displayString))")
     }
 
     private var collapsedFooter: some View {
@@ -385,15 +386,15 @@ struct SidebarFooter: View {
                 aiUsageButton
             }
             IconButton(symbol: notificationBellIcon, accessibilityLabel: "Notifications") { showNotifications.toggle() }
-                .help("Notifications")
+                .quickTooltip("Notifications")
                 .popover(isPresented: $showNotifications) {
                     NotificationPanel(onDismiss: { showNotifications = false })
                 }
             IconButton(symbol: "paintpalette", accessibilityLabel: "Theme Picker") { showThemePicker.toggle() }
-                .help("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
+                .quickTooltip("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
                 .popover(isPresented: $showThemePicker) { ThemePicker() }
             IconButton(symbol: sidebarToggleIcon, accessibilityLabel: sidebarToggleLabel) { postToggleSidebar() }
-                .help("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))")
+                .quickTooltip("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))")
         }
         .padding(.bottom, 8)
     }
@@ -401,7 +402,7 @@ struct SidebarFooter: View {
     private var expandedFooter: some View {
         HStack(spacing: 4) {
             IconButton(symbol: sidebarToggleIcon, accessibilityLabel: sidebarToggleLabel) { postToggleSidebar() }
-                .help("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))")
+                .quickTooltip("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))")
 
             Spacer()
 
@@ -409,12 +410,12 @@ struct SidebarFooter: View {
                 aiUsageButton
             }
             IconButton(symbol: notificationBellIcon, accessibilityLabel: "Notifications") { showNotifications.toggle() }
-                .help("Notifications")
+                .quickTooltip("Notifications")
                 .popover(isPresented: $showNotifications) {
                     NotificationPanel(onDismiss: { showNotifications = false })
                 }
             IconButton(symbol: "paintpalette", accessibilityLabel: "Theme Picker") { showThemePicker.toggle() }
-                .help("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
+                .quickTooltip("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
                 .popover(isPresented: $showThemePicker) { ThemePicker() }
         }
         .padding(.horizontal, 10)

--- a/Muxy/Views/Sidebar/AIUsagePanel.swift
+++ b/Muxy/Views/Sidebar/AIUsagePanel.swift
@@ -96,7 +96,7 @@ struct AIUsagePanel: View {
                 .buttonStyle(.plain)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .disabled(isRefreshing)
-                .help("Refresh usage")
+                .quickTooltip("Refresh usage")
                 if let lastRefreshDate {
                     Text(Self.relativeFormatter.localizedString(for: lastRefreshDate, relativeTo: Date()))
                         .font(.system(size: 11))
@@ -367,7 +367,7 @@ struct AIUsageMetricRowView: View {
                     }
                     .buttonStyle(.plain)
                     .onHover { pinHovered = $0 }
-                    .help(isPinned ? "Unpin from sidebar" : "Show this usage in the sidebar")
+                    .quickTooltip(isPinned ? "Unpin from sidebar" : "Show this usage in the sidebar")
                 }
 
                 Spacer()

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -119,6 +119,10 @@ struct ExpandedProjectRow: View {
                 showColorPicker = false
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .renameActiveProject)) { _ in
+            guard appState.activeProjectID == project.id else { return }
+            startRename()
+        }
     }
 
     private var projectHeader: some View {

--- a/Muxy/Views/Sidebar/ProjectIconColorPicker.swift
+++ b/Muxy/Views/Sidebar/ProjectIconColorPicker.swift
@@ -75,7 +75,7 @@ struct ProjectIconColorPicker: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(swatch.name)
+        .quickTooltip(swatch.name)
         .accessibilityLabel(swatch.name)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -39,7 +39,7 @@ struct ProjectRow: View {
 
     var body: some View {
         projectIcon
-            .help(project.name)
+            .quickTooltip(project.name)
             .contentShape(RoundedRectangle(cornerRadius: 8))
             .accessibilityElement(children: .combine)
             .accessibilityLabel(project.name)
@@ -134,6 +134,10 @@ struct ProjectRow: View {
                     onSetIconColor(id)
                     showColorPicker = false
                 }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .renameActiveProject)) { _ in
+                guard appState.activeProjectID == project.id else { return }
+                startRename()
             }
     }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -397,18 +397,20 @@ final class GhosttyTerminalNSView: NSView {
         currentKeyEvent = event
         keyTextAccumulator = []
         commandSelectorCalled = false
-        let interpretEvent = translatedOptionAsAlt(for: event) ? eventStrippingOption(event) : event
+        let optionAsAlt = translatedOptionAsAlt(for: event)
+        let interpretEvent = optionAsAlt ? eventStrippingOption(event) : event
         interpretKeyEvents([interpretEvent])
         currentKeyEvent = nil
 
         syncPreedit(clearIfNeeded: hadMarkedText)
 
         let commandWasCalled = commandSelectorCalled
+        let translationFlags = optionAsAlt ? flags.subtracting(.option) : flags
 
         if !keyTextAccumulator.isEmpty {
             for text in keyTextAccumulator {
                 var keyEvent = buildKeyEvent(from: event, action: action)
-                keyEvent.consumed_mods = commandWasCalled ? GHOSTTY_MODS_NONE : consumedModsFromFlags(flags)
+                keyEvent.consumed_mods = commandWasCalled ? GHOSTTY_MODS_NONE : consumedModsFromFlags(translationFlags)
                 text.withCString { ptr in
                     keyEvent.text = ptr
                     _ = ghostty_surface_key(surface, keyEvent)
@@ -416,7 +418,7 @@ final class GhosttyTerminalNSView: NSView {
             }
         } else {
             var keyEvent = buildKeyEvent(from: event, action: action)
-            keyEvent.consumed_mods = commandWasCalled ? GHOSTTY_MODS_NONE : consumedModsFromFlags(flags)
+            keyEvent.consumed_mods = commandWasCalled ? GHOSTTY_MODS_NONE : consumedModsFromFlags(translationFlags)
             keyEvent.composing = hasMarkedText() || hadMarkedText
 
             let text = filterSpecialCharacters(event.characters ?? "")

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -112,6 +112,9 @@ struct TerminalBridge: NSViewRepresentable {
     let onFocus: () -> Void
     let onProcessExit: () -> Void
     let onSplitRequest: (SplitDirection, SplitPosition) -> Void
+    @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(\.overlayActive) private var overlayActive
     @Environment(\.activeWorktreeKey) private var worktreeKey
 
@@ -148,6 +151,15 @@ struct TerminalBridge: NSViewRepresentable {
         view.onWorkingDirectoryChange = { [weak state] path in
             DispatchQueue.main.async {
                 state?.setWorkingDirectory(path)
+                guard let worktreeKey else { return }
+                ProjectPathSyncService.syncFromTerminalWorkingDirectory(
+                    projectID: worktreeKey.projectID,
+                    worktreeID: worktreeKey.worktreeID,
+                    path: path,
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore
+                )
             }
         }
         configureSearchCallbacks(view)
@@ -183,6 +195,15 @@ struct TerminalBridge: NSViewRepresentable {
         nsView.onWorkingDirectoryChange = { [weak state] path in
             DispatchQueue.main.async {
                 state?.setWorkingDirectory(path)
+                guard let worktreeKey else { return }
+                ProjectPathSyncService.syncFromTerminalWorkingDirectory(
+                    projectID: worktreeKey.projectID,
+                    worktreeID: worktreeKey.worktreeID,
+                    path: path,
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore
+                )
             }
         }
         configureSearchCallbacks(nsView)
@@ -247,7 +268,7 @@ struct TerminalBridge: NSViewRepresentable {
         }
     }
 
-    static func resolveFilePath(_ token: String, projectPath: String) -> String? {
+    nonisolated static func resolveFilePath(_ token: String, projectPath: String) -> String? {
         let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: "\"' \t\n\r()[]<>"))
         guard !cleaned.isEmpty else { return nil }
         let expanded = (cleaned as NSString).expandingTildeInPath

--- a/Muxy/Views/VCS/BranchPicker.swift
+++ b/Muxy/Views/VCS/BranchPicker.swift
@@ -38,7 +38,7 @@ struct BranchPicker: View {
             .contentShape(RoundedRectangle(cornerRadius: 5))
         }
         .buttonStyle(.plain)
-        .help(currentBranch ?? "detached")
+        .quickTooltip(currentBranch ?? "detached")
         .accessibilityLabel("Branch: \(currentBranch ?? "detached")")
         .accessibilityHint("Opens branch picker")
         .popover(isPresented: $showPopover, arrowEdge: .top) {

--- a/Muxy/Views/VCS/CreatePRSheet.swift
+++ b/Muxy/Views/VCS/CreatePRSheet.swift
@@ -139,7 +139,7 @@ struct CreatePRForm: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .help("Back to commit")
+            .quickTooltip("Back to commit")
 
             Image(systemName: "arrow.triangle.pull")
                 .font(.system(size: 12, weight: .semibold))
@@ -305,7 +305,7 @@ struct CreatePRForm: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("Show target branch, include and draft options")
+        .quickTooltip("Show target branch, include and draft options")
     }
 
     private var draftToggle: some View {

--- a/Muxy/Views/VCS/DiffViewerPane.swift
+++ b/Muxy/Views/VCS/DiffViewerPane.swift
@@ -77,7 +77,7 @@ private struct DiffViewerBreadcrumb: View {
             IconButton(symbol: "arrow.clockwise", size: 11, accessibilityLabel: "Refresh Diff") {
                 state.refresh(forceFull: false)
             }
-            .help("Refresh")
+            .quickTooltip("Refresh")
         }
         .padding(.horizontal, 10)
         .frame(height: 32)
@@ -106,6 +106,6 @@ private struct DiffViewerBreadcrumb: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(tooltip)
+        .quickTooltip(tooltip)
     }
 }

--- a/Muxy/Views/VCS/PullRequestsListView.swift
+++ b/Muxy/Views/VCS/PullRequestsListView.swift
@@ -211,7 +211,7 @@ struct PullRequestRow: View {
         .contentShape(Rectangle())
         .onHover { hovered = $0 }
         .onTapGesture(perform: onCheckout)
-        .help("Checkout PR #\(pr.number)")
+        .quickTooltip("Checkout PR #\(pr.number)")
     }
 
     @ViewBuilder
@@ -309,7 +309,7 @@ struct PullRequestsAutoSyncMenu: View {
         .buttonStyle(.plain)
         .menuIndicator(.hidden)
         .fixedSize()
-        .help(autoSyncHelp)
+        .quickTooltip(autoSyncHelp)
     }
 
     private var autoSyncHelp: String {

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -120,7 +120,7 @@ struct VCSTabView: View {
                 IconButton(symbol: "globe", accessibilityLabel: "Open Repository on Web") {
                     NSWorkspace.shared.open(url)
                 }
-                .help("Open repository on web")
+                .quickTooltip("Open repository on web")
             }
 
             VCSSectionVisibilityMenu(state: state)
@@ -494,7 +494,7 @@ struct VCSTabView: View {
         }
         .buttonStyle(.plain)
         .disabled(!commitEnabled || state.isCommitting)
-        .help("Commit staged changes")
+        .quickTooltip("Commit staged changes")
     }
 
     private var pullButton: some View {
@@ -527,7 +527,7 @@ struct VCSTabView: View {
         }
         .buttonStyle(.plain)
         .disabled(state.isPulling)
-        .help(state.aheadBehind.behind > 0
+        .quickTooltip(state.aheadBehind.behind > 0
             ? "Pull \(state.aheadBehind.behind) commit\(state.aheadBehind.behind == 1 ? "" : "s") from origin"
             : "Pull from origin")
     }
@@ -562,7 +562,7 @@ struct VCSTabView: View {
         }
         .buttonStyle(.plain)
         .disabled(state.isPushing)
-        .help(state.aheadBehind.ahead > 0
+        .quickTooltip(state.aheadBehind.ahead > 0
             ? "Push \(state.aheadBehind.ahead) commit\(state.aheadBehind.ahead == 1 ? "" : "s") to origin"
             : "Push to origin")
     }
@@ -723,7 +723,7 @@ struct VCSSectionVisibilityMenu: View {
         .fixedSize()
         .onHover { hovered = $0 }
         .accessibilityLabel("Show/Hide Sections")
-        .help("Show/Hide sections")
+        .quickTooltip("Show/Hide sections")
     }
 }
 
@@ -759,7 +759,7 @@ struct PRPill: View {
             tint: MuxyTheme.fgMuted,
             disabled: true
         ) {}
-            .help("Install GitHub CLI to create pull requests: brew install gh")
+            .quickTooltip("Install GitHub CLI to create pull requests: brew install gh")
     }
 
     private var createPRPill: some View {
@@ -777,7 +777,7 @@ struct PRPill: View {
         }
         .buttonStyle(.plain)
         .disabled(state.isOpeningPullRequest)
-        .help("Create a pull request")
+        .quickTooltip("Create a pull request")
         .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
         .overlay(RoundedRectangle(cornerRadius: 5).stroke(MuxyTheme.accent.opacity(0.35), lineWidth: 1))
     }
@@ -804,7 +804,7 @@ struct PRPill: View {
             .contentShape(RoundedRectangle(cornerRadius: 5))
         }
         .buttonStyle(.plain)
-        .help("Pull request #\(info.number)")
+        .quickTooltip("Pull request #\(info.number)")
         .popover(isPresented: $showPRPopover, arrowEdge: .top) {
             PRPopover(
                 state: state,
@@ -936,7 +936,7 @@ struct PRPopover: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(state.isRefreshingPullRequest)
-                .help("Refresh")
+                .quickTooltip("Refresh")
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -998,7 +998,7 @@ struct PRPopover: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(mergeDisabled)
-                .help(mergeHelp)
+                .quickTooltip(mergeHelp)
 
                 Button(action: onClose) {
                     HStack(spacing: 6) {
@@ -1441,7 +1441,7 @@ private struct SectionSplitLayout: View {
             IconButton(symbol: "minus", size: 11, accessibilityLabel: "Unstage All") {
                 state.unstageAll()
             }
-            .help("Unstage all")
+            .quickTooltip("Unstage all")
 
         case .changes:
             fileListModeToggle
@@ -1450,18 +1450,18 @@ private struct SectionSplitLayout: View {
             IconButton(symbol: "plus", size: 11, accessibilityLabel: "Stage All") {
                 state.stageAll()
             }
-            .help("Stage all")
+            .quickTooltip("Stage all")
 
             IconButton(symbol: "arrow.uturn.backward", size: 11, accessibilityLabel: "Discard All Changes") {
                 showDiscardAllConfirmation = true
             }
-            .help("Discard all changes")
+            .quickTooltip("Discard all changes")
 
         case .history:
             IconButton(symbol: "arrow.clockwise", size: 11, accessibilityLabel: "Refresh History") {
                 state.loadCommits()
             }
-            .help("Refresh history")
+            .quickTooltip("Refresh history")
 
         case .pullRequests:
             PullRequestsAutoSyncMenu(state: state)
@@ -1471,7 +1471,7 @@ private struct SectionSplitLayout: View {
                 IconButton(symbol: "arrow.clockwise", size: 11, accessibilityLabel: "Sync Pull Requests") {
                     state.loadPullRequests()
                 }
-                .help("Sync pull requests")
+                .quickTooltip("Sync pull requests")
             }
         }
     }
@@ -1487,7 +1487,7 @@ private struct SectionSplitLayout: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(state.mode == .unified ? "Switch to Split View" : "Switch to Unified View")
+        .quickTooltip(state.mode == .unified ? "Switch to Split View" : "Switch to Unified View")
     }
 
     private var fileListModeToggle: some View {
@@ -1501,7 +1501,7 @@ private struct SectionSplitLayout: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(state.fileListMode == .flat ? "Switch to Folder View" : "Switch to Flat View")
+        .quickTooltip(state.fileListMode == .flat ? "Switch to Folder View" : "Switch to Flat View")
     }
 
     @ViewBuilder
@@ -1517,7 +1517,7 @@ private struct SectionSplitLayout: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(anyExpanded ? "Collapse all" : "Expand all")
+        .quickTooltip(anyExpanded ? "Collapse all" : "Expand all")
     }
 
     @ViewBuilder
@@ -1724,17 +1724,17 @@ private struct FileRow: View {
     private var actionButtons: some View {
         HStack(spacing: 0) {
             IconButton(symbol: "doc.text", size: 11, accessibilityLabel: "Open in Editor", action: onOpenInEditor)
-                .help("Open in Editor")
+                .quickTooltip("Open in Editor")
             IconButton(symbol: "rectangle.split.2x1", size: 11, accessibilityLabel: "Open Diff in New Tab", action: onOpenDiff)
-                .help("Open Diff in New Tab")
+                .quickTooltip("Open Diff in New Tab")
             if isStaged {
                 IconButton(symbol: "minus", size: 11, accessibilityLabel: "Unstage", action: onUnstage)
-                    .help("Unstage")
+                    .quickTooltip("Unstage")
             } else {
                 IconButton(symbol: "plus", size: 11, accessibilityLabel: "Stage", action: onStage)
-                    .help("Stage")
+                    .quickTooltip("Stage")
                 IconButton(symbol: "arrow.uturn.backward", size: 11, accessibilityLabel: "Discard Changes", action: onDiscard)
-                    .help("Discard changes")
+                    .quickTooltip("Discard changes")
             }
         }
     }

--- a/Muxy/Views/VCS/WorktreeBranchPicker.swift
+++ b/Muxy/Views/VCS/WorktreeBranchPicker.swift
@@ -73,7 +73,7 @@ struct WorktreeBranchPicker: View {
             .contentShape(RoundedRectangle(cornerRadius: 5))
         }
         .buttonStyle(.plain)
-        .help("\(worktreeLabel) › \(branchLabel)")
+        .quickTooltip("\(worktreeLabel) › \(branchLabel)")
         .accessibilityLabel("Worktree \(worktreeLabel), Branch \(branchLabel)")
         .accessibilityHint("Opens worktree and branch picker")
         .popover(isPresented: $showPopover, arrowEdge: .top) {

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -80,22 +80,22 @@ struct PaneTabStrip: View {
                     .padding(.trailing, 4)
                 }
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
-                    .help(shortcutTooltip("Split Right", for: .splitRight))
+                    .quickTooltip(shortcutTooltip("Split Right", for: .splitRight))
                 IconButton(symbol: "square.split.1x2", accessibilityLabel: "Split Down") { onSplit(.vertical) }
-                    .help(shortcutTooltip("Split Down", for: .splitDown))
+                    .quickTooltip(shortcutTooltip("Split Down", for: .splitDown))
                 IconButton(symbol: "plus", accessibilityLabel: "New Tab") { onCreateTab() }
-                    .help(shortcutTooltip("New Tab", for: .newTab))
+                    .quickTooltip(shortcutTooltip("New Tab", for: .newTab))
                 if showVCSButton {
                     IconButton(symbol: "doc.text", size: 12, accessibilityLabel: "Quick Open") {
                         NotificationCenter.default.post(name: .quickOpen, object: nil)
                     }
-                    .help(shortcutTooltip("Quick Open", for: .quickOpen))
+                    .quickTooltip(shortcutTooltip("Quick Open", for: .quickOpen))
                     FileDiffIconButton(action: onCreateVCSTab)
-                        .help(shortcutTooltip("Source Control", for: .openVCSTab))
+                        .quickTooltip(shortcutTooltip("Source Control", for: .openVCSTab))
                     FileTreeIconButton {
                         NotificationCenter.default.post(name: .toggleFileTree, object: nil)
                     }
-                    .help(shortcutTooltip("File Tree", for: .toggleFileTree))
+                    .quickTooltip(shortcutTooltip("File Tree", for: .toggleFileTree))
                 }
             }
             .padding(.leading, 8)

--- a/Tests/MuxyTests/Models/KeyComboTests.swift
+++ b/Tests/MuxyTests/Models/KeyComboTests.swift
@@ -66,6 +66,27 @@ struct KeyComboTests {
         #expect(KeyCombo.normalized(key: "", keyCode: 126) == "uparrow")
     }
 
+    @Test("normalized key with special keyCodes when charactersIgnoringModifiers is empty")
+    func normalizedSpecialKeyCodesWithEmptyCharacters() {
+        #expect(KeyCombo.normalized(key: "", keyCode: 48) == "tab")
+        #expect(KeyCombo.normalized(key: "", keyCode: 36) == "return")
+        #expect(KeyCombo.normalized(key: "", keyCode: 49) == "space")
+        #expect(KeyCombo.normalized(key: "", keyCode: 51) == "delete")
+    }
+
+    @Test("swiftUIKeyEquivalent for special keys")
+    func swiftUIKeyEquivalentSpecialKeys() {
+        #expect(KeyCombo(key: "tab", modifiers: 0).swiftUIKeyEquivalent == Optional(.tab))
+        #expect(KeyCombo(key: "return", modifiers: 0).swiftUIKeyEquivalent == Optional(.return))
+        #expect(KeyCombo(key: "space", modifiers: 0).swiftUIKeyEquivalent == Optional(.space))
+        #expect(KeyCombo(key: "delete", modifiers: 0).swiftUIKeyEquivalent == Optional(.delete))
+    }
+
+    @Test("swiftUIKeyEquivalent returns nil for empty key")
+    func swiftUIKeyEquivalentEmptyKey() {
+        #expect(KeyCombo(key: "", modifiers: 0).swiftUIKeyEquivalent == nil)
+    }
+
     @Test("normalized key with ANSI letter keyCodes")
     func normalizedLetterKeyCodes() {
         #expect(KeyCombo.normalized(key: "\u{043C}", keyCode: 9) == "v")

--- a/Tests/MuxyTests/Models/ProjectTests.swift
+++ b/Tests/MuxyTests/Models/ProjectTests.swift
@@ -1,0 +1,288 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Project auto-rename")
+struct ProjectTests {
+    @Test("new project is not name-customized")
+    func newProjectNotCustomized() {
+        let project = Project(name: "my-app", path: "/Users/dev/my-app")
+        #expect(project.isNameCustomized == false)
+    }
+
+    @Test("decodes legacy project without isNameCustomized — name matches folder")
+    func legacyDecodesMatchingName() throws {
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "my-app",
+            "path": "/Users/dev/my-app",
+            "sortOrder": 0,
+            "createdAt": \(Date().timeIntervalSince1970)
+        }
+        """
+        let project = try JSONDecoder().decode(Project.self, from: Data(json.utf8))
+        #expect(project.isNameCustomized == false)
+    }
+
+    @Test("decodes legacy project without isNameCustomized — name differs from folder")
+    func legacyDecodesDifferingName() throws {
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "My Custom Name",
+            "path": "/Users/dev/my-app",
+            "sortOrder": 0,
+            "createdAt": \(Date().timeIntervalSince1970)
+        }
+        """
+        let project = try JSONDecoder().decode(Project.self, from: Data(json.utf8))
+        #expect(project.isNameCustomized == true)
+    }
+
+    @Test("decodes project with explicit isNameCustomized = true")
+    func decodesExplicitCustomized() throws {
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "whatever",
+            "path": "/Users/dev/whatever",
+            "sortOrder": 0,
+            "createdAt": \(Date().timeIntervalSince1970),
+            "isNameCustomized": true
+        }
+        """
+        let project = try JSONDecoder().decode(Project.self, from: Data(json.utf8))
+        #expect(project.isNameCustomized == true)
+    }
+}
+
+@Suite("ProjectStore auto-rename")
+@MainActor
+struct ProjectStoreAutoRenameTests {
+    private func makeStore() -> (ProjectStore, InMemoryProjectPersistence) {
+        let persistence = InMemoryProjectPersistence()
+        let store = ProjectStore(persistence: persistence)
+        return (store, persistence)
+    }
+
+    @Test("rename marks project as name-customized")
+    func renameSetsFlag() {
+        let (store, _) = makeStore()
+        let project = Project(name: "alpha", path: "/foo/alpha")
+        store.add(project)
+        store.rename(id: project.id, to: "My Project")
+        let updated = store.projects.first(where: { $0.id == project.id })
+        #expect(updated?.name == "My Project")
+        #expect(updated?.isNameCustomized == true)
+    }
+
+    @Test("updatePath auto-renames when not customized")
+    func updatePathAutoRenames() {
+        let (store, _) = makeStore()
+        let project = Project(name: "alpha", path: "/foo/alpha")
+        store.add(project)
+        store.updatePath(id: project.id, to: "/foo/beta")
+        let updated = store.projects.first(where: { $0.id == project.id })
+        #expect(updated?.path.hasSuffix("beta") == true)
+        #expect(updated?.name == "beta")
+    }
+
+    @Test("updatePath preserves name when customized")
+    func updatePathPreservesCustomName() {
+        let (store, _) = makeStore()
+        let project = Project(name: "alpha", path: "/foo/alpha")
+        store.add(project)
+        store.rename(id: project.id, to: "My Project")
+        store.updatePath(id: project.id, to: "/foo/beta")
+        let updated = store.projects.first(where: { $0.id == project.id })
+        #expect(updated?.path.hasSuffix("beta") == true)
+        #expect(updated?.name == "My Project")
+    }
+
+    @Test("updatePath is no-op when path unchanged")
+    func updatePathNoOp() {
+        let (store, _) = makeStore()
+        let project = Project(name: "alpha", path: "/foo/alpha")
+        store.add(project)
+        store.updatePath(id: project.id, to: "/foo/alpha")
+        #expect(store.projects.count == 1)
+        #expect(store.projects.first?.name == "alpha")
+    }
+
+}
+
+@Suite("ProjectPathSyncService")
+@MainActor
+struct ProjectPathSyncServiceTests {
+    @Test("single terminal CWD sync updates project, primary worktree, and workspace path")
+    func syncSingleTerminal() throws {
+        let context = makeContext(projectName: "alpha", projectPath: "/foo/alpha")
+        ProjectPathSyncService.syncFromTerminalWorkingDirectory(
+            projectID: context.project.id,
+            worktreeID: context.worktree.id,
+            path: "/foo/beta",
+            appState: context.appState,
+            projectStore: context.projectStore,
+            worktreeStore: context.worktreeStore
+        )
+
+        let project = try #require(context.projectStore.projects.first)
+        let worktree = try #require(context.worktreeStore.primary(for: project.id))
+        let area = try #require(context.appState.workspaceRoot(for: project.id)?.allAreas().first)
+        #expect(project.name == "beta")
+        #expect(project.path.hasSuffix("beta"))
+        #expect(worktree.name == "beta")
+        #expect(worktree.path.hasSuffix("beta"))
+        #expect(area.projectPath.hasSuffix("beta"))
+        #expect(area.activeTab?.content.pane?.projectPath.hasSuffix("beta") == true)
+    }
+
+    @Test("multiple terminals skip CWD sync")
+    func skipMultipleTerminals() throws {
+        let context = makeContext(projectName: "alpha", projectPath: "/foo/alpha")
+        context.appState.createTab(projectID: context.project.id)
+        ProjectPathSyncService.syncFromTerminalWorkingDirectory(
+            projectID: context.project.id,
+            worktreeID: context.worktree.id,
+            path: "/foo/beta",
+            appState: context.appState,
+            projectStore: context.projectStore,
+            worktreeStore: context.worktreeStore
+        )
+
+        let project = try #require(context.projectStore.projects.first)
+        let worktree = try #require(context.worktreeStore.primary(for: project.id))
+        #expect(project.path == "/foo/alpha")
+        #expect(project.name == "alpha")
+        #expect(worktree.path == "/foo/alpha")
+        #expect(worktree.name == "alpha")
+    }
+
+    @Test("manual project rename preserves name while syncing paths")
+    func syncPreservesManualProjectName() throws {
+        let context = makeContext(projectName: "alpha", projectPath: "/foo/alpha")
+        context.projectStore.rename(id: context.project.id, to: "Custom")
+        ProjectPathSyncService.syncFromTerminalWorkingDirectory(
+            projectID: context.project.id,
+            worktreeID: context.worktree.id,
+            path: "/foo/beta",
+            appState: context.appState,
+            projectStore: context.projectStore,
+            worktreeStore: context.worktreeStore
+        )
+
+        let project = try #require(context.projectStore.projects.first)
+        let worktree = try #require(context.worktreeStore.primary(for: project.id))
+        #expect(project.name == "Custom")
+        #expect(project.path.hasSuffix("beta"))
+        #expect(worktree.name == "beta")
+        #expect(worktree.path.hasSuffix("beta"))
+    }
+
+    private func makeContext(projectName: String, projectPath: String) -> ProjectPathSyncContext {
+        let projectPersistence = InMemoryProjectPersistence()
+        let projectStore = ProjectStore(persistence: projectPersistence)
+        let project = Project(name: projectName, path: projectPath)
+        projectStore.add(project)
+        let worktreeStore = WorktreeStore(
+            persistence: InMemoryWorktreePersistence(),
+            projects: projectStore.projects
+        )
+        worktreeStore.ensurePrimary(for: project)
+        let appState = AppState(
+            selectionStore: InMemorySelectionStore(),
+            terminalViews: InMemoryTerminalViewRemover(),
+            workspacePersistence: InMemoryWorkspacePersistence()
+        )
+        let worktree = worktreeStore.primary(for: project.id)!
+        appState.selectProject(project, worktree: worktree)
+        return ProjectPathSyncContext(
+            project: project,
+            worktree: worktree,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            appState: appState
+        )
+    }
+}
+
+private struct ProjectPathSyncContext {
+    let project: Project
+    let worktree: Worktree
+    let projectStore: ProjectStore
+    let worktreeStore: WorktreeStore
+    let appState: AppState
+}
+
+private final class InMemoryProjectPersistence: ProjectPersisting, @unchecked Sendable {
+    private var projects: [Project] = []
+
+    func loadProjects() throws -> [Project] {
+        projects
+    }
+
+    func saveProjects(_ projects: [Project]) throws {
+        self.projects = projects
+    }
+}
+
+private final class InMemoryWorktreePersistence: WorktreePersisting, @unchecked Sendable {
+    private var worktrees: [UUID: [Worktree]] = [:]
+
+    func loadWorktrees(projectID: UUID) throws -> [Worktree] {
+        worktrees[projectID] ?? []
+    }
+
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws {
+        self.worktrees[projectID] = worktrees
+    }
+
+    func removeWorktrees(projectID: UUID) throws {
+        worktrees.removeValue(forKey: projectID)
+    }
+}
+
+private final class InMemoryWorkspacePersistence: WorkspacePersisting, @unchecked Sendable {
+    private var snapshots: [WorkspaceSnapshot] = []
+
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] {
+        snapshots
+    }
+
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws {
+        snapshots = workspaces
+    }
+}
+
+@MainActor
+private final class InMemorySelectionStore: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+
+    func loadActiveProjectID() -> UUID? {
+        activeProjectID
+    }
+
+    func saveActiveProjectID(_ id: UUID?) {
+        activeProjectID = id
+    }
+
+    func loadActiveWorktreeIDs() -> [UUID: UUID] {
+        activeWorktreeIDs
+    }
+
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) {
+        activeWorktreeIDs = ids
+    }
+}
+
+@MainActor
+private final class InMemoryTerminalViewRemover: TerminalViewRemoving {
+    func removeView(for paneID: UUID) {}
+
+    func needsConfirmQuit(for paneID: UUID) -> Bool {
+        false
+    }
+}

--- a/Tests/MuxyTests/Services/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeStoreTests.swift
@@ -7,6 +7,18 @@ import Testing
 @Suite("WorktreeStore")
 @MainActor
 struct WorktreeStoreTests {
+    @Test("primary worktree name follows folder name instead of project name")
+    func primaryWorktreeNameUsesFolderName() throws {
+        let project = Project(name: "Custom", path: "/tmp/repo-folder", isNameCustomized: true)
+        let store = WorktreeStore(
+            persistence: WorktreePersistenceStub(initial: [:]),
+            projects: [project]
+        )
+
+        let primary = try #require(store.primary(for: project.id))
+        #expect(primary.name == "repo-folder")
+    }
+
     @Test("Worktree decodes legacy records without source metadata")
     func worktreeLegacyDecodeDefaultsToMuxy() throws {
         let json = """

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,6 +114,7 @@ Muxy/
     CommandShortcutStore.swift  @Observable store + JSON persistence for custom command shortcuts and command-layer prefix state
     ProjectStore.swift        @Observable store for projects list
     ProjectPersistence.swift  JSON persistence for projects
+    ProjectPathSyncService.swift  Syncs single-terminal CWD changes into ProjectStore, primary WorktreeStore entry, and workspace path copies
     ApprovedDevicesStore.swift Approved mobile devices (deviceID, SHA-256 token hash), revocation
     PairingRequestCoordinator.swift Queues pending pairing requests for UI approval prompts
     MobileServerService.swift  Lifecycle wrapper around MuxyRemoteServer


### PR DESCRIPTION
## Summary
- Adds app-wide themed quick tooltips with a custom SwiftUI/AppKit hover tracker, faster display timing, and cleanup when opening popovers or actions.
- Adds smoother sidebar drag resizing with persisted custom width, auto collapse/expand thresholds, and a setting to hide top-bar navigation arrows.
- Adds project commands for Cmd-N duplicate project, Cmd-Shift-N new window, command-menu project rename, special-key shortcut support, and single-terminal CWD-to-project path sync.

## Features
- New Project command duplicates the active project and inserts it next to the current project for faster multi-window/project workflows.
- New Window command opens another main Muxy window from the app command menu and Cmd-Shift-N.
- Rename Project command starts inline rename on the active sidebar project row from the command menu.
- Single-terminal CWD sync updates ProjectStore path, primary WorktreeStore path/name, and workspace terminal paths when a project has exactly one terminal.
- Project custom names are preserved during automatic path sync through the new isNameCustomized field and legacy decode inference.

## UI/UX
- Replaces native .help usage with themed quick tooltips across sidebar, editor, VCS, file tree, tab strip, and command controls.
- Adds a global TooltipOverlay and hides active tooltips before popovers/menu actions so stale tooltips do not linger.
- Makes sidebar resizing much smoother by disabling width animation during drag and only animating collapsed/expanded mode changes.
- Persists sidebar custom width and attached VCS panel width across launches.
- Allows VCS attached panel and file tree panel to be visible together instead of forcing one to close the other.
- Adds a General setting to show or hide top-bar navigation arrows.

## Shortcut and terminal handling
- Supports Tab, Return, Space, and Delete in KeyCombo normalization and SwiftUI KeyEquivalent mapping.
- Makes SwiftUI shortcut binding skip empty key combos instead of crashing on unset shortcuts.
- Fixes terminal Option-as-Alt handling so Option is omitted from consumed_mods when it was stripped for Alt translation.

## Tests
- Added Project decoding, auto-rename, ProjectStore updatePath, and ProjectPathSyncService coverage.
- Added WorktreeStore coverage for primary worktree names following folder names rather than custom project names.
- Added KeyCombo coverage for special key normalization, SwiftUI equivalents, and empty key handling.

## Verification
- `rtk swift test --filter ProjectTests --filter ProjectStoreAutoRenameTests --filter ProjectPathSyncServiceTests --filter WorktreeStoreTests` — passed, 22 tests in 4 suites.
- `scripts/checks.sh --fix` — blocked locally because swiftformat is 0.61.1 but .tool-versions expects 0.60.1.