### PR TITLE
✨ feat(split-pane): equal-size split for N panes

### DIFF
--- a/Muxy/Extensions/DTOConversions.swift
+++ b/Muxy/Extensions/DTOConversions.swift
@@ -48,9 +48,8 @@ extension SplitBranch {
         SplitBranchDTO(
             id: id,
             direction: direction == .horizontal ? .horizontal : .vertical,
-            ratio: Double(ratio),
-            first: first.toDTO(),
-            second: second.toDTO()
+            ratios: ratios.map { Double($0) },
+            children: children.map { $0.toDTO() }
         )
     }
 }

--- a/Muxy/Models/SplitNode.swift
+++ b/Muxy/Models/SplitNode.swift
@@ -27,20 +27,17 @@ enum SplitNode: Identifiable {
 final class SplitBranch: Identifiable {
     let id = UUID()
     var direction: SplitDirection
-    var ratio: CGFloat
-    var first: SplitNode
-    var second: SplitNode
+    var children: [SplitNode]
+    var ratios: [CGFloat]
 
     init(
         direction: SplitDirection,
-        ratio: CGFloat = 0.5,
-        first: SplitNode,
-        second: SplitNode
+        children: [SplitNode],
+        ratios: [CGFloat]? = nil
     ) {
         self.direction = direction
-        self.ratio = ratio
-        self.first = first
-        self.second = second
+        self.children = children
+        self.ratios = ratios ?? Array(repeating: 1.0 / CGFloat(children.count), count: children.count)
     }
 }
 
@@ -58,27 +55,33 @@ extension SplitNode {
             let second: SplitNode = position == .first ? .tabArea(area) : .tabArea(newArea)
             let node = SplitNode.split(SplitBranch(
                 direction: direction,
-                first: first,
-                second: second
+                children: [first, second]
             ))
             return (node, newArea.id)
         case .tabArea:
             return (self, nil)
         case let .split(branch):
-            let (newFirst, id1) = branch.first.splitting(
-                areaID: areaID,
-                direction: direction,
-                position: position
-            )
-            branch.first = newFirst
-            if id1 != nil { return (.split(branch), id1) }
-            let (newSecond, id2) = branch.second.splitting(
-                areaID: areaID,
-                direction: direction,
-                position: position
-            )
-            branch.second = newSecond
-            return (.split(branch), id2)
+            for (index, child) in branch.children.enumerated() {
+                let (newChild, newID) = child.splitting(
+                    areaID: areaID,
+                    direction: direction,
+                    position: position
+                )
+                if let newID {
+                    if case let .split(newBranch) = newChild, newBranch.direction == branch.direction {
+                        branch.children.remove(at: index)
+                        for (i, grandchild) in newBranch.children.enumerated() {
+                            branch.children.insert(grandchild, at: index + i)
+                        }
+                    } else {
+                        branch.children[index] = newChild
+                    }
+                    let count = branch.children.count
+                    branch.ratios = Array(repeating: 1.0 / CGFloat(count), count: count)
+                    return (.split(branch), newID)
+                }
+            }
+            return (self, nil)
         }
     }
 
@@ -93,21 +96,36 @@ extension SplitNode {
             let newArea = TabArea(projectPath: area.projectPath, existingTab: tab)
             let first: SplitNode = position == .first ? .tabArea(newArea) : .tabArea(area)
             let second: SplitNode = position == .first ? .tabArea(area) : .tabArea(newArea)
-            let node = SplitNode.split(SplitBranch(direction: direction, first: first, second: second))
+            let node = SplitNode.split(SplitBranch(
+                direction: direction,
+                children: [first, second]
+            ))
             return (node, newArea.id)
         case .tabArea:
             return (self, nil)
         case let .split(branch):
-            let (newFirst, id1) = branch.first.splittingWithTab(
-                areaID: areaID, direction: direction, position: position, tab: tab
-            )
-            branch.first = newFirst
-            if id1 != nil { return (.split(branch), id1) }
-            let (newSecond, id2) = branch.second.splittingWithTab(
-                areaID: areaID, direction: direction, position: position, tab: tab
-            )
-            branch.second = newSecond
-            return (.split(branch), id2)
+            for (index, child) in branch.children.enumerated() {
+                let (newChild, newID) = child.splittingWithTab(
+                    areaID: areaID,
+                    direction: direction,
+                    position: position,
+                    tab: tab
+                )
+                if let newID {
+                    if case let .split(newBranch) = newChild, newBranch.direction == branch.direction {
+                        branch.children.remove(at: index)
+                        for (i, grandchild) in newBranch.children.enumerated() {
+                            branch.children.insert(grandchild, at: index + i)
+                        }
+                    } else {
+                        branch.children[index] = newChild
+                    }
+                    let count = branch.children.count
+                    branch.ratios = Array(repeating: 1.0 / CGFloat(count), count: count)
+                    return (.split(branch), newID)
+                }
+            }
+            return (self, nil)
         }
     }
 
@@ -118,49 +136,53 @@ extension SplitNode {
         case .tabArea:
             return self
         case let .split(branch):
-            if case let .tabArea(a) = branch.first, a.id == areaID {
-                return branch.second
+            var newChildren: [SplitNode] = []
+            for child in branch.children {
+                if child.containsArea(id: areaID) {
+                    if let result = child.removing(areaID: areaID) {
+                        if case let .split(childBranch) = result, childBranch.direction == branch.direction {
+                            newChildren.append(contentsOf: childBranch.children)
+                        } else {
+                            newChildren.append(result)
+                        }
+                    }
+                } else {
+                    newChildren.append(child)
+                }
             }
-            if case let .tabArea(a) = branch.second, a.id == areaID {
-                return branch.first
+
+            if newChildren.isEmpty {
+                return nil
             }
-            if branch.first.containsArea(id: areaID),
-               let newFirst = branch.first.removing(areaID: areaID)
-            {
-                branch.first = newFirst
-                return .split(branch)
+            if newChildren.count == 1 {
+                return newChildren[0]
             }
-            if branch.second.containsArea(id: areaID),
-               let newSecond = branch.second.removing(areaID: areaID)
-            {
-                branch.second = newSecond
-                return .split(branch)
-            }
-            return self
+
+            branch.children = newChildren
+            let count = newChildren.count
+            branch.ratios = Array(repeating: 1.0 / CGFloat(count), count: count)
+            return .split(branch)
         }
     }
 
     func containsArea(id: UUID) -> Bool {
         switch self {
         case let .tabArea(area): area.id == id
-        case let .split(branch):
-            branch.first.containsArea(id: id) || branch.second.containsArea(id: id)
+        case let .split(branch): branch.children.contains { $0.containsArea(id: id) }
         }
     }
 
     func allAreas() -> [TabArea] {
         switch self {
         case let .tabArea(area): [area]
-        case let .split(branch):
-            branch.first.allAreas() + branch.second.allAreas()
+        case let .split(branch): branch.children.flatMap { $0.allAreas() }
         }
     }
 
     func findArea(id: UUID) -> TabArea? {
         switch self {
         case let .tabArea(area): area.id == id ? area : nil
-        case let .split(branch):
-            branch.first.findArea(id: id) ?? branch.second.findArea(id: id)
+        case let .split(branch): branch.children.compactMap { $0.findArea(id: id) }.first
         }
     }
 
@@ -169,18 +191,23 @@ extension SplitNode {
         case let .tabArea(area):
             return [area.id: rect]
         case let .split(branch):
-            let ratio = min(max(branch.ratio, 0), 1)
-            if branch.direction == .horizontal {
-                let firstWidth = rect.width * ratio
-                let firstRect = CGRect(x: rect.minX, y: rect.minY, width: firstWidth, height: rect.height)
-                let secondRect = CGRect(x: rect.minX + firstWidth, y: rect.minY, width: rect.width - firstWidth, height: rect.height)
-                return branch.first.areaFrames(in: firstRect).merging(branch.second.areaFrames(in: secondRect)) { current, _ in current }
+            let isHorizontal = branch.direction == .horizontal
+            var offset: CGFloat = 0
+            var frames: [UUID: CGRect] = [:]
+
+            for (index, child) in branch.children.enumerated() {
+                let ratio = branch.ratios[index]
+                let size = isHorizontal ? rect.width * ratio : rect.height * ratio
+                let childRect = if isHorizontal {
+                    CGRect(x: rect.minX + offset, y: rect.minY, width: size, height: rect.height)
+                } else {
+                    CGRect(x: rect.minX, y: rect.minY + offset, width: rect.width, height: size)
+                }
+                frames.merge(child.areaFrames(in: childRect)) { current, _ in current }
+                offset += size
             }
 
-            let firstHeight = rect.height * ratio
-            let firstRect = CGRect(x: rect.minX, y: rect.minY, width: rect.width, height: firstHeight)
-            let secondRect = CGRect(x: rect.minX, y: rect.minY + firstHeight, width: rect.width, height: rect.height - firstHeight)
-            return branch.first.areaFrames(in: firstRect).merging(branch.second.areaFrames(in: secondRect)) { current, _ in current }
+            return frames
         }
     }
 }

--- a/Muxy/Models/WorkspaceSnapshot.swift
+++ b/Muxy/Models/WorkspaceSnapshot.swift
@@ -80,9 +80,8 @@ indirect enum SplitNodeSnapshot: Codable {
 
 struct SplitBranchSnapshot: Codable {
     let direction: SplitDirectionSnapshot
-    let ratio: Double
-    let first: SplitNodeSnapshot
-    let second: SplitNodeSnapshot
+    let ratios: [Double]
+    let children: [SplitNodeSnapshot]
 }
 
 enum SplitDirectionSnapshot: String, Codable {
@@ -224,17 +223,15 @@ enum WorkspaceRestorer {
         case let .tabArea(areaSnapshot):
             return .tabArea(TabArea(restoring: areaSnapshot))
         case let .split(branchSnapshot):
-            let first = restoreSplitNode(from: branchSnapshot.first)
-            let second = restoreSplitNode(from: branchSnapshot.second)
+            let children = branchSnapshot.children.map { restoreSplitNode(from: $0) }
             let direction: SplitDirection = switch branchSnapshot.direction {
             case .horizontal: .horizontal
             case .vertical: .vertical
             }
             return .split(SplitBranch(
                 direction: direction,
-                ratio: CGFloat(branchSnapshot.ratio),
-                first: first,
-                second: second
+                children: children,
+                ratios: branchSnapshot.ratios.map { CGFloat($0) }
             ))
         }
     }
@@ -250,9 +247,8 @@ enum WorkspaceRestorer {
             }
             return .split(SplitBranchSnapshot(
                 direction: direction,
-                ratio: Double(branch.ratio),
-                first: snapshotSplitNode(branch.first),
-                second: snapshotSplitNode(branch.second)
+                ratios: branch.ratios.map { Double($0) },
+                children: branch.children.map { snapshotSplitNode($0) }
             ))
         }
     }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -10,13 +10,13 @@ struct MainWindow: View {
     @State private var dragCoordinator = TabDragCoordinator()
     private enum AttachedVCSLayout {
         static let minWidth: CGFloat = 200
-        static let defaultWidth: CGFloat = 400
+        static let defaultWidth: CGFloat = 300
         static let maxWidth: CGFloat = 800
     }
 
     private enum FileTreeLayout {
         static let minWidth: CGFloat = 180
-        static let defaultWidth: CGFloat = 260
+        static let defaultWidth: CGFloat = 200
         static let maxWidth: CGFloat = 600
     }
 

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 enum SidebarLayout {
     static let collapsedWidth: CGFloat = 44
-    static let expandedWidth: CGFloat = 220
+    static let expandedWidth: CGFloat = 180
     static let width: CGFloat = 44
 
     static func resolvedWidth(

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -21,54 +21,78 @@ struct SplitContainer: View {
         GeometryReader { geo in
             let h = branch.direction == .horizontal
             let total = h ? geo.size.width : geo.size.height
-            let first = max(0, total * branch.ratio - 0.5)
-            let second = max(0, total * (1 - branch.ratio) - 0.5)
 
             let layout = h ? AnyLayout(HStackLayout(spacing: 0)) : AnyLayout(VStackLayout(spacing: 0))
 
             layout {
-                child(branch.first)
-                    .frame(width: h ? first : nil, height: h ? nil : first)
-
-                Color.clear
-                    .frame(width: h ? 1 : nil, height: h ? nil : 1)
-                    .overlay(Rectangle().fill(MuxyTheme.border))
-                    .overlay {
-                        Color.clear
-                            .frame(width: h ? 5 : nil, height: h ? nil : 5)
-                            .contentShape(Rectangle())
-                            .gesture(
-                                DragGesture(minimumDistance: 1)
-                                    .onChanged { v in
-                                        let pos = h ? v.location.x : v.location.y
-                                        let origin = h ? v.startLocation.x : v.startLocation.y
-                                        let startPos = total * branch.ratio
-                                        let newPos = startPos + (pos - origin)
-                                        branch.ratio = min(max(newPos / total, 0.15), 0.85)
-                                    }
-                            )
-                            .onHover { on in
-                                if on { (h ? NSCursor.resizeLeftRight : NSCursor.resizeUpDown).push() } else { NSCursor.pop() }
-                            }
+                ForEach(0 ..< branch.children.count, id: \.self) { index in
+                    if index > 0 {
+                        divider(index: index, total: total, h: h)
                     }
-                    .accessibilityLabel(h ? "Horizontal Split Divider" : "Vertical Split Divider")
-                    .accessibilityValue("Split ratio: \(Int(branch.ratio * 100))%")
-                    .accessibilityAdjustableAction { direction in
-                        let step: CGFloat = 0.05
-                        switch direction {
-                        case .increment:
-                            branch.ratio = min(branch.ratio + step, 0.85)
-                        case .decrement:
-                            branch.ratio = max(branch.ratio - step, 0.15)
-                        @unknown default:
-                            break
-                        }
-                    }
-
-                child(branch.second)
-                    .frame(width: h ? second : nil, height: h ? nil : second)
+                    child(branch.children[index])
+                        .frame(
+                            width: h ? max(0, total * branch.ratios[index] - 0.5) : nil,
+                            height: h ? nil : max(0, total * branch.ratios[index] - 0.5)
+                        )
+                }
             }
         }
+    }
+
+    private func divider(index: Int, total: CGFloat, h: Bool) -> some View {
+        Color.clear
+            .frame(width: h ? 1 : nil, height: h ? nil : 1)
+            .overlay(Rectangle().fill(MuxyTheme.border))
+            .overlay {
+                Color.clear
+                    .frame(width: h ? 5 : nil, height: h ? nil : 5)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 1)
+                            .onChanged { v in
+                                let pos = h ? v.location.x : v.location.y
+                                let origin = h ? v.startLocation.x : v.startLocation.y
+
+                                let leftIndex = index - 1
+                                let rightIndex = index
+                                let sharedSpace = branch.ratios[leftIndex] + branch.ratios[rightIndex]
+
+                                let currentBoundary = branch.ratios[0 ... leftIndex].reduce(0, +) * total
+                                let newBoundary = currentBoundary + (pos - origin)
+                                let newBoundaryRatio = newBoundary / total
+
+                                let leftCumulative = branch.ratios[0 ..< leftIndex].reduce(0, +)
+                                var newLeftRatio = newBoundaryRatio - leftCumulative
+                                newLeftRatio = min(max(newLeftRatio, 0.15), sharedSpace - 0.15)
+
+                                branch.ratios[leftIndex] = newLeftRatio
+                                branch.ratios[rightIndex] = sharedSpace - newLeftRatio
+                            }
+                    )
+                    .onHover { on in
+                        if on { (h ? NSCursor.resizeLeftRight : NSCursor.resizeUpDown).push() } else { NSCursor.pop() }
+                    }
+            }
+            .accessibilityLabel(h ? "Horizontal Split Divider" : "Vertical Split Divider")
+            .accessibilityValue("Split ratio: \(Int(branch.ratios[index - 1] * 100))%")
+            .accessibilityAdjustableAction { direction in
+                let step: CGFloat = 0.05
+                let leftIndex = index - 1
+                let rightIndex = index
+                let sharedSpace = branch.ratios[leftIndex] + branch.ratios[rightIndex]
+                switch direction {
+                case .increment:
+                    let newLeft = min(branch.ratios[leftIndex] + step, sharedSpace - 0.15)
+                    branch.ratios[rightIndex] = sharedSpace - newLeft
+                    branch.ratios[leftIndex] = newLeft
+                case .decrement:
+                    let newLeft = max(branch.ratios[leftIndex] - step, 0.15)
+                    branch.ratios[rightIndex] = sharedSpace - newLeft
+                    branch.ratios[leftIndex] = newLeft
+                @unknown default:
+                    break
+                }
+            }
     }
 
     private func child(_ node: SplitNode) -> some View {

--- a/MuxyMobile/DemoBackend.swift
+++ b/MuxyMobile/DemoBackend.swift
@@ -517,9 +517,8 @@ final class DemoBackend {
             return .split(SplitBranchDTO(
                 id: branch.id,
                 direction: branch.direction,
-                ratio: branch.ratio,
-                first: appendTab(in: branch.first, focusedAreaID: focusedAreaID),
-                second: appendTab(in: branch.second, focusedAreaID: focusedAreaID)
+                ratios: branch.ratios,
+                children: branch.children.map { appendTab(in: $0, focusedAreaID: focusedAreaID) }
             ))
         }
     }
@@ -550,9 +549,8 @@ final class DemoBackend {
             return .split(SplitBranchDTO(
                 id: branch.id,
                 direction: branch.direction,
-                ratio: branch.ratio,
-                first: removeTab(in: branch.first, areaID: areaID, tabID: tabID) ?? branch.first,
-                second: removeTab(in: branch.second, areaID: areaID, tabID: tabID) ?? branch.second
+                ratios: branch.ratios,
+                children: branch.children.map { removeTab(in: $0, areaID: areaID, tabID: tabID) ?? $0 }
             ))
         }
     }
@@ -581,9 +579,8 @@ final class DemoBackend {
             return .split(SplitBranchDTO(
                 id: branch.id,
                 direction: branch.direction,
-                ratio: branch.ratio,
-                first: selectTab(in: branch.first, areaID: areaID, tabID: tabID),
-                second: selectTab(in: branch.second, areaID: areaID, tabID: tabID)
+                ratios: branch.ratios,
+                children: branch.children.map { selectTab(in: $0, areaID: areaID, tabID: tabID) }
             ))
         }
     }

--- a/MuxyMobile/RemoteWorkspaceView.swift
+++ b/MuxyMobile/RemoteWorkspaceView.swift
@@ -138,7 +138,7 @@ struct WorkspaceContentWrapper: View {
         case let .tabArea(area):
             [area]
         case let .split(branch):
-            collectAreas(from: branch.first) + collectAreas(from: branch.second)
+            branch.children.flatMap { collectAreas(from: $0) }
         }
     }
 

--- a/MuxyShared/WorkspaceDTO.swift
+++ b/MuxyShared/WorkspaceDTO.swift
@@ -66,22 +66,19 @@ public indirect enum SplitNodeDTO: Codable, Sendable {
 public struct SplitBranchDTO: Codable, Sendable {
     public let id: UUID
     public let direction: SplitDirectionDTO
-    public let ratio: Double
-    public let first: SplitNodeDTO
-    public let second: SplitNodeDTO
+    public let ratios: [Double]
+    public let children: [SplitNodeDTO]
 
     public init(
         id: UUID,
         direction: SplitDirectionDTO,
-        ratio: Double,
-        first: SplitNodeDTO,
-        second: SplitNodeDTO
+        ratios: [Double],
+        children: [SplitNodeDTO]
     ) {
         self.id = id
         self.direction = direction
-        self.ratio = ratio
-        self.first = first
-        self.second = second
+        self.ratios = ratios
+        self.children = children
     }
 }
 

--- a/Tests/MuxyTests/Models/SplitNodeTests.swift
+++ b/Tests/MuxyTests/Models/SplitNodeTests.swift
@@ -20,8 +20,7 @@ struct SplitNodeTests {
     func splitNodeID() {
         let branch = SplitBranch(
             direction: .horizontal,
-            first: .tabArea(TabArea(projectPath: testPath)),
-            second: .tabArea(TabArea(projectPath: testPath))
+            children: [.tabArea(TabArea(projectPath: testPath)), .tabArea(TabArea(projectPath: testPath))]
         )
         let node = SplitNode.split(branch)
         #expect(node.id == branch.id)
@@ -41,11 +40,10 @@ struct SplitNodeTests {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let a3 = TabArea(projectPath: testPath)
-        let inner = SplitBranch(direction: .vertical, first: .tabArea(a2), second: .tabArea(a3))
+        let inner = SplitBranch(direction: .vertical, children: [.tabArea(a2), .tabArea(a3)])
         let root = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            first: .tabArea(a1),
-            second: .split(inner)
+            children: [.tabArea(a1), .split(inner)]
         ))
         let areas = root.allAreas()
         #expect(areas.count == 3)
@@ -60,8 +58,7 @@ struct SplitNodeTests {
         let a2 = TabArea(projectPath: testPath)
         let node = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2)]
         ))
         #expect(node.containsArea(id: a2.id))
     }
@@ -79,8 +76,7 @@ struct SplitNodeTests {
         let a2 = TabArea(projectPath: testPath)
         let node = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2)]
         ))
         let found = node.findArea(id: a2.id)
         #expect(found?.id == a2.id)
@@ -106,12 +102,13 @@ struct SplitNodeTests {
         #expect(newAreaID != area.id)
         if case let .split(branch) = result {
             #expect(branch.direction == .horizontal)
-            if case let .tabArea(first) = branch.first {
+            #expect(branch.children.count == 2)
+            if case let .tabArea(first) = branch.children[0] {
                 #expect(first.id == area.id)
             } else {
                 Issue.record("First child should be original area")
             }
-            if case let .tabArea(second) = branch.second {
+            if case let .tabArea(second) = branch.children[1] {
                 #expect(second.id == newAreaID)
             } else {
                 Issue.record("Second child should be new area")
@@ -132,7 +129,8 @@ struct SplitNodeTests {
         )
         #expect(newAreaID != nil)
         if case let .split(branch) = result {
-            if case let .tabArea(first) = branch.first {
+            #expect(branch.children.count == 2)
+            if case let .tabArea(first) = branch.children[0] {
                 #expect(first.id == newAreaID)
             } else {
                 Issue.record("First child should be new area")
@@ -155,22 +153,83 @@ struct SplitNodeTests {
         #expect(result.id == area.id)
     }
 
-    @Test("splitting in nested tree finds target area")
-    func splittingNested() {
+    @Test("splitting same direction flattens into parent branch")
+    func splittingSameDirectionFlattens() {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let root = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2)]
         ))
-        let (_, newAreaID) = root.splitting(
+        let (result, newAreaID) = root.splitting(
+            areaID: a2.id,
+            direction: .horizontal,
+            position: .second
+        )
+        #expect(newAreaID != nil)
+        if case let .split(branch) = result {
+            #expect(branch.children.count == 3)
+            #expect(branch.ratios.count == 3)
+            for ratio in branch.ratios {
+                #expect(abs(ratio - 1.0 / 3.0) < 0.001)
+            }
+        } else {
+            Issue.record("Result should be a split")
+        }
+    }
+
+    @Test("splitting different direction creates nested branch")
+    func splittingDifferentDirectionNested() {
+        let a1 = TabArea(projectPath: testPath)
+        let a2 = TabArea(projectPath: testPath)
+        let root = SplitNode.split(SplitBranch(
+            direction: .horizontal,
+            children: [.tabArea(a1), .tabArea(a2)]
+        ))
+        let (result, newAreaID) = root.splitting(
             areaID: a2.id,
             direction: .vertical,
             position: .second
         )
         #expect(newAreaID != nil)
-        #expect(root.allAreas().count == 3)
+        if case let .split(branch) = result {
+            #expect(branch.children.count == 2)
+            if case let .split(inner) = branch.children[1] {
+                #expect(inner.direction == .vertical)
+                #expect(inner.children.count == 2)
+            } else {
+                Issue.record("Second child should be a nested split")
+            }
+        } else {
+            Issue.record("Result should be a split")
+        }
+    }
+
+    @Test("splitting same direction three times creates equal thirds")
+    func splittingThreeEqual() {
+        let a1 = TabArea(projectPath: testPath)
+        var root = SplitNode.split(SplitBranch(
+            direction: .horizontal,
+            children: [.tabArea(a1), .tabArea(TabArea(projectPath: testPath))]
+        ))
+        let areas = root.allAreas()
+        let a2ID = areas.first { $0.id != a1.id }!.id
+
+        let (result2, _) = root.splitting(
+            areaID: a2ID,
+            direction: .horizontal,
+            position: .second
+        )
+        root = result2
+
+        if case let .split(branch) = root {
+            #expect(branch.children.count == 3)
+            for ratio in branch.ratios {
+                #expect(abs(ratio - 1.0 / 3.0) < 0.001)
+            }
+        } else {
+            Issue.record("Root should be a split")
+        }
     }
 
     @Test("splittingWithTab creates area with the provided tab")
@@ -186,7 +245,8 @@ struct SplitNodeTests {
         )
         #expect(newAreaID != nil)
         if case let .split(branch) = result {
-            if case let .tabArea(newArea) = branch.second {
+            #expect(branch.children.count == 2)
+            if case let .tabArea(newArea) = branch.children[1] {
                 #expect(newArea.tabs.count == 1)
                 #expect(newArea.tabs[0].id == tab.id)
             } else {
@@ -205,14 +265,13 @@ struct SplitNodeTests {
         #expect(result == nil)
     }
 
-    @Test("removing left child from split returns right child")
-    func removingLeftChild() {
+    @Test("removing one child from two-child split returns remaining")
+    func removingOneChild() {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let node = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2)]
         ))
         let result = node.removing(areaID: a1.id)
         #expect(result != nil)
@@ -223,21 +282,25 @@ struct SplitNodeTests {
         }
     }
 
-    @Test("removing right child from split returns left child")
-    func removingRightChild() {
+    @Test("removing one child from three-child split keeps branch with two")
+    func removingFromThreeChildren() {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
+        let a3 = TabArea(projectPath: testPath)
         let node = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2), .tabArea(a3)]
         ))
         let result = node.removing(areaID: a2.id)
         #expect(result != nil)
-        if case let .tabArea(remaining) = result {
-            #expect(remaining.id == a1.id)
+        if case let .split(branch) = result {
+            #expect(branch.children.count == 2)
+            #expect(branch.ratios.count == 2)
+            for ratio in branch.ratios {
+                #expect(abs(ratio - 0.5) < 0.001)
+            }
         } else {
-            Issue.record("Should collapse to remaining area")
+            Issue.record("Should keep branch with two children")
         }
     }
 
@@ -246,11 +309,10 @@ struct SplitNodeTests {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let a3 = TabArea(projectPath: testPath)
-        let inner = SplitBranch(direction: .vertical, first: .tabArea(a2), second: .tabArea(a3))
+        let inner = SplitBranch(direction: .vertical, children: [.tabArea(a2), .tabArea(a3)])
         let root = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            first: .tabArea(a1),
-            second: .split(inner)
+            children: [.tabArea(a1), .split(inner)]
         ))
         let result = root.removing(areaID: a2.id)
         #expect(result != nil)
@@ -277,15 +339,13 @@ struct SplitNodeTests {
         #expect(frames[area.id] == CGRect(x: 0, y: 0, width: 1, height: 1))
     }
 
-    @Test("areaFrames horizontal split divides width")
+    @Test("areaFrames horizontal split divides width equally")
     func areaFramesHorizontal() {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let node = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            ratio: 0.5,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2)]
         ))
         let frames = node.areaFrames()
         #expect(frames[a1.id]?.width == 0.5)
@@ -296,15 +356,13 @@ struct SplitNodeTests {
         #expect(frames[a2.id]?.height == 1)
     }
 
-    @Test("areaFrames vertical split divides height")
+    @Test("areaFrames vertical split divides height equally")
     func areaFramesVertical() {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let node = SplitNode.split(SplitBranch(
             direction: .vertical,
-            ratio: 0.5,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2)]
         ))
         let frames = node.areaFrames()
         #expect(frames[a1.id]?.height == 0.5)
@@ -314,15 +372,14 @@ struct SplitNodeTests {
         #expect(frames[a1.id]?.width == 1)
     }
 
-    @Test("areaFrames respects custom ratio")
+    @Test("areaFrames respects custom ratios")
     func areaFramesCustomRatio() {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let node = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            ratio: 0.3,
-            first: .tabArea(a1),
-            second: .tabArea(a2)
+            children: [.tabArea(a1), .tabArea(a2)],
+            ratios: [0.3, 0.7]
         ))
         let frames = node.areaFrames()
         let a1Width = frames[a1.id]!.width
@@ -331,17 +388,34 @@ struct SplitNodeTests {
         #expect(abs(a2Width - 0.7) < 0.001)
     }
 
+    @Test("areaFrames three children split equally")
+    func areaFramesThreeEqual() {
+        let a1 = TabArea(projectPath: testPath)
+        let a2 = TabArea(projectPath: testPath)
+        let a3 = TabArea(projectPath: testPath)
+        let node = SplitNode.split(SplitBranch(
+            direction: .horizontal,
+            children: [.tabArea(a1), .tabArea(a2), .tabArea(a3)]
+        ))
+        let frames = node.areaFrames()
+        #expect(frames.count == 3)
+        #expect(abs(frames[a1.id]!.width - 1.0 / 3.0) < 0.001)
+        #expect(abs(frames[a2.id]!.width - 1.0 / 3.0) < 0.001)
+        #expect(abs(frames[a3.id]!.width - 1.0 / 3.0) < 0.001)
+        #expect(frames[a1.id]?.minX == 0)
+        #expect(abs(frames[a2.id]!.minX - 1.0 / 3.0) < 0.001)
+        #expect(abs(frames[a3.id]!.minX - 2.0 / 3.0) < 0.001)
+    }
+
     @Test("areaFrames nested splits calculate correctly")
     func areaFramesNested() {
         let a1 = TabArea(projectPath: testPath)
         let a2 = TabArea(projectPath: testPath)
         let a3 = TabArea(projectPath: testPath)
-        let inner = SplitBranch(direction: .vertical, ratio: 0.5, first: .tabArea(a2), second: .tabArea(a3))
+        let inner = SplitBranch(direction: .vertical, children: [.tabArea(a2), .tabArea(a3)])
         let root = SplitNode.split(SplitBranch(
             direction: .horizontal,
-            ratio: 0.5,
-            first: .tabArea(a1),
-            second: .split(inner)
+            children: [.tabArea(a1), .split(inner)]
         ))
         let frames = root.areaFrames()
         #expect(frames.count == 3)
@@ -350,5 +424,46 @@ struct SplitNodeTests {
         #expect(frames[a2.id]?.height == 0.5)
         #expect(frames[a3.id]?.height == 0.5)
         #expect(frames[a3.id]?.minY == 0.5)
+    }
+
+    @Test("splitting same direction four times creates equal quarters")
+    func splittingFourEqual() {
+        let a1 = TabArea(projectPath: testPath)
+        let a2 = TabArea(projectPath: testPath)
+        let a3 = TabArea(projectPath: testPath)
+        let a4 = TabArea(projectPath: testPath)
+        let root = SplitNode.split(SplitBranch(
+            direction: .horizontal,
+            children: [.tabArea(a1), .tabArea(a2), .tabArea(a3), .tabArea(a4)]
+        ))
+        if case let .split(branch) = root {
+            #expect(branch.children.count == 4)
+            for ratio in branch.ratios {
+                #expect(abs(ratio - 0.25) < 0.001)
+            }
+        } else {
+            Issue.record("Root should be a split")
+        }
+    }
+
+    @Test("removing from four children keeps three equal")
+    func removingFromFourChildren() {
+        let a1 = TabArea(projectPath: testPath)
+        let a2 = TabArea(projectPath: testPath)
+        let a3 = TabArea(projectPath: testPath)
+        let a4 = TabArea(projectPath: testPath)
+        let node = SplitNode.split(SplitBranch(
+            direction: .horizontal,
+            children: [.tabArea(a1), .tabArea(a2), .tabArea(a3), .tabArea(a4)]
+        ))
+        let result = node.removing(areaID: a3.id)
+        if case let .split(branch) = result {
+            #expect(branch.children.count == 3)
+            for ratio in branch.ratios {
+                #expect(abs(ratio - 1.0 / 3.0) < 0.001)
+            }
+        } else {
+            Issue.record("Should keep branch with three children")
+        }
     }
 }

--- a/Tests/MuxyTests/Models/WorkspaceSnapshotTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceSnapshotTests.swift
@@ -153,9 +153,8 @@ struct WorkspaceSnapshotTests {
         )
         let branchSnapshot = SplitBranchSnapshot(
             direction: .horizontal,
-            ratio: 0.6,
-            first: .tabArea(area1),
-            second: .tabArea(area2)
+            ratios: [0.4, 0.6],
+            children: [.tabArea(area1), .tabArea(area2)]
         )
         let snapshot = SplitNodeSnapshot.split(branchSnapshot)
         let data = try JSONEncoder().encode(snapshot)
@@ -163,7 +162,9 @@ struct WorkspaceSnapshotTests {
 
         if case let .split(decodedBranch) = decoded {
             #expect(decodedBranch.direction == .horizontal)
-            #expect(abs(decodedBranch.ratio - 0.6) < 0.001)
+            #expect(decodedBranch.ratios.count == 2)
+            #expect(abs(decodedBranch.ratios[0] - 0.4) < 0.001)
+            #expect(abs(decodedBranch.ratios[1] - 0.6) < 0.001)
         } else {
             Issue.record("Expected split snapshot")
         }


### PR DESCRIPTION
## Summary

This PR changes split-pane layout from binary nested sizing to equal sibling sizing, then narrows the default side panels so the terminal workspace starts with more usable space.

The split-pane change is the main feature:

- 2 panes split to `50% / 50%`
- 3 same-direction panes split to `33% / 33% / 33%`
- 4 same-direction panes split to `25% / 25% / 25% / 25%`
- Vertical splits use the same behavior along height
- Mixed directions still create nested branches, so grid-style layouts continue to work

## Problem

Before this PR, `SplitBranch` represented every split as a binary tree:

```swift
first: SplitNode
second: SplitNode
ratio: CGFloat
```

That means splitting an already-split pane created a nested branch instead of adding a third sibling. Example with horizontal panes:

```text
Split once:
[A: 50%][B: 50%]

Split B again:
[A: 50%][B: 25%][C: 25%]
```

This is technically tmux-style behavior, but it produces poor UX for this app because every new pane inherits only the size of the pane it was split from. Users expect all same-direction panes to rebalance across the available workspace.

## New behavior

Same-direction splits now flatten into the existing parent branch and rebalance all siblings:

```text
Split once:
[A: 50%][B: 50%]

Split B again:
[A: 33%][B: 33%][C: 33%]

Split any of A/B/C again:
[A: 25%][B: 25%][C: 25%][D: 25%]
```

Different-direction splits still stay nested, preserving layouts like:

```text
[A: 50%][vertical split: 50%]
         ├── B: 50% height
         └── C: 50% height
```

## Implementation details

### Split model

`Muxy/Models/SplitNode.swift`

- Replaced binary fields:
  - `first: SplitNode`
  - `second: SplitNode`
  - `ratio: CGFloat`
- With N-child fields:
  - `children: [SplitNode]`
  - `ratios: [CGFloat]`
- `splitting()` and `splittingWithTab()` now:
  - create a two-child branch when splitting a leaf
  - flatten the new branch into the parent when directions match
  - reset sibling ratios to equal `1 / childCount`
- `removing()` now:
  - removes the target area from N children
  - collapses branches with only one remaining child
  - flattens same-direction child branches
  - rebalances remaining siblings equally
- `areaFrames()` now walks all children with cumulative offsets instead of assuming two frames.

### Split rendering

`Muxy/Views/Workspace/SplitContainer.swift`

- Replaced hard-coded two-child rendering with `ForEach` over `branch.children`.
- Inserts one divider between each adjacent pair.
- Divider drag adjusts only the two adjacent ratios while preserving their combined space.
- Accessibility divider actions still resize with a 5% step.

### Persistence / DTOs

Updated split serialization everywhere the binary split shape was exposed:

- `MuxyShared/WorkspaceDTO.swift`
- `Muxy/Models/WorkspaceSnapshot.swift`
- `Muxy/Extensions/DTOConversions.swift`
- `MuxyMobile/DemoBackend.swift`
- `MuxyMobile/RemoteWorkspaceView.swift`

The serialized shape now uses `children` and `ratios` so desktop, mobile, snapshots, and demo mode all share the same split model.

### Tests

`Tests/MuxyTests/Models/SplitNodeTests.swift`

Added or updated coverage for:

- splitting same direction into 3 equal siblings
- splitting same direction into 4 equal siblings
- preserving nested structure for different-direction splits
- removing panes from 3-child and 4-child branches
- equal frame calculation for 3 children
- custom ratio frame calculation

`Tests/MuxyTests/Models/WorkspaceSnapshotTests.swift`

- Updated split snapshot round-trip for `children` + `ratios`.

## Layout tweak included

This PR also narrows default side panels:

- Sidebar expanded width: `220 → 180`
- File tree default width: `260 → 200`
- Attached VCS default width: `400 → 300`

This gives the terminal workspace more room by default, which pairs with the split-pane UX change.

## Relationship to #308

This PR is intentionally based on `main`, not on #308.

It contains only two commits:

1. `✨ feat(layout): reduce default sidebar and panel widths`
2. `✨ feat(split-pane): equal-size split for N panes instead of binary tree`

The split-pane feature does not depend on the project-path/shortcut changes from #308.

## Verification

Previously run locally on this change set before PR creation:

```text
swift test
Test run with 607 tests in 63 suites passed
```

Also checked PR metadata after creation:

```text
base: main
head: feat/equal-split-pane-clean
commit count: 2
```