### PR TITLE
Fix file tree showing git status from parent repo

### DIFF
--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -351,25 +351,31 @@ final class FileTreeState {
         }
     }
 
-    private struct StatusResult {
+    struct StatusResult {
         let fileStatuses: [String: FileStatus]
         let dirtyDirs: Set<String>
     }
 
-    nonisolated private static func loadStatuses(repoRoot: String) async -> StatusResult {
+    nonisolated static func loadStatuses(repoRoot: String) async -> StatusResult {
         await GitProcessRunner.offMain {
             loadStatusesSync(repoRoot: repoRoot)
         }
     }
 
-    nonisolated private static func loadStatusesSync(repoRoot: String) -> StatusResult {
+    nonisolated static func loadStatusesSync(repoRoot: String) -> StatusResult {
         guard let gitPath = GitProcessRunner.resolveExecutable("git") else {
+            return StatusResult(fileStatuses: [:], dirtyDirs: [])
+        }
+
+        let resolvedRoot = canonicalize(path: repoRoot)
+
+        guard let gitRoot = resolveGitRoot(gitPath: gitPath, path: resolvedRoot) else {
             return StatusResult(fileStatuses: [:], dirtyDirs: [])
         }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: gitPath)
-        process.arguments = ["-C", repoRoot, "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=normal"]
+        process.arguments = ["-C", resolvedRoot, "-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=normal"]
 
         var environment = ProcessInfo.processInfo.environment
         environment["GIT_OPTIONAL_LOCKS"] = "0"
@@ -390,17 +396,22 @@ final class FileTreeState {
         _ = try? stderrPipe.fileHandleForReading.readToEnd()
         process.waitUntilExit()
 
-        let normalizedRoot = repoRoot.hasSuffix("/") ? String(repoRoot.dropLast()) : repoRoot
+        let resolvedGitRoot = canonicalize(path: gitRoot)
         var fileStatuses: [String: FileStatus] = [:]
         var dirtyDirs: Set<String> = []
 
         for file in GitStatusParser.parseStatusPorcelain(outData, stats: [:]) {
-            let absolute = normalizedRoot + "/" + file.path
+            let absolute = resolvedGitRoot + "/" + file.path
             let trimmed = absolute.hasSuffix("/") ? String(absolute.dropLast()) : absolute
+
+            guard trimmed.hasPrefix(resolvedRoot + "/") || trimmed == resolvedRoot else {
+                continue
+            }
+
             fileStatuses[trimmed] = mapStatus(file)
 
             var current = (trimmed as NSString).deletingLastPathComponent
-            while current.count > normalizedRoot.count {
+            while current.count > resolvedRoot.count {
                 if dirtyDirs.contains(current) { break }
                 dirtyDirs.insert(current)
                 current = (current as NSString).deletingLastPathComponent
@@ -408,6 +419,47 @@ final class FileTreeState {
         }
 
         return StatusResult(fileStatuses: fileStatuses, dirtyDirs: dirtyDirs)
+    }
+
+    nonisolated private static func canonicalize(path: String) -> String {
+        let trimmed = path.hasSuffix("/") ? String(path.dropLast()) : path
+        guard let resolvedPtr = trimmed.withCString({ realpath($0, nil) }) else {
+            return trimmed
+        }
+        defer { free(resolvedPtr) }
+        let resolved = String(cString: resolvedPtr)
+        return resolved.hasSuffix("/") ? String(resolved.dropLast()) : resolved
+    }
+
+    nonisolated static func resolveGitRoot(gitPath: String, path: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: gitPath)
+        process.arguments = ["-C", path, "rev-parse", "--show-toplevel"]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_OPTIONAL_LOCKS"] = "0"
+        process.environment = environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
+        _ = try? stderrPipe.fileHandleForReading.readToEnd()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else { return nil }
+
+        let result = String(data: outData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return result.isEmpty ? nil : result
     }
 
     private func mergedEntries(in directoryPath: String, realEntries: [FileTreeEntry]) -> [FileTreeEntry] {

--- a/Tests/MuxyTests/Models/FileTreeStateTests.swift
+++ b/Tests/MuxyTests/Models/FileTreeStateTests.swift
@@ -290,6 +290,28 @@ struct FileTreeStateTests {
         }
         throw FileTreeStateTestError.timeout("FileTreeState children of \(path) never loaded")
     }
+
+    @Test("git statuses are scoped to rootPath, not parent repo root")
+    func gitStatusesScopedToTreeRoot() async throws {
+        let fixture = try GitRepoFixture()
+        defer { fixture.cleanup() }
+
+        let result = await FileTreeState.loadStatuses(repoRoot: fixture.subPath)
+
+        let insideFile = fixture.subPath + "/inside.txt"
+        let nestedFile = fixture.subPath + "/nested/deep.txt"
+        let nestedDir = fixture.subPath + "/nested"
+        let outsideFile = fixture.rootPath + "/outside.txt"
+
+        #expect(result.fileStatuses[insideFile] != nil,
+                "Expected status for file inside subfolder")
+        #expect(result.fileStatuses[nestedFile] != nil,
+                "Expected status for file nested in subfolder")
+        #expect(result.fileStatuses[outsideFile] == nil,
+                "Expected no status for file outside subfolder")
+        #expect(result.dirtyDirs.contains(nestedDir),
+                "Expected nested directory inside subfolder to be marked dirty")
+    }
 }
 
 private enum FileTreeStateTestError: Error {
@@ -331,5 +353,60 @@ private final class TreeFixture {
 
     func cleanup() {
         try? FileManager.default.removeItem(at: rootURL)
+    }
+}
+
+@MainActor
+private final class GitRepoFixture {
+    let rootURL: URL
+    let subURL: URL
+
+    var rootPath: String { realpath(rootURL.path) }
+    var subPath: String { realpath(subURL.path) }
+
+    init() throws {
+        let fm = FileManager.default
+        let parent = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        rootURL = parent.appendingPathComponent("repo")
+        subURL = rootURL.appendingPathComponent("sub")
+
+        try fm.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: subURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: subURL.appendingPathComponent("nested"), withIntermediateDirectories: true)
+
+        try runGit(arguments: ["-C", rootURL.path, "init"])
+        try "outside".write(to: rootURL.appendingPathComponent("outside.txt"), atomically: true, encoding: .utf8)
+        try "inside".write(to: rootURL.appendingPathComponent("sub/inside.txt"), atomically: true, encoding: .utf8)
+        try "deep".write(to: rootURL.appendingPathComponent("sub/nested/deep.txt"), atomically: true, encoding: .utf8)
+        try runGit(arguments: ["-C", rootURL.path, "add", "."])
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootURL.deletingLastPathComponent())
+    }
+
+    private func runGit(arguments: [String]) throws {
+        guard let gitPath = GitProcessRunner.resolveExecutable("git") else {
+            struct GitNotFound: Error {}
+            throw GitNotFound()
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: gitPath)
+        process.arguments = arguments
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_OPTIONAL_LOCKS"] = "0"
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+    }
+
+    private func realpath(_ path: String) -> String {
+        guard let resolvedPtr = path.withCString({ Darwin.realpath($0, nil) }) else {
+            return path
+        }
+        defer { free(resolvedPtr) }
+        return String(cString: resolvedPtr)
     }
 }


### PR DESCRIPTION
## Summary

When the file tree is opened at a subfolder inside a git repo (where the subfolder itself has no `.git`), it incorrectly displays git status changes from the entire parent repo. This PR scopes the file tree's git status detection to only include files within the tree's `rootPath`.

## The Bug

**Reproduction:**
1. Open a project whose path is a subfolder of a git repo (e.g. `/repo/sub/` where `/repo/.git/` exists)
2. Open the file tree
3. Modified files in `/repo/` (outside the subfolder) appear as changed in the file tree

**Root cause:** `FileTreeState.loadStatusesSync()` ran `git -C rootPath status --porcelain=v1` and built absolute paths by combining `rootPath` with the git-relative paths returned by git. But git always returns paths relative to the **actual git repository root**, not the directory passed to `-C`. When `rootPath` is a subfolder, this combination produced incorrect paths and pulled in changes from the entire parent repo.

## The Fix

`Muxy/Models/FileTreeState.swift`:
1. **Detect the real git root** via `git rev-parse --show-toplevel` in a new `resolveGitRoot()` helper.
2. **Build absolute paths from the detected git root**, not from the file tree's `rootPath`.
3. **Filter out status entries outside the file tree's scope** — only keep entries whose absolute path starts with `rootPath`.
4. **Canonicalize symlinks** with `realpath()` so `/var` vs `/private/var` (macOS temp dirs) don't break prefix comparisons.

Git review/diff functionality is fully preserved — only the scope detection logic is changed.

## Tests

Added `gitStatusesScopedToTreeRoot` regression test in `FileTreeStateTests` which:
- Creates a real git repo at a temp parent directory
- Opens `FileTreeState` rooted at a subfolder
- Verifies status entries inside the subfolder are present
- Verifies status entries outside the subfolder are excluded
- Verifies nested directories within the subfolder are still marked dirty

All 17 `FileTreeState` tests pass; build is clean.