### PR TITLE
Remember file tree and source control panel state per project

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-swiftformat 0.60.1
-swiftlint 0.57.1
+swiftformat 0.61.1
+swiftlint 0.63.2

--- a/Muxy/Models/SidebarPanelPreferences.swift
+++ b/Muxy/Models/SidebarPanelPreferences.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum SidebarPanelPreferences {
+    static let rememberPerProjectKey = "muxy.sidebars.rememberPerProject"
+    private static let fileTreeStatesKey = "muxy.sidebars.perProject.fileTreeVisible"
+    private static let vcsStatesKey = "muxy.sidebars.perProject.vcsVisible"
+
+    static var rememberPerProject: Bool {
+        get { UserDefaults.standard.bool(forKey: rememberPerProjectKey) }
+        set { UserDefaults.standard.set(newValue, forKey: rememberPerProjectKey) }
+    }
+
+    static func fileTreeVisible(for projectID: UUID) -> Bool {
+        states(forKey: fileTreeStatesKey)[projectID.uuidString] ?? false
+    }
+
+    static func setFileTreeVisible(_ visible: Bool, for projectID: UUID) {
+        update(stateKey: fileTreeStatesKey, projectID: projectID, value: visible)
+    }
+
+    static func vcsVisible(for projectID: UUID) -> Bool {
+        states(forKey: vcsStatesKey)[projectID.uuidString] ?? false
+    }
+
+    static func setVCSVisible(_ visible: Bool, for projectID: UUID) {
+        update(stateKey: vcsStatesKey, projectID: projectID, value: visible)
+    }
+
+    private static func states(forKey key: String) -> [String: Bool] {
+        (UserDefaults.standard.dictionary(forKey: key) as? [String: Bool]) ?? [:]
+    }
+
+    private static func update(stateKey: String, projectID: UUID, value: Bool) {
+        var dict = states(forKey: stateKey)
+        dict[projectID.uuidString] = value
+        UserDefaults.standard.set(dict, forKey: stateKey)
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -53,7 +53,9 @@ struct MainWindow: View {
     @State private var vcsStates: [WorktreeKey: VCSTabState] = [:]
     @State private var fileTreePanelVisible = false
     @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
+    @AppStorage(SidebarPanelPreferences.rememberPerProjectKey) private var rememberSidebarsPerProject = false
     @State private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
+    @State private var lastRestoredProjectID: UUID?
     @State private var showQuickOpen = false
     @State private var showWorktreeSwitcher = false
     @State private var isFullScreen = false
@@ -272,6 +274,13 @@ struct MainWindow: View {
                 ensureFileTreeState(for: project)
             }
         }
+        .modifier(SidebarVisibilityMemorySync(
+            activeProjectID: appState.activeProjectID,
+            rememberPerProject: rememberSidebarsPerProject,
+            restore: restoreSidebarVisibilityForActiveProject,
+            persist: persistSidebarVisibilityForActiveProject,
+            clearLastRestored: { lastRestoredProjectID = nil }
+        ))
         .modifier(FileTreeSelectionSync(
             filePath: activeEditorFilePath,
             panelVisible: fileTreePanelVisible,
@@ -648,6 +657,7 @@ struct MainWindow: View {
         if isShowing {
             fileTreePanelVisible = false
         }
+        persistSidebarVisibility(for: project)
     }
 
     private func toggleFileTreePanel() {
@@ -667,6 +677,49 @@ struct MainWindow: View {
         } else {
             NotificationCenter.default.post(name: .refocusActiveTerminal, object: nil)
         }
+        persistSidebarVisibility(for: project)
+    }
+
+    private func persistSidebarVisibility(for project: Project) {
+        guard rememberSidebarsPerProject else { return }
+        SidebarPanelPreferences.setFileTreeVisible(fileTreePanelVisible, for: project.id)
+        SidebarPanelPreferences.setVCSVisible(vcsPanelVisible, for: project.id)
+    }
+
+    private func restoreSidebarVisibility(for project: Project) {
+        guard rememberSidebarsPerProject else {
+            lastRestoredProjectID = project.id
+            return
+        }
+        let wantsVCS = SidebarPanelPreferences.vcsVisible(for: project.id)
+            && VCSDisplayMode.current == .attached
+        let wantsFileTree = SidebarPanelPreferences.fileTreeVisible(for: project.id)
+
+        if wantsVCS {
+            ensureVCSState(for: project)
+            vcsPanelVisible = true
+            fileTreePanelVisible = false
+        } else if wantsFileTree {
+            ensureFileTreeState(for: project)
+            fileTreePanelVisible = true
+            vcsPanelVisible = false
+        } else {
+            vcsPanelVisible = false
+            fileTreePanelVisible = false
+        }
+        lastRestoredProjectID = project.id
+    }
+
+    private func restoreSidebarVisibilityForActiveProject() {
+        guard let project = activeProject,
+              project.id != lastRestoredProjectID
+        else { return }
+        restoreSidebarVisibility(for: project)
+    }
+
+    private func persistSidebarVisibilityForActiveProject() {
+        guard let project = activeProject else { return }
+        persistSidebarVisibility(for: project)
     }
 
     private var activeVCSState: VCSTabState? {
@@ -852,6 +905,30 @@ private struct FileTreeSelectionSync: ViewModifier {
             .onChange(of: panelVisible) { _, visible in
                 guard visible else { return }
                 sync(filePath)
+            }
+    }
+}
+
+private struct SidebarVisibilityMemorySync: ViewModifier {
+    let activeProjectID: UUID?
+    let rememberPerProject: Bool
+    let restore: () -> Void
+    let persist: () -> Void
+    let clearLastRestored: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { restore() }
+            .onChange(of: activeProjectID) { _, newValue in
+                if newValue == nil {
+                    clearLastRestored()
+                } else {
+                    restore()
+                }
+            }
+            .onChange(of: rememberPerProject) { _, enabled in
+                guard enabled else { return }
+                persist()
             }
     }
 }

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -11,6 +11,8 @@ struct GeneralSettingsView: View {
     private var confirmRunningProcess = true
     @AppStorage(ProjectLifecyclePreferences.keepOpenWhenNoTabsKey)
     private var keepProjectsOpenWhenNoTabs = false
+    @AppStorage(SidebarPanelPreferences.rememberPerProjectKey)
+    private var rememberSidebarsPerProject = false
 
     var body: some View {
         SettingsContainer {
@@ -21,6 +23,16 @@ struct GeneralSettingsView: View {
                 SettingsToggleRow(
                     label: "Auto-expand worktrees on project switch",
                     isOn: $autoExpandWorktrees
+                )
+            }
+
+            SettingsSection(
+                "Side Panels",
+                footer: "Remember the show/hide state of the file tree and source control panels independently for each project."
+            ) {
+                SettingsToggleRow(
+                    label: "Remember file tree and source control per project",
+                    isOn: $rememberSidebarsPerProject
                 )
             }
 


### PR DESCRIPTION
## Summary

Adds an opt-in General setting that persists the show/hide state of the attached **File Tree** and **Source Control** side panels independently for each project. When the toggle is on, switching projects restores the last visibility state for that project; when off, behavior is unchanged (shared global state, default hidden).

Also bumps `.tool-versions` to match the currently bottled `swiftformat` 0.61.1 and `swiftlint` 0.63.2 (codebase already passes both).

### Why

Different projects have different workflows — some need the file tree always visible, others rely on source control diff, others want a clean terminal-only view. Today every project share one global toggle, so users have to re-toggle every time they switch.

### Behavior

- **Toggle off (default):** existing global behavior, both panels start hidden, user toggles per session.
- **Toggle on:** opening a project restores its last panel state. Toggling a panel writes the new state back to that project's slot in `UserDefaults`. Panels remain mutually exclusive (opening one closes the other) — same as today.
- Source control panel is only restored when `VCSDisplayMode` is `attached` (consistent with the existing toggle path).

## Changes

- `Muxy/Models/SidebarPanelPreferences.swift` — new store: `rememberPerProject` flag + per-project `[UUID: Bool]` maps for file tree / VCS visibility under `muxy.sidebars.*` keys.
- `Muxy/Views/MainWindow.swift`
  - Added `rememberSidebarsPerProject` `@AppStorage` and `lastRestoredProjectID` state.
  - `toggleAttachedVCSPanel` / `toggleFileTreePanel` now persist visibility for the active project.
  - New `restoreSidebarVisibility(for:)` runs on `onAppear` and on `activeProjectID` change.
  - Extracted into a small `SidebarVisibilityMemorySync` `ViewModifier` (3 small modifiers extracted from the main `body` to avoid a Swift type-checker timeout on the already-large view).
- `Muxy/Views/Settings/GeneralSettingsView.swift` — new "Side Panels" section with toggle: *Remember file tree and source control per project*.
- `.tool-versions` — bump `swiftformat` 0.60.1 → 0.61.1, `swiftlint` 0.57.1 → 0.63.2 (matches Homebrew bottled versions; codebase passes lint+format under both).

## Testing

- [x] `scripts/checks.sh --fix` — Formatting, Linting, macOS Build, Tests pass. iOS build step fails locally only because the runner is missing the iOS 26.4 SDK; unrelated to this change.
- [x] Manual on macOS:
  - Toggle off (default): existing behavior, panels reset across project switches as before.
  - Toggle on:
    - Project A: open file tree → switch to B → open source control → switch back to A. File tree restored on A, source control restored on B.
    - Toggling either panel within a project persists immediately.
    - Source control restoration respects `VCSDisplayMode` (skips when not `attached`).
    - Closing the only active project clears the last-restored marker so re-selecting re-runs restore.

## Screenshots

_To be added by the author._