### PR TITLE
Reduce GitHub Actions cost on public repo

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     name: Checks
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,6 +54,16 @@ jobs:
         run: scripts/setup.sh
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Cache SPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build
         run: swift build

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -3,6 +3,13 @@ name: Release (Beta)
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - ".gitignore"
+      - "LICENSE"
   workflow_dispatch:
 
 concurrency:
@@ -73,6 +80,16 @@ jobs:
         run: |
           chmod +x scripts/setup.sh
           scripts/setup.sh
+
+      - name: Cache SPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-release-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            spm-release-${{ runner.os }}-${{ matrix.arch }}-
 
       - name: Resolve Sparkle dependency
         run: swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,16 @@ jobs:
           chmod +x scripts/setup.sh
           scripts/setup.sh
 
+      - name: Cache SPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-release-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            spm-release-${{ runner.os }}-${{ matrix.arch }}-
+
       - name: Resolve Sparkle dependency
         run: swift package resolve
 

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @main
 struct MuxyApp: App {
-    static let launchDate = Date()
+    nonisolated static let launchDate = Date()
 
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @State private var appState: AppState

--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -133,7 +133,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
             String(bytes: UnsafeBufferPointer(start: rawPtr, count: Int(openURL.len)), encoding: .utf8)
         }
         guard let urlString, let url = URL(string: urlString) else { return false }
-        return view.onOpenURL?(url) ?? false
+        return MainActor.assumeIsolated {
+            view.onOpenURL?(url) ?? false
+        }
     }
 
     private func handleMouseOverLink(target: ghostty_target_s, link: ghostty_action_mouse_over_link_s) {

--- a/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
+++ b/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import Muxy
 
 @Suite("TerminalBridge.resolveFilePath")
+@MainActor
 struct TerminalBridgeResolveFilePathTests {
     private func makeTempDir() -> URL {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
- `checks.yml` now runs on `macos-latest` (free for public repos) instead of billed `macos-26`.
- All Swift workflows cache `.build` and `~/Library/Caches/org.swift.swiftpm` keyed on `Package.resolved`.
- `release-beta.yml` skips runs for docs/markdown-only commits.