### PR TITLE
Tab close management: close others/left/right + double-click rename

### DIFF
--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -350,6 +350,23 @@ struct MainWindow: View {
                 onCloseTab: { tabID in
                     appState.closeTab(tabID, areaID: area.id, projectID: project.id)
                 },
+                onCloseOtherTabs: { tabID in
+                    for id in area.tabs.filter({ $0.id != tabID && !$0.isPinned }).map(\.id) {
+                        appState.closeTab(id, areaID: area.id, projectID: project.id)
+                    }
+                },
+                onCloseTabsToLeft: { tabID in
+                    guard let index = area.tabs.firstIndex(where: { $0.id == tabID }) else { return }
+                    for id in area.tabs.prefix(index).filter({ !$0.isPinned }).map(\.id) {
+                        appState.closeTab(id, areaID: area.id, projectID: project.id)
+                    }
+                },
+                onCloseTabsToRight: { tabID in
+                    guard let index = area.tabs.firstIndex(where: { $0.id == tabID }) else { return }
+                    for id in area.tabs.suffix(from: index + 1).filter({ !$0.isPinned }).map(\.id) {
+                        appState.closeTab(id, areaID: area.id, projectID: project.id)
+                    }
+                },
                 onSplit: { dir in
                     appState.dispatch(.splitArea(.init(
                         projectID: project.id,

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -18,6 +18,12 @@ struct TabAreaView: View {
     @Environment(TabDragCoordinator.self) private var dragCoordinator
     @Environment(AppState.self) private var appState
 
+    private func closeTabs(_ tabIDs: [UUID]) {
+        for tabID in tabIDs {
+            onCloseTab(tabID)
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if showTabStrip {
@@ -32,6 +38,17 @@ struct TabAreaView: View {
                     onCreateTab: onCreateTab,
                     onCreateVCSTab: onCreateVCSTab,
                     onCloseTab: onCloseTab,
+                    onCloseOtherTabs: { tabID in
+                        closeTabs(area.tabs.filter { $0.id != tabID && !$0.isPinned }.map(\.id))
+                    },
+                    onCloseTabsToLeft: { tabID in
+                        guard let index = area.tabs.firstIndex(where: { $0.id == tabID }) else { return }
+                        closeTabs(area.tabs.prefix(index).filter { !$0.isPinned }.map(\.id))
+                    },
+                    onCloseTabsToRight: { tabID in
+                        guard let index = area.tabs.firstIndex(where: { $0.id == tabID }) else { return }
+                        closeTabs(area.tabs.suffix(from: index + 1).filter { !$0.isPinned }.map(\.id))
+                    },
                     onSplit: onSplit,
                     onDropAction: onDropAction,
                     onCreateTabAdjacent: { tabID, side in

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -26,6 +26,9 @@ struct PaneTabStrip: View {
     let onCreateTab: () -> Void
     let onCreateVCSTab: () -> Void
     let onCloseTab: (UUID) -> Void
+    let onCloseOtherTabs: (UUID) -> Void
+    let onCloseTabsToLeft: (UUID) -> Void
+    let onCloseTabsToRight: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
     let onCreateTabAdjacent: (UUID, TabArea.InsertSide) -> Void
@@ -125,8 +128,14 @@ struct PaneTabStrip: View {
                     hasUnread: NotificationStore.shared.hasUnread(tabID: tab.id),
                     isAnyDragging: dragState.draggedID != nil,
                     shortcutIndex: index < 9 ? index + 1 : nil,
+                    closableOthersCount: closableOthersCount(excluding: tab.id),
+                    closableLeftCount: closableCount(leftOf: index),
+                    closableRightCount: closableCount(rightOf: index),
                     onSelect: { onSelectTab(tab.id) },
                     onClose: { onCloseTab(tab.id) },
+                    onCloseOthers: { onCloseOtherTabs(tab.id) },
+                    onCloseLeft: { onCloseTabsToLeft(tab.id) },
+                    onCloseRight: { onCloseTabsToRight(tab.id) },
                     onCreateLeft: { onCreateTabAdjacent(tab.id, .left) },
                     onCreateRight: { onCreateTabAdjacent(tab.id, .right) },
                     onTogglePin: { onTogglePin(tab.id) },
@@ -163,6 +172,18 @@ struct PaneTabStrip: View {
                 )
             }
         }
+    }
+
+    private func closableOthersCount(excluding tabID: UUID) -> Int {
+        tabs.count(where: { $0.id != tabID && !$0.isPinned })
+    }
+
+    private func closableCount(leftOf index: Int) -> Int {
+        tabs.prefix(index).count(where: { !$0.isPinned })
+    }
+
+    private func closableCount(rightOf index: Int) -> Int {
+        tabs.suffix(from: index + 1).count(where: { !$0.isPinned })
     }
 
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {
@@ -287,8 +308,14 @@ private struct TabCell: View {
     var hasUnread: Bool = false
     var isAnyDragging: Bool = false
     var shortcutIndex: Int?
+    var closableOthersCount: Int = 0
+    var closableLeftCount: Int = 0
+    var closableRightCount: Int = 0
     let onSelect: () -> Void
     let onClose: () -> Void
+    let onCloseOthers: () -> Void
+    let onCloseLeft: () -> Void
+    let onCloseRight: () -> Void
     let onCreateLeft: () -> Void
     let onCreateRight: () -> Void
     let onTogglePin: () -> Void
@@ -359,6 +386,9 @@ private struct TabCell: View {
                         .focused($renameFieldFocused)
                         .onSubmit { commitRename() }
                         .onExitCommand { cancelRename() }
+                        .onChange(of: renameFieldFocused) { _, focused in
+                            if !focused, isRenaming { commitRename() }
+                        }
                 } else if !titleHidden {
                     Text(tab.title)
                         .font(.system(size: 12))
@@ -407,6 +437,7 @@ private struct TabCell: View {
             }
             .background(tabBackground)
             .contentShape(Rectangle())
+            .simultaneousGesture(TapGesture(count: 2).onEnded { startRename() })
             .onHover { hovering in
                 guard !isAnyDragging else { return }
                 hovered = hovering
@@ -443,6 +474,12 @@ private struct TabCell: View {
                 if !tab.isPinned {
                     Divider()
                     Button("Close Tab") { onClose() }
+                    Button("Close Other Tabs") { onCloseOthers() }
+                        .disabled(closableOthersCount == 0)
+                    Button("Close Tabs to the Left") { onCloseLeft() }
+                        .disabled(closableLeftCount == 0)
+                    Button("Close Tabs to the Right") { onCloseRight() }
+                        .disabled(closableRightCount == 0)
                 }
             }
             .popover(isPresented: $showColorPicker, arrowEdge: .bottom) {


### PR DESCRIPTION
Closes #297 (tab management portion). Adds context-menu options to close other tabs, tabs to the left, or tabs to the right, skipping pinned tabs. Also adds double-click to rename and commit-on-blur so rename mode exits cleanly.