### PR TITLE
Add syntax highlighting for .env files

### DIFF
--- a/Muxy/Syntax/Grammars/DataGrammars.swift
+++ b/Muxy/Syntax/Grammars/DataGrammars.swift
@@ -123,6 +123,33 @@ extension SyntaxGrammar {
         }()
     )
 
+    static let dotenv = SyntaxGrammar(
+        name: "DotEnv",
+        extensions: ["env"],
+        caseSensitiveKeywords: true,
+        lineComments: ["#"],
+        lineCommentScope: .comment,
+        blockComments: [],
+        strings: [
+            StringRule(id: 1, open: "\"", close: "\"", escape: "\\", multiline: false, scope: .string),
+            StringRule(id: 2, open: "'", close: "'", escape: nil, multiline: false, scope: .string),
+            StringRule(id: 3, open: "`", close: "`", escape: "\\", multiline: false, scope: .string),
+        ],
+        keywordGroups: [
+            KeywordGroup(words: ["export"], scope: .keyword),
+            KeywordGroup(words: ["true", "false", "null"], scope: .builtin),
+        ],
+        supportsNumbers: true,
+        supportsHashDirectives: false,
+        hashDirectiveScope: .preprocessor,
+        supportsAtAttributes: false,
+        atAttributeScope: .attribute,
+        highlightFunctionCalls: false,
+        highlightAllCapsAsConstant: true,
+        identifierStart: SyntaxGrammar.defaultIdentifierStart,
+        identifierBody: SyntaxGrammar.defaultIdentifierBody
+    )
+
     static let sql = SyntaxGrammar(
         name: "SQL",
         extensions: ["sql"],

--- a/Muxy/Syntax/SyntaxLanguageRegistry.swift
+++ b/Muxy/Syntax/SyntaxLanguageRegistry.swift
@@ -42,6 +42,7 @@ enum SyntaxLanguageRegistry {
         .yaml,
         .toml,
         .ini,
+        .dotenv,
         .sql,
         .dockerfile,
         .makefile,
@@ -59,11 +60,14 @@ enum SyntaxLanguageRegistry {
 
     static func grammar(forFile filename: String) -> SyntaxGrammar? {
         let url = URL(fileURLWithPath: filename)
+        let name = url.lastPathComponent.lowercased()
+        if name == ".env" || name.hasPrefix(".env.") {
+            return extensionMap["env"]
+        }
         let ext = url.pathExtension.lowercased()
         if !ext.isEmpty, let grammar = extensionMap[ext] {
             return grammar
         }
-        let name = url.lastPathComponent.lowercased()
         if let grammar = extensionMap[name] {
             return grammar
         }
@@ -123,6 +127,8 @@ enum SyntaxLanguageRegistry {
         "json": "json",
         "toml": "toml",
         "ini": "ini",
+        "env": "env",
+        "dotenv": "env",
         "sql": "sql",
         "lua": "lua",
         "perl": "pl",

--- a/Tests/MuxyTests/Models/SyntaxLanguageRegistryTests.swift
+++ b/Tests/MuxyTests/Models/SyntaxLanguageRegistryTests.swift
@@ -91,6 +91,17 @@ struct SyntaxLanguageRegistryTests {
         #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "JSON")?.name == "JSON")
     }
 
+    @Test("recognizes .env and prefixed env files as INI")
+    func envFiles() {
+        #expect(SyntaxLanguageRegistry.grammar(forFile: ".env")?.name == "DotEnv")
+        #expect(SyntaxLanguageRegistry.grammar(forFile: ".env.example")?.name == "DotEnv")
+        #expect(SyntaxLanguageRegistry.grammar(forFile: ".env.local")?.name == "DotEnv")
+        #expect(SyntaxLanguageRegistry.grammar(forFile: ".env.dist")?.name == "DotEnv")
+        #expect(SyntaxLanguageRegistry.grammar(forFile: "/a/b/.env.production")?.name == "DotEnv")
+        #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "env")?.name == "DotEnv")
+        #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "dotenv")?.name == "DotEnv")
+    }
+
     @Test("unknown language hint returns nil")
     func hintUnknown() {
         #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "brainfuck") == nil)


### PR DESCRIPTION
Adds a dedicated DotEnv grammar covering .env, .env.example, .env.local, and other .env.* variants. Highlights keys
   as constants, quoted values as strings, export as keyword, and # comments. Closes #296.