### PR TITLE
Add quit confirmation dialog with "don't ask again" option

### DIFF
--- a/Muxy/Models/QuitConfirmationPreferences.swift
+++ b/Muxy/Models/QuitConfirmationPreferences.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum QuitConfirmationPreferences {
+    static let confirmQuitKey = "muxy.app.confirmQuit"
+
+    static var confirmQuit: Bool {
+        get {
+            let defaults = UserDefaults.standard
+            if defaults.object(forKey: confirmQuitKey) == nil { return true }
+            return defaults.bool(forKey: confirmQuitKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: confirmQuitKey)
+        }
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -238,7 +238,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         let unsaved = hasUnsavedEditorTabs?() ?? []
-        guard !unsaved.isEmpty else { return .terminateNow }
+        guard !unsaved.isEmpty else { return confirmQuitIfNeeded() }
 
         let alert = NSAlert()
         alert.messageText = unsaved.count == 1
@@ -278,6 +278,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         default:
             return .terminateCancel
         }
+    }
+
+    @MainActor
+    private func confirmQuitIfNeeded() -> NSApplication.TerminateReply {
+        guard QuitConfirmationPreferences.confirmQuit else { return .terminateNow }
+
+        let alert = NSAlert()
+        alert.messageText = "Quit Muxy?"
+        alert.informativeText = "Are you sure you want to quit Muxy?"
+        alert.alertStyle = .warning
+        alert.icon = NSApp.applicationIconImage
+        alert.addButton(withTitle: "Quit")
+        alert.addButton(withTitle: "Cancel")
+        alert.buttons[0].keyEquivalent = "\r"
+        alert.buttons[1].keyEquivalent = "\u{1b}"
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = "Don't ask again"
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return .terminateCancel }
+        if alert.suppressionButton?.state == .on {
+            QuitConfirmationPreferences.confirmQuit = false
+        }
+        return .terminateNow
     }
 
     @MainActor
@@ -360,6 +384,7 @@ struct WindowConfigurator: NSViewRepresentable {
             Self.repositionTrafficLights(in: w)
             Self.hideTitlebarDecorationView(in: w)
             Self.neutralizeSafeAreaInsets(in: w)
+            Self.interceptCloseButton(in: w, coordinator: context.coordinator)
             context.coordinator.observe(window: w)
         }
         return v
@@ -416,6 +441,12 @@ struct WindowConfigurator: NSViewRepresentable {
         }
     }
 
+    static func interceptCloseButton(in window: NSWindow, coordinator: Coordinator) {
+        guard let button = window.standardWindowButton(.closeButton) else { return }
+        button.target = coordinator
+        button.action = #selector(Coordinator.handleCloseButton(_:))
+    }
+
     static let trafficLightY: CGFloat = 3.5
 
     static func repositionTrafficLights(in window: NSWindow) {
@@ -436,6 +467,13 @@ struct WindowConfigurator: NSViewRepresentable {
 
     final class Coordinator: NSObject {
         private var observations: [NSObjectProtocol] = []
+
+        @objc
+        func handleCloseButton(_: Any?) {
+            MainActor.assumeIsolated {
+                NSApp.terminate(nil)
+            }
+        }
 
         func observe(window: NSWindow) {
             guard observations.isEmpty else { return }

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -13,6 +13,8 @@ struct GeneralSettingsView: View {
     private var keepProjectsOpenWhenNoTabs = false
     @AppStorage(UpdateChannel.storageKey)
     private var updateChannelRaw = UpdateChannel.stable.rawValue
+    @AppStorage(QuitConfirmationPreferences.confirmQuitKey)
+    private var confirmQuit = true
 
     var body: some View {
         SettingsContainer {
@@ -53,10 +55,17 @@ struct GeneralSettingsView: View {
                 )
             }
 
-            SettingsSection("Tabs", showsDivider: false) {
+            SettingsSection("Tabs") {
                 SettingsToggleRow(
                     label: "Confirm before closing a tab with a running process",
                     isOn: $confirmRunningProcess
+                )
+            }
+
+            SettingsSection("Quit", showsDivider: false) {
+                SettingsToggleRow(
+                    label: "Confirm before quitting Muxy",
+                    isOn: $confirmQuit
                 )
             }
         }


### PR DESCRIPTION
Adds a confirmation dialog when quitting Muxy (Cmd+Q or red close button), with a "Don't ask again" checkbox. Users
   can re-enable the prompt from Settings → General → Quit. The red close button is rerouted through NSApp.terminate
  so cancelling keeps the main window open.