### PR TITLE
Bugfix/cmd click osc 8

### DIFF
--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -143,6 +143,7 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         let hasLink = link.len > 0 && link.url != nil
         DispatchQueue.main.async {
             view.hasOSC8LinkUnderCursor = hasLink
+            view.refreshCmdHoverCursor()
         }
     }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -543,8 +543,12 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private func updateCmdHoverCursor(modifierFlags: NSEvent.ModifierFlags) {
-        guard modifierFlags.contains(.command), !hasOSC8LinkUnderCursor else {
+        guard modifierFlags.contains(.command) else {
             setHandCursor(false)
+            return
+        }
+        if hasOSC8LinkUnderCursor {
+            setHandCursor(true)
             return
         }
         guard let word = readWordUnderMouse(), resolveCmdHoverFile?(word) == true else {
@@ -552,6 +556,10 @@ final class GhosttyTerminalNSView: NSView {
             return
         }
         setHandCursor(true)
+    }
+
+    func refreshCmdHoverCursor() {
+        updateCmdHoverCursor(modifierFlags: NSEvent.modifierFlags)
     }
 
     private func setHandCursor(_ on: Bool) {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -21,6 +21,7 @@ final class GhosttyTerminalNSView: NSView {
     var onOpenURL: ((URL) -> Bool)?
     private var isShowingHandCursor = false
     private var fileHoverUnderlineLayer: CAShapeLayer?
+    private var lastMouseTopDownPoint: CGPoint?
     var hasOSC8LinkUnderCursor: Bool = false
     var isFocused: Bool = false
     var overlayActive: Bool = false
@@ -534,6 +535,7 @@ final class GhosttyTerminalNSView: NSView {
     override func mouseMoved(with event: NSEvent) {
         guard let surface else { return }
         let pt = mousePoint(from: event)
+        lastMouseTopDownPoint = pt
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
         updateCmdHoverCursor(modifierFlags: event.modifierFlags)
     }
@@ -580,7 +582,7 @@ final class GhosttyTerminalNSView: NSView {
 
     private struct QuicklookWord {
         let text: String
-        let topLeftPixels: CGPoint
+        let topLeftPoints: CGPoint
     }
 
     private func readQuicklookWordUnderMouse() -> QuicklookWord? {
@@ -593,7 +595,7 @@ final class GhosttyTerminalNSView: NSView {
         guard !trimmed.isEmpty else { return nil }
         return QuicklookWord(
             text: trimmed,
-            topLeftPixels: CGPoint(x: text.tl_px_x, y: text.tl_px_y)
+            topLeftPoints: CGPoint(x: text.tl_px_x, y: text.tl_px_y)
         )
     }
 
@@ -602,6 +604,7 @@ final class GhosttyTerminalNSView: NSView {
         let underlineLayer = fileHoverUnderlineLayer ?? CAShapeLayer()
         if fileHoverUnderlineLayer == nil {
             underlineLayer.fillColor = nil
+            underlineLayer.isGeometryFlipped = true
             layer.addSublayer(underlineLayer)
             fileHoverUnderlineLayer = underlineLayer
         }
@@ -609,12 +612,11 @@ final class GhosttyTerminalNSView: NSView {
         let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
         let font = quicklookFont()
         let textSize = (word.text as NSString).size(withAttributes: [.font: font])
-        let lineHeight = max(font.ascender - font.descender + font.leading, textSize.height)
-        let x = word.topLeftPixels.x / scale
-        let topY = word.topLeftPixels.y / scale
-        let baselineY = bounds.height - topY - font.ascender
-        let underlineY = baselineY + font.underlinePosition
-        let y = underlineY.isFinite ? underlineY : bounds.height - topY - lineHeight + 2
+        let x = word.topLeftPoints.x
+        let rowHeight = terminalRowHeight() ?? max(textSize.height, font.ascender - font.descender + font.leading)
+        let mouseY = lastMouseTopDownPoint?.y ?? word.topLeftPoints.y
+        let rowTopY = floor(mouseY / rowHeight) * rowHeight
+        let y = rowTopY + rowHeight - max(2, font.underlineThickness)
         let width = max(textSize.width, 1)
         let thickness = max(font.underlineThickness, 1 / scale)
 
@@ -625,6 +627,7 @@ final class GhosttyTerminalNSView: NSView {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         underlineLayer.frame = bounds
+        underlineLayer.contentsScale = scale
         underlineLayer.path = path
         underlineLayer.strokeColor = NSColor.controlAccentColor.cgColor
         underlineLayer.lineWidth = thickness
@@ -643,6 +646,15 @@ final class GhosttyTerminalNSView: NSView {
             return .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
         }
         return Unmanaged<NSFont>.fromOpaque(fontPtr).takeUnretainedValue()
+    }
+
+    private func terminalRowHeight() -> CGFloat? {
+        guard let surface else { return nil }
+        var cells = ghostty_cells_s()
+        guard ghostty_surface_read_cells(surface, &cells) else { return nil }
+        defer { ghostty_surface_free_cells(surface, &cells) }
+        guard cells.rows > 0 else { return nil }
+        return bounds.height / CGFloat(cells.rows)
     }
 
     override func rightMouseDown(with event: NSEvent) {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -20,6 +20,7 @@ final class GhosttyTerminalNSView: NSView {
     var resolveCmdHoverFile: ((String) -> Bool)?
     var onOpenURL: ((URL) -> Bool)?
     private var isShowingHandCursor = false
+    private var fileHoverUnderlineLayer: CAShapeLayer?
     var hasOSC8LinkUnderCursor: Bool = false
     var isFocused: Bool = false
     var overlayActive: Bool = false
@@ -540,21 +541,26 @@ final class GhosttyTerminalNSView: NSView {
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         setHandCursor(false)
+        hideFileHoverUnderline()
     }
 
     private func updateCmdHoverCursor(modifierFlags: NSEvent.ModifierFlags) {
         guard modifierFlags.contains(.command) else {
             setHandCursor(false)
+            hideFileHoverUnderline()
             return
         }
         if hasOSC8LinkUnderCursor {
             setHandCursor(true)
+            hideFileHoverUnderline()
             return
         }
-        guard let word = readWordUnderMouse(), resolveCmdHoverFile?(word) == true else {
+        guard let word = readQuicklookWordUnderMouse(), resolveCmdHoverFile?(word.text) == true else {
             setHandCursor(false)
+            hideFileHoverUnderline()
             return
         }
+        showFileHoverUnderline(for: word)
         setHandCursor(true)
     }
 
@@ -570,6 +576,73 @@ final class GhosttyTerminalNSView: NSView {
         } else {
             NSCursor.pop()
         }
+    }
+
+    private struct QuicklookWord {
+        let text: String
+        let topLeftPixels: CGPoint
+    }
+
+    private func readQuicklookWordUnderMouse() -> QuicklookWord? {
+        guard let surface else { return nil }
+        var text = ghostty_text_s()
+        guard ghostty_surface_quicklook_word(surface, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let value = extractString(from: text) else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return QuicklookWord(
+            text: trimmed,
+            topLeftPixels: CGPoint(x: text.tl_px_x, y: text.tl_px_y)
+        )
+    }
+
+    private func showFileHoverUnderline(for word: QuicklookWord) {
+        guard let layer else { return }
+        let underlineLayer = fileHoverUnderlineLayer ?? CAShapeLayer()
+        if fileHoverUnderlineLayer == nil {
+            underlineLayer.fillColor = nil
+            layer.addSublayer(underlineLayer)
+            fileHoverUnderlineLayer = underlineLayer
+        }
+
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
+        let font = quicklookFont()
+        let textSize = (word.text as NSString).size(withAttributes: [.font: font])
+        let lineHeight = max(font.ascender - font.descender + font.leading, textSize.height)
+        let x = word.topLeftPixels.x / scale
+        let topY = word.topLeftPixels.y / scale
+        let baselineY = bounds.height - topY - font.ascender
+        let underlineY = baselineY + font.underlinePosition
+        let y = underlineY.isFinite ? underlineY : bounds.height - topY - lineHeight + 2
+        let width = max(textSize.width, 1)
+        let thickness = max(font.underlineThickness, 1 / scale)
+
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: x, y: y))
+        path.addLine(to: CGPoint(x: x + width, y: y))
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        underlineLayer.frame = bounds
+        underlineLayer.path = path
+        underlineLayer.strokeColor = NSColor.controlAccentColor.cgColor
+        underlineLayer.lineWidth = thickness
+        underlineLayer.isHidden = false
+        CATransaction.commit()
+    }
+
+    private func hideFileHoverUnderline() {
+        fileHoverUnderlineLayer?.isHidden = true
+    }
+
+    private func quicklookFont() -> NSFont {
+        guard let surface,
+              let fontPtr = ghostty_surface_quicklook_font(surface)
+        else {
+            return .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+        }
+        return Unmanaged<NSFont>.fromOpaque(fontPtr).takeUnretainedValue()
     }
 
     override func rightMouseDown(with event: NSEvent) {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -237,13 +237,15 @@ struct TerminalBridge: NSViewRepresentable {
             Self.resolveFilePath(token, projectPath: projectPath) != nil
         }
         view.onOpenURL = { url in
-            guard let projectID, url.isFileURL else { return false }
-            let path = url.path
-            guard !path.isEmpty, FileManager.default.fileExists(atPath: path) else { return false }
-            Task { @MainActor in
-                NotificationStore.shared.appState?.openFile(path, projectID: projectID, preserveFocus: true)
+            if let projectID, url.isFileURL {
+                let path = url.path
+                guard !path.isEmpty, FileManager.default.fileExists(atPath: path) else { return false }
+                Task { @MainActor in
+                    NotificationStore.shared.appState?.openFile(path, projectID: projectID, preserveFocus: true)
+                }
+                return true
             }
-            return true
+            return NSWorkspace.shared.open(url)
         }
     }
 


### PR DESCRIPTION
<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

closes #295 

## Changes

<!-- List the key changes -->

- Fixed cmd + click for links & files.
- Also added underline for file preview

## Testing

Reproduce:
- Link:
  - `printf '\e]8;;https://example.com\e\\not-a-url-label\e]8;;\e\\n'`
  -  cmd + hover on top of link
    - mouse icon should switch to hand
    - on click it should open correctly.
- Files:
  - `ls`
  -  cmd + hover on top of link
    - mouse icon should switch to hand
    - on click it should open correctly.

- [ x] `scripts/checks.sh` passes
- [ x] Tested manually on macOS

## Screenshots

<!-- If applicable, add screenshots -->
