### PR TITLE
Add current line highlight in built-in editor

### DIFF
--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -39,6 +39,7 @@ final class EditorSettings {
     var markdownPreviewFontFamily: String = EditorSettings.defaultMarkdownPreviewFontFamily { didSet { save() } }
     var markdownPreviewFontScale: CGFloat = EditorSettings.defaultMarkdownPreviewFontScale { didSet { save() } }
     var showLineNumbers: Bool = true { didSet { save() } }
+    var highlightCurrentLine: Bool = true { didSet { save() } }
 
     @ObservationIgnored private let store: CodableFileStore<Snapshot>
     @ObservationIgnored private var isBatchLoading = false
@@ -110,6 +111,7 @@ final class EditorSettings {
         markdownPreviewFontFamily = Self.defaultMarkdownPreviewFontFamily
         markdownPreviewFontScale = Self.defaultMarkdownPreviewFontScale
         showLineNumbers = true
+        highlightCurrentLine = true
         isBatchLoading = false
         save()
     }
@@ -129,6 +131,7 @@ final class EditorSettings {
                 Self.maxMarkdownPreviewFontScale
             )
             showLineNumbers = snapshot.showLineNumbers ?? true
+            highlightCurrentLine = snapshot.highlightCurrentLine ?? true
             isBatchLoading = false
         } catch {
             logger.error("Failed to load editor settings: \(error.localizedDescription)")
@@ -146,7 +149,8 @@ final class EditorSettings {
                 externalEditorCommand: externalEditorCommand,
                 markdownPreviewFontFamily: markdownPreviewFontFamily,
                 markdownPreviewFontScale: markdownPreviewFontScale,
-                showLineNumbers: showLineNumbers
+                showLineNumbers: showLineNumbers,
+                highlightCurrentLine: highlightCurrentLine
             ))
         } catch {
             logger.error("Failed to save editor settings: \(error.localizedDescription)")
@@ -163,4 +167,5 @@ private struct Snapshot: Codable {
     let markdownPreviewFontFamily: String?
     let markdownPreviewFontScale: CGFloat?
     let showLineNumbers: Bool?
+    let highlightCurrentLine: Bool?
 }

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -310,6 +310,7 @@ struct CodeEditorView: NSViewRepresentable {
         }
 
         coordinator.reconcileLineNumberGutter()
+        coordinator.reconcileCurrentLineHighlight()
         updateNSViewViewportMode(scrollView: scrollView, textView: textView, coordinator: coordinator)
     }
 
@@ -473,7 +474,7 @@ struct CodeEditorView: NSViewRepresentable {
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate, SyntaxHighlightCoordinator, SearchControllerHost, ViewportEditHistoryHost,
-        LineNumberGutterHost
+        LineNumberGutterHost, CurrentLineHighlightHost
     {
         let state: EditorTabState
         let editorSettings: EditorSettings
@@ -539,6 +540,9 @@ struct CodeEditorView: NSViewRepresentable {
             if editorSettings.showLineNumbers {
                 loaded.append(LineNumberGutterExtension(host: self))
             }
+            if editorSettings.highlightCurrentLine {
+                loaded.append(CurrentLineHighlightExtension(host: self))
+            }
             extensions = loaded
         }
 
@@ -561,6 +565,26 @@ struct CodeEditorView: NSViewRepresentable {
                     return true
                 }
                 refreshViewport(force: true)
+            }
+        }
+
+        func reconcileCurrentLineHighlight() {
+            let hasHighlight = extensions.contains(where: { $0 is CurrentLineHighlightExtension })
+            if editorSettings.highlightCurrentLine, !hasHighlight {
+                let ext = CurrentLineHighlightExtension(host: self)
+                extensions.append(ext)
+                if let context = makeRenderContext() {
+                    ext.didMount(context: context)
+                }
+                return
+            }
+            if !editorSettings.highlightCurrentLine, hasHighlight {
+                let context = makeRenderContext()
+                extensions.removeAll { ext in
+                    guard ext is CurrentLineHighlightExtension else { return false }
+                    if let context { ext.willUnmount(context: context) }
+                    return true
+                }
             }
         }
 
@@ -1414,7 +1438,16 @@ struct CodeEditorView: NSViewRepresentable {
             let localLineStart = lineStartOffsets[max(0, min(localLineIndex, lineStartOffsets.count - 1))]
             state.cursorColumn = max(1, loc - localLineStart + 1)
 
+            notifySelectionDidChange()
+
             updateCurrentSelection(in: textView, range: range)
+        }
+
+        private func notifySelectionDidChange() {
+            guard let context = makeRenderContext() else { return }
+            for ext in extensions {
+                ext.selectionDidChange(context: context)
+            }
         }
 
         private func handleMoveAtViewportBoundary(direction: Int) -> Bool {
@@ -1495,6 +1528,7 @@ struct CodeEditorView: NSViewRepresentable {
             state.cursorLine = globalLine + 1
             let cursorLineStart = lineStartOffsets[max(0, min(newLocalLine, lineStartOffsets.count - 1))]
             state.cursorColumn = max(1, safeCursor - cursorLineStart + 1)
+            notifySelectionDidChange()
         }
 
         private func updateCurrentSelection(in textView: NSTextView, range: NSRange) {

--- a/Muxy/Views/Editor/Extensions/CurrentLineHighlightExtension.swift
+++ b/Muxy/Views/Editor/Extensions/CurrentLineHighlightExtension.swift
@@ -1,0 +1,130 @@
+import AppKit
+
+@MainActor
+protocol CurrentLineHighlightHost: AnyObject {
+    var viewportState: ViewportState? { get }
+    var containerView: ViewportContainerView? { get }
+    var scrollView: NSScrollView? { get }
+    var textView: NSTextView? { get }
+}
+
+@MainActor
+final class CurrentLineHighlightExtension: EditorExtension {
+    let identifier = "current-line-highlight"
+
+    private weak var host: CurrentLineHighlightHost?
+    private var highlightView: CurrentLineHighlightView?
+    private var lastAppliedFrame: NSRect = .zero
+    private var lastAppliedHidden = true
+    private var lastAppliedColor: CGColor?
+
+    init(host: CurrentLineHighlightHost) {
+        self.host = host
+    }
+
+    func didMount(context: EditorRenderContext) {
+        installHighlight()
+        refreshHighlight(context: context)
+    }
+
+    func willUnmount(context _: EditorRenderContext) {
+        removeHighlight()
+    }
+
+    func renderViewport(context: EditorRenderContext, lineRange _: Range<Int>) {
+        ensureInstalled()
+        refreshHighlight(context: context)
+    }
+
+    func applyIncremental(context: EditorRenderContext, lineRange _: Range<Int>, edit _: EditorTextEdit) {
+        ensureInstalled()
+        repositionHighlight(context: context)
+    }
+
+    func selectionDidChange(context: EditorRenderContext) {
+        repositionHighlight(context: context)
+    }
+
+    private func ensureInstalled() {
+        guard highlightView == nil else { return }
+        installHighlight()
+    }
+
+    private func installHighlight() {
+        guard highlightView == nil,
+              let host,
+              let container = host.containerView
+        else { return }
+
+        let view = CurrentLineHighlightView()
+        view.wantsLayer = true
+        view.autoresizingMask = []
+        view.frame = .zero
+        view.isHidden = true
+        container.addSubview(view, positioned: .above, relativeTo: nil)
+        highlightView = view
+        lastAppliedFrame = .zero
+        lastAppliedHidden = true
+        lastAppliedColor = nil
+    }
+
+    private func removeHighlight() {
+        highlightView?.removeFromSuperview()
+        highlightView = nil
+        lastAppliedColor = nil
+    }
+
+    private func refreshHighlight(context: EditorRenderContext) {
+        guard let view = highlightView else { return }
+        applyAppearance(to: view)
+        repositionHighlight(context: context)
+    }
+
+    private func repositionHighlight(context: EditorRenderContext) {
+        guard let view = highlightView,
+              let host,
+              let container = host.containerView,
+              let viewport = host.viewportState
+        else { return }
+
+        let backingLine = max(0, context.state.cursorLine - 1)
+        guard let localLine = viewport.viewportLine(forBackingStoreLine: backingLine) else {
+            if !lastAppliedHidden {
+                view.isHidden = true
+                lastAppliedHidden = true
+            }
+            return
+        }
+
+        let lineHeight = viewport.estimatedLineHeight
+        let topInset = context.textView.textContainerInset.height
+        let yOffset = viewport.viewportYOffset()
+        let originY = yOffset + topInset + CGFloat(localLine) * lineHeight
+        let frame = NSRect(x: 0, y: originY, width: container.frame.width, height: lineHeight)
+
+        if frame != lastAppliedFrame {
+            view.frame = frame
+            lastAppliedFrame = frame
+        }
+        if lastAppliedHidden {
+            view.isHidden = false
+            lastAppliedHidden = false
+        }
+    }
+
+    private func applyAppearance(to view: CurrentLineHighlightView) {
+        let palette = EditorThemePalette.active
+        let color = palette.foreground.withAlphaComponent(0.08).cgColor
+        if let lastAppliedColor, CFEqual(lastAppliedColor, color) { return }
+        view.layer?.backgroundColor = color
+        lastAppliedColor = color
+    }
+}
+
+private final class CurrentLineHighlightView: NSView {
+    override var isFlipped: Bool { true }
+
+    override func hitTest(_: NSPoint) -> NSView? {
+        nil
+    }
+}

--- a/Muxy/Views/Editor/Extensions/EditorExtension.swift
+++ b/Muxy/Views/Editor/Extensions/EditorExtension.swift
@@ -13,6 +13,8 @@ protocol EditorExtension: AnyObject {
     func applyIncremental(context: EditorRenderContext, lineRange: Range<Int>, edit: EditorTextEdit)
 
     func textDidChange(context: EditorRenderContext)
+
+    func selectionDidChange(context: EditorRenderContext)
 }
 
 extension EditorExtension {
@@ -21,4 +23,5 @@ extension EditorExtension {
     func renderViewport(context _: EditorRenderContext, lineRange _: Range<Int>) {}
     func applyIncremental(context _: EditorRenderContext, lineRange _: Range<Int>, edit _: EditorTextEdit) {}
     func textDidChange(context _: EditorRenderContext) {}
+    func selectionDidChange(context _: EditorRenderContext) {}
 }

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -88,6 +88,8 @@ struct EditorSettingsView: View {
                 SettingsSection("Appearance", showsDivider: false) {
                     SettingsToggleRow(label: "Show Line Numbers", isOn: $settings.showLineNumbers)
 
+                    SettingsToggleRow(label: "Highlight Current Line", isOn: $settings.highlightCurrentLine)
+
                     SettingsRow("Font Family") {
                         Picker("", selection: $settings.fontFamily) {
                             ForEach(monoFonts, id: \.self) { family in


### PR DESCRIPTION
Adds a "Highlight Current Line" toggle in Editor settings (default on)
  that tints the active line across the gutter and text. Implemented as
  an unwirable EditorExtension mirroring the line-numbers pattern.