### PR TITLE
Add fuzzy find-in-files overlay (Cmd+Shift+F)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ GhosttyKit.xcframework
 GhosttyKit/ghostty.h
 Muxy/Resources/ghostty
 Muxy/Resources/terminfo
+Muxy/Resources/rg
 /ghostty
 /build
 .agents/

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -212,6 +212,12 @@ struct MuxyCommands: Commands {
             }
             .shortcut(for: .quickOpen, store: keyBindings)
 
+            Button("Find in Files") {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.findInFiles)
+            }
+            .shortcut(for: .findInFiles, store: keyBindings)
+
             Button("Save") {
                 guard isMainWindowFocused else { return }
                 performShortcutAction(.saveFile)

--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -11,6 +11,7 @@ extension Notification.Name {
     static let toggleFileTree = Notification.Name("MuxyToggleFileTree")
     static let refocusActiveTerminal = Notification.Name("MuxyRefocusActiveTerminal")
     static let quickOpen = Notification.Name("MuxyQuickOpen")
+    static let findInFiles = Notification.Name("MuxyFindInFiles")
     static let switchWorktree = Notification.Name("MuxySwitchWorktree")
     static let saveActiveEditor = Notification.Name("MuxySaveActiveEditor")
     static let windowFullScreenDidChange = Notification.Name("MuxyWindowFullScreenDidChange")

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -228,7 +228,13 @@ final class AppState {
         dispatch(.createVCSTab(projectID: projectID, areaID: nil))
     }
 
-    func openFile(_ filePath: String, projectID: UUID, preserveFocus: Bool = false) {
+    func openFile(
+        _ filePath: String,
+        projectID: UUID,
+        preserveFocus: Bool = false,
+        line: Int? = nil,
+        column: Int = 1
+    ) {
         let settings = EditorSettings.shared
         if settings.defaultEditor == .terminalCommand {
             let command = settings.externalEditorCommand.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -240,10 +246,29 @@ final class AppState {
         for area in allAreas(for: projectID) {
             if let tab = area.tabs.first(where: { $0.content.editorState?.filePath == filePath }) {
                 dispatch(.selectTab(projectID: projectID, areaID: area.id, tabID: tab.id))
+                if let line, let editorState = tab.content.editorState {
+                    requestEditorJump(state: editorState, line: line, column: column)
+                }
                 return
             }
         }
         dispatch(.createEditorTab(projectID: projectID, areaID: nil, filePath: filePath, suppressInitialFocus: preserveFocus))
+        if let line {
+            for area in allAreas(for: projectID) {
+                if let tab = area.tabs.first(where: { $0.content.editorState?.filePath == filePath }),
+                   let editorState = tab.content.editorState
+                {
+                    requestEditorJump(state: editorState, line: line, column: column)
+                    break
+                }
+            }
+        }
+    }
+
+    private func requestEditorJump(state: EditorTabState, line: Int, column: Int) {
+        state.pendingJumpLine = line
+        state.pendingJumpColumn = max(1, column)
+        state.pendingJumpVersion &+= 1
     }
 
     func handleFileMoved(from oldPath: String, to newPath: String) {

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -266,6 +266,9 @@ final class AppState {
     }
 
     private func requestEditorJump(state: EditorTabState, line: Int, column: Int) {
+        if state.isMarkdownFile, state.markdownViewMode != .code {
+            state.markdownViewMode = .code
+        }
         state.pendingJumpLine = line
         state.pendingJumpColumn = max(1, column)
         state.pendingJumpVersion &+= 1

--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -52,6 +52,9 @@ final class EditorTabState: Identifiable {
     var isReadOnly = false
     var cursorLine: Int = 1
     var cursorColumn: Int = 1
+    var pendingJumpLine: Int?
+    var pendingJumpColumn: Int = 1
+    var pendingJumpVersion: Int = 0
     var searchVisible = false
     var searchFocusVersion = 0
     var editorFocusVersion = 0

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -48,6 +48,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case findInTerminal
     case openVCSTab
     case quickOpen
+    case findInFiles
     case switchWorktree
     case saveFile
     case toggleSidebar
@@ -96,6 +97,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .findInTerminal,
         .openVCSTab,
         .quickOpen,
+        .findInFiles,
         .switchWorktree,
         .saveFile,
         .toggleSidebar,
@@ -145,6 +147,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .findInTerminal: ShortcutMetadata(displayName: "Find", category: "Terminal", scope: .mainWindow)
         case .openVCSTab: ShortcutMetadata(displayName: "Source Control", category: "App", scope: .mainWindow)
         case .quickOpen: ShortcutMetadata(displayName: "Quick Open", category: "App", scope: .mainWindow)
+        case .findInFiles: ShortcutMetadata(displayName: "Find in Files", category: "App", scope: .mainWindow)
         case .switchWorktree: ShortcutMetadata(displayName: "Switch Worktree", category: "Project Navigation", scope: .mainWindow)
         case .saveFile: ShortcutMetadata(displayName: "Save File", category: "Editor", scope: .mainWindow)
         case .toggleSidebar: ShortcutMetadata(displayName: "Toggle Sidebar", category: "App", scope: .mainWindow)
@@ -262,6 +265,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .selectProject9, combo: KeyCombo(key: "9", control: true)),
         Self(action: .findInTerminal, combo: KeyCombo(key: "f", command: true)),
         Self(action: .quickOpen, combo: KeyCombo(key: "p", command: true)),
+        Self(action: .findInFiles, combo: KeyCombo(key: "f", command: true, shift: true)),
         Self(action: .switchWorktree, combo: KeyCombo(key: "o", command: true, shift: true)),
         Self(action: .saveFile, combo: KeyCombo(key: "s", command: true)),
         Self(action: .toggleSidebar, combo: KeyCombo(key: "b", command: true)),

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -127,6 +127,9 @@ struct ShortcutActionDispatcher {
         case .quickOpen:
             notificationCenter.post(name: .quickOpen, object: nil)
             return true
+        case .findInFiles:
+            notificationCenter.post(name: .findInFiles, object: nil)
+            return true
         case .switchWorktree:
             notificationCenter.post(name: .switchWorktree, object: nil)
             return true

--- a/Muxy/Services/TextSearchService.swift
+++ b/Muxy/Services/TextSearchService.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+struct TextSearchMatch: Identifiable, Equatable {
+    let id: String
+    let absolutePath: String
+    let relativePath: String
+    let lineNumber: Int
+    let column: Int
+    let lineText: String
+    let matchStart: Int
+    let matchEnd: Int
+}
+
+enum TextSearchService {
+    static let maxResults = 200
+    static let minQueryLength = 2
+
+    static func search(query: String, in projectPath: String) async -> [TextSearchMatch] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard trimmed.count >= minQueryLength else { return [] }
+        guard let executable = ripgrepExecutableURL() else { return [] }
+
+        return await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = executable
+            process.arguments = arguments(query: trimmed, projectPath: projectPath)
+
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+
+            let resultsBox = MatchesBox()
+            let handle = stdoutPipe.fileHandleForReading
+
+            handle.readabilityHandler = { fileHandle in
+                let data = fileHandle.availableData
+                if data.isEmpty { return }
+                guard let chunk = String(data: data, encoding: .utf8) else { return }
+                let done = resultsBox.append(chunk: chunk, projectPath: projectPath, limit: maxResults)
+                if done, process.isRunning {
+                    process.terminate()
+                }
+            }
+
+            process.terminationHandler = { _ in
+                handle.readabilityHandler = nil
+                if let remaining = try? handle.readToEnd(), let chunk = String(data: remaining, encoding: .utf8) {
+                    _ = resultsBox.append(chunk: chunk, projectPath: projectPath, limit: maxResults)
+                }
+                continuation.resume(returning: resultsBox.take())
+            }
+
+            do {
+                try process.run()
+            } catch {
+                handle.readabilityHandler = nil
+                continuation.resume(returning: [])
+            }
+        }
+    }
+
+    static func ripgrepExecutableURL() -> URL? {
+        if let bundled = Bundle.main.url(forResource: "rg", withExtension: nil) {
+            return bundled
+        }
+        let pathCandidates = ["/opt/homebrew/bin/rg", "/usr/local/bin/rg", "/usr/bin/rg"]
+        for candidate in pathCandidates where FileManager.default.isExecutableFile(atPath: candidate) {
+            return URL(fileURLWithPath: candidate)
+        }
+        return nil
+    }
+
+    private static func arguments(query: String, projectPath: String) -> [String] {
+        [
+            "--json",
+            "--smart-case",
+            "--max-count", "20",
+            "--max-columns", "300",
+            "--max-filesize", "2M",
+            "--no-config",
+            "--",
+            query,
+            projectPath,
+        ]
+    }
+
+    static func parseLine(_ line: String, projectPath: String) -> TextSearchMatch? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        guard let type = object["type"] as? String, type == "match" else { return nil }
+        guard let payload = object["data"] as? [String: Any] else { return nil }
+        guard let pathDict = payload["path"] as? [String: Any] else { return nil }
+        guard let absolutePath = pathDict["text"] as? String else { return nil }
+        guard let lineNumber = payload["line_number"] as? Int else { return nil }
+        guard let lineDict = payload["lines"] as? [String: Any] else { return nil }
+        guard var lineText = lineDict["text"] as? String else { return nil }
+        if lineText.hasSuffix("\n") { lineText.removeLast() }
+        if lineText.hasSuffix("\r") { lineText.removeLast() }
+
+        var matchStart = 0
+        var matchEnd = lineText.utf8.count
+        if let submatches = payload["submatches"] as? [[String: Any]], let first = submatches.first {
+            matchStart = (first["start"] as? Int) ?? 0
+            matchEnd = (first["end"] as? Int) ?? matchStart
+        }
+
+        let prefix = projectPath.hasSuffix("/") ? projectPath : projectPath + "/"
+        let relative = absolutePath.hasPrefix(prefix)
+            ? String(absolutePath.dropFirst(prefix.count))
+            : absolutePath
+
+        let column = columnFromUTF8Offset(matchStart, in: lineText)
+
+        return TextSearchMatch(
+            id: "\(absolutePath):\(lineNumber):\(matchStart)",
+            absolutePath: absolutePath,
+            relativePath: relative,
+            lineNumber: lineNumber,
+            column: column,
+            lineText: lineText,
+            matchStart: matchStart,
+            matchEnd: matchEnd
+        )
+    }
+
+    static func columnFromUTF8Offset(_ utf8Offset: Int, in text: String) -> Int {
+        guard utf8Offset > 0 else { return 1 }
+        let utf8 = text.utf8
+        var consumed = 0
+        var characterCount = 0
+        var index = utf8.startIndex
+        while index != utf8.endIndex, consumed < utf8Offset {
+            consumed += 1
+            index = utf8.index(after: index)
+            if let scalarIndex = index.samePosition(in: text.unicodeScalars) {
+                characterCount = text.unicodeScalars.distance(from: text.unicodeScalars.startIndex, to: scalarIndex)
+            }
+        }
+        return characterCount + 1
+    }
+}
+
+private final class MatchesBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffer = ""
+    private var matches: [TextSearchMatch] = []
+
+    func append(chunk: String, projectPath: String, limit: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if matches.count >= limit { return true }
+
+        buffer.append(chunk)
+
+        while let newlineRange = buffer.range(of: "\n") {
+            let line = String(buffer[buffer.startIndex ..< newlineRange.lowerBound])
+            buffer.removeSubrange(buffer.startIndex ..< newlineRange.upperBound)
+
+            if line.isEmpty { continue }
+            if let match = TextSearchService.parseLine(line, projectPath: projectPath) {
+                matches.append(match)
+                if matches.count >= limit { return true }
+            }
+        }
+
+        return matches.count >= limit
+    }
+
+    func take() -> [TextSearchMatch] {
+        lock.lock()
+        defer { lock.unlock() }
+        return matches
+    }
+}

--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct FindInFilesOverlay: View {
+    let projectPath: String
+    let onSelect: (TextSearchMatch) -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        PaletteOverlay<TextSearchMatch>(
+            placeholder: "Search text in files...",
+            emptyLabel: "Type at least \(TextSearchService.minQueryLength) characters",
+            noMatchLabel: "No matches found",
+            search: { query in
+                await TextSearchService.search(query: query, in: projectPath)
+            },
+            onSelect: { match in onSelect(match) },
+            onDismiss: onDismiss,
+            row: { match, isHighlighted in
+                AnyView(TextMatchRow(match: match, isHighlighted: isHighlighted))
+            }
+        )
+    }
+}
+
+private struct TextMatchRow: View {
+    let match: TextSearchMatch
+    let isHighlighted: Bool
+    @State private var hovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    .frame(width: 14)
+                Text(match.relativePath)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(":\(match.lineNumber)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(MuxyTheme.fgDim)
+                Spacer(minLength: 0)
+            }
+            highlightedSnippet
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(MuxyTheme.fgDim)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.leading, 20)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
+        .onHover { hovered = $0 }
+    }
+
+    private var highlightedSnippet: Text {
+        let utf8 = Array(match.lineText.utf8)
+        guard match.matchStart >= 0,
+              match.matchEnd <= utf8.count,
+              match.matchStart < match.matchEnd
+        else {
+            return Text(match.lineText)
+        }
+        let prefixData = Data(utf8[0 ..< match.matchStart])
+        let matchData = Data(utf8[match.matchStart ..< match.matchEnd])
+        let suffixData = Data(utf8[match.matchEnd ..< utf8.count])
+        let prefix = String(data: prefixData, encoding: .utf8) ?? ""
+        let middle = String(data: matchData, encoding: .utf8) ?? ""
+        let suffix = String(data: suffixData, encoding: .utf8) ?? ""
+        return Text(prefix)
+            + Text(middle).foregroundColor(MuxyTheme.fg).bold()
+            + Text(suffix)
+    }
+}

--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -5,75 +5,254 @@ struct FindInFilesOverlay: View {
     let onSelect: (TextSearchMatch) -> Void
     let onDismiss: () -> Void
 
+    @State private var query = ""
+    @State private var groups: [FileMatchGroup] = []
+    @State private var highlightedMatchID: String?
+    @State private var isSearching = false
+    @State private var searchTask: Task<Void, Never>?
+
     var body: some View {
-        PaletteOverlay<TextSearchMatch>(
-            placeholder: "Search text in files...",
-            emptyLabel: "Type at least \(TextSearchService.minQueryLength) characters",
-            noMatchLabel: "No matches found",
-            search: { query in
-                await TextSearchService.search(query: query, in: projectPath)
-            },
-            onSelect: { match in onSelect(match) },
-            onDismiss: onDismiss,
-            row: { match, isHighlighted in
-                AnyView(TextMatchRow(match: match, isHighlighted: isHighlighted))
+        ZStack {
+            Color.black.opacity(0.3)
+                .ignoresSafeArea()
+                .onTapGesture { onDismiss() }
+
+            VStack(spacing: 0) {
+                searchField
+                Divider().overlay(MuxyTheme.border)
+                resultsList
             }
-        )
+            .frame(width: 640, height: 460)
+            .background(MuxyTheme.bg)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(MuxyTheme.border, lineWidth: 1))
+            .shadow(color: .black.opacity(0.4), radius: 20, y: 8)
+            .padding(.top, 60)
+            .frame(maxHeight: .infinity, alignment: .top)
+            .accessibilityAddTraits(.isModal)
+        }
+        .onAppear { performSearch(debounce: false) }
+        .onDisappear { searchTask?.cancel() }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .font(.system(size: 13))
+                .accessibilityHidden(true)
+            PaletteSearchField(
+                text: $query,
+                placeholder: "Search text in files...",
+                onSubmit: { confirmSelection() },
+                onEscape: { onDismiss() },
+                onArrowUp: { moveHighlight(-1) },
+                onArrowDown: { moveHighlight(1) }
+            )
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .onChange(of: query) { performSearch() }
+    }
+
+    @ViewBuilder
+    private var resultsList: some View {
+        if groups.isEmpty, !isSearching {
+            VStack {
+                Spacer()
+                Text(query.trimmingCharacters(in: .whitespaces).count < TextSearchService.minQueryLength
+                    ? "Type at least \(TextSearchService.minQueryLength) characters"
+                    : "No matches found")
+                    .font(.system(size: 12))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                Spacer()
+            }
+            .frame(maxHeight: .infinity)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: true) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(groups) { group in
+                            FileGroupHeader(group: group)
+                            ForEach(group.matches) { match in
+                                MatchRow(
+                                    match: match,
+                                    isHighlighted: match.id == highlightedMatchID
+                                )
+                                .contentShape(Rectangle())
+                                .onTapGesture { onSelect(match) }
+                                .id(match.id)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .onChange(of: highlightedMatchID) { _, newID in
+                    guard let newID else { return }
+                    withAnimation(.linear(duration: 0.05)) {
+                        proxy.scrollTo(newID, anchor: nil)
+                    }
+                }
+            }
+        }
+    }
+
+    private func performSearch(debounce: Bool = true) {
+        searchTask?.cancel()
+        isSearching = true
+        let currentQuery = query
+
+        searchTask = Task {
+            if debounce {
+                try? await Task.sleep(for: .milliseconds(50))
+                guard !Task.isCancelled else { return }
+            }
+
+            let found = await TextSearchService.search(query: currentQuery, in: projectPath)
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                groups = FileMatchGroup.group(found)
+                highlightedMatchID = groups.first?.matches.first?.id
+                isSearching = false
+            }
+        }
+    }
+
+    private func moveHighlight(_ delta: Int) {
+        let flat = groups.flatMap(\.matches)
+        guard !flat.isEmpty else { return }
+        guard let current = highlightedMatchID,
+              let index = flat.firstIndex(where: { $0.id == current })
+        else {
+            highlightedMatchID = (delta > 0 ? flat.first : flat.last)?.id
+            return
+        }
+        let next = max(0, min(flat.count - 1, index + delta))
+        highlightedMatchID = flat[next].id
+    }
+
+    private func confirmSelection() {
+        guard let id = highlightedMatchID,
+              let match = groups.flatMap(\.matches).first(where: { $0.id == id })
+        else { return }
+        onSelect(match)
     }
 }
 
-private struct TextMatchRow: View {
+struct FileMatchGroup: Identifiable {
+    let id: String
+    let absolutePath: String
+    let relativePath: String
+    let matches: [TextSearchMatch]
+
+    static func group(_ matches: [TextSearchMatch]) -> [FileMatchGroup] {
+        var order: [String] = []
+        var bucket: [String: [TextSearchMatch]] = [:]
+        for match in matches {
+            if bucket[match.absolutePath] == nil {
+                order.append(match.absolutePath)
+                bucket[match.absolutePath] = []
+            }
+            bucket[match.absolutePath]?.append(match)
+        }
+        return order.compactMap { path in
+            guard let entries = bucket[path], let first = entries.first else { return nil }
+            return FileMatchGroup(
+                id: path,
+                absolutePath: path,
+                relativePath: first.relativePath,
+                matches: entries
+            )
+        }
+    }
+}
+
+private struct FileGroupHeader: View {
+    let group: FileMatchGroup
+
+    private var fileName: String {
+        (group.relativePath as NSString).lastPathComponent
+    }
+
+    private var directory: String {
+        (group.relativePath as NSString).deletingLastPathComponent
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(fileName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+                .lineLimit(1)
+            if !directory.isEmpty {
+                Text(directory)
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgDim)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 8)
+            Text("\(group.matches.count)")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundStyle(MuxyTheme.bg)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(MuxyTheme.fgMuted))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+}
+
+private struct MatchRow: View {
     let match: TextSearchMatch
     let isHighlighted: Bool
     @State private var hovered = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            HStack(spacing: 6) {
-                Image(systemName: "doc.text")
-                    .font(.system(size: 11))
-                    .foregroundStyle(MuxyTheme.fgMuted)
-                    .frame(width: 14)
-                Text(match.relativePath)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MuxyTheme.fg)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Text(":\(match.lineNumber)")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(MuxyTheme.fgDim)
-                Spacer(minLength: 0)
-            }
-            highlightedSnippet
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(MuxyTheme.fgDim)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .padding(.leading, 20)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
-        .onHover { hovered = $0 }
+        highlightedSnippet
+            .font(.system(size: 12, design: .monospaced))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.leading, 24)
+            .padding(.trailing, 12)
+            .padding(.vertical, 3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
+            .onHover { hovered = $0 }
     }
 
     private var highlightedSnippet: Text {
+        let trimmed = trimLeadingWhitespace(match.lineText)
         let utf8 = Array(match.lineText.utf8)
+        let removed = utf8.count - Array(trimmed.utf8).count
+
+        let adjustedStart = max(0, match.matchStart - removed)
+        let adjustedEnd = max(adjustedStart, match.matchEnd - removed)
+        let trimmedUTF8 = Array(trimmed.utf8)
+
         guard match.matchStart >= 0,
               match.matchEnd <= utf8.count,
-              match.matchStart < match.matchEnd
+              match.matchStart < match.matchEnd,
+              adjustedEnd <= trimmedUTF8.count
         else {
-            return Text(match.lineText)
+            return Text(trimmed).foregroundColor(MuxyTheme.fgDim)
         }
-        let prefixData = Data(utf8[0 ..< match.matchStart])
-        let matchData = Data(utf8[match.matchStart ..< match.matchEnd])
-        let suffixData = Data(utf8[match.matchEnd ..< utf8.count])
-        let prefix = String(data: prefixData, encoding: .utf8) ?? ""
-        let middle = String(data: matchData, encoding: .utf8) ?? ""
-        let suffix = String(data: suffixData, encoding: .utf8) ?? ""
-        return Text(prefix)
+
+        let prefix = String(data: Data(trimmedUTF8[0 ..< adjustedStart]), encoding: .utf8) ?? ""
+        let middle = String(data: Data(trimmedUTF8[adjustedStart ..< adjustedEnd]), encoding: .utf8) ?? ""
+        let suffix = String(data: Data(trimmedUTF8[adjustedEnd ..< trimmedUTF8.count]), encoding: .utf8) ?? ""
+        return Text(prefix).foregroundColor(MuxyTheme.fgDim)
             + Text(middle).foregroundColor(MuxyTheme.fg).bold()
-            + Text(suffix)
+            + Text(suffix).foregroundColor(MuxyTheme.fgDim)
+    }
+
+    private func trimLeadingWhitespace(_ text: String) -> String {
+        var index = text.startIndex
+        while index < text.endIndex, text[index] == " " || text[index] == "\t" {
+            index = text.index(after: index)
+        }
+        return String(text[index...])
     }
 }

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -343,6 +343,8 @@ struct CodeEditorView: NSViewRepresentable {
             }
         }
 
+        applyPendingJumpIfNeeded(coordinator: coordinator)
+
         let themeChanged = coordinator.lastThemeVersion != themeVersion
         let font = editorSettings.resolvedFont
         let fontChanged = textView.font != font
@@ -427,6 +429,20 @@ struct CodeEditorView: NSViewRepresentable {
         }
     }
 
+    private func applyPendingJumpIfNeeded(coordinator: Coordinator) {
+        guard let line = state.pendingJumpLine else { return }
+        let version = state.pendingJumpVersion
+        if coordinator.lastPendingJumpVersion != version {
+            coordinator.lastPendingJumpVersion = version
+            coordinator.pendingJumpDeferred = true
+        }
+        guard coordinator.pendingJumpDeferred, coordinator.hasAppliedInitialContent else { return }
+        coordinator.pendingJumpDeferred = false
+        let column = state.pendingJumpColumn
+        coordinator.applyPendingJump(line: line, column: column)
+        state.pendingJumpLine = nil
+    }
+
     private func updateSearchViewport(coordinator: Coordinator) {
         if !state.searchVisible, coordinator.lastSearchVisible {
             coordinator.lastSearchVisible = false
@@ -492,6 +508,8 @@ struct CodeEditorView: NSViewRepresentable {
         var lastSearchVisible = false
         var lastSearchNeedle = ""
         var lastSearchNavigationVersion = -1
+        var lastPendingJumpVersion = 0
+        var pendingJumpDeferred = false
         var lastSearchCaseSensitive = false
         var lastSearchUseRegex = false
         var lastReplaceVersion = 0
@@ -1485,6 +1503,10 @@ struct CodeEditorView: NSViewRepresentable {
             }
 
             return false
+        }
+
+        func applyPendingJump(line: Int, column: Int) {
+            scrollToGlobalLine(max(0, line - 1), column: max(0, column - 1))
         }
 
         private func scrollToGlobalLine(_ globalLine: Int, column: Int) {

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -1506,10 +1506,10 @@ struct CodeEditorView: NSViewRepresentable {
         }
 
         func applyPendingJump(line: Int, column: Int) {
-            scrollToGlobalLine(max(0, line - 1), column: max(0, column - 1))
+            scrollToGlobalLine(max(0, line - 1), column: max(0, column - 1), placeNearTop: true)
         }
 
-        private func scrollToGlobalLine(_ globalLine: Int, column: Int) {
+        private func scrollToGlobalLine(_ globalLine: Int, column: Int, placeNearTop: Bool = false) {
             guard let viewport = viewportState, let scrollView, let textView else { return }
 
             let targetScrollY = viewport.scrollY(forLine: globalLine)
@@ -1520,7 +1520,9 @@ struct CodeEditorView: NSViewRepresentable {
             let lineBottom = targetScrollY + viewport.estimatedLineHeight
 
             var newScrollY = currentScrollY
-            if lineBottom > currentScrollY + visibleHeight {
+            if placeNearTop, lineTop < currentScrollY || lineBottom > currentScrollY + visibleHeight {
+                newScrollY = lineTop - visibleHeight / 3
+            } else if lineBottom > currentScrollY + visibleHeight {
                 newScrollY = lineBottom - visibleHeight
             } else if lineTop < currentScrollY {
                 newScrollY = lineTop

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -55,6 +55,7 @@ struct MainWindow: View {
     @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
     @State private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
     @State private var showQuickOpen = false
+    @State private var showFindInFiles = false
     @State private var showWorktreeSwitcher = false
     @State private var isFullScreen = false
     @State private var sidebarExpanded = UserDefaults.standard.bool(forKey: "muxy.sidebarExpanded")
@@ -168,7 +169,7 @@ struct MainWindow: View {
                 }
             }
         }
-        .environment(\.overlayActive, showQuickOpen || showWorktreeSwitcher)
+        .environment(\.overlayActive, showQuickOpen || showFindInFiles || showWorktreeSwitcher)
         .overlay(alignment: toastAlignment) {
             if let toast = ToastState.shared.message {
                 HStack(spacing: 6) {
@@ -204,6 +205,24 @@ struct MainWindow: View {
             }
         }
         .overlay {
+            if showFindInFiles, let project = activeProject {
+                FindInFilesOverlay(
+                    projectPath: activeWorktreePath(for: project),
+                    onSelect: { match in
+                        showFindInFiles = false
+                        appState.openFile(
+                            match.absolutePath,
+                            projectID: project.id,
+                            line: match.lineNumber,
+                            column: match.column
+                        )
+                    },
+                    onDismiss: { showFindInFiles = false }
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.98)))
+            }
+        }
+        .overlay {
             if showWorktreeSwitcher {
                 WorktreeSwitcherOverlay(
                     items: worktreeSwitcherItems,
@@ -223,6 +242,7 @@ struct MainWindow: View {
             }
         }
         .animation(.easeInOut(duration: 0.15), value: showQuickOpen)
+        .animation(.easeInOut(duration: 0.15), value: showFindInFiles)
         .animation(.easeInOut(duration: 0.15), value: showWorktreeSwitcher)
         .animation(.easeInOut(duration: 0.2), value: ToastState.shared.message != nil)
         .coordinateSpace(name: DragCoordinateSpace.mainWindow)
@@ -238,6 +258,9 @@ struct MainWindow: View {
         .ignoresSafeArea(.container, edges: .top)
         .onReceive(NotificationCenter.default.publisher(for: .quickOpen)) { _ in
             showQuickOpen.toggle()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .findInFiles)) { _ in
+            showFindInFiles.toggle()
         }
         .onReceive(NotificationCenter.default.publisher(for: .switchWorktree)) { _ in
             showWorktreeSwitcher.toggle()

--- a/Package.swift
+++ b/Package.swift
@@ -41,11 +41,12 @@ let package = Package(
                 .product(name: "Yams", package: "Yams"),
             ],
             path: "Muxy",
-            exclude: ["Info.plist", "Muxy.entitlements", "Resources/ghostty", "Resources/terminfo"],
+            exclude: ["Info.plist", "Muxy.entitlements", "Resources/ghostty", "Resources/terminfo", "Resources/rg"],
             resources: [
                 .process("Resources"),
                 .copy("Resources/ghostty"),
                 .copy("Resources/terminfo"),
+                .copy("Resources/rg"),
             ],
             linkerSettings: [
                 .unsafeFlags([

--- a/Tests/MuxyTests/Services/TextSearchServiceTests.swift
+++ b/Tests/MuxyTests/Services/TextSearchServiceTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TextSearchService")
+struct TextSearchServiceTests {
+    @Test("parses ripgrep match line")
+    func parsesMatch() throws {
+        let line = #"{"type":"match","data":{"path":{"text":"/proj/src/foo.swift"},"lines":{"text":"  let answer = 42\n"},"line_number":12,"absolute_offset":120,"submatches":[{"match":{"text":"answer"},"start":6,"end":12}]}}"#
+        let match = try #require(TextSearchService.parseLine(line, projectPath: "/proj"))
+
+        #expect(match.absolutePath == "/proj/src/foo.swift")
+        #expect(match.relativePath == "src/foo.swift")
+        #expect(match.lineNumber == 12)
+        #expect(match.lineText == "  let answer = 42")
+        #expect(match.matchStart == 6)
+        #expect(match.matchEnd == 12)
+        #expect(match.column == 7)
+    }
+
+    @Test("returns nil for non-match types")
+    func ignoresBeginAndEnd() throws {
+        let begin = #"{"type":"begin","data":{"path":{"text":"/proj/x"}}}"#
+        let end = #"{"type":"end","data":{"path":{"text":"/proj/x"},"stats":{}}}"#
+        #expect(TextSearchService.parseLine(begin, projectPath: "/proj") == nil)
+        #expect(TextSearchService.parseLine(end, projectPath: "/proj") == nil)
+    }
+
+    @Test("falls back to absolute path when not under project")
+    func absoluteWhenOutsideProject() throws {
+        let line = #"{"type":"match","data":{"path":{"text":"/other/foo.swift"},"lines":{"text":"hit\n"},"line_number":1,"absolute_offset":0,"submatches":[{"match":{"text":"hit"},"start":0,"end":3}]}}"#
+        let match = try #require(TextSearchService.parseLine(line, projectPath: "/proj"))
+        #expect(match.relativePath == "/other/foo.swift")
+    }
+
+    @Test("computes column for multibyte characters")
+    func multibyteColumn() {
+        let column = TextSearchService.columnFromUTF8Offset(4, in: "héllo world")
+        #expect(column == 4)
+    }
+}

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -98,6 +98,7 @@ Muxy/
       GitModels.swift             GitStatusFile, DiffDisplayRow, NumstatEntry
     GitDirectoryWatcher.swift FSEvents watcher for .git changes
     FileSearchService.swift   Quick open file search via /usr/bin/find subprocess
+    TextSearchService.swift   Find-in-files text search via bundled ripgrep (--json), streaming match parser
     FileTreeService.swift     Lazy directory listing that respects .gitignore via git check-ignore
     FileSystemOperations.swift Off-main create / rename / move / copy / trash primitives
     FileClipboard.swift       NSPasteboard wrapper for file cut/copy/paste with cut-marker type
@@ -158,6 +159,7 @@ Muxy/
       UUIDFramePreferenceKey.swift  Generic PreferenceKey for frame tracking
       NotificationBadge.swift Unread count badge for sidebar project icons
       QuickOpenOverlay.swift  Cmd+P file search overlay (name substring match via find)
+      FindInFilesOverlay.swift  Cmd+Shift+F text-content search overlay backed by ripgrep; jumps to file/line
       AppBundleIconView.swift Renders and caches installed app bundle icons for menus and launcher controls
       OpenInIDEControl.swift  Split button for opening the active project or editor file in the remembered or selected IDE
     Terminal/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,10 +7,44 @@ FORK_REPO="muxy-app/ghostty"
 XCFRAMEWORK_DIR="$PROJECT_ROOT/GhosttyKit.xcframework"
 RESOURCES_DIR="$PROJECT_ROOT/Muxy/Resources/ghostty"
 TERMINFO_DIR="$PROJECT_ROOT/Muxy/Resources/terminfo"
+RIPGREP_VERSION="15.1.0"
+RIPGREP_BINARY="$PROJECT_ROOT/Muxy/Resources/rg"
+
+fetch_ripgrep() {
+    if [[ -x "$RIPGREP_BINARY" ]]; then
+        return 0
+    fi
+    local arch
+    case "$(uname -m)" in
+        arm64) arch="aarch64-apple-darwin" ;;
+        x86_64) arch="x86_64-apple-darwin" ;;
+        *) echo "Error: unsupported architecture $(uname -m)"; return 1 ;;
+    esac
+    local archive="ripgrep-${RIPGREP_VERSION}-${arch}.tar.gz"
+    local url="https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/${archive}"
+    echo "==> Downloading ripgrep ${RIPGREP_VERSION} (${arch})"
+    local tmp
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    curl -fsSL "$url" -o "$tmp/$archive"
+    tar xzf "$tmp/$archive" -C "$tmp"
+    mkdir -p "$(dirname "$RIPGREP_BINARY")"
+    cp "$tmp/ripgrep-${RIPGREP_VERSION}-${arch}/rg" "$RIPGREP_BINARY"
+    chmod +x "$RIPGREP_BINARY"
+    codesign --force --sign - "$RIPGREP_BINARY" >/dev/null 2>&1 || true
+    echo "    Installed: $RIPGREP_BINARY"
+}
+
+if [[ -d "$XCFRAMEWORK_DIR" && -d "$RESOURCES_DIR/shell-integration" && -d "$TERMINFO_DIR" && -x "$RIPGREP_BINARY" ]]; then
+    echo "==> GhosttyKit.xcframework, resources, and ripgrep already present, skipping download"
+    echo "    To re-download, remove: rm -rf GhosttyKit.xcframework Muxy/Resources/ghostty Muxy/Resources/terminfo Muxy/Resources/rg"
+    exit 0
+fi
+
+fetch_ripgrep
 
 if [[ -d "$XCFRAMEWORK_DIR" && -d "$RESOURCES_DIR/shell-integration" && -d "$TERMINFO_DIR" ]]; then
-    echo "==> GhosttyKit.xcframework and resources already present, skipping download"
-    echo "    To re-download, remove: rm -rf GhosttyKit.xcframework Muxy/Resources/ghostty Muxy/Resources/terminfo"
+    echo "==> GhosttyKit.xcframework and resources already present"
     exit 0
 fi
 


### PR DESCRIPTION
Adds a Cmd+Shift+F palette to search text content across the active project, powered by ripgrep bundled via
  scripts/setup.sh. Selecting a result opens the file and jumps to the matched line.