### PR TITLE
Fix dropped text not rendering until next user event

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Select Xcode
+        run: sudo xcode-select -s "/Applications/Xcode_$(grep '^xcode ' .tool-versions | awk '{print $2}').app"
+
       - name: Read tool versions
         run: |
           echo "SWIFTFORMAT_VERSION=$(grep '^swiftformat ' .tool-versions | awk '{print $2}')" >> "$GITHUB_ENV"

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -145,10 +145,18 @@ jobs:
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --team-id "$APPLE_TEAM_ID"
-          xcrun notarytool submit \
+          set +e
+          submit_output=$(xcrun notarytool submit \
             "build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg" \
             --keychain-profile "notary-profile" \
-            --wait
+            --wait \
+            --output-format json)
+          submit_status=$?
+          echo "$submit_output"
+          submission_id=$(echo "$submit_output" | python3 -c 'import sys, json; print(json.load(sys.stdin)["id"])')
+          xcrun notarytool log "$submission_id" --keychain-profile "notary-profile" || true
+          set -e
+          if [ "$submit_status" -ne 0 ]; then exit "$submit_status"; fi
           xcrun stapler staple \
             "build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,18 @@ jobs:
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --team-id "$APPLE_TEAM_ID"
-          xcrun notarytool submit \
+          set +e
+          submit_output=$(xcrun notarytool submit \
             "build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg" \
             --keychain-profile "notary-profile" \
-            --wait
+            --wait \
+            --output-format json)
+          submit_status=$?
+          echo "$submit_output"
+          submission_id=$(echo "$submit_output" | python3 -c 'import sys, json; print(json.load(sys.stdin)["id"])')
+          xcrun notarytool log "$submission_id" --keychain-profile "notary-profile" || true
+          set -e
+          if [ "$submit_status" -ne 0 ]; then exit "$submit_status"; fi
           xcrun stapler staple \
             "build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg"
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 swiftformat 0.60.1
 swiftlint 0.57.1
+xcode 16.4

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1016,7 +1016,7 @@ extension GhosttyTerminalNSView {
     }
 
     private func scheduleFocusAndInsertAfterDrop(text: String) {
-        DispatchQueue.main.async { [weak self] in
+        RunLoop.main.perform(inModes: [.default]) { [weak self] in
             guard let self else { return }
             NSApp.activate()
             window?.makeKeyAndOrderFront(nil)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1017,12 +1017,14 @@ extension GhosttyTerminalNSView {
 
     private func scheduleFocusAndInsertAfterDrop(text: String) {
         RunLoop.main.perform(inModes: [.default]) { [weak self] in
-            guard let self else { return }
-            NSApp.activate()
-            window?.makeKeyAndOrderFront(nil)
-            window?.makeFirstResponder(self)
-            notifySurfaceFocused()
-            insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                NSApp.activate()
+                self.window?.makeKeyAndOrderFront(nil)
+                self.window?.makeFirstResponder(self)
+                self.notifySurfaceFocused()
+                self.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
         }
     }
 


### PR DESCRIPTION
Schedules post-drop focus and text insertion on the main run loop's default mode instead of via
  DispatchQueue.main.async, so the ghostty render commits a CATransaction immediately rather than waiting for the
  next user event. Fixes #339.