### PR TITLE
Fix Sparkle channel filter blocking stable updates

### DIFF
--- a/Muxy/Services/UpdateService.swift
+++ b/Muxy/Services/UpdateService.swift
@@ -133,6 +133,9 @@ private final class FeedDelegate: NSObject, SPUUpdaterDelegate {
     }
 
     func allowedChannels(for _: SPUUpdater) -> Set<String> {
-        [channel.rawValue]
+        switch channel {
+        case .stable: []
+        case .beta: [channel.rawValue]
+        }
     }
 }

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -36,13 +36,18 @@ SIZE=$(stat -f%z "$DMG")
 FILENAME=$(basename "$DMG")
 PUB_DATE=$(date -u "+%a, %d %b %Y %H:%M:%S %z")
 
+CHANNEL_ELEMENT=""
+if [[ "$CHANNEL" != "stable" ]]; then
+  CHANNEL_ELEMENT="
+      <sparkle:channel>${CHANNEL}</sparkle:channel>"
+fi
+
 NEW_ITEM_FILE=$(mktemp)
 trap 'rm -f "$NEW_ITEM_FILE"' EXIT
 cat > "$NEW_ITEM_FILE" << EOF
     <item>
       <title>Version ${VERSION}</title>
-      <pubDate>${PUB_DATE}</pubDate>
-      <sparkle:channel>${CHANNEL}</sparkle:channel>
+      <pubDate>${PUB_DATE}</pubDate>${CHANNEL_ELEMENT}
       <sparkle:version>${BUILD_NUMBER}</sparkle:version>
       <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>


### PR DESCRIPTION
## Summary

- Stable appcast items were tagged `<sparkle:channel>stable</sparkle:channel>`, which Sparkle filters out for clients with no matching `allowedChannels` (every release prior to 0.26.0). Drop the tag for the default stable channel in `generate-appcast.sh`.
- Return empty `allowedChannels` on stable so untagged items always pass; keep `["beta"]` for the beta channel.