### PR TITLE
Auto-refresh editor on external file changes

### DIFF
--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -73,6 +73,7 @@ final class EditorTabState: Identifiable {
     var replaceAllVersion = 0
     var currentSelection = ""
     var awaitingLargeFileConfirmation = false
+    var hasExternalChange = false
     var largeFileSize: Int64 = 0
     var backingStore: TextBackingStore?
     var markdownViewMode: EditorMarkdownViewMode = .code
@@ -93,6 +94,8 @@ final class EditorTabState: Identifiable {
     @ObservationIgnored var markdownPreviewMaxScrollTop: CGFloat = 0
     @ObservationIgnored var markdownPreviewViewportHeight: CGFloat = 0
 
+    @ObservationIgnored private var fileWatcher: EditorFileWatcher?
+    @ObservationIgnored private var lastDiskModificationDate: Date?
     @ObservationIgnored let markdownSyncCoordinator = MarkdownSyncCoordinator()
     @ObservationIgnored private var markdownSyncAnchorsCache: [MarkdownSyncAnchor] = []
     @ObservationIgnored private var markdownSyncAnchorsCacheVersion: Int = -1
@@ -134,11 +137,14 @@ final class EditorTabState: Identifiable {
 
     private enum SaveError: LocalizedError {
         case fileIsReadOnly(String)
+        case externalChangeUnresolved(String)
 
         var errorDescription: String? {
             switch self {
             case let .fileIsReadOnly(path):
                 "File is read-only: \(URL(fileURLWithPath: path).lastPathComponent)"
+            case let .externalChangeUnresolved(path):
+                "File changed on disk: \(URL(fileURLWithPath: path).lastPathComponent). Resolve the conflict before saving."
             }
         }
     }
@@ -158,6 +164,7 @@ final class EditorTabState: Identifiable {
         filePath = newPath
         syntaxHighlighter = Self.makeSyntaxHighlighter(for: newPath)
         refreshReadOnlyStatus()
+        installFileWatcher()
     }
 
     func markdownSyncAnchors() -> [MarkdownSyncAnchor] {
@@ -205,6 +212,42 @@ final class EditorTabState: Identifiable {
 
     deinit {
         loadTask?.cancel()
+    }
+
+    private func installFileWatcher() {
+        fileWatcher = nil
+        let path = filePath
+        fileWatcher = EditorFileWatcher(filePath: path) { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleFileWatcherFire()
+            }
+        }
+    }
+
+    private func handleFileWatcherFire() {
+        guard !isLoading, !isSaving, !awaitingLargeFileConfirmation else { return }
+        guard let currentMTime = Self.modificationDate(at: filePath) else { return }
+        if let lastDiskModificationDate, currentMTime == lastDiskModificationDate { return }
+        if isModified {
+            hasExternalChange = true
+            return
+        }
+        performLoad()
+    }
+
+    func reloadFromDisk() {
+        hasExternalChange = false
+        performLoad()
+    }
+
+    func keepLocalChanges() {
+        hasExternalChange = false
+        lastDiskModificationDate = Self.modificationDate(at: filePath)
+    }
+
+    private static func modificationDate(at path: String) -> Date? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path) else { return nil }
+        return attrs[.modificationDate] as? Date
     }
 
     func loadFile() {
@@ -269,6 +312,12 @@ final class EditorTabState: Identifiable {
                         isModified = false
                         isLoading = false
                         isIncrementalLoading = hasMore
+                        if !hasMore {
+                            lastDiskModificationDate = Self.modificationDate(at: path)
+                            if fileWatcher == nil {
+                                installFileWatcher()
+                            }
+                        }
                     case let .appended(text):
                         if let backingStore {
                             backingStore.appendText(text)
@@ -291,6 +340,10 @@ final class EditorTabState: Identifiable {
                         }
                         if isIncrementalLoading {
                             isIncrementalLoading = false
+                        }
+                        lastDiskModificationDate = Self.modificationDate(at: path)
+                        if fileWatcher == nil {
+                            installFileWatcher()
                         }
                     }
                 }
@@ -426,6 +479,9 @@ final class EditorTabState: Identifiable {
 
     func saveFileAsync() async throws {
         guard !isSaving else { return }
+        if hasExternalChange {
+            throw SaveError.externalChangeUnresolved(filePath)
+        }
         isSaving = true
         guard let store = backingStore else {
             isSaving = false
@@ -447,6 +503,7 @@ final class EditorTabState: Identifiable {
             try await Self.writeFile(text: textToSave, path: path)
             isSaving = false
             isModified = false
+            lastDiskModificationDate = Self.modificationDate(at: path)
         } catch {
             isSaving = false
             throw error

--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -156,6 +156,7 @@ final class EditorTabState: Identifiable {
             markdownViewMode = .preview
         }
         syntaxHighlighter = Self.makeSyntaxHighlighter(for: filePath)
+        installFileWatcher()
         loadFile()
     }
 
@@ -216,8 +217,7 @@ final class EditorTabState: Identifiable {
 
     private func installFileWatcher() {
         fileWatcher = nil
-        let path = filePath
-        fileWatcher = EditorFileWatcher(filePath: path) { [weak self] in
+        fileWatcher = EditorFileWatcher(filePath: filePath) { [weak self] in
             Task { @MainActor [weak self] in
                 self?.handleFileWatcherFire()
             }
@@ -314,9 +314,6 @@ final class EditorTabState: Identifiable {
                         isIncrementalLoading = hasMore
                         if !hasMore {
                             lastDiskModificationDate = Self.modificationDate(at: path)
-                            if fileWatcher == nil {
-                                installFileWatcher()
-                            }
                         }
                     case let .appended(text):
                         if let backingStore {
@@ -342,9 +339,6 @@ final class EditorTabState: Identifiable {
                             isIncrementalLoading = false
                         }
                         lastDiskModificationDate = Self.modificationDate(at: path)
-                        if fileWatcher == nil {
-                            installFileWatcher()
-                        }
                     }
                 }
 

--- a/Muxy/Services/EditorFileWatcher.swift
+++ b/Muxy/Services/EditorFileWatcher.swift
@@ -47,12 +47,13 @@ final class EditorFileWatcher: @unchecked Sendable {
     }
 
     deinit {
-        handler = nil
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
         debounceWork?.cancel()
-        guard let stream else { return }
-        FSEventStreamStop(stream)
-        FSEventStreamInvalidate(stream)
-        FSEventStreamRelease(stream)
+        handler = nil
     }
 
     private func scheduleRefresh() {

--- a/Muxy/Services/EditorFileWatcher.swift
+++ b/Muxy/Services/EditorFileWatcher.swift
@@ -1,0 +1,66 @@
+import CoreServices
+import Foundation
+
+final class EditorFileWatcher: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "app.muxy.editor-file-watcher", qos: .utility)
+    private let filePath: String
+    private let debounceInterval: TimeInterval
+    private var stream: FSEventStreamRef?
+    private var debounceWork: DispatchWorkItem?
+    private var handler: (@Sendable () -> Void)?
+
+    init?(filePath: String, debounceInterval: TimeInterval = 0.3, handler: @escaping @Sendable () -> Void) {
+        self.filePath = filePath
+        self.debounceInterval = debounceInterval
+        self.handler = handler
+
+        let directory = (filePath as NSString).deletingLastPathComponent
+        guard !directory.isEmpty else { return nil }
+
+        var context = FSEventStreamContext()
+        context.info = Unmanaged.passUnretained(self).toOpaque()
+
+        let paths = [directory] as CFArray
+        guard let stream = FSEventStreamCreate(
+            nil,
+            { _, clientInfo, numEvents, eventPaths, _, _ in
+                guard let clientInfo, numEvents > 0 else { return }
+                let watcher = Unmanaged<EditorFileWatcher>.fromOpaque(clientInfo).takeUnretainedValue()
+                guard let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String]
+                else { return }
+                let target = (watcher.filePath as NSString).resolvingSymlinksInPath
+                let matched = paths.contains { ($0 as NSString).resolvingSymlinksInPath == target }
+                guard matched else { return }
+                watcher.scheduleRefresh()
+            },
+            &context,
+            paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            debounceInterval,
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes)
+        )
+        else { return nil }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+    }
+
+    deinit {
+        handler = nil
+        debounceWork?.cancel()
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+    }
+
+    private func scheduleRefresh() {
+        debounceWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.handler?()
+        }
+        debounceWork = work
+        queue.asyncAfter(deadline: .now() + debounceInterval, execute: work)
+    }
+}

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -19,6 +19,10 @@ struct EditorPane: View {
             } else if let error = state.errorMessage {
                 errorView(error)
             } else {
+                if state.hasExternalChange {
+                    externalChangeBanner
+                    Rectangle().fill(MuxyTheme.border).frame(height: 1)
+                }
                 editorContentLayer
             }
         }
@@ -226,6 +230,29 @@ struct EditorPane: View {
 
     private var showsCodeEditor: Bool {
         !state.isMarkdownFile || state.markdownViewMode != .preview
+    }
+
+    private var externalChangeBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(MuxyTheme.diffHunkFg)
+            Text("This file changed on disk. You have unsaved changes.")
+                .font(.system(size: 11))
+                .foregroundStyle(MuxyTheme.fg)
+            Spacer()
+            Button("Reload from Disk") {
+                state.reloadFromDisk()
+            }
+            .controlSize(.small)
+            Button("Keep My Changes") {
+                state.keepLocalChanges()
+            }
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(MuxyTheme.surface)
     }
 
     private var loadingView: some View {

--- a/Tests/MuxyTests/Services/EditorFileWatcherTests.swift
+++ b/Tests/MuxyTests/Services/EditorFileWatcherTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("EditorFileWatcher")
+struct EditorFileWatcherTests {
+    private func makeTempFile(contents: String = "initial") -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("EditorFileWatcherTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("file.txt")
+        try? contents.data(using: .utf8)?.write(to: url)
+        return url
+    }
+
+    @Test("init returns nil for empty path")
+    func initRejectsEmptyPath() {
+        let watcher = EditorFileWatcher(filePath: "") {}
+        #expect(watcher == nil)
+    }
+
+    @Test("fires handler when watched file changes")
+    func firesOnChange() async throws {
+        let url = makeTempFile()
+        let counter = FireCounter()
+        let watcher = EditorFileWatcher(filePath: url.path, debounceInterval: 0.1) {
+            counter.increment()
+        }
+        #expect(watcher != nil)
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+        try "updated".data(using: .utf8)!.write(to: url)
+
+        let fired = await waitFor(timeout: 5.0) { counter.value > 0 }
+        #expect(fired)
+        _ = watcher
+    }
+
+    @Test("ignores changes to sibling files in the same directory")
+    func ignoresSiblingChanges() async throws {
+        let url = makeTempFile()
+        let sibling = url.deletingLastPathComponent().appendingPathComponent("other.txt")
+        let counter = FireCounter()
+        let watcher = EditorFileWatcher(filePath: url.path, debounceInterval: 0.1) {
+            counter.increment()
+        }
+        #expect(watcher != nil)
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+        try "sibling".data(using: .utf8)!.write(to: sibling)
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        #expect(counter.value == 0)
+        _ = watcher
+    }
+
+    @Test("debounces rapid successive writes into a single fire")
+    func debouncesRapidWrites() async throws {
+        let url = makeTempFile()
+        let counter = FireCounter()
+        let watcher = EditorFileWatcher(filePath: url.path, debounceInterval: 0.4) {
+            counter.increment()
+        }
+        #expect(watcher != nil)
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+        for index in 0 ..< 5 {
+            try "v\(index)".data(using: .utf8)!.write(to: url)
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
+        #expect(counter.value == 1)
+        _ = watcher
+    }
+
+    private func waitFor(timeout: TimeInterval, condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return condition()
+    }
+}
+
+private final class FireCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}


### PR DESCRIPTION
Adds an FSEvents watcher per editor tab so any open file (not just markdown) refreshes when changed on disk. If the
   buffer is dirty, a banner offers Reload from Disk or Keep My Changes and blocks save until resolved.

Closes #329