### PR TITLE
Auto-refresh file tree for non-git projects, hide deleted files, add manual refresh

### DIFF
--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -7,7 +7,6 @@ final class FileTreeState {
         case modified
         case added
         case untracked
-        case deleted
         case renamed
         case conflict
     }
@@ -41,7 +40,7 @@ final class FileTreeState {
     var cutPaths: Set<String> = []
     var dropHighlightPath: String?
 
-    @ObservationIgnored private var watcher: GitDirectoryWatcher?
+    @ObservationIgnored private var watcher: FileSystemWatcher?
     @ObservationIgnored nonisolated(unsafe) private var remoteChangeObserver: NSObjectProtocol?
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
     @ObservationIgnored private var statusTask: Task<Void, Never>?
@@ -115,15 +114,12 @@ final class FileTreeState {
     }
 
     func visibleRootEntries() -> [FileTreeEntry] {
-        let entries = mergedEntries(in: normalizedRootPath, realEntries: rootEntries)
-        guard showOnlyChanges else { return entries }
-        return entries.filter { entryHasChanges($0) }
+        guard showOnlyChanges else { return rootEntries }
+        return rootEntries.filter { entryHasChanges($0) }
     }
 
     func visibleChildren(of entry: FileTreeEntry) -> [FileTreeEntry]? {
-        let realEntries = children[entry.absolutePath] ?? []
-        let entries = mergedEntries(in: entry.absolutePath, realEntries: realEntries)
-        guard !entries.isEmpty || children[entry.absolutePath] != nil else { return nil }
+        guard let entries = children[entry.absolutePath] else { return nil }
         guard showOnlyChanges else { return entries }
         return entries.filter { entryHasChanges($0) }
     }
@@ -251,7 +247,6 @@ final class FileTreeState {
             toggle(entry)
             return
         }
-        guard status(for: path) != .deleted else { return }
         open(path)
     }
 
@@ -333,7 +328,7 @@ final class FileTreeState {
     }
 
     private func installWatcher() {
-        watcher = GitDirectoryWatcher(directoryPath: rootPath) { [weak self] in
+        watcher = FileSystemWatcher(directoryPath: rootPath) { [weak self] in
             Task { @MainActor [weak self] in
                 self?.refresh()
             }
@@ -395,9 +390,10 @@ final class FileTreeState {
         var dirtyDirs: Set<String> = []
 
         for file in GitStatusParser.parseStatusPorcelain(outData, stats: [:]) {
+            guard let status = mapStatus(file) else { continue }
             let absolute = normalizedRoot + "/" + file.path
             let trimmed = absolute.hasSuffix("/") ? String(absolute.dropLast()) : absolute
-            fileStatuses[trimmed] = mapStatus(file)
+            fileStatuses[trimmed] = status
 
             var current = (trimmed as NSString).deletingLastPathComponent
             while current.count > normalizedRoot.count {
@@ -410,52 +406,7 @@ final class FileTreeState {
         return StatusResult(fileStatuses: fileStatuses, dirtyDirs: dirtyDirs)
     }
 
-    private func mergedEntries(in directoryPath: String, realEntries: [FileTreeEntry]) -> [FileTreeEntry] {
-        let existingPaths = Set(realEntries.map(\.absolutePath))
-        var entries = realEntries
-        entries.append(contentsOf: syntheticEntries(in: directoryPath, excluding: existingPaths))
-        entries.sort { lhs, rhs in
-            if lhs.isDirectory != rhs.isDirectory { return lhs.isDirectory && !rhs.isDirectory }
-            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-        }
-        return entries
-    }
-
-    private func syntheticEntries(in directoryPath: String, excluding existingPaths: Set<String>) -> [FileTreeEntry] {
-        let prefix = directoryPath.hasSuffix("/") ? directoryPath : directoryPath + "/"
-        var entriesByPath: [String: FileTreeEntry] = [:]
-
-        for absolutePath in statuses.keys where absolutePath.hasPrefix(prefix) {
-            let remainder = String(absolutePath.dropFirst(prefix.count))
-            guard !remainder.isEmpty else { continue }
-
-            let components = remainder.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true)
-            guard let first = components.first else { continue }
-
-            let name = String(first)
-            let childPath = prefix + name
-            guard !existingPaths.contains(childPath), entriesByPath[childPath] == nil else { continue }
-
-            let isDirectory = components.count > 1
-            let relativePath: String = if childPath.hasPrefix(normalizedRootPath + "/") {
-                String(childPath.dropFirst(normalizedRootPath.count + 1))
-            } else {
-                name
-            }
-
-            entriesByPath[childPath] = FileTreeEntry(
-                name: name,
-                absolutePath: childPath,
-                relativePath: relativePath,
-                isDirectory: isDirectory,
-                isIgnored: false
-            )
-        }
-
-        return Array(entriesByPath.values)
-    }
-
-    nonisolated private static func mapStatus(_ file: GitStatusFile) -> FileStatus {
+    nonisolated private static func mapStatus(_ file: GitStatusFile) -> FileStatus? {
         let x = file.xStatus
         let y = file.yStatus
 
@@ -469,7 +420,7 @@ final class FileTreeState {
             return .added
         }
         if x == "D" || y == "D" {
-            return .deleted
+            return nil
         }
         if x == "R" || y == "R" || x == "C" || y == "C" {
             return .renamed

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -182,7 +182,7 @@ final class VCSTabState {
     @ObservationIgnored private var commitLogTask: Task<Void, Never>?
     @ObservationIgnored private var prListTask: Task<Void, Never>?
     @ObservationIgnored private var prAutoSyncTask: Task<Void, Never>?
-    @ObservationIgnored private var watcher: GitDirectoryWatcher?
+    @ObservationIgnored private var watcher: FileSystemWatcher?
     @ObservationIgnored nonisolated(unsafe) private var remoteChangeObserver: NSObjectProtocol?
     @ObservationIgnored private var isRefreshing = false
     @ObservationIgnored private var pendingRefresh = false
@@ -228,7 +228,9 @@ final class VCSTabState {
     }
 
     private func startWatching() {
-        watcher = GitDirectoryWatcher(directoryPath: projectPath) { [weak self] in
+        let gitPath = (projectPath as NSString).appendingPathComponent(".git")
+        guard FileManager.default.fileExists(atPath: gitPath) else { return }
+        watcher = FileSystemWatcher(directoryPath: projectPath) { [weak self] in
             Task { @MainActor [weak self] in
                 self?.watcherDidFire()
             }

--- a/Muxy/Services/FileSystemWatcher.swift
+++ b/Muxy/Services/FileSystemWatcher.swift
@@ -1,15 +1,14 @@
 import CoreServices
 import Foundation
 
-final class GitDirectoryWatcher: @unchecked Sendable {
-    private let queue = DispatchQueue(label: "app.muxy.git-watcher", qos: .utility)
+final class FileSystemWatcher: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "app.muxy.fs-watcher", qos: .utility)
     private var stream: FSEventStreamRef?
     private var debounceWork: DispatchWorkItem?
     private var handler: (@Sendable () -> Void)?
 
     init?(directoryPath: String, handler: @escaping @Sendable () -> Void) {
-        let gitPath = (directoryPath as NSString).appendingPathComponent(".git")
-        guard FileManager.default.fileExists(atPath: gitPath) else { return nil }
+        guard FileManager.default.fileExists(atPath: directoryPath) else { return nil }
 
         self.handler = handler
 
@@ -21,7 +20,7 @@ final class GitDirectoryWatcher: @unchecked Sendable {
             nil,
             { _, clientInfo, numEvents, eventPaths, eventFlags, _ in
                 guard let clientInfo, numEvents > 0 else { return }
-                let watcher = Unmanaged<GitDirectoryWatcher>.fromOpaque(clientInfo).takeUnretainedValue()
+                let watcher = Unmanaged<FileSystemWatcher>.fromOpaque(clientInfo).takeUnretainedValue()
                 guard let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String]
                 else { return }
                 let flags = Array(UnsafeBufferPointer(start: eventFlags, count: numEvents))

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -118,24 +118,36 @@ struct FileTreeView: View {
     }
 
     private var header: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 0) {
             Text((state.rootPath as NSString).lastPathComponent)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
                 .lineLimit(1)
                 .truncationMode(.head)
+                .padding(.leading, 10)
             Spacer(minLength: 0)
-            IconButton(
-                symbol: state.showOnlyChanges ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle",
-                color: state.showOnlyChanges ? MuxyTheme.accent : MuxyTheme.fgMuted,
-                hoverColor: state.showOnlyChanges ? MuxyTheme.accent : MuxyTheme.fg,
-                accessibilityLabel: "Show Only Changes"
-            ) {
-                state.showOnlyChanges.toggle()
+            HStack(spacing: 0) {
+                IconButton(
+                    symbol: "arrow.clockwise",
+                    color: MuxyTheme.fgMuted,
+                    hoverColor: MuxyTheme.fg,
+                    accessibilityLabel: "Refresh"
+                ) {
+                    state.refresh()
+                }
+                .help("Refresh")
+                IconButton(
+                    symbol: state.showOnlyChanges ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle",
+                    color: state.showOnlyChanges ? MuxyTheme.accent : MuxyTheme.fgMuted,
+                    hoverColor: state.showOnlyChanges ? MuxyTheme.accent : MuxyTheme.fg,
+                    accessibilityLabel: "Show Only Changes"
+                ) {
+                    state.showOnlyChanges.toggle()
+                }
+                .help(state.showOnlyChanges ? "Show All Files" : "Show Only Changed Files")
             }
-            .help(state.showOnlyChanges ? "Show All Files" : "Show Only Changed Files")
+            .padding(.trailing, 4)
         }
-        .padding(.horizontal, 10)
         .frame(height: 32)
         .contextMenu {
             FileTreeContextMenuContents(
@@ -414,8 +426,7 @@ private struct FileTreeRow: View {
         case .added,
              .untracked:
             return MuxyTheme.diffAddFg
-        case .deleted,
-             .conflict:
+        case .conflict:
             return MuxyTheme.diffRemoveFg
         }
     }
@@ -434,7 +445,7 @@ private struct FileTreeRow: View {
         state.selectOnly(entry.absolutePath)
         if entry.isDirectory {
             state.toggle(entry)
-        } else if state.status(for: entry.absolutePath) != .deleted {
+        } else {
             onOpenFile(entry.absolutePath)
         }
     }

--- a/Tests/MuxyTests/Services/EditorFileWatcherTests.swift
+++ b/Tests/MuxyTests/Services/EditorFileWatcherTests.swift
@@ -5,12 +5,13 @@ import Testing
 
 @Suite("EditorFileWatcher")
 struct EditorFileWatcherTests {
-    private func makeTempFile(contents: String = "initial") -> URL {
+    private func makeTempFile(contents: String = "initial") async -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("EditorFileWatcherTests-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent("file.txt")
         try? contents.data(using: .utf8)?.write(to: url)
+        try? await Task.sleep(nanoseconds: 500_000_000)
         return url
     }
 
@@ -22,7 +23,7 @@ struct EditorFileWatcherTests {
 
     @Test("fires handler when watched file changes")
     func firesOnChange() async throws {
-        let url = makeTempFile()
+        let url = await makeTempFile()
         let counter = FireCounter()
         let watcher = EditorFileWatcher(filePath: url.path, debounceInterval: 0.1) {
             counter.increment()
@@ -39,7 +40,7 @@ struct EditorFileWatcherTests {
 
     @Test("ignores changes to sibling files in the same directory")
     func ignoresSiblingChanges() async throws {
-        let url = makeTempFile()
+        let url = await makeTempFile()
         let sibling = url.deletingLastPathComponent().appendingPathComponent("other.txt")
         let counter = FireCounter()
         let watcher = EditorFileWatcher(filePath: url.path, debounceInterval: 0.1) {
@@ -57,7 +58,7 @@ struct EditorFileWatcherTests {
 
     @Test("debounces rapid successive writes into a single fire")
     func debouncesRapidWrites() async throws {
-        let url = makeTempFile()
+        let url = await makeTempFile()
         let counter = FireCounter()
         let watcher = EditorFileWatcher(filePath: url.path, debounceInterval: 0.4) {
             counter.increment()

--- a/docs/developer/architecture/file-tree.md
+++ b/docs/developer/architecture/file-tree.md
@@ -10,7 +10,7 @@ flowchart TB
   State -->|load children| Service[FileTreeService]
   Service -->|git check-ignore| Git
   Service -->|fallback prune list| FS[Filesystem]
-  GitWatcher[GitDirectoryWatcher<br/>FSEvents] --> State
+  FSWatcher[FileSystemWatcher<br/>FSEvents] --> State
   Status[git status --porcelain=v1 -z] --> State
   State --> View[FileTreeView]
   View --> Commands[FileTreeCommands] --> Ops[FileSystemOperations<br/>off-main]
@@ -18,14 +18,13 @@ flowchart TB
 
 - `FileTreeState` is per `WorktreeKey`, held by `MainWindow`.
 - `FileTreeService.loadChildren` is lazy and respects `.gitignore` via `git check-ignore --stdin`. Non-git folders fall back to a hardcoded prune list shared with `FileSearchService`.
-- Per-file statuses come from `git status --porcelain=v1 -z`. Modified → diff hunk color; added/untracked → diff add color; deleted/conflict → diff remove color. Parent directories of changed files inherit the modified color.
-- The tree subscribes to `.vcsRepoDidChange` and uses `GitDirectoryWatcher` so external changes refresh without user action — there is no manual refresh button.
+- Per-file statuses come from `git status --porcelain=v1 -z`. Modified/renamed → diff hunk color; added/untracked → diff add color; conflict → diff remove color. Parent directories of changed files inherit the modified color. Deleted files are not shown — the tree mirrors the on-disk state.
+- The tree subscribes to `.vcsRepoDidChange` and uses `FileSystemWatcher` (FSEvents on the project root, regardless of git status) so external changes refresh without user action. A manual refresh button is also available in the panel header.
 
 ## Behaviors
 
 - **Active editor file** is auto-expanded and highlighted via `MuxyTheme.accentSoft`.
 - **Show only changes** filters to entries in the status set; directories without changed descendants are hidden.
-- **Deleted paths** become synthetic rows so removals show in both views.
 - **Panel width** persists in `UserDefaults` under `muxy.fileTreeWidth`; expansion state is in-memory only.
 
 ## File operations


### PR DESCRIPTION
  Fixes #345. The FS watcher used to require a .git directory, so non-git projects never auto-refreshed; it now
  watches any project root. Deleted files are no longer surfaced as synthetic rows — the tree mirrors disk. A manual
  refresh button is added to the header.