### PR TITLE
Pause rendering for occluded terminal panes to reclaim IOSurface memory

### DIFF
--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -29,6 +29,10 @@ final class GhosttyTerminalNSView: NSView {
 
     var processExitHandled = false
 
+    private var isPaneVisible = true
+    private var isWindowVisible = true
+    nonisolated(unsafe) private var occlusionObserver: NSObjectProtocol?
+
     var closesOnCommandExit: Bool {
         command != nil
     }
@@ -150,6 +154,8 @@ final class GhosttyTerminalNSView: NSView {
         if let paneID = TerminalViewRegistry.shared.paneID(for: self) {
             RemoteTerminalStreamer.shared.attach(paneID: paneID, surface: surface)
         }
+
+        applyOcclusionState()
     }
 
     func destroySurface() {
@@ -180,6 +186,10 @@ final class GhosttyTerminalNSView: NSView {
             NotificationCenter.default.removeObserver(observer)
             screenChangeObserver = nil
         }
+        if let observer = occlusionObserver {
+            NotificationCenter.default.removeObserver(observer)
+            occlusionObserver = nil
+        }
         delayedResizeWorkItem?.cancel()
         delayedResizeWorkItem = nil
         destroySurface()
@@ -188,6 +198,7 @@ final class GhosttyTerminalNSView: NSView {
 
     deinit {
         screenChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
+        occlusionObserver.flatMap { NotificationCenter.default.removeObserver($0) }
         delayedResizeWorkItem?.cancel()
         if let surface {
             ghostty_surface_free(surface)
@@ -202,6 +213,8 @@ final class GhosttyTerminalNSView: NSView {
 
         screenChangeObserver.flatMap { NotificationCenter.default.removeObserver($0) }
         screenChangeObserver = nil
+        occlusionObserver.flatMap { NotificationCenter.default.removeObserver($0) }
+        occlusionObserver = nil
         delayedResizeWorkItem?.cancel()
         delayedResizeWorkItem = nil
 
@@ -221,6 +234,17 @@ final class GhosttyTerminalNSView: NSView {
             }
         }
 
+        occlusionObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.updateWindowVisibility()
+            }
+        }
+
+        updateWindowVisibility()
         updateMetalLayerSize(deferred: true)
     }
 
@@ -235,6 +259,24 @@ final class GhosttyTerminalNSView: NSView {
     override func viewDidChangeBackingProperties() {
         super.viewDidChangeBackingProperties()
         updateMetalLayerSize(deferred: true)
+    }
+
+    func setVisible(_ visible: Bool) {
+        guard isPaneVisible != visible else { return }
+        isPaneVisible = visible
+        applyOcclusionState()
+    }
+
+    private func applyOcclusionState() {
+        guard let surface else { return }
+        ghostty_surface_set_occlusion(surface, isPaneVisible && isWindowVisible)
+    }
+
+    private func updateWindowVisibility() {
+        let visible = window?.occlusionState.contains(.visible) ?? true
+        guard isWindowVisible != visible else { return }
+        isWindowVisible = visible
+        applyOcclusionState()
     }
 
     func applyColorScheme(isDark: Bool) {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -21,6 +21,7 @@ struct TerminalPane: View {
             TerminalBridge(
                 state: state,
                 focused: focused,
+                visible: visible,
                 areaID: areaID,
                 onFocus: onFocus,
                 onProcessExit: onProcessExit,
@@ -111,6 +112,7 @@ struct RemoteControlledPlaceholder: View {
 struct TerminalBridge: NSViewRepresentable {
     let state: TerminalPaneState
     let focused: Bool
+    let visible: Bool
     let areaID: UUID
     let onFocus: () -> Void
     let onProcessExit: () -> Void
@@ -140,6 +142,7 @@ struct TerminalBridge: NSViewRepresentable {
         }
         view.isFocused = focused
         view.overlayActive = overlayActive
+        view.setVisible(visible)
         view.onFocus = onFocus
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
@@ -176,6 +179,7 @@ struct TerminalBridge: NSViewRepresentable {
             nsView.envVars = Self.buildEnvVars(paneID: state.id, worktreeKey: key)
         }
         nsView.overlayActive = overlayActive
+        nsView.setVisible(visible)
         nsView.onFocus = onFocus
         nsView.onProcessExit = onProcessExit
         nsView.onSplitRequest = onSplitRequest

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -81,7 +81,7 @@ struct TabAreaView: View {
                     TabContentView(
                         tab: tab,
                         focused: isActive && isFocused && isActiveProject,
-                        visible: isActive,
+                        visible: isActive && isActiveProject,
                         areaID: area.id,
                         onFocus: onFocus,
                         onProcessExit: { onForceCloseTab(tab.id) },


### PR DESCRIPTION
  Inactive tabs, background worktrees, and occluded windows kept their CAMetalLayer swap chains alive, causing
  IOSurface memory to grow with uptime (issue #347). Now we plumb a visible flag and observe
  NSWindow.didChangeOcclusionStateNotification, forwarding both into ghostty_surface_set_occlusion so the renderer
  pauses and drawables are released. Fixes #347.