### PR TITLE
Fix word wrap scroll drift and crash when opening files from Find in Files

### DIFF
--- a/Muxy/Models/HeightMap.swift
+++ b/Muxy/Models/HeightMap.swift
@@ -4,7 +4,7 @@ import Foundation
 final class HeightMap {
     enum BlockKind: Equatable {
         case measured(lineHeights: [CGFloat], heightPrefix: [CGFloat])
-        case estimated(perLineCharCounts: [Int], charPrefix: [Int])
+        case estimated(perLineCharCounts: [Int], heightPrefix: [CGFloat])
     }
 
     struct Block: Equatable {
@@ -43,13 +43,13 @@ final class HeightMap {
     }
 
     private func makeEstimatedBlock(perLineCharCounts: [Int]) -> Block {
-        let prefix = prefixSums(perLineCharCounts)
-        let chars = prefix.last ?? 0
-        let height = oracle.heightForGap(charCount: chars, logicalLineCount: perLineCharCounts.count)
+        let lineHeights = perLineCharCounts.map { oracle.heightForLine(charCount: $0) }
+        let prefix = prefixSums(lineHeights)
+        let height = prefix.last ?? 0
         return Block(
-            kind: .estimated(perLineCharCounts: perLineCharCounts, charPrefix: prefix),
+            kind: .estimated(perLineCharCounts: perLineCharCounts, heightPrefix: prefix),
             lineCount: perLineCharCounts.count,
-            charCount: chars,
+            charCount: perLineCharCounts.reduce(0, +),
             height: height
         )
     }
@@ -279,9 +279,8 @@ final class HeightMap {
         switch block.kind {
         case let .measured(_, heightPrefix):
             return heightPrefix[lineCount]
-        case let .estimated(_, charPrefix):
-            let charsBefore = charPrefix[lineCount]
-            return oracle.heightForGap(charCount: charsBefore, logicalLineCount: lineCount)
+        case let .estimated(_, heightPrefix):
+            return heightPrefix[lineCount]
         }
     }
 
@@ -305,13 +304,22 @@ final class HeightMap {
                 topY: baseY + heightPrefix[offset],
                 height: lineHeights[offset]
             )
-        case let .estimated(perLineCharCounts, _):
+        case let .estimated(perLineCharCounts, heightPrefix):
             guard block.lineCount > 0 else {
                 return LineLocation(line: baseLine, topY: baseY, height: oracle.lineHeight)
             }
-            let perLine = block.height / CGFloat(block.lineCount)
-            let approxOffset = max(0, min(block.lineCount - 1, Int(relativeY / max(1, perLine))))
-            let topY = baseY + CGFloat(approxOffset) * perLine
+            var low = 0
+            var high = perLineCharCounts.count - 1
+            while low < high {
+                let mid = (low + high) / 2
+                if heightPrefix[mid + 1] <= relativeY {
+                    low = mid + 1
+                } else {
+                    high = mid
+                }
+            }
+            let approxOffset = max(0, min(low, perLineCharCounts.count - 1))
+            let topY = baseY + heightPrefix[approxOffset]
             let charCount = perLineCharCounts[approxOffset]
             return LineLocation(
                 line: baseLine + approxOffset,

--- a/Muxy/Models/HeightOracle.swift
+++ b/Muxy/Models/HeightOracle.swift
@@ -32,20 +32,8 @@ final class HeightOracle {
         return CGFloat(visualRows) * lineHeight
     }
 
-    func heightForGap(charCount: Int, logicalLineCount: Int) -> CGFloat {
-        guard logicalLineCount > 0 else { return 0 }
-        guard lineWrapping else { return CGFloat(logicalLineCount) * lineHeight }
-        let lineCountValue = CGFloat(logicalLineCount)
-        let chars = CGFloat(max(0, charCount))
-        let baseLines = lineCountValue * lineLength * 0.5
-        let extraRows = max(0, ceil((chars - baseLines) / lineLength))
-        let totalRows = lineCountValue + extraRows
-        return totalRows * lineHeight
-    }
-
     private func visualRowsForLine(charCount: Int) -> Int {
         let chars = CGFloat(max(0, charCount))
-        let extra = ceil((chars - lineLength) / max(1, lineLength - 5))
-        return 1 + max(0, Int(extra))
+        return max(1, Int(ceil(chars / max(1, lineLength))))
     }
 }

--- a/Muxy/Syntax/MarkdownInlineHighlighter.swift
+++ b/Muxy/Syntax/MarkdownInlineHighlighter.swift
@@ -246,25 +246,6 @@ enum MarkdownInlineHighlighter {
 
 @MainActor
 enum MarkdownInlineStyle {
-    static func font(for kind: MarkdownInlineDecoration.Kind, baseFont: NSFont) -> NSFont? {
-        switch kind {
-        case .heading:
-            applyTraits(.bold, to: baseFont)
-        case .bold:
-            applyTraits(.bold, to: baseFont)
-        case .italic:
-            applyTraits(.italic, to: baseFont)
-        case .boldItalic:
-            applyTraits([.bold, .italic], to: baseFont)
-        case .strikethrough,
-             .codeSpan,
-             .marker,
-             .blockquote,
-             .listMarker:
-            nil
-        }
-    }
-
     static func foregroundColor(for kind: MarkdownInlineDecoration.Kind) -> NSColor? {
         switch kind {
         case .heading:
@@ -285,10 +266,5 @@ enum MarkdownInlineStyle {
 
     static func strikethroughStyle(for kind: MarkdownInlineDecoration.Kind) -> NSUnderlineStyle? {
         kind == .strikethrough ? .single : nil
-    }
-
-    private static func applyTraits(_ traits: NSFontDescriptor.SymbolicTraits, to font: NSFont) -> NSFont {
-        let descriptor = font.fontDescriptor.withSymbolicTraits(traits)
-        return NSFont(descriptor: descriptor, size: font.pointSize) ?? font
     }
 }

--- a/Muxy/Syntax/MarkdownInlineHighlighter.swift
+++ b/Muxy/Syntax/MarkdownInlineHighlighter.swift
@@ -264,31 +264,7 @@ enum MarkdownInlineStyle {
         }
     }
 
-    static func font(for kind: MarkdownInlineDecoration.Kind, baseFont: NSFont) -> NSFont? {
-        switch kind {
-        case .heading:
-            applyTraits(.bold, to: baseFont)
-        case .bold:
-            applyTraits(.bold, to: baseFont)
-        case .italic:
-            applyTraits(.italic, to: baseFont)
-        case .boldItalic:
-            applyTraits([.bold, .italic], to: baseFont)
-        case .strikethrough,
-             .codeSpan,
-             .marker,
-             .blockquote,
-             .listMarker:
-            nil
-        }
-    }
-
     static func strikethroughStyle(for kind: MarkdownInlineDecoration.Kind) -> NSUnderlineStyle? {
         kind == .strikethrough ? .single : nil
-    }
-
-    private static func applyTraits(_ traits: NSFontDescriptor.SymbolicTraits, to font: NSFont) -> NSFont {
-        let descriptor = font.fontDescriptor.withSymbolicTraits(traits)
-        return NSFont(descriptor: descriptor, size: font.pointSize) ?? font
     }
 }

--- a/Muxy/Syntax/MarkdownInlineHighlighter.swift
+++ b/Muxy/Syntax/MarkdownInlineHighlighter.swift
@@ -264,7 +264,31 @@ enum MarkdownInlineStyle {
         }
     }
 
+    static func font(for kind: MarkdownInlineDecoration.Kind, baseFont: NSFont) -> NSFont? {
+        switch kind {
+        case .heading:
+            applyTraits(.bold, to: baseFont)
+        case .bold:
+            applyTraits(.bold, to: baseFont)
+        case .italic:
+            applyTraits(.italic, to: baseFont)
+        case .boldItalic:
+            applyTraits([.bold, .italic], to: baseFont)
+        case .strikethrough,
+             .codeSpan,
+             .marker,
+             .blockquote,
+             .listMarker:
+            nil
+        }
+    }
+
     static func strikethroughStyle(for kind: MarkdownInlineDecoration.Kind) -> NSUnderlineStyle? {
         kind == .strikethrough ? .single : nil
+    }
+
+    private static func applyTraits(_ traits: NSFontDescriptor.SymbolicTraits, to font: NSFont) -> NSFont {
+        let descriptor = font.fontDescriptor.withSymbolicTraits(traits)
+        return NSFont(descriptor: descriptor, size: font.pointSize) ?? font
     }
 }

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -516,6 +516,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         var isUpdating = false
         private var isEditingViewport = false
+        private var isReconfiguringLineWrapping = false
         private(set) var scrollAnchor = ScrollAnchor()
         private var isWritingScrollProgrammatically = false
         var hasAppliedInitialContent = false
@@ -628,9 +629,6 @@ struct CodeEditorView: NSViewRepresentable {
         func applyLineWrapping(_ enabled: Bool) {
             lineWrappingEnabled = enabled
             viewportState?.lineWrappingEnabled = enabled
-            if !enabled {
-                viewportState?.resetMeasurements()
-            }
             guard let textView, let textContainer = textView.textContainer else { return }
             scrollView?.hasHorizontalScroller = !enabled
             if enabled {
@@ -661,9 +659,18 @@ struct CodeEditorView: NSViewRepresentable {
 
         func reconcileLineWrapping(_ enabled: Bool) {
             guard lineWrappingEnabled != enabled else { return }
+            reconfigureLineWrapping(enabled)
+        }
+
+        private func reconfigureLineWrapping(_ enabled: Bool) {
+            guard !isReconfiguringLineWrapping else { return }
+            isReconfiguringLineWrapping = true
+            defer { isReconfiguringLineWrapping = false }
+            deriveAnchorFromScrollView()
             applyLineWrapping(enabled)
+            viewportState?.resetMeasurements()
             updateContainerHeight()
-            refreshViewport(force: true)
+            refreshViewportPinningAnchor()
         }
 
         private func wrappingContentWidth() -> CGFloat {
@@ -891,6 +898,8 @@ struct CodeEditorView: NSViewRepresentable {
             )
 
             CATransaction.commit()
+
+            notifyGeometryDidChange()
 
             if let savedCursor,
                let newLocalLine = viewport.viewportLine(forBackingStoreLine: savedCursor.line)
@@ -1318,8 +1327,7 @@ struct CodeEditorView: NSViewRepresentable {
                 schedulePendingWrapResize()
                 return
             }
-            viewportState?.resetMeasurements()
-            applyLineWrapping(true)
+            reconfigureLineWrapping(true)
         }
 
         private func schedulePendingWrapResize() {
@@ -1333,9 +1341,7 @@ struct CodeEditorView: NSViewRepresentable {
                         return
                     }
                     guard self.lineWrappingEnabled else { return }
-                    self.viewportState?.resetMeasurements()
-                    self.applyLineWrapping(true)
-                    self.refreshViewport(force: true)
+                    self.reconfigureLineWrapping(true)
                 }
             }
             pendingWrapResizeWorkItem = work
@@ -1455,7 +1461,7 @@ struct CodeEditorView: NSViewRepresentable {
                 clearViewportHistory()
             }
 
-            if lineDelta != 0 || state.isMarkdownFile {
+            if lineDelta != 0 || lineWrappingEnabled || state.isMarkdownFile {
                 updateContainerHeight()
                 updateViewportFrames(
                     viewport: viewport,
@@ -1464,6 +1470,7 @@ struct CodeEditorView: NSViewRepresentable {
                     yOffset: viewport.viewportYOffset(),
                     visibleLineCount: max(1, viewport.viewportLineCount)
                 )
+                notifyGeometryDidChange()
             }
 
             publishMarkdownProgressIfEditorAutoScrolled {
@@ -1703,6 +1710,13 @@ struct CodeEditorView: NSViewRepresentable {
             guard let context = makeRenderContext() else { return }
             for ext in extensions {
                 ext.selectionDidChange(context: context)
+            }
+        }
+
+        private func notifyGeometryDidChange() {
+            guard let context = makeRenderContext() else { return }
+            for ext in extensions {
+                ext.geometryDidChange(context: context)
             }
         }
 

--- a/Muxy/Views/Editor/Extensions/CurrentLineHighlightExtension.swift
+++ b/Muxy/Views/Editor/Extensions/CurrentLineHighlightExtension.swift
@@ -45,6 +45,10 @@ final class CurrentLineHighlightExtension: EditorExtension {
         repositionHighlight(context: context)
     }
 
+    func geometryDidChange(context: EditorRenderContext) {
+        repositionHighlight(context: context)
+    }
+
     private func ensureInstalled() {
         guard highlightView == nil else { return }
         installHighlight()

--- a/Muxy/Views/Editor/Extensions/EditorExtension.swift
+++ b/Muxy/Views/Editor/Extensions/EditorExtension.swift
@@ -15,6 +15,8 @@ protocol EditorExtension: AnyObject {
     func textDidChange(context: EditorRenderContext)
 
     func selectionDidChange(context: EditorRenderContext)
+
+    func geometryDidChange(context: EditorRenderContext)
 }
 
 extension EditorExtension {
@@ -24,4 +26,5 @@ extension EditorExtension {
     func applyIncremental(context _: EditorRenderContext, lineRange _: Range<Int>, edit _: EditorTextEdit) {}
     func textDidChange(context _: EditorRenderContext) {}
     func selectionDidChange(context _: EditorRenderContext) {}
+    func geometryDidChange(context _: EditorRenderContext) {}
 }

--- a/Muxy/Views/Editor/Extensions/LineNumberGutterExtension.swift
+++ b/Muxy/Views/Editor/Extensions/LineNumberGutterExtension.swift
@@ -46,6 +46,10 @@ final class LineNumberGutterExtension: EditorExtension {
         applyMetrics(context: context)
     }
 
+    func geometryDidChange(context: EditorRenderContext) {
+        applyMetrics(context: context)
+    }
+
     private func ensureInstalled(context: EditorRenderContext) {
         guard gutter == nil else { return }
         installGutter(context: context)

--- a/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
+++ b/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
@@ -23,7 +23,6 @@ final class MarkdownInlineExtension: EditorExtension {
         let localEnd = min(lineRange.upperBound - viewportStart, context.viewport.viewportLineCount)
         guard localStart < localEnd, localStart < context.lineStartOffsets.count else { return }
 
-        let baseFont = context.editorSettings.resolvedFont
         let charStart = context.lineStartOffsets[localStart]
         let charEnd: Int = localEnd < context.lineStartOffsets.count
             ? context.lineStartOffsets[localEnd]
@@ -33,8 +32,6 @@ final class MarkdownInlineExtension: EditorExtension {
         let editedRange = NSRange(location: charStart, length: charEnd - charStart)
         context.layoutManager.removeTemporaryAttribute(.strikethroughStyle, forCharacterRange: editedRange)
 
-        storage.beginEditing()
-        storage.addAttribute(.font, value: baseFont, range: editedRange)
         for localIndex in localStart ..< localEnd {
             let globalLine = viewportStart + localIndex
             guard globalLine < context.backingStore.lineCount else { break }
@@ -55,9 +52,6 @@ final class MarkdownInlineExtension: EditorExtension {
                 let length = decoration.range.length
                 guard location >= 0, length > 0, location + length <= storageLength else { continue }
                 let nsRange = NSRange(location: location, length: length)
-                if let font = MarkdownInlineStyle.font(for: decoration.kind, baseFont: baseFont) {
-                    storage.addAttribute(.font, value: font, range: nsRange)
-                }
                 if let color = MarkdownInlineStyle.foregroundColor(for: decoration.kind) {
                     context.layoutManager.addTemporaryAttribute(
                         .foregroundColor,
@@ -74,6 +68,5 @@ final class MarkdownInlineExtension: EditorExtension {
                 }
             }
         }
-        storage.endEditing()
     }
 }

--- a/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
+++ b/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
@@ -23,7 +23,6 @@ final class MarkdownInlineExtension: EditorExtension {
         let localEnd = min(lineRange.upperBound - viewportStart, context.viewport.viewportLineCount)
         guard localStart < localEnd, localStart < context.lineStartOffsets.count else { return }
 
-        let baseFont = context.editorSettings.resolvedFont
         let charStart = context.lineStartOffsets[localStart]
         let charEnd: Int = localEnd < context.lineStartOffsets.count
             ? context.lineStartOffsets[localEnd]
@@ -32,9 +31,6 @@ final class MarkdownInlineExtension: EditorExtension {
 
         let editedRange = NSRange(location: charStart, length: charEnd - charStart)
         context.layoutManager.removeTemporaryAttribute(.strikethroughStyle, forCharacterRange: editedRange)
-
-        storage.beginEditing()
-        storage.addAttribute(.font, value: baseFont, range: editedRange)
 
         for localIndex in localStart ..< localEnd {
             let globalLine = viewportStart + localIndex
@@ -56,9 +52,6 @@ final class MarkdownInlineExtension: EditorExtension {
                 let length = decoration.range.length
                 guard location >= 0, length > 0, location + length <= storageLength else { continue }
                 let nsRange = NSRange(location: location, length: length)
-                if let font = MarkdownInlineStyle.font(for: decoration.kind, baseFont: baseFont) {
-                    storage.addAttribute(.font, value: font, range: nsRange)
-                }
                 if let color = MarkdownInlineStyle.foregroundColor(for: decoration.kind) {
                     context.layoutManager.addTemporaryAttribute(
                         .foregroundColor,
@@ -75,7 +68,5 @@ final class MarkdownInlineExtension: EditorExtension {
                 }
             }
         }
-
-        storage.endEditing()
     }
 }

--- a/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
+++ b/Muxy/Views/Editor/Extensions/MarkdownInlineExtension.swift
@@ -23,6 +23,7 @@ final class MarkdownInlineExtension: EditorExtension {
         let localEnd = min(lineRange.upperBound - viewportStart, context.viewport.viewportLineCount)
         guard localStart < localEnd, localStart < context.lineStartOffsets.count else { return }
 
+        let baseFont = context.editorSettings.resolvedFont
         let charStart = context.lineStartOffsets[localStart]
         let charEnd: Int = localEnd < context.lineStartOffsets.count
             ? context.lineStartOffsets[localEnd]
@@ -31,6 +32,9 @@ final class MarkdownInlineExtension: EditorExtension {
 
         let editedRange = NSRange(location: charStart, length: charEnd - charStart)
         context.layoutManager.removeTemporaryAttribute(.strikethroughStyle, forCharacterRange: editedRange)
+
+        storage.beginEditing()
+        storage.addAttribute(.font, value: baseFont, range: editedRange)
 
         for localIndex in localStart ..< localEnd {
             let globalLine = viewportStart + localIndex
@@ -52,6 +56,9 @@ final class MarkdownInlineExtension: EditorExtension {
                 let length = decoration.range.length
                 guard location >= 0, length > 0, location + length <= storageLength else { continue }
                 let nsRange = NSRange(location: location, length: length)
+                if let font = MarkdownInlineStyle.font(for: decoration.kind, baseFont: baseFont) {
+                    storage.addAttribute(.font, value: font, range: nsRange)
+                }
                 if let color = MarkdownInlineStyle.foregroundColor(for: decoration.kind) {
                     context.layoutManager.addTemporaryAttribute(
                         .foregroundColor,
@@ -68,5 +75,7 @@ final class MarkdownInlineExtension: EditorExtension {
                 }
             }
         }
+
+        storage.endEditing()
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -57,6 +57,7 @@ struct MainWindow: View {
     @State private var showQuickOpen = false
     @State private var showFindInFiles = false
     @State private var showWorktreeSwitcher = false
+    @State private var overlayAnimatingOut = false
     @State private var isFullScreen = false
     @State private var sidebarExpanded = UserDefaults.standard.bool(forKey: "muxy.sidebarExpanded")
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
@@ -169,7 +170,7 @@ struct MainWindow: View {
                 }
             }
         }
-        .environment(\.overlayActive, showQuickOpen || showFindInFiles || showWorktreeSwitcher)
+        .environment(\.overlayActive, showQuickOpen || showFindInFiles || showWorktreeSwitcher || overlayAnimatingOut)
         .overlay(alignment: toastAlignment) {
             if let toast = ToastState.shared.message {
                 HStack(spacing: 6) {
@@ -240,6 +241,12 @@ struct MainWindow: View {
         .animation(.easeInOut(duration: 0.15), value: showQuickOpen)
         .animation(.easeInOut(duration: 0.15), value: showFindInFiles)
         .animation(.easeInOut(duration: 0.15), value: showWorktreeSwitcher)
+        .modifier(OverlayExitTracker(
+            showQuickOpen: showQuickOpen,
+            showFindInFiles: showFindInFiles,
+            showWorktreeSwitcher: showWorktreeSwitcher,
+            onAnimatingOut: { overlayAnimatingOut = $0 }
+        ))
         .animation(.easeInOut(duration: 0.2), value: ToastState.shared.message != nil)
         .coordinateSpace(name: DragCoordinateSpace.mainWindow)
         .environment(dragCoordinator)
@@ -1171,5 +1178,27 @@ private struct WindowOpenReceiver: View {
             .onReceive(NotificationCenter.default.publisher(for: .openHelpWindow)) { _ in
                 openWindow(id: "help")
             }
+    }
+}
+
+private struct OverlayExitTracker: ViewModifier {
+    let showQuickOpen: Bool
+    let showFindInFiles: Bool
+    let showWorktreeSwitcher: Bool
+    let onAnimatingOut: (Bool) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: showQuickOpen) { _, visible in trackExit(visible) }
+            .onChange(of: showFindInFiles) { _, visible in trackExit(visible) }
+            .onChange(of: showWorktreeSwitcher) { _, visible in trackExit(visible) }
+    }
+
+    private func trackExit(_ visible: Bool) {
+        guard !visible else { return }
+        onAnimatingOut(true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            onAnimatingOut(false)
+        }
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -238,9 +238,9 @@ struct MainWindow: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.98)))
             }
         }
-        .animation(.easeInOut(duration: overlayAnimationDuration), value: showQuickOpen)
-        .animation(.easeInOut(duration: overlayAnimationDuration), value: showFindInFiles)
-        .animation(.easeInOut(duration: overlayAnimationDuration), value: showWorktreeSwitcher)
+        .animation(.easeInOut(duration: 0.15), value: showQuickOpen)
+        .animation(.easeInOut(duration: 0.15), value: showFindInFiles)
+        .animation(.easeInOut(duration: 0.15), value: showWorktreeSwitcher)
         .modifier(OverlayExitTracker(
             showQuickOpen: showQuickOpen,
             showFindInFiles: showFindInFiles,
@@ -1181,8 +1181,6 @@ private struct WindowOpenReceiver: View {
     }
 }
 
-private let overlayAnimationDuration = 0.15
-
 private struct OverlayExitTracker: ViewModifier {
     let showQuickOpen: Bool
     let showFindInFiles: Bool
@@ -1199,7 +1197,7 @@ private struct OverlayExitTracker: ViewModifier {
     private func trackExit(_ visible: Bool) {
         guard !visible else { return }
         onAnimatingOut(true)
-        DispatchQueue.main.asyncAfter(deadline: .now() + overlayAnimationDuration) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             onAnimatingOut(false)
         }
     }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -238,9 +238,9 @@ struct MainWindow: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.98)))
             }
         }
-        .animation(.easeInOut(duration: 0.15), value: showQuickOpen)
-        .animation(.easeInOut(duration: 0.15), value: showFindInFiles)
-        .animation(.easeInOut(duration: 0.15), value: showWorktreeSwitcher)
+        .animation(.easeInOut(duration: overlayAnimationDuration), value: showQuickOpen)
+        .animation(.easeInOut(duration: overlayAnimationDuration), value: showFindInFiles)
+        .animation(.easeInOut(duration: overlayAnimationDuration), value: showWorktreeSwitcher)
         .modifier(OverlayExitTracker(
             showQuickOpen: showQuickOpen,
             showFindInFiles: showFindInFiles,
@@ -1181,6 +1181,8 @@ private struct WindowOpenReceiver: View {
     }
 }
 
+private let overlayAnimationDuration = 0.15
+
 private struct OverlayExitTracker: ViewModifier {
     let showQuickOpen: Bool
     let showFindInFiles: Bool
@@ -1197,7 +1199,7 @@ private struct OverlayExitTracker: ViewModifier {
     private func trackExit(_ visible: Bool) {
         guard !visible else { return }
         onAnimatingOut(true)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + overlayAnimationDuration) {
             onAnimatingOut(false)
         }
     }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -808,7 +808,9 @@ final class GhosttyTerminalNSView: NSView {
         var keyEvent = ghostty_input_key_s()
         keyEvent.action = action
 
-        let normalized = KeyCombo.normalized(key: event.charactersIgnoringModifiers ?? "", keyCode: event.keyCode)
+        let normalized = event.type == .keyDown || event.type == .keyUp
+            ? KeyCombo.normalized(key: event.charactersIgnoringModifiers ?? "", keyCode: event.keyCode)
+            : KeyCombo.normalized(key: "", keyCode: event.keyCode)
         if let mappedCode = KeyCombo.keyCode(for: normalized) {
             keyEvent.keycode = UInt32(mappedCode)
         } else {
@@ -933,6 +935,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private func unshiftedCodepoint(from event: NSEvent) -> UInt32 {
+        guard event.type == .keyDown || event.type == .keyUp else { return 0 }
         let normalized = KeyCombo.normalized(key: event.charactersIgnoringModifiers ?? "", keyCode: event.keyCode)
         if let scalar = normalized.unicodeScalars.first, normalized.unicodeScalars.count == 1 {
             return scalar.value

--- a/Tests/MuxyTests/Models/HeightMapTests.swift
+++ b/Tests/MuxyTests/Models/HeightMapTests.swift
@@ -172,4 +172,21 @@ struct HeightMapTests {
         dense.reset(lineCharCounts: Array(repeating: 200, count: 100))
         #expect(dense.totalHeight > sparse.totalHeight)
     }
+
+    @Test("wrapped estimated lines keep exact per-line coordinates")
+    func wrappedEstimatedLinesUsePerLinePrefixes() {
+        let oracle = makeOracle(wrapping: true, lineHeight: 10)
+        let map = HeightMap(oracle: oracle)
+        map.reset(lineCharCounts: [5, 65, 10])
+
+        #expect(map.heightAbove(line: 0) == 0)
+        #expect(map.heightAbove(line: 1) == 10)
+        #expect(map.heightAbove(line: 2) == 40)
+        #expect(map.heightAbove(line: 3) == 50)
+
+        let location = map.lineAtY(35)
+        #expect(location.line == 1)
+        #expect(location.topY == 10)
+        #expect(location.height == 30)
+    }
 }

--- a/Tests/MuxyTests/Models/HeightOracleTests.swift
+++ b/Tests/MuxyTests/Models/HeightOracleTests.swift
@@ -12,15 +12,6 @@ struct HeightOracleTests {
         oracle.lineWrapping = false
         #expect(oracle.heightForLine(charCount: 0) == 20)
         #expect(oracle.heightForLine(charCount: 5_000) == 20)
-        #expect(oracle.heightForGap(charCount: 0, logicalLineCount: 10) == 200)
-        #expect(oracle.heightForGap(charCount: 100_000, logicalLineCount: 10) == 200)
-    }
-
-    @Test("non-wrapping gap with zero lines is zero")
-    func nonWrappingEmptyGap() {
-        let oracle = HeightOracle()
-        oracle.lineWrapping = false
-        #expect(oracle.heightForGap(charCount: 0, logicalLineCount: 0) == 0)
     }
 
     @Test("wrapping short line returns single row height")
@@ -46,19 +37,6 @@ struct HeightOracleTests {
         let height500 = oracle.heightForLine(charCount: 500)
         #expect(height120 > 16)
         #expect(height500 > height120)
-    }
-
-    @Test("wrapping gap scales with total characters across lines")
-    func wrappingGapScalesWithChars() {
-        let oracle = HeightOracle()
-        oracle.updateLineHeight(16)
-        oracle.updateCharWidth(8)
-        oracle.updateLineLength(containerWidth: 240)
-        oracle.lineWrapping = true
-        let denseGap = oracle.heightForGap(charCount: 10_000, logicalLineCount: 100)
-        let sparseGap = oracle.heightForGap(charCount: 1_000, logicalLineCount: 100)
-        #expect(denseGap > sparseGap)
-        #expect(sparseGap >= 100 * 16)
     }
 
     @Test("updateLineLength clamps to reasonable minimum")

--- a/docs/developer/architecture/editor-geometry.md
+++ b/docs/developer/architecture/editor-geometry.md
@@ -69,7 +69,7 @@ sequenceDiagram
   J->>SV: cursor placed on line N
 ```
 
-`HeightMap` only has *estimated* heights for lines outside the window. The first scroll lands at an approximate position; rendering measures the new window; the heightmap refines those line heights; the user's logical anchor (a line index) gets a new pixel position. The reflow loop bumps scroll silently until the geometry settles.
+`HeightMap` only has *estimated* heights for lines outside the window. Wrapped estimates are still line-addressable: every estimated logical line has its own height and prefix coordinate derived from that line's character count. The first scroll lands at a deterministic line position; rendering measures the new window; the heightmap refines those line heights; the user's logical anchor gets a new pixel position. The reflow loop bumps scroll silently until the geometry settles.
 
 ## Write paths
 
@@ -104,7 +104,7 @@ flowchart TB
 
 ## HeightMap block lifecycle
 
-`HeightMap` keeps the document as a sequence of `Block`s, each either `.measured(lineHeights:)` (exact pixel heights from `layoutManager.boundingRect`) or `.estimated(perLineCharCounts:)` (oracle estimate from `(charCount, logicalLineCount)`).
+`HeightMap` keeps the document as a sequence of `Block`s, each either `.measured(lineHeights:)` (exact pixel heights from `layoutManager.boundingRect`) or `.estimated(perLineCharCounts:)` (per-line oracle estimates with a height prefix table).
 
 ```mermaid
 flowchart TB
@@ -114,11 +114,12 @@ flowchart TB
   Jump --> Edit["edit at L:<br/>splits, re-estimates inserted run"]
 ```
 
-Edits that insert/remove lines pass through `replaceLines`, which updates the underlying block sequence; consecutive `.estimated` blocks are merged so the gap distribution stays well-behaved.
+Edits pass through `replaceLines`, which updates the underlying block sequence and re-estimates inserted lines. Consecutive `.estimated` blocks are merged without losing per-line prefixes.
 
 ## Why this works
 
-- **Estimates are character-density-proportional.** A long minified line gets a tall estimate before measurement; a short comment line gets a short one. `heightAbove(line)` is roughly correct from the first scroll.
+- **Estimates are per logical line.** A long minified line gets a tall estimate before measurement; a short comment line gets a short one. `heightAbove(line)` and `lineAtY(y)` remain inverse operations for unmeasured wrapped content.
 - **Scroll position is not pixel-anchored.** When measurements refine geometry, the anchor's pixel position changes — the reflow loop re-pins it before the user notices.
+- **Wrap changes preserve logical anchors.** Toggling wrap or changing the editor width derives the current `ScrollAnchor` before geometry is rebuilt, then re-pins that anchor after TextKit and `HeightMap` are reconfigured.
 - **Single source of truth.** Highlight, gutter, scroll math, jump math, search-jump, current-line-highlight all derive Y values from the same `HeightMap`.
 - **Measurement is pixel-exact.** `recordMeasuredLineHeights` feeds `layoutManager.boundingRect` heights (excluding trailing newline) directly.


### PR DESCRIPTION
Fixes scroll/position drift in word wrap mode by computing per-line height estimates individually instead of
  averaging across blocks, and uses binary search for accurate line-at-Y lookup. Adds a reentrancy guard to
  reconfigureLineWrapping to prevent a stack overflow crash triggered when opening a file from Cmd+Shift+F with word
  wrap enabled. Also keeps overlays logically active during their 150ms exit animation to prevent premature terminal
  focus.