### PR TITLE
팔레트 ESC 키가 풀스크린을 종료하는 버그 수정

### DIFF
--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -197,6 +197,10 @@ struct PaletteSearchField: NSViewRepresentable {
             textView _: NSTextView,
             doCommandBy commandSelector: Selector
         ) -> Bool {
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                parent.onEscape()
+                return true
+            }
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 parent.onSubmit()
                 return true


### PR DESCRIPTION
## 문제

팔레트(Quick Open / Worktree Switcher)가 열린 상태에서 ESC를 누르면 팔레트가 닫히는 게 아니라 macOS 풀스크린이 종료됨.

## 원인

검색 필드의 field editor가 ESC를 받으면 `cancelOperation:` selector로 변환해 dispatch하는데, NSTextField delegate(`Coordinator`)가 이 selector를 처리하지 않고 있어 responder chain 위로 전파 → macOS native 풀스크린 종료 동작이 트리거됨.

## 수정

`PaletteSearchField.Coordinator.control(_:textView:doCommandBy:)`에 `cancelOperation:` 핸들러 추가. `CodeEditorRepresentable`에서 이미 사용 중인 canonical NSTextField pattern.

## 테스트

- 풀스크린 진입 → Cmd+Shift+P 또는 Cmd+P → ESC: 팔레트만 닫히고 풀스크린 유지 ✓
- 일반 윈도우에서도 정상 닫힘 ✓