### PR TITLE
Fix palette ESC key exiting fullscreen instead of closing palette

### DIFF
--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -197,6 +197,10 @@ struct PaletteSearchField: NSViewRepresentable {
             textView _: NSTextView,
             doCommandBy commandSelector: Selector
         ) -> Bool {
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                parent.onEscape()
+                return true
+            }
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 parent.onSubmit()
                 return true


### PR DESCRIPTION
## Summary

Fix palette (Quick Open / Worktree Switcher) ESC key exiting macOS fullscreen instead of closing the palette.

## Changes

Handle cancelOperation: in PaletteSearchField.Coordinator to consume ESC at the palette level

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

None
