### PR TITLE
Spring cleaning: extract Git protocol, file-move helper, and section markers

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -97,6 +97,8 @@ final class AppState {
         self.workspacePersistence = workspacePersistence
     }
 
+    // MARK: Persistence & restoration
+
     func restoreSelection(projects: [Project], worktrees: [UUID: [Worktree]]) {
         let snapshots: [WorkspaceSnapshot]
         do {
@@ -168,6 +170,8 @@ final class AppState {
         return focusedAreaID[key]
     }
 
+    // MARK: Project & worktree selection
+
     func selectProject(_ project: Project, worktree: Worktree) {
         dispatch(.selectProject(
             projectID: project.id,
@@ -197,6 +201,8 @@ final class AppState {
         return workspaceRoots[key]?.allAreas() ?? []
     }
 
+    // MARK: Splits & areas
+
     func splitFocusedArea(direction: SplitDirection, projectID: UUID) {
         guard let area = focusedArea(for: projectID) else { return }
         dispatch(.splitArea(.init(
@@ -210,6 +216,8 @@ final class AppState {
     func closeArea(_ areaID: UUID, projectID: UUID) {
         dispatch(.closeArea(projectID: projectID, areaID: areaID))
     }
+
+    // MARK: Tab creation & file open
 
     func createTab(projectID: UUID) {
         dispatch(.createTab(projectID: projectID, areaID: nil))
@@ -275,21 +283,7 @@ final class AppState {
     }
 
     func handleFileMoved(from oldPath: String, to newPath: String) {
-        guard oldPath != newPath else { return }
-        let oldPrefix = oldPath + "/"
-        for (_, root) in workspaceRoots {
-            for area in root.allAreas() {
-                for tab in area.tabs {
-                    guard let editorState = tab.content.editorState else { continue }
-                    let currentPath = editorState.filePath
-                    if currentPath == oldPath {
-                        editorState.updateFilePath(newPath)
-                    } else if currentPath.hasPrefix(oldPrefix) {
-                        editorState.updateFilePath(newPath + "/" + String(currentPath.dropFirst(oldPrefix.count)))
-                    }
-                }
-            }
-        }
+        EditorTabPathMigrator.applyFileMove(from: oldPath, to: newPath, in: workspaceRoots)
     }
 
     func openDiffViewer(vcs: VCSTabState, filePath: String, isStaged: Bool, projectID: UUID) {
@@ -318,6 +312,8 @@ final class AppState {
         }
         dispatch(.createExternalEditorTab(projectID: projectID, areaID: nil, filePath: filePath, command: command))
     }
+
+    // MARK: Tab close & confirmation
 
     func closeTab(_ tabID: UUID, projectID: UUID) {
         guard let area = focusedArea(for: projectID) else { return }
@@ -404,6 +400,8 @@ final class AppState {
     func cancelCloseLastTab() {
         pendingLastTabClose = nil
     }
+
+    // MARK: Layouts
 
     func availableLayouts(for projectID: UUID) -> [LayoutDescriptor] {
         guard let path = activeWorktreePath(for: projectID) else { return [] }
@@ -498,6 +496,8 @@ final class AppState {
         return terminalViews.needsConfirmQuit(for: paneID)
     }
 
+    // MARK: Tab selection
+
     func selectTabByIndex(_ index: Int, projectID: UUID) {
         dispatch(.selectTabByIndex(projectID: projectID, areaID: nil, index: index))
     }
@@ -521,6 +521,8 @@ final class AppState {
         area.togglePin(tabID)
         saveWorkspaces()
     }
+
+    // MARK: Dispatch
 
     func dispatch(_ action: Action) {
         if case let .focusArea(projectID, areaID) = action,
@@ -585,6 +587,8 @@ final class AppState {
         saveWorkspaces()
         saveSelection()
     }
+
+    // MARK: Navigation history
 
     func goBack() {
         step(delta: -1)
@@ -704,6 +708,8 @@ final class AppState {
         return area.tabs.contains(where: { $0.id == tabID })
     }
 
+    // MARK: Focus & pane navigation
+
     func focusArea(_ areaID: UUID, projectID: UUID) {
         dispatch(.focusArea(projectID: projectID, areaID: areaID))
     }
@@ -723,6 +729,8 @@ final class AppState {
     func focusPaneDown(projectID: UUID) {
         dispatch(.focusPaneDown(projectID: projectID))
     }
+
+    // MARK: Project lifecycle
 
     func selectProjectByIndex(_ index: Int, projects: [Project], worktrees: [UUID: [Worktree]]) {
         guard index >= 0, index < projects.count else { return }

--- a/Muxy/Models/EditorTabPathMigrator.swift
+++ b/Muxy/Models/EditorTabPathMigrator.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+@MainActor
+enum EditorTabPathMigrator {
+    static func applyFileMove(
+        from oldPath: String,
+        to newPath: String,
+        in workspaceRoots: [WorktreeKey: SplitNode]
+    ) {
+        guard oldPath != newPath else { return }
+        let oldPrefix = oldPath + "/"
+        for (_, root) in workspaceRoots {
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    guard let editorState = tab.content.editorState else { continue }
+                    let currentPath = editorState.filePath
+                    if currentPath == oldPath {
+                        editorState.updateFilePath(newPath)
+                    } else if currentPath.hasPrefix(oldPrefix) {
+                        editorState.updateFilePath(newPath + "/" + String(currentPath.dropFirst(oldPrefix.count)))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -190,6 +190,8 @@ final class VCSTabState {
     private(set) var hasCompletedInitialLoad = false
     @ObservationIgnored private static let commitsPerPage = 100
 
+    // MARK: Lifecycle
+
     init(projectPath: String) {
         self.projectPath = projectPath
         pullRequestAutoSyncMinutes = VCSPersistedSettings.loadAutoSyncMinutes(repoPath: projectPath)
@@ -226,6 +228,8 @@ final class VCSTabState {
             NotificationCenter.default.removeObserver(remoteChangeObserver)
         }
     }
+
+    // MARK: Refresh & watching
 
     private func startWatching() {
         let gitPath = (projectPath as NSString).appendingPathComponent(".git")
@@ -403,6 +407,8 @@ final class VCSTabState {
             || old.deletions != new.deletions
     }
 
+    // MARK: File expansion
+
     func toggleExpanded(filePath: String) {
         if expandedFilePaths.contains(filePath) {
             expandedFilePaths.remove(filePath)
@@ -500,6 +506,8 @@ final class VCSTabState {
         return FileStats(additions: file.additions, deletions: file.deletions, binary: file.isBinary)
     }
 
+    // MARK: Branches
+
     func loadBranches() {
         loadBranchesTask?.cancel()
         isLoadingBranches = true
@@ -563,6 +571,8 @@ final class VCSTabState {
         }
     }
 
+    // MARK: Staging
+
     func stageFile(_ path: String) {
         performGitOperation {
             try await self.git.stageFiles(repoPath: self.projectPath, paths: [path])
@@ -604,6 +614,8 @@ final class VCSTabState {
             try await self.git.discardAll(repoPath: self.projectPath)
         }
     }
+
+    // MARK: Commit, push, pull
 
     func commit() {
         let message = commitMessage.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -687,6 +699,8 @@ final class VCSTabState {
             }
         }
     }
+
+    // MARK: History
 
     func loadCommits() {
         commitLogTask?.cancel()
@@ -807,6 +821,8 @@ final class VCSTabState {
         }
     }
 
+    // MARK: Helpers
+
     private func performGitOperation(_ operation: @escaping () async throws -> Void) {
         Task { [weak self] in
             guard let self else { return }
@@ -820,6 +836,8 @@ final class VCSTabState {
             }
         }
     }
+
+    // MARK: Pull requests
 
     private func fetchPRInfo(branch: String, headSha: String?, forceFresh: Bool) {
         prInfoTask?.cancel()
@@ -1092,6 +1110,8 @@ final class VCSTabState {
         (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 
+    // MARK: Diff loading
+
     private func diffHints(for filePath: String) -> GitRepositoryService.DiffHints {
         guard let file = files.first(where: { $0.path == filePath }) else {
             return .unknown
@@ -1208,6 +1228,8 @@ final class VCSTabState {
             }
         }
     }
+
+    // MARK: Section visibility & collapse
 
     func setChangesVisible(_ visible: Bool) {
         guard changesVisible != visible else { return }

--- a/Muxy/Services/Git/GitRepositoryServicing.swift
+++ b/Muxy/Services/Git/GitRepositoryServicing.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+protocol GitRepositoryServicing {
+    // MARK: Branch state
+
+    func currentBranch(repoPath: String) async throws -> String
+    func headSha(repoPath: String) async -> String?
+    func aheadBehind(repoPath: String, branch: String) async -> GitRepositoryService.AheadBehind
+    func defaultBranch(repoPath: String) async -> String?
+    func listBranches(repoPath: String) async throws -> [String]
+    func switchBranch(repoPath: String, branch: String) async throws
+    func createAndSwitchBranch(repoPath: String, name: String) async throws
+
+    // MARK: Remotes
+
+    func hasRemoteBranch(repoPath: String, branch: String) async -> Bool
+    func listRemoteBranches(repoPath: String) async throws -> [String]
+    func remoteWebURL(repoPath: String, remote: String) async -> URL?
+    func deleteRemoteBranch(repoPath: String, branch: String, remote: String) async throws
+
+    // MARK: Working tree
+
+    func changedFiles(repoPath: String) async throws -> [GitStatusFile]
+    func patchAndCompare(
+        repoPath: String,
+        filePath: String,
+        lineLimit: Int?,
+        hints: GitRepositoryService.DiffHints
+    ) async throws -> GitRepositoryService.PatchAndCompareResult
+
+    // MARK: Staging
+
+    func stageFiles(repoPath: String, paths: [String]) async throws
+    func stageAll(repoPath: String) async throws
+    func unstageFiles(repoPath: String, paths: [String]) async throws
+    func unstageAll(repoPath: String) async throws
+    func discardFiles(repoPath: String, paths: [String], untrackedPaths: [String]) async throws
+    func discardAll(repoPath: String) async throws
+
+    // MARK: Commits
+
+    func commit(repoPath: String, message: String) async throws -> String
+    func push(repoPath: String) async throws
+    func pushSetUpstream(repoPath: String, branch: String) async throws
+    func pull(repoPath: String) async throws
+    func commitLog(repoPath: String, maxCount: Int, skip: Int) async throws -> [GitCommit]
+    func cherryPick(repoPath: String, hash: String) async throws
+    func revert(repoPath: String, hash: String) async throws
+    func createBranch(repoPath: String, name: String, startPoint: String) async throws
+    func createTag(repoPath: String, name: String, hash: String) async throws
+    func checkoutDetached(repoPath: String, hash: String) async throws
+
+    // MARK: Pull requests
+
+    func isGhInstalled() async -> Bool
+    func cachedPullRequestInfo(
+        repoPath: String,
+        branch: String,
+        headSha: String,
+        forceFresh: Bool
+    ) async -> GitRepositoryService.PRInfo?
+    func pullRequestInfo(
+        repoPath: String,
+        branch: String,
+        headSha: String?
+    ) async -> GitRepositoryService.PRInfo?
+    func listPullRequests(
+        repoPath: String,
+        filter: GitRepositoryService.PRListFilter,
+        limit: Int
+    ) async throws -> [GitRepositoryService.PRListItem]
+    func checkoutPullRequest(repoPath: String, number: Int) async throws
+    // swiftlint:disable:next function_parameter_count
+    func createPullRequest(
+        repoPath: String,
+        branch: String,
+        baseBranch: String,
+        title: String,
+        body: String,
+        draft: Bool
+    ) async throws -> GitRepositoryService.PRInfo
+    func mergePullRequest(
+        repoPath: String,
+        number: Int,
+        method: GitRepositoryService.PRMergeMethod,
+        deleteBranch: Bool
+    ) async throws
+    func closePullRequest(repoPath: String, number: Int) async throws
+}
+
+extension GitRepositoryServicing {
+    func remoteWebURL(repoPath: String) async -> URL? {
+        await remoteWebURL(repoPath: repoPath, remote: "origin")
+    }
+
+    func deleteRemoteBranch(repoPath: String, branch: String) async throws {
+        try await deleteRemoteBranch(repoPath: repoPath, branch: branch, remote: "origin")
+    }
+
+    func patchAndCompare(
+        repoPath: String,
+        filePath: String,
+        lineLimit: Int?
+    ) async throws -> GitRepositoryService.PatchAndCompareResult {
+        try await patchAndCompare(
+            repoPath: repoPath,
+            filePath: filePath,
+            lineLimit: lineLimit,
+            hints: .unknown
+        )
+    }
+
+    func commitLog(repoPath: String, maxCount: Int = 100, skip: Int = 0) async throws -> [GitCommit] {
+        try await commitLog(repoPath: repoPath, maxCount: maxCount, skip: skip)
+    }
+
+    func pullRequestInfo(repoPath: String, branch: String) async -> GitRepositoryService.PRInfo? {
+        await pullRequestInfo(repoPath: repoPath, branch: branch, headSha: nil)
+    }
+
+    func listPullRequests(
+        repoPath: String,
+        filter: GitRepositoryService.PRListFilter = .open,
+        limit: Int = 100
+    ) async throws -> [GitRepositoryService.PRListItem] {
+        try await listPullRequests(repoPath: repoPath, filter: filter, limit: limit)
+    }
+
+    func createPullRequest(
+        repoPath: String,
+        branch: String,
+        baseBranch: String,
+        title: String,
+        body: String
+    ) async throws -> GitRepositoryService.PRInfo {
+        try await createPullRequest(
+            repoPath: repoPath,
+            branch: branch,
+            baseBranch: baseBranch,
+            title: title,
+            body: body,
+            draft: false
+        )
+    }
+
+    func mergePullRequest(
+        repoPath: String,
+        number: Int,
+        method: GitRepositoryService.PRMergeMethod = .merge
+    ) async throws {
+        try await mergePullRequest(
+            repoPath: repoPath,
+            number: number,
+            method: method,
+            deleteBranch: true
+        )
+    }
+}
+
+extension GitRepositoryService: GitRepositoryServicing {}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -65,6 +65,8 @@ struct MainWindow: View {
     @AppStorage("muxy.notifications.toastPosition") private var toastPositionRaw = ToastPosition.topCenter.rawValue
     private let trafficLightWidth: CGFloat = 75
 
+    // MARK: View body
+
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
@@ -323,6 +325,8 @@ struct MainWindow: View {
         }
     }
 
+    // MARK: Top bar
+
     private var navigationArrows: some View {
         HStack(spacing: 2) {
             NavigationArrowButton(
@@ -542,6 +546,8 @@ struct MainWindow: View {
         return OpenerPreferences.recents.compactMap { allByID[$0.key] }
     }
 
+    // MARK: Opener (worktree switcher)
+
     private func handleOpenerSelection(_ item: OpenerItem) {
         OpenerPreferences.remember(.init(key: item.id, category: item.category))
         switch item {
@@ -579,6 +585,8 @@ struct MainWindow: View {
             appState.dispatch(.selectTab(projectID: tab.projectID, areaID: tab.areaID, tabID: tab.tabID))
         }
     }
+
+    // MARK: Toast & sidebar layout
 
     private var toastPosition: ToastPosition {
         ToastPosition(rawValue: toastPositionRaw) ?? .topCenter
@@ -681,6 +689,8 @@ struct MainWindow: View {
             .sorted { $0.worktreeID.uuidString < $1.worktreeID.uuidString }
     }
 
+    // MARK: Shortcut handling
+
     private func handleShortcutAction(_ action: ShortcutAction) -> Bool {
         shortcutDispatcher.perform(action, activeProject: activeProject) { project in
             openVCS(for: project)
@@ -731,6 +741,8 @@ struct MainWindow: View {
         else { return nil }
         return fileTreeStates[key]
     }
+
+    // MARK: VCS & file-tree side panels
 
     private func ensureFileTreeState(for project: Project) {
         guard let key = appState.activeWorktreeKey(for: project.id) else { return }
@@ -873,6 +885,8 @@ struct MainWindow: View {
         let worktreeID = appState.activeProjectID.flatMap { appState.activeWorktreeID[$0] }?.uuidString ?? ""
         return "\(projectID):\(worktreeID)"
     }
+
+    // MARK: Close confirmations & alerts
 
     private func presentCloseConfirmation(_ kind: CloseConfirmationKind) {
         guard let window = NSApp.keyWindow ?? NSApp.mainWindow,

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -65,6 +65,8 @@ final class GhosttyTerminalNSView: NSView {
         fatalError("init(coder:) is not supported")
     }
 
+    // MARK: Accessibility & selection
+
     override func accessibilitySelectedText() -> String? {
         readSelectionText()
     }
@@ -86,6 +88,8 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private var pendingSurfaceCreation = false
+
+    // MARK: Surface lifecycle
 
     func createSurface() {
         guard surface == nil, let app = GhosttyService.shared.app else { return }
@@ -388,6 +392,8 @@ final class GhosttyTerminalNSView: NSView {
 
     private var currentTrackingArea: NSTrackingArea?
 
+    // MARK: Keyboard
+
     private func setupTrackingArea() {
         if let existing = currentTrackingArea { removeTrackingArea(existing) }
         let area = NSTrackingArea(
@@ -530,6 +536,8 @@ final class GhosttyTerminalNSView: NSView {
         }
         return false
     }
+
+    // MARK: Mouse & hover
 
     private func mousePoint(from event: NSEvent) -> NSPoint {
         let local = convert(event.locationInWindow, from: nil)
@@ -797,6 +805,8 @@ final class GhosttyTerminalNSView: NSView {
         }
     }
 
+    // MARK: Scroll & input encoding
+
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
         var mods: ghostty_input_scroll_mods_t = 0
@@ -949,6 +959,8 @@ final class GhosttyTerminalNSView: NSView {
         return scalar.value
     }
 
+    // MARK: Search
+
     func sendSearchQuery(_ needle: String) {
         guard let surface else { return }
         let action = "search:\(needle)"
@@ -972,6 +984,8 @@ final class GhosttyTerminalNSView: NSView {
         let action = "start_search"
         ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
     }
+
+    // MARK: Text & key injection
 
     func sendText(_ text: String) {
         guard let surface else { return }

--- a/Tests/MuxyTests/Models/EditorTabPathMigratorTests.swift
+++ b/Tests/MuxyTests/Models/EditorTabPathMigratorTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("EditorTabPathMigrator")
+@MainActor
+struct EditorTabPathMigratorTests {
+    private func makeTempProject() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeEditorTab(projectPath: String, filePath: String) throws -> TerminalTab {
+        try "".write(toFile: filePath, atomically: true, encoding: .utf8)
+        let state = EditorTabState(projectPath: projectPath, filePath: filePath)
+        return TerminalTab(editorState: state)
+    }
+
+    private func makeWorkspaceRoots(tabs: [TerminalTab], projectPath: String) -> [WorktreeKey: SplitNode] {
+        let area = TabArea(projectPath: projectPath, existingTab: tabs[0])
+        for tab in tabs.dropFirst() {
+            area.tabs.append(tab)
+        }
+        let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+        return [key: .tabArea(area)]
+    }
+
+    @Test("renames an exact-match editor tab")
+    func renamesExactMatch() throws {
+        let project = makeTempProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+
+        let oldPath = project.appendingPathComponent("old.txt").path
+        let tab = try makeEditorTab(projectPath: project.path, filePath: oldPath)
+        let roots = makeWorkspaceRoots(tabs: [tab], projectPath: project.path)
+
+        let newPath = project.appendingPathComponent("new.txt").path
+        EditorTabPathMigrator.applyFileMove(from: oldPath, to: newPath, in: roots)
+
+        #expect(tab.content.editorState?.filePath == newPath)
+    }
+
+    @Test("rewrites tabs whose paths are inside a renamed directory")
+    func rewritesNestedPaths() throws {
+        let project = makeTempProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+
+        let oldDir = project.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: oldDir, withIntermediateDirectories: true)
+        let nested = oldDir.appendingPathComponent("a.txt").path
+        let tab = try makeEditorTab(projectPath: project.path, filePath: nested)
+        let roots = makeWorkspaceRoots(tabs: [tab], projectPath: project.path)
+
+        let newDir = project.appendingPathComponent("lib").path
+        EditorTabPathMigrator.applyFileMove(from: oldDir.path, to: newDir, in: roots)
+
+        #expect(tab.content.editorState?.filePath == newDir + "/a.txt")
+    }
+
+    @Test("ignores tabs whose paths only share a prefix without a path boundary")
+    func ignoresPrefixWithoutBoundary() throws {
+        let project = makeTempProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+
+        let foo = project.appendingPathComponent("foo.txt").path
+        let foobar = project.appendingPathComponent("foobar.txt").path
+        let fooTab = try makeEditorTab(projectPath: project.path, filePath: foo)
+        let foobarTab = try makeEditorTab(projectPath: project.path, filePath: foobar)
+        let roots = makeWorkspaceRoots(tabs: [fooTab, foobarTab], projectPath: project.path)
+
+        let movedFoo = project.appendingPathComponent("renamed.txt").path
+        EditorTabPathMigrator.applyFileMove(from: foo, to: movedFoo, in: roots)
+
+        #expect(fooTab.content.editorState?.filePath == movedFoo)
+        #expect(foobarTab.content.editorState?.filePath == foobar)
+    }
+
+    @Test("no-op when oldPath equals newPath")
+    func noOpForIdenticalPaths() throws {
+        let project = makeTempProject()
+        defer { try? FileManager.default.removeItem(at: project) }
+
+        let path = project.appendingPathComponent("x.txt").path
+        let tab = try makeEditorTab(projectPath: project.path, filePath: path)
+        let roots = makeWorkspaceRoots(tabs: [tab], projectPath: project.path)
+
+        EditorTabPathMigrator.applyFileMove(from: path, to: path, in: roots)
+
+        #expect(tab.content.editorState?.filePath == path)
+    }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "refactor": {
+      "source": "github/awesome-copilot",
+      "sourceType": "github",
+      "skillPath": "skills/refactor/SKILL.md",
+      "computedHash": "87789a786b96f99ba0680e89345a975106e10e7db1071c7cdc2e76d507c449d6"
+    },
     "swiftui-expert-skill": {
       "source": "avdlee/swiftui-agent-skill",
       "sourceType": "github",


### PR DESCRIPTION
Adds GitRepositoryServicing protocol over GitRepositoryService and extracts EditorTabPathMigrator from AppState
  with unit tests. Adds // MARK: section dividers to AppState, VCSTabState, MainWindow, and GhosttyTerminalNSView
  for navigation. No behavior changes.