### PR TITLE
Fix frozen pane after merging split panes via drag

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -607,6 +607,17 @@ final class AppState {
             onProjectsEmptied?(effects.projectIDsToRemove)
         }
 
+        for collapse in effects.deferredAreaCollapses {
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      let root = self.workspaceRoots[collapse.key],
+                      let area = root.findArea(id: collapse.areaID),
+                      area.tabs.isEmpty
+                else { return }
+                self.dispatch(.closeArea(projectID: collapse.key.projectID, areaID: collapse.areaID))
+            }
+        }
+
         pruneNavigationHistory()
         recordCurrentNavigationEntry()
 

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -12,9 +12,14 @@ struct WorkspaceState {
 
 @MainActor
 struct WorkspaceSideEffects {
+    struct DeferredAreaCollapse {
+        let key: WorktreeKey
+        let areaID: UUID
+    }
+
     var paneIDsToRemove: [UUID] = []
     var projectIDsToRemove: [UUID] = []
-    var deferredAreaCollapses: [(key: WorktreeKey, areaID: UUID)] = []
+    var deferredAreaCollapses: [DeferredAreaCollapse] = []
 }
 
 @MainActor

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -14,6 +14,7 @@ struct WorkspaceState {
 struct WorkspaceSideEffects {
     var paneIDsToRemove: [UUID] = []
     var projectIDsToRemove: [UUID] = []
+    var deferredAreaCollapses: [(key: WorktreeKey, areaID: UUID)] = []
 }
 
 @MainActor

--- a/Muxy/Models/WorkspaceReducer/SplitReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/SplitReducer.swift
@@ -51,7 +51,7 @@ enum SplitReducer {
             FocusReducer.focusArea(destinationAreaID, key: key, state: &state)
 
             guard sourceArea.tabs.isEmpty else { return }
-            collapseEmptyArea(sourceAreaID, key: key, state: &state, effects: &effects)
+            effects.deferredAreaCollapses.append((key: key, areaID: sourceAreaID))
 
         case let .toNewSplit(tabID, sourceAreaID, targetAreaID, split):
             guard let root = state.workspaceRoots[key],

--- a/Muxy/Models/WorkspaceReducer/SplitReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/SplitReducer.swift
@@ -51,7 +51,7 @@ enum SplitReducer {
             FocusReducer.focusArea(destinationAreaID, key: key, state: &state)
 
             guard sourceArea.tabs.isEmpty else { return }
-            effects.deferredAreaCollapses.append((key: key, areaID: sourceAreaID))
+            effects.deferredAreaCollapses.append(.init(key: key, areaID: sourceAreaID))
 
         case let .toNewSplit(tabID, sourceAreaID, targetAreaID, split):
             guard let root = state.workspaceRoots[key],
@@ -60,12 +60,7 @@ enum SplitReducer {
             else { return }
 
             let shouldCollapseSource = sourceArea.tabs.isEmpty
-            if shouldCollapseSource, sourceAreaID != targetAreaID {
-                collapseEmptyArea(sourceAreaID, key: key, state: &state, effects: &effects)
-            }
-
-            guard let currentRoot = state.workspaceRoots[key] else { return }
-            let (newRoot, newAreaID) = currentRoot.splittingWithTab(
+            let (newRoot, newAreaID) = root.splittingWithTab(
                 areaID: targetAreaID,
                 direction: split.direction,
                 position: split.position,
@@ -77,13 +72,9 @@ enum SplitReducer {
                 FocusReducer.focusArea(newAreaID, key: key, state: &state)
             }
 
-            guard shouldCollapseSource, sourceAreaID == targetAreaID else { return }
-            if let updatedRoot = state.workspaceRoots[key],
-               let emptyArea = updatedRoot.findArea(id: targetAreaID),
-               emptyArea.tabs.isEmpty
-            {
-                collapseEmptyArea(targetAreaID, key: key, state: &state, effects: &effects)
-            }
+            guard shouldCollapseSource else { return }
+            let collapseAreaID = (sourceAreaID == targetAreaID) ? targetAreaID : sourceAreaID
+            effects.deferredAreaCollapses.append(.init(key: key, areaID: collapseAreaID))
         }
     }
 

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -643,6 +643,46 @@ struct WorkspaceReducerTests {
         #expect(root.allAreas().count == 2)
     }
 
+    @Test("moveTab toNewSplit defers collapse when source becomes empty")
+    func moveTabToNewSplitDefersCollapse() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let sourceAreaID = state.focusedAreaID[key]!
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: sourceAreaID,
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+        let targetAreaID = state.focusedAreaID[key]!
+
+        let sourceArea = state.workspaceRoots[key]!.findArea(id: sourceAreaID)!
+        let tabToMove = sourceArea.tabs[0].id
+
+        let effects = WorkspaceReducer.reduce(
+            action: .moveTab(
+                projectID: projectID,
+                request: .toNewSplit(
+                    tabID: tabToMove,
+                    sourceAreaID: sourceAreaID,
+                    targetAreaID: targetAreaID,
+                    split: SplitPlacement(direction: .horizontal, position: .second)
+                )
+            ),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[key]!.findArea(id: sourceAreaID) != nil)
+        #expect(state.workspaceRoots[key]!.findArea(id: sourceAreaID)!.tabs.isEmpty)
+        #expect(effects.deferredAreaCollapses.contains(where: { $0.areaID == sourceAreaID }))
+    }
+
     @Test("selectNextProject cycles forward through projects")
     func selectNextProject() {
         let p1 = Project(name: "A", path: "/a")

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -574,6 +574,43 @@ struct WorkspaceReducerTests {
         #expect(destArea.tabs.contains(where: { $0.id == tabToMove }))
     }
 
+    @Test("moveTab toArea defers collapse of empty source area")
+    func moveTabToAreaDefersCollapse() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let firstAreaID = state.focusedAreaID[key]!
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: firstAreaID,
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+        let secondAreaID = state.focusedAreaID[key]!
+
+        let sourceArea = state.workspaceRoots[key]!.findArea(id: firstAreaID)!
+        let tabToMove = sourceArea.tabs[0].id
+
+        let effects = WorkspaceReducer.reduce(
+            action: .moveTab(
+                projectID: projectID,
+                request: .toArea(tabID: tabToMove, sourceAreaID: firstAreaID, destinationAreaID: secondAreaID)
+            ),
+            state: &state
+        )
+
+        let destArea = state.workspaceRoots[key]!.findArea(id: secondAreaID)!
+        #expect(destArea.tabs.contains(where: { $0.id == tabToMove }))
+        #expect(state.workspaceRoots[key]!.findArea(id: firstAreaID) != nil)
+        #expect(state.workspaceRoots[key]!.findArea(id: firstAreaID)!.tabs.isEmpty)
+        #expect(effects.deferredAreaCollapses.contains(where: { $0.areaID == firstAreaID }))
+    }
+
     @Test("moveTab toNewSplit creates new split with tab")
     func moveTabToNewSplit() {
         let projectID = UUID()


### PR DESCRIPTION
Defer the empty-source-area collapse to the next runloop in SplitReducer.moveTab, so SwiftUI processes the tab
  move on a stable split tree before the structural collapse — avoiding a simultaneous teardown that left the
  merged pane's cached NSView in a broken state.

  Closes #349.