### PR TITLE
Reload markdown preview from disk on demand and on external changes

### DIFF
--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -318,6 +318,7 @@ final class EditorTabState: Identifiable {
                         store.loadFromText(text)
                         backingStore = store
                         backingStoreVersion += 1
+                        previewRefreshVersion += 1
                         refreshReadOnlyStatus()
                         isModified = false
                         isLoading = false
@@ -329,6 +330,7 @@ final class EditorTabState: Identifiable {
                         if let backingStore {
                             backingStore.appendText(text)
                             backingStoreVersion += 1
+                            previewRefreshVersion += 1
                         }
                         if isLoading {
                             isLoading = false
@@ -340,6 +342,7 @@ final class EditorTabState: Identifiable {
                         if let backingStore {
                             backingStore.finishLoading()
                             backingStoreVersion += 1
+                            previewRefreshVersion += 1
                         }
                         refreshReadOnlyStatus()
                         if isLoading {

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct EditorPane: View {
@@ -168,7 +169,7 @@ struct EditorPane: View {
                         guard let projectID = appState.activeProjectID else { return }
                         appState.openMarkdownLinkTarget(path, projectID: projectID, fragment: fragment)
                     },
-                    onReloadFromDisk: { state.reloadFromDisk() }
+                    onReloadFromDisk: { reloadMarkdownFromDisk() }
                 )
             }
         }
@@ -186,6 +187,30 @@ struct EditorPane: View {
         .onAppear { acquireMarkdownPreviewFocusIfNeeded() }
         .onChange(of: focused) { _, _ in acquireMarkdownPreviewFocusIfNeeded() }
         .onChange(of: state.markdownViewMode) { _, _ in acquireMarkdownPreviewFocusIfNeeded() }
+    }
+
+    private func reloadMarkdownFromDisk() {
+        guard state.isModified, !state.hasExternalChange else {
+            state.reloadFromDisk()
+            return
+        }
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
+            state.reloadFromDisk()
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = "Discard Unsaved Changes?"
+        alert.informativeText = "Reloading \(state.fileName) from disk will discard your unsaved changes."
+        alert.alertStyle = .warning
+        alert.icon = NSApp.applicationIconImage
+        alert.addButton(withTitle: "Reload from Disk")
+        alert.addButton(withTitle: "Cancel")
+        alert.buttons[0].keyEquivalent = "\r"
+        alert.buttons[1].keyEquivalent = "\u{1b}"
+        alert.beginSheetModal(for: window) { response in
+            guard response == .alertFirstButtonReturn else { return }
+            state.reloadFromDisk()
+        }
     }
 
     private func acquireMarkdownPreviewFocusIfNeeded() {

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -167,7 +167,8 @@ struct EditorPane: View {
                     onOpenInternalLink: { path, fragment in
                         guard let projectID = appState.activeProjectID else { return }
                         appState.openMarkdownLinkTarget(path, projectID: projectID, fragment: fragment)
-                    }
+                    },
+                    onReloadFromDisk: { state.reloadFromDisk() }
                 )
             }
         }

--- a/Muxy/Views/Markdown/MarkdownTabView.swift
+++ b/Muxy/Views/Markdown/MarkdownTabView.swift
@@ -14,6 +14,41 @@ struct MarkdownPreviewScrollReport: Equatable {
     var maxScrollTop: CGFloat { max(0, scrollHeight - clientHeight) }
 }
 
+final class MarkdownPreviewWebView: WKWebView {
+    var onReloadFromDisk: (() -> Void)?
+
+    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
+        super.willOpenMenu(menu, with: event)
+        for item in menu.items where item.identifier?.rawValue == "WKMenuItemIdentifierReload" {
+            menu.removeItem(item)
+        }
+        let reloadItem = NSMenuItem(
+            title: "Reload",
+            action: #selector(triggerReloadFromDisk),
+            keyEquivalent: "r"
+        )
+        reloadItem.keyEquivalentModifierMask = [.command]
+        reloadItem.target = self
+        menu.insertItem(reloadItem, at: 0)
+        menu.insertItem(NSMenuItem.separator(), at: 1)
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.modifierFlags.contains(.command),
+           event.charactersIgnoringModifiers?.lowercased() == "r"
+        {
+            onReloadFromDisk?()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    @objc
+    private func triggerReloadFromDisk() {
+        onReloadFromDisk?()
+    }
+}
+
 struct MarkdownWebView: NSViewRepresentable {
     struct ContentUpdateRequest {
         let html: String
@@ -53,6 +88,7 @@ struct MarkdownWebView: NSViewRepresentable {
     var onLayoutChanged: (() -> Void)?
     var onAnchorGeometryChanged: (([MarkdownPreviewAnchorGeometry]) -> Void)?
     var onOpenInternalLink: ((String, String?) -> Void)?
+    var onReloadFromDisk: (() -> Void)?
 
     private var configuration: Configuration {
         Configuration(
@@ -86,7 +122,7 @@ struct MarkdownWebView: NSViewRepresentable {
         Coordinator()
     }
 
-    func makeNSView(context: Context) -> WKWebView {
+    func makeNSView(context: Context) -> MarkdownPreviewWebView {
         let config = WKWebViewConfiguration()
         config.setURLSchemeHandler(
             MarkdownAssetSchemeHandler(),
@@ -102,12 +138,13 @@ struct MarkdownWebView: NSViewRepresentable {
         )
         context.coordinator.installBridge(into: config)
 
-        let webView = WKWebView(frame: .zero, configuration: config)
+        let webView = MarkdownPreviewWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.wantsLayer = true
         webView.layer?.backgroundColor = palette.background.cgColor
         webView.setValue(false, forKey: "drawsBackground")
         webView.underPageBackgroundColor = palette.background
+        webView.onReloadFromDisk = onReloadFromDisk
         context.coordinator.configure(with: configuration)
         if scrollSyncEnabled {
             context.coordinator.applyPreferredScroll(
@@ -121,7 +158,8 @@ struct MarkdownWebView: NSViewRepresentable {
         return webView
     }
 
-    func updateNSView(_ webView: WKWebView, context: Context) {
+    func updateNSView(_ webView: MarkdownPreviewWebView, context: Context) {
+        webView.onReloadFromDisk = onReloadFromDisk
         context.coordinator.configure(with: configuration)
         context.coordinator.updateHTML(
             contentUpdateRequest,
@@ -129,8 +167,9 @@ struct MarkdownWebView: NSViewRepresentable {
         )
     }
 
-    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+    static func dismantleNSView(_ webView: MarkdownPreviewWebView, coordinator: Coordinator) {
         webView.navigationDelegate = nil
+        webView.onReloadFromDisk = nil
         webView.configuration.userContentController.removeScriptMessageHandler(forName: MarkdownWebBridge.scrollHandlerName)
         webView.configuration.userContentController.removeScriptMessageHandler(forName: MarkdownWebBridge.linkHandlerName)
         webView.configuration.userContentController

--- a/Tests/MuxyTests/Models/EditorTabStateTests.swift
+++ b/Tests/MuxyTests/Models/EditorTabStateTests.swift
@@ -20,4 +20,36 @@ struct EditorTabStateTests {
         #expect(state.markdownViewMode == .preview)
         #expect(state.markdownScrollSyncEnabled)
     }
+
+    @Test("reloadFromDisk picks up external file changes")
+    func reloadFromDiskPicksUpExternalChanges() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        let fileURL = tempDirectory.appendingPathComponent("notes.md")
+        try "# Old\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let state = EditorTabState(projectPath: tempDirectory.path, filePath: fileURL.path)
+
+        try await waitForLoad(state)
+        #expect(state.backingStore?.fullText() == "# Old\n")
+        let initialPreviewVersion = state.previewRefreshVersion
+
+        try "# New\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        state.reloadFromDisk()
+        try await waitForLoad(state)
+
+        #expect(state.backingStore?.fullText() == "# New\n")
+        #expect(state.previewRefreshVersion > initialPreviewVersion)
+    }
+
+    private func waitForLoad(_ state: EditorTabState, timeout: TimeInterval = 2.0) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while state.isLoading || state.isIncrementalLoading {
+            if Date() >= deadline {
+                throw NSError(domain: "EditorTabStateTests", code: -1, userInfo: [NSLocalizedDescriptionKey: "Load did not finish in time"])
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
 }


### PR DESCRIPTION
Adds a "Reload" item (⌘R) to the markdown preview's right-click menu and ensures the preview re-renders whenever
  the backing store reloads from disk.

  Fixes #359