### PR TITLE
Add OSC 9;4 progress reporting in tabs

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -601,6 +601,7 @@ final class AppState {
 
         for paneID in effects.paneIDsToRemove {
             terminalViews.removeView(for: paneID)
+            TerminalProgressStore.shared.resetPane(paneID)
         }
 
         if !effects.projectIDsToRemove.isEmpty {
@@ -612,6 +613,10 @@ final class AppState {
 
         if let activeTabID = NotificationNavigator.activeTabID(appState: self) {
             NotificationStore.shared.markAsRead(tabID: activeTabID)
+        }
+
+        if let activePaneID = NotificationNavigator.activePaneID(appState: self) {
+            TerminalProgressStore.shared.clearCompletion(for: activePaneID)
         }
 
         saveWorkspaces()

--- a/Muxy/Models/TerminalProgress.swift
+++ b/Muxy/Models/TerminalProgress.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct TerminalProgress: Equatable {
+    enum Kind: Equatable {
+        case set
+        case error
+        case indeterminate
+        case paused
+    }
+
+    let kind: Kind
+    let percent: Int?
+
+    static func clamping(kind: Kind, percent: Int?) -> TerminalProgress {
+        let normalized = percent.map { max(0, min(100, $0)) }
+        return TerminalProgress(kind: kind, percent: normalized)
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -47,6 +47,7 @@ struct MuxyApp: App {
                     NotificationStore.shared.appState = appState
                     NotificationStore.shared.worktreeStore = worktreeStore
                     NotificationStore.shared.markAllAsRead()
+                    TerminalProgressStore.shared.appState = appState
                     appDelegate.onTerminate = { [appState] in
                         appState.saveWorkspaces()
                     }

--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -54,6 +54,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
             return true
         case GHOSTTY_ACTION_OPEN_URL:
             return handleOpenURL(target: target, openURL: action.action.open_url)
+        case GHOSTTY_ACTION_PROGRESS_REPORT:
+            handleProgressReport(target: target, report: action.action.progress_report)
+            return true
         default:
             return false
         }
@@ -177,6 +180,32 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         let value = total.total >= 0 ? Int(total.total) : nil
         DispatchQueue.main.async {
             view.onSearchTotal?(value)
+        }
+    }
+
+    private func handleProgressReport(target: ghostty_target_s, report: ghostty_action_progress_report_s) {
+        guard let view = surfaceView(from: target) else { return }
+        let progress = Self.makeProgress(from: report)
+        DispatchQueue.main.async {
+            view.onProgressReport?(progress)
+        }
+    }
+
+    private static func makeProgress(from report: ghostty_action_progress_report_s) -> TerminalProgress? {
+        let percent: Int? = report.progress >= 0 ? Int(report.progress) : nil
+        switch report.state {
+        case GHOSTTY_PROGRESS_STATE_REMOVE:
+            return nil
+        case GHOSTTY_PROGRESS_STATE_SET:
+            return TerminalProgress.clamping(kind: .set, percent: percent)
+        case GHOSTTY_PROGRESS_STATE_ERROR:
+            return TerminalProgress.clamping(kind: .error, percent: percent)
+        case GHOSTTY_PROGRESS_STATE_INDETERMINATE:
+            return TerminalProgress(kind: .indeterminate, percent: nil)
+        case GHOSTTY_PROGRESS_STATE_PAUSE:
+            return TerminalProgress.clamping(kind: .paused, percent: percent)
+        default:
+            return nil
         }
     }
 

--- a/Muxy/Services/NotificationNavigator.swift
+++ b/Muxy/Services/NotificationNavigator.swift
@@ -74,6 +74,17 @@ enum NotificationNavigator {
         return area.activeTabID
     }
 
+    static func activePaneID(appState: AppState) -> UUID? {
+        guard let projectID = appState.activeProjectID,
+              let key = appState.activeWorktreeKey(for: projectID),
+              let areaID = appState.focusedAreaID[key],
+              let area = appState.workspaceRoots[key]?.findArea(id: areaID),
+              let activeTabID = area.activeTabID,
+              let tab = area.tabs.first(where: { $0.id == activeTabID })
+        else { return nil }
+        return tab.content.pane?.id
+    }
+
     static func isActiveTab(_ tabID: UUID, appState: AppState) -> Bool {
         activeTabID(appState: appState) == tabID
     }

--- a/Muxy/Services/TerminalProgressStore.swift
+++ b/Muxy/Services/TerminalProgressStore.swift
@@ -1,0 +1,74 @@
+import AppKit
+import Foundation
+
+@MainActor
+@Observable
+final class TerminalProgressStore {
+    static let shared = TerminalProgressStore()
+
+    var appState: AppState?
+
+    private(set) var progresses: [UUID: TerminalProgress] = [:]
+    private(set) var completionPending: Set<UUID> = []
+    private var paneToProject: [UUID: UUID] = [:]
+    private(set) var lastCompletionAt: [UUID: Date] = [:]
+
+    init() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.clearActivePaneCompletion()
+            }
+        }
+    }
+
+    private func clearActivePaneCompletion() {
+        guard let appState, let paneID = NotificationNavigator.activePaneID(appState: appState) else { return }
+        clearCompletion(for: paneID)
+    }
+
+    func setProgress(_ progress: TerminalProgress?, for paneID: UUID, projectID: UUID?) {
+        let existing = progresses[paneID]
+
+        if let projectID {
+            paneToProject[paneID] = projectID
+        }
+
+        if let progress {
+            progresses[paneID] = progress
+            return
+        }
+
+        progresses.removeValue(forKey: paneID)
+        guard existing != nil else { return }
+        completionPending.insert(paneID)
+        lastCompletionAt[paneID] = Date()
+    }
+
+    func clearCompletion(for paneID: UUID) {
+        completionPending.remove(paneID)
+        lastCompletionAt.removeValue(forKey: paneID)
+    }
+
+    func resetPane(_ paneID: UUID) {
+        progresses.removeValue(forKey: paneID)
+        completionPending.remove(paneID)
+        paneToProject.removeValue(forKey: paneID)
+        lastCompletionAt.removeValue(forKey: paneID)
+    }
+
+    func progress(for paneID: UUID) -> TerminalProgress? {
+        progresses[paneID]
+    }
+
+    func isCompletionPending(for paneID: UUID) -> Bool {
+        completionPending.contains(paneID)
+    }
+
+    func hasCompletionPending(for projectID: UUID) -> Bool {
+        completionPending.contains { paneToProject[$0] == projectID }
+    }
+}

--- a/Muxy/Services/TerminalProgressStore.swift
+++ b/Muxy/Services/TerminalProgressStore.swift
@@ -11,10 +11,10 @@ final class TerminalProgressStore {
     private(set) var progresses: [UUID: TerminalProgress] = [:]
     private(set) var completionPending: Set<UUID> = []
     private var paneToProject: [UUID: UUID] = [:]
-    private(set) var lastCompletionAt: [UUID: Date] = [:]
+    nonisolated(unsafe) private var didBecomeActiveObserver: NSObjectProtocol?
 
     init() {
-        NotificationCenter.default.addObserver(
+        didBecomeActiveObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,
             queue: .main
@@ -22,6 +22,12 @@ final class TerminalProgressStore {
             Task { @MainActor in
                 self?.clearActivePaneCompletion()
             }
+        }
+    }
+
+    deinit {
+        if let didBecomeActiveObserver {
+            NotificationCenter.default.removeObserver(didBecomeActiveObserver)
         }
     }
 
@@ -45,19 +51,16 @@ final class TerminalProgressStore {
         progresses.removeValue(forKey: paneID)
         guard existing != nil else { return }
         completionPending.insert(paneID)
-        lastCompletionAt[paneID] = Date()
     }
 
     func clearCompletion(for paneID: UUID) {
         completionPending.remove(paneID)
-        lastCompletionAt.removeValue(forKey: paneID)
     }
 
     func resetPane(_ paneID: UUID) {
         progresses.removeValue(forKey: paneID)
         completionPending.remove(paneID)
         paneToProject.removeValue(forKey: paneID)
-        lastCompletionAt.removeValue(forKey: paneID)
     }
 
     func progress(for paneID: UUID) -> TerminalProgress? {

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -201,6 +201,7 @@ struct ExpandedProjectRow: View {
     private var projectIcon: some View {
         let logo = resolvedLogo
         let unread = NotificationStore.shared.unreadCount(for: project.id)
+        let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
             RoundedRectangle(cornerRadius: 6)
                 .fill(iconBackground(hasLogo: logo != nil))
@@ -222,6 +223,11 @@ struct ExpandedProjectRow: View {
             if unread > 0 {
                 NotificationBadge(count: unread)
                     .offset(x: 4, y: -4)
+            } else if hasCompletion {
+                Circle()
+                    .fill(MuxyTheme.accent)
+                    .frame(width: 8, height: 8)
+                    .offset(x: 2, y: -2)
             }
         }
     }

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -145,6 +145,7 @@ struct ProjectRow: View {
     private var projectIcon: some View {
         let logo = resolvedLogo
         let unread = NotificationStore.shared.unreadCount(for: project.id)
+        let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
             RoundedRectangle(cornerRadius: 6)
                 .fill(iconBackground(hasLogo: logo != nil))
@@ -167,6 +168,11 @@ struct ProjectRow: View {
             if unread > 0 {
                 NotificationBadge(count: unread)
                     .offset(x: 4, y: -4)
+            } else if hasCompletion {
+                Circle()
+                    .fill(MuxyTheme.accent)
+                    .frame(width: 8, height: 8)
+                    .offset(x: 2, y: -2)
             }
         }
         .overlay {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -17,6 +17,7 @@ final class GhosttyTerminalNSView: NSView {
     var onSearchEnd: (() -> Void)?
     var onSearchTotal: ((Int?) -> Void)?
     var onSearchSelected: ((Int?) -> Void)?
+    var onProgressReport: ((TerminalProgress?) -> Void)?
     var onCmdClickFile: ((String) -> Void)?
     var resolveCmdHoverFile: ((String) -> Bool)?
     var onOpenURL: ((URL) -> Bool)?
@@ -182,6 +183,7 @@ final class GhosttyTerminalNSView: NSView {
         onSearchEnd = nil
         onSearchTotal = nil
         onSearchSelected = nil
+        onProgressReport = nil
         if let observer = screenChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             screenChangeObserver = nil

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -159,6 +159,7 @@ struct TerminalBridge: NSViewRepresentable {
         }
         configureSearchCallbacks(view)
         configureFileOpenCallback(view)
+        configureProgressCallback(view)
         context.coordinator.wasFocused = focused
         if focused, !overlayActive {
             view.notifySurfaceFocused()
@@ -196,6 +197,7 @@ struct TerminalBridge: NSViewRepresentable {
         }
         configureSearchCallbacks(nsView)
         configureFileOpenCallback(nsView)
+        configureProgressCallback(nsView)
         let wasFocused = context.coordinator.wasFocused
         let wasOverlayActive = context.coordinator.wasOverlayActive
         context.coordinator.wasFocused = focused
@@ -284,6 +286,16 @@ struct TerminalBridge: NSViewRepresentable {
         guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory) else { return nil }
         guard !isDirectory.boolValue else { return nil }
         return candidate
+    }
+
+    private func configureProgressCallback(_ view: GhosttyTerminalNSView) {
+        let paneID = state.id
+        let projectID = worktreeKey?.projectID
+        view.onProgressReport = { progress in
+            Task { @MainActor in
+                TerminalProgressStore.shared.setProgress(progress, for: paneID, projectID: projectID)
+            }
+        }
     }
 
     private func configureSearchCallbacks(_ view: GhosttyTerminalNSView) {

--- a/Muxy/Views/Terminal/TerminalProgressCircle.swift
+++ b/Muxy/Views/Terminal/TerminalProgressCircle.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct TerminalProgressCircle: View {
+    let progress: TerminalProgress
+    var size: CGFloat = 12
+    var lineWidth: CGFloat = 1.5
+
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(tintColor.opacity(0.25), lineWidth: lineWidth)
+
+            if progress.kind == .indeterminate {
+                Circle()
+                    .trim(from: 0, to: 0.28)
+                    .stroke(tintColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                    .rotationEffect(.degrees(rotation))
+            } else {
+                Circle()
+                    .trim(from: 0, to: trimEnd)
+                    .stroke(tintColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .animation(.easeInOut(duration: 0.2), value: trimEnd)
+            }
+        }
+        .frame(width: size, height: size)
+        .onAppear {
+            guard progress.kind == .indeterminate else { return }
+            startSpin()
+        }
+        .onChange(of: progress.kind) { _, kind in
+            guard kind == .indeterminate else { return }
+            startSpin()
+        }
+        .accessibilityElement()
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var trimEnd: CGFloat {
+        let value = CGFloat(progress.percent ?? 100) / 100
+        return max(0.001, min(1, value))
+    }
+
+    private var tintColor: Color {
+        switch progress.kind {
+        case .set,
+             .indeterminate: MuxyTheme.accent
+        case .error: Color(nsColor: .systemRed)
+        case .paused: MuxyTheme.warning
+        }
+    }
+
+    private var accessibilityLabel: String {
+        switch progress.kind {
+        case .set: "Progress \(progress.percent ?? 0) percent"
+        case .error: "Progress error"
+        case .indeterminate: "Working"
+        case .paused: "Progress paused"
+        }
+    }
+
+    private func startSpin() {
+        rotation = 0
+        withAnimation(.linear(duration: 1.0).repeatForever(autoreverses: false)) {
+            rotation = 360
+        }
+    }
+}

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -337,7 +337,7 @@ private struct TabCell: View {
     @State private var completionFlashOn = false
     @State private var flashTask: Task<Void, any Error>?
     @FocusState private var renameFieldFocused: Bool
-    @Bindable private var progressStore = TerminalProgressStore.shared
+    private let progressStore = TerminalProgressStore.shared
 
     private static let springLoadDelay: Duration = .milliseconds(250)
 
@@ -583,6 +583,9 @@ private struct TabCell: View {
         flashTask?.cancel()
         withAnimation(.easeIn(duration: 0.15)) {
             completionFlashOn = true
+        }
+        if active, let paneID = tab.paneID {
+            progressStore.clearCompletion(for: paneID)
         }
         flashTask = Task { @MainActor in
             try await Task.sleep(for: .milliseconds(450))

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 struct PaneTabStrip: View {
     struct TabSnapshot: Identifiable {
         let id: UUID
+        let paneID: UUID?
         let title: String
         let kind: TerminalTab.Kind
         let isPinned: Bool
@@ -44,6 +45,7 @@ struct PaneTabStrip: View {
         tabs.map { tab in
             TabSnapshot(
                 id: tab.id,
+                paneID: tab.content.pane?.id,
                 title: tab.title,
                 kind: tab.kind,
                 isPinned: tab.isPinned,
@@ -332,7 +334,10 @@ private struct TabCell: View {
     @State private var measuredWidth: CGFloat = TabCell.maxWidth
     @State private var externalDragOverCell = false
     @State private var springLoadTask: Task<Void, any Error>?
+    @State private var completionFlashOn = false
+    @State private var flashTask: Task<Void, any Error>?
     @FocusState private var renameFieldFocused: Bool
+    @Bindable private var progressStore = TerminalProgressStore.shared
 
     private static let springLoadDelay: Duration = .milliseconds(250)
 
@@ -362,6 +367,16 @@ private struct TabCell: View {
         return nil
     }
 
+    private var paneProgress: TerminalProgress? {
+        guard let paneID = tab.paneID else { return nil }
+        return progressStore.progress(for: paneID)
+    }
+
+    private var hasCompletionPending: Bool {
+        guard let paneID = tab.paneID else { return false }
+        return progressStore.isCompletionPending(for: paneID)
+    }
+
     private var showBadge: Bool {
         guard let shortcutIndex,
               let action = ShortcutAction.tabAction(for: shortcutIndex)
@@ -378,7 +393,7 @@ private struct TabCell: View {
                     .foregroundStyle(active ? MuxyTheme.fg : MuxyTheme.fgMuted)
                     .opacity(titleHidden && hovered && !tab.isPinned ? 0 : 1)
                     .overlay(alignment: .topTrailing) {
-                        if hasUnread, !active {
+                        if hasUnread || hasCompletionPending, !active {
                             Circle()
                                 .fill(MuxyTheme.accent)
                                 .frame(width: 6, height: 6)
@@ -416,17 +431,8 @@ private struct TabCell: View {
             }
             .onPreferenceChange(TabWidthPreferenceKey.self) { measuredWidth = $0 }
             .overlay(alignment: titleHidden ? .center : .trailing) {
-                if !tab.isPinned {
-                    let visible = titleHidden ? hovered : (active || hovered)
-                    Image(systemName: "xmark")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(MuxyTheme.fgDim)
-                        .padding(.trailing, titleHidden ? 0 : 10)
-                        .opacity(visible ? 1 : 0)
-                        .onTapGesture(perform: onClose)
-                        .accessibilityLabel("Close Tab")
-                        .accessibilityAddTraits(.isButton)
-                }
+                trailingAccessory
+                    .padding(.trailing, titleHidden ? 0 : 10)
             }
             .overlay {
                 if showBadge, let shortcutIndex,
@@ -444,6 +450,13 @@ private struct TabCell: View {
                 }
             }
             .background(tabBackground)
+            .overlay {
+                Rectangle()
+                    .fill(MuxyTheme.accent)
+                    .opacity(completionFlashOn ? 0.18 : 0)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
             .contentShape(Rectangle())
             .onHover { hovering in
                 guard !isAnyDragging else { return }
@@ -510,8 +523,13 @@ private struct TabCell: View {
         .onChange(of: externalDragOverCell) { _, hovering in
             handleExternalDragHover(hovering: hovering)
         }
+        .onChange(of: hasCompletionPending) { _, pending in
+            guard pending else { return }
+            triggerCompletionFlash()
+        }
         .onDisappear {
             springLoadTask?.cancel()
+            flashTask?.cancel()
         }
     }
 
@@ -532,6 +550,45 @@ private struct TabCell: View {
         springLoadTask = Task { @MainActor in
             try await Task.sleep(for: Self.springLoadDelay)
             onSelect()
+        }
+    }
+
+    private var closeButtonVisible: Bool {
+        guard !tab.isPinned else { return false }
+        if paneProgress != nil { return hovered }
+        return titleHidden ? hovered : (active || hovered)
+    }
+
+    private var trailingAccessory: some View {
+        ZStack {
+            if !tab.isPinned {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(MuxyTheme.fgDim)
+                    .opacity(closeButtonVisible ? 1 : 0)
+                    .allowsHitTesting(closeButtonVisible)
+                    .onTapGesture(perform: onClose)
+                    .accessibilityLabel("Close Tab")
+                    .accessibilityAddTraits(.isButton)
+            }
+            if let progress = paneProgress, !closeButtonVisible {
+                TerminalProgressCircle(progress: progress)
+                    .transition(.opacity)
+            }
+        }
+        .frame(width: 14, height: 14)
+    }
+
+    private func triggerCompletionFlash() {
+        flashTask?.cancel()
+        withAnimation(.easeIn(duration: 0.15)) {
+            completionFlashOn = true
+        }
+        flashTask = Task { @MainActor in
+            try await Task.sleep(for: .milliseconds(450))
+            withAnimation(.easeOut(duration: 0.4)) {
+                completionFlashOn = false
+            }
         }
     }
 

--- a/Tests/MuxyTests/Services/TerminalProgressStoreTests.swift
+++ b/Tests/MuxyTests/Services/TerminalProgressStoreTests.swift
@@ -90,7 +90,6 @@ struct TerminalProgressStoreTests {
     func scopesByProject() {
         let store = TerminalProgressStore()
         let paneA = UUID()
-        let paneB = UUID()
         let projectA = UUID()
         let projectB = UUID()
 
@@ -99,7 +98,5 @@ struct TerminalProgressStoreTests {
 
         #expect(store.hasCompletionPending(for: projectA))
         #expect(!store.hasCompletionPending(for: projectB))
-
-        _ = paneB
     }
 }

--- a/Tests/MuxyTests/Services/TerminalProgressStoreTests.swift
+++ b/Tests/MuxyTests/Services/TerminalProgressStoreTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("TerminalProgressStore")
+struct TerminalProgressStoreTests {
+    @Test("setProgress stores active progress")
+    func storesProgress() {
+        let store = TerminalProgressStore()
+        let pane = UUID()
+        let project = UUID()
+
+        store.setProgress(.clamping(kind: .set, percent: 42), for: pane, projectID: project)
+
+        #expect(store.progress(for: pane) == TerminalProgress(kind: .set, percent: 42))
+        #expect(!store.isCompletionPending(for: pane))
+    }
+
+    @Test("clamps percent into 0...100")
+    func clampsPercent() {
+        let low = TerminalProgress.clamping(kind: .set, percent: -5)
+        let high = TerminalProgress.clamping(kind: .set, percent: 250)
+        let nilValue = TerminalProgress.clamping(kind: .set, percent: nil)
+
+        #expect(low.percent == 0)
+        #expect(high.percent == 100)
+        #expect(nilValue.percent == nil)
+    }
+
+    @Test("transition from active to nil marks completion-pending")
+    func marksCompletion() {
+        let store = TerminalProgressStore()
+        let pane = UUID()
+        let project = UUID()
+
+        store.setProgress(.clamping(kind: .set, percent: 80), for: pane, projectID: project)
+        store.setProgress(nil, for: pane, projectID: project)
+
+        #expect(store.progress(for: pane) == nil)
+        #expect(store.isCompletionPending(for: pane))
+        #expect(store.hasCompletionPending(for: project))
+    }
+
+    @Test("nil progress without prior active does not mark completion")
+    func noFalseCompletion() {
+        let store = TerminalProgressStore()
+        let pane = UUID()
+        let project = UUID()
+
+        store.setProgress(nil, for: pane, projectID: project)
+
+        #expect(!store.isCompletionPending(for: pane))
+        #expect(!store.hasCompletionPending(for: project))
+    }
+
+    @Test("clearCompletion removes pending state")
+    func clearsCompletion() {
+        let store = TerminalProgressStore()
+        let pane = UUID()
+        let project = UUID()
+
+        store.setProgress(.clamping(kind: .indeterminate, percent: nil), for: pane, projectID: project)
+        store.setProgress(nil, for: pane, projectID: project)
+
+        store.clearCompletion(for: pane)
+
+        #expect(!store.isCompletionPending(for: pane))
+        #expect(!store.hasCompletionPending(for: project))
+    }
+
+    @Test("resetPane clears all per-pane state")
+    func resetsPane() {
+        let store = TerminalProgressStore()
+        let pane = UUID()
+        let project = UUID()
+
+        store.setProgress(.clamping(kind: .set, percent: 30), for: pane, projectID: project)
+        store.setProgress(nil, for: pane, projectID: project)
+
+        store.resetPane(pane)
+
+        #expect(store.progress(for: pane) == nil)
+        #expect(!store.isCompletionPending(for: pane))
+        #expect(!store.hasCompletionPending(for: project))
+    }
+
+    @Test("hasCompletionPending scopes by project")
+    func scopesByProject() {
+        let store = TerminalProgressStore()
+        let paneA = UUID()
+        let paneB = UUID()
+        let projectA = UUID()
+        let projectB = UUID()
+
+        store.setProgress(.clamping(kind: .set, percent: 50), for: paneA, projectID: projectA)
+        store.setProgress(nil, for: paneA, projectID: projectA)
+
+        #expect(store.hasCompletionPending(for: projectA))
+        #expect(!store.hasCompletionPending(for: projectB))
+
+        _ = paneB
+    }
+}

--- a/docs/developer/architecture/ghostty-integration.md
+++ b/docs/developer/architecture/ghostty-integration.md
@@ -32,6 +32,10 @@ sequenceDiagram
 | `GhosttyRuntimeEventAdapter` | C callback bridge. Dispatches OSC/desktop-notification + `GHOSTTY_ACTION_PWD` events back to Swift. |
 | `TerminalViewRegistry` | Tracks live surfaces; performs `paneID(for:)` reverse lookup for notifications and remote routing. |
 
+## Progress reporting (OSC 9;4)
+
+`GHOSTTY_ACTION_PROGRESS_REPORT` events flow through `GhosttyRuntimeEventAdapter` into `TerminalProgressStore`, keyed by pane ID. The store tracks active progress, records completion-pending state when progress transitions back to `REMOVE`, and aggregates by project for the sidebar dot. Each tab renders a `TerminalProgressCircle` in its trailing slot (the close-button position); hover reveals the close button. Project icons surface a dot until the user opens the completed pane.
+
 ## Working-directory tracking
 
 When a user runs `cd` inside a terminal, libghostty emits `GHOSTTY_ACTION_PWD`. `GhosttyRuntimeEventAdapter` forwards that to `TerminalPane`, which updates `TerminalPaneState.currentWorkingDirectory`. The cwd is persisted via `TerminalTabSnapshot`, so reopening the workspace lands each pane in its last-used directory.


### PR DESCRIPTION
Surfaces libghostty's progress reports (OSC 9;4) in the UI: each tab shows a circular indicator in its trailing
  slot (replacing the close button until hover), and the project sidebar shows a dot when a tab has completed.
  Closes #358.