### PR TITLE
Auto-refresh worktrees when VCS refreshes

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -19,6 +19,7 @@ extension Notification.Name {
     static let toggleNotificationPanel = Notification.Name("MuxyToggleNotificationPanel")
     static let toggleAIUsage = Notification.Name("MuxyToggleAIUsage")
     static let vcsRepoDidChange = Notification.Name("MuxyVCSRepoDidChange")
+    static let vcsDidRefresh = Notification.Name("MuxyVCSDidRefresh")
     static let externalDragHoverChanged = Notification.Name("MuxyExternalDragHoverChanged")
 }
 

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -381,6 +381,14 @@ final class VCSTabState {
                 for path in expandedFilePaths where validPaths.contains(path) {
                     loadDiff(filePath: path, forceFull: false)
                 }
+
+                if !incremental {
+                    NotificationCenter.default.post(
+                        name: .vcsDidRefresh,
+                        object: nil,
+                        userInfo: ["repoPath": projectPath]
+                    )
+                }
             } catch {
                 guard !Task.isCancelled else { return }
                 files = []

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -9,6 +9,7 @@ struct MuxyApp: App {
     @State private var appState: AppState
     @State private var projectStore: ProjectStore
     @State private var worktreeStore: WorktreeStore
+    @State private var vcsWorktreeAutoRefresher: VCSWorktreeAutoRefresher
     private let updateService = UpdateService.shared
 
     init() {
@@ -28,9 +29,15 @@ struct MuxyApp: App {
             projects: projectStore.projects,
             worktrees: worktreeStore.worktrees
         )
+        let vcsWorktreeAutoRefresher = VCSWorktreeAutoRefresher(
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        )
         _appState = State(initialValue: appState)
         _projectStore = State(initialValue: projectStore)
         _worktreeStore = State(initialValue: worktreeStore)
+        _vcsWorktreeAutoRefresher = State(initialValue: vcsWorktreeAutoRefresher)
     }
 
     var body: some Scene {

--- a/Muxy/Services/VCSWorktreeAutoRefresher.swift
+++ b/Muxy/Services/VCSWorktreeAutoRefresher.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+@MainActor
+final class VCSWorktreeAutoRefresher {
+    private let appState: AppState
+    private let projectStore: ProjectStore
+    private let worktreeStore: WorktreeStore
+    nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
+
+    init(appState: AppState, projectStore: ProjectStore, worktreeStore: WorktreeStore) {
+        self.appState = appState
+        self.projectStore = projectStore
+        self.worktreeStore = worktreeStore
+        observe(.vcsDidRefresh)
+        observe(.vcsRepoDidChange)
+    }
+
+    deinit {
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func observe(_ name: Notification.Name) {
+        let token = NotificationCenter.default.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let path = notification.userInfo?["repoPath"] as? String else { return }
+            MainActor.assumeIsolated {
+                self?.handleRefresh(repoPath: path)
+            }
+        }
+        observers.append(token)
+    }
+
+    private func handleRefresh(repoPath: String) {
+        guard let projectID = worktreeStore.projectID(forWorktreePath: repoPath) else { return }
+        guard let project = projectStore.projects.first(where: { $0.id == projectID }) else { return }
+        Task { [appState, worktreeStore] in
+            await WorktreeRefreshHelper.refresh(
+                project: project,
+                appState: appState,
+                worktreeStore: worktreeStore,
+                isRefreshing: nil,
+                presentErrors: false
+            )
+        }
+    }
+}

--- a/Muxy/Services/VCSWorktreeAutoRefresher.swift
+++ b/Muxy/Services/VCSWorktreeAutoRefresher.swift
@@ -6,6 +6,8 @@ final class VCSWorktreeAutoRefresher {
     private let projectStore: ProjectStore
     private let worktreeStore: WorktreeStore
     nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
+    private var inFlight: Set<UUID> = []
+    private var pending: Set<UUID> = []
 
     init(appState: AppState, projectStore: ProjectStore, worktreeStore: WorktreeStore) {
         self.appState = appState
@@ -38,7 +40,16 @@ final class VCSWorktreeAutoRefresher {
     private func handleRefresh(repoPath: String) {
         guard let projectID = worktreeStore.projectID(forWorktreePath: repoPath) else { return }
         guard let project = projectStore.projects.first(where: { $0.id == projectID }) else { return }
-        Task { [appState, worktreeStore] in
+        guard !inFlight.contains(projectID) else {
+            pending.insert(projectID)
+            return
+        }
+        runRefresh(project: project)
+    }
+
+    private func runRefresh(project: Project) {
+        inFlight.insert(project.id)
+        Task { [appState, worktreeStore, projectStore] in
             await WorktreeRefreshHelper.refresh(
                 project: project,
                 appState: appState,
@@ -46,6 +57,10 @@ final class VCSWorktreeAutoRefresher {
                 isRefreshing: nil,
                 presentErrors: false
             )
+            inFlight.remove(project.id)
+            guard pending.remove(project.id) != nil else { return }
+            guard let updated = projectStore.projects.first(where: { $0.id == project.id }) else { return }
+            runRefresh(project: updated)
         }
     }
 }

--- a/Muxy/Views/Sidebar/WorktreeRefreshHelper.swift
+++ b/Muxy/Views/Sidebar/WorktreeRefreshHelper.swift
@@ -1,5 +1,8 @@
 import AppKit
+import os
 import SwiftUI
+
+private let logger = Logger(subsystem: "app.muxy", category: "WorktreeRefreshHelper")
 
 @MainActor
 enum WorktreeRefreshHelper {
@@ -26,7 +29,11 @@ enum WorktreeRefreshHelper {
                 appState.removeWorktree(projectID: project.id, worktree: worktree, replacement: replacement)
             }
         } catch {
-            guard presentErrors else { return }
+            guard presentErrors else {
+                logger
+                    .error("Worktree refresh failed for \(project.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return
+            }
             presentError(error.localizedDescription)
         }
     }

--- a/Muxy/Views/Sidebar/WorktreeRefreshHelper.swift
+++ b/Muxy/Views/Sidebar/WorktreeRefreshHelper.swift
@@ -7,12 +7,13 @@ enum WorktreeRefreshHelper {
         project: Project,
         appState: AppState,
         worktreeStore: WorktreeStore,
-        isRefreshing: Binding<Bool>
+        isRefreshing: Binding<Bool>? = nil,
+        presentErrors: Bool = true
     ) async {
-        guard !isRefreshing.wrappedValue else { return }
+        if isRefreshing?.wrappedValue == true { return }
         let previous = worktreeStore.list(for: project.id)
-        isRefreshing.wrappedValue = true
-        defer { isRefreshing.wrappedValue = false }
+        isRefreshing?.wrappedValue = true
+        defer { isRefreshing?.wrappedValue = false }
 
         do {
             let refreshed = try await worktreeStore.refreshFromGit(project: project)
@@ -25,6 +26,7 @@ enum WorktreeRefreshHelper {
                 appState.removeWorktree(projectID: project.id, worktree: worktree, replacement: replacement)
             }
         } catch {
+            guard presentErrors else { return }
             presentError(error.localizedDescription)
         }
     }

--- a/Tests/MuxyTests/Services/VCSWorktreeAutoRefresherTests.swift
+++ b/Tests/MuxyTests/Services/VCSWorktreeAutoRefresherTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import MuxyShared
+import Testing
+
+@testable import Muxy
+
+@Suite("VCSWorktreeAutoRefresher")
+@MainActor
+struct VCSWorktreeAutoRefresherTests {
+    @Test(".vcsDidRefresh triggers refreshFromGit for the matching project")
+    func vcsDidRefreshTriggersRefresh() async {
+        let context = makeContext()
+        await runRefresh(context: context, notification: .vcsDidRefresh)
+        await #expect(context.gitService.callCount(forRepoPath: context.project.path) == 1)
+        #expect(context.worktreeStore.list(for: context.project.id).contains { $0.path == context.featurePath })
+    }
+
+    @Test(".vcsRepoDidChange triggers refreshFromGit for the matching project")
+    func vcsRepoDidChangeTriggersRefresh() async {
+        let context = makeContext()
+        await runRefresh(context: context, notification: .vcsRepoDidChange)
+        await #expect(context.gitService.callCount(forRepoPath: context.project.path) == 1)
+        #expect(context.worktreeStore.list(for: context.project.id).contains { $0.path == context.featurePath })
+    }
+
+    @Test("notification with unknown repoPath is a no-op")
+    func unknownRepoPathIsNoOp() async {
+        let context = makeContext()
+        NotificationCenter.default.post(
+            name: .vcsDidRefresh,
+            object: nil,
+            userInfo: ["repoPath": "/tmp/muxy-test-unknown-\(UUID().uuidString)"]
+        )
+        await drainMainQueue()
+        await #expect(context.gitService.callCount(forRepoPath: context.project.path) == 0)
+        #expect(context.worktreeStore.list(for: context.project.id).count == 1)
+    }
+
+    private func runRefresh(context: Context, notification: Notification.Name) async {
+        NotificationCenter.default.post(
+            name: notification,
+            object: nil,
+            userInfo: ["repoPath": context.project.path]
+        )
+        await context.gitService.awaitCall(forRepoPath: context.project.path)
+        await drainMainQueue()
+    }
+
+    private func drainMainQueue() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async {
+                DispatchQueue.main.async {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    private func makeContext() -> Context {
+        let suffix = UUID().uuidString
+        let projectPath = "/tmp/muxy-test-repo-\(suffix)"
+        let featurePath = "/tmp/muxy-test-repo-\(suffix)-feature-x"
+        let project = Project(name: "Repo", path: projectPath)
+        let projectStore = ProjectStore(persistence: ProjectPersistenceStub(initial: [project]))
+        let gitService = TrackingGitWorktreeListingStub(recordsByRepoPath: [
+            projectPath: [
+                GitWorktreeRecord(
+                    path: projectPath,
+                    branch: "main",
+                    head: nil,
+                    isBare: false,
+                    isDetached: false
+                ),
+                GitWorktreeRecord(
+                    path: featurePath,
+                    branch: "feature-x",
+                    head: nil,
+                    isBare: false,
+                    isDetached: false
+                ),
+            ]
+        ])
+        let worktreeStore = WorktreeStore(
+            persistence: WorktreePersistenceStub(initial: [
+                project.id: [Worktree(name: project.name, path: project.path, isPrimary: true)]
+            ]),
+            listGitWorktrees: gitService.listWorktrees,
+            projects: [project]
+        )
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let refresher = VCSWorktreeAutoRefresher(
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        )
+        return Context(
+            project: project,
+            featurePath: featurePath,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            appState: appState,
+            gitService: gitService,
+            refresher: refresher
+        )
+    }
+
+    @MainActor
+    private final class Context {
+        let project: Project
+        let featurePath: String
+        let projectStore: ProjectStore
+        let worktreeStore: WorktreeStore
+        let appState: AppState
+        let gitService: TrackingGitWorktreeListingStub
+        let refresher: VCSWorktreeAutoRefresher
+
+        init(
+            project: Project,
+            featurePath: String,
+            projectStore: ProjectStore,
+            worktreeStore: WorktreeStore,
+            appState: AppState,
+            gitService: TrackingGitWorktreeListingStub,
+            refresher: VCSWorktreeAutoRefresher
+        ) {
+            self.project = project
+            self.featurePath = featurePath
+            self.projectStore = projectStore
+            self.worktreeStore = worktreeStore
+            self.appState = appState
+            self.gitService = gitService
+            self.refresher = refresher
+        }
+    }
+}
+
+private actor GitWorktreeCallTracker {
+    private let recordsByRepoPath: [String: [GitWorktreeRecord]]
+    private var calls: [String: Int] = [:]
+    private var pendingContinuations: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    init(recordsByRepoPath: [String: [GitWorktreeRecord]]) {
+        self.recordsByRepoPath = recordsByRepoPath
+    }
+
+    func record(repoPath: String) -> [GitWorktreeRecord] {
+        calls[repoPath, default: 0] += 1
+        let waiters = pendingContinuations.removeValue(forKey: repoPath) ?? []
+        for continuation in waiters {
+            continuation.resume()
+        }
+        return recordsByRepoPath[repoPath] ?? []
+    }
+
+    func callCount(forRepoPath repoPath: String) -> Int {
+        calls[repoPath, default: 0]
+    }
+
+    func awaitCall(forRepoPath repoPath: String) async {
+        if calls[repoPath, default: 0] > 0 { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            pendingContinuations[repoPath, default: []].append(continuation)
+        }
+    }
+}
+
+private final class TrackingGitWorktreeListingStub: Sendable {
+    let tracker: GitWorktreeCallTracker
+
+    init(recordsByRepoPath: [String: [GitWorktreeRecord]]) {
+        self.tracker = GitWorktreeCallTracker(recordsByRepoPath: recordsByRepoPath)
+    }
+
+    @Sendable
+    func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
+        await tracker.record(repoPath: repoPath)
+    }
+
+    func callCount(forRepoPath repoPath: String) async -> Int {
+        await tracker.callCount(forRepoPath: repoPath)
+    }
+
+    func awaitCall(forRepoPath repoPath: String) async {
+        await tracker.awaitCall(forRepoPath: repoPath)
+    }
+}
+
+private final class ProjectPersistenceStub: ProjectPersisting {
+    private var projects: [Project]
+
+    init(initial: [Project] = []) {
+        projects = initial
+    }
+
+    func loadProjects() throws -> [Project] { projects }
+    func saveProjects(_ projects: [Project]) throws { self.projects = projects }
+}
+
+private final class WorktreePersistenceStub: WorktreePersisting {
+    private var storage: [UUID: [Worktree]]
+
+    init(initial: [UUID: [Worktree]] = [:]) {
+        storage = initial
+    }
+
+    func loadWorktrees(projectID: UUID) throws -> [Worktree] {
+        storage[projectID] ?? []
+    }
+
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws {
+        storage[projectID] = worktrees
+    }
+
+    func removeWorktrees(projectID: UUID) throws {
+        storage.removeValue(forKey: projectID)
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws { snapshots = workspaces }
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for paneID: UUID) {}
+    func needsConfirmQuit(for paneID: UUID) -> Bool { false }
+}

--- a/docs/developer/architecture/vcs.md
+++ b/docs/developer/architecture/vcs.md
@@ -51,6 +51,15 @@ flowchart TB
 
 No rollback on partial failure — errors surface to the sheet so the user retries from where it stopped. Ahead/behind counts come from `GitRepositoryService.aheadBehind`.
 
+## Worktree auto-refresh
+
+`VCSWorktreeAutoRefresher` keeps `WorktreeStore` aligned with `git worktree list` without a manual click. It listens for two notifications, both keyed by `userInfo["repoPath"]`:
+
+- `.vcsDidRefresh` — posted by `VCSTabState` after every full refresh.
+- `.vcsRepoDidChange` — posted by `RemoteServerDelegate` on remote-driven repo changes.
+
+On a hit, it resolves the repo path to a project via `WorktreeStore.projectID(forWorktreePath:)` and runs `WorktreeRefreshHelper.refresh` with `presentErrors: false` (failures log to `os.Logger`, no alert). A per-project in-flight guard coalesces overlapping notifications into a single trailing refresh.
+
 ## Pull Requests section
 
 Independent from the rest of VCS; never auto-fetches with the file/branch refresh. Exposes search, a state filter (Open/Closed/Merged/All), a manual sync button, and an auto-sync interval (Off / 5m / 15m / 30m / 1h) persisted per-repo at `UserDefaults["vcs.prAutoSyncMinutes.<repoPath>"]`.


### PR DESCRIPTION
VCSTabState now posts a .vcsDidRefresh signal on full refreshes; a new VCSWorktreeAutoRefresher listens
  (alongside .vcsRepoDidChange) and re-syncs the project's worktrees against git worktree list, picking up
  externally-added worktrees and dropping externally-removed ones without a manual click.