### PR TITLE
Fix VCS diff view hang from stderr pipe deadlock and orphaned git processes

### DIFF
--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -19,6 +19,12 @@ enum GitProcessRunner {
         attributes: .concurrent
     )
 
+    private static let stderrDrainQueue = DispatchQueue(
+        label: "app.muxy.git-stderr-drain",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
     private static let searchPaths = [
         "/opt/homebrew/bin",
         "/usr/local/bin",
@@ -38,21 +44,28 @@ enum GitProcessRunner {
         return nil
     }
 
+    private struct ProcessSpec {
+        let executable: String
+        let arguments: [String]
+        let workingDirectory: String?
+        let lineLimit: Int?
+        let signpostName: StaticString
+    }
+
     static func runGit(
         repoPath: String,
         arguments: [String],
         lineLimit: Int? = nil
     ) async throws -> GitProcessResult {
-        let fullArgs = ["git", "-C", repoPath] + arguments
-        return try await dispatch {
-            try runProcessSync(
+        try await runProcess(
+            ProcessSpec(
                 executable: "/usr/bin/env",
-                arguments: fullArgs,
+                arguments: ["git", "-C", repoPath] + arguments,
                 workingDirectory: nil,
                 lineLimit: lineLimit,
                 signpostName: "git"
             )
-        }
+        )
     }
 
     static func runCommand(
@@ -60,14 +73,25 @@ enum GitProcessRunner {
         arguments: [String],
         workingDirectory: String
     ) async throws -> GitProcessResult {
-        try await dispatch {
-            try runProcessSync(
+        try await runProcess(
+            ProcessSpec(
                 executable: executable,
                 arguments: arguments,
                 workingDirectory: workingDirectory,
                 lineLimit: nil,
                 signpostName: "command"
             )
+        )
+    }
+
+    private static func runProcess(_ spec: ProcessSpec) async throws -> GitProcessResult {
+        let handle = ProcessHandle()
+        return try await withTaskCancellationHandler {
+            try await dispatch {
+                try runProcessSync(spec, handle: handle)
+            }
+        } onCancel: {
+            handle.terminate()
         }
     }
 
@@ -107,24 +131,21 @@ enum GitProcessRunner {
     }
 
     private static func runProcessSync(
-        executable: String,
-        arguments: [String],
-        workingDirectory: String?,
-        lineLimit: Int?,
-        signpostName: StaticString
+        _ spec: ProcessSpec,
+        handle: ProcessHandle
     ) throws -> GitProcessResult {
-        let signpostID = GitSignpost.begin(signpostName, arguments.prefix(3).joined(separator: " "))
-        defer { GitSignpost.end(signpostName, signpostID) }
+        let signpostID = GitSignpost.begin(spec.signpostName, spec.arguments.prefix(3).joined(separator: " "))
+        defer { GitSignpost.end(spec.signpostName, signpostID) }
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
+        process.executableURL = URL(fileURLWithPath: spec.executable)
+        process.arguments = spec.arguments
 
         var environment = ProcessInfo.processInfo.environment
         environment["GIT_OPTIONAL_LOCKS"] = "0"
         process.environment = environment
 
-        if let workingDirectory {
+        if let workingDirectory = spec.workingDirectory {
             process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
         }
 
@@ -139,13 +160,37 @@ enum GitProcessRunner {
             throw GitProcessError.launchFailed(error.localizedDescription)
         }
 
-        let stdoutData: Data = if let lineLimit {
-            try readWithLineLimit(handle: stdoutPipe.fileHandleForReading, process: process, lineLimit: lineLimit)
-        } else {
-            stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        guard handle.attach(process) else {
+            process.waitUntilExit()
+            return GitProcessResult(
+                status: process.terminationStatus,
+                stdout: "",
+                stdoutData: Data(),
+                stderr: "",
+                truncated: true
+            )
         }
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        defer { handle.detach() }
+
+        let stderrCollector = AsyncDataCollector()
+        stderrCollector.start(reading: stderrPipe.fileHandleForReading, on: stderrDrainQueue)
+
+        let stdoutData: Data
+        do {
+            stdoutData = try readStdout(
+                handle: stdoutPipe.fileHandleForReading,
+                process: process,
+                lineLimit: spec.lineLimit
+            )
+        } catch {
+            handle.terminate()
+            _ = stderrCollector.wait()
+            process.waitUntilExit()
+            throw error
+        }
+
         process.waitUntilExit()
+        let stderrData = stderrCollector.wait()
 
         let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
         let stderr = String(data: stderrData, encoding: .utf8) ?? ""
@@ -157,6 +202,17 @@ enum GitProcessRunner {
             stderr: stderr,
             truncated: truncated
         )
+    }
+
+    private static func readStdout(
+        handle: FileHandle,
+        process: Process,
+        lineLimit: Int?
+    ) throws -> Data {
+        guard let lineLimit else {
+            return handle.readDataToEndOfFile()
+        }
+        return try readWithLineLimit(handle: handle, process: process, lineLimit: lineLimit)
     }
 
     private static func readWithLineLimit(
@@ -184,5 +240,64 @@ enum GitProcessRunner {
                 return collected
             }
         }
+    }
+}
+
+private final class ProcessHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+
+    func attach(_ process: Process) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if cancelled {
+            terminateRunning(process)
+            return false
+        }
+        self.process = process
+        return true
+    }
+
+    func detach() {
+        lock.lock()
+        defer { lock.unlock() }
+        process = nil
+    }
+
+    func terminate() {
+        lock.lock()
+        defer { lock.unlock() }
+        cancelled = true
+        guard let process else { return }
+        terminateRunning(process)
+    }
+
+    private func terminateRunning(_ process: Process) {
+        guard process.isRunning else { return }
+        process.terminate()
+    }
+}
+
+private final class AsyncDataCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    func start(reading handle: FileHandle, on queue: DispatchQueue) {
+        queue.async { [self] in
+            let collected = handle.readDataToEndOfFile()
+            lock.lock()
+            data = collected
+            lock.unlock()
+            semaphore.signal()
+        }
+    }
+
+    func wait() -> Data {
+        semaphore.wait()
+        lock.lock()
+        defer { lock.unlock() }
+        return data
     }
 }


### PR DESCRIPTION
Drain stderr concurrently so git can't block writing to a full stderr pipe while stdout is being read. Hook git
  process termination to Task cancellation so rapidly switching diffs no longer leaves running processes behind.