### PR TITLE
Add adjustable UI scale for app chrome

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -379,6 +379,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 struct WindowConfigurator: NSViewRepresentable {
     let configVersion: Int
+    let uiScalePreset: UIScale.Preset
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -407,6 +408,7 @@ struct WindowConfigurator: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {
         guard let w = nsView.window else { return }
         Self.applyWindowBackground(w)
+        Self.repositionTrafficLights(in: w)
     }
 
     private static func applyWindowBackground(_ window: NSWindow) {
@@ -462,17 +464,23 @@ struct WindowConfigurator: NSViewRepresentable {
     }
 
     static let trafficLightY: CGFloat = 3.5
+    static let baselineTitleBarHeight: CGFloat = 32
 
-    static func repositionTrafficLights(in window: NSWindow) {
-        let y: CGFloat
+    static func desiredTrafficLightY() -> CGFloat {
+        let scaledTitleBarHeight = UIMetrics.scaled(baselineTitleBarHeight)
+        let extraVerticalSpace = scaledTitleBarHeight - baselineTitleBarHeight
         if #available(macOS 26.0, *) {
             let buttonHeight: CGFloat = 14
-            y = (32 - buttonHeight) / 2
-        } else {
-            y = trafficLightY
+            return (baselineTitleBarHeight - buttonHeight - extraVerticalSpace) / 2
         }
+        return trafficLightY - extraVerticalSpace / 2
+    }
+
+    static func repositionTrafficLights(in window: NSWindow) {
+        let y = desiredTrafficLightY()
         for button in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
             guard let btn = window.standardWindowButton(button) else { continue }
+            guard abs(btn.frame.origin.y - y) > 0.5 else { continue }
             var frame = btn.frame
             frame.origin.y = y
             btn.frame = frame
@@ -481,6 +489,7 @@ struct WindowConfigurator: NSViewRepresentable {
 
     final class Coordinator: NSObject {
         private var observations: [NSObjectProtocol] = []
+        private var buttonFrameObservations: [NSObjectProtocol] = []
 
         @objc
         func handleCloseButton(_: Any?) {
@@ -499,6 +508,9 @@ struct WindowConfigurator: NSViewRepresentable {
                 NSWindow.didChangeBackingPropertiesNotification,
                 NSWindow.didExitFullScreenNotification,
                 NSWindow.didEnterFullScreenNotification,
+                NSWindow.didUpdateNotification,
+                NSWindow.didBecomeKeyNotification,
+                NSWindow.didBecomeMainNotification,
             ]
             for name in names {
                 let token = NotificationCenter.default.addObserver(
@@ -530,10 +542,35 @@ struct WindowConfigurator: NSViewRepresentable {
                 }
                 observations.append(token)
             }
+
+            observeButtonFrames(window: window)
+        }
+
+        private func observeButtonFrames(window: NSWindow) {
+            buttonFrameObservations.forEach { NotificationCenter.default.removeObserver($0) }
+            buttonFrameObservations.removeAll()
+            for type in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
+                guard let button = window.standardWindowButton(type) else { continue }
+                button.postsFrameChangedNotifications = true
+                let token = NotificationCenter.default.addObserver(
+                    forName: NSView.frameDidChangeNotification,
+                    object: button,
+                    queue: .main
+                ) { [weak window] _ in
+                    guard let window else { return }
+                    DispatchQueue.main.async {
+                        MainActor.assumeIsolated {
+                            WindowConfigurator.repositionTrafficLights(in: window)
+                        }
+                    }
+                }
+                buttonFrameObservations.append(token)
+            }
         }
 
         deinit {
             observations.forEach { NotificationCenter.default.removeObserver($0) }
+            buttonFrameObservations.forEach { NotificationCenter.default.removeObserver($0) }
         }
     }
 }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -550,8 +550,8 @@ struct WindowConfigurator: NSViewRepresentable {
             buttonFrameObservations.forEach { NotificationCenter.default.removeObserver($0) }
             buttonFrameObservations.removeAll()
             for type in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
-                guard let button = window.standardWindowButton(type) else { continue }
-                button.postsFrameChangedNotifications = true
+                guard let button = MainActor.assumeIsolated({ window.standardWindowButton(type) }) else { continue }
+                MainActor.assumeIsolated { button.postsFrameChangedNotifications = true }
                 let token = NotificationCenter.default.addObserver(
                     forName: NSView.frameDidChangeNotification,
                     object: button,

--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -41,6 +41,7 @@ enum UIMetrics {
     static var radiusSM: CGFloat { scaled(4) }
     static var radiusMD: CGFloat { scaled(6) }
     static var radiusLG: CGFloat { scaled(8) }
+    static var radiusXL: CGFloat { scaled(10) }
 
     static var sidebarCollapsedWidth: CGFloat { scaled(44) }
     static var sidebarExpandedWidth: CGFloat { scaled(220) }

--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+import SwiftUI
+
+@MainActor
+enum UIMetrics {
+    static var fontMicro: CGFloat { scaled(8) }
+    static var fontXS: CGFloat { scaled(9) }
+    static var fontCaption: CGFloat { scaled(10) }
+    static var fontFootnote: CGFloat { scaled(11) }
+    static var fontBody: CGFloat { scaled(12) }
+    static var fontEmphasis: CGFloat { scaled(13) }
+    static var fontHeadline: CGFloat { scaled(14) }
+    static var fontTitle: CGFloat { scaled(15) }
+    static var fontTitleLarge: CGFloat { scaled(16) }
+    static var fontDisplay: CGFloat { scaled(20) }
+    static var fontHero: CGFloat { scaled(24) }
+    static var fontMega: CGFloat { scaled(28) }
+
+    static var spacing1: CGFloat { scaled(2) }
+    static var spacing2: CGFloat { scaled(4) }
+    static var spacing3: CGFloat { scaled(6) }
+    static var spacing4: CGFloat { scaled(8) }
+    static var spacing5: CGFloat { scaled(10) }
+    static var spacing6: CGFloat { scaled(12) }
+    static var spacing7: CGFloat { scaled(16) }
+    static var spacing8: CGFloat { scaled(20) }
+    static var spacing9: CGFloat { scaled(24) }
+    static var spacing10: CGFloat { scaled(32) }
+
+    static var iconXS: CGFloat { scaled(10) }
+    static var iconSM: CGFloat { scaled(12) }
+    static var iconMD: CGFloat { scaled(14) }
+    static var iconLG: CGFloat { scaled(16) }
+    static var iconXL: CGFloat { scaled(20) }
+    static var iconXXL: CGFloat { scaled(28) }
+
+    static var controlSmall: CGFloat { scaled(20) }
+    static var controlMedium: CGFloat { scaled(24) }
+    static var controlLarge: CGFloat { scaled(32) }
+
+    static var radiusSM: CGFloat { scaled(4) }
+    static var radiusMD: CGFloat { scaled(6) }
+    static var radiusLG: CGFloat { scaled(8) }
+
+    static var sidebarCollapsedWidth: CGFloat { scaled(44) }
+    static var sidebarExpandedWidth: CGFloat { scaled(220) }
+
+    static var tabBarHeight: CGFloat { scaled(28) }
+    static var headerHeight: CGFloat { scaled(36) }
+
+    static func scaled(_ value: CGFloat) -> CGFloat {
+        value * UIScale.shared.multiplier
+    }
+}

--- a/Muxy/Theme/UIScale.swift
+++ b/Muxy/Theme/UIScale.swift
@@ -1,0 +1,92 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "UIScale")
+
+@MainActor
+@Observable
+final class UIScale {
+    static let shared = UIScale()
+
+    enum Preset: String, Codable, CaseIterable, Identifiable {
+        case regular
+        case large
+        case extraLarge
+
+        var id: String { rawValue }
+
+        var multiplier: CGFloat {
+            switch self {
+            case .regular: 1.00
+            case .large: 1.12
+            case .extraLarge: 1.24
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .regular: "Default"
+            case .large: "Large"
+            case .extraLarge: "Extra Large"
+            }
+        }
+    }
+
+    static let defaultPreset: Preset = .regular
+    static let minSliderValue: CGFloat = 0.85
+    static let maxSliderValue: CGFloat = 1.30
+    static let sliderStep: CGFloat = 0.02
+
+    var preset: Preset = UIScale.defaultPreset {
+        didSet { save() }
+    }
+
+    var multiplier: CGFloat { preset.multiplier }
+
+    @ObservationIgnored private let store: CodableFileStore<Snapshot>
+    @ObservationIgnored private var isLoading = false
+
+    private init() {
+        store = CodableFileStore(
+            fileURL: MuxyFileStorage.fileURL(filename: "ui-scale.json"),
+            options: CodableFileStoreOptions(
+                prettyPrinted: true,
+                sortedKeys: true,
+                filePermissions: FilePermissions.privateFile
+            )
+        )
+        load()
+    }
+
+    func resetToDefaults() {
+        preset = Self.defaultPreset
+    }
+
+    func scaled(_ value: CGFloat) -> CGFloat {
+        value * multiplier
+    }
+
+    private func load() {
+        do {
+            guard let snapshot = try store.load() else { return }
+            isLoading = true
+            preset = snapshot.preset ?? Self.defaultPreset
+            isLoading = false
+        } catch {
+            logger.error("Failed to load UI scale settings: \(error.localizedDescription)")
+        }
+    }
+
+    private func save() {
+        guard !isLoading else { return }
+        do {
+            try store.save(Snapshot(preset: preset))
+        } catch {
+            logger.error("Failed to save UI scale settings: \(error.localizedDescription)")
+        }
+    }
+}
+
+private struct Snapshot: Codable {
+    let preset: UIScale.Preset?
+}

--- a/Muxy/Theme/UIScale.swift
+++ b/Muxy/Theme/UIScale.swift
@@ -33,9 +33,6 @@ final class UIScale {
     }
 
     static let defaultPreset: Preset = .regular
-    static let minSliderValue: CGFloat = 0.85
-    static let maxSliderValue: CGFloat = 1.30
-    static let sliderStep: CGFloat = 0.02
 
     var preset: Preset = UIScale.defaultPreset {
         didSet { save() }
@@ -58,19 +55,11 @@ final class UIScale {
         load()
     }
 
-    func resetToDefaults() {
-        preset = Self.defaultPreset
-    }
-
-    func scaled(_ value: CGFloat) -> CGFloat {
-        value * multiplier
-    }
-
     private func load() {
         do {
             guard let snapshot = try store.load() else { return }
             isLoading = true
-            preset = snapshot.preset ?? Self.defaultPreset
+            preset = snapshot.preset
             isLoading = false
         } catch {
             logger.error("Failed to load UI scale settings: \(error.localizedDescription)")
@@ -88,5 +77,5 @@ final class UIScale {
 }
 
 private struct Snapshot: Codable {
-    let preset: UIScale.Preset?
+    let preset: UIScale.Preset
 }

--- a/Muxy/Views/Components/DebugButton.swift
+++ b/Muxy/Views/Components/DebugButton.swift
@@ -10,11 +10,11 @@ struct DebugButton: View {
             showingPopover.toggle()
         } label: {
             Image(systemName: "ladybug.fill")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(hovered ? MuxyTheme.warning : MuxyTheme.warning.opacity(0.75))
-                .frame(width: 22, height: 22)
+                .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
                 .contentShape(Rectangle())
-                .background(hovered ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: 5))
+                .background(hovered ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
@@ -30,32 +30,32 @@ private struct DebugInfoPopover: View {
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 6) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "ladybug.fill")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     .foregroundStyle(MuxyTheme.warning)
                 Text("Debug")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg)
-                Spacer(minLength: 12)
+                Spacer(minLength: UIMetrics.spacing6)
                 Text("DEV")
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
                     .foregroundStyle(MuxyTheme.bg)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
+                    .padding(.horizontal, UIMetrics.scaled(5))
+                    .padding(.vertical, UIMetrics.scaled(1))
                     .background(MuxyTheme.warning, in: Capsule())
             }
 
-            VStack(spacing: 6) {
+            VStack(spacing: UIMetrics.spacing3) {
                 metricRow("Memory", value: snapshot.memoryString, icon: "memorychip")
                 metricRow("CPU", value: snapshot.cpuString, icon: "cpu")
                 metricRow("Threads", value: "\(snapshot.threadCount)", icon: "rectangle.split.3x1")
                 metricRow("Uptime", value: snapshot.uptimeString, icon: "clock")
             }
         }
-        .padding(12)
-        .frame(width: 220)
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(220))
         .background(MuxyTheme.bg)
         .onReceive(timer) { _ in
             snapshot = DebugMetrics.current()
@@ -63,17 +63,17 @@ private struct DebugInfoPopover: View {
     }
 
     private func metricRow(_ label: String, value: String, icon: String) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: icon)
-                .font(.system(size: 10, weight: .medium))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 14)
+                .frame(width: UIMetrics.iconMD)
             Text(label)
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
-            Spacer(minLength: 8)
+            Spacer(minLength: UIMetrics.spacing4)
             Text(value)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .monospaced))
                 .foregroundStyle(MuxyTheme.fg)
         }
     }

--- a/Muxy/Views/Components/FileDiffIcon.swift
+++ b/Muxy/Views/Components/FileDiffIcon.swift
@@ -48,8 +48,8 @@ struct FileDiffIconButton: View {
                     hovered ? MuxyTheme.fg : MuxyTheme.fgMuted,
                     style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round)
                 )
-                .frame(width: 13, height: 13)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.fontEmphasis, height: UIMetrics.fontEmphasis)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Components/FileDiffIcon.swift
+++ b/Muxy/Views/Components/FileDiffIcon.swift
@@ -48,7 +48,7 @@ struct FileDiffIconButton: View {
                     hovered ? MuxyTheme.fg : MuxyTheme.fgMuted,
                     style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round)
                 )
-                .frame(width: UIMetrics.fontEmphasis, height: UIMetrics.fontEmphasis)
+                .frame(width: UIMetrics.scaled(13), height: UIMetrics.scaled(13))
                 .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }

--- a/Muxy/Views/Components/FileTreeIcon.swift
+++ b/Muxy/Views/Components/FileTreeIcon.swift
@@ -7,9 +7,9 @@ struct FileTreeIconButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: "sidebar.left")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -22,12 +22,12 @@ struct FindInFilesOverlay: View {
                 Divider().overlay(MuxyTheme.border)
                 resultsList
             }
-            .frame(width: 640, height: 460)
+            .frame(width: UIMetrics.scaled(640), height: UIMetrics.scaled(460))
             .background(MuxyTheme.bg)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(MuxyTheme.border, lineWidth: 1))
-            .shadow(color: .black.opacity(0.4), radius: 20, y: 8)
-            .padding(.top, 60)
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing5))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing5).stroke(MuxyTheme.border, lineWidth: 1))
+            .shadow(color: .black.opacity(0.4), radius: UIMetrics.spacing8, y: UIMetrics.spacing4)
+            .padding(.top, UIMetrics.scaled(60))
             .frame(maxHeight: .infinity, alignment: .top)
             .accessibilityAddTraits(.isModal)
         }
@@ -36,10 +36,10 @@ struct FindInFilesOverlay: View {
     }
 
     private var searchField: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .font(.system(size: 13))
+                .font(.system(size: UIMetrics.fontEmphasis))
                 .accessibilityHidden(true)
             PaletteSearchField(
                 text: $query,
@@ -50,8 +50,8 @@ struct FindInFilesOverlay: View {
                 onArrowDown: { moveHighlight(1) }
             )
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.spacing5)
         .onChange(of: query) { performSearch() }
     }
 
@@ -63,7 +63,7 @@ struct FindInFilesOverlay: View {
                 Text(query.trimmingCharacters(in: .whitespaces).count < TextSearchService.minQueryLength
                     ? "Type at least \(TextSearchService.minQueryLength) characters"
                     : "No matches found")
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
                 Spacer()
             }
@@ -85,7 +85,7 @@ struct FindInFilesOverlay: View {
                             }
                         }
                     }
-                    .padding(.vertical, 4)
+                    .padding(.vertical, UIMetrics.spacing2)
                 }
                 .onChange(of: highlightedMatchID) { _, newID in
                     guard let newID else { return }
@@ -180,28 +180,28 @@ private struct FileGroupHeader: View {
     }
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: UIMetrics.spacing3) {
             Text(fileName)
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
                 .lineLimit(1)
             if !directory.isEmpty {
                 Text(directory)
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgDim)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Spacer(minLength: 8)
+            Spacer(minLength: UIMetrics.spacing4)
             Text("\(group.matches.count)")
-                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
                 .foregroundStyle(MuxyTheme.bg)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 2)
+                .padding(.horizontal, UIMetrics.scaled(7))
+                .padding(.vertical, UIMetrics.spacing1)
                 .background(Capsule().fill(MuxyTheme.fgMuted))
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.spacing3)
     }
 }
 
@@ -212,12 +212,12 @@ private struct MatchRow: View {
 
     var body: some View {
         highlightedSnippet
-            .font(.system(size: 12, design: .monospaced))
+            .font(.system(size: UIMetrics.fontBody, design: .monospaced))
             .lineLimit(1)
             .truncationMode(.tail)
-            .padding(.leading, 24)
-            .padding(.trailing, 12)
-            .padding(.vertical, 3)
+            .padding(.leading, UIMetrics.spacing9)
+            .padding(.trailing, UIMetrics.spacing6)
+            .padding(.vertical, UIMetrics.scaled(3))
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
             .onHover { hovered = $0 }

--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -24,9 +24,9 @@ struct FindInFilesOverlay: View {
             }
             .frame(width: UIMetrics.scaled(640), height: UIMetrics.scaled(460))
             .background(MuxyTheme.bg)
-            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing5))
-            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing5).stroke(MuxyTheme.border, lineWidth: 1))
-            .shadow(color: .black.opacity(0.4), radius: UIMetrics.spacing8, y: UIMetrics.spacing4)
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusXL))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusXL).stroke(MuxyTheme.border, lineWidth: 1))
+            .shadow(color: .black.opacity(0.4), radius: UIMetrics.scaled(20), y: UIMetrics.scaled(8))
             .padding(.top, UIMetrics.scaled(60))
             .frame(maxHeight: .infinity, alignment: .top)
             .accessibilityAddTraits(.isModal)

--- a/Muxy/Views/Components/IconButton.swift
+++ b/Muxy/Views/Components/IconButton.swift
@@ -12,9 +12,9 @@ struct IconButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: symbol)
-                .font(.system(size: size, weight: .semibold))
+                .font(.system(size: UIMetrics.scaled(size), weight: .semibold))
                 .foregroundStyle(hovered ? hoverColor : color)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Components/NotificationBadge.swift
+++ b/Muxy/Views/Components/NotificationBadge.swift
@@ -6,7 +6,7 @@ struct NotificationBadge: View {
     var body: some View {
         Circle()
             .fill(MuxyTheme.accent)
-            .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+            .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
             .accessibilityLabel("\(count) unread notification\(count == 1 ? "" : "s")")
     }
 }

--- a/Muxy/Views/Components/NotificationBadge.swift
+++ b/Muxy/Views/Components/NotificationBadge.swift
@@ -6,7 +6,7 @@ struct NotificationBadge: View {
     var body: some View {
         Circle()
             .fill(MuxyTheme.accent)
-            .frame(width: 8, height: 8)
+            .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
             .accessibilityLabel("\(count) unread notification\(count == 1 ? "" : "s")")
     }
 }

--- a/Muxy/Views/Components/OpenInIDEControl.swift
+++ b/Muxy/Views/Components/OpenInIDEControl.swift
@@ -25,16 +25,16 @@ struct OpenInIDEControl: View {
             Button(action: openDefaultIDE) {
                 Group {
                     if let defaultIDE {
-                        AppBundleIconView(appURL: defaultIDE.appURL, fallbackSystemName: defaultIDE.symbolName, size: 16)
+                        AppBundleIconView(appURL: defaultIDE.appURL, fallbackSystemName: defaultIDE.symbolName, size: UIMetrics.iconLG)
                     } else {
                         Image(systemName: "chevron.left.forwardslash.chevron.right")
-                            .font(.system(size: 11, weight: .semibold))
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                             .foregroundStyle(primaryForeground)
                     }
                 }
-                .frame(width: 22, height: 24)
+                .frame(width: UIMetrics.scaled(22), height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
-                .background(hoveredPrimary ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: 5))
+                .background(hoveredPrimary ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             }
             .buttonStyle(.plain)
             .disabled(projectPath == nil || defaultIDE == nil)
@@ -52,20 +52,20 @@ struct OpenInIDEControl: View {
     private var expandedSplitButton: some View {
         HStack(spacing: 0) {
             Button(action: openDefaultIDE) {
-                HStack(spacing: 6) {
+                HStack(spacing: UIMetrics.spacing3) {
                     if let defaultIDE {
-                        AppBundleIconView(appURL: defaultIDE.appURL, fallbackSystemName: defaultIDE.symbolName, size: 16)
+                        AppBundleIconView(appURL: defaultIDE.appURL, fallbackSystemName: defaultIDE.symbolName, size: UIMetrics.iconLG)
                     } else {
                         Image(systemName: "chevron.left.forwardslash.chevron.right")
                     }
                     Text(defaultIDE.map { "Open in \($0.displayName)" } ?? "Open in IDE")
                 }
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(primaryForeground)
-                .padding(.horizontal, 8)
-                .frame(height: 24)
+                .padding(.horizontal, UIMetrics.spacing4)
+                .frame(height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
-                .background(hoveredPrimary ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: 5))
+                .background(hoveredPrimary ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             }
             .buttonStyle(.plain)
             .disabled(projectPath == nil || defaultIDE == nil)
@@ -73,7 +73,7 @@ struct OpenInIDEControl: View {
             .help(helpText)
             .accessibilityLabel(helpText)
 
-            menuToggleButton(width: 18)
+            menuToggleButton(width: UIMetrics.scaled(18))
         }
         .popover(isPresented: $showingMenu, arrowEdge: .bottom) {
             menuPopoverContent
@@ -86,9 +86,9 @@ struct OpenInIDEControl: View {
             showingMenu.toggle()
         } label: {
             Image(systemName: "chevron.down")
-                .font(.system(size: 8, weight: .semibold))
+                .font(.system(size: UIMetrics.fontMicro, weight: .semibold))
                 .foregroundStyle(menuForeground)
-                .frame(width: width, height: 24)
+                .frame(width: width, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -110,17 +110,17 @@ struct OpenInIDEControl: View {
                 }
                 if !installedApps.isEmpty {
                     Divider()
-                        .padding(.vertical, 4)
+                        .padding(.vertical, UIMetrics.spacing2)
                 }
             }
 
             if installedApps.isEmpty {
                 Text("No supported IDEs found")
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
-                    .padding(.leading, 10)
-                    .padding(.trailing, 12)
-                    .padding(.vertical, 8)
+                    .padding(.leading, UIMetrics.spacing5)
+                    .padding(.trailing, UIMetrics.spacing6)
+                    .padding(.vertical, UIMetrics.spacing4)
             } else {
                 if !editorApps.isEmpty {
                     menuSection(title: "Editors & IDEs", apps: editorApps)
@@ -130,20 +130,20 @@ struct OpenInIDEControl: View {
                 }
             }
         }
-        .padding(8)
+        .padding(UIMetrics.spacing4)
         .fixedSize(horizontal: true, vertical: true)
         .background(MuxyTheme.bg)
     }
 
     private func menuSection(title: String, apps: [IDEIntegrationService.IDEApplication]) -> some View {
-        VStack(alignment: .leading, spacing: 1) {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
             Text(title)
-                .font(.system(size: 11, weight: .semibold))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .padding(.leading, 9)
-                .padding(.trailing, 12)
-                .padding(.top, 4)
-                .padding(.bottom, 1)
+                .padding(.leading, UIMetrics.scaled(9))
+                .padding(.trailing, UIMetrics.spacing6)
+                .padding(.top, UIMetrics.spacing2)
+                .padding(.bottom, UIMetrics.scaled(1))
 
             ForEach(apps) { ide in
                 menuButton(for: ide)
@@ -242,17 +242,17 @@ private struct IDEMenuRow: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 7) {
-                AppBundleIconView(appURL: ide.appURL, fallbackSystemName: ide.symbolName, size: 14)
+            HStack(spacing: UIMetrics.scaled(7)) {
+                AppBundleIconView(appURL: ide.appURL, fallbackSystemName: ide.symbolName, size: UIMetrics.iconMD)
                 Text(ide.displayName)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
             }
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.leading, 9)
-            .padding(.trailing, 12)
-            .padding(.vertical, 4)
+            .padding(.leading, UIMetrics.scaled(9))
+            .padding(.trailing, UIMetrics.spacing6)
+            .padding(.vertical, UIMetrics.spacing2)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(hovered ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: 5))
+            .background(hovered ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -271,17 +271,17 @@ private struct IDEMenuActionRow: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 7) {
-                AppBundleIconView(appURL: appURL, fallbackSystemName: fallbackSystemName, size: 14)
+            HStack(spacing: UIMetrics.scaled(7)) {
+                AppBundleIconView(appURL: appURL, fallbackSystemName: fallbackSystemName, size: UIMetrics.iconMD)
                 Text(title)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
             }
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.leading, 9)
-            .padding(.trailing, 12)
-            .padding(.vertical, 4)
+            .padding(.leading, UIMetrics.scaled(9))
+            .padding(.trailing, UIMetrics.spacing6)
+            .padding(.vertical, UIMetrics.spacing2)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(hovered ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: 5))
+            .background(hovered ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Components/OpenerOverlay.swift
+++ b/Muxy/Views/Components/OpenerOverlay.swift
@@ -49,9 +49,9 @@ struct OpenerOverlay: View {
             }
             .frame(width: UIMetrics.scaled(560), height: UIMetrics.scaled(460))
             .background(MuxyTheme.bg)
-            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing5))
-            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing5).stroke(MuxyTheme.border, lineWidth: 1))
-            .shadow(color: .black.opacity(0.4), radius: UIMetrics.spacing8, y: UIMetrics.spacing4)
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusXL))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusXL).stroke(MuxyTheme.border, lineWidth: 1))
+            .shadow(color: .black.opacity(0.4), radius: UIMetrics.scaled(20), y: UIMetrics.scaled(8))
             .padding(.top, UIMetrics.scaled(60))
             .frame(maxHeight: .infinity, alignment: .top)
             .accessibilityAddTraits(.isModal)

--- a/Muxy/Views/Components/OpenerOverlay.swift
+++ b/Muxy/Views/Components/OpenerOverlay.swift
@@ -47,12 +47,12 @@ struct OpenerOverlay: View {
                 Divider().overlay(MuxyTheme.border)
                 resultsList
             }
-            .frame(width: 560, height: 460)
+            .frame(width: UIMetrics.scaled(560), height: UIMetrics.scaled(460))
             .background(MuxyTheme.bg)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(MuxyTheme.border, lineWidth: 1))
-            .shadow(color: .black.opacity(0.4), radius: 20, y: 8)
-            .padding(.top, 60)
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing5))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing5).stroke(MuxyTheme.border, lineWidth: 1))
+            .shadow(color: .black.opacity(0.4), radius: UIMetrics.spacing8, y: UIMetrics.spacing4)
+            .padding(.top, UIMetrics.scaled(60))
             .frame(maxHeight: .infinity, alignment: .top)
             .accessibilityAddTraits(.isModal)
         }
@@ -72,10 +72,10 @@ struct OpenerOverlay: View {
     }
 
     private var searchField: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .font(.system(size: 13))
+                .font(.system(size: UIMetrics.fontEmphasis))
                 .accessibilityHidden(true)
             PaletteSearchField(
                 text: $query,
@@ -86,13 +86,13 @@ struct OpenerOverlay: View {
                 onArrowDown: { moveHighlight(1) }
             )
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.spacing5)
     }
 
     private var categoryChips: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 ForEach(OpenerCategory.allCases) { category in
                     OpenerCategoryChip(
                         category: category,
@@ -101,8 +101,8 @@ struct OpenerOverlay: View {
                     )
                 }
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
+            .padding(.horizontal, UIMetrics.spacing5)
+            .padding(.vertical, UIMetrics.spacing3)
         }
     }
 
@@ -112,7 +112,7 @@ struct OpenerOverlay: View {
                 VStack {
                     Spacer()
                     Text(query.isEmpty ? "No items" : "No matches")
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fgMuted)
                     Spacer()
                 }
@@ -189,14 +189,14 @@ private struct OpenerCategoryChip: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 5) {
+            HStack(spacing: UIMetrics.scaled(5)) {
                 Image(systemName: category.symbol)
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                 Text(category.label)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
             }
-            .padding(.horizontal, 9)
-            .padding(.vertical, 4)
+            .padding(.horizontal, UIMetrics.scaled(9))
+            .padding(.vertical, UIMetrics.spacing2)
             .foregroundStyle(isOn ? MuxyTheme.fg : MuxyTheme.fgMuted)
             .background(isOn ? MuxyTheme.surface : (hovered ? MuxyTheme.hover : .clear), in: Capsule())
             .overlay(Capsule().stroke(isOn ? MuxyTheme.accent.opacity(0.6) : MuxyTheme.border, lineWidth: 1))
@@ -213,14 +213,14 @@ private struct OpenerSectionHeader: View {
     var body: some View {
         HStack {
             Text(title.uppercased())
-                .font(.system(size: 9, weight: .bold))
+                .font(.system(size: UIMetrics.fontXS, weight: .bold))
                 .tracking(0.6)
                 .foregroundStyle(MuxyTheme.fgDim)
             Spacer()
         }
-        .padding(.horizontal, 12)
-        .padding(.top, 8)
-        .padding(.bottom, 3)
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.top, UIMetrics.spacing4)
+        .padding(.bottom, UIMetrics.scaled(3))
     }
 }
 
@@ -231,41 +231,41 @@ private struct OpenerRow: View {
     @State private var hovered = false
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: UIMetrics.spacing5) {
             Image(systemName: item.category.symbol)
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 16, alignment: .center)
+                .frame(width: UIMetrics.iconLG, alignment: .center)
             Text(item.title)
-                .font(.system(size: 12, weight: .medium))
+                .font(.system(size: UIMetrics.fontBody, weight: .medium))
                 .foregroundStyle(MuxyTheme.fg)
                 .lineLimit(1)
                 .truncationMode(.middle)
             if case let .worktree(wt) = item, wt.isPrimary {
                 Text("PRIMARY")
-                    .font(.system(size: 8, weight: .bold))
+                    .font(.system(size: UIMetrics.fontMicro, weight: .bold))
                     .tracking(0.5)
                     .foregroundStyle(MuxyTheme.fgDim)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 1)
+                    .padding(.horizontal, UIMetrics.spacing2)
+                    .padding(.vertical, UIMetrics.scaled(1))
                     .background(MuxyTheme.surface, in: Capsule())
             }
             if let subtitle = item.subtitle {
                 Text(subtitle)
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgDim)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Spacer(minLength: 4)
+            Spacer(minLength: UIMetrics.spacing2)
             if isActive {
                 Image(systemName: "checkmark")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                     .foregroundStyle(MuxyTheme.accent)
             }
         }
-        .frame(height: 28)
-        .padding(.horizontal, 12)
+        .frame(height: UIMetrics.scaled(28))
+        .padding(.horizontal, UIMetrics.spacing6)
         .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
         .onHover { hovered = $0 }
     }

--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -31,12 +31,12 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
                 Divider().overlay(MuxyTheme.border)
                 resultsList
             }
-            .frame(width: 500, height: 380)
+            .frame(width: UIMetrics.scaled(500), height: UIMetrics.scaled(380))
             .background(MuxyTheme.bg)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(RoundedRectangle(cornerRadius: 10).stroke(MuxyTheme.border, lineWidth: 1))
-            .shadow(color: .black.opacity(0.4), radius: 20, y: 8)
-            .padding(.top, 60)
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing5))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing5).stroke(MuxyTheme.border, lineWidth: 1))
+            .shadow(color: .black.opacity(0.4), radius: UIMetrics.spacing8, y: UIMetrics.spacing4)
+            .padding(.top, UIMetrics.scaled(60))
             .frame(maxHeight: .infinity, alignment: .top)
             .accessibilityAddTraits(.isModal)
         }
@@ -49,10 +49,10 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
     }
 
     private var searchField: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .font(.system(size: 13))
+                .font(.system(size: UIMetrics.fontEmphasis))
                 .accessibilityHidden(true)
             PaletteSearchField(
                 text: $query,
@@ -63,8 +63,8 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
                 onArrowDown: { moveHighlight(1) }
             )
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.spacing5)
         .onChange(of: query) {
             performSearch()
         }
@@ -76,7 +76,7 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
                 VStack {
                     Spacer()
                     Text(query.isEmpty ? emptyLabel : noMatchLabel)
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fgMuted)
                     Spacer()
                 }
@@ -143,7 +143,7 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
 struct PaletteSearchField: NSViewRepresentable {
     @Binding var text: String
     let placeholder: String
-    var fontSize: CGFloat = 13
+    var fontSize: CGFloat = UIMetrics.fontEmphasis
     let onSubmit: () -> Void
     let onEscape: () -> Void
     let onArrowUp: () -> Void

--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -33,9 +33,9 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
             }
             .frame(width: UIMetrics.scaled(500), height: UIMetrics.scaled(380))
             .background(MuxyTheme.bg)
-            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing5))
-            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing5).stroke(MuxyTheme.border, lineWidth: 1))
-            .shadow(color: .black.opacity(0.4), radius: UIMetrics.spacing8, y: UIMetrics.spacing4)
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusXL))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusXL).stroke(MuxyTheme.border, lineWidth: 1))
+            .shadow(color: .black.opacity(0.4), radius: UIMetrics.scaled(20), y: UIMetrics.scaled(8))
             .padding(.top, UIMetrics.scaled(60))
             .frame(maxHeight: .infinity, alignment: .top)
             .accessibilityAddTraits(.isModal)

--- a/Muxy/Views/Components/PopoverPicker.swift
+++ b/Muxy/Views/Components/PopoverPicker.swift
@@ -76,7 +76,7 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
                 }
             }
         }
-        .frame(width: fixedSize ? 300 : nil, height: fixedSize ? 420 : nil)
+        .frame(width: fixedSize ? UIMetrics.scaled(300) : nil, height: fixedSize ? UIMetrics.scaled(420) : nil)
         .frame(maxWidth: fixedSize ? nil : .infinity, maxHeight: fixedSize ? nil : .infinity)
         .background(MuxyTheme.bg)
     }
@@ -88,23 +88,23 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            HStack(spacing: 8) {
+            HStack(spacing: UIMetrics.spacing4) {
                 if let icon {
                     Image(systemName: icon)
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                 }
                 Text(title)
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
                 Spacer()
                 ProgressView()
                     .controlSize(.small)
                     .scaleEffect(0.7)
-                    .frame(width: 12, height: 12)
+                    .frame(width: UIMetrics.iconSM, height: UIMetrics.iconSM)
                     .opacity(isBusy ? 1 : 0)
             }
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
+            .padding(.horizontal, UIMetrics.fontHeadline)
+            .padding(.vertical, UIMetrics.spacing5)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Components/PopoverPicker.swift
+++ b/Muxy/Views/Components/PopoverPicker.swift
@@ -103,7 +103,7 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
                     .opacity(isBusy ? 1 : 0)
             }
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, UIMetrics.fontHeadline)
+            .padding(.horizontal, UIMetrics.scaled(14))
             .padding(.vertical, UIMetrics.spacing5)
             .contentShape(Rectangle())
         }

--- a/Muxy/Views/Components/QuickOpenOverlay.swift
+++ b/Muxy/Views/Components/QuickOpenOverlay.swift
@@ -56,26 +56,26 @@ private struct FileResultRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: fileIcon)
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 16)
-            VStack(alignment: .leading, spacing: 1) {
+                .frame(width: UIMetrics.iconLG)
+            VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
                 Text(result.fileName)
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
                     .foregroundStyle(MuxyTheme.fg)
                     .lineLimit(1)
                 Text(result.relativePath)
-                    .font(.system(size: 10))
+                    .font(.system(size: UIMetrics.fontCaption))
                     .foregroundStyle(MuxyTheme.fgDim)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
             Spacer()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.spacing3)
         .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
         .onHover { isHovered in
             hovered = isHovered

--- a/Muxy/Views/Components/SearchableListPicker.swift
+++ b/Muxy/Views/Components/SearchableListPicker.swift
@@ -18,29 +18,29 @@ struct SearchableListPicker<Item: Identifiable, RowContent: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(MuxyTheme.fgMuted)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .accessibilityHidden(true)
                 PaletteSearchField(
                     text: $searchText,
                     placeholder: placeholder,
-                    fontSize: 12,
+                    fontSize: UIMetrics.fontBody,
                     onSubmit: { confirmSelection() },
                     onEscape: {},
                     onArrowUp: { moveHighlight(-1) },
                     onArrowDown: { moveHighlight(1) }
                 )
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
+            .padding(.horizontal, UIMetrics.spacing5)
+            .padding(.vertical, UIMetrics.spacing4)
 
             Divider().overlay(MuxyTheme.border)
 
             if filteredItems.isEmpty {
                 Text(emptyLabel)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -54,7 +54,7 @@ struct SearchableListPicker<Item: Identifiable, RowContent: View>: View {
                                     .id(item.id)
                             }
                         }
-                        .padding(.vertical, 4)
+                        .padding(.vertical, UIMetrics.spacing2)
                     }
                     .onChange(of: highlightedIndex) { _, newIndex in
                         guard let newIndex, newIndex < filteredItems.count else { return }

--- a/Muxy/Views/Components/SegmentedPicker.swift
+++ b/Muxy/Views/Components/SegmentedPicker.swift
@@ -11,15 +11,15 @@ struct SegmentedPicker<T: Hashable>: View {
                     selection = option.value
                 } label: {
                     Text(option.label)
-                        .font(.system(size: 11, weight: selection == option.value ? .semibold : .regular))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: selection == option.value ? .semibold : .regular))
                         .foregroundStyle(selection == option.value ? MuxyTheme.fg : MuxyTheme.fgMuted)
                         .frame(maxWidth: .infinity)
-                        .padding(.vertical, 5)
+                        .padding(.vertical, UIMetrics.scaled(5))
                         .background(
                             selection == option.value
                                 ? MuxyTheme.surface
                                 : Color.clear,
-                            in: RoundedRectangle(cornerRadius: 4)
+                            in: RoundedRectangle(cornerRadius: UIMetrics.spacing2)
                         )
                 }
                 .buttonStyle(.plain)
@@ -28,13 +28,13 @@ struct SegmentedPicker<T: Hashable>: View {
                    selection != options[index + 1].value
                 {
                     Divider()
-                        .frame(height: 14)
+                        .frame(height: UIMetrics.iconMD)
                         .opacity(0.4)
                 }
             }
         }
-        .padding(2)
-        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: 6))
+        .padding(UIMetrics.spacing1)
+        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
         .accessibilityRepresentation {
             Picker(selection: $selection, label: EmptyView()) {
                 ForEach(Array(options.enumerated()), id: \.offset) { _, option in

--- a/Muxy/Views/Components/SegmentedPicker.swift
+++ b/Muxy/Views/Components/SegmentedPicker.swift
@@ -19,7 +19,7 @@ struct SegmentedPicker<T: Hashable>: View {
                             selection == option.value
                                 ? MuxyTheme.surface
                                 : Color.clear,
-                            in: RoundedRectangle(cornerRadius: UIMetrics.spacing2)
+                            in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                         )
                 }
                 .buttonStyle(.plain)
@@ -28,7 +28,7 @@ struct SegmentedPicker<T: Hashable>: View {
                    selection != options[index + 1].value
                 {
                     Divider()
-                        .frame(height: UIMetrics.iconMD)
+                        .frame(height: UIMetrics.scaled(14))
                         .opacity(0.4)
                 }
             }

--- a/Muxy/Views/Components/ToolbarIconStrip.swift
+++ b/Muxy/Views/Components/ToolbarIconStrip.swift
@@ -7,6 +7,6 @@ struct ToolbarIconStrip<Content: View>: View {
         HStack(spacing: 0) {
             content()
         }
-        .padding(.trailing, 4)
+        .padding(.trailing, UIMetrics.spacing2)
     }
 }

--- a/Muxy/Views/Components/UpdateBadge.swift
+++ b/Muxy/Views/Components/UpdateBadge.swift
@@ -7,22 +7,22 @@ struct UpdateBadge: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: "arrow.down.circle.fill")
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
                 Text("Update \(version)")
-                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
                     .lineLimit(1)
             }
             .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.scaled(3))
             .background(
-                RoundedRectangle(cornerRadius: 5)
+                RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                     .fill(MuxyTheme.surface)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 5)
+                RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                     .stroke(MuxyTheme.border, lineWidth: 1)
             )
         }

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -359,7 +359,7 @@ private struct EditorMarkdownModePicker: View {
                         .foregroundStyle(scrollSyncEnabled ? MuxyTheme.accent : MuxyTheme.fg)
                         .frame(width: UIMetrics.scaled(22), height: UIMetrics.controlSmall)
                         .background(
-                            RoundedRectangle(cornerRadius: UIMetrics.spacing2)
+                            RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                                 .fill(scrollSyncEnabled ? MuxyTheme.surface : Color.clear)
                         )
                         .contentShape(Rectangle())
@@ -370,7 +370,7 @@ private struct EditorMarkdownModePicker: View {
 
                 Rectangle()
                     .fill(MuxyTheme.border)
-                    .frame(width: 1, height: UIMetrics.iconMD)
+                    .frame(width: 1, height: UIMetrics.scaled(14))
                     .padding(.horizontal, UIMetrics.spacing1)
             }
             ForEach(EditorMarkdownViewMode.allCases, id: \.self) { candidate in
@@ -381,7 +381,7 @@ private struct EditorMarkdownModePicker: View {
                         .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                         .frame(width: UIMetrics.scaled(22), height: UIMetrics.controlSmall)
                         .background(
-                            RoundedRectangle(cornerRadius: UIMetrics.spacing2)
+                            RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                                 .fill(mode == candidate ? MuxyTheme.surface : Color.clear)
                         )
                         .contentShape(Rectangle())
@@ -436,7 +436,7 @@ private struct EditorBreadcrumb: View {
             if state.isModified {
                 Circle()
                     .fill(MuxyTheme.fg)
-                    .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
+                    .frame(width: UIMetrics.scaled(6), height: UIMetrics.scaled(6))
             }
             if state.isReadOnly {
                 Label("Read-only", systemImage: "lock.fill")

--- a/Muxy/Views/Editor/EditorPane.swift
+++ b/Muxy/Views/Editor/EditorPane.swift
@@ -49,22 +49,22 @@ struct EditorPane: View {
             editorMainContent
 
             if state.isIncrementalLoading {
-                HStack(spacing: 6) {
+                HStack(spacing: UIMetrics.spacing3) {
                     ProgressView().controlSize(.mini)
                     Text("Loading full file...")
-                        .font(.system(size: 11))
+                        .font(.system(size: UIMetrics.fontFootnote))
                         .foregroundStyle(MuxyTheme.fgMuted)
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+                .padding(.horizontal, UIMetrics.spacing4)
+                .padding(.vertical, UIMetrics.spacing3)
                 .background(MuxyTheme.bg.opacity(0.92))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 6)
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                         .stroke(MuxyTheme.border, lineWidth: 1)
                 )
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .padding(.top, 6)
-                .padding(.trailing, state.searchVisible && showsCodeEditor ? 260 : 8)
+                .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                .padding(.top, UIMetrics.spacing3)
+                .padding(.trailing, state.searchVisible && showsCodeEditor ? UIMetrics.scaled(260) : UIMetrics.spacing4)
             }
 
             if state.searchVisible, showsCodeEditor {
@@ -251,11 +251,11 @@ struct EditorPane: View {
     }
 
     private var markdownPreviewLoadingView: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: UIMetrics.spacing5) {
             ProgressView()
                 .controlSize(.small)
             Text("Loading full markdown preview...")
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -267,12 +267,12 @@ struct EditorPane: View {
     }
 
     private var externalChangeBanner: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.diffHunkFg)
             Text("This file changed on disk. You have unsaved changes.")
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fg)
             Spacer()
             Button("Reload from Disk") {
@@ -284,8 +284,8 @@ struct EditorPane: View {
             }
             .controlSize(.small)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.vertical, UIMetrics.spacing3)
         .background(MuxyTheme.surface)
     }
 
@@ -298,20 +298,20 @@ struct EditorPane: View {
     }
 
     private var largeFileConfirmation: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: UIMetrics.spacing7) {
             Spacer()
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 28))
+                .font(.system(size: UIMetrics.fontMega))
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text("Large File")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             Text("This file is \(formattedLargeFileSize). Large files may slow down the editor.")
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 360)
-            HStack(spacing: 8) {
+            HStack(spacing: UIMetrics.spacing4) {
                 Button("Cancel") {
                     state.cancelLargeFileOpen()
                 }
@@ -337,7 +337,7 @@ struct EditorPane: View {
         VStack {
             Spacer()
             Text(error)
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.diffRemoveFg)
             Spacer()
         }
@@ -349,17 +349,17 @@ private struct EditorMarkdownModePicker: View {
     @Binding var scrollSyncEnabled: Bool
 
     var body: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: UIMetrics.spacing1) {
             if mode == .split {
                 Button {
                     scrollSyncEnabled.toggle()
                 } label: {
                     Image(systemName: "arrow.up.and.down")
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                         .foregroundStyle(scrollSyncEnabled ? MuxyTheme.accent : MuxyTheme.fg)
-                        .frame(width: 22, height: 20)
+                        .frame(width: UIMetrics.scaled(22), height: UIMetrics.controlSmall)
                         .background(
-                            RoundedRectangle(cornerRadius: 4)
+                            RoundedRectangle(cornerRadius: UIMetrics.spacing2)
                                 .fill(scrollSyncEnabled ? MuxyTheme.surface : Color.clear)
                         )
                         .contentShape(Rectangle())
@@ -370,18 +370,18 @@ private struct EditorMarkdownModePicker: View {
 
                 Rectangle()
                     .fill(MuxyTheme.border)
-                    .frame(width: 1, height: 14)
-                    .padding(.horizontal, 2)
+                    .frame(width: 1, height: UIMetrics.iconMD)
+                    .padding(.horizontal, UIMetrics.spacing1)
             }
             ForEach(EditorMarkdownViewMode.allCases, id: \.self) { candidate in
                 Button {
                     mode = candidate
                 } label: {
                     Image(systemName: candidate.symbol)
-                        .font(.system(size: 10, weight: .medium))
-                        .frame(width: 22, height: 20)
+                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                        .frame(width: UIMetrics.scaled(22), height: UIMetrics.controlSmall)
                         .background(
-                            RoundedRectangle(cornerRadius: 4)
+                            RoundedRectangle(cornerRadius: UIMetrics.spacing2)
                                 .fill(mode == candidate ? MuxyTheme.surface : Color.clear)
                         )
                         .contentShape(Rectangle())
@@ -391,13 +391,13 @@ private struct EditorMarkdownModePicker: View {
                 .accessibilityLabel("Markdown \(candidate.title) View")
             }
         }
-        .padding(2)
+        .padding(UIMetrics.spacing1)
         .background(MuxyTheme.bg)
         .overlay(
-            RoundedRectangle(cornerRadius: 6)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 .stroke(MuxyTheme.border, lineWidth: 1)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
     }
 
     private func helpText(for candidate: EditorMarkdownViewMode, currentMode: EditorMarkdownViewMode) -> String {
@@ -423,12 +423,12 @@ private struct EditorBreadcrumb: View {
     }
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: UIMetrics.spacing2) {
             Image(systemName: "doc.text")
-                .font(.system(size: 10))
+                .font(.system(size: UIMetrics.fontCaption))
                 .foregroundStyle(MuxyTheme.fgDim)
             Text(relativePath)
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -436,11 +436,11 @@ private struct EditorBreadcrumb: View {
             if state.isModified {
                 Circle()
                     .fill(MuxyTheme.fg)
-                    .frame(width: 6, height: 6)
+                    .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
             }
             if state.isReadOnly {
                 Label("Read-only", systemImage: "lock.fill")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                     .foregroundStyle(MuxyTheme.diffHunkFg)
             }
             Spacer()
@@ -449,14 +449,14 @@ private struct EditorBreadcrumb: View {
                     mode: $state.markdownViewMode,
                     scrollSyncEnabled: $state.markdownScrollSyncEnabled
                 )
-                .padding(.trailing, 6)
+                .padding(.trailing, UIMetrics.spacing3)
             }
             Text("Ln \(state.cursorLine), Col \(state.cursorColumn)")
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                 .foregroundStyle(MuxyTheme.fgDim)
         }
-        .padding(.horizontal, 10)
-        .frame(height: 32)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .frame(height: UIMetrics.scaled(32))
         .background(MuxyTheme.bg)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(breadcrumbAccessibilityLabel)

--- a/Muxy/Views/Editor/EditorSearchBar.swift
+++ b/Muxy/Views/Editor/EditorSearchBar.swift
@@ -19,27 +19,27 @@ struct EditorSearchBar: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(alignment: .top, spacing: 4) {
+            HStack(alignment: .top, spacing: UIMetrics.spacing2) {
                 Button {
                     state.replaceVisible.toggle()
                 } label: {
                     Image(systemName: state.replaceVisible ? "chevron.down" : "chevron.right")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 }
                 .buttonStyle(EditorSearchButtonStyle())
                 .help(state.replaceVisible ? "Hide Replace" : "Show Replace")
                 .accessibilityLabel(state.replaceVisible ? "Hide Replace" : "Show Replace")
-                .padding(.top, 1)
+                .padding(.top, UIMetrics.scaled(1))
 
-                VStack(spacing: 4) {
+                VStack(spacing: UIMetrics.spacing2) {
                     searchRow
                     if state.replaceVisible {
                         replaceRow
                     }
                 }
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.spacing3)
             .background(MuxyTheme.bg.opacity(0.95))
 
             Rectangle().fill(MuxyTheme.border).frame(height: 1)
@@ -52,16 +52,16 @@ struct EditorSearchBar: View {
     }
 
     private var searchRow: some View {
-        HStack(spacing: 6) {
-            HStack(spacing: 4) {
+        HStack(spacing: UIMetrics.spacing3) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .accessibilityHidden(true)
 
                 TextField("Search", text: $state.searchNeedle)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fg)
                     .focused($isFieldFocused)
                     .onSubmit { onNext() }
@@ -73,7 +73,7 @@ struct EditorSearchBar: View {
 
                 if !displayText.isEmpty {
                     Text(displayText)
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .lineLimit(1)
                         .fixedSize()
@@ -91,32 +91,32 @@ struct EditorSearchBar: View {
                     help: "Regular Expression"
                 )
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.spacing2)
             .background(MuxyTheme.surface)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
             .overlay(
-                RoundedRectangle(cornerRadius: 6)
+                RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                     .strokeBorder(MuxyTheme.border, lineWidth: 1)
             )
 
             Button(action: onPrevious) {
                 Image(systemName: "chevron.up")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
             }
             .buttonStyle(EditorSearchButtonStyle())
             .accessibilityLabel("Previous Match")
 
             Button(action: onNext) {
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
             }
             .buttonStyle(EditorSearchButtonStyle())
             .accessibilityLabel("Next Match")
 
             Button(action: onClose) {
                 Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
             }
             .buttonStyle(EditorSearchButtonStyle())
             .accessibilityLabel("Close Search")
@@ -124,25 +124,25 @@ struct EditorSearchBar: View {
     }
 
     private var replaceRow: some View {
-        HStack(spacing: 6) {
-            HStack(spacing: 4) {
+        HStack(spacing: UIMetrics.spacing3) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: "arrow.2.squarepath")
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .accessibilityHidden(true)
 
                 TextField("Replace", text: $state.replaceText)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fg)
                     .onSubmit(onReplace)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.spacing2)
             .background(MuxyTheme.surface)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
             .overlay(
-                RoundedRectangle(cornerRadius: 6)
+                RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                     .strokeBorder(MuxyTheme.border, lineWidth: 1)
             )
 
@@ -160,11 +160,11 @@ struct EditorSearchBar: View {
 private struct EditorSearchButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(width: 22, height: 22)
+            .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
             .contentShape(Rectangle())
             .foregroundStyle(MuxyTheme.fgMuted)
             .background(configuration.isPressed ? MuxyTheme.surface : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
     }
 }
 
@@ -173,16 +173,16 @@ private struct EditorSearchTextButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.system(size: 11, weight: .medium))
+            .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
             .foregroundStyle(isEnabled ? MuxyTheme.fg : MuxyTheme.fgDim)
-            .padding(.horizontal, 8)
-            .frame(height: 22)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .frame(height: UIMetrics.scaled(22))
             .background(configuration.isPressed ? MuxyTheme.surface : MuxyTheme.bg)
             .overlay(
-                RoundedRectangle(cornerRadius: 4)
+                RoundedRectangle(cornerRadius: UIMetrics.spacing2)
                     .strokeBorder(MuxyTheme.border, lineWidth: 1)
             )
-            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
     }
 }
 
@@ -196,11 +196,11 @@ private struct EditorSearchOptionToggle: View {
             isOn.toggle()
         } label: {
             Text(label)
-                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
                 .foregroundStyle(isOn ? MuxyTheme.fg : MuxyTheme.fgMuted)
-                .frame(width: 20, height: 18)
+                .frame(width: UIMetrics.controlSmall, height: UIMetrics.scaled(18))
                 .background(isOn ? MuxyTheme.border : .clear)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
         }
         .buttonStyle(.plain)
         .help(help)

--- a/Muxy/Views/Editor/EditorSearchBar.swift
+++ b/Muxy/Views/Editor/EditorSearchBar.swift
@@ -164,7 +164,7 @@ private struct EditorSearchButtonStyle: ButtonStyle {
             .contentShape(Rectangle())
             .foregroundStyle(MuxyTheme.fgMuted)
             .background(configuration.isPressed ? MuxyTheme.surface : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
     }
 }
 
@@ -179,10 +179,10 @@ private struct EditorSearchTextButtonStyle: ButtonStyle {
             .frame(height: UIMetrics.scaled(22))
             .background(configuration.isPressed ? MuxyTheme.surface : MuxyTheme.bg)
             .overlay(
-                RoundedRectangle(cornerRadius: UIMetrics.spacing2)
+                RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                     .strokeBorder(MuxyTheme.border, lineWidth: 1)
             )
-            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
     }
 }
 
@@ -200,7 +200,7 @@ private struct EditorSearchOptionToggle: View {
                 .foregroundStyle(isOn ? MuxyTheme.fg : MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.controlSmall, height: UIMetrics.scaled(18))
                 .background(isOn ? MuxyTheme.border : .clear)
-                .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+                .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
         }
         .buttonStyle(.plain)
         .help(help)

--- a/Muxy/Views/EmptyProjectPlaceholder.swift
+++ b/Muxy/Views/EmptyProjectPlaceholder.swift
@@ -5,24 +5,24 @@ struct EmptyProjectPlaceholder: View {
     let onCreateTab: () -> Void
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: UIMetrics.spacing7) {
             Spacer()
             Image(systemName: "macwindow.badge.plus")
-                .font(.system(size: 28))
+                .font(.system(size: UIMetrics.fontMega))
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text("No tabs in \(project.name)")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             Text("Open a new terminal tab to start working in this project.")
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .multilineTextAlignment(.center)
-                .frame(maxWidth: 360)
+                .frame(maxWidth: UIMetrics.scaled(360))
             Button(action: onCreateTab) {
-                HStack(spacing: 8) {
+                HStack(spacing: UIMetrics.spacing4) {
                     Text("New Tab")
                     Text(KeyBindingStore.shared.combo(for: .newTab).displayString)
-                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
                         .opacity(0.72)
                 }
             }

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -57,7 +57,7 @@ struct FileTreeView: View {
                                 .id(pending.token)
                             }
                         }
-                        .padding(.vertical, 4)
+                        .padding(.vertical, UIMetrics.spacing2)
                     }
                     .frame(maxWidth: .infinity, minHeight: 0, alignment: .top)
                 }
@@ -120,11 +120,11 @@ struct FileTreeView: View {
     private var header: some View {
         HStack(spacing: 0) {
             Text((state.rootPath as NSString).lastPathComponent)
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
                 .lineLimit(1)
                 .truncationMode(.head)
-                .padding(.leading, 10)
+                .padding(.leading, UIMetrics.spacing5)
             Spacer(minLength: 0)
             ToolbarIconStrip {
                 IconButton(
@@ -147,7 +147,7 @@ struct FileTreeView: View {
                 .help(state.showOnlyChanges ? "Show All Files" : "Show Only Changed Files")
             }
         }
-        .frame(height: 32)
+        .frame(height: UIMetrics.scaled(32))
         .contextMenu {
             FileTreeContextMenuContents(
                 path: state.rootPath,
@@ -326,8 +326,8 @@ private struct FileTreeRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 4) {
-            Color.clear.frame(width: CGFloat(depth) * 12)
+        HStack(spacing: UIMetrics.spacing2) {
+            Color.clear.frame(width: CGFloat(depth) * UIMetrics.spacing6)
             icon
             if isRenaming {
                 FileTreeRenameField(
@@ -337,15 +337,15 @@ private struct FileTreeRow: View {
                 )
             } else {
                 Text(entry.name)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(textColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 6)
-        .frame(height: 22)
+        .padding(.horizontal, UIMetrics.spacing3)
+        .frame(height: UIMetrics.scaled(22))
         .opacity(rowOpacity)
         .background(rowBackground)
         .overlay(dropOverlay)
@@ -385,17 +385,17 @@ private struct FileTreeRow: View {
     @ViewBuilder
     private var dropOverlay: some View {
         if isDropHighlighted {
-            RoundedRectangle(cornerRadius: 3)
+            RoundedRectangle(cornerRadius: UIMetrics.scaled(3))
                 .stroke(MuxyTheme.accent, lineWidth: 1)
-                .padding(.horizontal, 4)
+                .padding(.horizontal, UIMetrics.spacing2)
         }
     }
 
     private var icon: some View {
         Image(systemName: iconSymbol)
-            .font(.system(size: 11))
+            .font(.system(size: UIMetrics.fontFootnote))
             .foregroundStyle(iconColor)
-            .frame(width: 14)
+            .frame(width: UIMetrics.iconMD)
     }
 
     private var iconSymbol: String {
@@ -477,12 +477,12 @@ private struct FileTreeNewEntryRow: View {
     let commands: FileTreeCommands
 
     var body: some View {
-        HStack(spacing: 4) {
-            Color.clear.frame(width: CGFloat(depth) * 12)
+        HStack(spacing: UIMetrics.spacing2) {
+            Color.clear.frame(width: CGFloat(depth) * UIMetrics.spacing6)
             Image(systemName: kind == .folder ? "folder" : "doc")
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 14)
+                .frame(width: UIMetrics.iconMD)
             FileTreeRenameField(
                 initialName: "",
                 commit: { commands.commitNewEntry(name: $0) },
@@ -490,8 +490,8 @@ private struct FileTreeNewEntryRow: View {
             )
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 6)
-        .frame(height: 22)
+        .padding(.horizontal, UIMetrics.spacing3)
+        .frame(height: UIMetrics.scaled(22))
     }
 }
 
@@ -508,7 +508,7 @@ private struct FileTreeRenameField: View {
     var body: some View {
         TextField("", text: $text)
             .textFieldStyle(.plain)
-            .font(.system(size: 12))
+            .font(.system(size: UIMetrics.fontBody))
             .foregroundStyle(MuxyTheme.fg)
             .focused($focused)
             .onAppear {

--- a/Muxy/Views/Help/HelpView.swift
+++ b/Muxy/Views/Help/HelpView.swift
@@ -124,7 +124,7 @@ private struct HelpQuickStart: View {
                                     .foregroundStyle(MuxyTheme.fgMuted)
                                     .padding(.horizontal, UIMetrics.spacing3)
                                     .padding(.vertical, UIMetrics.spacing1)
-                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
                             }
                         }
                         Text(step.detail)
@@ -173,7 +173,7 @@ private struct HelpShortcutsView: View {
                                     .foregroundStyle(MuxyTheme.fgMuted)
                                     .padding(.horizontal, UIMetrics.spacing3)
                                     .padding(.vertical, UIMetrics.spacing1)
-                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
                             }
                             .padding(.vertical, UIMetrics.scaled(3))
                         }
@@ -306,7 +306,7 @@ private struct HelpFeaturesView: View {
 private struct HelpLinksView: View {
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: UIMetrics.fontHeadline) {
+            VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
                 Text("Links")
                     .font(.system(size: UIMetrics.scaled(22), weight: .bold))
                     .foregroundStyle(MuxyTheme.fg)

--- a/Muxy/Views/Help/HelpView.swift
+++ b/Muxy/Views/Help/HelpView.swift
@@ -56,9 +56,9 @@ struct HelpView: View {
 private struct HelpWelcomeView: View {
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing7) {
                 Text("Welcome to Muxy")
-                    .font(.system(size: 22, weight: .bold))
+                    .font(.system(size: UIMetrics.scaled(22), weight: .bold))
                     .foregroundStyle(MuxyTheme.fg)
                 Text(
                     "Muxy is a native macOS terminal multiplexer organised around projects, "
@@ -70,16 +70,16 @@ private struct HelpWelcomeView: View {
                 HelpQuickStart()
 
                 Text("Where to next")
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg)
-                    .padding(.top, 8)
+                    .padding(.top, UIMetrics.spacing4)
                 Text(
                     "Use the sidebar to browse keyboard shortcuts, an overview of features, "
                         + "and links to the docs, repository, mobile app, and Discord."
                 )
                 .foregroundStyle(MuxyTheme.fgMuted)
             }
-            .padding(24)
+            .padding(UIMetrics.spacing9)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
@@ -102,33 +102,33 @@ private struct HelpQuickStart: View {
     ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
             Text("Quick start")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             ForEach(Array(steps.enumerated()), id: \.element.id) { index, step in
-                HStack(alignment: .top, spacing: 12) {
+                HStack(alignment: .top, spacing: UIMetrics.spacing6) {
                     Text("\(index + 1)")
-                        .font(.system(size: 12, weight: .semibold, design: .rounded))
-                        .frame(width: 22, height: 22)
+                        .font(.system(size: UIMetrics.fontBody, weight: .semibold, design: .rounded))
+                        .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
                         .background(MuxyTheme.fgMuted.opacity(0.15), in: Circle())
                         .foregroundStyle(MuxyTheme.fg)
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
+                        HStack(spacing: UIMetrics.spacing4) {
                             Text(step.title)
-                                .font(.system(size: 13, weight: .semibold))
+                                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                                 .foregroundStyle(MuxyTheme.fg)
                             if let shortcut = step.shortcut {
                                 Text(shortcut)
-                                    .font(.system(size: 11, weight: .medium, design: .rounded))
+                                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
                                     .foregroundStyle(MuxyTheme.fgMuted)
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: 4))
+                                    .padding(.horizontal, UIMetrics.spacing3)
+                                    .padding(.vertical, UIMetrics.spacing1)
+                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
                             }
                         }
                         Text(step.detail)
-                            .font(.system(size: 12))
+                            .font(.system(size: UIMetrics.fontBody))
                             .foregroundStyle(MuxyTheme.fgMuted)
                     }
                 }
@@ -149,38 +149,38 @@ private struct HelpShortcutsView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing8) {
                 Text("Keyboard Shortcuts")
-                    .font(.system(size: 22, weight: .bold))
+                    .font(.system(size: UIMetrics.scaled(22), weight: .bold))
                     .foregroundStyle(MuxyTheme.fg)
                 Text("Defaults shown. All shortcuts can be remapped in Settings → Shortcuts.")
                     .foregroundStyle(MuxyTheme.fgMuted)
 
                 ForEach(groups, id: \.category) { group in
-                    VStack(alignment: .leading, spacing: 6) {
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
                         Text(group.category)
-                            .font(.system(size: 13, weight: .semibold))
+                            .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                             .foregroundStyle(MuxyTheme.fg)
-                            .padding(.bottom, 2)
+                            .padding(.bottom, UIMetrics.spacing1)
                         ForEach(group.actions) { action in
                             HStack {
                                 Text(action.displayName)
-                                    .font(.system(size: 12))
+                                    .font(.system(size: UIMetrics.fontBody))
                                     .foregroundStyle(MuxyTheme.fg)
                                 Spacer()
                                 Text(KeyBindingStore.shared.combo(for: action).displayString)
-                                    .font(.system(size: 11, weight: .medium, design: .rounded))
+                                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
                                     .foregroundStyle(MuxyTheme.fgMuted)
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: 4))
+                                    .padding(.horizontal, UIMetrics.spacing3)
+                                    .padding(.vertical, UIMetrics.spacing1)
+                                    .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
                             }
-                            .padding(.vertical, 3)
+                            .padding(.vertical, UIMetrics.scaled(3))
                         }
                     }
                 }
             }
-            .padding(24)
+            .padding(UIMetrics.spacing9)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
@@ -259,20 +259,20 @@ private struct HelpFeaturesView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing7) {
                 Text("Features")
-                    .font(.system(size: 22, weight: .bold))
+                    .font(.system(size: UIMetrics.scaled(22), weight: .bold))
                     .foregroundStyle(MuxyTheme.fg)
                 Text("Every feature has a short overview here and a full page in the documentation.")
                     .foregroundStyle(MuxyTheme.fgMuted)
 
-                VStack(spacing: 8) {
+                VStack(spacing: UIMetrics.spacing4) {
                     ForEach(features) { feature in
                         FeatureRow(feature: feature)
                     }
                 }
             }
-            .padding(24)
+            .padding(UIMetrics.spacing9)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
@@ -281,13 +281,13 @@ private struct HelpFeaturesView: View {
         let feature: Feature
 
         var body: some View {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .top, spacing: UIMetrics.spacing6) {
+                VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
                     Text(feature.title)
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                         .foregroundStyle(MuxyTheme.fg)
                     Text(feature.summary)
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fgMuted)
                 }
                 Spacer()
@@ -296,9 +296,9 @@ private struct HelpFeaturesView: View {
                 }
                 .buttonStyle(.link)
             }
-            .padding(12)
+            .padding(UIMetrics.spacing6)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(MuxyTheme.fgMuted.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
+            .background(MuxyTheme.fgMuted.opacity(0.06), in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
         }
     }
 }
@@ -306,9 +306,9 @@ private struct HelpFeaturesView: View {
 private struct HelpLinksView: View {
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: UIMetrics.fontHeadline) {
                 Text("Links")
-                    .font(.system(size: 22, weight: .bold))
+                    .font(.system(size: UIMetrics.scaled(22), weight: .bold))
                     .foregroundStyle(MuxyTheme.fg)
                 Text("Find more information, file an issue, or join the community.")
                     .foregroundStyle(MuxyTheme.fgMuted)
@@ -339,7 +339,7 @@ private struct HelpLinksView: View {
                     action: HelpLinks.openIssues
                 )
             }
-            .padding(24)
+            .padding(UIMetrics.spacing9)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
@@ -352,28 +352,28 @@ private struct HelpLinksView: View {
 
         var body: some View {
             Button(action: action) {
-                HStack(spacing: 12) {
+                HStack(spacing: UIMetrics.spacing6) {
                     Image(systemName: systemImage)
-                        .font(.system(size: 14))
+                        .font(.system(size: UIMetrics.fontHeadline))
                         .foregroundStyle(MuxyTheme.fg)
-                        .frame(width: 24, height: 24)
-                        .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
-                    VStack(alignment: .leading, spacing: 2) {
+                        .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
+                        .background(MuxyTheme.fgMuted.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                         Text(title)
-                            .font(.system(size: 13, weight: .semibold))
+                            .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                             .foregroundStyle(MuxyTheme.fg)
                         Text(subtitle)
-                            .font(.system(size: 11))
+                            .font(.system(size: UIMetrics.fontFootnote))
                             .foregroundStyle(MuxyTheme.fgMuted)
                     }
                     Spacer()
                     Image(systemName: "arrow.up.right.square")
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fgMuted)
                 }
-                .padding(12)
+                .padding(UIMetrics.spacing6)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(MuxyTheme.fgMuted.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
+                .background(MuxyTheme.fgMuted.opacity(0.06), in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -181,7 +181,7 @@ struct MainWindow: View {
                         .font(.system(size: UIMetrics.fontBody, weight: .medium))
                         .foregroundStyle(MuxyTheme.fg)
                 }
-                .padding(.horizontal, UIMetrics.fontHeadline)
+                .padding(.horizontal, UIMetrics.scaled(14))
                 .padding(.vertical, UIMetrics.spacing4)
                 .background(MuxyTheme.bg, in: Capsule())
                 .overlay(Capsule().stroke(MuxyTheme.border, lineWidth: 1))

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -63,7 +63,7 @@ struct MainWindow: View {
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage("muxy.notifications.toastPosition") private var toastPositionRaw = ToastPosition.topCenter.rawValue
-    private let trafficLightWidth: CGFloat = 75
+    @MainActor private var trafficLightWidth: CGFloat { UIMetrics.scaled(75) }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -81,7 +81,7 @@ struct MainWindow: View {
                 }
                 topBarContent
             }
-            .frame(height: 32)
+            .frame(height: UIMetrics.scaled(32))
             .background(WindowDragRepresentable())
             .background(MuxyTheme.bg)
 
@@ -173,16 +173,16 @@ struct MainWindow: View {
         .environment(\.overlayActive, showQuickOpen || showFindInFiles || showWorktreeSwitcher || overlayAnimatingOut)
         .overlay(alignment: toastAlignment) {
             if let toast = ToastState.shared.message {
-                HStack(spacing: 6) {
+                HStack(spacing: UIMetrics.spacing3) {
                     Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                         .foregroundStyle(MuxyTheme.diffAddFg)
                     Text(toast)
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: UIMetrics.fontBody, weight: .medium))
                         .foregroundStyle(MuxyTheme.fg)
                 }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
+                .padding(.horizontal, UIMetrics.fontHeadline)
+                .padding(.vertical, UIMetrics.spacing4)
                 .background(MuxyTheme.bg, in: Capsule())
                 .overlay(Capsule().stroke(MuxyTheme.border, lineWidth: 1))
                 .padding(toastEdgePadding)
@@ -256,7 +256,7 @@ struct MainWindow: View {
             onMouseBack: { appState.goBack() },
             onMouseForward: { appState.goForward() }
         ))
-        .background(WindowConfigurator(configVersion: ghostty.configVersion))
+        .background(WindowConfigurator(configVersion: ghostty.configVersion, uiScalePreset: UIScale.shared.preset))
         .background(WindowTitleUpdater(title: windowTitle))
         .ignoresSafeArea(.container, edges: .top)
         .onReceive(NotificationCenter.default.publisher(for: .quickOpen)) { _ in
@@ -324,7 +324,7 @@ struct MainWindow: View {
     }
 
     private var navigationArrows: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: UIMetrics.spacing1) {
             NavigationArrowButton(
                 symbol: "chevron.left",
                 isEnabled: appState.navigation.canGoBack,
@@ -340,7 +340,7 @@ struct MainWindow: View {
                 appState.goForward()
             }
         }
-        .padding(.trailing, 4)
+        .padding(.trailing, UIMetrics.spacing2)
     }
 
     @ViewBuilder
@@ -430,9 +430,9 @@ struct MainWindow: View {
                     HStack {
                         if let project = activeProject {
                             Text(project.name)
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                                 .foregroundStyle(MuxyTheme.fgMuted)
-                                .padding(.leading, 12)
+                                .padding(.leading, UIMetrics.spacing6)
                         }
                         Spacer(minLength: 0)
                     }
@@ -442,7 +442,7 @@ struct MainWindow: View {
                     HStack(spacing: 0) {
                         if AppEnvironment.isDevelopment {
                             devModeBadge
-                                .padding(.trailing, 6)
+                                .padding(.trailing, UIMetrics.spacing3)
                         }
                         if let project = activeProject {
                             OpenInIDEControl(
@@ -456,7 +456,7 @@ struct MainWindow: View {
                             UpdateBadge(version: version) {
                                 UpdateService.shared.checkForUpdates()
                             }
-                            .padding(.trailing, 4)
+                            .padding(.trailing, UIMetrics.spacing2)
                         }
                         if let project = activeProject, activeProjectHasSplitWorkspace {
                             IconButton(symbol: "doc.text", size: 12, accessibilityLabel: "Quick Open") {
@@ -472,7 +472,7 @@ struct MainWindow: View {
                             .help("File Tree (\(KeyBindingStore.shared.combo(for: .toggleFileTree).displayString))")
                         }
                     }
-                    .padding(.trailing, 4)
+                    .padding(.trailing, UIMetrics.spacing2)
                 }
         }
     }
@@ -594,11 +594,13 @@ struct MainWindow: View {
     }
 
     private var toastEdgePadding: EdgeInsets {
-        switch toastPosition {
-        case .topCenter: EdgeInsets(top: 40, leading: 0, bottom: 0, trailing: 0)
-        case .topRight: EdgeInsets(top: 40, leading: 0, bottom: 0, trailing: 16)
-        case .bottomCenter: EdgeInsets(top: 0, leading: 0, bottom: 16, trailing: 0)
-        case .bottomRight: EdgeInsets(top: 0, leading: 0, bottom: 16, trailing: 16)
+        let big = UIMetrics.scaled(40)
+        let small = UIMetrics.spacing7
+        return switch toastPosition {
+        case .topCenter: EdgeInsets(top: big, leading: 0, bottom: 0, trailing: 0)
+        case .topRight: EdgeInsets(top: big, leading: 0, bottom: 0, trailing: small)
+        case .bottomCenter: EdgeInsets(top: 0, leading: 0, bottom: small, trailing: 0)
+        case .bottomRight: EdgeInsets(top: 0, leading: 0, bottom: small, trailing: small)
         }
     }
 
@@ -629,7 +631,7 @@ struct MainWindow: View {
         return max(navigationMinimum, sidebarWidth)
     }
 
-    private var navigationArrowsWidth: CGFloat { 52 }
+    private var navigationArrowsWidth: CGFloat { UIMetrics.scaled(52) }
 
     private var devModeBadge: some View {
         DebugButton()
@@ -713,7 +715,7 @@ struct MainWindow: View {
             .accessibilityHidden(true)
             .overlay {
                 Color.clear
-                    .frame(width: 5)
+                    .frame(width: UIMetrics.scaled(5))
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 1)
@@ -1030,9 +1032,9 @@ private struct NavigationArrowButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: symbol)
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(foregroundColor)
-                .frame(width: 22, height: 22)
+                .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Markdown/PathBreadcrumb.swift
+++ b/Muxy/Views/Markdown/PathBreadcrumb.swift
@@ -8,15 +8,15 @@ struct PathBreadcrumb: View {
     }
 
     var body: some View {
-        HStack(spacing: 3) {
+        HStack(spacing: UIMetrics.scaled(3)) {
             ForEach(Array(components.enumerated()), id: \.offset) { index, component in
                 if index > 0 {
                     Image(systemName: "chevron.right")
-                        .font(.system(size: 7, weight: .bold))
+                        .font(.system(size: UIMetrics.scaled(7), weight: .bold))
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
                 Text(component)
-                    .font(.system(size: 10))
+                    .font(.system(size: UIMetrics.fontCaption))
                     .foregroundStyle(index == components.count - 1 ? MuxyTheme.fg : MuxyTheme.fgMuted)
                     .lineLimit(1)
             }

--- a/Muxy/Views/NotificationPanel.swift
+++ b/Muxy/Views/NotificationPanel.swift
@@ -149,7 +149,7 @@ private struct NotificationRow: View {
         HStack(alignment: .top, spacing: UIMetrics.spacing4) {
             Circle()
                 .fill(item.isRead ? Color.clear : MuxyTheme.accent)
-                .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
+                .frame(width: UIMetrics.scaled(6), height: UIMetrics.scaled(6))
                 .padding(.top, UIMetrics.scaled(5))
 
             VStack(alignment: .leading, spacing: UIMetrics.spacing1) {

--- a/Muxy/Views/NotificationPanel.swift
+++ b/Muxy/Views/NotificationPanel.swift
@@ -50,26 +50,26 @@ struct NotificationPanel: View {
                 notificationList(currentItems)
             }
         }
-        .frame(width: 320, height: 400)
+        .frame(width: UIMetrics.scaled(320), height: UIMetrics.scaled(400))
     }
 
     private var header: some View {
         HStack {
             Text("Notifications")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             Spacer()
             Button {
                 NotificationStore.shared.clear()
             } label: {
                 Text("Clear All")
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgMuted)
             }
             .buttonStyle(.plain)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.vertical, UIMetrics.spacing4)
     }
 
     private func notificationList(_ currentItems: [NotificationPanelItem]) -> some View {
@@ -86,7 +86,7 @@ struct NotificationPanel: View {
                     .accessibilityAddTraits(.isButton)
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, UIMetrics.spacing2)
         }
         .background(MuxyTheme.bg)
     }
@@ -95,22 +95,22 @@ struct NotificationPanel: View {
         VStack(spacing: 0) {
             HStack {
                 Text("Notifications")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg)
                 Spacer()
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
+            .padding(.horizontal, UIMetrics.spacing5)
+            .padding(.vertical, UIMetrics.spacing4)
 
             Divider().overlay(MuxyTheme.border)
 
-            VStack(spacing: 8) {
+            VStack(spacing: UIMetrics.spacing4) {
                 Spacer()
                 Image(systemName: "bell.slash")
-                    .font(.system(size: 24, weight: .light))
+                    .font(.system(size: UIMetrics.fontHero, weight: .light))
                     .foregroundStyle(MuxyTheme.fgMuted)
                 Text("No notifications")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
                     .foregroundStyle(MuxyTheme.fgMuted)
                 Spacer()
             }
@@ -146,24 +146,24 @@ private struct NotificationRow: View {
     @State private var hovered = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: UIMetrics.spacing4) {
             Circle()
                 .fill(item.isRead ? Color.clear : MuxyTheme.accent)
-                .frame(width: 6, height: 6)
-                .padding(.top, 5)
+                .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
+                .padding(.top, UIMetrics.scaled(5))
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                 HStack {
                     Image(systemName: item.sourceIcon)
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgMuted)
                     Text(item.title)
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                         .foregroundStyle(MuxyTheme.fg)
                         .lineLimit(1)
                     Spacer()
                     Text(item.relativeTimestamp)
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgMuted)
                     if hovered {
                         dismissButton
@@ -172,14 +172,14 @@ private struct NotificationRow: View {
 
                 if !item.body.isEmpty {
                     Text(item.body)
-                        .font(.system(size: 11))
+                        .font(.system(size: UIMetrics.fontFootnote))
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .lineLimit(2)
                 }
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.vertical, UIMetrics.spacing3)
         .background(isHighlighted ? MuxyTheme.surface : (hovered ? MuxyTheme.hover : .clear))
         .onHover { hovered = $0 }
     }
@@ -189,9 +189,9 @@ private struct NotificationRow: View {
             onRemove()
         } label: {
             Image(systemName: "xmark")
-                .font(.system(size: 8, weight: .bold))
+                .font(.system(size: UIMetrics.fontMicro, weight: .bold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 14, height: 14)
+                .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 .background(MuxyTheme.surface, in: Circle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Settings/AppearanceSettingsView.swift
+++ b/Muxy/Views/Settings/AppearanceSettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AppearanceSettingsView: View {
     @State private var themeService = ThemeService.shared
+    @State private var uiScale = UIScale.shared
     @State private var showLightThemePicker = false
     @State private var showDarkThemePicker = false
     @State private var currentLightTheme: String?
@@ -12,6 +13,19 @@ struct AppearanceSettingsView: View {
 
     var body: some View {
         SettingsContainer {
+            SettingsSection("Interface") {
+                SettingsRow("Size") {
+                    Picker("", selection: $uiScale.preset) {
+                        ForEach(UIScale.Preset.allCases) { preset in
+                            Text(preset.title).tag(preset)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .frame(width: SettingsMetrics.controlWidth)
+                }
+            }
+
             SettingsSection("Terminal") {
                 SettingsRow("Light Theme") {
                     themeButton(

--- a/Muxy/Views/Settings/ShortcutBadge.swift
+++ b/Muxy/Views/Settings/ShortcutBadge.swift
@@ -14,8 +14,8 @@ struct ShortcutBadge: View {
             .overlay(Capsule().strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
             .shadow(
                 color: .black.opacity(0.25),
-                radius: compact ? UIMetrics.scaled(2) : UIMetrics.spacing2,
-                y: compact ? UIMetrics.scaled(1) : UIMetrics.scaled(2)
+                radius: UIMetrics.scaled(compact ? 2 : 4),
+                y: UIMetrics.scaled(compact ? 1 : 2)
             )
             .accessibilityLabel("Keyboard shortcut: \(label)")
     }

--- a/Muxy/Views/Settings/ShortcutBadge.swift
+++ b/Muxy/Views/Settings/ShortcutBadge.swift
@@ -6,13 +6,17 @@ struct ShortcutBadge: View {
 
     var body: some View {
         Text(label)
-            .font(.system(size: compact ? 9 : 11, weight: .medium, design: .rounded))
+            .font(.system(size: compact ? UIMetrics.fontXS : UIMetrics.fontFootnote, weight: .medium, design: .rounded))
             .foregroundStyle(.white)
-            .padding(.horizontal, compact ? 4 : 6)
-            .padding(.vertical, compact ? 1 : 3)
+            .padding(.horizontal, compact ? UIMetrics.spacing2 : UIMetrics.spacing3)
+            .padding(.vertical, compact ? UIMetrics.scaled(1) : UIMetrics.scaled(3))
             .background(.ultraThinMaterial, in: Capsule())
             .overlay(Capsule().strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
-            .shadow(color: .black.opacity(0.25), radius: compact ? 2 : 4, y: compact ? 1 : 2)
+            .shadow(
+                color: .black.opacity(0.25),
+                radius: compact ? UIMetrics.scaled(2) : UIMetrics.spacing2,
+                y: compact ? UIMetrics.scaled(1) : UIMetrics.scaled(2)
+            )
             .accessibilityLabel("Keyboard shortcut: \(label)")
     }
 }

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
+@MainActor
 enum SidebarLayout {
-    static let collapsedWidth: CGFloat = 44
-    static let expandedWidth: CGFloat = 220
-    static let width: CGFloat = 44
+    static var collapsedWidth: CGFloat { UIMetrics.sidebarCollapsedWidth }
+    static var expandedWidth: CGFloat { UIMetrics.sidebarExpandedWidth }
+    static var width: CGFloat { UIMetrics.sidebarCollapsedWidth }
 
     static func resolvedWidth(
         expanded: Bool,
@@ -89,7 +90,7 @@ struct Sidebar: View {
 
     private var projectList: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            LazyVStack(spacing: 4) {
+            LazyVStack(spacing: UIMetrics.spacing2) {
                 ForEach(Array(projectStore.projects.enumerated()), id: \.element.id) { index, project in
                     Group {
                         if isWide {
@@ -130,8 +131,8 @@ struct Sidebar: View {
                 }
                 addButton
             }
-            .padding(.horizontal, isWide ? 6 : 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, isWide ? UIMetrics.spacing3 : UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.spacing2)
             .onPreferenceChange(UUIDFramePreferenceKey<SidebarFrameTag>.self) { frames in
                 guard dragState.draggedID != nil else { return }
                 dragState.frames = frames
@@ -238,35 +239,35 @@ private struct AddProjectButton: View {
 
     private var collapsedLayout: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 6)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 .fill(MuxyTheme.hover)
             Image(systemName: "plus")
-                .font(.system(size: 13, weight: .bold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .bold))
                 .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
         }
-        .frame(width: 28, height: 28)
-        .padding(3)
+        .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
+        .padding(UIMetrics.scaled(3))
     }
 
     private var expandedLayout: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             ZStack {
-                RoundedRectangle(cornerRadius: 6)
+                RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                     .fill(MuxyTheme.surface)
                 Image(systemName: "plus")
-                    .font(.system(size: 13, weight: .bold))
+                    .font(.system(size: UIMetrics.fontEmphasis, weight: .bold))
                     .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
             }
-            .frame(width: 28, height: 28)
+            .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
 
             Text("Add Project")
-                .font(.system(size: 12, weight: .medium))
+                .font(.system(size: UIMetrics.fontBody, weight: .medium))
                 .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
                 .lineLimit(1)
             Spacer()
         }
-        .padding(4)
-        .background(hovered ? MuxyTheme.hover : Color.clear, in: RoundedRectangle(cornerRadius: 8))
+        .padding(UIMetrics.spacing2)
+        .background(hovered ? MuxyTheme.hover : Color.clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
     }
 }
 
@@ -380,7 +381,7 @@ struct SidebarFooter: View {
     }
 
     private var collapsedFooter: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: UIMetrics.spacing2) {
             if usageEnabled {
                 aiUsageButton
             }
@@ -395,11 +396,11 @@ struct SidebarFooter: View {
             IconButton(symbol: sidebarToggleIcon, accessibilityLabel: sidebarToggleLabel) { postToggleSidebar() }
                 .help("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))")
         }
-        .padding(.bottom, 8)
+        .padding(.bottom, UIMetrics.spacing4)
     }
 
     private var expandedFooter: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: UIMetrics.spacing2) {
             IconButton(symbol: sidebarToggleIcon, accessibilityLabel: sidebarToggleLabel) { postToggleSidebar() }
                 .help("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))")
 
@@ -417,8 +418,8 @@ struct SidebarFooter: View {
                 .help("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
                 .popover(isPresented: $showThemePicker) { ThemePicker(mode: .sidebar) }
         }
-        .padding(.horizontal, 10)
-        .padding(.bottom, 8)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.bottom, UIMetrics.spacing4)
     }
 
     private func refreshUsage() {

--- a/Muxy/Views/Sidebar/AIUsagePanel.swift
+++ b/Muxy/Views/Sidebar/AIUsagePanel.swift
@@ -29,22 +29,22 @@ struct AIUsagePreviewButton: View {
     }
 
     private var expandedLabel: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: UIMetrics.spacing2) {
             iconGlyph
             if let percentLabel {
                 Text(percentLabel)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     .foregroundStyle(foreground)
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
             }
         }
-        .frame(height: 24)
+        .frame(height: UIMetrics.controlMedium)
     }
 
     private var compactLabel: some View {
         iconGlyph
-            .frame(width: 24, height: 24)
+            .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
     }
 
     @ViewBuilder
@@ -53,7 +53,7 @@ struct AIUsagePreviewButton: View {
             ProviderIconView(iconName: display.iconName, size: 14, style: .monochrome(foreground))
         } else {
             Image(systemName: "sparkles")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(foreground)
         }
     }
@@ -72,13 +72,13 @@ struct AIUsagePanel: View {
     }()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 6) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "sparkles")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fgMuted)
                 Text("AI Usage")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fgMuted)
                 Spacer()
                 Button(action: onRefresh) {
@@ -88,10 +88,10 @@ struct AIUsagePanel: View {
                                 .controlSize(.small)
                         } else {
                             Image(systemName: "arrow.clockwise")
-                                .font(.system(size: 11, weight: .semibold))
+                                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                         }
                     }
-                    .frame(width: 14, height: 14)
+                    .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(MuxyTheme.fgMuted)
@@ -99,28 +99,28 @@ struct AIUsagePanel: View {
                 .help("Refresh usage")
                 if let lastRefreshDate {
                     Text(Self.relativeFormatter.localizedString(for: lastRefreshDate, relativeTo: Date()))
-                        .font(.system(size: 11))
+                        .font(.system(size: UIMetrics.fontFootnote))
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
             }
 
             if snapshots.isEmpty {
                 Text(isRefreshing ? "Refreshing usage data..." : "No usage data yet.")
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
 
             if !snapshots.isEmpty {
-                VStack(alignment: .leading, spacing: 10) {
+                VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
                     ForEach(snapshots) { snapshot in
                         AIProviderUsageView(snapshot: snapshot)
                     }
                 }
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.spacing5)
+        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
     }
 }
 
@@ -130,18 +130,18 @@ struct AIProviderUsageView: View {
     @AppStorage(AIUsageSettingsStore.sidebarPreviewProviderIDKey) private var pinnedRawValue: String = ""
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 6) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
+            HStack(spacing: UIMetrics.spacing3) {
                 ProviderIconView(iconName: snapshot.providerIconName, size: 14, style: .monochrome(MuxyTheme.fg))
                 Text(snapshot.providerName)
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
                     .foregroundStyle(MuxyTheme.fg)
-                Spacer(minLength: 4)
+                Spacer(minLength: UIMetrics.spacing2)
             }
 
             switch snapshot.state {
             case .available:
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
                     ForEach(snapshot.rows) { row in
                         AIUsageMetricRowView(
                             row: row,
@@ -158,7 +158,7 @@ struct AIProviderUsageView: View {
             case let .unavailable(message),
                  let .error(message):
                 Text(message)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
         }
@@ -344,25 +344,25 @@ struct AIUsageMetricRowView: View {
     }()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 4) {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(3)) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Text(row.label)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
 
                 if paceDetailText != nil {
                     Circle()
                         .fill(paceIndicatorColor)
-                        .frame(width: 6, height: 6)
+                        .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
                 }
 
                 if canPin {
                     Button(action: togglePin) {
                         Image(systemName: isPinned ? "pin.fill" : "pin")
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                             .foregroundStyle(isPinned ? MuxyTheme.accent : (pinHovered ? MuxyTheme.fg : MuxyTheme.fgMuted))
                             .rotationEffect(.degrees(45))
-                            .frame(width: 14, height: 14)
+                            .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
@@ -373,12 +373,12 @@ struct AIUsageMetricRowView: View {
                 Spacer()
                 if let percent = displayPercent {
                     Text("\(Int(percent.rounded()))%")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: UIMetrics.fontBody, weight: .medium))
                         .foregroundStyle(MuxyTheme.fg)
                 }
                 if let detail = displayDetail {
                     Text(detail)
-                        .font(.system(size: 11))
+                        .font(.system(size: UIMetrics.fontFootnote))
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
             }
@@ -390,16 +390,16 @@ struct AIUsageMetricRowView: View {
             }
 
             if let resetDate = row.resetDate {
-                HStack(spacing: 6) {
+                HStack(spacing: UIMetrics.spacing3) {
                     Text("Resets \(Self.resetFormatter.string(from: resetDate))")
-                        .font(.system(size: 11))
+                        .font(.system(size: UIMetrics.fontFootnote))
                         .foregroundStyle(MuxyTheme.fgDim)
 
                     Spacer(minLength: 0)
 
                     if let paceDetailText {
                         Text(paceDetailText)
-                            .font(.system(size: 11))
+                            .font(.system(size: UIMetrics.fontFootnote))
                             .foregroundStyle(MuxyTheme.fgDim)
                             .lineLimit(1)
                     }

--- a/Muxy/Views/Sidebar/AIUsagePanel.swift
+++ b/Muxy/Views/Sidebar/AIUsagePanel.swift
@@ -353,7 +353,7 @@ struct AIUsageMetricRowView: View {
                 if paceDetailText != nil {
                     Circle()
                         .fill(paceIndicatorColor)
-                        .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
+                        .frame(width: UIMetrics.scaled(6), height: UIMetrics.scaled(6))
                 }
 
                 if canPin {

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -31,12 +31,12 @@ struct CreateWorktreeSheet: View {
     private let gitWorktree = GitWorktreeService.shared
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: UIMetrics.fontHeadline) {
             Text("New Worktree")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Name").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
+            VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                Text("Name").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
                 TextField("feature-x", text: $name)
                     .textFieldStyle(.roundedBorder)
             }
@@ -47,8 +47,8 @@ struct CreateWorktreeSheet: View {
             )
 
             if createNewBranch {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Branch Name").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
+                VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                    Text("Branch Name").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
                     TextField("feature-x", text: $branchName)
                         .textFieldStyle(.roundedBorder)
                         .onChange(of: branchName) { _, newValue in
@@ -56,8 +56,8 @@ struct CreateWorktreeSheet: View {
                         }
                 }
             } else {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Branch").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
+                VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                    Text("Branch").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
                     Picker("", selection: $selectedExistingBranch) {
                         ForEach(availableBranches, id: \.self) { branch in
                             Text(branch).tag(branch)
@@ -77,7 +77,7 @@ struct CreateWorktreeSheet: View {
 
             if let errorMessage {
                 Text(errorMessage)
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -91,8 +91,8 @@ struct CreateWorktreeSheet: View {
                     .disabled(!canCreate || inProgress)
             }
         }
-        .padding(20)
-        .frame(width: 460)
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(460))
         .task {
             loadLocation()
             await loadBranches()
@@ -109,18 +109,18 @@ struct CreateWorktreeSheet: View {
     }
 
     private var locationSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Location").font(.system(size: 11)).foregroundStyle(MuxyTheme.fgMuted)
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+            Text("Location").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
+            HStack(spacing: UIMetrics.spacing4) {
                 Text(parentDirectoryPath)
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
                     .foregroundStyle(MuxyTheme.fg)
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
-                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
+                    .padding(.horizontal, UIMetrics.spacing4)
+                    .padding(.vertical, UIMetrics.spacing3)
+                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
 
                 Button("Choose Folder...") {
                     chooseParentDirectory()
@@ -138,65 +138,65 @@ struct CreateWorktreeSheet: View {
     }
 
     private var setupCommandsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing4) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 10))
+                    .font(.system(size: UIMetrics.fontCaption))
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
                 Text("Setup commands from .muxy/worktree.json")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg)
             }
             Text("These commands will run in the new worktree's terminal. Only enable this if you trust this repository.")
-                .font(.system(size: 10))
+                .font(.system(size: UIMetrics.fontCaption))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .fixedSize(horizontal: false, vertical: true)
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                 ForEach(setupCommands, id: \.self) { command in
                     Text(command)
-                        .font(.system(size: 10, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fg)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .padding(8)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
+            .padding(UIMetrics.spacing4)
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
             Toggle("Run these commands after creating the worktree", isOn: $runSetup)
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
         }
-        .padding(10)
-        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: 6))
+        .padding(UIMetrics.spacing5)
+        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
     }
 
     private var setupCommandsGuideSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing4) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "info.circle")
-                    .font(.system(size: 10))
+                    .font(.system(size: UIMetrics.fontCaption))
                     .foregroundStyle(MuxyTheme.fgDim)
                 Text("Optional setup commands")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg)
             }
             Text("To run setup commands after creating a worktree, add .muxy/worktree.json in this repository.")
-                .font(.system(size: 10))
+                .font(.system(size: UIMetrics.fontCaption))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .fixedSize(horizontal: false, vertical: true)
             Text("\(project.path)/.muxy/worktree.json")
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                 .foregroundStyle(MuxyTheme.fg)
                 .textSelection(.enabled)
             Text("{\n  \"setup\": [\n    \"pnpm install\",\n    \"pnpm dev\"\n  ]\n}")
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                 .foregroundStyle(MuxyTheme.fg)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(8)
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
+                .padding(UIMetrics.spacing4)
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
         }
-        .padding(10)
-        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: 6))
+        .padding(UIMetrics.spacing5)
+        .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
     }
 
     private func loadSetupCommands() {

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -31,7 +31,7 @@ struct CreateWorktreeSheet: View {
     private let gitWorktree = GitWorktreeService.shared
 
     var body: some View {
-        VStack(alignment: .leading, spacing: UIMetrics.fontHeadline) {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
             Text("New Worktree")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
 
@@ -120,7 +120,7 @@ struct CreateWorktreeSheet: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, UIMetrics.spacing4)
                     .padding(.vertical, UIMetrics.spacing3)
-                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
 
                 Button("Choose Folder...") {
                     chooseParentDirectory()
@@ -161,7 +161,7 @@ struct CreateWorktreeSheet: View {
                 }
             }
             .padding(UIMetrics.spacing4)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             Toggle("Run these commands after creating the worktree", isOn: $runSetup)
                 .font(.system(size: UIMetrics.fontFootnote))
         }
@@ -193,7 +193,7 @@ struct CreateWorktreeSheet: View {
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(UIMetrics.spacing4)
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
         }
         .padding(UIMetrics.spacing5)
         .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -122,34 +122,34 @@ struct ExpandedProjectRow: View {
     }
 
     private var projectHeader: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             projectIcon
 
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
                 Text(project.name)
-                    .font(.system(size: 13, weight: isActive ? .semibold : .medium))
+                    .font(.system(size: UIMetrics.fontEmphasis, weight: isActive ? .semibold : .medium))
                     .foregroundStyle(MuxyTheme.fg)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
                 if isGitRepo, let worktree = activeWorktree {
                     Text(worktree.isPrimary ? "primary" : worktree.name)
-                        .font(.system(size: 11, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fg)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
             }
 
-            Spacer(minLength: 4)
+            Spacer(minLength: UIMetrics.spacing2)
 
             if isGitRepo {
                 worktreeChevron
             }
         }
-        .padding(4)
-        .background(headerBackground, in: RoundedRectangle(cornerRadius: 8))
-        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .padding(UIMetrics.spacing2)
+        .background(headerBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
+        .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(projectHeaderAccessibilityLabel)
         .accessibilityAddTraits(isActive ? .isSelected : [])
@@ -187,11 +187,11 @@ struct ExpandedProjectRow: View {
             }
         } label: {
             Image(systemName: "chevron.right")
-                .font(.system(size: 9, weight: .semibold))
+                .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
                 .rotationEffect(.degrees(worktreesExpanded ? 90 : 0))
                 .animation(.easeInOut(duration: 0.15), value: worktreesExpanded)
-                .frame(width: 18, height: 18)
+                .frame(width: UIMetrics.scaled(18), height: UIMetrics.scaled(18))
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -203,37 +203,37 @@ struct ExpandedProjectRow: View {
         let unread = NotificationStore.shared.unreadCount(for: project.id)
         let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
-            RoundedRectangle(cornerRadius: 6)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 .fill(iconBackground(hasLogo: logo != nil))
 
             if let logo {
                 Image(nsImage: logo)
                     .resizable()
                     .scaledToFill()
-                    .frame(width: 28, height: 28)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
+                    .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
             } else {
                 Text(displayLetter)
-                    .font(.system(size: 13, weight: .bold))
+                    .font(.system(size: UIMetrics.fontEmphasis, weight: .bold))
                     .foregroundStyle(letterForeground)
             }
         }
-        .frame(width: 28, height: 28)
+        .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
         .overlay(alignment: .topTrailing) {
             if unread > 0 {
                 NotificationBadge(count: unread)
-                    .offset(x: 4, y: -4)
+                    .offset(x: UIMetrics.spacing2, y: -UIMetrics.spacing2)
             } else if hasCompletion {
                 Circle()
                     .fill(MuxyTheme.accent)
-                    .frame(width: 8, height: 8)
-                    .offset(x: 2, y: -2)
+                    .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+                    .offset(x: UIMetrics.spacing1, y: -UIMetrics.spacing1)
             }
         }
     }
 
     private var worktreeList: some View {
-        VStack(spacing: 1) {
+        VStack(spacing: UIMetrics.scaled(1)) {
             ForEach(worktrees) { worktree in
                 ExpandedWorktreeRow(
                     projectID: project.id,
@@ -260,8 +260,8 @@ struct ExpandedProjectRow: View {
                 showCreateWorktreeSheet = true
             }
         }
-        .padding(.top, 2)
-        .padding(.bottom, 4)
+        .padding(.top, UIMetrics.spacing1)
+        .padding(.bottom, UIMetrics.spacing2)
     }
 
     private var projectHeaderAccessibilityLabel: String {
@@ -447,22 +447,22 @@ private struct ExpandedWorktreeRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: UIMetrics.spacing3) {
             leadingIndicator
 
             if isRenaming {
                 TextField("", text: $renameText)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     .foregroundStyle(MuxyTheme.fg)
                     .focused($renameFieldFocused)
                     .onSubmit { commitRename() }
                     .onExitCommand { cancelRename() }
             } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: 4) {
+                    HStack(spacing: UIMetrics.spacing2) {
                         Text(displayName)
-                            .font(.system(size: 12, weight: activeStyle ? .semibold : .regular))
+                            .font(.system(size: UIMetrics.fontBody, weight: activeStyle ? .semibold : .regular))
                             .foregroundStyle(MuxyTheme.fg)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -474,7 +474,7 @@ private struct ExpandedWorktreeRow: View {
 
                     if let branch = branchLabel {
                         Text(branch)
-                            .font(.system(size: 10, design: .monospaced))
+                            .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                             .foregroundStyle(MuxyTheme.fg)
                             .lineLimit(1)
                             .truncationMode(.middle)
@@ -482,12 +482,12 @@ private struct ExpandedWorktreeRow: View {
                 }
             }
 
-            Spacer(minLength: 2)
+            Spacer(minLength: UIMetrics.spacing1)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 7)
-        .background(rowBackground, in: RoundedRectangle(cornerRadius: 6))
-        .contentShape(RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, UIMetrics.spacing4)
+        .padding(.vertical, UIMetrics.scaled(7))
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+        .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
         .onHover { hovered = $0 }
         .onTapGesture {
             guard !isRenaming else { return }
@@ -495,7 +495,7 @@ private struct ExpandedWorktreeRow: View {
         }
         .contextMenu {
             if worktree.isPrimary {
-                Text("Primary worktree").font(.system(size: 11))
+                Text("Primary worktree").font(.system(size: UIMetrics.fontFootnote))
             } else if let onRemove {
                 Button("Rename") { startRename() }
                 Divider()
@@ -503,7 +503,7 @@ private struct ExpandedWorktreeRow: View {
             } else {
                 Button("Rename") { startRename() }
                 Divider()
-                Text("External worktree").font(.system(size: 11))
+                Text("External worktree").font(.system(size: UIMetrics.fontFootnote))
             }
         }
         .accessibilityElement(children: .combine)
@@ -524,12 +524,12 @@ private struct ExpandedWorktreeRow: View {
         let unread = NotificationStore.shared.unreadCount(for: projectID, worktreeID: worktree.id)
         ZStack {
             if unread > 0 {
-                Circle().fill(MuxyTheme.accent).frame(width: 8, height: 8)
+                Circle().fill(MuxyTheme.accent).frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
             } else if selected {
-                Circle().fill(MuxyTheme.accent.opacity(0.4)).frame(width: 5, height: 5)
+                Circle().fill(MuxyTheme.accent.opacity(0.4)).frame(width: UIMetrics.scaled(5), height: UIMetrics.scaled(5))
             }
         }
-        .frame(width: 8, height: 8)
+        .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
     }
 
     private var activeStyle: Bool { selected && projectActive }
@@ -563,18 +563,18 @@ private struct ExpandedNewWorktreeButton: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "plus")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fg)
-                    .frame(width: 8, height: 8)
+                    .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
                 Text("New Worktree")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fg)
                 Spacer()
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.scaled(5))
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
@@ -585,11 +585,11 @@ private struct ExpandedNewWorktreeButton: View {
 private struct PrimaryBadge: View {
     var body: some View {
         Text("PRIMARY")
-            .font(.system(size: 8, weight: .bold))
+            .font(.system(size: UIMetrics.fontMicro, weight: .bold))
             .tracking(0.4)
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, 4)
-            .padding(.vertical, 1)
+            .padding(.horizontal, UIMetrics.spacing2)
+            .padding(.vertical, UIMetrics.scaled(1))
             .background(MuxyTheme.surface, in: Capsule())
     }
 }
@@ -601,19 +601,19 @@ private struct ExpandedRenamePopover: View {
     @FocusState private var isFocused: Bool
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: UIMetrics.spacing4) {
             Text("Rename Project")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             TextField("Project name", text: $text)
                 .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .focused($isFocused)
                 .onSubmit { onCommit() }
                 .onExitCommand { onCancel() }
         }
-        .padding(12)
-        .frame(width: 200)
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(200))
         .onAppear { isFocused = true }
     }
 }

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -226,7 +226,7 @@ struct ExpandedProjectRow: View {
             } else if hasCompletion {
                 Circle()
                     .fill(MuxyTheme.accent)
-                    .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+                    .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
                     .offset(x: UIMetrics.spacing1, y: -UIMetrics.spacing1)
             }
         }
@@ -524,12 +524,12 @@ private struct ExpandedWorktreeRow: View {
         let unread = NotificationStore.shared.unreadCount(for: projectID, worktreeID: worktree.id)
         ZStack {
             if unread > 0 {
-                Circle().fill(MuxyTheme.accent).frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+                Circle().fill(MuxyTheme.accent).frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
             } else if selected {
                 Circle().fill(MuxyTheme.accent.opacity(0.4)).frame(width: UIMetrics.scaled(5), height: UIMetrics.scaled(5))
             }
         }
-        .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+        .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
     }
 
     private var activeStyle: Bool { selected && projectActive }
@@ -567,7 +567,7 @@ private struct ExpandedNewWorktreeButton: View {
                 Image(systemName: "plus")
                     .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fg)
-                    .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+                    .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
                 Text("New Worktree")
                     .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fg)

--- a/Muxy/Views/Sidebar/LogoCropperSheet.swift
+++ b/Muxy/Views/Sidebar/LogoCropperSheet.swift
@@ -25,9 +25,9 @@ struct LogoCropperSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: UIMetrics.spacing7) {
             Text("Crop Logo")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
 
             ZStack {
@@ -52,7 +52,7 @@ struct LogoCropperSheet: View {
                 cropMask
             }
             .frame(width: cropSize + 40, height: cropSize + 40)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
             .overlay {
                 ScrollWheelView { delta in
                     let zoomFactor: CGFloat = 1.0 + delta * 0.03
@@ -62,20 +62,20 @@ struct LogoCropperSheet: View {
                 .allowsHitTesting(false)
             }
 
-            HStack(spacing: 12) {
+            HStack(spacing: UIMetrics.spacing6) {
                 previewIcon
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                     Text("Preview")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                         .foregroundStyle(MuxyTheme.fgMuted)
                     Text("Drag to reposition, scroll to zoom")
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
                 Spacer()
             }
 
-            HStack(spacing: 8) {
+            HStack(spacing: UIMetrics.spacing4) {
                 Button("Cancel") { onCancel() }
                     .keyboardShortcut(.cancelAction)
                 Spacer()
@@ -83,20 +83,20 @@ struct LogoCropperSheet: View {
                     .keyboardShortcut(.defaultAction)
             }
         }
-        .padding(20)
-        .frame(width: 300)
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(300))
         .onAppear { fitImageInitially() }
     }
 
     private var previewIcon: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 8)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusLG)
                 .fill(MuxyTheme.surface)
-                .frame(width: 32, height: 32)
+                .frame(width: UIMetrics.spacing10, height: UIMetrics.spacing10)
 
             croppedPreview
-                .frame(width: 32, height: 32)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .frame(width: UIMetrics.spacing10, height: UIMetrics.spacing10)
+                .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
         }
     }
 

--- a/Muxy/Views/Sidebar/LogoCropperSheet.swift
+++ b/Muxy/Views/Sidebar/LogoCropperSheet.swift
@@ -92,10 +92,10 @@ struct LogoCropperSheet: View {
         ZStack {
             RoundedRectangle(cornerRadius: UIMetrics.radiusLG)
                 .fill(MuxyTheme.surface)
-                .frame(width: UIMetrics.spacing10, height: UIMetrics.spacing10)
+                .frame(width: UIMetrics.scaled(32), height: UIMetrics.scaled(32))
 
             croppedPreview
-                .frame(width: UIMetrics.spacing10, height: UIMetrics.spacing10)
+                .frame(width: UIMetrics.scaled(32), height: UIMetrics.scaled(32))
                 .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
         }
     }

--- a/Muxy/Views/Sidebar/ProjectIconColorPicker.swift
+++ b/Muxy/Views/Sidebar/ProjectIconColorPicker.swift
@@ -21,15 +21,15 @@ struct ProjectIconColorPicker: View {
     let selectedID: String?
     let onSelect: (String?) -> Void
 
-    private let columns = Array(repeating: GridItem(.fixed(24), spacing: 8), count: 6)
+    private let columns = Array(repeating: GridItem(.fixed(24), spacing: UIMetrics.spacing4), count: 6)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
             Text(title)
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
 
-            LazyVGrid(columns: columns, spacing: 8) {
+            LazyVGrid(columns: columns, spacing: UIMetrics.spacing4) {
                 ForEach(ProjectIconColor.palette) { swatch in
                     swatchButton(swatch)
                 }
@@ -40,11 +40,11 @@ struct ProjectIconColorPicker: View {
             Button {
                 onSelect(nil)
             } label: {
-                HStack(spacing: 6) {
+                HStack(spacing: UIMetrics.spacing3) {
                     Image(systemName: "arrow.uturn.backward")
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     Text("Reset to Default")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 }
                 .foregroundStyle(MuxyTheme.fgMuted)
             }
@@ -52,8 +52,8 @@ struct ProjectIconColorPicker: View {
             .disabled(selectedID == nil)
             .opacity(selectedID == nil ? 0.4 : 1)
         }
-        .padding(12)
-        .frame(width: 216)
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(216))
     }
 
     private func swatchButton(_ swatch: ProjectIconColor.Swatch) -> some View {
@@ -64,14 +64,14 @@ struct ProjectIconColorPicker: View {
             ZStack {
                 Circle()
                     .fill(swatch.color)
-                    .frame(width: 22, height: 22)
+                    .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
                 if isSelected {
                     Circle()
                         .strokeBorder(swatch.foreground, lineWidth: 2)
-                        .frame(width: 18, height: 18)
+                        .frame(width: UIMetrics.scaled(18), height: UIMetrics.scaled(18))
                 }
             }
-            .frame(width: 24, height: 24)
+            .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -40,7 +40,7 @@ struct ProjectRow: View {
     var body: some View {
         projectIcon
             .help(project.name)
-            .contentShape(RoundedRectangle(cornerRadius: 8))
+            .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
             .accessibilityElement(children: .combine)
             .accessibilityLabel(project.name)
             .accessibilityValue(isActive ? "Active" : "")
@@ -147,36 +147,36 @@ struct ProjectRow: View {
         let unread = NotificationStore.shared.unreadCount(for: project.id)
         let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
-            RoundedRectangle(cornerRadius: 6)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 .fill(iconBackground(hasLogo: logo != nil))
 
             if let logo {
                 Image(nsImage: logo)
                     .resizable()
                     .scaledToFill()
-                    .frame(width: 28, height: 28)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
+                    .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
             } else {
                 Text(displayLetter)
-                    .font(.system(size: 13, weight: .bold))
+                    .font(.system(size: UIMetrics.fontEmphasis, weight: .bold))
                     .foregroundStyle(letterForeground)
             }
         }
-        .frame(width: 28, height: 28)
-        .padding(3)
+        .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
+        .padding(UIMetrics.scaled(3))
         .overlay(alignment: .topTrailing) {
             if unread > 0 {
                 NotificationBadge(count: unread)
-                    .offset(x: 4, y: -4)
+                    .offset(x: UIMetrics.spacing2, y: -UIMetrics.spacing2)
             } else if hasCompletion {
                 Circle()
                     .fill(MuxyTheme.accent)
-                    .frame(width: 8, height: 8)
-                    .offset(x: 2, y: -2)
+                    .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+                    .offset(x: UIMetrics.spacing1, y: -UIMetrics.spacing1)
             }
         }
         .overlay {
-            RoundedRectangle(cornerRadius: 11)
+            RoundedRectangle(cornerRadius: UIMetrics.scaled(11))
                 .strokeBorder(isActive ? MuxyTheme.accent : .clear, lineWidth: 1.5)
                 .animation(.easeInOut(duration: 0.15), value: isActive)
         }
@@ -184,7 +184,7 @@ struct ProjectRow: View {
             if isRefreshingWorktrees {
                 ProgressView()
                     .controlSize(.mini)
-                    .padding(4)
+                    .padding(UIMetrics.spacing2)
             }
         }
     }
@@ -282,19 +282,19 @@ private struct RenamePopover: View {
     @FocusState private var isFocused: Bool
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: UIMetrics.spacing4) {
             Text("Rename Project")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             TextField("Project name", text: $text)
                 .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .focused($isFocused)
                 .onSubmit { onCommit() }
                 .onExitCommand { onCancel() }
         }
-        .padding(12)
-        .frame(width: 200)
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(200))
         .onAppear { isFocused = true }
     }
 }

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -171,7 +171,7 @@ struct ProjectRow: View {
             } else if hasCompletion {
                 Circle()
                     .fill(MuxyTheme.accent)
-                    .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+                    .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
                     .offset(x: UIMetrics.spacing1, y: -UIMetrics.spacing1)
             }
         }

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -232,7 +232,7 @@ private struct WorktreePopoverRow: View {
                 .fill(selected ? MuxyTheme.accent : MuxyTheme.fgDim.opacity(0.35))
                 .frame(width: UIMetrics.scaled(7), height: UIMetrics.scaled(7))
         }
-        .frame(width: UIMetrics.spacing5)
+        .frame(width: UIMetrics.scaled(10))
     }
 
     private var rowBackground: AnyShapeStyle {

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -55,8 +55,8 @@ struct WorktreePopover: View {
                         Task { await requestRemove(worktree: worktree) }
                     } : nil
                 )
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
+                .padding(.horizontal, UIMetrics.spacing3)
+                .padding(.vertical, UIMetrics.spacing1)
             }
         )
     }
@@ -163,38 +163,38 @@ private struct WorktreePopoverRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: UIMetrics.spacing5) {
             indicator
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
                 if isRenaming {
                     TextField("", text: $renameText)
                         .textFieldStyle(.plain)
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                         .foregroundStyle(MuxyTheme.fg)
                         .focused($renameFieldFocused)
                         .onSubmit { commitRename() }
                         .onExitCommand { cancelRename() }
                 } else {
-                    HStack(spacing: 6) {
+                    HStack(spacing: UIMetrics.spacing3) {
                         Text(displayName)
-                            .font(.system(size: 12, weight: selected ? .semibold : .medium))
+                            .font(.system(size: UIMetrics.fontBody, weight: selected ? .semibold : .medium))
                             .foregroundStyle(selected ? MuxyTheme.fg : MuxyTheme.fg.opacity(0.9))
                             .lineLimit(1)
                             .truncationMode(.middle)
                         if worktree.isPrimary {
                             Text("PRIMARY")
-                                .font(.system(size: 8, weight: .bold))
+                                .font(.system(size: UIMetrics.fontMicro, weight: .bold))
                                 .tracking(0.5)
                                 .foregroundStyle(MuxyTheme.fgDim)
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 1)
+                                .padding(.horizontal, UIMetrics.spacing2)
+                                .padding(.vertical, UIMetrics.scaled(1))
                                 .background(MuxyTheme.surface, in: Capsule())
                         }
                     }
                 }
                 if let branch = branchSubtitle, !isRenaming {
                     Text(branch)
-                        .font(.system(size: 10, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fgDim)
                         .lineLimit(1)
                         .truncationMode(.middle)
@@ -202,10 +202,10 @@ private struct WorktreePopoverRow: View {
             }
             Spacer(minLength: 4)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(rowBackground, in: RoundedRectangle(cornerRadius: 6))
-        .contentShape(RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.vertical, UIMetrics.scaled(7))
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+        .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
         .onHover { hovered = $0 }
         .onTapGesture {
             guard !isRenaming else { return }
@@ -213,7 +213,7 @@ private struct WorktreePopoverRow: View {
         }
         .contextMenu {
             if worktree.isPrimary {
-                Text("Primary worktree").font(.system(size: 11))
+                Text("Primary worktree").font(.system(size: UIMetrics.fontFootnote))
             } else if let onRemove {
                 Button("Rename") { startRename() }
                 Divider()
@@ -221,7 +221,7 @@ private struct WorktreePopoverRow: View {
             } else {
                 Button("Rename") { startRename() }
                 Divider()
-                Text("External worktree").font(.system(size: 11))
+                Text("External worktree").font(.system(size: UIMetrics.fontFootnote))
             }
         }
     }
@@ -230,9 +230,9 @@ private struct WorktreePopoverRow: View {
         ZStack {
             Circle()
                 .fill(selected ? MuxyTheme.accent : MuxyTheme.fgDim.opacity(0.35))
-                .frame(width: 7, height: 7)
+                .frame(width: UIMetrics.scaled(7), height: UIMetrics.scaled(7))
         }
-        .frame(width: 10)
+        .frame(width: UIMetrics.spacing5)
     }
 
     private var rowBackground: AnyShapeStyle {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -77,26 +77,26 @@ struct RemoteControlledPlaceholder: View {
     let onTakeOver: () -> Void
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: UIMetrics.spacing7) {
             Spacer()
             Image(systemName: "iphone.gen3")
-                .font(.system(size: 28))
+                .font(.system(size: UIMetrics.fontMega))
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text("Controlled by \(deviceName)")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             Text("This terminal session is currently being used on \(deviceName). Take over to resume on Mac.")
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 360)
             Button {
                 onTakeOver()
             } label: {
-                HStack(spacing: 8) {
+                HStack(spacing: UIMetrics.spacing4) {
                     Text("Take Over")
                     Text("⌘↩")
-                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
                         .opacity(0.72)
                 }
             }

--- a/Muxy/Views/Terminal/TerminalSearchBar.swift
+++ b/Muxy/Views/Terminal/TerminalSearchBar.swift
@@ -87,6 +87,6 @@ private struct SearchBarButtonStyle: ButtonStyle {
             .contentShape(Rectangle())
             .foregroundStyle(MuxyTheme.fgMuted)
             .background(configuration.isPressed ? MuxyTheme.surface : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
     }
 }

--- a/Muxy/Views/Terminal/TerminalSearchBar.swift
+++ b/Muxy/Views/Terminal/TerminalSearchBar.swift
@@ -10,16 +10,16 @@ struct TerminalSearchBar: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 6) {
-                HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing3) {
+                HStack(spacing: UIMetrics.spacing2) {
                     Image(systemName: "magnifyingglass")
-                        .font(.system(size: 11))
+                        .font(.system(size: UIMetrics.fontFootnote))
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .accessibilityHidden(true)
 
                     TextField("Search", text: $searchState.needle)
                         .textFieldStyle(.plain)
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fg)
                         .focused($isFieldFocused)
                         .onSubmit { onNavigateNext() }
@@ -29,45 +29,45 @@ struct TerminalSearchBar: View {
 
                     if !searchState.displayText.isEmpty {
                         Text(searchState.displayText)
-                            .font(.system(size: 10))
+                            .font(.system(size: UIMetrics.fontCaption))
                             .foregroundStyle(MuxyTheme.fgMuted)
                             .lineLimit(1)
                             .fixedSize()
                             .accessibilityLabel("Search results: \(searchState.displayText)")
                     }
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
+                .padding(.horizontal, UIMetrics.spacing4)
+                .padding(.vertical, UIMetrics.spacing2)
                 .background(MuxyTheme.surface)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 6)
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                         .strokeBorder(MuxyTheme.border, lineWidth: 1)
                 )
 
                 Button(action: onNavigatePrevious) {
                     Image(systemName: "chevron.up")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 }
                 .buttonStyle(SearchBarButtonStyle())
                 .accessibilityLabel("Previous Match")
 
                 Button(action: onNavigateNext) {
                     Image(systemName: "chevron.down")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 }
                 .buttonStyle(SearchBarButtonStyle())
                 .accessibilityLabel("Next Match")
 
                 Button(action: onClose) {
                     Image(systemName: "xmark")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 }
                 .buttonStyle(SearchBarButtonStyle())
                 .accessibilityLabel("Close Search")
             }
-            .padding(.horizontal, 8)
-            .frame(height: 32)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .frame(height: UIMetrics.scaled(32))
             .background(MuxyTheme.bg.opacity(0.95))
 
             Rectangle().fill(MuxyTheme.border).frame(height: 1)
@@ -83,10 +83,10 @@ struct TerminalSearchBar: View {
 private struct SearchBarButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(width: 22, height: 22)
+            .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
             .contentShape(Rectangle())
             .foregroundStyle(MuxyTheme.fgMuted)
             .background(configuration.isPressed ? MuxyTheme.surface : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.spacing2))
     }
 }

--- a/Muxy/Views/ThemePicker.swift
+++ b/Muxy/Views/ThemePicker.swift
@@ -29,7 +29,7 @@ struct ThemePicker: View {
                 )
             }
         )
-        .frame(width: 280, height: 400)
+        .frame(width: UIMetrics.scaled(280), height: UIMetrics.scaled(400))
         .task {
             themes = await themeService.loadThemes()
             currentTheme = currentName()
@@ -65,10 +65,10 @@ private struct ThemeRow: View {
     @State private var hovered = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 4) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Text(theme.name)
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fg)
                     .lineLimit(1)
 
@@ -76,7 +76,7 @@ private struct ThemeRow: View {
 
                 if isActive {
                     Image(systemName: "checkmark")
-                        .font(.system(size: 9, weight: .bold))
+                        .font(.system(size: UIMetrics.fontXS, weight: .bold))
                         .foregroundStyle(Color.accentColor)
                 }
             }
@@ -86,24 +86,24 @@ private struct ThemeRow: View {
                     .fill(Color(nsColor: theme.background))
                     .overlay(
                         Text("Ab")
-                            .font(.system(size: 9, weight: .medium, design: .monospaced))
+                            .font(.system(size: UIMetrics.fontXS, weight: .medium, design: .monospaced))
                             .foregroundStyle(Color(nsColor: theme.foreground))
                     )
-                    .frame(width: 24)
+                    .frame(width: UIMetrics.controlMedium)
 
                 ForEach(Array(theme.palette.enumerated()), id: \.offset) { _, color in
                     Rectangle().fill(Color(nsColor: color))
                 }
             }
-            .frame(height: 14)
-            .clipShape(RoundedRectangle(cornerRadius: 3))
+            .frame(height: UIMetrics.iconMD)
+            .clipShape(RoundedRectangle(cornerRadius: UIMetrics.scaled(3)))
             .overlay(
-                RoundedRectangle(cornerRadius: 3)
+                RoundedRectangle(cornerRadius: UIMetrics.scaled(3))
                     .strokeBorder(MuxyTheme.border, lineWidth: 0.5)
             )
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.vertical, UIMetrics.scaled(5))
         .background(isHighlighted ? MuxyTheme.surface : (hovered ? MuxyTheme.hover : .clear))
         .onHover { hovered = $0 }
     }

--- a/Muxy/Views/ThemePicker.swift
+++ b/Muxy/Views/ThemePicker.swift
@@ -95,7 +95,7 @@ private struct ThemeRow: View {
                     Rectangle().fill(Color(nsColor: color))
                 }
             }
-            .frame(height: UIMetrics.iconMD)
+            .frame(height: UIMetrics.scaled(14))
             .clipShape(RoundedRectangle(cornerRadius: UIMetrics.scaled(3)))
             .overlay(
                 RoundedRectangle(cornerRadius: UIMetrics.scaled(3))

--- a/Muxy/Views/VCS/BranchPicker.swift
+++ b/Muxy/Views/VCS/BranchPicker.swift
@@ -132,7 +132,7 @@ private struct BranchRow: View {
             Circle()
                 .fill(isActive ? MuxyTheme.accent : MuxyTheme.fgDim.opacity(0.35))
                 .frame(width: UIMetrics.scaled(7), height: UIMetrics.scaled(7))
-                .frame(width: UIMetrics.spacing5)
+                .frame(width: UIMetrics.scaled(10))
 
             Text(name)
                 .font(.system(size: UIMetrics.fontBody, weight: isActive ? .semibold : .medium, design: .monospaced))

--- a/Muxy/Views/VCS/BranchPicker.swift
+++ b/Muxy/Views/VCS/BranchPicker.swift
@@ -19,23 +19,23 @@ struct BranchPicker: View {
             onRefresh()
             showPopover.toggle()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: "arrow.triangle.branch")
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                 Text(currentBranch ?? "detached")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(maxWidth: 120, alignment: .leading)
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 8, weight: .bold))
+                    .font(.system(size: UIMetrics.fontMicro, weight: .bold))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
             .foregroundStyle(MuxyTheme.fg.opacity(0.85))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
-            .contentShape(RoundedRectangle(cornerRadius: 5))
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.scaled(3))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
         }
         .buttonStyle(.plain)
         .help(currentBranch ?? "detached")
@@ -102,8 +102,8 @@ struct BranchPickerContent: View {
                     isActive: item.name == currentBranch,
                     isHighlighted: isHighlighted
                 )
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
+                .padding(.horizontal, UIMetrics.spacing3)
+                .padding(.vertical, UIMetrics.spacing1)
                 .contextMenu {
                     if let onDeleteBranch, item.name != currentBranch {
                         Button("Delete Branch", role: .destructive) {
@@ -128,14 +128,14 @@ private struct BranchRow: View {
     @State private var hovered = false
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: UIMetrics.spacing5) {
             Circle()
                 .fill(isActive ? MuxyTheme.accent : MuxyTheme.fgDim.opacity(0.35))
-                .frame(width: 7, height: 7)
-                .frame(width: 10)
+                .frame(width: UIMetrics.scaled(7), height: UIMetrics.scaled(7))
+                .frame(width: UIMetrics.spacing5)
 
             Text(name)
-                .font(.system(size: 12, weight: isActive ? .semibold : .medium, design: .monospaced))
+                .font(.system(size: UIMetrics.fontBody, weight: isActive ? .semibold : .medium, design: .monospaced))
                 .foregroundStyle(isActive ? MuxyTheme.fg : MuxyTheme.fg.opacity(0.9))
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -144,13 +144,13 @@ private struct BranchRow: View {
 
             if isActive {
                 Image(systemName: "checkmark")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                     .foregroundStyle(MuxyTheme.accent)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(rowBackground, in: RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.vertical, UIMetrics.scaled(7))
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
         .onHover { hovered = $0 }
     }
 

--- a/Muxy/Views/VCS/CommitHistoryView.swift
+++ b/Muxy/Views/VCS/CommitHistoryView.swift
@@ -201,7 +201,7 @@ private struct CommitRow: View {
         Circle()
             .fill(commit.isMerge ? .clear : dotColor)
             .stroke(dotColor, lineWidth: commit.isMerge ? 1.5 : 0)
-            .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
+            .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
     }
 
     private var refBadges: some View {

--- a/Muxy/Views/VCS/CommitHistoryView.swift
+++ b/Muxy/Views/VCS/CommitHistoryView.swift
@@ -19,13 +19,13 @@ struct CommitHistoryView: View {
         if state.isLoadingCommits, state.commits.isEmpty {
             ProgressView()
                 .frame(maxWidth: .infinity)
-                .padding(20)
+                .padding(UIMetrics.spacing8)
         } else if state.commits.isEmpty {
             Text("No commits")
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 20)
+                .padding(.vertical, UIMetrics.spacing8)
         } else {
             commitList
         }
@@ -54,13 +54,13 @@ struct CommitHistoryView: View {
                         ProgressView()
                             .controlSize(.small)
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, 10)
+                            .padding(.vertical, UIMetrics.spacing5)
                     } else {
                         Text("Load more")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                             .foregroundStyle(MuxyTheme.accent)
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, 10)
+                            .padding(.vertical, UIMetrics.spacing5)
                     }
                 }
                 .buttonStyle(.plain)
@@ -141,28 +141,28 @@ private struct CommitRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             commitDot
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                 Text(commit.subject)
-                    .font(.system(size: 12, weight: .regular))
+                    .font(.system(size: UIMetrics.fontBody, weight: .regular))
                     .foregroundStyle(MuxyTheme.fg)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
-                HStack(spacing: 6) {
+                HStack(spacing: UIMetrics.spacing3) {
                     if !commit.refs.isEmpty {
                         refBadges
                     }
 
                     Text(commit.authorName)
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgDim)
                         .lineLimit(1)
 
                     Text(relativeDate(commit.authorDate))
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
             }
@@ -171,13 +171,13 @@ private struct CommitRow: View {
 
             if hovered {
                 Text(commit.shortHash)
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                     .foregroundStyle(MuxyTheme.fgDim)
-                    .padding(.trailing, 2)
+                    .padding(.trailing, UIMetrics.spacing1)
             }
         }
-        .padding(.horizontal, 10)
-        .frame(height: 40)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .frame(height: UIMetrics.scaled(40))
         .background(hovered ? MuxyTheme.hover : .clear)
         .contentShape(Rectangle())
         .onHover { hovered = $0 }
@@ -201,7 +201,7 @@ private struct CommitRow: View {
         Circle()
             .fill(commit.isMerge ? .clear : dotColor)
             .stroke(dotColor, lineWidth: commit.isMerge ? 1.5 : 0)
-            .frame(width: 8, height: 8)
+            .frame(width: UIMetrics.spacing4, height: UIMetrics.spacing4)
     }
 
     private var refBadges: some View {
@@ -231,17 +231,17 @@ private struct CommitRow: View {
             "tag"
         }
 
-        return HStack(spacing: 2) {
+        return HStack(spacing: UIMetrics.spacing1) {
             Image(systemName: icon)
-                .font(.system(size: 8, weight: .semibold))
+                .font(.system(size: UIMetrics.fontMicro, weight: .semibold))
             Text(ref.name)
-                .font(.system(size: 9, weight: .semibold))
+                .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                 .lineLimit(1)
         }
         .foregroundStyle(color)
-        .padding(.horizontal, 5)
-        .padding(.vertical, 1)
-        .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 3))
+        .padding(.horizontal, UIMetrics.scaled(5))
+        .padding(.vertical, UIMetrics.scaled(1))
+        .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: UIMetrics.scaled(3)))
     }
 
     @ViewBuilder
@@ -341,9 +341,9 @@ private struct NameInputSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: UIMetrics.spacing7) {
             Text(title)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
 
             TextField(placeholder, text: $name)
@@ -353,7 +353,7 @@ private struct NameInputSheet: View {
                     onSubmit()
                 }
 
-            HStack(spacing: 8) {
+            HStack(spacing: UIMetrics.spacing4) {
                 Button("Cancel", action: onCancel)
                     .keyboardShortcut(.cancelAction)
 
@@ -364,7 +364,7 @@ private struct NameInputSheet: View {
                 .disabled(!isValid)
             }
         }
-        .padding(20)
-        .frame(width: 300)
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(300))
     }
 }

--- a/Muxy/Views/VCS/CreateBranchSheet.swift
+++ b/Muxy/Views/VCS/CreateBranchSheet.swift
@@ -17,13 +17,13 @@ struct CreateBranchSheet: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: UIMetrics.fontHeadline) {
             Text("New Branch")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
                 Text("Branch Name")
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgMuted)
                 TextField("feature-x", text: $name)
                     .textFieldStyle(.roundedBorder)
@@ -33,7 +33,7 @@ struct CreateBranchSheet: View {
 
             if let currentBranch {
                 Text("Created from \(currentBranch)")
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
 
@@ -46,8 +46,8 @@ struct CreateBranchSheet: View {
                     .disabled(!canCreate)
             }
         }
-        .padding(20)
-        .frame(width: 360)
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(360))
         .onAppear { nameFocused = true }
     }
 }

--- a/Muxy/Views/VCS/CreateBranchSheet.swift
+++ b/Muxy/Views/VCS/CreateBranchSheet.swift
@@ -17,7 +17,7 @@ struct CreateBranchSheet: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: UIMetrics.fontHeadline) {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
             Text("New Branch")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
 

--- a/Muxy/Views/VCS/CreatePRSheet.swift
+++ b/Muxy/Views/VCS/CreatePRSheet.swift
@@ -82,7 +82,7 @@ struct CreatePRForm: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
             header
             titleField
             descriptionField
@@ -97,7 +97,7 @@ struct CreatePRForm: View {
                 }
             }
 
-            HStack(spacing: 10) {
+            HStack(spacing: UIMetrics.spacing5) {
                 advancedToggle
                 if advanced {
                     draftToggle
@@ -110,7 +110,7 @@ struct CreatePRForm: View {
                 warning(errorMessage)
             }
         }
-        .padding(10)
+        .padding(UIMetrics.spacing5)
         .background(MuxyTheme.bg)
         .onAppear(perform: applyDefaults)
         .onChange(of: availableBaseBranches) { _, newList in
@@ -126,48 +126,48 @@ struct CreatePRForm: View {
     }
 
     private var header: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Button(action: onCancel) {
-                HStack(spacing: 4) {
+                HStack(spacing: UIMetrics.spacing2) {
                     Image(systemName: "chevron.left")
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                     Text("Back")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 }
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .padding(.vertical, 3)
+                .padding(.vertical, UIMetrics.scaled(3))
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .help("Back to commit")
 
             Image(systemName: "arrow.triangle.pull")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(MuxyTheme.accent)
             Text("New Pull Request")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
             Spacer(minLength: 0)
         }
     }
 
     private var targetBranchField: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
             fieldLabel("Target Branch")
             if availableBaseBranches.isEmpty {
                 if context.isLoadingRemoteBranches {
-                    HStack(spacing: 6) {
+                    HStack(spacing: UIMetrics.spacing3) {
                         ProgressView().controlSize(.small)
                         Text("Loading remote branches…")
-                            .font(.system(size: 11))
+                            .font(.system(size: UIMetrics.fontFootnote))
                             .foregroundStyle(MuxyTheme.fgMuted)
                     }
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 7)
+                    .padding(.horizontal, UIMetrics.spacing4)
+                    .padding(.vertical, UIMetrics.scaled(7))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .themedFieldBackground()
                 } else {
                     Text("No branches found.")
-                        .font(.system(size: 11))
+                        .font(.system(size: UIMetrics.fontFootnote))
                         .foregroundStyle(MuxyTheme.diffRemoveFg)
                 }
             } else {
@@ -190,22 +190,22 @@ struct CreatePRForm: View {
                     }
                     .disabled(context.isLoadingRemoteBranches)
                 } label: {
-                    HStack(spacing: 6) {
+                    HStack(spacing: UIMetrics.spacing3) {
                         Image(systemName: "arrow.triangle.branch")
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                             .foregroundStyle(MuxyTheme.fgDim)
                         Text(baseBranch.isEmpty ? "Select branch" : baseBranch)
-                            .font(.system(size: 12, design: .monospaced))
+                            .font(.system(size: UIMetrics.fontBody, design: .monospaced))
                             .foregroundStyle(MuxyTheme.fg)
                             .lineLimit(1)
                             .truncationMode(.middle)
                         Spacer(minLength: 4)
                         Image(systemName: "chevron.down")
-                            .font(.system(size: 9, weight: .bold))
+                            .font(.system(size: UIMetrics.fontXS, weight: .bold))
                             .foregroundStyle(MuxyTheme.fgDim)
                     }
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 7)
+                    .padding(.horizontal, UIMetrics.spacing4)
+                    .padding(.vertical, UIMetrics.scaled(7))
                     .contentShape(Rectangle())
                 }
                 .menuStyle(.button)
@@ -217,7 +217,7 @@ struct CreatePRForm: View {
     }
 
     private var titleField: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
             fieldLabel("Title")
             ThemedTextField(
                 text: $title,
@@ -230,21 +230,21 @@ struct CreatePRForm: View {
     }
 
     private var descriptionField: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
             fieldLabel("Description")
             TextEditor(text: $bodyText)
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fg)
                 .scrollContentBackground(.hidden)
-                .padding(.horizontal, 4)
-                .padding(.vertical, 3)
-                .frame(height: 100)
+                .padding(.horizontal, UIMetrics.spacing2)
+                .padding(.vertical, UIMetrics.scaled(3))
+                .frame(height: UIMetrics.scaled(100))
                 .themedFieldBackground()
         }
     }
 
     private var newBranchField: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
             fieldLabel("New Branch")
             ThemedTextField(
                 text: $newBranchName,
@@ -258,16 +258,16 @@ struct CreatePRForm: View {
                 }
             }
             Text("A new branch will be created from \(currentBranchSnapshot) for this pull request.")
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgDim)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
 
     private var includeSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
             fieldLabel("Include")
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
                 includeRadio(label: "All changes (staged + unstaged)", value: true)
                 includeRadio(label: "Only staged changes", value: false)
             }
@@ -278,12 +278,12 @@ struct CreatePRForm: View {
         Button {
             includeAll = value
         } label: {
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: includeAll == value ? "largecircle.fill.circle" : "circle")
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(includeAll == value ? MuxyTheme.accent : MuxyTheme.fgDim)
                 Text(label)
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fg)
             }
             .contentShape(Rectangle())
@@ -295,11 +295,11 @@ struct CreatePRForm: View {
         Button {
             advanced.toggle()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: advanced ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
                 Text("Advanced")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
             }
             .foregroundStyle(MuxyTheme.fgMuted)
             .contentShape(Rectangle())
@@ -311,7 +311,7 @@ struct CreatePRForm: View {
     private var draftToggle: some View {
         Toggle(isOn: $draft) {
             Text("Create as draft")
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fg)
         }
         .toggleStyle(.checkbox)
@@ -319,21 +319,21 @@ struct CreatePRForm: View {
 
     private func warning(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 11))
+            .font(.system(size: UIMetrics.fontFootnote))
             .foregroundStyle(MuxyTheme.diffRemoveFg)
             .fixedSize(horizontal: false, vertical: true)
     }
 
     private var footerButtons: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: UIMetrics.spacing3) {
             Button(action: onCancel) {
                 Text("Cancel")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     .foregroundStyle(MuxyTheme.fg)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
-                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+                    .padding(.horizontal, UIMetrics.spacing6)
+                    .padding(.vertical, UIMetrics.spacing3)
+                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                    .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusMD).stroke(MuxyTheme.border, lineWidth: 1))
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -341,22 +341,22 @@ struct CreatePRForm: View {
 
             let submitEnabled = canSubmit && !inProgress
             Button(action: submit) {
-                HStack(spacing: 4) {
+                HStack(spacing: UIMetrics.spacing2) {
                     if inProgress {
                         ProgressView().controlSize(.mini)
                     }
                     Text("Create PR")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 }
                 .foregroundStyle(submitEnabled ? MuxyTheme.bg : MuxyTheme.fgDim)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
+                .padding(.horizontal, UIMetrics.spacing6)
+                .padding(.vertical, UIMetrics.spacing3)
                 .background(
                     submitEnabled ? MuxyTheme.accent : MuxyTheme.surface,
-                    in: RoundedRectangle(cornerRadius: 6)
+                    in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 6)
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                         .stroke(MuxyTheme.border, lineWidth: submitEnabled ? 0 : 1)
                 )
                 .contentShape(Rectangle())
@@ -369,7 +369,7 @@ struct CreatePRForm: View {
 
     private func fieldLabel(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 11))
+            .font(.system(size: UIMetrics.fontFootnote))
             .foregroundStyle(MuxyTheme.fgMuted)
     }
 
@@ -416,10 +416,10 @@ private struct ThemedTextField: View {
     var body: some View {
         TextField(placeholder, text: $text)
             .textFieldStyle(.plain)
-            .font(.system(size: 12, design: monospaced ? .monospaced : .default))
+            .font(.system(size: UIMetrics.fontBody, design: monospaced ? .monospaced : .default))
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 7)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.scaled(7))
             .frame(maxWidth: .infinity, alignment: .leading)
             .themedFieldBackground()
             .onSubmit { onSubmit?() }
@@ -428,7 +428,7 @@ private struct ThemedTextField: View {
 
 private extension View {
     func themedFieldBackground() -> some View {
-        background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
-            .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+        background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusMD).stroke(MuxyTheme.border, lineWidth: 1))
     }
 }

--- a/Muxy/Views/VCS/DiffBodyView.swift
+++ b/Muxy/Views/VCS/DiffBodyView.swift
@@ -14,7 +14,7 @@ struct DiffBodyView: View {
             if isLoading, diff == nil {
                 ProgressView()
                     .frame(maxWidth: .infinity)
-                    .padding(UIMetrics.fontHeadline)
+                    .padding(UIMetrics.scaled(14))
             } else if let error {
                 Text(error)
                     .font(.system(size: UIMetrics.fontBody))

--- a/Muxy/Views/VCS/DiffBodyView.swift
+++ b/Muxy/Views/VCS/DiffBodyView.swift
@@ -14,13 +14,13 @@ struct DiffBodyView: View {
             if isLoading, diff == nil {
                 ProgressView()
                     .frame(maxWidth: .infinity)
-                    .padding(14)
+                    .padding(UIMetrics.fontHeadline)
             } else if let error {
                 Text(error)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(12)
+                    .padding(UIMetrics.spacing6)
             } else if let diff {
                 VStack(spacing: 0) {
                     if diff.truncated, let onLoadFull {
@@ -46,10 +46,10 @@ struct DiffBodyView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 Text("No diff output")
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(12)
+                    .padding(UIMetrics.spacing6)
             }
         }
         .background(MuxyTheme.bg)
@@ -58,15 +58,15 @@ struct DiffBodyView: View {
     private func truncatedBanner(onLoadFull: @escaping () -> Void) -> some View {
         HStack {
             Text("Large diff preview")
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 .foregroundStyle(MuxyTheme.fgMuted)
             Spacer(minLength: 0)
             Button("Load full diff", action: onLoadFull)
                 .buttonStyle(.plain)
-                .font(.system(size: 11, weight: .semibold))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(MuxyTheme.accent)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .padding(.vertical, UIMetrics.spacing4)
     }
 }

--- a/Muxy/Views/VCS/DiffComponents.swift
+++ b/Muxy/Views/VCS/DiffComponents.swift
@@ -8,14 +8,14 @@ struct DiffSectionDivider: View {
     var body: some View {
         HStack(spacing: 0) {
             Text(text)
-                .font(.system(size: 11, design: .monospaced))
+                .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
                 .foregroundStyle(MuxyTheme.fgDim)
                 .lineLimit(1)
                 .truncationMode(.tail)
-                .padding(.leading, 10)
-            Spacer(minLength: 8)
+                .padding(.leading, UIMetrics.spacing5)
+            Spacer(minLength: UIMetrics.spacing4)
         }
-        .frame(height: 28)
+        .frame(height: UIMetrics.scaled(28))
         .frame(maxWidth: .infinity)
         .background(MuxyTheme.bg)
         .overlay(alignment: .top) {

--- a/Muxy/Views/VCS/DiffViewerPane.swift
+++ b/Muxy/Views/VCS/DiffViewerPane.swift
@@ -36,13 +36,13 @@ private struct DiffViewerBreadcrumb: View {
     }
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: UIMetrics.spacing3) {
             FileDiffIcon()
                 .stroke(MuxyTheme.fgDim, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
-                .frame(width: 11, height: 11)
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
 
             Text(state.filePath)
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -50,22 +50,22 @@ private struct DiffViewerBreadcrumb: View {
 
             if state.isStaged {
                 Text("Staged")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fgMuted)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
+                    .padding(.horizontal, UIMetrics.scaled(5))
+                    .padding(.vertical, UIMetrics.scaled(1))
                     .background(MuxyTheme.surface, in: Capsule())
             }
 
             if let diff = loadedDiff {
                 if diff.additions > 0 {
                     Text("+\(diff.additions)")
-                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold, design: .monospaced))
                         .foregroundStyle(MuxyTheme.diffAddFg)
                 }
                 if diff.deletions > 0 {
                     Text("-\(diff.deletions)")
-                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold, design: .monospaced))
                         .foregroundStyle(MuxyTheme.diffRemoveFg)
                 }
             }
@@ -79,8 +79,8 @@ private struct DiffViewerBreadcrumb: View {
             }
             .help("Refresh")
         }
-        .padding(.horizontal, 10)
-        .frame(height: 32)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .frame(height: UIMetrics.scaled(32))
         .background(MuxyTheme.bg)
     }
 
@@ -89,8 +89,8 @@ private struct DiffViewerBreadcrumb: View {
             modeButton(.split, symbol: "rectangle.split.2x1", tooltip: "Side by side")
             modeButton(.unified, symbol: "rectangle", tooltip: "Inline")
         }
-        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
-        .overlay(RoundedRectangle(cornerRadius: 5).stroke(MuxyTheme.border, lineWidth: 1))
+        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+        .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(MuxyTheme.border, lineWidth: 1))
     }
 
     private func modeButton(_ mode: VCSTabState.ViewMode, symbol: String, tooltip: String) -> some View {
@@ -99,9 +99,9 @@ private struct DiffViewerBreadcrumb: View {
             state.mode = mode
         } label: {
             Image(systemName: symbol)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 .foregroundStyle(selected ? MuxyTheme.fg : MuxyTheme.fgMuted)
-                .frame(width: 22, height: 20)
+                .frame(width: UIMetrics.scaled(22), height: UIMetrics.controlSmall)
                 .background(selected ? MuxyTheme.bg : Color.clear)
                 .contentShape(Rectangle())
         }

--- a/Muxy/Views/VCS/DiffViewerPane.swift
+++ b/Muxy/Views/VCS/DiffViewerPane.swift
@@ -39,7 +39,7 @@ private struct DiffViewerBreadcrumb: View {
         HStack(spacing: UIMetrics.spacing3) {
             FileDiffIcon()
                 .stroke(MuxyTheme.fgDim, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
-                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
+                .frame(width: UIMetrics.scaled(11), height: UIMetrics.scaled(11))
 
             Text(state.filePath)
                 .font(.system(size: UIMetrics.fontFootnote))

--- a/Muxy/Views/VCS/PullRequestsListView.swift
+++ b/Muxy/Views/VCS/PullRequestsListView.swift
@@ -36,8 +36,8 @@ struct PullRequestsListView: View {
             }
             .padding(.horizontal, UIMetrics.spacing3)
             .frame(height: UIMetrics.scaled(22))
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
-            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing2).stroke(MuxyTheme.border, lineWidth: 1))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(MuxyTheme.border, lineWidth: 1))
 
             Menu {
                 ForEach([
@@ -66,8 +66,8 @@ struct PullRequestsListView: View {
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .padding(.horizontal, UIMetrics.spacing3)
                 .frame(height: UIMetrics.scaled(22))
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
-                .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing2).stroke(MuxyTheme.border, lineWidth: 1))
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+                .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(MuxyTheme.border, lineWidth: 1))
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
@@ -267,8 +267,8 @@ struct PullRequestRow: View {
             .foregroundStyle(MuxyTheme.fg)
             .padding(.horizontal, UIMetrics.spacing4)
             .frame(height: UIMetrics.scaled(22))
-            .background(MuxyTheme.bg, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
-            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing2).stroke(MuxyTheme.border, lineWidth: 1))
+            .background(MuxyTheme.bg, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(MuxyTheme.border, lineWidth: 1))
         }
         .buttonStyle(.plain)
         .disabled(isCheckingOut)

--- a/Muxy/Views/VCS/PullRequestsListView.swift
+++ b/Muxy/Views/VCS/PullRequestsListView.swift
@@ -14,30 +14,30 @@ struct PullRequestsListView: View {
     }
 
     private var controlsBar: some View {
-        HStack(spacing: 6) {
-            HStack(spacing: 4) {
+        HStack(spacing: UIMetrics.spacing3) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fgDim)
                 TextField("Search", text: $state.pullRequestSearchQuery)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 11))
+                    .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fg)
                 if !state.pullRequestSearchQuery.isEmpty {
                     Button {
                         state.pullRequestSearchQuery = ""
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 10))
+                            .font(.system(size: UIMetrics.fontCaption))
                             .foregroundStyle(MuxyTheme.fgDim)
                     }
                     .buttonStyle(.plain)
                 }
             }
-            .padding(.horizontal, 6)
-            .frame(height: 22)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
-            .overlay(RoundedRectangle(cornerRadius: 4).stroke(MuxyTheme.border, lineWidth: 1))
+            .padding(.horizontal, UIMetrics.spacing3)
+            .frame(height: UIMetrics.scaled(22))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing2).stroke(MuxyTheme.border, lineWidth: 1))
 
             Menu {
                 ForEach([
@@ -57,24 +57,24 @@ struct PullRequestsListView: View {
                     }
                 }
             } label: {
-                HStack(spacing: 3) {
+                HStack(spacing: UIMetrics.scaled(3)) {
                     Text(filterLabel(state.pullRequestStateFilter))
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     Image(systemName: "chevron.down")
-                        .font(.system(size: 8, weight: .bold))
+                        .font(.system(size: UIMetrics.fontMicro, weight: .bold))
                 }
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .padding(.horizontal, 6)
-                .frame(height: 22)
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 4))
-                .overlay(RoundedRectangle(cornerRadius: 4).stroke(MuxyTheme.border, lineWidth: 1))
+                .padding(.horizontal, UIMetrics.spacing3)
+                .frame(height: UIMetrics.scaled(22))
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+                .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing2).stroke(MuxyTheme.border, lineWidth: 1))
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
+        .padding(.horizontal, UIMetrics.spacing4)
+        .padding(.vertical, UIMetrics.spacing3)
     }
 
     private func filterLabel(_ filter: GitRepositoryService.PRListFilter) -> String {
@@ -122,24 +122,24 @@ struct PullRequestsListView: View {
     }
 
     private var unfetchedState: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: UIMetrics.spacing4) {
             Text("Pull requests not synced yet")
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
             Button {
                 state.loadPullRequests()
             } label: {
-                HStack(spacing: 4) {
+                HStack(spacing: UIMetrics.spacing2) {
                     Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                     Text("Sync now")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 }
                 .foregroundStyle(MuxyTheme.fg)
-                .padding(.horizontal, 10)
-                .frame(height: 24)
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
-                .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+                .padding(.horizontal, UIMetrics.spacing5)
+                .frame(height: UIMetrics.controlMedium)
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusMD).stroke(MuxyTheme.border, lineWidth: 1))
             }
             .buttonStyle(.plain)
         }
@@ -147,17 +147,17 @@ struct PullRequestsListView: View {
     }
 
     private func emptyState(icon: String, text: String) -> some View {
-        VStack(spacing: 6) {
+        VStack(spacing: UIMetrics.spacing3) {
             Image(systemName: icon)
-                .font(.system(size: 16))
+                .font(.system(size: UIMetrics.fontTitleLarge))
                 .foregroundStyle(MuxyTheme.fgDim)
             Text(text)
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(20)
+        .padding(UIMetrics.spacing8)
     }
 }
 
@@ -169,31 +169,31 @@ struct PullRequestRow: View {
     @State private var hovered = false
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             stateBadge
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
+                HStack(spacing: UIMetrics.spacing3) {
                     Text(pr.title)
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: UIMetrics.fontBody, weight: .medium))
                         .foregroundStyle(MuxyTheme.fg)
                         .lineLimit(1)
                         .truncationMode(.tail)
                     Text("#\(pr.number)")
-                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
-                HStack(spacing: 4) {
+                HStack(spacing: UIMetrics.spacing2) {
                     Text(pr.author)
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgMuted)
                     Text("•")
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgDim)
                     Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: 9))
+                        .font(.system(size: UIMetrics.fontXS))
                         .foregroundStyle(MuxyTheme.fgDim)
                     Text("\(pr.headBranch) → \(pr.baseBranch)")
-                        .font(.system(size: 10, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .lineLimit(1)
                         .truncationMode(.middle)
@@ -205,8 +205,8 @@ struct PullRequestRow: View {
                 checkoutButton
             }
         }
-        .padding(.horizontal, 10)
-        .frame(height: 44)
+        .padding(.horizontal, UIMetrics.spacing5)
+        .frame(height: UIMetrics.scaled(44))
         .background(hovered ? MuxyTheme.surface : MuxyTheme.bg)
         .contentShape(Rectangle())
         .onHover { hovered = $0 }
@@ -218,9 +218,9 @@ struct PullRequestRow: View {
     private var stateBadge: some View {
         let (symbol, color) = stateAppearance
         Image(systemName: symbol)
-            .font(.system(size: 11, weight: .semibold))
+            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
             .foregroundStyle(color)
-            .frame(width: 14)
+            .frame(width: UIMetrics.iconMD)
     }
 
     private var stateAppearance: (String, Color) {
@@ -239,36 +239,36 @@ struct PullRequestRow: View {
             EmptyView()
         case .pending:
             Image(systemName: "clock")
-                .font(.system(size: 10))
+                .font(.system(size: UIMetrics.fontCaption))
                 .foregroundStyle(MuxyTheme.fgMuted)
         case .success:
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 10))
+                .font(.system(size: UIMetrics.fontCaption))
                 .foregroundStyle(MuxyTheme.diffAddFg)
         case .failure:
             Image(systemName: "xmark.octagon.fill")
-                .font(.system(size: 10))
+                .font(.system(size: UIMetrics.fontCaption))
                 .foregroundStyle(MuxyTheme.diffRemoveFg)
         }
     }
 
     private var checkoutButton: some View {
         Button(action: onCheckout) {
-            HStack(spacing: 3) {
+            HStack(spacing: UIMetrics.scaled(3)) {
                 if isCheckingOut {
                     ProgressView().controlSize(.mini)
                 } else {
                     Image(systemName: "arrow.down.to.line")
-                        .font(.system(size: 9, weight: .bold))
+                        .font(.system(size: UIMetrics.fontXS, weight: .bold))
                 }
                 Text("Checkout")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
             }
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, 8)
-            .frame(height: 22)
-            .background(MuxyTheme.bg, in: RoundedRectangle(cornerRadius: 4))
-            .overlay(RoundedRectangle(cornerRadius: 4).stroke(MuxyTheme.border, lineWidth: 1))
+            .padding(.horizontal, UIMetrics.spacing4)
+            .frame(height: UIMetrics.scaled(22))
+            .background(MuxyTheme.bg, in: RoundedRectangle(cornerRadius: UIMetrics.spacing2))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.spacing2).stroke(MuxyTheme.border, lineWidth: 1))
         }
         .buttonStyle(.plain)
         .disabled(isCheckingOut)
@@ -301,9 +301,9 @@ struct PullRequestsAutoSyncMenu: View {
             }
         } label: {
             Image(systemName: state.pullRequestAutoSyncMinutes > 0 ? "clock.fill" : "clock")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(state.pullRequestAutoSyncMinutes > 0 ? MuxyTheme.accent : MuxyTheme.fgMuted)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -105,7 +105,7 @@ struct VCSTabView: View {
 
     private var header: some View {
         HStack(spacing: 0) {
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 worktreeBranchPicker
 
                 PRPill(
@@ -115,7 +115,7 @@ struct VCSTabView: View {
                     onRequestClose: { prInfo in pendingClosePR = prInfo }
                 )
             }
-            .padding(.leading, 8)
+            .padding(.leading, UIMetrics.spacing4)
 
             Spacer(minLength: 0)
 
@@ -132,7 +132,7 @@ struct VCSTabView: View {
                 if state.isRefreshingPullRequest {
                     ProgressView()
                         .controlSize(.small)
-                        .frame(width: 24, height: 24)
+                        .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 } else {
                     IconButton(symbol: "arrow.clockwise", accessibilityLabel: "Refresh") {
                         state.refresh()
@@ -140,7 +140,7 @@ struct VCSTabView: View {
                 }
             }
         }
-        .frame(height: 32)
+        .frame(height: UIMetrics.scaled(32))
         .background(MuxyTheme.bg)
         .sheet(isPresented: $showCreateWorktreeSheet) {
             if let project = owningProject {
@@ -374,7 +374,7 @@ struct VCSTabView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if state.files.isEmpty, state.errorMessage != nil {
             Text(state.errorMessage ?? "")
-                .font(.system(size: 12))
+                .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -432,22 +432,22 @@ struct VCSTabView: View {
     }
 
     private var commitArea: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: UIMetrics.spacing4) {
             ZStack(alignment: .topLeading) {
                 if state.commitMessage.isEmpty {
                     Text("Commit message (⌘↵ to commit on \(state.branchName ?? "branch"))")
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fgDim)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 10)
+                        .padding(.horizontal, UIMetrics.spacing5)
+                        .padding(.vertical, UIMetrics.spacing5)
                         .allowsHitTesting(false)
                 }
                 TextEditor(text: $state.commitMessage)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fg)
                     .scrollContentBackground(.hidden)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 9)
+                    .padding(.horizontal, UIMetrics.scaled(5))
+                    .padding(.vertical, UIMetrics.scaled(9))
                     .frame(minHeight: 27, maxHeight: 50)
                     .onKeyPress(.return, phases: .down) { keyPress in
                         if keyPress.modifiers.contains(.command) {
@@ -457,16 +457,16 @@ struct VCSTabView: View {
                         return .ignored
                     }
             }
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
-            .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusMD).stroke(MuxyTheme.border, lineWidth: 1))
 
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 commitButton
                 pullButton
                 pushButton
             }
         }
-        .padding(10)
+        .padding(UIMetrics.spacing5)
         .background(MuxyTheme.bg)
     }
 
@@ -474,25 +474,25 @@ struct VCSTabView: View {
         Button {
             state.commit()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 if state.isCommitting {
                     ProgressView().controlSize(.mini)
                 } else {
                     Image(systemName: "checkmark")
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                 }
                 Text("Commit")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
             }
             .foregroundStyle(commitEnabled ? MuxyTheme.bg : MuxyTheme.fgDim)
             .frame(maxWidth: .infinity)
             .frame(height: Self.actionButtonHeight)
             .background(
                 commitEnabled ? MuxyTheme.accent : MuxyTheme.surface,
-                in: RoundedRectangle(cornerRadius: 6)
+                in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 6)
+                RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                     .stroke(MuxyTheme.border, lineWidth: commitEnabled ? 0 : 1)
             )
         }
@@ -505,29 +505,29 @@ struct VCSTabView: View {
         Button {
             state.pull()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 if state.isPulling {
                     ProgressView().controlSize(.mini)
                 } else {
                     Image(systemName: "arrow.down")
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                 }
                 Text("Pull")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 if state.aheadBehind.behind > 0 {
                     Text("\(state.aheadBehind.behind)")
-                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold, design: .monospaced))
                         .foregroundStyle(MuxyTheme.bg)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
+                        .padding(.horizontal, UIMetrics.scaled(5))
+                        .padding(.vertical, UIMetrics.scaled(1))
                         .background(MuxyTheme.diffAddFg, in: Capsule())
                 }
             }
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, 10)
+            .padding(.horizontal, UIMetrics.spacing5)
             .frame(height: Self.actionButtonHeight)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
-            .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusMD).stroke(MuxyTheme.border, lineWidth: 1))
         }
         .buttonStyle(.plain)
         .disabled(state.isPulling)
@@ -540,29 +540,29 @@ struct VCSTabView: View {
         Button {
             state.push()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 if state.isPushing {
                     ProgressView().controlSize(.mini)
                 } else {
                     Image(systemName: "arrow.up")
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                 }
                 Text("Push")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 if state.aheadBehind.ahead > 0 {
                     Text("\(state.aheadBehind.ahead)")
-                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold, design: .monospaced))
                         .foregroundStyle(MuxyTheme.bg)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
+                        .padding(.horizontal, UIMetrics.scaled(5))
+                        .padding(.vertical, UIMetrics.scaled(1))
                         .background(MuxyTheme.accent, in: Capsule())
                 }
             }
             .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, 10)
+            .padding(.horizontal, UIMetrics.spacing5)
             .frame(height: Self.actionButtonHeight)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
-            .overlay(RoundedRectangle(cornerRadius: 6).stroke(MuxyTheme.border, lineWidth: 1))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusMD).stroke(MuxyTheme.border, lineWidth: 1))
         }
         .buttonStyle(.plain)
         .disabled(state.isPushing)
@@ -571,7 +571,7 @@ struct VCSTabView: View {
             : "Push to origin")
     }
 
-    private static let actionButtonHeight: CGFloat = 28
+    @MainActor private static var actionButtonHeight: CGFloat { UIMetrics.scaled(28) }
 
     private func presentDiscardConfirmation(
         title: String,
@@ -717,9 +717,9 @@ struct VCSSectionVisibilityMenu: View {
             }
         } label: {
             Image(systemName: "sidebar.squares.left")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -768,44 +768,44 @@ struct PRPill: View {
 
     private var createPRPill: some View {
         Button(action: onRequestCreate) {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: "arrow.triangle.pull")
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
                 Text("Create PR")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
             }
             .foregroundStyle(MuxyTheme.accent)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.scaled(3))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(state.isOpeningPullRequest)
         .help("Create a pull request")
-        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
-        .overlay(RoundedRectangle(cornerRadius: 5).stroke(MuxyTheme.accent.opacity(0.35), lineWidth: 1))
+        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+        .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(MuxyTheme.accent.opacity(0.35), lineWidth: 1))
     }
 
     private func hasPRPill(info: GitRepositoryService.PRInfo) -> some View {
         Button {
             showPRPopover = true
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: prStateIcon(info))
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
                     .foregroundStyle(prStateColor(info))
                 Text("PR #\(info.number)")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg.opacity(0.85))
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 8, weight: .bold))
+                    .font(.system(size: UIMetrics.fontMicro, weight: .bold))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
-            .overlay(RoundedRectangle(cornerRadius: 5).stroke(prStateColor(info).opacity(0.35), lineWidth: 1))
-            .contentShape(RoundedRectangle(cornerRadius: 5))
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.scaled(3))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(prStateColor(info).opacity(0.35), lineWidth: 1))
+            .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
         }
         .buttonStyle(.plain)
         .help("Pull request #\(info.number)")
@@ -882,18 +882,18 @@ struct PRPill: View {
         action: @escaping () -> Void = {}
     ) -> some View {
         Button(action: action) {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: icon)
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
                 Text(text)
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
             }
             .foregroundStyle(tint)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
-            .overlay(RoundedRectangle(cornerRadius: 5).stroke(tint.opacity(0.35), lineWidth: 1))
-            .contentShape(RoundedRectangle(cornerRadius: 5))
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.scaled(3))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(tint.opacity(0.35), lineWidth: 1))
+            .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
         }
         .buttonStyle(.plain)
         .disabled(disabled)
@@ -911,16 +911,16 @@ struct PRPopover: View {
     @State private var mergeMethod: GitRepositoryService.PRMergeMethod = .squash
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+            HStack(spacing: UIMetrics.spacing4) {
                 Image(systemName: stateIcon)
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                     .foregroundStyle(stateColor)
-                VStack(alignment: .leading, spacing: 1) {
+                VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
                     Text("Pull Request #\(info.number)")
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                     Text(stateLabel)
-                        .font(.system(size: 10))
+                        .font(.system(size: UIMetrics.fontCaption))
                         .foregroundStyle(MuxyTheme.fgMuted)
                 }
                 Spacer(minLength: 0)
@@ -932,18 +932,18 @@ struct PRPopover: View {
                             ProgressView().controlSize(.mini)
                         } else {
                             Image(systemName: "arrow.clockwise")
-                                .font(.system(size: 11, weight: .semibold))
+                                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                                 .foregroundStyle(MuxyTheme.fgMuted)
                         }
                     }
-                    .frame(width: 20, height: 20)
+                    .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
                 }
                 .buttonStyle(.plain)
                 .disabled(state.isRefreshingPullRequest)
                 .help("Refresh")
             }
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
                 infoRow(label: "Base", value: info.baseBranch)
                 if let label = mergeableLabel {
                     infoRow(
@@ -958,18 +958,18 @@ struct PRPopover: View {
             Divider()
 
             Button(action: onOpenInBrowser) {
-                HStack(spacing: 6) {
+                HStack(spacing: UIMetrics.spacing3) {
                     Image(systemName: "arrow.up.right.square")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     Text("Open on GitHub")
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     Spacer(minLength: 0)
                 }
                 .foregroundStyle(MuxyTheme.fg)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+                .padding(.horizontal, UIMetrics.spacing4)
+                .padding(.vertical, UIMetrics.spacing3)
                 .frame(maxWidth: .infinity)
-                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             }
             .buttonStyle(.plain)
 
@@ -980,24 +980,24 @@ struct PRPopover: View {
                 )
 
                 Button { onMerge(mergeMethod) } label: {
-                    HStack(spacing: 6) {
+                    HStack(spacing: UIMetrics.spacing3) {
                         if state.isMergingPullRequest {
                             ProgressView().controlSize(.mini)
                         } else {
                             Image(systemName: "arrow.triangle.merge")
-                                .font(.system(size: 11, weight: .bold))
+                                .font(.system(size: UIMetrics.fontFootnote, weight: .bold))
                         }
                         Text(state.isMergingPullRequest ? "Merging…" : mergeMethod.label)
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                         Spacer(minLength: 0)
                     }
                     .foregroundStyle(mergeDisabled ? MuxyTheme.fgDim : MuxyTheme.bg)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
+                    .padding(.horizontal, UIMetrics.spacing4)
+                    .padding(.vertical, UIMetrics.spacing3)
                     .frame(maxWidth: .infinity)
                     .background(
                         mergeDisabled ? MuxyTheme.surface : MuxyTheme.accent,
-                        in: RoundedRectangle(cornerRadius: 5)
+                        in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                     )
                 }
                 .buttonStyle(.plain)
@@ -1005,29 +1005,29 @@ struct PRPopover: View {
                 .help(mergeHelp)
 
                 Button(action: onClose) {
-                    HStack(spacing: 6) {
+                    HStack(spacing: UIMetrics.spacing3) {
                         if state.isClosingPullRequest {
                             ProgressView().controlSize(.mini)
                         } else {
                             Image(systemName: "xmark.circle")
-                                .font(.system(size: 11, weight: .semibold))
+                                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                         }
                         Text("Close PR")
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                         Spacer(minLength: 0)
                     }
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
+                    .padding(.horizontal, UIMetrics.spacing4)
+                    .padding(.vertical, UIMetrics.spacing3)
                     .frame(maxWidth: .infinity)
-                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
+                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
                 }
                 .buttonStyle(.plain)
                 .disabled(state.isClosingPullRequest)
             }
         }
-        .padding(12)
-        .frame(width: 260)
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(260))
         .task(id: info.number) {
             onRefresh()
         }
@@ -1157,13 +1157,13 @@ struct PRPopover: View {
     }
 
     private func infoRow(label: String, value: String, valueColor: Color = MuxyTheme.fg) -> some View {
-        HStack(spacing: 6) {
+        HStack(spacing: UIMetrics.spacing3) {
             Text(label)
-                .font(.system(size: 11))
+                .font(.system(size: UIMetrics.fontFootnote))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 70, alignment: .leading)
+                .frame(width: UIMetrics.scaled(70), alignment: .leading)
             Text(value)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .monospaced))
                 .foregroundStyle(valueColor)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -1181,7 +1181,7 @@ private struct SectionSplitLayout: View {
     let onOpenInEditor: (String) -> Void
     let onOpenDiff: (String, Bool) -> Void
 
-    private static let sectionHeaderHeight: CGFloat = 30
+    @MainActor private static var sectionHeaderHeight: CGFloat { UIMetrics.scaled(30) }
 
     private var hasStaged: Bool { !state.stagedFiles.isEmpty }
 
@@ -1297,7 +1297,7 @@ private struct SectionSplitLayout: View {
         Rectangle().fill(MuxyTheme.border).frame(height: 1)
             .overlay {
                 Color.clear
-                    .frame(height: 5)
+                    .frame(height: UIMetrics.scaled(5))
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 1)
@@ -1357,7 +1357,7 @@ private struct SectionSplitLayout: View {
                 sectionHeader(for: .changes, collapsed: false)
                 if state.files.isEmpty {
                     Text("No changes")
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
@@ -1394,31 +1394,31 @@ private struct SectionSplitLayout: View {
         let isCollapsedState = collapsed
 
         return HStack(spacing: 0) {
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 Button {
                     toggleCollapsed(section)
                 } label: {
-                    HStack(spacing: 6) {
+                    HStack(spacing: UIMetrics.spacing3) {
                         Image(systemName: isCollapsedState ? "chevron.right" : "chevron.down")
-                            .font(.system(size: 9, weight: .bold))
+                            .font(.system(size: UIMetrics.fontXS, weight: .bold))
                             .foregroundStyle(MuxyTheme.fgDim)
-                            .frame(width: 10)
+                            .frame(width: UIMetrics.spacing5)
 
                         Text(section.title)
-                            .font(.system(size: 11, weight: .semibold))
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                             .foregroundStyle(MuxyTheme.fgMuted)
                     }
                 }
                 .buttonStyle(.plain)
 
                 Text("\(sectionCount(for: section))")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                     .foregroundStyle(MuxyTheme.bg)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 1)
+                    .padding(.horizontal, UIMetrics.spacing3)
+                    .padding(.vertical, UIMetrics.scaled(1))
                     .background(MuxyTheme.fgMuted, in: Capsule())
             }
-            .padding(.leading, 8)
+            .padding(.leading, UIMetrics.spacing4)
 
             Spacer(minLength: 0)
 
@@ -1489,9 +1489,9 @@ private struct SectionSplitLayout: View {
             state.mode = state.mode == .unified ? .split : .unified
         } label: {
             Image(systemName: state.mode == .unified ? "rectangle.split.2x1" : "rectangle")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -1503,9 +1503,9 @@ private struct SectionSplitLayout: View {
             state.fileListMode = state.fileListMode == .flat ? .folders : .flat
         } label: {
             Image(systemName: state.fileListMode == .flat ? "folder" : "list.bullet")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -1519,9 +1519,9 @@ private struct SectionSplitLayout: View {
             state.setExpanded(files: files, expanded: !anyExpanded)
         } label: {
             Image(systemName: anyExpanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 24, height: 24)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -1677,23 +1677,23 @@ private struct FileRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: expanded ? "chevron.down" : "chevron.right")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgDim)
-                .frame(width: 12)
+                .frame(width: UIMetrics.iconSM)
 
             Text(statusText)
-                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .bold, design: .monospaced))
                 .foregroundStyle(statusColor)
-                .frame(width: 14)
+                .frame(width: UIMetrics.iconMD)
 
             FileDiffIcon()
                 .stroke(statusColor, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
-                .frame(width: 11, height: 11)
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
 
             Text(displayPath)
-                .font(.system(size: 12, weight: .medium))
+                .font(.system(size: UIMetrics.fontBody, weight: .medium))
                 .foregroundStyle(MuxyTheme.fg)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -1705,24 +1705,24 @@ private struct FileRow: View {
 
             if stats.binary {
                 Text("Binary")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
                     .foregroundStyle(MuxyTheme.fgMuted)
             } else {
                 if let additions = stats.additions {
                     Text("+\(additions)")
-                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontBody, weight: .semibold, design: .monospaced))
                         .foregroundStyle(MuxyTheme.diffAddFg)
                 }
                 if let deletions = stats.deletions {
                     Text("-\(deletions)")
-                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontBody, weight: .semibold, design: .monospaced))
                         .foregroundStyle(MuxyTheme.diffRemoveFg)
                 }
             }
         }
-        .padding(.leading, 10 + CGFloat(depth) * 14)
-        .padding(.trailing, 10)
-        .frame(height: 34)
+        .padding(.leading, UIMetrics.spacing5 + CGFloat(depth) * UIMetrics.iconMD)
+        .padding(.trailing, UIMetrics.spacing5)
+        .frame(height: UIMetrics.scaled(34))
         .background(MuxyTheme.bg)
         .contentShape(Rectangle())
         .onHover { hovered = $0 }
@@ -1756,33 +1756,33 @@ private struct FolderRow: View {
     let onToggle: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: expanded ? "chevron.down" : "chevron.right")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgDim)
-                .frame(width: 12)
+                .frame(width: UIMetrics.iconSM)
 
             Image(systemName: "folder")
-                .font(.system(size: 11, weight: .semibold))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: 11, height: 11)
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
 
             Text(name)
-                .font(.system(size: 12, weight: .medium))
+                .font(.system(size: UIMetrics.fontBody, weight: .medium))
                 .foregroundStyle(MuxyTheme.fg)
                 .lineLimit(1)
                 .truncationMode(.tail)
 
             Text("\(fileCount) \(fileCount == 1 ? "file" : "files")")
-                .font(.system(size: 10, weight: .regular))
+                .font(.system(size: UIMetrics.fontCaption, weight: .regular))
                 .foregroundStyle(MuxyTheme.fgDim)
                 .lineLimit(1)
 
             Spacer()
         }
-        .padding(.leading, 10 + CGFloat(depth) * 14)
-        .padding(.trailing, 10)
-        .frame(height: 30)
+        .padding(.leading, UIMetrics.spacing5 + CGFloat(depth) * UIMetrics.iconMD)
+        .padding(.trailing, UIMetrics.spacing5)
+        .frame(height: UIMetrics.scaled(30))
         .background(MuxyTheme.bg)
         .contentShape(Rectangle())
         .onTapGesture(perform: onToggle)

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1402,7 +1402,7 @@ private struct SectionSplitLayout: View {
                         Image(systemName: isCollapsedState ? "chevron.right" : "chevron.down")
                             .font(.system(size: UIMetrics.fontXS, weight: .bold))
                             .foregroundStyle(MuxyTheme.fgDim)
-                            .frame(width: UIMetrics.spacing5)
+                            .frame(width: UIMetrics.scaled(10))
 
                         Text(section.title)
                             .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
@@ -1690,7 +1690,7 @@ private struct FileRow: View {
 
             FileDiffIcon()
                 .stroke(statusColor, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
-                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
+                .frame(width: UIMetrics.scaled(11), height: UIMetrics.scaled(11))
 
             Text(displayPath)
                 .font(.system(size: UIMetrics.fontBody, weight: .medium))
@@ -1765,7 +1765,7 @@ private struct FolderRow: View {
             Image(systemName: "folder")
                 .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
+                .frame(width: UIMetrics.scaled(11), height: UIMetrics.scaled(11))
 
             Text(name)
                 .font(.system(size: UIMetrics.fontBody, weight: .medium))

--- a/Muxy/Views/VCS/VCSWindowView.swift
+++ b/Muxy/Views/VCS/VCSWindowView.swift
@@ -18,7 +18,7 @@ struct VCSWindowView: View {
                 VCSTabView(state: state, focused: true, onFocus: {})
             } else {
                 Text("No project selected")
-                    .font(.system(size: 13))
+                    .font(.system(size: UIMetrics.fontEmphasis))
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }

--- a/Muxy/Views/VCS/WorktreeBranchPicker.swift
+++ b/Muxy/Views/VCS/WorktreeBranchPicker.swift
@@ -45,32 +45,32 @@ struct WorktreeBranchPicker: View {
 
     var body: some View {
         Button(action: open) {
-            HStack(spacing: 4) {
+            HStack(spacing: UIMetrics.spacing2) {
                 Image(systemName: "square.stack.3d.up")
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                 Text(worktreeLabel)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 7, weight: .bold))
+                    .font(.system(size: UIMetrics.scaled(7), weight: .bold))
                     .foregroundStyle(MuxyTheme.fgDim)
                 Image(systemName: "arrow.triangle.branch")
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                 Text(branchLabel)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 8, weight: .bold))
+                    .font(.system(size: UIMetrics.fontMicro, weight: .bold))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
             .frame(maxWidth: 160, alignment: .leading)
             .foregroundStyle(MuxyTheme.fg.opacity(0.85))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 5))
-            .contentShape(RoundedRectangle(cornerRadius: 5))
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.scaled(3))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
         }
         .buttonStyle(.plain)
         .help("\(worktreeLabel) › \(branchLabel)")
@@ -94,7 +94,7 @@ struct WorktreeBranchPicker: View {
                 segmentButton(item)
             }
         }
-        .frame(height: 32)
+        .frame(height: UIMetrics.scaled(32))
     }
 
     private func segmentButton(_ item: Segment) -> some View {
@@ -106,13 +106,13 @@ struct WorktreeBranchPicker: View {
             }
         } label: {
             Text(item.title)
-                .font(.system(size: 11, weight: isActive ? .semibold : .medium))
+                .font(.system(size: UIMetrics.fontFootnote, weight: isActive ? .semibold : .medium))
                 .foregroundStyle(isActive ? MuxyTheme.fg : MuxyTheme.fgDim)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .overlay(alignment: .bottom) {
                     Rectangle()
                         .fill(isActive ? MuxyTheme.accent : Color.clear)
-                        .frame(height: 2)
+                        .frame(height: UIMetrics.scaled(2))
                 }
                 .contentShape(Rectangle())
         }
@@ -159,7 +159,7 @@ struct WorktreeBranchPicker: View {
                 }
             }
         }
-        .frame(width: 320, height: 460)
+        .frame(width: UIMetrics.scaled(320), height: UIMetrics.scaled(460))
         .background(MuxyTheme.bg)
     }
 }

--- a/Muxy/Views/WelcomeView.swift
+++ b/Muxy/Views/WelcomeView.swift
@@ -4,10 +4,10 @@ struct WelcomeView: View {
     var body: some View {
         VStack(spacing: 0) {
             WindowDragRepresentable()
-                .frame(height: 32)
+                .frame(height: UIMetrics.scaled(32))
             Spacer()
             Text("No project selected")
-                .font(.system(size: 13))
+                .font(.system(size: UIMetrics.fontEmphasis))
                 .foregroundStyle(MuxyTheme.fgDim)
             Spacer()
         }

--- a/Muxy/Views/Workspace/DropZoneOverlay.swift
+++ b/Muxy/Views/Workspace/DropZoneOverlay.swift
@@ -6,10 +6,10 @@ struct DropZoneHighlight: View {
     var body: some View {
         GeometryReader { geo in
             let rect = highlightRect(in: geo.size)
-            RoundedRectangle(cornerRadius: 4)
+            RoundedRectangle(cornerRadius: UIMetrics.spacing2)
                 .fill(MuxyTheme.accent.opacity(0.15))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 4)
+                    RoundedRectangle(cornerRadius: UIMetrics.spacing2)
                         .strokeBorder(MuxyTheme.accent.opacity(0.4), lineWidth: 2)
                 )
                 .frame(width: rect.width, height: rect.height)

--- a/Muxy/Views/Workspace/DropZoneOverlay.swift
+++ b/Muxy/Views/Workspace/DropZoneOverlay.swift
@@ -6,10 +6,10 @@ struct DropZoneHighlight: View {
     var body: some View {
         GeometryReader { geo in
             let rect = highlightRect(in: geo.size)
-            RoundedRectangle(cornerRadius: UIMetrics.spacing2)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                 .fill(MuxyTheme.accent.opacity(0.15))
                 .overlay(
-                    RoundedRectangle(cornerRadius: UIMetrics.spacing2)
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                         .strokeBorder(MuxyTheme.accent.opacity(0.4), lineWidth: 2)
                 )
                 .frame(width: rect.width, height: rect.height)

--- a/Muxy/Views/Workspace/LayoutPickerMenu.swift
+++ b/Muxy/Views/Workspace/LayoutPickerMenu.swift
@@ -16,8 +16,8 @@ struct LayoutPickerMenu: View {
                 }
             } label: {
                 Image(systemName: "rectangle.split.2x2")
-                    .font(.system(size: 13, weight: .semibold))
-                    .frame(width: 24, height: 24)
+                    .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
+                    .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                     .contentShape(Rectangle())
             }
             .menuStyle(.borderlessButton)

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -35,7 +35,7 @@ struct SplitContainer: View {
                     .overlay(Rectangle().fill(MuxyTheme.border))
                     .overlay {
                         Color.clear
-                            .frame(width: h ? 5 : nil, height: h ? nil : 5)
+                            .frame(width: h ? UIMetrics.scaled(5) : nil, height: h ? nil : UIMetrics.scaled(5))
                             .contentShape(Rectangle())
                             .gesture(
                                 DragGesture(minimumDistance: 1)

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -396,7 +396,7 @@ private struct TabCell: View {
                         if hasUnread || hasCompletionPending, !active {
                             Circle()
                                 .fill(MuxyTheme.accent)
-                                .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
+                                .frame(width: UIMetrics.scaled(6), height: UIMetrics.scaled(6))
                                 .offset(x: UIMetrics.scaled(3), y: -UIMetrics.scaled(3))
                         }
                     }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -65,12 +65,12 @@ struct PaneTabStrip: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .frame(height: 32)
+            .frame(height: UIMetrics.scaled(32))
 
             HStack(spacing: 0) {
                 if showDevelopmentBadge {
                     developmentBadge
-                        .padding(.trailing, 6)
+                        .padding(.trailing, UIMetrics.spacing3)
                 }
                 if isWindowTitleBar {
                     OpenInIDEControl(
@@ -84,7 +84,7 @@ struct PaneTabStrip: View {
                     UpdateBadge(version: version) {
                         UpdateService.shared.checkForUpdates()
                     }
-                    .padding(.trailing, 4)
+                    .padding(.trailing, UIMetrics.spacing2)
                 }
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
                     .help(shortcutTooltip("Split Right", for: .splitRight))
@@ -105,12 +105,12 @@ struct PaneTabStrip: View {
                     .help(shortcutTooltip("File Tree", for: .toggleFileTree))
                 }
             }
-            .padding(.leading, 8)
-            .padding(.trailing, 4)
+            .padding(.leading, UIMetrics.spacing4)
+            .padding(.trailing, UIMetrics.spacing2)
             .fixedSize(horizontal: true, vertical: false)
             .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
         }
-        .frame(height: 32)
+        .frame(height: UIMetrics.scaled(32))
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
             guard dragState.draggedID != nil else { return }
             dragState.frames = frames
@@ -388,7 +388,7 @@ private struct TabCell: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            HStack(spacing: 6) {
+            HStack(spacing: UIMetrics.spacing3) {
                 tabIconView
                     .foregroundStyle(active ? MuxyTheme.fg : MuxyTheme.fgMuted)
                     .opacity(titleHidden && hovered && !tab.isPinned ? 0 : 1)
@@ -396,15 +396,15 @@ private struct TabCell: View {
                         if hasUnread || hasCompletionPending, !active {
                             Circle()
                                 .fill(MuxyTheme.accent)
-                                .frame(width: 6, height: 6)
-                                .offset(x: 3, y: -3)
+                                .frame(width: UIMetrics.spacing3, height: UIMetrics.spacing3)
+                                .offset(x: UIMetrics.scaled(3), y: -UIMetrics.scaled(3))
                         }
                     }
 
                 if isRenaming {
                     TextField("", text: $renameText)
                         .textFieldStyle(.plain)
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(MuxyTheme.fg)
                         .focused($renameFieldFocused)
                         .onSubmit { commitRename() }
@@ -414,16 +414,16 @@ private struct TabCell: View {
                         }
                 } else if !titleHidden {
                     Text(tab.title)
-                        .font(.system(size: 12))
+                        .font(.system(size: UIMetrics.fontBody))
                         .foregroundStyle(active ? MuxyTheme.fg : MuxyTheme.fgMuted)
                         .lineLimit(1)
                         .truncationMode(.head)
                 }
             }
-            .padding(.leading, titleHidden ? 0 : 12)
-            .padding(.trailing, titleHidden ? 0 : 28)
+            .padding(.leading, titleHidden ? 0 : UIMetrics.spacing6)
+            .padding(.trailing, titleHidden ? 0 : UIMetrics.iconXXL)
             .frame(maxWidth: .infinity, alignment: titleHidden ? .center : .leading)
-            .frame(height: 32)
+            .frame(height: UIMetrics.scaled(32))
             .background {
                 GeometryReader { geo in
                     Color.clear.preference(key: TabWidthPreferenceKey.self, value: geo.size.width)
@@ -432,7 +432,7 @@ private struct TabCell: View {
             .onPreferenceChange(TabWidthPreferenceKey.self) { measuredWidth = $0 }
             .overlay(alignment: titleHidden ? .center : .trailing) {
                 trailingAccessory
-                    .padding(.trailing, titleHidden ? 0 : 10)
+                    .padding(.trailing, titleHidden ? 0 : UIMetrics.spacing5)
             }
             .overlay {
                 if showBadge, let shortcutIndex,
@@ -445,7 +445,7 @@ private struct TabCell: View {
                 if let accentColor = bottomAccentColor {
                     Rectangle()
                         .fill(accentColor)
-                        .frame(height: 2)
+                        .frame(height: UIMetrics.scaled(2))
                         .accessibilityHidden(true)
                 }
             }
@@ -563,7 +563,7 @@ private struct TabCell: View {
         ZStack {
             if !tab.isPinned {
                 Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                     .foregroundStyle(MuxyTheme.fgDim)
                     .opacity(closeButtonVisible ? 1 : 0)
                     .allowsHitTesting(closeButtonVisible)
@@ -576,7 +576,7 @@ private struct TabCell: View {
                     .transition(.opacity)
             }
         }
-        .frame(width: 14, height: 14)
+        .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
     }
 
     private func triggerCompletionFlash() {
@@ -628,20 +628,20 @@ private struct TabCell: View {
     private var tabIconView: some View {
         if tab.isPinned {
             Image(systemName: "pin.fill")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
         } else if tab.kind == .vcs {
             FileDiffIcon()
                 .stroke(style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
-                .frame(width: 12, height: 12)
+                .frame(width: UIMetrics.iconSM, height: UIMetrics.iconSM)
         } else if tab.kind == .editor {
             Image(systemName: "pencil.line")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
         } else if tab.kind == .diffViewer {
             Image(systemName: "rectangle.split.2x1")
-                .font(.system(size: 11, weight: .semibold))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
         } else {
             Image(systemName: "terminal")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
         }
     }
 }

--- a/Tests/MuxyTests/Models/UIScaleTests.swift
+++ b/Tests/MuxyTests/Models/UIScaleTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("UIScale")
+@MainActor
+struct UIScaleTests {
+    @Test("Each preset returns a distinct, ordered multiplier")
+    func presetMultipliersAreOrdered() {
+        let presets = UIScale.Preset.allCases
+        #expect(presets == [.regular, .large, .extraLarge])
+
+        let multipliers = presets.map(\.multiplier)
+        #expect(multipliers == multipliers.sorted())
+        #expect(Set(multipliers).count == multipliers.count)
+        #expect(UIScale.Preset.regular.multiplier == 1.0)
+    }
+
+    @Test("UIMetrics.scaled multiplies by the active preset multiplier")
+    func metricsScaleWithPreset() {
+        let scale = UIScale.shared
+        let original = scale.preset
+        defer { scale.preset = original }
+
+        scale.preset = .regular
+        let baseline = UIMetrics.fontBody
+        #expect(baseline == 12.0)
+
+        scale.preset = .large
+        #expect(UIMetrics.fontBody == 12.0 * UIScale.Preset.large.multiplier)
+        #expect(UIMetrics.scaled(10) == 10 * UIScale.Preset.large.multiplier)
+
+        scale.preset = .extraLarge
+        #expect(UIMetrics.iconLG == 16 * UIScale.Preset.extraLarge.multiplier)
+    }
+
+    @Test("Preset is round-trip codable")
+    func presetIsCodable() throws {
+        for preset in UIScale.Preset.allCases {
+            let data = try JSONEncoder().encode(preset)
+            let decoded = try JSONDecoder().decode(UIScale.Preset.self, from: data)
+            #expect(decoded == preset)
+        }
+    }
+}

--- a/docs/developer/architecture/README.md
+++ b/docs/developer/architecture/README.md
@@ -45,6 +45,7 @@ flowchart TB
 | [File Tree](file-tree.md) | Lazy tree, git-status colors, file ops |
 | [VCS](vcs.md) | Source Control tab, PR flow |
 | [Notifications](notifications.md) | Sources, routing, click-to-navigate |
+| [UI Scaling](ui-scaling.md) | Centralized chrome metrics with user-adjustable scale |
 | [AI Usage](ai-usage.md) | Provider registry, credentials, refresh lifecycle |
 | [Remote Server](remote-server.md) | WebSocket server, terminal streaming, pairing |
 | [CLI & URL Scheme](cli-and-url-scheme.md) | `muxy` wrapper, `muxy://` URL, socket entry |

--- a/docs/developer/architecture/ui-scaling.md
+++ b/docs/developer/architecture/ui-scaling.md
@@ -8,7 +8,7 @@ The Settings window is intentionally excluded so it stays at the system-native p
 
 - **`Muxy/Theme/UIScale.swift`** — `@Observable @MainActor` singleton that stores the user's scale preset and persists to `~/Library/Application Support/Muxy/ui-scale.json`. Exposes `multiplier: CGFloat` derived from the preset.
 - **`Muxy/Theme/UIMetrics.swift`** — semantic design tokens (font sizes, spacings, icon sizes, control heights, radii, sidebar widths). Each token reads `UIScale.shared.multiplier` so SwiftUI's `@Observable` tracking re-renders dependent views automatically when the multiplier changes.
-- **Settings UI** — `AppearanceSettingsView` exposes a segmented picker under "Interface" → "Size" with four presets: `small (0.90×)`, `regular (1.00×)`, `large (1.12×)`, `extraLarge (1.24×)`.
+- **Settings UI** — `AppearanceSettingsView` exposes a segmented picker under "Interface" → "Size" with three presets: `regular (1.00×)`, `large (1.12×)`, `extraLarge (1.24×)`.
 
 ## Usage convention
 

--- a/docs/developer/architecture/ui-scaling.md
+++ b/docs/developer/architecture/ui-scaling.md
@@ -1,0 +1,51 @@
+# UI Scaling
+
+Muxy supports a centralized UI scale that resizes the main app chrome — sidebar, tabs, toolbars, file tree, source-control surfaces, panels, badges — without using `.scaleEffect()` (which rasterizes at the original size and produces blurry text). Instead, every metric is a real CGFloat that is multiplied by a user-chosen multiplier at the source.
+
+The Settings window is intentionally excluded so it stays at the system-native preferences size regardless of the active scale.
+
+## Components
+
+- **`Muxy/Theme/UIScale.swift`** — `@Observable @MainActor` singleton that stores the user's scale preset and persists to `~/Library/Application Support/Muxy/ui-scale.json`. Exposes `multiplier: CGFloat` derived from the preset.
+- **`Muxy/Theme/UIMetrics.swift`** — semantic design tokens (font sizes, spacings, icon sizes, control heights, radii, sidebar widths). Each token reads `UIScale.shared.multiplier` so SwiftUI's `@Observable` tracking re-renders dependent views automatically when the multiplier changes.
+- **Settings UI** — `AppearanceSettingsView` exposes a segmented picker under "Interface" → "Size" with four presets: `small (0.90×)`, `regular (1.00×)`, `large (1.12×)`, `extraLarge (1.24×)`.
+
+## Usage convention
+
+All chrome views must read sizes from `UIMetrics` instead of hardcoding numeric literals:
+
+```swift
+// good
+.font(.system(size: UIMetrics.fontBody))
+.padding(.horizontal, UIMetrics.spacing4)
+.frame(width: UIMetrics.iconLG, height: UIMetrics.iconLG)
+.background(.quaternary, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+
+// fallback for one-off values (still scales, no semantic match)
+.frame(width: UIMetrics.scaled(120))
+```
+
+Existing centralized layout enums (`SidebarLayout`, `SettingsMetrics`) delegate to `UIMetrics`, so views that already use them inherit scaling automatically.
+
+## Scope
+
+Scaling applies to **app chrome only** — the user-content areas and the Settings window keep their own sizing:
+
+| Surface | Source of truth |
+| --- | --- |
+| Terminal contents | libghostty config (`~/.config/ghostty/config`) |
+| Editor body text | `EditorSettings.fontSize` |
+| Markdown preview body | `EditorSettings.markdownPreviewFontScale` |
+| Settings window (`SettingsMetrics`) | static literals — fixed at the macOS-native preferences size |
+
+This avoids double-scaling. The terminal and editor each have their own font controls in Settings; the UI scale only governs the surrounding shell.
+
+## Adding new chrome
+
+When writing a new SwiftUI view:
+
+1. Pick a semantic token from `UIMetrics` (e.g. `.fontBody`, `.spacing4`, `.iconLG`).
+2. If no semantic token fits, use `UIMetrics.scaled(value)` to apply the multiplier to a literal — but prefer adding a new token when the value is reused.
+3. Never write raw `CGFloat` literals for sizes / spacings / fonts. Reviewers reject those.
+
+1px borders, dividers, and strokes stay at literal `1` since they are intentional pixel-perfect lines.


### PR DESCRIPTION
Adds a Default / Large / Extra Large picker under Settings → Appearance → Interface that resizes the whole app
  shell — sidebar, tabs, toolbars, panels, overlays, file tree, source-control surfaces, editor breadcrumb — without
  using .scaleEffect.

Closes #251 