### PR TITLE
Cycle all tabs with keyboard

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -293,17 +293,17 @@ struct MuxyCommands: Commands {
             }
             .shortcut(for: .focusPaneDown, store: keyBindings)
 
-            Button("Cycle Next Pane") {
+            Button("Cycle Next Tab (All Panes)") {
                 guard isMainWindowFocused else { return }
-                performShortcutAction(.cycleNextPane)
+                performShortcutAction(.cycleNextTabAcrossPanes)
             }
-            .shortcut(for: .cycleNextPane, store: keyBindings)
+            .shortcut(for: .cycleNextTabAcrossPanes, store: keyBindings)
 
-            Button("Cycle Previous Pane") {
+            Button("Cycle Previous Tab (All Panes)") {
                 guard isMainWindowFocused else { return }
-                performShortcutAction(.cyclePreviousPane)
+                performShortcutAction(.cyclePreviousTabAcrossPanes)
             }
-            .shortcut(for: .cyclePreviousPane, store: keyBindings)
+            .shortcut(for: .cyclePreviousTabAcrossPanes, store: keyBindings)
         }
 
         CommandGroup(after: .toolbar) {

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -292,6 +292,18 @@ struct MuxyCommands: Commands {
                 performShortcutAction(.focusPaneDown)
             }
             .shortcut(for: .focusPaneDown, store: keyBindings)
+
+            Button("Cycle Next Pane") {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.cycleNextPane)
+            }
+            .shortcut(for: .cycleNextPane, store: keyBindings)
+
+            Button("Cycle Previous Pane") {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.cyclePreviousPane)
+            }
+            .shortcut(for: .cyclePreviousPane, store: keyBindings)
         }
 
         CommandGroup(after: .toolbar) {

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -49,8 +49,8 @@ final class AppState {
         case focusPaneRight(projectID: UUID)
         case focusPaneUp(projectID: UUID)
         case focusPaneDown(projectID: UUID)
-        case cycleNextPane(projectID: UUID)
-        case cyclePreviousPane(projectID: UUID)
+        case cycleNextTabAcrossPanes(projectID: UUID)
+        case cyclePreviousTabAcrossPanes(projectID: UUID)
         case moveTab(projectID: UUID, request: TabMoveRequest)
         case selectNextProject(projects: [Project], worktrees: [UUID: [Worktree]])
         case selectPreviousProject(projects: [Project], worktrees: [UUID: [Worktree]])
@@ -774,12 +774,12 @@ final class AppState {
         dispatch(.focusPaneDown(projectID: projectID))
     }
 
-    func cycleNextPane(projectID: UUID) {
-        dispatch(.cycleNextPane(projectID: projectID))
+    func cycleNextTabAcrossPanes(projectID: UUID) {
+        dispatch(.cycleNextTabAcrossPanes(projectID: projectID))
     }
 
-    func cyclePreviousPane(projectID: UUID) {
-        dispatch(.cyclePreviousPane(projectID: projectID))
+    func cyclePreviousTabAcrossPanes(projectID: UUID) {
+        dispatch(.cyclePreviousTabAcrossPanes(projectID: projectID))
     }
 
     func selectProjectByIndex(_ index: Int, projects: [Project], worktrees: [UUID: [Worktree]]) {

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -49,6 +49,8 @@ final class AppState {
         case focusPaneRight(projectID: UUID)
         case focusPaneUp(projectID: UUID)
         case focusPaneDown(projectID: UUID)
+        case cycleNextPane(projectID: UUID)
+        case cyclePreviousPane(projectID: UUID)
         case moveTab(projectID: UUID, request: TabMoveRequest)
         case selectNextProject(projects: [Project], worktrees: [UUID: [Worktree]])
         case selectPreviousProject(projects: [Project], worktrees: [UUID: [Worktree]])
@@ -770,6 +772,14 @@ final class AppState {
 
     func focusPaneDown(projectID: UUID) {
         dispatch(.focusPaneDown(projectID: projectID))
+    }
+
+    func cycleNextPane(projectID: UUID) {
+        dispatch(.cycleNextPane(projectID: projectID))
+    }
+
+    func cyclePreviousPane(projectID: UUID) {
+        dispatch(.cyclePreviousPane(projectID: projectID))
     }
 
     func selectProjectByIndex(_ index: Int, projects: [Project], worktrees: [UUID: [Worktree]]) {

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -19,6 +19,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case focusPaneRight
     case focusPaneUp
     case focusPaneDown
+    case cycleNextPane
+    case cyclePreviousPane
     case nextTab
     case previousTab
     case toggleThemePicker
@@ -69,6 +71,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .focusPaneRight,
         .focusPaneUp,
         .focusPaneDown,
+        .cycleNextPane,
+        .cyclePreviousPane,
         .nextTab,
         .previousTab,
         .toggleThemePicker,
@@ -122,6 +126,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .focusPaneRight: ShortcutMetadata(displayName: "Focus Pane Right", category: "Panes", scope: .mainWindow)
         case .focusPaneUp: ShortcutMetadata(displayName: "Focus Pane Up", category: "Panes", scope: .mainWindow)
         case .focusPaneDown: ShortcutMetadata(displayName: "Focus Pane Down", category: "Panes", scope: .mainWindow)
+        case .cycleNextPane: ShortcutMetadata(displayName: "Cycle Next Pane", category: "Panes", scope: .mainWindow)
+        case .cyclePreviousPane: ShortcutMetadata(displayName: "Cycle Previous Pane", category: "Panes", scope: .mainWindow)
         case .nextTab: ShortcutMetadata(displayName: "Next Tab", category: "Tab Navigation", scope: .mainWindow)
         case .previousTab: ShortcutMetadata(displayName: "Previous Tab", category: "Tab Navigation", scope: .mainWindow)
         case .selectTab1: ShortcutMetadata(displayName: "Tab 1", category: "Tab Navigation", scope: .mainWindow)
@@ -237,6 +243,8 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .focusPaneRight, combo: KeyCombo(key: KeyCombo.rightArrowKey, command: true, option: true)),
         Self(action: .focusPaneUp, combo: KeyCombo(key: KeyCombo.upArrowKey, command: true, option: true)),
         Self(action: .focusPaneDown, combo: KeyCombo(key: KeyCombo.downArrowKey, command: true, option: true)),
+        Self(action: .cycleNextPane, combo: KeyCombo(key: KeyCombo.tabKey, control: true)),
+        Self(action: .cyclePreviousPane, combo: KeyCombo(key: KeyCombo.tabKey, shift: true, control: true)),
         Self(action: .toggleThemePicker, combo: KeyCombo(key: "k", command: true, shift: true)),
         Self(action: .openVCSTab, combo: KeyCombo(key: "k", command: true)),
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -19,8 +19,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case focusPaneRight
     case focusPaneUp
     case focusPaneDown
-    case cycleNextPane
-    case cyclePreviousPane
+    case cycleNextTabAcrossPanes
+    case cyclePreviousTabAcrossPanes
     case nextTab
     case previousTab
     case toggleThemePicker
@@ -71,8 +71,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .focusPaneRight,
         .focusPaneUp,
         .focusPaneDown,
-        .cycleNextPane,
-        .cyclePreviousPane,
+        .cycleNextTabAcrossPanes,
+        .cyclePreviousTabAcrossPanes,
         .nextTab,
         .previousTab,
         .toggleThemePicker,
@@ -126,8 +126,16 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .focusPaneRight: ShortcutMetadata(displayName: "Focus Pane Right", category: "Panes", scope: .mainWindow)
         case .focusPaneUp: ShortcutMetadata(displayName: "Focus Pane Up", category: "Panes", scope: .mainWindow)
         case .focusPaneDown: ShortcutMetadata(displayName: "Focus Pane Down", category: "Panes", scope: .mainWindow)
-        case .cycleNextPane: ShortcutMetadata(displayName: "Cycle Next Pane", category: "Panes", scope: .mainWindow)
-        case .cyclePreviousPane: ShortcutMetadata(displayName: "Cycle Previous Pane", category: "Panes", scope: .mainWindow)
+        case .cycleNextTabAcrossPanes: ShortcutMetadata(
+                displayName: "Cycle Next Tab (All Panes)",
+                category: "Tab Navigation",
+                scope: .mainWindow
+            )
+        case .cyclePreviousTabAcrossPanes: ShortcutMetadata(
+                displayName: "Cycle Previous Tab (All Panes)",
+                category: "Tab Navigation",
+                scope: .mainWindow
+            )
         case .nextTab: ShortcutMetadata(displayName: "Next Tab", category: "Tab Navigation", scope: .mainWindow)
         case .previousTab: ShortcutMetadata(displayName: "Previous Tab", category: "Tab Navigation", scope: .mainWindow)
         case .selectTab1: ShortcutMetadata(displayName: "Tab 1", category: "Tab Navigation", scope: .mainWindow)
@@ -243,8 +251,8 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .focusPaneRight, combo: KeyCombo(key: KeyCombo.rightArrowKey, command: true, option: true)),
         Self(action: .focusPaneUp, combo: KeyCombo(key: KeyCombo.upArrowKey, command: true, option: true)),
         Self(action: .focusPaneDown, combo: KeyCombo(key: KeyCombo.downArrowKey, command: true, option: true)),
-        Self(action: .cycleNextPane, combo: KeyCombo(key: KeyCombo.tabKey, control: true)),
-        Self(action: .cyclePreviousPane, combo: KeyCombo(key: KeyCombo.tabKey, shift: true, control: true)),
+        Self(action: .cycleNextTabAcrossPanes, combo: KeyCombo(key: KeyCombo.tabKey, control: true)),
+        Self(action: .cyclePreviousTabAcrossPanes, combo: KeyCombo(key: KeyCombo.tabKey, shift: true, control: true)),
         Self(action: .toggleThemePicker, combo: KeyCombo(key: "k", command: true, shift: true)),
         Self(action: .openVCSTab, combo: KeyCombo(key: "k", command: true)),
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),

--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -13,6 +13,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
     static let rightArrowKey = "rightarrow"
     static let upArrowKey = "uparrow"
     static let downArrowKey = "downarrow"
+    static let tabKey = "tab"
     private static func keyName(for keyCode: UInt16) -> String? {
         switch Int(keyCode) {
         case kVK_ANSI_A: "a"
@@ -82,6 +83,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
         case kVK_RightArrow: rightArrowKey
         case kVK_DownArrow: downArrowKey
         case kVK_UpArrow: upArrowKey
+        case kVK_Tab: tabKey
         default: nil
         }
     }
@@ -128,6 +130,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
         case Self.rightArrowKey: .rightArrow
         case Self.upArrowKey: .upArrow
         case Self.downArrowKey: .downArrow
+        case Self.tabKey: .tab
         default: KeyEquivalent(Character(key))
         }
     }
@@ -154,6 +157,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
         case Self.rightArrowKey: "→"
         case Self.upArrowKey: "↑"
         case Self.downArrowKey: "↓"
+        case Self.tabKey: "⇥"
         default: key.uppercased()
         }
         parts += keyDisplay
@@ -179,7 +183,9 @@ struct KeyCombo: Codable, Equatable, Hashable {
 
     static func normalized(key: String, keyCode: UInt16? = nil) -> String {
         let lowercased = key.lowercased()
-        if lowercased == leftArrowKey || lowercased == rightArrowKey || lowercased == upArrowKey || lowercased == downArrowKey {
+        if lowercased == leftArrowKey || lowercased == rightArrowKey || lowercased == upArrowKey || lowercased == downArrowKey ||
+            lowercased == tabKey
+        {
             return lowercased
         }
 

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -168,6 +168,12 @@ enum WorkspaceReducer {
         case let .focusPaneDown(projectID):
             FocusReducer.focusPane(projectID: projectID, direction: .down, state: &state)
 
+        case let .cycleNextPane(projectID):
+            FocusReducer.cyclePane(projectID: projectID, forward: true, state: &state)
+
+        case let .cyclePreviousPane(projectID):
+            FocusReducer.cyclePane(projectID: projectID, forward: false, state: &state)
+
         case let .applyLayout(projectID, worktreePath, config):
             applyLayout(
                 projectID: projectID,

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -168,11 +168,11 @@ enum WorkspaceReducer {
         case let .focusPaneDown(projectID):
             FocusReducer.focusPane(projectID: projectID, direction: .down, state: &state)
 
-        case let .cycleNextPane(projectID):
-            FocusReducer.cyclePane(projectID: projectID, forward: true, state: &state)
+        case let .cycleNextTabAcrossPanes(projectID):
+            FocusReducer.cycleTabAcrossPanes(projectID: projectID, forward: true, state: &state)
 
-        case let .cyclePreviousPane(projectID):
-            FocusReducer.cyclePane(projectID: projectID, forward: false, state: &state)
+        case let .cyclePreviousTabAcrossPanes(projectID):
+            FocusReducer.cycleTabAcrossPanes(projectID: projectID, forward: false, state: &state)
 
         case let .applyLayout(projectID, worktreePath, config):
             applyLayout(

--- a/Muxy/Models/WorkspaceReducer/FocusReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/FocusReducer.swift
@@ -33,6 +33,31 @@ enum FocusReducer {
         focusPane(key: key, direction: direction, state: &state)
     }
 
+    static func cyclePane(projectID: UUID, forward: Bool, state: inout WorkspaceState) {
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
+              let root = state.workspaceRoots[key],
+              let focusedID = state.focusedAreaID[key]
+        else { return }
+        let frames = root.areaFrames()
+        let sortedAreas = root.allAreas().sorted { lhs, rhs in
+            guard let lhsFrame = frames[lhs.id], let rhsFrame = frames[rhs.id] else { return false }
+            if lhsFrame.minY != rhsFrame.minY { return lhsFrame.minY < rhsFrame.minY }
+            return lhsFrame.minX < rhsFrame.minX
+        }
+        let entries = sortedAreas.flatMap { area in
+            area.tabs.map { tab in (areaID: area.id, tabID: tab.id) }
+        }
+        guard entries.count > 1,
+              let activeTabID = root.findArea(id: focusedID)?.activeTabID,
+              let currentIndex = entries.firstIndex(where: { $0.areaID == focusedID && $0.tabID == activeTabID })
+        else { return }
+        let nextIndex = forward
+            ? (currentIndex + 1) % entries.count
+            : (currentIndex - 1 + entries.count) % entries.count
+        let next = entries[nextIndex]
+        TabReducer.selectTab(projectID: projectID, areaID: next.areaID, tabID: next.tabID, state: &state)
+    }
+
     static func popFocusHistory(key: WorktreeKey, validAreas: [TabArea], state: inout WorkspaceState) -> UUID? {
         let validIDs = Set(validAreas.map(\.id))
         while let last = state.focusHistory[key]?.popLast() {

--- a/Muxy/Models/WorkspaceReducer/FocusReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/FocusReducer.swift
@@ -33,7 +33,7 @@ enum FocusReducer {
         focusPane(key: key, direction: direction, state: &state)
     }
 
-    static func cyclePane(projectID: UUID, forward: Bool, state: inout WorkspaceState) {
+    static func cycleTabAcrossPanes(projectID: UUID, forward: Bool, state: inout WorkspaceState) {
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
               let root = state.workspaceRoots[key],
               let focusedID = state.focusedAreaID[key]

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -88,13 +88,13 @@ struct ShortcutActionDispatcher {
             guard let projectID = appState.activeProjectID else { return false }
             appState.focusPaneDown(projectID: projectID)
             return true
-        case .cycleNextPane:
+        case .cycleNextTabAcrossPanes:
             guard let projectID = appState.activeProjectID else { return false }
-            appState.cycleNextPane(projectID: projectID)
+            appState.cycleNextTabAcrossPanes(projectID: projectID)
             return true
-        case .cyclePreviousPane:
+        case .cyclePreviousTabAcrossPanes:
             guard let projectID = appState.activeProjectID else { return false }
-            appState.cyclePreviousPane(projectID: projectID)
+            appState.cyclePreviousTabAcrossPanes(projectID: projectID)
             return true
         case .nextTab:
             guard let projectID = appState.activeProjectID else { return false }

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -88,6 +88,14 @@ struct ShortcutActionDispatcher {
             guard let projectID = appState.activeProjectID else { return false }
             appState.focusPaneDown(projectID: projectID)
             return true
+        case .cycleNextPane:
+            guard let projectID = appState.activeProjectID else { return false }
+            appState.cycleNextPane(projectID: projectID)
+            return true
+        case .cyclePreviousPane:
+            guard let projectID = appState.activeProjectID else { return false }
+            appState.cyclePreviousPane(projectID: projectID)
+            return true
         case .nextTab:
             guard let projectID = appState.activeProjectID else { return false }
             appState.selectNextTab(projectID: projectID)

--- a/Tests/MuxyTests/Models/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/KeyBindingTests.swift
@@ -81,6 +81,13 @@ struct KeyBindingTests {
         #expect(combos.count == unique.count)
     }
 
+    @Test("KeyBinding.defaults includes cycle pane shortcuts")
+    func defaultsIncludesCyclePaneShortcuts() {
+        let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
+        #expect(combos[.cycleNextPane] == KeyCombo(key: "tab", control: true))
+        #expect(combos[.cyclePreviousPane] == KeyCombo(key: "tab", shift: true, control: true))
+    }
+
     @Test("KeyBinding Codable round-trip")
     func codableRoundTrip() throws {
         let binding = KeyBinding(

--- a/Tests/MuxyTests/Models/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/KeyBindingTests.swift
@@ -81,11 +81,11 @@ struct KeyBindingTests {
         #expect(combos.count == unique.count)
     }
 
-    @Test("KeyBinding.defaults includes cycle pane shortcuts")
-    func defaultsIncludesCyclePaneShortcuts() {
+    @Test("KeyBinding.defaults includes cycle tab across panes shortcuts")
+    func defaultsIncludesCycleTabAcrossPanesShortcuts() {
         let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
-        #expect(combos[.cycleNextPane] == KeyCombo(key: "tab", control: true))
-        #expect(combos[.cyclePreviousPane] == KeyCombo(key: "tab", shift: true, control: true))
+        #expect(combos[.cycleNextTabAcrossPanes] == KeyCombo(key: "tab", control: true))
+        #expect(combos[.cyclePreviousTabAcrossPanes] == KeyCombo(key: "tab", shift: true, control: true))
     }
 
     @Test("KeyBinding Codable round-trip")

--- a/Tests/MuxyTests/Models/KeyComboTests.swift
+++ b/Tests/MuxyTests/Models/KeyComboTests.swift
@@ -46,6 +46,12 @@ struct KeyComboTests {
         #expect(KeyCombo(key: "downarrow", command: true).displayString == "⌘↓")
     }
 
+    @Test("displayString for tab key")
+    func displayStringTabKey() {
+        #expect(KeyCombo(key: "tab", control: true).displayString == "⌃⇥")
+        #expect(KeyCombo(key: "tab", shift: true, control: true).displayString == "⌃⇧⇥")
+    }
+
     @Test("displayString for letter key is uppercased")
     func displayStringLetter() {
         let combo = KeyCombo(key: "t", command: true)
@@ -64,6 +70,11 @@ struct KeyComboTests {
         #expect(KeyCombo.normalized(key: "", keyCode: 124) == "rightarrow")
         #expect(KeyCombo.normalized(key: "", keyCode: 125) == "downarrow")
         #expect(KeyCombo.normalized(key: "", keyCode: 126) == "uparrow")
+    }
+
+    @Test("normalized key with tab keyCode")
+    func normalizedTabKeyCode() {
+        #expect(KeyCombo.normalized(key: "", keyCode: 48) == "tab")
     }
 
     @Test("normalized key with ANSI letter keyCodes")

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -539,8 +539,8 @@ struct WorkspaceReducerTests {
         #expect(state.focusedAreaID[key] == bottomAreaID)
     }
 
-    @Test("cycleNextPane walks tabs in focused pane before next pane")
-    func cycleNextPaneWalksTabsBeforeNextPane() {
+    @Test("cycleNextTabAcrossPanes walks tabs in focused pane before next pane")
+    func cycleNextTabAcrossPanesWalksTabsBeforeNextPane() {
         let projectID = UUID()
         let worktreeID = UUID()
         var state = makeState(projectID: projectID, worktreeID: worktreeID)
@@ -573,22 +573,22 @@ struct WorkspaceReducerTests {
         )
 
         _ = WorkspaceReducer.reduce(
-            action: .cycleNextPane(projectID: projectID),
+            action: .cycleNextTabAcrossPanes(projectID: projectID),
             state: &state
         )
         #expect(state.focusedAreaID[key] == firstAreaID)
         #expect(area(in: state, key: key, areaID: firstAreaID)?.activeTabID == secondTabID)
 
         _ = WorkspaceReducer.reduce(
-            action: .cycleNextPane(projectID: projectID),
+            action: .cycleNextTabAcrossPanes(projectID: projectID),
             state: &state
         )
         #expect(state.focusedAreaID[key] == secondAreaID)
         #expect(area(in: state, key: key, areaID: secondAreaID)?.activeTabID == secondAreaTabID)
     }
 
-    @Test("cyclePreviousPane walks backward across panes")
-    func cyclePreviousPaneWalksBackwardAcrossPanes() {
+    @Test("cyclePreviousTabAcrossPanes walks backward across panes")
+    func cyclePreviousTabAcrossPanesWalksBackward() {
         let projectID = UUID()
         let worktreeID = UUID()
         var state = makeState(projectID: projectID, worktreeID: worktreeID)
@@ -619,15 +619,15 @@ struct WorkspaceReducerTests {
         )
 
         _ = WorkspaceReducer.reduce(
-            action: .cyclePreviousPane(projectID: projectID),
+            action: .cyclePreviousTabAcrossPanes(projectID: projectID),
             state: &state
         )
         #expect(state.focusedAreaID[key] == firstAreaID)
         #expect(area(in: state, key: key, areaID: firstAreaID)?.activeTabID == secondFirstAreaTabID)
     }
 
-    @Test("cyclePane wraps between first and last entries")
-    func cyclePaneWrapsBetweenFirstAndLastEntries() {
+    @Test("cycleTabAcrossPanes wraps between first and last entries")
+    func cycleTabAcrossPanesWrapsBetweenFirstAndLastEntries() {
         let projectID = UUID()
         let worktreeID = UUID()
         var state = makeState(projectID: projectID, worktreeID: worktreeID)
@@ -657,22 +657,22 @@ struct WorkspaceReducerTests {
             state: &state
         )
         _ = WorkspaceReducer.reduce(
-            action: .cycleNextPane(projectID: projectID),
+            action: .cycleNextTabAcrossPanes(projectID: projectID),
             state: &state
         )
         #expect(state.focusedAreaID[key] == firstAreaID)
         #expect(area(in: state, key: key, areaID: firstAreaID)?.activeTabID == firstTabID)
 
         _ = WorkspaceReducer.reduce(
-            action: .cyclePreviousPane(projectID: projectID),
+            action: .cyclePreviousTabAcrossPanes(projectID: projectID),
             state: &state
         )
         #expect(state.focusedAreaID[key] == secondAreaID)
         #expect(area(in: state, key: key, areaID: secondAreaID)?.activeTabID == lastTabID)
     }
 
-    @Test("cyclePane does nothing with one tab total")
-    func cyclePaneDoesNothingWithOneTabTotal() {
+    @Test("cycleTabAcrossPanes does nothing with one tab total")
+    func cycleTabAcrossPanesDoesNothingWithOneTabTotal() {
         let projectID = UUID()
         let worktreeID = UUID()
         var state = makeState(projectID: projectID, worktreeID: worktreeID)
@@ -681,14 +681,14 @@ struct WorkspaceReducerTests {
         let tabID = area(in: state, key: key, areaID: areaID)!.activeTabID
 
         _ = WorkspaceReducer.reduce(
-            action: .cycleNextPane(projectID: projectID),
+            action: .cycleNextTabAcrossPanes(projectID: projectID),
             state: &state
         )
         #expect(state.focusedAreaID[key] == areaID)
         #expect(area(in: state, key: key, areaID: areaID)?.activeTabID == tabID)
 
         _ = WorkspaceReducer.reduce(
-            action: .cyclePreviousPane(projectID: projectID),
+            action: .cyclePreviousTabAcrossPanes(projectID: projectID),
             state: &state
         )
         #expect(state.focusedAreaID[key] == areaID)

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -36,6 +36,10 @@ struct WorkspaceReducerTests {
         return root.findArea(id: focusedID)
     }
 
+    private func area(in state: WorkspaceState, key: WorktreeKey, areaID: UUID) -> TabArea? {
+        state.workspaceRoots[key]?.findArea(id: areaID)
+    }
+
     @Test("selectProject creates workspace if new")
     func selectProjectNew() {
         let projectID = UUID()
@@ -533,6 +537,162 @@ struct WorkspaceReducerTests {
             state: &state
         )
         #expect(state.focusedAreaID[key] == bottomAreaID)
+    }
+
+    @Test("cycleNextPane walks tabs in focused pane before next pane")
+    func cycleNextPaneWalksTabsBeforeNextPane() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let firstAreaID = state.focusedAreaID[key]!
+
+        _ = WorkspaceReducer.reduce(
+            action: .createTab(projectID: projectID, areaID: firstAreaID),
+            state: &state
+        )
+        let firstAreaTabs = area(in: state, key: key, areaID: firstAreaID)!.tabs
+        let firstTabID = firstAreaTabs[0].id
+        let secondTabID = firstAreaTabs[1].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: firstAreaID,
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+        let secondAreaID = state.focusedAreaID[key]!
+        let secondAreaTabID = area(in: state, key: key, areaID: secondAreaID)!.tabs[0].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .selectTab(projectID: projectID, areaID: firstAreaID, tabID: firstTabID),
+            state: &state
+        )
+
+        _ = WorkspaceReducer.reduce(
+            action: .cycleNextPane(projectID: projectID),
+            state: &state
+        )
+        #expect(state.focusedAreaID[key] == firstAreaID)
+        #expect(area(in: state, key: key, areaID: firstAreaID)?.activeTabID == secondTabID)
+
+        _ = WorkspaceReducer.reduce(
+            action: .cycleNextPane(projectID: projectID),
+            state: &state
+        )
+        #expect(state.focusedAreaID[key] == secondAreaID)
+        #expect(area(in: state, key: key, areaID: secondAreaID)?.activeTabID == secondAreaTabID)
+    }
+
+    @Test("cyclePreviousPane walks backward across panes")
+    func cyclePreviousPaneWalksBackwardAcrossPanes() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let firstAreaID = state.focusedAreaID[key]!
+
+        _ = WorkspaceReducer.reduce(
+            action: .createTab(projectID: projectID, areaID: firstAreaID),
+            state: &state
+        )
+        let secondFirstAreaTabID = area(in: state, key: key, areaID: firstAreaID)!.tabs[1].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: firstAreaID,
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+        let secondAreaID = state.focusedAreaID[key]!
+        let secondAreaTabID = area(in: state, key: key, areaID: secondAreaID)!.tabs[0].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .selectTab(projectID: projectID, areaID: secondAreaID, tabID: secondAreaTabID),
+            state: &state
+        )
+
+        _ = WorkspaceReducer.reduce(
+            action: .cyclePreviousPane(projectID: projectID),
+            state: &state
+        )
+        #expect(state.focusedAreaID[key] == firstAreaID)
+        #expect(area(in: state, key: key, areaID: firstAreaID)?.activeTabID == secondFirstAreaTabID)
+    }
+
+    @Test("cyclePane wraps between first and last entries")
+    func cyclePaneWrapsBetweenFirstAndLastEntries() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let firstAreaID = state.focusedAreaID[key]!
+
+        _ = WorkspaceReducer.reduce(
+            action: .createTab(projectID: projectID, areaID: firstAreaID),
+            state: &state
+        )
+        let firstTabID = area(in: state, key: key, areaID: firstAreaID)!.tabs[0].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: firstAreaID,
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+        let secondAreaID = state.focusedAreaID[key]!
+        let lastTabID = area(in: state, key: key, areaID: secondAreaID)!.tabs[0].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .selectTab(projectID: projectID, areaID: secondAreaID, tabID: lastTabID),
+            state: &state
+        )
+        _ = WorkspaceReducer.reduce(
+            action: .cycleNextPane(projectID: projectID),
+            state: &state
+        )
+        #expect(state.focusedAreaID[key] == firstAreaID)
+        #expect(area(in: state, key: key, areaID: firstAreaID)?.activeTabID == firstTabID)
+
+        _ = WorkspaceReducer.reduce(
+            action: .cyclePreviousPane(projectID: projectID),
+            state: &state
+        )
+        #expect(state.focusedAreaID[key] == secondAreaID)
+        #expect(area(in: state, key: key, areaID: secondAreaID)?.activeTabID == lastTabID)
+    }
+
+    @Test("cyclePane does nothing with one tab total")
+    func cyclePaneDoesNothingWithOneTabTotal() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let areaID = state.focusedAreaID[key]!
+        let tabID = area(in: state, key: key, areaID: areaID)!.activeTabID
+
+        _ = WorkspaceReducer.reduce(
+            action: .cycleNextPane(projectID: projectID),
+            state: &state
+        )
+        #expect(state.focusedAreaID[key] == areaID)
+        #expect(area(in: state, key: key, areaID: areaID)?.activeTabID == tabID)
+
+        _ = WorkspaceReducer.reduce(
+            action: .cyclePreviousPane(projectID: projectID),
+            state: &state
+        )
+        #expect(state.focusedAreaID[key] == areaID)
+        #expect(area(in: state, key: key, areaID: areaID)?.activeTabID == tabID)
     }
 
     @Test("moveTab toArea moves tab between areas")

--- a/docs/features/tabs-and-splits.md
+++ b/docs/features/tabs-and-splits.md
@@ -49,6 +49,7 @@ Custom titles and colors are saved in the workspace snapshot and survive worktre
 | Split Down | `⌘⇧D` |
 | Close Pane | `⌘⇧W` |
 | Focus Pane | `⌘⌥←/→/↑/↓` |
+| Cycle Panes | `⌃Tab` / `⌃⇧Tab` |
 
 ## Drag and drop
 

--- a/docs/features/tabs-and-splits.md
+++ b/docs/features/tabs-and-splits.md
@@ -49,7 +49,7 @@ Custom titles and colors are saved in the workspace snapshot and survive worktre
 | Split Down | `⌘⇧D` |
 | Close Pane | `⌘⇧W` |
 | Focus Pane | `⌘⌥←/→/↑/↓` |
-| Cycle Panes | `⌃Tab` / `⌃⇧Tab` |
+| Cycle Tab (All Panes) | `⌃Tab` / `⌃⇧Tab` |
 
 ## Drag and drop
 

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -22,6 +22,8 @@ Every shortcut listed here can be remapped in **Settings → Keyboard Shortcuts*
 | Focus Pane Right | `Cmd+Opt+→` |
 | Focus Pane Up | `Cmd+Opt+↑` |
 | Focus Pane Down | `Cmd+Opt+↓` |
+| Cycle Next Pane | `Ctrl+Tab` |
+| Cycle Previous Pane | `Ctrl+Shift+Tab` |
 
 ## Tab navigation
 

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -22,8 +22,6 @@ Every shortcut listed here can be remapped in **Settings → Keyboard Shortcuts*
 | Focus Pane Right | `Cmd+Opt+→` |
 | Focus Pane Up | `Cmd+Opt+↑` |
 | Focus Pane Down | `Cmd+Opt+↓` |
-| Cycle Next Pane | `Ctrl+Tab` |
-| Cycle Previous Pane | `Ctrl+Shift+Tab` |
 
 ## Tab navigation
 
@@ -31,6 +29,8 @@ Every shortcut listed here can be remapped in **Settings → Keyboard Shortcuts*
 | --- | --- |
 | Next Tab | `Cmd+]` |
 | Previous Tab | `Cmd+[` |
+| Cycle Next Tab (All Panes) | `Ctrl+Tab` |
+| Cycle Previous Tab (All Panes) | `Ctrl+Shift+Tab` |
 | Tab 1–9 | `Cmd+1` … `Cmd+9` |
 
 ## Project navigation


### PR DESCRIPTION
## Summary

Allow to navigate between all open tabs and panes in the active workspace with the keyboard

## Changes


Add Ctrl+Tab / Ctrl+Shift+Tab to cycle through every tab across every pane in the active workspace.

Cycle order is spatial (top→bottom, then left→right) so it stays predictable regardless of split history.

Defaults are remappable in Settings → Keyboard Shortcuts.
