### PR TITLE
fix: prevent SIGABRT from uncaught ObjC exception in file tree git pipe

### DIFF
--- a/Muxy/Services/FileTreeService.swift
+++ b/Muxy/Services/FileTreeService.swift
@@ -116,7 +116,7 @@ enum FileTreeService {
                 payload.append(0)
             }
         }
-        stdinPipe.fileHandleForWriting.write(payload)
+        try? stdinPipe.fileHandleForWriting.write(contentsOf: payload)
         try? stdinPipe.fileHandleForWriting.close()
 
         let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()


### PR DESCRIPTION
No idea about your opinion on clanker PRs but here's one. pretty small fix for an issue that was annoying me. 

## Summary
- `FileHandle.write(_:)` raises an ObjC `NSException` when the git `check-ignore --stdin` pipe breaks, which Swift cannot catch — leading to `abort()` / SIGABRT
- Replaces with the throwing `write(contentsOf:)` API, caught by `try?` — matching the existing pattern already used for the same pipe's `close()` and `readToEnd()` calls on adjacent lines

## Root Cause
`FileTreeService.ignoredNames()` pipes candidate filenames into `git check-ignore --stdin`. If the git process exits before all data is written, `FileHandle.write(_:)` (deprecated, non-throwing) raises an ObjC exception on the `app.muxy.git-runner` dispatch queue, which propagates to `abort()`.

## Verification
- Fix ran for 10+ hours in isolated experiment with zero crash recurrence