### PR TITLE
Materialize PTY headlessly for remote takeover of unmounted panes

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -199,6 +199,19 @@ final class AppState {
         return workspaceRoots[key]?.allAreas() ?? []
     }
 
+    func locatePane(paneID: UUID) -> (worktreeKey: WorktreeKey, pane: TerminalPaneState)? {
+        for (key, root) in workspaceRoots {
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    if let pane = tab.content.pane, pane.id == paneID {
+                        return (key, pane)
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
     func splitFocusedArea(direction: SplitDirection, projectID: UUID) {
         guard let area = focusedArea(for: projectID) else { return }
         dispatch(.splitArea(.init(

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -228,7 +228,10 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         else { return }
 
         let size = ghostty_surface_size(surface)
-        guard size.cell_width_px > 0, size.cell_height_px > 0 else { return }
+        guard size.cell_width_px > 0, size.cell_height_px > 0 else {
+            logger.warning("Cannot resize pane \(paneID): cell metrics not yet available")
+            return
+        }
 
         let w = cols * size.cell_width_px
         let h = rows * size.cell_height_px
@@ -271,7 +274,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     }
 
     func takeOverPane(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32) {
-        ensureTerminalView(paneID: paneID, cols: cols, rows: rows)
+        ensureTerminalView(paneID: paneID)
         let snapshotBytes = buildTerminalSnapshot(paneID: paneID)
         PaneOwnershipStore.shared.assign(paneID: paneID, to: clientID)
         if let bytes = snapshotBytes, !bytes.isEmpty {
@@ -282,7 +285,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         applyPTYSize(paneID: paneID, cols: cols, rows: rows)
     }
 
-    private func ensureTerminalView(paneID: UUID, cols: UInt32, rows: UInt32) {
+    private func ensureTerminalView(paneID: UUID) {
         if TerminalViewRegistry.shared.existingView(for: paneID) != nil { return }
         guard let location = appState.locatePane(paneID: paneID) else {
             logger.warning("Cannot materialize pane \(paneID): no matching tab in workspace")
@@ -298,7 +301,10 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         if view.envVars.isEmpty {
             view.envVars = TerminalEnvVarBuilder.build(paneID: paneID, worktreeKey: location.worktreeKey)
         }
-        view.materializeHeadless(cols: cols, rows: rows)
+        view.materializeHeadless()
+        if view.surface == nil {
+            logger.warning("Headless materialization left pane \(paneID) without a surface")
+        }
     }
 
     private func buildTerminalSnapshot(paneID: UUID) -> Data? {

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -271,6 +271,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     }
 
     func takeOverPane(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32) {
+        ensureTerminalView(paneID: paneID, cols: cols, rows: rows)
         let snapshotBytes = buildTerminalSnapshot(paneID: paneID)
         PaneOwnershipStore.shared.assign(paneID: paneID, to: clientID)
         if let bytes = snapshotBytes, !bytes.isEmpty {
@@ -279,6 +280,25 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             server?.send(event, to: clientID)
         }
         applyPTYSize(paneID: paneID, cols: cols, rows: rows)
+    }
+
+    private func ensureTerminalView(paneID: UUID, cols: UInt32, rows: UInt32) {
+        if TerminalViewRegistry.shared.existingView(for: paneID) != nil { return }
+        guard let location = appState.locatePane(paneID: paneID) else {
+            logger.warning("Cannot materialize pane \(paneID): no matching tab in workspace")
+            return
+        }
+        let pane = location.pane
+        let view = TerminalViewRegistry.shared.view(
+            for: paneID,
+            workingDirectory: pane.currentWorkingDirectory ?? pane.projectPath,
+            command: pane.startupCommand,
+            commandInteractive: pane.startupCommandInteractive
+        )
+        if view.envVars.isEmpty {
+            view.envVars = TerminalEnvVarBuilder.build(paneID: paneID, worktreeKey: location.worktreeKey)
+        }
+        view.materializeHeadless(cols: cols, rows: rows)
     }
 
     private func buildTerminalSnapshot(paneID: UUID) -> Data? {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -329,6 +329,23 @@ final class GhosttyTerminalNSView: NSView {
         updateMetalLayerSize(deferred: false)
     }
 
+    func materializeHeadless(cols: UInt32, rows: UInt32) {
+        guard surface == nil else { return }
+        let safeCols = max(cols, 1)
+        let safeRows = max(rows, 1)
+        let pixelWidth = CGFloat(safeCols) * Self.headlessCellWidth
+        let pixelHeight = CGFloat(safeRows) * Self.headlessCellHeight
+        if frame.size != NSSize(width: pixelWidth, height: pixelHeight) {
+            setFrameSize(NSSize(width: pixelWidth, height: pixelHeight))
+        }
+        if surface == nil {
+            createSurface()
+        }
+    }
+
+    private static let headlessCellWidth: CGFloat = 8
+    private static let headlessCellHeight: CGFloat = 16
+
     private func backingPixelSize() -> (width: UInt32, height: UInt32)? {
         let size = convertToBacking(bounds).size
         let width = Int(floor(size.width))

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -329,22 +329,13 @@ final class GhosttyTerminalNSView: NSView {
         updateMetalLayerSize(deferred: false)
     }
 
-    func materializeHeadless(cols: UInt32, rows: UInt32) {
+    func materializeHeadless() {
         guard surface == nil else { return }
-        let safeCols = max(cols, 1)
-        let safeRows = max(rows, 1)
-        let pixelWidth = CGFloat(safeCols) * Self.headlessCellWidth
-        let pixelHeight = CGFloat(safeRows) * Self.headlessCellHeight
-        if frame.size != NSSize(width: pixelWidth, height: pixelHeight) {
-            setFrameSize(NSSize(width: pixelWidth, height: pixelHeight))
+        if frame.size.width <= 0 || frame.size.height <= 0 {
+            setFrameSize(NSSize(width: 1, height: 1))
         }
-        if surface == nil {
-            createSurface()
-        }
+        createSurface()
     }
-
-    private static let headlessCellWidth: CGFloat = 8
-    private static let headlessCellHeight: CGFloat = 16
 
     private func backingPixelSize() -> (width: UInt32, height: UInt32)? {
         let size = convertToBacking(bounds).size

--- a/Muxy/Views/Terminal/TerminalEnvVarBuilder.swift
+++ b/Muxy/Views/Terminal/TerminalEnvVarBuilder.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+@MainActor
+enum TerminalEnvVarBuilder {
+    static func build(paneID: UUID, worktreeKey key: WorktreeKey) -> [(key: String, value: String)] {
+        var vars: [(key: String, value: String)] = [
+            (key: "MUXY_PANE_ID", value: paneID.uuidString),
+            (key: "MUXY_PROJECT_ID", value: key.projectID.uuidString),
+            (key: "MUXY_WORKTREE_ID", value: key.worktreeID.uuidString),
+            (key: "MUXY_SOCKET_PATH", value: NotificationSocketServer.socketPath),
+        ]
+        if let hookPath = MuxyNotificationHooks.hookScriptPath {
+            vars.append((key: "MUXY_HOOK_SCRIPT", value: hookPath))
+        }
+        return vars
+    }
+}

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -138,7 +138,7 @@ struct TerminalBridge: NSViewRepresentable {
             commandInteractive: state.startupCommandInteractive
         )
         if view.envVars.isEmpty, let key = worktreeKey {
-            view.envVars = Self.buildEnvVars(paneID: state.id, worktreeKey: key)
+            view.envVars = TerminalEnvVarBuilder.build(paneID: state.id, worktreeKey: key)
         }
         view.isFocused = focused
         view.overlayActive = overlayActive
@@ -177,7 +177,7 @@ struct TerminalBridge: NSViewRepresentable {
 
     func updateNSView(_ nsView: GhosttyTerminalNSView, context: Context) {
         if nsView.envVars.isEmpty, nsView.surface == nil, let key = worktreeKey {
-            nsView.envVars = Self.buildEnvVars(paneID: state.id, worktreeKey: key)
+            nsView.envVars = TerminalEnvVarBuilder.build(paneID: state.id, worktreeKey: key)
         }
         nsView.overlayActive = overlayActive
         nsView.setVisible(visible)
@@ -232,19 +232,6 @@ struct TerminalBridge: NSViewRepresentable {
                 ]
             )
         }
-    }
-
-    private static func buildEnvVars(paneID: UUID, worktreeKey key: WorktreeKey) -> [(key: String, value: String)] {
-        var vars: [(key: String, value: String)] = [
-            (key: "MUXY_PANE_ID", value: paneID.uuidString),
-            (key: "MUXY_PROJECT_ID", value: key.projectID.uuidString),
-            (key: "MUXY_WORKTREE_ID", value: key.worktreeID.uuidString),
-            (key: "MUXY_SOCKET_PATH", value: NotificationSocketServer.socketPath),
-        ]
-        if let hookPath = MuxyNotificationHooks.hookScriptPath {
-            vars.append((key: "MUXY_HOOK_SCRIPT", value: hookPath))
-        }
-        return vars
     }
 
     private func configureFileOpenCallback(_ view: GhosttyTerminalNSView) {


### PR DESCRIPTION
Remote takeover failed silently when the target pane belonged to a project the Mac hadn't mounted. PTY creation is
  now decoupled from SwiftUI mounting, so takeOverPane materializes the Ghostty surface on demand and the SwiftUI
  view adopts it later.