### PR TITLE
Number tabs globally across split panes

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -39,7 +39,7 @@ final class AppState {
         case createDiffViewerTab(projectID: UUID, areaID: UUID?, request: DiffViewerRequest)
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
-        case selectTabByIndex(projectID: UUID, areaID: UUID?, index: Int)
+        case selectTabByIndex(projectID: UUID, index: Int)
         case selectNextTab(projectID: UUID)
         case selectPreviousTab(projectID: UUID)
         case splitArea(SplitAreaRequest)
@@ -212,13 +212,14 @@ final class AppState {
         return nil
     }
 
-    func shortcutOffset(forAreaID areaID: UUID, projectID: UUID) -> Int {
-        var offset = 0
+    func shortcutOffsets(for projectID: UUID) -> [UUID: Int] {
+        var offsets: [UUID: Int] = [:]
+        var running = 0
         for area in allAreas(for: projectID) {
-            if area.id == areaID { return offset }
-            offset += area.tabs.count
+            offsets[area.id] = running
+            running += area.tabs.count
         }
-        return 0
+        return offsets
     }
 
     func splitFocusedArea(direction: SplitDirection, projectID: UUID) {
@@ -555,7 +556,7 @@ final class AppState {
     }
 
     func selectTabByIndex(_ index: Int, projectID: UUID) {
-        dispatch(.selectTabByIndex(projectID: projectID, areaID: nil, index: index))
+        dispatch(.selectTabByIndex(projectID: projectID, index: index))
     }
 
     func selectNextTab(projectID: UUID) {

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -212,6 +212,15 @@ final class AppState {
         return nil
     }
 
+    func shortcutOffset(forAreaID areaID: UUID, projectID: UUID) -> Int {
+        var offset = 0
+        for area in allAreas(for: projectID) {
+            if area.id == areaID { return offset }
+            offset += area.tabs.count
+        }
+        return 0
+    }
+
     func splitFocusedArea(direction: SplitDirection, projectID: UUID) {
         guard let area = focusedArea(for: projectID) else { return }
         dispatch(.splitArea(.init(

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -133,8 +133,8 @@ enum WorkspaceReducer {
         case let .selectTab(projectID, areaID, tabID):
             TabReducer.selectTab(projectID: projectID, areaID: areaID, tabID: tabID, state: &state)
 
-        case let .selectTabByIndex(projectID, areaID, index):
-            TabReducer.selectTabByIndex(projectID: projectID, areaID: areaID, index: index, state: &state)
+        case let .selectTabByIndex(projectID, index):
+            TabReducer.selectTabByIndex(projectID: projectID, index: index, state: &state)
 
         case let .selectNextTab(projectID):
             TabReducer.selectNextTab(projectID: projectID, state: state)

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -98,12 +98,22 @@ enum TabReducer {
         area.selectTab(tabID)
     }
 
-    static func selectTabByIndex(projectID: UUID, areaID: UUID?, index: Int, state: inout WorkspaceState) {
+    static func selectTabByIndex(projectID: UUID, areaID _: UUID?, index: Int, state: inout WorkspaceState) {
+        guard index >= 0 else { return }
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
-              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
+              let root = state.workspaceRoots[key]
         else { return }
-        FocusReducer.focusArea(area.id, key: key, state: &state)
-        area.selectTabByIndex(index)
+        var remaining = index
+        for area in root.allAreas() {
+            guard remaining < area.tabs.count else {
+                remaining -= area.tabs.count
+                continue
+            }
+            let tab = area.tabs[remaining]
+            FocusReducer.focusArea(area.id, key: key, state: &state)
+            area.selectTab(tab.id)
+            return
+        }
     }
 
     static func selectNextTab(projectID: UUID, state: WorkspaceState) {

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -98,7 +98,7 @@ enum TabReducer {
         area.selectTab(tabID)
     }
 
-    static func selectTabByIndex(projectID: UUID, areaID _: UUID?, index: Int, state: inout WorkspaceState) {
+    static func selectTabByIndex(projectID: UUID, index: Int, state: inout WorkspaceState) {
         guard index >= 0 else { return }
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
               let root = state.workspaceRoots[key]

--- a/Muxy/Views/Workspace/PaneNode.swift
+++ b/Muxy/Views/Workspace/PaneNode.swift
@@ -7,6 +7,7 @@ struct PaneNode: View {
     var showTabStrip = true
     var showVCSButton = true
     let projectID: UUID
+    let shortcutOffsets: [UUID: Int]
     let onFocusArea: (UUID) -> Void
     let onSelectTab: (UUID, UUID) -> Void
     let onCreateTab: (UUID) -> Void
@@ -27,6 +28,7 @@ struct PaneNode: View {
                 showTabStrip: showTabStrip,
                 showVCSButton: showVCSButton,
                 projectID: projectID,
+                shortcutIndexOffset: shortcutOffsets[area.id] ?? 0,
                 onFocus: { onFocusArea(area.id) },
                 onSelectTab: { tabID in onSelectTab(area.id, tabID) },
                 onCreateTab: { onCreateTab(area.id) },
@@ -43,6 +45,7 @@ struct PaneNode: View {
                 isActiveProject: isActiveProject,
                 showVCSButton: showVCSButton,
                 projectID: projectID,
+                shortcutOffsets: shortcutOffsets,
                 onFocusArea: onFocusArea,
                 onSelectTab: onSelectTab,
                 onCreateTab: onCreateTab,

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -7,6 +7,7 @@ struct SplitContainer: View {
     let isActiveProject: Bool
     let showVCSButton: Bool
     let projectID: UUID
+    let shortcutOffsets: [UUID: Int]
     let onFocusArea: (UUID) -> Void
     let onSelectTab: (UUID, UUID) -> Void
     let onCreateTab: (UUID) -> Void
@@ -78,6 +79,7 @@ struct SplitContainer: View {
             isActiveProject: isActiveProject,
             showVCSButton: showVCSButton,
             projectID: projectID,
+            shortcutOffsets: shortcutOffsets,
             onFocusArea: onFocusArea,
             onSelectTab: onSelectTab,
             onCreateTab: onCreateTab,

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -7,6 +7,7 @@ struct TabAreaView: View {
     let showTabStrip: Bool
     let showVCSButton: Bool
     let projectID: UUID
+    let shortcutIndexOffset: Int
     let onFocus: () -> Void
     let onSelectTab: (UUID) -> Void
     let onCreateTab: () -> Void
@@ -38,7 +39,7 @@ struct TabAreaView: View {
                     isFocused: isFocused,
                     showVCSButton: showVCSButton,
                     projectID: projectID,
-                    shortcutIndexOffset: appState.shortcutOffset(forAreaID: area.id, projectID: projectID),
+                    shortcutIndexOffset: shortcutIndexOffset,
                     onSelectTab: onSelectTab,
                     onCreateTab: onCreateTab,
                     onCreateVCSTab: onCreateVCSTab,

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -38,6 +38,7 @@ struct TabAreaView: View {
                     isFocused: isFocused,
                     showVCSButton: showVCSButton,
                     projectID: projectID,
+                    shortcutIndexOffset: appState.shortcutOffset(forAreaID: area.id, projectID: projectID),
                     onSelectTab: onSelectTab,
                     onCreateTab: onCreateTab,
                     onCreateVCSTab: onCreateVCSTab,

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -126,6 +126,7 @@ struct PaneTabStrip: View {
 
         return HStack(spacing: 0) {
             ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
+                let globalIndex = shortcutIndexOffset + index
                 TabCell(
                     tab: tab,
                     active: tab.id == activeTabID,
@@ -133,7 +134,7 @@ struct PaneTabStrip: View {
                     areaID: areaID,
                     hasUnread: NotificationStore.shared.hasUnread(tabID: tab.id),
                     isAnyDragging: dragState.draggedID != nil,
-                    shortcutIndex: shortcutIndexOffset + index < 9 ? shortcutIndexOffset + index + 1 : nil,
+                    shortcutIndex: globalIndex < 9 ? globalIndex + 1 : nil,
                     closableOthersCount: closableOthersCount(excluding: tab.id),
                     closableLeftCount: closableCount(leftOf: index),
                     closableRightCount: closableCount(rightOf: index),

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -24,6 +24,7 @@ struct PaneTabStrip: View {
     var openInIDEFilePath: String?
     var openInIDECursorProvider: () -> (line: Int?, column: Int?) = { (nil, nil) }
     let projectID: UUID
+    var shortcutIndexOffset: Int = 0
     let onSelectTab: (UUID) -> Void
     let onCreateTab: () -> Void
     let onCreateVCSTab: () -> Void
@@ -132,7 +133,7 @@ struct PaneTabStrip: View {
                     areaID: areaID,
                     hasUnread: NotificationStore.shared.hasUnread(tabID: tab.id),
                     isAnyDragging: dragState.draggedID != nil,
-                    shortcutIndex: index < 9 ? index + 1 : nil,
+                    shortcutIndex: shortcutIndexOffset + index < 9 ? shortcutIndexOffset + index + 1 : nil,
                     closableOthersCount: closableOthersCount(excluding: tab.id),
                     closableLeftCount: closableCount(leftOf: index),
                     closableRightCount: closableCount(rightOf: index),

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -31,6 +31,7 @@ struct TerminalArea: View {
                 showTabStrip: !rootIsTabArea,
                 showVCSButton: false,
                 projectID: project.id,
+                shortcutOffsets: appState.shortcutOffsets(for: project.id),
                 onFocusArea: { areaID in
                     appState.dispatch(.focusArea(projectID: project.id, areaID: areaID))
                 },

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -914,4 +914,71 @@ struct WorkspaceReducerTests {
         let area = focusedArea(in: state, projectID: projectID)!
         #expect(area.activeTabID == area.tabs[0].id)
     }
+
+    @Test("selectTabByIndex with negative index does nothing")
+    func selectTabByIndexNegative() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+
+        _ = WorkspaceReducer.reduce(
+            action: .createTab(projectID: projectID, areaID: nil),
+            state: &state
+        )
+        
+        let area = focusedArea(in: state, projectID: projectID)!
+        let originalTabID = area.activeTabID
+
+        _ = WorkspaceReducer.reduce(
+            action: .selectTabByIndex(projectID: projectID, areaID: nil, index: -1),
+            state: &state
+        )
+
+        let newArea = focusedArea(in: state, projectID: projectID)!
+        #expect(newArea.activeTabID == originalTabID)
+    }
+
+    @Test("selectTabByIndex selects cross-pane global index")
+    func selectTabByIndexCrossPane() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+
+        _ = WorkspaceReducer.reduce(action: .createTab(projectID: projectID, areaID: nil), state: &state)
+        
+        let firstAreaID = state.focusedAreaID[key]!
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: firstAreaID,
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+
+        let secondAreaID = state.focusedAreaID[key]!
+
+        _ = WorkspaceReducer.reduce(
+            action: .createTab(projectID: projectID, areaID: secondAreaID),
+            state: &state
+        )
+
+        let firstArea = area(in: state, key: key, areaID: firstAreaID)!
+        let secondArea = area(in: state, key: key, areaID: secondAreaID)!
+        
+        #expect(firstArea.tabs.count == 2)
+        #expect(secondArea.tabs.count == 2)
+
+        _ = WorkspaceReducer.reduce(
+            action: .selectTabByIndex(projectID: projectID, areaID: nil, index: 3),
+            state: &state
+        )
+
+        #expect(state.focusedAreaID[key] == secondAreaID)
+        let newSecondArea = area(in: state, key: key, areaID: secondAreaID)!
+        #expect(newSecondArea.activeTabID == newSecondArea.tabs[1].id)
+    }
 }

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -907,7 +907,7 @@ struct WorkspaceReducerTests {
         )
 
         _ = WorkspaceReducer.reduce(
-            action: .selectTabByIndex(projectID: projectID, areaID: nil, index: 0),
+            action: .selectTabByIndex(projectID: projectID, index: 0),
             state: &state
         )
 
@@ -925,12 +925,12 @@ struct WorkspaceReducerTests {
             action: .createTab(projectID: projectID, areaID: nil),
             state: &state
         )
-        
+
         let area = focusedArea(in: state, projectID: projectID)!
         let originalTabID = area.activeTabID
 
         _ = WorkspaceReducer.reduce(
-            action: .selectTabByIndex(projectID: projectID, areaID: nil, index: -1),
+            action: .selectTabByIndex(projectID: projectID, index: -1),
             state: &state
         )
 
@@ -946,7 +946,7 @@ struct WorkspaceReducerTests {
         let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
 
         _ = WorkspaceReducer.reduce(action: .createTab(projectID: projectID, areaID: nil), state: &state)
-        
+
         let firstAreaID = state.focusedAreaID[key]!
 
         _ = WorkspaceReducer.reduce(
@@ -968,12 +968,12 @@ struct WorkspaceReducerTests {
 
         let firstArea = area(in: state, key: key, areaID: firstAreaID)!
         let secondArea = area(in: state, key: key, areaID: secondAreaID)!
-        
+
         #expect(firstArea.tabs.count == 2)
         #expect(secondArea.tabs.count == 2)
 
         _ = WorkspaceReducer.reduce(
-            action: .selectTabByIndex(projectID: projectID, areaID: nil, index: 3),
+            action: .selectTabByIndex(projectID: projectID, index: 3),
             state: &state
         )
 


### PR DESCRIPTION
## Summary

Number all tabs with consecutive numbers for easy access

## Changes

Instead of showing independent numbers for tabs in every pane, show consecutive numbers for all panes to allow easy navigation between them.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

<img width="3154" height="130" alt="image" src="https://github.com/user-attachments/assets/8bc631d9-9af9-4ab1-b1d3-1759f2446df6" />

