### PR TITLE
fix: preserve mobile connections toggle across app updates

### DIFF
--- a/Muxy/Services/MobileServerService.swift
+++ b/Muxy/Services/MobileServerService.swift
@@ -79,7 +79,8 @@ final class MobileServerService {
     }
 
     func setEnabled(_ enabled: Bool) {
-        guard enabled != isEnabled else { return }
+        if enabled, isEnabled, server != nil { return }
+        if !enabled, !isEnabled { return }
         isEnabled = enabled
         if enabled {
             start()
@@ -155,8 +156,6 @@ final class MobileServerService {
             logger.error("Mobile server failed to start on port \(port): \(error.localizedDescription)")
             isPortInUse = Self.isAddressInUseError(error)
             retireCurrentServer()
-            isEnabled = false
-            UserDefaults.standard.set(false, forKey: Self.enabledKey)
             lastError = friendlyMessage(for: error, port: port)
         }
     }


### PR DESCRIPTION
Transient bind failures (common right after a Sparkle relaunch) were persisting isEnabled = false, flipping the
  user's preference off on every update. Failure path now only surfaces the error; setEnabled allows retrying when
  the preference is on but no server is running.