### PR TITLE
refresh VCS reliably after PR checkout

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -1210,8 +1210,7 @@ final class VCSTabState {
                 guard !Task.isCancelled else { return }
                 ToastState.shared.show("Checked out PR #\(item.number)")
                 commits = []
-                performRefresh(incremental: false, forcePRFetch: true)
-                loadBranches()
+                await refreshAndWait()
             } catch {
                 guard !Task.isCancelled else { return }
                 showStatus(errorText(error), isError: true)


### PR DESCRIPTION
checkoutPullRequest fired performRefresh without awaiting it, so the PR pill and branch info could remain stale
  after checkout. Now awaits refreshAndWait so the VCS view fully reflects the new branch state.