### PR TITLE
Add opt-in anonymous Sentry crash reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to `.env` and fill in your values.
+# `.env` is git-ignored. The values below are read by the app in DEBUG builds
+# only (e.g. when running via `swift run Muxy`).
+
+# Sentry DSN. Leave empty to disable Sentry locally.
+# Find yours at https://sentry.io/settings/<org>/projects/<project>/keys/
+SENTRY_DSN=

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -126,6 +126,8 @@ jobs:
           echo "public_key=$SPARKLE_PUBLIC_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Build and package
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           chmod +x scripts/build-release.sh scripts/create-icns.sh
           scripts/build-release.sh \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,8 @@ jobs:
           echo "public_key=$SPARKLE_PUBLIC_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Build and package
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           chmod +x scripts/build-release.sh scripts/create-icns.sh
           scripts/build-release.sh \

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.env
 GhosttyKit.xcframework
 GhosttyKit/ghostty.h
 Muxy/Resources/ghostty

--- a/Muxy/Info.plist
+++ b/Muxy/Info.plist
@@ -30,6 +30,8 @@
 	<string>public.app-category.developer-tools</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SentryDSN</key>
+	<string>__MUXY_SENTRY_DSN__</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>A process running in Muxy's terminal would like to use AppleScript.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/Muxy/Models/SentryConsent.swift
+++ b/Muxy/Models/SentryConsent.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum SentryConsent: String {
+    case allowed
+    case denied
+
+    static let storageKey = "muxy.sentry.consent"
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -220,6 +220,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
+        SentryService.shared.start()
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
         setAppIcon()
@@ -229,7 +230,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ThemeService.shared.migrateToPairedThemeIfNeeded()
         observeSystemAppearanceChanges()
         UpdateService.shared.start()
-        SentryService.shared.start()
         ModifierKeyMonitor.shared.start()
         NotificationSocketServer.shared.start()
         AIProviderRegistry.shared.installAll()

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -229,6 +229,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ThemeService.shared.migrateToPairedThemeIfNeeded()
         observeSystemAppearanceChanges()
         UpdateService.shared.start()
+        SentryService.shared.start()
         ModifierKeyMonitor.shared.start()
         NotificationSocketServer.shared.start()
         AIProviderRegistry.shared.installAll()

--- a/Muxy/Services/DotEnvLoader.swift
+++ b/Muxy/Services/DotEnvLoader.swift
@@ -1,0 +1,40 @@
+#if DEBUG
+import Foundation
+
+enum DotEnvLoader {
+    static func value(for key: String) -> String? {
+        guard let url = locateDotEnv() else { return nil }
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        for line in contents.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+            guard let separator = trimmed.firstIndex(of: "=") else { continue }
+            let name = trimmed[..<separator].trimmingCharacters(in: .whitespaces)
+            guard name == key else { continue }
+            var raw = trimmed[trimmed.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+            if raw.hasPrefix("\"") && raw.hasSuffix("\"") && raw.count >= 2 {
+                raw = String(raw.dropFirst().dropLast())
+            } else if raw.hasPrefix("'") && raw.hasSuffix("'") && raw.count >= 2 {
+                raw = String(raw.dropFirst().dropLast())
+            }
+            return raw.isEmpty ? nil : raw
+        }
+        return nil
+    }
+
+    private static func locateDotEnv() -> URL? {
+        let fileManager = FileManager.default
+        var directory = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        for _ in 0 ..< 6 {
+            let candidate = directory.appendingPathComponent(".env")
+            if fileManager.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            let parent = directory.deletingLastPathComponent()
+            if parent.path == directory.path { break }
+            directory = parent
+        }
+        return nil
+    }
+}
+#endif

--- a/Muxy/Services/SentryService.swift
+++ b/Muxy/Services/SentryService.swift
@@ -14,7 +14,7 @@ final class SentryService {
     let hasDSN: Bool
     private let dsn: String?
     private let defaults: UserDefaults
-    private let starter: (String) -> Void
+    private let starter: (SentryStartContext) -> Void
     private let stopper: () -> Void
 
     var needsPrompt: Bool {
@@ -33,7 +33,7 @@ final class SentryService {
     init(
         dsn: String?,
         defaults: UserDefaults,
-        starter: @escaping (String) -> Void,
+        starter: @escaping (SentryStartContext) -> Void,
         stopper: @escaping () -> Void
     ) {
         self.dsn = dsn
@@ -46,7 +46,12 @@ final class SentryService {
 
     func start() {
         guard hasDSN, let dsn, consent == .allowed, !started else { return }
-        starter(dsn)
+        let context = SentryStartContext(
+            dsn: dsn,
+            releaseName: Self.releaseName,
+            environment: Self.environment(from: defaults)
+        )
+        starter(context)
         started = true
         logger.info("Sentry started")
     }
@@ -92,17 +97,17 @@ final class SentryService {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
     }
 
-    private static var environment: String {
-        let channel = UserDefaults.standard.string(forKey: UpdateChannel.storageKey)
+    private static func environment(from defaults: UserDefaults) -> String {
+        let channel = defaults.string(forKey: UpdateChannel.storageKey)
             .flatMap { UpdateChannel(rawValue: $0) } ?? .stable
         return channel == .beta ? "beta" : "production"
     }
 
-    private static let defaultStarter: (String) -> Void = { dsn in
+    private static let defaultStarter: (SentryStartContext) -> Void = { context in
         SentrySDK.start { options in
-            options.dsn = dsn
-            options.releaseName = releaseName
-            options.environment = environment
+            options.dsn = context.dsn
+            options.releaseName = context.releaseName
+            options.environment = context.environment
             options.sendDefaultPii = false
             options.enableAutoBreadcrumbTracking = false
             options.enableNetworkBreadcrumbs = false
@@ -119,4 +124,10 @@ final class SentryService {
     private static let defaultStopper: () -> Void = {
         SentrySDK.close()
     }
+}
+
+struct SentryStartContext {
+    let dsn: String
+    let releaseName: String?
+    let environment: String
 }

--- a/Muxy/Services/SentryService.swift
+++ b/Muxy/Services/SentryService.swift
@@ -1,0 +1,122 @@
+import Foundation
+import os
+import Sentry
+
+private let logger = Logger(subsystem: "app.muxy", category: "Sentry")
+
+@MainActor @Observable
+final class SentryService {
+    static let shared = SentryService()
+
+    private(set) var consent: SentryConsent?
+    private var started = false
+
+    let hasDSN: Bool
+    private let dsn: String?
+    private let defaults: UserDefaults
+    private let starter: (String) -> Void
+    private let stopper: () -> Void
+
+    var needsPrompt: Bool {
+        hasDSN && consent == nil
+    }
+
+    convenience init() {
+        self.init(
+            dsn: Self.resolveBundledDSN(),
+            defaults: .standard,
+            starter: Self.defaultStarter,
+            stopper: Self.defaultStopper
+        )
+    }
+
+    init(
+        dsn: String?,
+        defaults: UserDefaults,
+        starter: @escaping (String) -> Void,
+        stopper: @escaping () -> Void
+    ) {
+        self.dsn = dsn
+        hasDSN = dsn != nil
+        self.defaults = defaults
+        self.starter = starter
+        self.stopper = stopper
+        consent = Self.loadStoredConsent(from: defaults)
+    }
+
+    func start() {
+        guard hasDSN, let dsn, consent == .allowed, !started else { return }
+        starter(dsn)
+        started = true
+        logger.info("Sentry started")
+    }
+
+    func stop() {
+        guard started else { return }
+        stopper()
+        started = false
+        logger.info("Sentry stopped")
+    }
+
+    func setConsent(_ newValue: SentryConsent) {
+        consent = newValue
+        defaults.set(newValue.rawValue, forKey: SentryConsent.storageKey)
+        switch newValue {
+        case .allowed:
+            start()
+        case .denied:
+            stop()
+        }
+    }
+
+    private static func loadStoredConsent(from defaults: UserDefaults) -> SentryConsent? {
+        guard let raw = defaults.string(forKey: SentryConsent.storageKey) else { return nil }
+        return SentryConsent(rawValue: raw)
+    }
+
+    private static func resolveBundledDSN() -> String? {
+        if let bundled = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String {
+            let trimmed = bundled.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty, trimmed != "__MUXY_SENTRY_DSN__" {
+                return trimmed
+            }
+        }
+        #if DEBUG
+        return DotEnvLoader.value(for: "SENTRY_DSN")
+        #else
+        return nil
+        #endif
+    }
+
+    private static var releaseName: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
+    private static var environment: String {
+        let channel = UserDefaults.standard.string(forKey: UpdateChannel.storageKey)
+            .flatMap { UpdateChannel(rawValue: $0) } ?? .stable
+        return channel == .beta ? "beta" : "production"
+    }
+
+    private static let defaultStarter: (String) -> Void = { dsn in
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.releaseName = releaseName
+            options.environment = environment
+            options.sendDefaultPii = false
+            options.enableAutoBreadcrumbTracking = false
+            options.enableNetworkBreadcrumbs = false
+            options.enableSwizzling = false
+            options.attachStacktrace = true
+            options.beforeSend = { event in
+                event.user = nil
+                event.serverName = nil
+                return event
+            }
+        }
+    }
+
+    private static let defaultStopper: () -> Void = {
+        SentrySDK.close()
+    }
+}

--- a/Muxy/Services/SentryService.swift
+++ b/Muxy/Services/SentryService.swift
@@ -111,7 +111,8 @@ final class SentryService {
             options.sendDefaultPii = false
             options.enableAutoBreadcrumbTracking = false
             options.enableNetworkBreadcrumbs = false
-            options.enableSwizzling = false
+            options.enableSwizzling = true
+            options.enableUncaughtNSExceptionReporting = true
             options.attachStacktrace = true
             options.beforeSend = { event in
                 event.user = nil

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1298,16 +1298,30 @@ private struct SentryConsentPrompter: ViewModifier {
         }
     }
 
+    @MainActor
     private func presentWhenWindowReady() async {
         if let window = readyWindow() {
             present(on: window)
             return
         }
-        let notifications = NotificationCenter.default.notifications(named: NSWindow.didBecomeKeyNotification)
-        for await _ in notifications {
-            if let window = readyWindow() {
-                present(on: window)
-                return
+        await waitForKeyWindow()
+        if let window = readyWindow() {
+            present(on: window)
+        }
+    }
+
+    @MainActor
+    private func waitForKeyWindow() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            var token: NSObjectProtocol?
+            token = NotificationCenter.default.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                guard NSApp.keyWindow ?? NSApp.mainWindow != nil else { return }
+                if let token { NotificationCenter.default.removeObserver(token) }
+                continuation.resume()
             }
         }
     }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -295,6 +295,7 @@ struct MainWindow: View {
             guard isPresented, let pending = appState.pendingLayoutApply else { return }
             presentLayoutApplyConfirmation(pending: pending)
         }
+        .modifier(SentryConsentPrompter())
     }
 
     private var navigationArrows: some View {
@@ -1283,6 +1284,52 @@ private struct SidePanelNotificationListeners: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .toggleRichInput)) { _ in
                 onToggleRichInput()
             }
+    }
+}
+
+private struct SentryConsentPrompter: ViewModifier {
+    @State private var hasPrompted = false
+
+    func body(content: Content) -> some View {
+        content.task {
+            guard !hasPrompted, SentryService.shared.needsPrompt else { return }
+            hasPrompted = true
+            await presentWhenWindowReady()
+        }
+    }
+
+    private func presentWhenWindowReady() async {
+        for _ in 0 ..< 20 {
+            if let window = NSApp.keyWindow ?? NSApp.mainWindow, window.attachedSheet == nil {
+                present(on: window)
+                return
+            }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+    }
+
+    @MainActor
+    private func present(on window: NSWindow) {
+        let alert = NSAlert()
+        alert.messageText = "Help improve Muxy?"
+        alert.informativeText = """
+        Muxy can send anonymous crash and error reports so we can fix bugs faster. \
+        No personal data, no project contents, no file paths are sent — only crash \
+        details and an anonymous installation ID.
+
+        You can change this anytime in Settings → General → Diagnostics.
+        """
+        alert.alertStyle = .informational
+        alert.icon = NSApp.applicationIconImage
+        alert.addButton(withTitle: "Allow")
+        alert.addButton(withTitle: "Don't Allow")
+        alert.buttons[0].keyEquivalent = "\r"
+        alert.buttons[1].keyEquivalent = "\u{1b}"
+
+        alert.beginSheetModal(for: window) { response in
+            let consent: SentryConsent = response == .alertFirstButtonReturn ? .allowed : .denied
+            SentryService.shared.setConsent(consent)
+        }
     }
 }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1312,16 +1312,22 @@ private struct SentryConsentPrompter: ViewModifier {
 
     @MainActor
     private func waitForKeyWindow() async {
+        let center = NotificationCenter.default
+        let holder = ObserverHolder()
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            var token: NSObjectProtocol?
-            token = NotificationCenter.default.addObserver(
+            holder.token = center.addObserver(
                 forName: NSWindow.didBecomeKeyNotification,
                 object: nil,
                 queue: .main
             ) { _ in
-                guard NSApp.keyWindow ?? NSApp.mainWindow != nil else { return }
-                if let token { NotificationCenter.default.removeObserver(token) }
-                continuation.resume()
+                MainActor.assumeIsolated {
+                    guard NSApp.keyWindow ?? NSApp.mainWindow != nil else { return }
+                    if let token = holder.token {
+                        center.removeObserver(token)
+                        holder.token = nil
+                        continuation.resume()
+                    }
+                }
             }
         }
     }
@@ -1355,6 +1361,11 @@ private struct SentryConsentPrompter: ViewModifier {
             SentryService.shared.setConsent(consent)
         }
     }
+}
+
+@MainActor
+private final class ObserverHolder {
+    var token: NSObjectProtocol?
 }
 
 private struct OverlayExitTracker: ViewModifier {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1299,13 +1299,23 @@ private struct SentryConsentPrompter: ViewModifier {
     }
 
     private func presentWhenWindowReady() async {
-        for _ in 0 ..< 20 {
-            if let window = NSApp.keyWindow ?? NSApp.mainWindow, window.attachedSheet == nil {
+        if let window = readyWindow() {
+            present(on: window)
+            return
+        }
+        let notifications = NotificationCenter.default.notifications(named: NSWindow.didBecomeKeyNotification)
+        for await _ in notifications {
+            if let window = readyWindow() {
                 present(on: window)
                 return
             }
-            try? await Task.sleep(nanoseconds: 250_000_000)
         }
+    }
+
+    @MainActor
+    private func readyWindow() -> NSWindow? {
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow else { return nil }
+        return window.attachedSheet == nil ? window : nil
     }
 
     @MainActor

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -14,6 +14,7 @@ struct GeneralSettingsView: View {
     private var updateChannelRaw = UpdateChannel.stable.rawValue
     @AppStorage(QuitConfirmationPreferences.confirmQuitKey)
     private var confirmQuit = true
+    @State private var sentry = SentryService.shared
 
     var body: some View {
         SettingsContainer {
@@ -69,13 +70,34 @@ struct GeneralSettingsView: View {
                 )
             }
 
-            SettingsSection("Quit", showsDivider: false) {
+            SettingsSection("Quit", showsDivider: sentry.hasDSN) {
                 SettingsToggleRow(
                     label: "Confirm before quitting Muxy",
                     isOn: $confirmQuit
                 )
             }
+
+            if sentry.hasDSN {
+                SettingsSection(
+                    "Diagnostics",
+                    footer: "Anonymous crash reports help us fix bugs. "
+                        + "Reports never include project paths, file contents, or personal data.",
+                    showsDivider: false
+                ) {
+                    SettingsToggleRow(
+                        label: "Send anonymous crash reports",
+                        isOn: sentryConsentBinding
+                    )
+                }
+            }
         }
+    }
+
+    private var sentryConsentBinding: Binding<Bool> {
+        Binding(
+            get: { sentry.consent == .allowed },
+            set: { newValue in sentry.setConsent(newValue ? .allowed : .denied) }
+        )
     }
 
     private var channelBinding: Binding<UpdateChannel> {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "990b88e655dec9cabee156c67691837b9010d69e9d6b2d27b971fa71e442434f",
+  "originHash" : "066ab307b4a0e89ca1cb729d2423eb57ebcd8a19de8762c00940d2cb612c1569",
   "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "cf44aa8cb4147f39e698c1f28be0b6b2c89f79d2",
+        "version" : "8.58.2"
+      }
+    },
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.1"),
         .package(url: "https://github.com/jpsim/Yams", from: "5.1.0"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.40.0"),
     ],
     targets: [
         .target(
@@ -39,6 +40,7 @@ let package = Package(
                 "MuxyServer",
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "Yams", package: "Yams"),
+                .product(name: "Sentry", package: "sentry-cocoa"),
             ],
             path: "Muxy",
             exclude: ["Info.plist", "Muxy.entitlements", "Resources/ghostty", "Resources/terminfo", "Resources/rg"],

--- a/Tests/MuxyTests/Services/SentryServiceTests.swift
+++ b/Tests/MuxyTests/Services/SentryServiceTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("SentryService")
+@MainActor
+struct SentryServiceTests {
+    @Test("needsPrompt is true when DSN is present and consent is undecided")
+    func needsPromptWhenDSNAndUndecided() {
+        let (service, _, suiteName) = makeService(dsn: "https://public@example.ingest.sentry.io/1")
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        #expect(service.hasDSN)
+        #expect(service.consent == nil)
+        #expect(service.needsPrompt)
+    }
+
+    @Test("needsPrompt is false when DSN is missing")
+    func needsPromptFalseWithoutDSN() {
+        let (service, _, suiteName) = makeService(dsn: nil)
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        #expect(!service.hasDSN)
+        #expect(!service.needsPrompt)
+    }
+
+    @Test("setConsent persists denied and reports needsPrompt false")
+    func setConsentDeniedPersists() {
+        let (service, defaults, suiteName) = makeService(dsn: "https://public@example.ingest.sentry.io/1")
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        service.setConsent(.denied)
+
+        #expect(service.consent == .denied)
+        #expect(!service.needsPrompt)
+        #expect(defaults.string(forKey: SentryConsent.storageKey) == "denied")
+    }
+
+    @Test("setConsent allowed starts the SDK; denied stops it")
+    func setConsentTogglesStartAndStop() {
+        var startCount = 0
+        var stopCount = 0
+        let (service, defaults, suiteName) = makeService(
+            dsn: "https://public@example.ingest.sentry.io/1",
+            starter: { _ in startCount += 1 },
+            stopper: { stopCount += 1 }
+        )
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        service.setConsent(.allowed)
+        #expect(startCount == 1)
+        #expect(stopCount == 0)
+
+        service.setConsent(.allowed)
+        #expect(startCount == 1, "start must be idempotent")
+
+        service.setConsent(.denied)
+        #expect(stopCount == 1)
+
+        service.setConsent(.denied)
+        #expect(stopCount == 1, "stop must be idempotent")
+    }
+
+    @Test("start is a no-op when DSN is missing even with allowed consent")
+    func startNoOpWithoutDSN() {
+        var startCount = 0
+        let (service, defaults, suiteName) = makeService(
+            dsn: nil,
+            starter: { _ in startCount += 1 }
+        )
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        service.setConsent(.allowed)
+
+        #expect(startCount == 0)
+    }
+
+    @Test("loads previously stored consent on init")
+    func loadsPersistedConsent() {
+        let suiteName = "muxy.tests.sentry.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            Issue.record("Unable to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(SentryConsent.allowed.rawValue, forKey: SentryConsent.storageKey)
+
+        let service = SentryService(
+            dsn: "https://public@example.ingest.sentry.io/1",
+            defaults: defaults,
+            starter: { _ in },
+            stopper: {}
+        )
+
+        #expect(service.consent == .allowed)
+        #expect(!service.needsPrompt)
+    }
+
+    private func makeService(
+        dsn: String?,
+        starter: @escaping (String) -> Void = { _ in },
+        stopper: @escaping () -> Void = {}
+    ) -> (SentryService, UserDefaults, String) {
+        let suiteName = "muxy.tests.sentry.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Unable to create isolated UserDefaults suite")
+        }
+        let service = SentryService(
+            dsn: dsn,
+            defaults: defaults,
+            starter: starter,
+            stopper: stopper
+        )
+        return (service, defaults, suiteName)
+    }
+}

--- a/Tests/MuxyTests/Services/SentryServiceTests.swift
+++ b/Tests/MuxyTests/Services/SentryServiceTests.swift
@@ -97,9 +97,24 @@ struct SentryServiceTests {
         #expect(!service.needsPrompt)
     }
 
+    @Test("environment is derived from the injected defaults' update channel")
+    func startContextEnvironmentReflectsChannel() {
+        var capturedEnvironments: [String] = []
+        let (service, defaults, suiteName) = makeService(
+            dsn: "https://public@example.ingest.sentry.io/1",
+            starter: { context in capturedEnvironments.append(context.environment) }
+        )
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(UpdateChannel.beta.rawValue, forKey: UpdateChannel.storageKey)
+        service.setConsent(.allowed)
+
+        #expect(capturedEnvironments == ["beta"])
+    }
+
     private func makeService(
         dsn: String?,
-        starter: @escaping (String) -> Void = { _ in },
+        starter: @escaping (SentryStartContext) -> Void = { _ in },
         stopper: @escaping () -> Void = {}
     ) -> (SentryService, UserDefaults, String) {
         let suiteName = "muxy.tests.sentry.\(UUID().uuidString)"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -46,7 +46,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$ARCH" || -z "$VERSION" ]]; then
-    echo "Usage: $0 --arch <arm64|x86_64> --version <X.Y.Z[-beta.N]> [--sign-identity <identity>] [--sparkle-public-key <key>] [--sparkle-feed-url <url>]"
+    echo "Usage: $0 --arch <arm64|x86_64> --version <X.Y.Z[-beta.N]> [--sign-identity <identity>] [--sparkle-public-key <key>] [--sparkle-feed-url <url>] [--sentry-dsn <dsn>]"
     exit 1
 fi
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -10,6 +10,7 @@ VERSION=""
 SIGN_IDENTITY=""
 SPARKLE_PUBLIC_KEY=""
 SPARKLE_FEED_URL=""
+SENTRY_DSN="${SENTRY_DSN:-}"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -31,6 +32,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --sparkle-feed-url)
             SPARKLE_FEED_URL="$2"
+            shift 2
+            ;;
+        --sentry-dsn)
+            SENTRY_DSN="$2"
             shift 2
             ;;
         *)
@@ -85,6 +90,11 @@ fi
 cp "$PROJECT_ROOT/Muxy/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$APP_BUNDLE/Contents/Info.plist"
+
+if [[ -n "$SENTRY_DSN" ]]; then
+    echo "==> Injecting Sentry DSN into Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :SentryDSN $SENTRY_DSN" "$APP_BUNDLE/Contents/Info.plist"
+fi
 
 echo "==> Generating app icon"
 "$SCRIPT_DIR/create-icns.sh" "$APP_BUNDLE/Contents/Resources/AppIcon.icns"


### PR DESCRIPTION
Adds Sentry-cocoa for opt-in anonymous crash/error reporting. Users see a one-time prompt on next launch and can     toggle it any time in Settings → General → Diagnostics. No PII, no breadcrumbs, no hostname. DSN comes from
  SENTRY_DSN (CI secret + local .env); without it, Sentry stays inert.