### PR TITLE
Move update badge to leftmost position in top-right toolbar

### DIFF
--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -437,6 +437,12 @@ struct MainWindow: View {
                 }
                 .overlay(alignment: .trailing) {
                     HStack(spacing: 0) {
+                        if let version = UpdateService.shared.availableUpdateVersion {
+                            UpdateBadge(version: version) {
+                                UpdateService.shared.checkForUpdates()
+                            }
+                            .padding(.trailing, UIMetrics.spacing2)
+                        }
                         if AppEnvironment.isDevelopment {
                             devModeBadge
                                 .padding(.trailing, UIMetrics.spacing3)
@@ -448,12 +454,6 @@ struct MainWindow: View {
                                 cursorProvider: activeEditorCursor
                             )
                             LayoutPickerMenu(projectID: project.id)
-                        }
-                        if let version = UpdateService.shared.availableUpdateVersion {
-                            UpdateBadge(version: version) {
-                                UpdateService.shared.checkForUpdates()
-                            }
-                            .padding(.trailing, UIMetrics.spacing2)
                         }
                         if let project = activeProject, activeProjectHasSplitWorkspace {
                             IconButton(symbol: "doc.text", size: 12, accessibilityLabel: "Quick Open") {

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -69,6 +69,12 @@ struct PaneTabStrip: View {
             .frame(height: UIMetrics.scaled(32))
 
             HStack(spacing: 0) {
+                if isWindowTitleBar, let version = UpdateService.shared.availableUpdateVersion {
+                    UpdateBadge(version: version) {
+                        UpdateService.shared.checkForUpdates()
+                    }
+                    .padding(.trailing, UIMetrics.spacing2)
+                }
                 if showDevelopmentBadge {
                     developmentBadge
                         .padding(.trailing, UIMetrics.spacing3)
@@ -80,12 +86,6 @@ struct PaneTabStrip: View {
                         cursorProvider: openInIDECursorProvider
                     )
                     LayoutPickerMenu(projectID: projectID)
-                }
-                if isWindowTitleBar, let version = UpdateService.shared.availableUpdateVersion {
-                    UpdateBadge(version: version) {
-                        UpdateService.shared.checkForUpdates()
-                    }
-                    .padding(.trailing, UIMetrics.spacing2)
                 }
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
                     .help(shortcutTooltip("Split Right", for: .splitRight))


### PR DESCRIPTION
The update badge previously rendered between the layout picker and the split/action icons. Move it to the very left
   of the right-side toolbar in both MainWindow and PaneTabStrip so it sits ahead of dev/IDE/layout/action icons.