### PR TITLE
Add broadcast toggle to Rich Input panel for sending to all visible panes

### DIFF
--- a/Muxy/Models/RichInputPreferences.swift
+++ b/Muxy/Models/RichInputPreferences.swift
@@ -12,6 +12,9 @@ enum RichInputPreferences {
 
     static let positionKey = "muxy.richInput.position"
     static let defaultPosition: RichInputPanelPosition = .right
+
+    static let broadcastKey = "muxy.richInput.broadcast"
+    static let defaultBroadcast = false
 }
 
 enum RichInputPanelPosition: String, CaseIterable, Identifiable {

--- a/Muxy/Services/RichInputSubmitter.swift
+++ b/Muxy/Services/RichInputSubmitter.swift
@@ -13,6 +13,11 @@ enum RichInputSubmitter {
     }
 
     static func submit(richInput: RichInputState, paneID: UUID, appendReturn: Bool) {
+        submit(richInput: richInput, paneIDs: [paneID], appendReturn: appendReturn)
+    }
+
+    static func submit(richInput: RichInputState, paneIDs: [UUID], appendReturn: Bool) {
+        guard !paneIDs.isEmpty else { return }
         let body = richInput.text
         let fileAttachments = richInput.fileAttachments
         let imageAttachments = richInput.imageAttachments
@@ -35,29 +40,42 @@ enum RichInputSubmitter {
             strategy: EditorSettings.shared.richInputImageStrategy
         )
 
+        let views = paneIDs.compactMap { TerminalViewRegistry.shared.existingView(for: $0) }
+        guard !views.isEmpty else { return }
+        let needsClipboard = segments.contains { if case .image = $0 { true } else { false } }
+        let primaryView = views.first
+
         Task { @MainActor in
-            guard let view = TerminalViewRegistry.shared.existingView(for: paneID) else { return }
-            view.clearTerminalInput()
+            for view in views {
+                view.clearTerminalInput()
+            }
             try? await Task.sleep(for: initialDelay)
 
             var savedClipboard: [NSPasteboardItem]?
+            if needsClipboard {
+                savedClipboard = SystemPasteboardSnapshot.capture()
+            }
+
             for segment in segments {
                 switch segment {
                 case let .text(chunk):
                     if !chunk.isEmpty {
-                        view.submitRichInput(text: chunk)
+                        for view in views {
+                            view.submitRichInput(text: chunk)
+                        }
                     }
                 case let .image(url):
-                    if savedClipboard == nil {
-                        savedClipboard = SystemPasteboardSnapshot.capture()
+                    for view in views {
+                        view.pasteImageURL(url)
                     }
-                    view.pasteImageURL(url)
                     try? await Task.sleep(for: imagePasteDelay)
                 }
             }
 
             if appendReturn {
-                view.sendRemoteBytes(TerminalControlBytes.carriageReturn)
+                for view in views {
+                    view.sendRemoteBytes(TerminalControlBytes.carriageReturn)
+                }
             }
 
             if let savedClipboard {
@@ -65,7 +83,7 @@ enum RichInputSubmitter {
                 SystemPasteboardSnapshot.restore(items: savedClipboard)
             }
 
-            view.window?.makeFirstResponder(view)
+            primaryView?.window?.makeFirstResponder(primaryView)
         }
     }
 

--- a/Muxy/Services/RichInputSubmitter.swift
+++ b/Muxy/Services/RichInputSubmitter.swift
@@ -41,38 +41,20 @@ enum RichInputSubmitter {
         let hasImageSegment = segments.contains { if case .image = $0 { true } else { false } }
         let focusTarget = views.count == 1 ? views.first : nil
 
-        if !hasImageSegment {
-            let payload = textOnlyPayload(segments: segments, appendReturn: appendReturn)
-            Task { @MainActor in
-                for view in views {
-                    view.clearTerminalInput()
-                }
-                try? await Task.sleep(for: initialDelay)
-                for view in views {
-                    view.sendRemoteBytes(payload)
-                }
-                if let focusTarget {
-                    focusTarget.window?.makeFirstResponder(focusTarget)
-                }
-            }
-            return
-        }
-
         Task { @MainActor in
             for view in views {
                 view.clearTerminalInput()
             }
             try? await Task.sleep(for: initialDelay)
 
-            let savedClipboard = SystemPasteboardSnapshot.capture()
+            let savedClipboard = hasImageSegment ? SystemPasteboardSnapshot.capture() : nil
 
             for segment in segments {
                 switch segment {
                 case let .text(chunk):
-                    if !chunk.isEmpty {
-                        for view in views {
-                            view.submitRichInput(text: chunk)
-                        }
+                    guard !chunk.isEmpty else { continue }
+                    for view in views {
+                        view.submitRichInput(text: chunk)
                     }
                 case let .image(url):
                     for view in views {
@@ -88,28 +70,15 @@ enum RichInputSubmitter {
                 }
             }
 
-            try? await Task.sleep(for: imagePasteDelay)
-            SystemPasteboardSnapshot.restore(items: savedClipboard)
+            if let savedClipboard {
+                try? await Task.sleep(for: imagePasteDelay)
+                SystemPasteboardSnapshot.restore(items: savedClipboard)
+            }
 
             if let focusTarget {
                 focusTarget.window?.makeFirstResponder(focusTarget)
             }
         }
-    }
-
-    private static func textOnlyPayload(segments: [Segment], appendReturn: Bool) -> Data {
-        var payload = Data()
-        for segment in segments {
-            guard case let .text(chunk) = segment, !chunk.isEmpty else { continue }
-            let sanitized = chunk.replacingOccurrences(of: "\u{1B}[201~", with: "")
-            payload.append(TerminalControlBytes.bracketedPasteStart)
-            payload.append(Data(sanitized.utf8))
-            payload.append(TerminalControlBytes.bracketedPasteEnd)
-        }
-        if appendReturn {
-            payload.append(TerminalControlBytes.carriageReturn)
-        }
-        return payload
     }
 
     nonisolated static func resolveSegments(

--- a/Muxy/Services/RichInputSubmitter.swift
+++ b/Muxy/Services/RichInputSubmitter.swift
@@ -12,10 +12,6 @@ enum RichInputSubmitter {
         case image(URL)
     }
 
-    static func submit(richInput: RichInputState, paneID: UUID, appendReturn: Bool) {
-        submit(richInput: richInput, paneIDs: [paneID], appendReturn: appendReturn)
-    }
-
     static func submit(richInput: RichInputState, paneIDs: [UUID], appendReturn: Bool) {
         guard !paneIDs.isEmpty else { return }
         let body = richInput.text
@@ -42,8 +38,25 @@ enum RichInputSubmitter {
 
         let views = paneIDs.compactMap { TerminalViewRegistry.shared.existingView(for: $0) }
         guard !views.isEmpty else { return }
-        let needsClipboard = segments.contains { if case .image = $0 { true } else { false } }
-        let primaryView = views.first
+        let hasImageSegment = segments.contains { if case .image = $0 { true } else { false } }
+        let focusTarget = views.count == 1 ? views.first : nil
+
+        if !hasImageSegment {
+            let payload = textOnlyPayload(segments: segments, appendReturn: appendReturn)
+            Task { @MainActor in
+                for view in views {
+                    view.clearTerminalInput()
+                }
+                try? await Task.sleep(for: initialDelay)
+                for view in views {
+                    view.sendRemoteBytes(payload)
+                }
+                if let focusTarget {
+                    focusTarget.window?.makeFirstResponder(focusTarget)
+                }
+            }
+            return
+        }
 
         Task { @MainActor in
             for view in views {
@@ -51,10 +64,7 @@ enum RichInputSubmitter {
             }
             try? await Task.sleep(for: initialDelay)
 
-            var savedClipboard: [NSPasteboardItem]?
-            if needsClipboard {
-                savedClipboard = SystemPasteboardSnapshot.capture()
-            }
+            let savedClipboard = SystemPasteboardSnapshot.capture()
 
             for segment in segments {
                 switch segment {
@@ -78,13 +88,28 @@ enum RichInputSubmitter {
                 }
             }
 
-            if let savedClipboard {
-                try? await Task.sleep(for: imagePasteDelay)
-                SystemPasteboardSnapshot.restore(items: savedClipboard)
-            }
+            try? await Task.sleep(for: imagePasteDelay)
+            SystemPasteboardSnapshot.restore(items: savedClipboard)
 
-            primaryView?.window?.makeFirstResponder(primaryView)
+            if let focusTarget {
+                focusTarget.window?.makeFirstResponder(focusTarget)
+            }
         }
+    }
+
+    private static func textOnlyPayload(segments: [Segment], appendReturn: Bool) -> Data {
+        var payload = Data()
+        for segment in segments {
+            guard case let .text(chunk) = segment, !chunk.isEmpty else { continue }
+            let sanitized = chunk.replacingOccurrences(of: "\u{1B}[201~", with: "")
+            payload.append(TerminalControlBytes.bracketedPasteStart)
+            payload.append(Data(sanitized.utf8))
+            payload.append(TerminalControlBytes.bracketedPasteEnd)
+        }
+        if appendReturn {
+            payload.append(TerminalControlBytes.carriageReturn)
+        }
+        return payload
     }
 
     nonisolated static func resolveSegments(

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -75,6 +75,7 @@ struct MainWindow: View {
     @AppStorage(RichInputPreferences.floatingKey) private var richInputFloating = RichInputPreferences.defaultFloating
     @AppStorage(RichInputPreferences.positionKey) private var richInputPosition: RichInputPanelPosition = RichInputPreferences
         .defaultPosition
+    @AppStorage(RichInputPreferences.broadcastKey) private var richInputBroadcast = RichInputPreferences.defaultBroadcast
     @State private var richInputStates: [WorktreeKey: RichInputState] = [:]
     @State private var showQuickOpen = false
     @State private var showFindInFiles = false
@@ -1025,8 +1026,16 @@ struct MainWindow: View {
     }
 
     private func submitRichInput(_ richInput: RichInputState, appendReturn: Bool) {
-        guard let paneID = activeRichInputPaneID else { return }
-        RichInputSubmitter.submit(richInput: richInput, paneID: paneID, appendReturn: appendReturn)
+        let paneIDs = richInputBroadcast ? visibleTerminalPaneIDs() : [activeRichInputPaneID].compactMap(\.self)
+        guard !paneIDs.isEmpty else { return }
+        RichInputSubmitter.submit(richInput: richInput, paneIDs: paneIDs, appendReturn: appendReturn)
+    }
+
+    private func visibleTerminalPaneIDs() -> [UUID] {
+        guard let project = activeProject,
+              let root = appState.workspaceRoot(for: project.id)
+        else { return [] }
+        return root.allAreas().compactMap { $0.activeTab?.content.pane?.id }
     }
 
     private var activeVCSState: VCSTabState? {

--- a/Muxy/Views/Terminal/RichInputSidePanel.swift
+++ b/Muxy/Views/Terminal/RichInputSidePanel.swift
@@ -176,7 +176,7 @@ struct RichInputSidePanel: View {
     }
 
     private var broadcastToggleLabel: String {
-        broadcast ? "Broadcast On — Send to All Visible Panes" : "Broadcast Off — Send to Active Pane"
+        broadcast ? "Broadcast On — Send to All Split Panes" : "Broadcast Off — Send to Active Pane"
     }
 
     private func toggleBroadcast() {

--- a/Muxy/Views/Terminal/RichInputSidePanel.swift
+++ b/Muxy/Views/Terminal/RichInputSidePanel.swift
@@ -12,6 +12,7 @@ struct RichInputSidePanel: View {
     @AppStorage(RichInputPreferences.positionKey) private var position: RichInputPanelPosition = RichInputPreferences
         .defaultPosition
     @AppStorage(RichInputPreferences.floatingKey) private var floating: Bool = RichInputPreferences.defaultFloating
+    @AppStorage(RichInputPreferences.broadcastKey) private var broadcast: Bool = RichInputPreferences.defaultBroadcast
 
     var body: some View {
         VStack(spacing: 0) {
@@ -105,6 +106,14 @@ struct RichInputSidePanel: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
             Spacer(minLength: 8)
+            Button(action: toggleBroadcast) {
+                Image(systemName: broadcastToggleIcon)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(broadcast ? MuxyTheme.accent : MuxyTheme.fgMuted)
+            }
+            .buttonStyle(RichInputToolbarButtonStyle())
+            .accessibilityLabel(broadcastToggleLabel)
+            .help(broadcastToggleLabel)
             Button(action: toggleFloating) {
                 Image(systemName: pinToggleIcon)
                     .font(.system(size: 11, weight: .semibold))
@@ -160,6 +169,18 @@ struct RichInputSidePanel: View {
 
     private func toggleFloating() {
         floating.toggle()
+    }
+
+    private var broadcastToggleIcon: String {
+        broadcast ? "dot.radiowaves.left.and.right" : "antenna.radiowaves.left.and.right.slash"
+    }
+
+    private var broadcastToggleLabel: String {
+        broadcast ? "Broadcast On — Send to All Visible Panes" : "Broadcast Off — Send to Active Pane"
+    }
+
+    private func toggleBroadcast() {
+        broadcast.toggle()
     }
 
     private func increaseFontSize() {


### PR DESCRIPTION
Adds a broadcast toggle to the Rich Input panel header. When enabled, cmd+enter and cmd+shift+enter send the
  content to the visible terminal of every split area in the current workspace. Preference persists via AppStorage