### PR TITLE
Reply to client WebSocket keep-alive pings

### DIFF
--- a/MuxyServer/ClientConnection.swift
+++ b/MuxyServer/ClientConnection.swift
@@ -69,8 +69,9 @@ final class ClientConnection: @unchecked Sendable {
                 return
             }
 
-            let isWebSocket = context?.protocolMetadata(definition: NWProtocolWebSocket.definition) != nil
-            guard isWebSocket else {
+            let metadata = context?.protocolMetadata(definition: NWProtocolWebSocket.definition)
+                as? NWProtocolWebSocket.Metadata
+            guard let metadata, metadata.opcode == .text || metadata.opcode == .binary else {
                 self.receiveNextMessage()
                 return
             }

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -166,6 +166,7 @@ public final class MuxyRemoteServer: @unchecked Sendable {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
             let ws = NWProtocolWebSocket.Options()
+            ws.autoReplyPing = true
             params.defaultProtocolStack.applicationProtocols.insert(ws, at: 0)
             listener = try NWListener(using: params, on: endpointPort)
         } catch {


### PR DESCRIPTION
Companion clients that send WebSocket keep-alive pings (Android OkHttp by default) drop the socket ~40s after every connect: `NWProtocolWebSocket.Options.autoReplyPing` defaults to false, so the remote server never replies, and the client tears the connection down on the missing pong.

Enables `autoReplyPing` on the listener options and filters non-text/binary frames out of `ClientConnection.handleData` so the framework's auto-reply pings don't reach the JSON decoder.