### PR TITLE
Improve AI commit/PR generation quality and safety

### DIFF
--- a/Muxy/Services/AIAssistant/AIAssistantPrompts.swift
+++ b/Muxy/Services/AIAssistant/AIAssistantPrompts.swift
@@ -7,32 +7,84 @@ enum AIAssistantTask {
 
 enum AIAssistantPrompts {
     static let defaultCommitUserPrompt = """
-    Write a concise, conventional git commit message for the staged changes below.
-    - Subject line in imperative mood, max 72 characters.
-    - Optional body, wrapped at 72 characters, explaining the why.
-    - Do not include code fences, quotes, or any extra commentary.
+    Write the commit message for the staged changes below.
+
+    How to read the diff:
+    1. Group hunks by the underlying change they implement (one diff often
+       contains one logical change spread across many files).
+    2. Identify the dominant change. Treat refactors, renames, test updates,
+       and formatting as supporting context unless they ARE the change.
+    3. If you see unrelated upstream changes (e.g. from a recent merge of the
+       base branch), ignore them and focus only on this commit's intent.
+
+    Then write the message per the system prompt's format.
     """
 
     static let defaultPullRequestUserPrompt = """
-    Write a pull request title and short description for the diff below.
-    - Title: short, imperative, max 70 characters.
-    - Description: 1-3 short bullet points or sentences focused on the why.
-    - Do not include code fences or extra commentary.
+    Draft a PR title and body for the diff below.
+
+    Diff scope:
+    - The committed section is this branch's changes relative to the
+      merge-base with the base branch. Commits already on the base branch
+      are NOT included.
+    - If the branch was recently merged with the base, you may still see
+      hunks that look like upstream code (imports moved, files reformatted
+      by another PR, lockfile churn). Ignore anything that does not match
+      this branch's intent. When in doubt, prefer narrower claims.
+    - The working-tree section, when present, lists uncommitted changes.
+      Treat them as part of the same PR.
+
+    How to read the diff:
+    1. Group hunks by the underlying change.
+    2. Pick the single dominant outcome - that is the title.
+    3. The body explains why it matters and any reviewer-relevant context.
+
+    Output the JSON object only.
     """
 
     static func systemPrompt(for task: AIAssistantTask) -> String {
         switch task {
         case .commitMessage:
             """
-            You are an assistant that generates git commit messages.
-            Output ONLY the commit message in plain text. No code fences, no preamble, no JSON.
-            Subject line first, then a blank line, then optional body. No trailing notes.
+            You are a senior engineer writing a git commit message for a teammate.
+            Goals: explain the WHY, not the WHAT. The diff already shows the what.
+
+            Output format (STRICT):
+            - Plain text only. No code fences, no preamble, no trailing notes.
+            - Subject line: imperative mood, <=72 chars, no trailing period, no
+              scope prefix unless the repo already uses Conventional Commits.
+            - Then a blank line.
+            - Optional body: wrapped at 72 chars, focused on motivation,
+              trade-offs, or non-obvious mechanics. Skip the body for trivial
+              changes.
+
+            Never:
+            - Restate the file list or function names already visible in the diff.
+            - Begin with "This commit", "Updated", "Changed" - start with the action.
+            - Mention tests, lint, or formatting unless they are the actual subject.
             """
         case .pullRequest:
             """
-            You are an assistant that generates pull request metadata.
-            Output ONLY a single JSON object with exactly two string keys: "title" and "body".
-            No code fences, no preamble, no trailing text. Example:
+            You are a senior engineer drafting a pull request for review.
+            Goals: a reviewer should know in 10 seconds what this PR does and why.
+
+            Output format (STRICT):
+            - A single JSON object with exactly two string keys: "title" and "body".
+            - No code fences, no preamble, no trailing text. The response must
+              parse as JSON.
+
+            Title rules:
+            - Imperative mood, <=70 chars, no trailing period.
+            - Describes the outcome, not the mechanism. ("Fix crash on launch",
+              not "Remove blocking DNS call".)
+
+            Body rules:
+            - 1-3 short bullets OR 1-2 short sentences. Markdown allowed.
+            - Focus on WHY and user-visible impact. Skip file lists.
+            - If the change has a non-obvious risk, migration, or follow-up,
+              name it in one final line.
+
+            Example:
             {"title": "Fix crash on launch", "body": "Avoid blocking DNS by removing hostName lookup."}
             """
         }

--- a/Muxy/Services/AIAssistant/AIAssistantProvider.swift
+++ b/Muxy/Services/AIAssistant/AIAssistantProvider.swift
@@ -29,20 +29,25 @@ enum AIAssistantProvider: String, CaseIterable, Identifiable, Codable {
     func builtInArguments(model: String?) -> [String] {
         switch self {
         case .claude:
-            var args = ["-p", "--output-format", "text"]
+            var args = [
+                "-p",
+                "--output-format", "text",
+                "--tools", "",
+                "--permission-mode", "dontAsk",
+            ]
             if let model, !model.isEmpty {
                 args.append(contentsOf: ["--model", model])
             }
             return args
         case .codex:
-            var args = ["exec", "--skip-git-repo-check"]
+            var args = ["exec", "--skip-git-repo-check", "--sandbox", "read-only"]
             if let model, !model.isEmpty {
                 args.append(contentsOf: ["--model", model])
             }
             args.append("-")
             return args
         case .opencode:
-            var args = ["run"]
+            var args = ["run", "--pure"]
             if let model, !model.isEmpty {
                 args.append(contentsOf: ["--model", model])
             }

--- a/Muxy/Services/AIAssistant/AIAssistantService.swift
+++ b/Muxy/Services/AIAssistant/AIAssistantService.swift
@@ -22,17 +22,25 @@ enum AIAssistantService {
     private static let diffLineLimit = 4000
     private static let truncationMarker = "\n[diff truncated by Muxy at \(diffLineLimit) lines]\n"
 
-    private static let excludedPathspecs: [String] = [
-        ":(exclude,glob)**/Package.resolved",
-        ":(exclude,glob)**/*.lock",
-        ":(exclude,glob)**/*.lockfile",
-        ":(exclude,glob)**/package-lock.json",
-        ":(exclude,glob)**/yarn.lock",
-        ":(exclude,glob)**/pnpm-lock.yaml",
-        ":(exclude,glob)**/Pods/**",
-        ":(exclude,glob)**/*.xcframework/**",
-        ":(exclude,glob)**/*.pbxproj",
+    private static let excludedPatterns: [String] = [
+        "**/Package.resolved",
+        "**/*.lock",
+        "**/*.lockfile",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/pnpm-lock.yaml",
+        "**/Pods/**",
+        "**/*.xcframework/**",
+        "**/*.pbxproj",
     ]
+
+    private static var excludedPathspecs: [String] {
+        excludedPatterns.map { ":(exclude,glob)\($0)" }
+    }
+
+    private static var untrackedExcludeFlags: [String] {
+        excludedPatterns.flatMap { ["-x", $0] }
+    }
 
     static func generateCommitMessage(
         repoPath: String,
@@ -156,14 +164,13 @@ enum AIAssistantService {
     private static func untrackedFilesDiff(repoPath: String) async -> String {
         let listing = try? await GitProcessRunner.runGit(
             repoPath: repoPath,
-            arguments: ["ls-files", "--others", "--exclude-standard", "-z"],
+            arguments: ["ls-files", "--others", "--exclude-standard", "-z"] + untrackedExcludeFlags,
             lineLimit: diffLineLimit
         )
         guard let listing, listing.status == 0 else { return "" }
         let paths = listing.stdout
             .split(separator: "\u{0}", omittingEmptySubsequences: true)
             .map(String.init)
-            .filter { !shouldExcludeUntrackedPath($0) }
         guard !paths.isEmpty else { return "" }
 
         var pieces: [String] = []
@@ -185,15 +192,6 @@ enum AIAssistantService {
         let output = result.truncated ? result.stdout + truncationMarker : result.stdout
         let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : output
-    }
-
-    private static func shouldExcludeUntrackedPath(_ path: String) -> Bool {
-        let lowercased = path.lowercased()
-        let suffixes = [".lock", ".lockfile", ".resolved", ".pbxproj"]
-        if suffixes.contains(where: { lowercased.hasSuffix($0) }) { return true }
-        let segments = ["/pods/", "/.xcframework/", "/node_modules/"]
-        let normalized = "/" + lowercased
-        return segments.contains(where: { normalized.contains($0) })
     }
 
     private static func diffArgs(_ baseArguments: [String]) -> [String] {

--- a/Muxy/Services/AIAssistant/AIAssistantService.swift
+++ b/Muxy/Services/AIAssistant/AIAssistantService.swift
@@ -22,6 +22,18 @@ enum AIAssistantService {
     private static let diffLineLimit = 4000
     private static let truncationMarker = "\n[diff truncated by Muxy at \(diffLineLimit) lines]\n"
 
+    private static let excludedPathspecs: [String] = [
+        ":(exclude,glob)**/Package.resolved",
+        ":(exclude,glob)**/*.lock",
+        ":(exclude,glob)**/*.lockfile",
+        ":(exclude,glob)**/package-lock.json",
+        ":(exclude,glob)**/yarn.lock",
+        ":(exclude,glob)**/pnpm-lock.yaml",
+        ":(exclude,glob)**/Pods/**",
+        ":(exclude,glob)**/*.xcframework/**",
+        ":(exclude,glob)**/*.pbxproj",
+    ]
+
     static func generateCommitMessage(
         repoPath: String,
         branch: String?
@@ -81,11 +93,21 @@ enum AIAssistantService {
     }
 
     private static func stagedDiff(repoPath: String) async throws -> String {
-        let staged = try await runDiff(repoPath: repoPath, arguments: ["diff", "--cached", "--no-color"])
+        let staged = try await runDiff(repoPath: repoPath, arguments: diffArgs(["diff", "--cached", "--no-color"]))
         if !staged.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return staged
         }
-        return try await runDiff(repoPath: repoPath, arguments: ["diff", "--no-color"])
+        let working = try await runDiff(repoPath: repoPath, arguments: diffArgs(["diff", "--no-color"]))
+        let untracked = await untrackedFilesDiff(repoPath: repoPath)
+
+        var sections: [String] = []
+        if !working.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            sections.append(working)
+        }
+        if !untracked.isEmpty {
+            sections.append("=== Untracked files ===\n\(untracked)")
+        }
+        return sections.joined(separator: "\n\n")
     }
 
     private static func branchDiff(
@@ -97,14 +119,85 @@ enum AIAssistantService {
             let range = "\(baseBranch)...\(branch)"
             let committed = try await runDiff(
                 repoPath: repoPath,
-                arguments: ["diff", "--no-color", range]
+                arguments: diffArgs(["diff", "--no-color", range])
             )
-            let working = try await runDiff(repoPath: repoPath, arguments: ["diff", "--no-color", "HEAD"])
-            return [committed, working]
-                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-                .joined(separator: "\n")
+            let working = try await runDiff(
+                repoPath: repoPath,
+                arguments: diffArgs(["diff", "--no-color", "HEAD"])
+            )
+            let untracked = await untrackedFilesDiff(repoPath: repoPath)
+
+            var sections: [String] = []
+            if !committed.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                sections.append("=== Committed changes (\(branch) vs merge-base with \(baseBranch)) ===\n\(committed)")
+            }
+            if !working.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                sections.append("=== Uncommitted working-tree changes ===\n\(working)")
+            }
+            if !untracked.isEmpty {
+                sections.append("=== Untracked files ===\n\(untracked)")
+            }
+            return sections.joined(separator: "\n\n")
         }
-        return try await runDiff(repoPath: repoPath, arguments: ["diff", "--no-color", "HEAD"])
+
+        let working = try await runDiff(repoPath: repoPath, arguments: diffArgs(["diff", "--no-color", "HEAD"]))
+        let untracked = await untrackedFilesDiff(repoPath: repoPath)
+        if untracked.isEmpty {
+            return working
+        }
+        var sections: [String] = []
+        if !working.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            sections.append(working)
+        }
+        sections.append("=== Untracked files ===\n\(untracked)")
+        return sections.joined(separator: "\n\n")
+    }
+
+    private static func untrackedFilesDiff(repoPath: String) async -> String {
+        let listing = try? await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["ls-files", "--others", "--exclude-standard", "-z"],
+            lineLimit: diffLineLimit
+        )
+        guard let listing, listing.status == 0 else { return "" }
+        let paths = listing.stdout
+            .split(separator: "\u{0}", omittingEmptySubsequences: true)
+            .map(String.init)
+            .filter { !shouldExcludeUntrackedPath($0) }
+        guard !paths.isEmpty else { return "" }
+
+        var pieces: [String] = []
+        for path in paths {
+            if let rendered = await renderUntrackedFile(repoPath: repoPath, relativePath: path) {
+                pieces.append(rendered)
+            }
+        }
+        return pieces.joined(separator: "\n")
+    }
+
+    private static func renderUntrackedFile(repoPath: String, relativePath: String) async -> String? {
+        let result = try? await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["diff", "--no-color", "--no-index", "--", "/dev/null", relativePath],
+            lineLimit: diffLineLimit
+        )
+        guard let result else { return nil }
+        let output = result.truncated ? result.stdout + truncationMarker : result.stdout
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : output
+    }
+
+    private static func shouldExcludeUntrackedPath(_ path: String) -> Bool {
+        let lowercased = path.lowercased()
+        let suffixes = [".lock", ".lockfile", ".resolved", ".pbxproj"]
+        if suffixes.contains(where: { lowercased.hasSuffix($0) }) { return true }
+        let segments = ["/pods/", "/.xcframework/", "/node_modules/"]
+        let normalized = "/" + lowercased
+        return segments.contains(where: { normalized.contains($0) })
+    }
+
+    private static func diffArgs(_ baseArguments: [String]) -> [String] {
+        baseArguments + ["--"] + excludedPathspecs
     }
 
     private static func runDiff(repoPath: String, arguments: [String]) async throws -> String {

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -20,7 +20,7 @@ struct SettingsView: View {
             AIUsageSettingsView()
                 .tabItem { Label("AI Usage", systemImage: "chart.bar") }
         }
-        .frame(width: 500, height: 500)
+        .frame(width: 720, height: 560)
         .resetsSettingsFocusOnOutsideClick()
     }
 }

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -20,7 +20,30 @@ struct SettingsView: View {
             AIUsageSettingsView()
                 .tabItem { Label("AI Usage", systemImage: "chart.bar") }
         }
-        .frame(width: 720, height: 560)
+        .frame(minWidth: 720, minHeight: 560)
+        .background(SettingsWindowConfigurator(minSize: NSSize(width: 720, height: 560)))
         .resetsSettingsFocusOnOutsideClick()
     }
+}
+
+private struct SettingsWindowConfigurator: NSViewRepresentable {
+    let minSize: NSSize
+
+    func makeNSView(context _: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { [weak view] in
+            guard let window = view?.window else { return }
+            window.styleMask.insert(.resizable)
+            window.minSize = minSize
+            if window.frame.width < minSize.width || window.frame.height < minSize.height {
+                var frame = window.frame
+                frame.size.width = max(frame.size.width, minSize.width)
+                frame.size.height = max(frame.size.height, minSize.height)
+                window.setFrame(frame, display: true)
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_: NSView, context _: Context) {}
 }


### PR DESCRIPTION
- Sharpen system/user prompts so the model focuses on the dominant change and explains the why, not the what.
- Exclude lockfiles, Pods, and pbxproj from diffs and include untracked files so PR drafts reflect real intent.
- Lock down provider invocations (Claude tools off, Codex read-only sandbox, opencode --pure) to prevent the assistant from taking actions on the repo.