### PR TITLE
Allow maximizing panes

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -82,6 +82,7 @@ final class AppState {
     var workspaceRoots: [WorktreeKey: SplitNode] = [:]
     var focusedAreaID: [WorktreeKey: UUID] = [:]
     var pendingLayoutApply: PendingLayoutApply?
+    var maximizedAreaID: [WorktreeKey: UUID] = [:]
     var pendingLastTabClose: PendingTabClose?
     var pendingUnsavedEditorTabClose: PendingTabClose?
     var pendingProcessTabClose: PendingTabClose?
@@ -213,6 +214,10 @@ final class AppState {
     }
 
     func shortcutOffsets(for projectID: UUID) -> [UUID: Int] {
+        guard let key = activeWorktreeKey(for: projectID) else { return [:] }
+        if let maximizedAreaID = maximizedAreaID[key] {
+            return [maximizedAreaID: 0]
+        }
         var offsets: [UUID: Int] = [:]
         var running = 0
         for area in allAreas(for: projectID) {
@@ -230,6 +235,22 @@ final class AppState {
             direction: direction,
             position: .second
         )))
+    }
+
+    func toggleMaximize(areaID: UUID, for projectID: UUID) {
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key]
+        else { return }
+        guard case .split = root else {
+            maximizedAreaID.removeValue(forKey: key)
+            return
+        }
+        if maximizedAreaID[key] == areaID {
+            maximizedAreaID.removeValue(forKey: key)
+        } else {
+            dispatch(.focusArea(projectID: projectID, areaID: areaID))
+            maximizedAreaID[key] = areaID
+        }
     }
 
     func closeArea(_ areaID: UUID, projectID: UUID) {
@@ -556,6 +577,15 @@ final class AppState {
     }
 
     func selectTabByIndex(_ index: Int, projectID: UUID) {
+        if let key = activeWorktreeKey(for: projectID),
+           let areaID = maximizedAreaID[key],
+           let root = workspaceRoots[key],
+           let area = root.findArea(id: areaID)
+        {
+            guard index >= 0, index < area.tabs.count else { return }
+            dispatch(.selectTab(projectID: projectID, areaID: areaID, tabID: area.tabs[index].id))
+            return
+        }
         dispatch(.selectTabByIndex(projectID: projectID, index: index))
     }
 
@@ -580,6 +610,20 @@ final class AppState {
     }
 
     func dispatch(_ action: Action) {
+        switch action {
+        case let .focusPaneLeft(projectID),
+             let .focusPaneRight(projectID),
+             let .focusPaneUp(projectID),
+             let .focusPaneDown(projectID):
+            if let key = activeWorktreeKey(for: projectID),
+               maximizedAreaID[key] != nil
+            {
+                return
+            }
+        default:
+            break
+        }
+
         if case let .focusArea(projectID, areaID) = action,
            let key = activeWorktreeKey(for: projectID),
            focusedAreaID[key] == areaID
@@ -622,6 +666,7 @@ final class AppState {
         if focusHistory != workspace.focusHistory {
             focusHistory = workspace.focusHistory
         }
+        invalidateMaximizedAreas(for: action)
         reconcilePendingClosures()
 
         for paneID in effects.paneIDsToRemove {
@@ -775,6 +820,38 @@ final class AppState {
               let area = root.findArea(id: areaID)
         else { return false }
         return area.tabs.contains(where: { $0.id == tabID })
+    }
+
+    private func invalidateMaximizedAreas(for action: Action) {
+        if case let .splitArea(req) = action,
+           let key = activeWorktreeKey(for: req.projectID),
+           maximizedAreaID[key] == req.areaID
+        {
+            maximizedAreaID.removeValue(forKey: key)
+        }
+
+        if case let .removeWorktree(projectID, worktreeID, _, _) = action {
+            maximizedAreaID.removeValue(forKey: WorktreeKey(projectID: projectID, worktreeID: worktreeID))
+        }
+
+        for key in Array(maximizedAreaID.keys) {
+            guard let areaID = maximizedAreaID[key] else { continue }
+            guard let root = workspaceRoots[key] else {
+                maximizedAreaID.removeValue(forKey: key)
+                continue
+            }
+            if case .tabArea = root {
+                maximizedAreaID.removeValue(forKey: key)
+                continue
+            }
+            if root.findArea(id: areaID) == nil {
+                maximizedAreaID.removeValue(forKey: key)
+                continue
+            }
+            if focusedAreaID[key] != areaID {
+                maximizedAreaID.removeValue(forKey: key)
+            }
+        }
     }
 
     func focusArea(_ areaID: UUID, projectID: UUID) {

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -61,6 +61,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case toggleAIUsage
     case navigateBack
     case navigateForward
+    case toggleMaximizePane
 
     static let allCases: [Self] = [
         .newTab,
@@ -115,6 +116,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .toggleAIUsage,
         .navigateBack,
         .navigateForward,
+        .toggleMaximizePane,
     ]
 
     var id: String { rawValue }
@@ -186,6 +188,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .newProject: ShortcutMetadata(displayName: "New Project", category: "App", scope: .mainWindow)
         case .openProject: ShortcutMetadata(displayName: "Open Project", category: "App", scope: .mainWindow)
         case .reloadConfig: ShortcutMetadata(displayName: "Reload Configuration", category: "App", scope: .global)
+        case .toggleMaximizePane: ShortcutMetadata(displayName: "Toggle Maximize Pane", category: "Panes", scope: .mainWindow)
         }
     }
 
@@ -305,5 +308,6 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .toggleAIUsage, combo: KeyCombo(key: "l", command: true)),
         Self(action: .navigateBack, combo: KeyCombo(key: KeyCombo.leftArrowKey, command: true, control: true)),
         Self(action: .navigateForward, combo: KeyCombo(key: KeyCombo.rightArrowKey, command: true, control: true)),
+        Self(action: .toggleMaximizePane, combo: KeyCombo(key: KeyCombo.returnKey, command: true, option: true)),
     ]
 }

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -168,6 +168,12 @@ struct ShortcutActionDispatcher {
             guard appState.navigation.canGoForward else { return false }
             appState.goForward()
             return true
+        case .toggleMaximizePane:
+            guard let projectID = appState.activeProjectID,
+                  let areaID = appState.focusedAreaID(for: projectID)
+            else { return false }
+            appState.toggleMaximize(areaID: areaID, for: projectID)
+            return true
         case .selectTab1,
              .selectTab2,
              .selectTab3,

--- a/Muxy/Views/Workspace/PaneNode.swift
+++ b/Muxy/Views/Workspace/PaneNode.swift
@@ -17,6 +17,8 @@ struct PaneNode: View {
     let onSplit: (UUID, SplitDirection) -> Void
     let onCloseArea: (UUID) -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    var showMaximizeButton = false
+    var onToggleMaximize: ((UUID) -> Void)?
 
     var body: some View {
         switch node {
@@ -36,7 +38,9 @@ struct PaneNode: View {
                 onCloseTab: { tabID in onCloseTab(area.id, tabID) },
                 onForceCloseTab: { tabID in onForceCloseTab(area.id, tabID) },
                 onSplit: { dir in onSplit(area.id, dir) },
-                onDropAction: onDropAction
+                onDropAction: onDropAction,
+                showMaximizeButton: showMaximizeButton,
+                onToggleMaximize: onToggleMaximize.map { toggle in { toggle(area.id) } }
             )
         case let .split(branch):
             SplitContainer(
@@ -54,7 +58,9 @@ struct PaneNode: View {
                 onForceCloseTab: onForceCloseTab,
                 onSplit: onSplit,
                 onCloseArea: onCloseArea,
-                onDropAction: onDropAction
+                onDropAction: onDropAction,
+                showMaximizeButton: showMaximizeButton,
+                onToggleMaximize: onToggleMaximize
             )
         }
     }

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -17,6 +17,8 @@ struct SplitContainer: View {
     let onSplit: (UUID, SplitDirection) -> Void
     let onCloseArea: (UUID) -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    var showMaximizeButton = false
+    var onToggleMaximize: ((UUID) -> Void)?
 
     var body: some View {
         GeometryReader { geo in
@@ -88,7 +90,9 @@ struct SplitContainer: View {
             onForceCloseTab: onForceCloseTab,
             onSplit: onSplit,
             onCloseArea: onCloseArea,
-            onDropAction: onDropAction
+            onDropAction: onDropAction,
+            showMaximizeButton: showMaximizeButton,
+            onToggleMaximize: onToggleMaximize
         )
     }
 }

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -16,6 +16,9 @@ struct TabAreaView: View {
     let onForceCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    var showMaximizeButton = false
+    var isMaximized = false
+    var onToggleMaximize: (() -> Void)?
     @Environment(TabDragCoordinator.self) private var dragCoordinator
     @Environment(AppState.self) private var appState
     @State private var isExternalDragHovering = false
@@ -57,6 +60,9 @@ struct TabAreaView: View {
                     },
                     onSplit: onSplit,
                     onDropAction: onDropAction,
+                    showMaximizeButton: showMaximizeButton,
+                    isMaximized: isMaximized,
+                    onToggleMaximize: onToggleMaximize,
                     onCreateTabAdjacent: { tabID, side in
                         area.createTabAdjacent(to: tabID, side: side)
                     },

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -34,6 +34,9 @@ struct PaneTabStrip: View {
     let onCloseTabsToRight: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
     let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    var showMaximizeButton = false
+    var isMaximized = false
+    var onToggleMaximize: (() -> Void)?
     let onCreateTabAdjacent: (UUID, TabArea.InsertSide) -> Void
     let onTogglePin: (UUID) -> Void
     let onSetCustomTitle: (UUID, String?) -> Void
@@ -86,6 +89,14 @@ struct PaneTabStrip: View {
                         cursorProvider: openInIDECursorProvider
                     )
                     LayoutPickerMenu(projectID: projectID)
+                }
+                if showMaximizeButton || isMaximized, let onToggleMaximize {
+                    let symbol = isMaximized
+                        ? "arrow.down.right.and.arrow.up.left"
+                        : "arrow.up.left.and.arrow.down.right"
+                    let label = isMaximized ? "Restore Pane" : "Maximize Pane"
+                    IconButton(symbol: symbol, accessibilityLabel: label, action: onToggleMaximize)
+                        .help(shortcutTooltip("Toggle Maximize Pane", for: .toggleMaximizePane))
                 }
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
                     .help(shortcutTooltip("Split Right", for: .splitRight))

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -22,8 +22,66 @@ struct TerminalArea: View {
         return false
     }
 
+    private var maximizedArea: TabArea? {
+        guard let areaID = appState.maximizedAreaID[worktreeKey] else { return nil }
+        return root?.findArea(id: areaID)
+    }
+
     var body: some View {
         if let root {
+            workspaceContent(root: root)
+                .environment(\.activeWorktreeKey, worktreeKey)
+                .onPreferenceChange(AreaFramePreferenceKey.self) { frames in
+                    guard isActiveProject, dragCoordinator.activeDrag != nil else { return }
+                    dragCoordinator.setAreaFrames(frames, forProject: project.id)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func workspaceContent(root: SplitNode) -> some View {
+        switch maximizedArea {
+        case let area?:
+            MaximizedAreaView(
+                area: area,
+                isActiveProject: isActiveProject,
+                projectID: project.id,
+                onToggleMaximize: {
+                    appState.toggleMaximize(areaID: area.id, for: project.id)
+                },
+                onSelectTab: { tabID in
+                    appState.dispatch(.selectTab(projectID: project.id, areaID: area.id, tabID: tabID))
+                },
+                onCreateTab: {
+                    appState.dispatch(.createTab(projectID: project.id, areaID: area.id))
+                },
+                onCreateVCSTab: {
+                    VCSDisplayMode.current.route(
+                        tab: { appState.dispatch(.createVCSTab(projectID: project.id, areaID: area.id)) },
+                        window: { openWindow(id: "vcs") },
+                        attached: { NotificationCenter.default.post(name: .toggleAttachedVCS, object: nil) }
+                    )
+                },
+                onCloseTab: { tabID in
+                    appState.closeTab(tabID, areaID: area.id, projectID: project.id)
+                },
+                onForceCloseTab: { tabID in
+                    appState.forceCloseTab(tabID, areaID: area.id, projectID: project.id)
+                },
+                onSplit: { dir in
+                    appState.dispatch(.splitArea(.init(
+                        projectID: project.id,
+                        areaID: area.id,
+                        direction: dir,
+                        position: .second
+                    )))
+                },
+                onDropAction: { result in
+                    appState.dispatch(result.action(projectID: project.id))
+                }
+            )
+            .padding(16)
+        case nil:
             PaneNode(
                 node: root,
                 focusedAreaID: focusedAreaID,
@@ -67,13 +125,55 @@ struct TerminalArea: View {
                 },
                 onDropAction: { result in
                     appState.dispatch(result.action(projectID: project.id))
+                },
+                showMaximizeButton: !rootIsTabArea,
+                onToggleMaximize: { areaID in
+                    appState.toggleMaximize(areaID: areaID, for: project.id)
                 }
             )
-            .environment(\.activeWorktreeKey, worktreeKey)
-            .onPreferenceChange(AreaFramePreferenceKey.self) { frames in
-                guard isActiveProject, dragCoordinator.activeDrag != nil else { return }
-                dragCoordinator.setAreaFrames(frames, forProject: project.id)
-            }
         }
+    }
+}
+
+private struct MaximizedAreaView: View {
+    let area: TabArea
+    let isActiveProject: Bool
+    let projectID: UUID
+    let onToggleMaximize: () -> Void
+    let onSelectTab: (UUID) -> Void
+    let onCreateTab: () -> Void
+    let onCreateVCSTab: () -> Void
+    let onCloseTab: (UUID) -> Void
+    let onForceCloseTab: (UUID) -> Void
+    let onSplit: (SplitDirection) -> Void
+    let onDropAction: (TabDragCoordinator.DropResult) -> Void
+
+    var body: some View {
+        TabAreaView(
+            area: area,
+            isFocused: true,
+            isActiveProject: isActiveProject,
+            showTabStrip: true,
+            showVCSButton: false,
+            projectID: projectID,
+            shortcutIndexOffset: 0,
+            onFocus: {},
+            onSelectTab: onSelectTab,
+            onCreateTab: onCreateTab,
+            onCreateVCSTab: onCreateVCSTab,
+            onCloseTab: onCloseTab,
+            onForceCloseTab: onForceCloseTab,
+            onSplit: onSplit,
+            onDropAction: onDropAction,
+            showMaximizeButton: true,
+            isMaximized: true,
+            onToggleMaximize: onToggleMaximize
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(MuxyTheme.border, lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.35), radius: 24, x: 0, y: 8)
     }
 }

--- a/Tests/MuxyTests/Models/AppStateMaximizeTests.swift
+++ b/Tests/MuxyTests/Models/AppStateMaximizeTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("AppState maximize panes")
+@MainActor
+struct AppStateMaximizeTests {
+    @Test("maximized pane blocks directional focus into hidden panes")
+    func maximizedPaneBlocksDirectionalFocusIntoHiddenPanes() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let (_, secondAreaID) = splitWorkspace(appState, projectID: projectID, key: key)
+
+        appState.toggleMaximize(areaID: secondAreaID, for: projectID)
+        appState.dispatch(.focusPaneLeft(projectID: projectID))
+
+        #expect(appState.focusedAreaID[key] == secondAreaID)
+        #expect(appState.shortcutOffsets(for: projectID) == [secondAreaID: 0])
+    }
+
+    @Test("cross-pane tab cycling restores full layout when focus leaves maximized pane")
+    func crossPaneTabCyclingRestoresFullLayoutWhenFocusLeavesMaximizedPane() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let (firstAreaID, secondAreaID) = splitWorkspace(appState, projectID: projectID, key: key)
+
+        appState.toggleMaximize(areaID: secondAreaID, for: projectID)
+        appState.dispatch(.cycleNextTabAcrossPanes(projectID: projectID))
+
+        #expect(appState.focusedAreaID[key] == firstAreaID)
+        #expect(appState.maximizedAreaID[key] == nil)
+    }
+
+    @Test("reverse cross-pane tab cycling restores full layout when focus leaves maximized pane")
+    func reverseCrossPaneTabCyclingRestoresFullLayoutWhenFocusLeavesMaximizedPane() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let (firstAreaID, secondAreaID) = splitWorkspace(appState, projectID: projectID, key: key)
+
+        appState.toggleMaximize(areaID: firstAreaID, for: projectID)
+        appState.dispatch(.cyclePreviousTabAcrossPanes(projectID: projectID))
+
+        #expect(appState.focusedAreaID[key] == secondAreaID)
+        #expect(appState.maximizedAreaID[key] == nil)
+    }
+
+    @Test("indexed tab selection uses maximized pane numbering")
+    func indexedTabSelectionUsesMaximizedPaneNumbering() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let (firstAreaID, secondAreaID) = splitWorkspace(appState, projectID: projectID, key: key)
+        let root = appState.workspaceRoots[key]!
+        let firstArea = root.findArea(id: firstAreaID)!
+        let secondArea = root.findArea(id: secondAreaID)!
+        firstArea.createTab()
+        firstArea.createTab()
+        secondArea.createTab()
+        secondArea.createTab()
+        let secondAreaFirstTabID = secondArea.tabs[0].id
+
+        appState.toggleMaximize(areaID: secondAreaID, for: projectID)
+        appState.selectTabByIndex(0, projectID: projectID)
+
+        #expect(appState.focusedAreaID[key] == secondAreaID)
+        #expect(appState.maximizedAreaID[key] == secondAreaID)
+        #expect(secondArea.activeTabID == secondAreaFirstTabID)
+        #expect(firstArea.activeTabID != secondAreaFirstTabID)
+    }
+
+    @Test("direct area focus restores full layout when focus leaves maximized pane")
+    func directAreaFocusRestoresFullLayoutWhenFocusLeavesMaximizedPane() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let (firstAreaID, secondAreaID) = splitWorkspace(appState, projectID: projectID, key: key)
+
+        appState.toggleMaximize(areaID: secondAreaID, for: projectID)
+        appState.dispatch(.focusArea(projectID: projectID, areaID: firstAreaID))
+
+        #expect(appState.focusedAreaID[key] == firstAreaID)
+        #expect(appState.maximizedAreaID[key] == nil)
+    }
+
+    @Test("maximize guard uses action project")
+    func maximizeGuardUsesActionProject() {
+        let firstProjectID = UUID()
+        let firstWorktreeID = UUID()
+        let secondProjectID = UUID()
+        let secondWorktreeID = UUID()
+        let appState = makeAppState(projectID: firstProjectID, worktreeID: firstWorktreeID)
+        let firstKey = WorktreeKey(projectID: firstProjectID, worktreeID: firstWorktreeID)
+        let secondKey = WorktreeKey(projectID: secondProjectID, worktreeID: secondWorktreeID)
+        let (_, firstProjectSecondAreaID) = splitWorkspace(appState, projectID: firstProjectID, key: firstKey)
+        let secondProjectFirstArea = TabArea(projectPath: "/tmp/test-2")
+
+        appState.activeWorktreeID[secondProjectID] = secondWorktreeID
+        appState.workspaceRoots[secondKey] = .tabArea(secondProjectFirstArea)
+        appState.focusedAreaID[secondKey] = secondProjectFirstArea.id
+        appState.dispatch(.splitArea(.init(
+            projectID: secondProjectID,
+            areaID: secondProjectFirstArea.id,
+            direction: .horizontal,
+            position: .second
+        )))
+        let secondProjectSecondAreaID = appState.focusedAreaID[secondKey]!
+        appState.toggleMaximize(areaID: firstProjectSecondAreaID, for: firstProjectID)
+
+        appState.dispatch(.focusPaneLeft(projectID: secondProjectID))
+
+        #expect(appState.focusedAreaID[firstKey] == firstProjectSecondAreaID)
+        #expect(appState.maximizedAreaID[firstKey] == firstProjectSecondAreaID)
+        #expect(appState.focusedAreaID[secondKey] == secondProjectFirstArea.id)
+        #expect(secondProjectSecondAreaID != secondProjectFirstArea.id)
+    }
+
+    @Test("single area workspace does not maximize")
+    func singleAreaWorkspaceDoesNotMaximize() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let areaID = appState.focusedAreaID[key]!
+
+        appState.toggleMaximize(areaID: areaID, for: projectID)
+
+        #expect(appState.maximizedAreaID[key] == nil)
+    }
+
+    @Test("splitting a maximized pane restores the full layout")
+    func splittingMaximizedPaneRestoresFullLayout() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let (_, secondAreaID) = splitWorkspace(appState, projectID: projectID, key: key)
+
+        appState.toggleMaximize(areaID: secondAreaID, for: projectID)
+        appState.dispatch(.splitArea(.init(
+            projectID: projectID,
+            areaID: secondAreaID,
+            direction: .horizontal,
+            position: .second
+        )))
+
+        #expect(appState.maximizedAreaID[key] == nil)
+    }
+
+    private func makeAppState(projectID: UUID, worktreeID: UUID) -> AppState {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: "/tmp/test")
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        return appState
+    }
+
+    private func splitWorkspace(
+        _ appState: AppState,
+        projectID: UUID,
+        key: WorktreeKey
+    ) -> (firstAreaID: UUID, secondAreaID: UUID) {
+        let firstAreaID = appState.focusedAreaID[key]!
+        appState.dispatch(.splitArea(.init(
+            projectID: projectID,
+            areaID: firstAreaID,
+            direction: .horizontal,
+            position: .second
+        )))
+        return (firstAreaID, appState.focusedAreaID[key]!)
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws { snapshots = workspaces }
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for paneID: UUID) {}
+    func needsConfirmQuit(for paneID: UUID) -> Bool { false }
+}

--- a/Tests/MuxyTests/Models/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/KeyBindingTests.swift
@@ -88,6 +88,12 @@ struct KeyBindingTests {
         #expect(combos[.cyclePreviousTabAcrossPanes] == KeyCombo(key: "tab", shift: true, control: true))
     }
 
+    @Test("KeyBinding.defaults includes maximize pane shortcut")
+    func defaultsIncludesMaximizePaneShortcut() {
+        let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
+        #expect(combos[.toggleMaximizePane] == KeyCombo(key: KeyCombo.returnKey, command: true, option: true))
+    }
+
     @Test("KeyBinding Codable round-trip")
     func codableRoundTrip() throws {
         let binding = KeyBinding(

--- a/docs/developer/architecture/state-management.md
+++ b/docs/developer/architecture/state-management.md
@@ -32,6 +32,12 @@ classDiagram
 
 A workspace tree is keyed by `WorktreeKey(projectID, worktreeID)`. `AppState.activeWorktreeID[projectID]` tracks the visible worktree per project.
 
+## Pane maximize state
+
+`AppState.maximizedAreaID` stores the temporarily maximized pane per `WorktreeKey`. It is presentation state, not persisted workspace state: the split tree stays intact while `TerminalArea` renders only the selected `TabArea`.
+
+When a pane is maximized, tab shortcut offsets are scoped to that pane so `⌘1…9` selects visible tabs only. The maximize state is cleared when the workspace is no longer split, the maximized area disappears, focus moves to another area, or the maximized pane is split.
+
 ## Persistence
 
 | File | Contents |

--- a/docs/features/tabs-and-splits.md
+++ b/docs/features/tabs-and-splits.md
@@ -49,7 +49,14 @@ Custom titles and colors are saved in the workspace snapshot and survive worktre
 | Split Down | `⌘⇧D` |
 | Close Pane | `⌘⇧W` |
 | Focus Pane | `⌘⌥←/→/↑/↓` |
+| Toggle Maximize Pane | `⌘⌥↩` |
 | Cycle Tab (All Panes) | `⌃Tab` / `⌃⇧Tab` |
+
+## Maximize pane
+
+Use the maximize button in a pane's tab strip, or press `⌘⌥↩`, to temporarily focus that pane in a split workspace. Press the same shortcut or the restore button to show the full split tree again.
+
+Maximize is available only when the worktree has multiple panes. Moving focus to another pane or splitting the maximized pane restores the full layout.
 
 ## Drag and drop
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -39,6 +39,7 @@ Projects persist in `~/Library/Application Support/Muxy/projects.json`.
 | New tab | `⌘T` |
 | Split right / down | `⌘D` / `⌘⇧D` |
 | Focus pane | `⌘⌥←/→/↑/↓` |
+| Maximize pane | `⌘⌥↩` |
 | Close pane / tab | `⌘⇧W` / `⌘W` |
 | Switch tabs | `⌘1…9`, `⌘]` / `⌘[` |
 

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -22,6 +22,7 @@ Every shortcut listed here can be remapped in **Settings → Keyboard Shortcuts*
 | Focus Pane Right | `Cmd+Opt+→` |
 | Focus Pane Up | `Cmd+Opt+↑` |
 | Focus Pane Down | `Cmd+Opt+↓` |
+| Toggle Maximize Pane | `Cmd+Opt+Return` |
 
 ## Tab navigation
 


### PR DESCRIPTION
## Summary

Adds a way to temporarily maximize a pane in split workspaces so users can focus on one pane without losing the existing layout.

## Changes

- Add maximize/restore state for split panes.
- Add a pane tab-strip control and Cmd+Opt+Return shortcut.
- Scope tab-number shortcuts while a pane is maximized.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

Icon added in tabs

<img width="815" height="70" alt="image" src="https://github.com/user-attachments/assets/01e40b2c-ca02-4fb9-89bb-f2ea6dee45ae" />

Maximized panel

<img width="3440" height="1486" alt="image" src="https://github.com/user-attachments/assets/4e182890-c50c-4f7f-b66d-79349b9a94c0" />
