### PR TITLE
Fix Korean text search in Find in Files

### DIFF
--- a/Muxy/Services/TextSearchService.swift
+++ b/Muxy/Services/TextSearchService.swift
@@ -19,16 +19,19 @@ enum TextSearchService {
         let trimmed = query.trimmingCharacters(in: .whitespaces)
         guard trimmed.count >= minQueryLength else { return [] }
         guard let executable = ripgrepExecutableURL() else { return [] }
+        guard let patternData = trimmed.data(using: .utf8) else { return [] }
 
         return await withCheckedContinuation { continuation in
             let process = Process()
             process.executableURL = executable
-            process.arguments = arguments(query: trimmed, projectPath: projectPath)
+            process.arguments = arguments(projectPath: projectPath)
 
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
+            let stdinPipe = Pipe()
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
+            process.standardInput = stdinPipe
 
             let resultsBox = MatchesBox()
             let handle = stdoutPipe.fileHandleForReading
@@ -53,8 +56,11 @@ enum TextSearchService {
 
             do {
                 try process.run()
+                stdinPipe.fileHandleForWriting.write(patternData)
+                try? stdinPipe.fileHandleForWriting.close()
             } catch {
                 handle.readabilityHandler = nil
+                try? stdinPipe.fileHandleForWriting.close()
                 continuation.resume(returning: [])
             }
         }
@@ -71,7 +77,7 @@ enum TextSearchService {
         return nil
     }
 
-    private static func arguments(query: String, projectPath: String) -> [String] {
+    private static func arguments(projectPath: String) -> [String] {
         [
             "--json",
             "--smart-case",
@@ -79,8 +85,9 @@ enum TextSearchService {
             "--max-columns", "300",
             "--max-filesize", "2M",
             "--no-config",
+            "-f",
+            "-",
             "--",
-            query,
             projectPath,
         ]
     }

--- a/Tests/MuxyTests/Services/TextSearchServiceTests.swift
+++ b/Tests/MuxyTests/Services/TextSearchServiceTests.swift
@@ -39,4 +39,51 @@ struct TextSearchServiceTests {
         let column = TextSearchService.columnFromUTF8Offset(4, in: "héllo world")
         #expect(column == 4)
     }
+
+    @Test("parses Korean ripgrep match offsets")
+    func parsesKoreanMatchOffsets() throws {
+        let line = #"{"type":"match","data":{"path":{"text":"/proj/greeting.md"},"lines":{"text":"안녕하세요\n"},"line_number":1,"absolute_offset":0,"submatches":[{"match":{"text":"안녕"},"start":0,"end":6}]}}"#
+        let match = try #require(TextSearchService.parseLine(line, projectPath: "/proj"))
+
+        #expect(match.relativePath == "greeting.md")
+        #expect(match.lineNumber == 1)
+        #expect(match.lineText == "안녕하세요")
+        #expect(match.matchStart == 0)
+        #expect(match.matchEnd == 6)
+        #expect(match.column == 1)
+    }
+
+    @Test("searches Korean text through ripgrep")
+    func searchesKoreanText() async throws {
+        guard TextSearchService.ripgrepExecutableURL() != nil else { return }
+        let directory = try makeSearchFixture()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let matches = await TextSearchService.search(query: "안녕", in: directory.path)
+
+        #expect(matches.contains { $0.lineText == "안녕하세요" })
+    }
+
+    @Test("keeps regex search semantics")
+    func keepsRegexSearchSemantics() async throws {
+        guard TextSearchService.ripgrepExecutableURL() != nil else { return }
+        let directory = try makeSearchFixture()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let matches = await TextSearchService.search(query: "foo.*bar", in: directory.path)
+
+        #expect(matches.contains { $0.lineText == "foo123bar" })
+    }
+
+    private func makeSearchFixture() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-text-search-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("test.md")
+        try """
+        안녕하세요
+        foo123bar
+        """.write(to: file, atomically: true, encoding: .utf8)
+        return directory
+    }
 }


### PR DESCRIPTION
<h2><u>Summary</u></h2>
Fixes Unicode text search in Find in Files by passing ripgrep patterns through stdin instead of process arguments, avoiding macOS argument normalization issues with Korean and other non-ASCII text.

<h2><u>Changes</u></h2>
- Pass Find in Files search patterns to ripgrep with `-f -` via stdin.
- Preserve existing regex search behavior and query length rules.
- Add coverage for Korean search, Korean match offsets, and regex matching.

<h2><u>Testing</u></h2>
- `swift test --filter TextSearchServiceTests` passes.
- Tested manually on macOS with `swift run Muxy` using Korean search in Find in Files.

<h2><u>Screenshot</u></h2>
<img width="1314" height="805" alt="image" src="https://github.com/user-attachments/assets/975e0bee-835c-4608-a53b-ac410b8f80c4" />