### PR TITLE
Reduce launch hangs and filter modal-alert hang reports

### DIFF
--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -47,11 +47,16 @@ final class EditorSettings {
     @ObservationIgnored private var isBatchLoading = false
 
     var resolvedFont: NSFont {
-        if let font = NSFont(name: fontFamily, size: fontSize) {
-            return font
+        if let cached = cachedResolvedFont, cached.fontName == fontFamily, cached.pointSize == fontSize {
+            return cached
         }
-        return NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        let font = NSFont(name: fontFamily, size: fontSize)
+            ?? NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        cachedResolvedFont = font
+        return font
     }
+
+    @ObservationIgnored private var cachedResolvedFont: NSFont?
 
     var resolvedMarkdownPreviewFontFamilyCSS: String {
         if markdownPreviewFontFamily == Self.systemFontFamilyToken {
@@ -75,12 +80,16 @@ final class EditorSettings {
         "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Arial, sans-serif"
 
     static var availableMarkdownPreviewFonts: [String] {
+        if let cached = cachedMarkdownPreviewFonts { return cached }
         let families = NSFontManager.shared.availableFontFamilies.sorted()
-        return [systemFontFamilyToken] + families
+        let result = [systemFontFamilyToken] + families
+        cachedMarkdownPreviewFonts = result
+        return result
     }
 
     static var availableMonospacedFonts: [String] {
-        NSFontManager.shared
+        if let cached = cachedMonospacedFonts { return cached }
+        let result = NSFontManager.shared
             .availableFontFamilies
             .filter { family in
                 guard let font = NSFont(name: family, size: 13) else { return false }
@@ -90,7 +99,12 @@ final class EditorSettings {
                     || family.localizedCaseInsensitiveContains("consolas")
             }
             .sorted()
+        cachedMonospacedFonts = result
+        return result
     }
+
+    private static var cachedMarkdownPreviewFonts: [String]?
+    private static var cachedMonospacedFonts: [String]?
 
     private init() {
         store = CodableFileStore(

--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -186,6 +186,44 @@ final class FileTreeState {
         return result
     }
 
+    enum FlatRowItem: Identifiable {
+        case entry(FileTreeEntry, depth: Int)
+        case pendingNew(PendingNewEntry, depth: Int)
+
+        var id: String {
+            switch self {
+            case let .entry(entry, _):
+                "e:\(entry.absolutePath)"
+            case let .pendingNew(pending, _):
+                "p:\(pending.token.uuidString)"
+            }
+        }
+    }
+
+    func flatVisibleRows() -> [FlatRowItem] {
+        var result: [FlatRowItem] = []
+        for entry in visibleRootEntries() {
+            appendFlat(entry, depth: 0, into: &result)
+        }
+        if let pending = pendingNewEntry, pending.parentPath == normalizedRootPath {
+            result.append(.pendingNew(pending, depth: 0))
+        }
+        return result
+    }
+
+    private func appendFlat(_ entry: FileTreeEntry, depth: Int, into result: inout [FlatRowItem]) {
+        result.append(.entry(entry, depth: depth))
+        guard entry.isDirectory, expanded.contains(entry.absolutePath),
+              let children = visibleChildren(of: entry)
+        else { return }
+        for child in children {
+            appendFlat(child, depth: depth + 1, into: &result)
+        }
+        if let pending = pendingNewEntry, pending.parentPath == entry.absolutePath {
+            result.append(.pendingNew(pending, depth: depth + 1))
+        }
+    }
+
     func entry(at path: String) -> FileTreeEntry? {
         let parent = parentDirectory(of: path)
         let candidates: [FileTreeEntry]

--- a/Muxy/Services/PaneOwnershipStore.swift
+++ b/Muxy/Services/PaneOwnershipStore.swift
@@ -7,12 +7,7 @@ import SystemConfiguration
 final class PaneOwnershipStore {
     static let shared = PaneOwnershipStore()
 
-    var macDeviceName: String = {
-        if let name = SCDynamicStoreCopyComputerName(nil, nil) as String?, !name.isEmpty {
-            return name
-        }
-        return "Mac"
-    }()
+    var macDeviceName: String = "Mac"
 
     private var owners: [UUID: PaneOwnerDTO] = [:]
     private var deviceNames: [UUID: String] = [:]
@@ -20,7 +15,14 @@ final class PaneOwnershipStore {
 
     var onOwnershipChanged: ((UUID, PaneOwnerDTO) -> Void)?
 
-    private init() {}
+    private init() {
+        Task.detached(priority: .utility) {
+            guard let name = SCDynamicStoreCopyComputerName(nil, nil) as String?,
+                  !name.isEmpty
+            else { return }
+            await MainActor.run { PaneOwnershipStore.shared.macDeviceName = name }
+        }
+    }
 
     func owner(for paneID: UUID) -> PaneOwnerDTO {
         owners[paneID] ?? .mac(deviceName: macDeviceName)

--- a/Muxy/Services/SentryService.swift
+++ b/Muxy/Services/SentryService.swift
@@ -117,10 +117,30 @@ final class SentryService {
             options.beforeSend = { event in
                 event.user = nil
                 event.serverName = nil
+                if isModalAlertHang(event) { return nil }
                 return event
             }
         }
     }
+
+    nonisolated static func isModalAlertHang(_ event: Event) -> Bool {
+        guard event.exceptions?.contains(where: { $0.type == "App Hanging" }) == true else {
+            return false
+        }
+        let frames = event.exceptions?.flatMap { $0.stacktrace?.frames ?? [] } ?? []
+        return frames.contains { frame in
+            guard let function = frame.function else { return false }
+            return modalAlertFrameSignatures.contains { function.contains($0) }
+        }
+    }
+
+    nonisolated private static let modalAlertFrameSignatures: [String] = [
+        "runModal",
+        "_NSTryRunModal",
+        "_doModalLoop",
+        "NSOpenPanel",
+        "NSSavePanel",
+    ]
 
     private static let defaultStopper: () -> Void = {
         SentrySDK.close()

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -38,23 +38,26 @@ struct FileTreeView: View {
                     ZStack(alignment: .top) {
                         emptySpaceTarget
                         LazyVStack(alignment: .leading, spacing: 0) {
-                            ForEach(state.visibleRootEntries(), id: \.absolutePath) { entry in
-                                FileTreeRowGroup(
-                                    entry: entry,
-                                    depth: 0,
-                                    state: state,
-                                    commands: commands,
-                                    onOpenFile: onOpenFile,
-                                    requestFocus: requestKeyboardFocus
-                                )
-                            }
-                            if let pending = state.pendingNewEntry, pending.parentPath == normalizedRootPath {
-                                FileTreeNewEntryRow(
-                                    kind: pending.kind,
-                                    depth: 0,
-                                    commands: commands
-                                )
-                                .id(pending.token)
+                            ForEach(state.flatVisibleRows()) { item in
+                                switch item {
+                                case let .entry(entry, depth):
+                                    FileTreeRow(
+                                        entry: entry,
+                                        depth: depth,
+                                        state: state,
+                                        commands: commands,
+                                        onOpenFile: onOpenFile,
+                                        requestFocus: requestKeyboardFocus
+                                    )
+                                    .id(entry.absolutePath)
+                                case let .pendingNew(pending, depth):
+                                    FileTreeNewEntryRow(
+                                        kind: pending.kind,
+                                        depth: depth,
+                                        commands: commands
+                                    )
+                                    .id(pending.token)
+                                }
                             }
                         }
                         .padding(.vertical, UIMetrics.spacing2)
@@ -257,46 +260,6 @@ struct FileTreeView: View {
 
     private func requestKeyboardFocus() {
         focusToken &+= 1
-    }
-
-    private var normalizedRootPath: String {
-        state.rootPath.hasSuffix("/") ? String(state.rootPath.dropLast()) : state.rootPath
-    }
-}
-
-private struct FileTreeRowGroup: View {
-    let entry: FileTreeEntry
-    let depth: Int
-    @Bindable var state: FileTreeState
-    let commands: FileTreeCommands
-    let onOpenFile: (String) -> Void
-    let requestFocus: () -> Void
-
-    var body: some View {
-        FileTreeRow(
-            entry: entry,
-            depth: depth,
-            state: state,
-            commands: commands,
-            onOpenFile: onOpenFile,
-            requestFocus: requestFocus
-        )
-        if entry.isDirectory, state.isExpanded(entry), let children = state.visibleChildren(of: entry) {
-            ForEach(children, id: \.absolutePath) { child in
-                FileTreeRowGroup(
-                    entry: child,
-                    depth: depth + 1,
-                    state: state,
-                    commands: commands,
-                    onOpenFile: onOpenFile,
-                    requestFocus: requestFocus
-                )
-            }
-            if let pending = state.pendingNewEntry, pending.parentPath == entry.absolutePath {
-                FileTreeNewEntryRow(kind: pending.kind, depth: depth + 1, commands: commands)
-                    .id(pending.token)
-            }
-        }
     }
 }
 

--- a/Tests/MuxyTests/Services/SentryServiceTests.swift
+++ b/Tests/MuxyTests/Services/SentryServiceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Sentry
 import Testing
 
 @testable import Muxy
@@ -97,6 +98,48 @@ struct SentryServiceTests {
         #expect(!service.needsPrompt)
     }
 
+    @Test("isModalAlertHang ignores non-hang events")
+    func isModalAlertHangIgnoresNonHang() {
+        let event = makeEvent(type: "NSException", frames: ["runModal"])
+        #expect(!SentryService.isModalAlertHang(event))
+    }
+
+    @Test("isModalAlertHang ignores hangs without a modal frame")
+    func isModalAlertHangIgnoresUnrelatedHang() {
+        let event = makeEvent(
+            type: "App Hanging",
+            frames: ["mach_msg2_trap", "SecTrustEvaluateIfNecessary"]
+        )
+        #expect(!SentryService.isModalAlertHang(event))
+    }
+
+    @Test("isModalAlertHang matches NSAlert runModal frames")
+    func isModalAlertHangMatchesAlertRunModal() {
+        let event = makeEvent(
+            type: "App Hanging",
+            frames: ["objc_msgSend", "-[NSApplication runModalForWindow:]", "-[NSAlert runModal]"]
+        )
+        #expect(SentryService.isModalAlertHang(event))
+    }
+
+    @Test("isModalAlertHang matches NSOpenPanel frames")
+    func isModalAlertHangMatchesOpenPanel() {
+        let event = makeEvent(
+            type: "App Hanging",
+            frames: ["-[NSOpenPanel runModal]"]
+        )
+        #expect(SentryService.isModalAlertHang(event))
+    }
+
+    @Test("isModalAlertHang matches modal loop frames")
+    func isModalAlertHangMatchesDoModalLoop() {
+        let event = makeEvent(
+            type: "App Hanging",
+            frames: ["-[NSApplication _doModalLoop:peek:]"]
+        )
+        #expect(SentryService.isModalAlertHang(event))
+    }
+
     @Test("environment is derived from the injected defaults' update channel")
     func startContextEnvironmentReflectsChannel() {
         var capturedEnvironments: [String] = []
@@ -110,6 +153,20 @@ struct SentryServiceTests {
         service.setConsent(.allowed)
 
         #expect(capturedEnvironments == ["beta"])
+    }
+
+    private func makeEvent(type: String, frames functionNames: [String]) -> Event {
+        let frames: [Frame] = functionNames.map { name in
+            let frame = Frame()
+            frame.function = name
+            return frame
+        }
+        let stacktrace = SentryStacktrace(frames: frames, registers: [:])
+        let exception = Exception(value: "App hanging for at least 2000 ms.", type: type)
+        exception.stacktrace = stacktrace
+        let event = Event()
+        event.exceptions = [exception]
+        return event
     }
 
     private func makeService(


### PR DESCRIPTION
- Defers `SCDynamicStoreCopyComputerName` off the main thread and caches resolved fonts / font lists to avoid main-thread stalls on launch.
- Flattens the file tree into a single `LazyVStack` so only visible rows are built.
- Drops Sentry events for hangs caused by user-driven modal alerts/panels to cut noise.