### PR TITLE
feat(jujutsu): add support for jj workspaces

### DIFF
--- a/Muxy/Models/VCSKind.swift
+++ b/Muxy/Models/VCSKind.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum VCSKind: String, Codable, Hashable, CaseIterable {
+    case git
+    case jjColocated
+    case jjNative
+
+    static func detect(at path: String) async -> VCSKind? {
+        let fm = FileManager.default
+        var current = (path as NSString).standardizingPath
+        var isDirectory = ObjCBool(false)
+
+        while true {
+            let jjPath = (current as NSString).appendingPathComponent(".jj")
+            let gitPath = (current as NSString).appendingPathComponent(".git")
+
+            let hasJJ = fm.fileExists(atPath: jjPath, isDirectory: &isDirectory) && isDirectory.boolValue
+            let hasGit = fm.fileExists(atPath: gitPath)
+
+            if hasJJ {
+                return hasGit ? .jjColocated : .jjNative
+            }
+
+            if hasGit {
+                return .git
+            }
+
+            let parent = (current as NSString).deletingLastPathComponent
+            if parent == current {
+                break
+            }
+            current = parent
+        }
+
+        return nil
+    }
+
+    var isJujutsu: Bool {
+        switch self {
+        case .jjColocated,
+             .jjNative:
+            true
+        case .git:
+            false
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .git:
+            "Git"
+        case .jjColocated:
+            "Jujutsu (colocated)"
+        case .jjNative:
+            "Jujutsu"
+        }
+    }
+}

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -1,35 +1,10 @@
 import Foundation
 
-struct GitWorktreeRecord: Hashable {
-    let path: String
-    let branch: String?
-    let head: String?
-    let isBare: Bool
-    let isDetached: Bool
-    let isPrunable: Bool
-
-    init(
-        path: String,
-        branch: String?,
-        head: String?,
-        isBare: Bool,
-        isDetached: Bool,
-        isPrunable: Bool = false
-    ) {
-        self.path = path
-        self.branch = branch
-        self.head = head
-        self.isBare = isBare
-        self.isDetached = isDetached
-        self.isPrunable = isPrunable
-    }
-}
-
 protocol GitWorktreeListing {
-    func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord]
+    func listWorktrees(repoPath: String) async throws -> [WorktreeRecord]
 }
 
-actor GitWorktreeService: GitWorktreeListing {
+actor GitWorktreeService: WorktreeService, GitWorktreeListing {
     static let shared = GitWorktreeService()
 
     enum GitWorktreeError: LocalizedError {
@@ -46,7 +21,7 @@ actor GitWorktreeService: GitWorktreeListing {
         }
     }
 
-    func isGitRepository(_ path: String) async -> Bool {
+    func isRepository(_ path: String) async -> Bool {
         guard let result = try? runGit(repoPath: path, arguments: ["rev-parse", "--is-inside-work-tree"]) else {
             return false
         }
@@ -65,7 +40,7 @@ actor GitWorktreeService: GitWorktreeListing {
         return !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
+    func listWorktrees(repoPath: String) async throws -> [WorktreeRecord] {
         let result = try runGit(repoPath: repoPath, arguments: ["worktree", "list", "--porcelain"])
         guard result.status == 0 else {
             throw GitWorktreeError.commandFailed(
@@ -103,7 +78,7 @@ actor GitWorktreeService: GitWorktreeListing {
         }
     }
 
-    func removeWorktree(repoPath: String, path: String, force: Bool = false) async throws {
+    func removeWorktree(repoPath: String, path: String, force: Bool) async throws {
         var args: [String] = ["worktree", "remove"]
         if force { args.append("--force") }
         args += ["--", path]
@@ -126,8 +101,8 @@ actor GitWorktreeService: GitWorktreeListing {
         }
     }
 
-    private func parsePorcelain(_ raw: String) -> [GitWorktreeRecord] {
-        var records: [GitWorktreeRecord] = []
+    private func parsePorcelain(_ raw: String) -> [WorktreeRecord] {
+        var records: [WorktreeRecord] = []
         var currentPath: String?
         var currentBranch: String?
         var currentHead: String?
@@ -137,7 +112,7 @@ actor GitWorktreeService: GitWorktreeListing {
 
         func flush() {
             guard let path = currentPath else { return }
-            records.append(GitWorktreeRecord(
+            records.append(WorktreeRecord(
                 path: path,
                 branch: currentBranch,
                 head: currentHead,

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -530,29 +530,46 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         guard !trimmedName.isEmpty else {
             throw RemoteVCSError.invalidInput("Worktree name is required.")
         }
+        let service = await WorktreeServiceFactory.service(for: project.path)
+        let vcsKind = await VCSKind.detect(at: project.path)
+        let isJJ = vcsKind?.isJujutsu ?? false
+
         let trimmedBranch = branch.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedBranch.isEmpty else {
+        if !isJJ, trimmedBranch.isEmpty {
             throw RemoteVCSError.invalidInput("Branch name is required.")
         }
+
         let slug = Self.worktreeSlug(from: trimmedName)
-        let worktreeDirectory = WorktreeLocationResolver.worktreeDirectory(for: project, slug: slug)
+        let worktreeDirectory: String
+        if isJJ {
+            let projectURL = URL(fileURLWithPath: project.path, isDirectory: true)
+            let parentDirectory = projectURL.deletingLastPathComponent().path
+            let projectDirName = projectURL.lastPathComponent
+            worktreeDirectory = URL(fileURLWithPath: parentDirectory, isDirectory: true)
+                .appendingPathComponent("\(projectDirName)-\(slug)", isDirectory: true)
+                .path
+        } else {
+            worktreeDirectory = WorktreeLocationResolver.worktreeDirectory(for: project, slug: slug)
+        }
 
         if FileManager.default.fileExists(atPath: worktreeDirectory) {
             throw RemoteVCSError.invalidInput("A worktree with this name already exists on disk.")
         }
 
-        let parentDirectory = URL(fileURLWithPath: worktreeDirectory)
-            .deletingLastPathComponent()
-            .path
-        try await GitProcessRunner.offMainThrowing {
-            try FileManager.default.createDirectory(
-                atPath: parentDirectory,
-                withIntermediateDirectories: true,
-                attributes: nil
-            )
+        if !isJJ {
+            let parentDirectory = URL(fileURLWithPath: worktreeDirectory)
+                .deletingLastPathComponent()
+                .path
+            try await GitProcessRunner.offMainThrowing {
+                try FileManager.default.createDirectory(
+                    atPath: parentDirectory,
+                    withIntermediateDirectories: true,
+                    attributes: nil
+                )
+            }
         }
 
-        try await GitWorktreeService.shared.addWorktree(
+        try await service.addWorktree(
             repoPath: project.path,
             path: worktreeDirectory,
             branch: trimmedBranch,
@@ -562,8 +579,8 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         let worktree = Worktree(
             name: trimmedName,
             path: worktreeDirectory,
-            branch: trimmedBranch,
-            ownsBranch: createBranch,
+            branch: trimmedBranch.isEmpty ? nil : trimmedBranch,
+            ownsBranch: isJJ ? false : createBranch,
             isPrimary: false
         )
         worktreeStore.add(worktree, to: project.id)

--- a/Muxy/Services/Worktree/JJWorktreeService.swift
+++ b/Muxy/Services/Worktree/JJWorktreeService.swift
@@ -1,0 +1,140 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "JJWorktreeService")
+
+enum JJWorktreeError: LocalizedError {
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .commandFailed(message):
+            message
+        }
+    }
+}
+
+actor JJWorktreeService: WorktreeService {
+    static let shared = JJWorktreeService()
+
+    func isRepository(_ path: String) async -> Bool {
+        let kind = await VCSKind.detect(at: path)
+        return kind?.isJujutsu ?? false
+    }
+
+    func hasUncommittedChanges(worktreePath: String) async -> Bool {
+        guard let result = try? await runJJ(
+            repoPath: worktreePath,
+            arguments: ["diff", "--summary"]
+        )
+        else {
+            return false
+        }
+        guard result.status == 0 else { return false }
+        return !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func listWorktrees(repoPath: String) async throws -> [WorktreeRecord] {
+        let kind = await VCSKind.detect(at: repoPath)
+        guard kind?.isJujutsu ?? false else {
+            return []
+        }
+
+        let result = try await runJJ(
+            repoPath: repoPath,
+            arguments: ["workspace", "list"]
+        )
+        guard result.status == 0 else {
+            throw JJWorktreeError.commandFailed(
+                result.stderr.isEmpty ? "Failed to list workspaces." : result.stderr
+            )
+        }
+
+        let lines = result.stdout
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        var records: [WorktreeRecord] = []
+        for line in lines {
+            let name = String(line.prefix { $0 != ":" }).trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty else { continue }
+
+            let rootResult = try? await runJJ(
+                repoPath: repoPath,
+                arguments: ["workspace", "root", "--name", name]
+            )
+            guard let rootResult, rootResult.status == 0 else { continue }
+
+            let path = rootResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !path.isEmpty else { continue }
+
+            let branch: String? = {
+                guard let colonIndex = line.firstIndex(of: ":") else { return nil }
+                let afterColon = line[line.index(after: colonIndex)...]
+                let trimmed = afterColon.trimmingCharacters(in: .whitespaces)
+                return trimmed.isEmpty ? nil : trimmed
+            }()
+
+            records.append(WorktreeRecord(
+                name: name,
+                path: path,
+                branch: branch,
+                head: nil,
+                isBare: false,
+                isDetached: false,
+                isPrunable: false
+            ))
+        }
+
+        return records
+    }
+
+    func addWorktree(repoPath: String, path: String, branch: String, createBranch: Bool) async throws {
+        let name = URL(fileURLWithPath: path).lastPathComponent
+        guard !name.isEmpty else {
+            throw JJWorktreeError.commandFailed("Invalid workspace name.")
+        }
+
+        var args: [String] = ["workspace", "add", "--name", name]
+        let trimmedBranch = branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedBranch.isEmpty {
+            args += ["-r", trimmedBranch]
+        }
+        args.append(path)
+
+        let result = try await runJJ(repoPath: repoPath, arguments: args)
+        guard result.status == 0 else {
+            throw JJWorktreeError.commandFailed(
+                result.stderr.isEmpty ? "Failed to add workspace." : result.stderr
+            )
+        }
+    }
+
+    func removeWorktree(repoPath: String, path: String, force: Bool) async throws {
+        let name = URL(fileURLWithPath: path).lastPathComponent
+        guard !name.isEmpty else {
+            throw JJWorktreeError.commandFailed("Invalid workspace name.")
+        }
+
+        let result = try await runJJ(
+            repoPath: repoPath,
+            arguments: ["workspace", "forget", name]
+        )
+        guard result.status == 0 else {
+            throw JJWorktreeError.commandFailed(
+                result.stderr.isEmpty ? "Failed to remove workspace." : result.stderr
+            )
+        }
+
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    private func runJJ(repoPath: String, arguments: [String]) async throws -> GitProcessResult {
+        try await GitProcessRunner.runCommand(
+            executable: "/usr/bin/env",
+            arguments: ["jj", "-R", repoPath] + arguments,
+            workingDirectory: repoPath
+        )
+    }
+}

--- a/Muxy/Services/Worktree/WorktreeRecord.swift
+++ b/Muxy/Services/Worktree/WorktreeRecord.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct WorktreeRecord: Hashable {
+    let name: String
+    let path: String
+    let branch: String?
+    let head: String?
+    let isBare: Bool
+    let isDetached: Bool
+    let isPrunable: Bool
+
+    init(
+        name: String = "",
+        path: String,
+        branch: String?,
+        head: String?,
+        isBare: Bool,
+        isDetached: Bool,
+        isPrunable: Bool = false
+    ) {
+        self.name = name
+        self.path = path
+        self.branch = branch
+        self.head = head
+        self.isBare = isBare
+        self.isDetached = isDetached
+        self.isPrunable = isPrunable
+    }
+}

--- a/Muxy/Services/Worktree/WorktreeService.swift
+++ b/Muxy/Services/Worktree/WorktreeService.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol WorktreeService: Sendable {
+    func isRepository(_ path: String) async -> Bool
+    func hasUncommittedChanges(worktreePath: String) async -> Bool
+    func listWorktrees(repoPath: String) async throws -> [WorktreeRecord]
+    func addWorktree(repoPath: String, path: String, branch: String, createBranch: Bool) async throws
+    func removeWorktree(repoPath: String, path: String, force: Bool) async throws
+}

--- a/Muxy/Services/Worktree/WorktreeServiceFactory.swift
+++ b/Muxy/Services/Worktree/WorktreeServiceFactory.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum WorktreeServiceFactory {
+    static func service(for path: String) async -> any WorktreeService {
+        let kind = await VCSKind.detect(at: path)
+        if kind?.isJujutsu ?? false {
+            return JJWorktreeService.shared
+        }
+        return GitWorktreeService.shared
+    }
+
+    static func isRepository(_ path: String) async -> Bool {
+        let kind = await VCSKind.detect(at: path)
+        return kind != nil
+    }
+}

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -9,17 +9,18 @@ final class WorktreeStore {
     private(set) var worktrees: [UUID: [Worktree]] = [:]
     private var projectIDByPath: [String: UUID] = [:]
     private let persistence: any WorktreePersisting
-    private let listGitWorktrees: @Sendable (String) async throws -> [GitWorktreeRecord]
+    private let listWorktrees: @Sendable (String) async throws -> [WorktreeRecord]
 
     init(
         persistence: any WorktreePersisting,
-        listGitWorktrees: @escaping @Sendable (String) async throws -> [GitWorktreeRecord] = {
-            try await GitWorktreeService.shared.listWorktrees(repoPath: $0)
+        listWorktrees: @escaping @Sendable (String) async throws -> [WorktreeRecord] = {
+            let service = await WorktreeServiceFactory.service(for: $0)
+            return try await service.listWorktrees(repoPath: $0)
         },
         projects: [Project] = []
     ) {
         self.persistence = persistence
-        self.listGitWorktrees = listGitWorktrees
+        self.listWorktrees = listWorktrees
         guard !projects.isEmpty else { return }
         loadAll(projects: projects)
     }
@@ -90,9 +91,9 @@ final class WorktreeStore {
         }
     }
 
-    func refreshFromGit(project: Project) async throws -> [Worktree] {
+    func refreshWorktrees(project: Project) async throws -> [Worktree] {
         ensurePrimary(for: project)
-        let records = try await listGitWorktrees(project.path).filter { !$0.isBare && !$0.isPrunable }
+        let records = try await listWorktrees(project.path).filter { !$0.isBare && !$0.isPrunable }
         var list = worktrees[project.id] ?? []
         let projectKey = Self.canonicalPath(project.path)
         let recordKeys = Set(records.map { Self.canonicalPath($0.path) })
@@ -162,17 +163,20 @@ final class WorktreeStore {
         repoPath: String
     ) async {
         guard worktree.canBeRemoved else { return }
+        let service = await WorktreeServiceFactory.service(for: repoPath)
         do {
-            try await GitWorktreeService.shared.removeWorktree(
+            try await service.removeWorktree(
                 repoPath: repoPath,
                 path: worktree.path,
                 force: true
             )
         } catch {
-            logger.error("Failed to remove git worktree at \(worktree.path): \(error)")
+            logger.error("Failed to remove worktree at \(worktree.path): \(error)")
         }
 
-        if worktree.ownsBranch,
+        let vcsKind = await VCSKind.detect(at: repoPath)
+        if vcsKind == .git,
+           worktree.ownsBranch,
            let branch = worktree.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
            !branch.isEmpty
         {
@@ -196,9 +200,10 @@ final class WorktreeStore {
         let root = MuxyFileStorage.worktreeRoot(forProjectID: project.id)
         guard FileManager.default.fileExists(atPath: root.path) else { return }
         let children = (try? FileManager.default.contentsOfDirectory(atPath: root.path)) ?? []
+        let service = await WorktreeServiceFactory.service(for: project.path)
         for child in children {
             let childPath = root.appendingPathComponent(child).path
-            try? await GitWorktreeService.shared.removeWorktree(
+            try? await service.removeWorktree(
                 repoPath: project.path,
                 path: childPath,
                 force: true
@@ -292,7 +297,7 @@ final class WorktreeStore {
         }
     }
 
-    private func defaultName(for record: GitWorktreeRecord) -> String {
+    private func defaultName(for record: WorktreeRecord) -> String {
         if let branch = record.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
            !branch.isEmpty
         {

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -26,13 +26,18 @@ struct CreateWorktreeSheet: View {
     @State private var runSetup = false
     @State private var inProgress = false
     @State private var errorMessage: String?
+    @State private var vcsKind: VCSKind?
+    @State private var revision: String = ""
 
     private let gitRepository = GitRepositoryService()
-    private let gitWorktree = GitWorktreeService.shared
+
+    private var isJujutsu: Bool {
+        vcsKind?.isJujutsu ?? false
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
-            Text("New Worktree")
+            Text(isJujutsu ? "New Workspace" : "New Worktree")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
 
             VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
@@ -41,33 +46,45 @@ struct CreateWorktreeSheet: View {
                     .textFieldStyle(.roundedBorder)
             }
 
-            SegmentedPicker(
-                selection: $createNewBranch,
-                options: [(true, "Create new branch"), (false, "Use existing branch")]
-            )
-
-            if createNewBranch {
+            if isJujutsu {
                 VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
-                    Text("Branch Name").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
-                    TextField("feature-x", text: $branchName)
+                    Text("Revision or Bookmark (optional)")
+                        .font(.system(size: UIMetrics.fontFootnote))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                    TextField("@", text: $revision)
                         .textFieldStyle(.roundedBorder)
-                        .onChange(of: branchName) { _, newValue in
-                            branchNameEdited = newValue != name
-                        }
                 }
             } else {
-                VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
-                    Text("Branch").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
-                    Picker("", selection: $selectedExistingBranch) {
-                        ForEach(availableBranches, id: \.self) { branch in
-                            Text(branch).tag(branch)
-                        }
+                SegmentedPicker(
+                    selection: $createNewBranch,
+                    options: [(true, "Create new branch"), (false, "Use existing branch")]
+                )
+
+                if createNewBranch {
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                        Text("Branch Name").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
+                        TextField("feature-x", text: $branchName)
+                            .textFieldStyle(.roundedBorder)
+                            .onChange(of: branchName) { _, newValue in
+                                branchNameEdited = newValue != name
+                            }
                     }
-                    .labelsHidden()
+                } else {
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                        Text("Branch").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
+                        Picker("", selection: $selectedExistingBranch) {
+                            ForEach(availableBranches, id: \.self) { branch in
+                                Text(branch).tag(branch)
+                            }
+                        }
+                        .labelsHidden()
+                    }
                 }
             }
 
-            locationSection
+            if !isJujutsu {
+                locationSection
+            }
 
             if setupCommands.isEmpty {
                 setupCommandsGuideSection
@@ -94,16 +111,19 @@ struct CreateWorktreeSheet: View {
         .padding(UIMetrics.spacing8)
         .frame(width: UIMetrics.scaled(460))
         .task {
-            loadLocation()
-            await loadBranches()
+            vcsKind = await VCSKind.detect(at: project.path)
+            if !isJujutsu {
+                loadLocation()
+                await loadBranches()
+            }
             loadSetupCommands()
         }
         .onChange(of: name) { _, newValue in
-            guard createNewBranch, !branchNameEdited else { return }
+            guard !isJujutsu, createNewBranch, !branchNameEdited else { return }
             branchName = newValue
         }
         .onChange(of: createNewBranch) { _, isCreatingNewBranch in
-            guard isCreatingNewBranch, !branchNameEdited else { return }
+            guard !isJujutsu, isCreatingNewBranch, !branchNameEdited else { return }
             branchName = name
         }
     }
@@ -240,6 +260,9 @@ struct CreateWorktreeSheet: View {
 
     private var canCreate: Bool {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else { return false }
+        if isJujutsu {
+            return true
+        }
         if createNewBranch {
             return !branchName.trimmingCharacters(in: .whitespaces).isEmpty
         }
@@ -267,6 +290,60 @@ struct CreateWorktreeSheet: View {
         inProgress = true
         errorMessage = nil
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let service = await WorktreeServiceFactory.service(for: project.path)
+
+        if isJujutsu {
+            await createJujutsuWorkspace(service: service, trimmedName: trimmedName)
+        } else {
+            await createGitWorktree(service: service, trimmedName: trimmedName)
+        }
+    }
+
+    @MainActor
+    private func createJujutsuWorkspace(service: any WorktreeService, trimmedName: String) async {
+        let slug = Self.slug(from: trimmedName)
+        let projectURL = URL(fileURLWithPath: project.path, isDirectory: true)
+        let parentDirectory = projectURL.deletingLastPathComponent().path
+        let projectDirName = projectURL.lastPathComponent
+        let worktreeDirectory = URL(fileURLWithPath: parentDirectory, isDirectory: true)
+            .appendingPathComponent("\(projectDirName)-\(slug)", isDirectory: true)
+            .path
+
+        if FileManager.default.fileExists(atPath: worktreeDirectory) {
+            inProgress = false
+            errorMessage = "A workspace with this name already exists on disk."
+            return
+        }
+
+        let trimmedRevision = revision.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        do {
+            try await service.addWorktree(
+                repoPath: project.path,
+                path: worktreeDirectory,
+                branch: trimmedRevision,
+                createBranch: false
+            )
+        } catch {
+            inProgress = false
+            errorMessage = error.localizedDescription
+            return
+        }
+
+        let worktree = Worktree(
+            name: trimmedName,
+            path: worktreeDirectory,
+            branch: trimmedRevision.isEmpty ? nil : trimmedRevision,
+            ownsBranch: false,
+            isPrimary: false
+        )
+        worktreeStore.add(worktree, to: project.id)
+        inProgress = false
+        onFinish(.created(worktree, runSetup: runSetup))
+    }
+
+    @MainActor
+    private func createGitWorktree(service: any WorktreeService, trimmedName: String) async {
         let branch = createNewBranch
             ? branchName.trimmingCharacters(in: .whitespaces)
             : selectedExistingBranch
@@ -298,7 +375,7 @@ struct CreateWorktreeSheet: View {
         }
 
         do {
-            try await gitWorktree.addWorktree(
+            try await service.addWorktree(
                 repoPath: project.path,
                 path: worktreeDirectory,
                 branch: branch,

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -21,7 +21,7 @@ struct ExpandedProjectRow: View {
     @State private var hovered = false
     @State private var isRenaming = false
     @State private var renameText = ""
-    @State private var isGitRepo = false
+    @State private var isVCSRepo = false
     @State private var showCreateWorktreeSheet = false
     @State private var logoCropImage: IdentifiableExpandedImage?
     @State private var worktreesExpanded = false
@@ -51,18 +51,18 @@ struct ExpandedProjectRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             projectHeader
-            if worktreesExpanded, isGitRepo {
+            if worktreesExpanded, isVCSRepo {
                 worktreeList
             }
         }
         .task(id: project.path) {
-            isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path)
-            if autoExpandWorktrees, isActive, isGitRepo {
+            isVCSRepo = await WorktreeServiceFactory.isRepository(project.path)
+            if autoExpandWorktrees, isActive, isVCSRepo {
                 worktreesExpanded = true
             }
         }
         .onChange(of: isActive) { _, active in
-            guard autoExpandWorktrees, active, isGitRepo else { return }
+            guard autoExpandWorktrees, active, isVCSRepo else { return }
             withAnimation(.easeInOut(duration: 0.15)) {
                 worktreesExpanded = true
             }
@@ -78,7 +78,7 @@ struct ExpandedProjectRow: View {
             }
             Divider()
             Button("Rename Project") { startRename() }
-            if isGitRepo {
+            if isVCSRepo {
                 Divider()
                 Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
                 Button("New Worktree…") { showCreateWorktreeSheet = true }
@@ -132,7 +132,7 @@ struct ExpandedProjectRow: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
 
-                if isGitRepo, let worktree = activeWorktree {
+                if isVCSRepo, let worktree = activeWorktree {
                     Text(worktree.isPrimary ? "primary" : worktree.name)
                         .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fg)
@@ -143,7 +143,7 @@ struct ExpandedProjectRow: View {
 
             Spacer(minLength: UIMetrics.spacing2)
 
-            if isGitRepo {
+            if isVCSRepo {
                 worktreeChevron
             }
         }
@@ -163,7 +163,7 @@ struct ExpandedProjectRow: View {
         }
         .onTapGesture {
             guard !isAnyDragging else { return }
-            if isActive, isGitRepo {
+            if isActive, isVCSRepo {
                 withAnimation(.easeInOut(duration: 0.15)) {
                     worktreesExpanded.toggle()
                 }
@@ -266,7 +266,7 @@ struct ExpandedProjectRow: View {
 
     private var projectHeaderAccessibilityLabel: String {
         var label = project.name
-        if isGitRepo, let worktree = activeWorktree {
+        if isVCSRepo, let worktree = activeWorktree {
             label += ", worktree: \(worktree.isPrimary ? "primary" : worktree.name)"
         }
         return label
@@ -344,7 +344,8 @@ struct ExpandedProjectRow: View {
     }
 
     private func requestRemove(worktree: Worktree) async {
-        let hasChanges = await GitWorktreeService.shared.hasUncommittedChanges(worktreePath: worktree.path)
+        let service = await WorktreeServiceFactory.service(for: project.path)
+        let hasChanges = await service.hasUncommittedChanges(worktreePath: worktree.path)
         if !hasChanges {
             performRemove(worktree: worktree)
             return

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -19,7 +19,7 @@ struct ProjectRow: View {
     @State private var isRenaming = false
     @State private var renameText = ""
     @State private var showWorktreePopover = false
-    @State private var isGitRepo = false
+    @State private var isVCSRepo = false
     @State private var showCreateWorktreeSheet = false
     @State private var logoCropImage: IdentifiableImage?
     @State private var isRefreshingWorktrees = false
@@ -58,7 +58,7 @@ struct ProjectRow: View {
                 onSelect()
             }
             .task(id: project.path) {
-                isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path)
+                isVCSRepo = await WorktreeServiceFactory.isRepository(project.path)
             }
             .contextMenu {
                 Button("Set Logo...") { pickLogoImage() }
@@ -71,7 +71,7 @@ struct ProjectRow: View {
                 }
                 Divider()
                 Button("Rename Project") { startRename() }
-                if isGitRepo {
+                if isVCSRepo {
                     Divider()
                     Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
                     Button("New Worktree…") { showCreateWorktreeSheet = true }
@@ -85,7 +85,7 @@ struct ProjectRow: View {
             .popover(isPresented: $showWorktreePopover, arrowEdge: .trailing) {
                 WorktreePopover(
                     project: project,
-                    isGitRepo: isGitRepo,
+                    isVCSRepo: isVCSRepo,
                     onDismiss: { showWorktreePopover = false },
                     onRequestCreate: {
                         showWorktreePopover = false

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct WorktreePopover: View {
     let project: Project
-    let isGitRepo: Bool
+    let isVCSRepo: Bool
     let onDismiss: () -> Void
     let onRequestCreate: () -> Void
     var fixedSize: Bool = true
@@ -62,7 +62,7 @@ struct WorktreePopover: View {
     }
 
     private var footerActions: [PopoverFooterAction] {
-        guard isGitRepo else { return [] }
+        guard isVCSRepo else { return [] }
         return [
             PopoverFooterAction(
                 title: "Refresh Worktrees",
@@ -88,7 +88,8 @@ struct WorktreePopover: View {
     }
 
     private func requestRemove(worktree: Worktree) async {
-        let hasChanges = await GitWorktreeService.shared.hasUncommittedChanges(worktreePath: worktree.path)
+        let service = await WorktreeServiceFactory.service(for: project.path)
+        let hasChanges = await service.hasUncommittedChanges(worktreePath: worktree.path)
         if !hasChanges {
             performRemove(worktree: worktree)
             return

--- a/Muxy/Views/Sidebar/WorktreeRefreshHelper.swift
+++ b/Muxy/Views/Sidebar/WorktreeRefreshHelper.swift
@@ -19,7 +19,7 @@ enum WorktreeRefreshHelper {
         defer { isRefreshing?.wrappedValue = false }
 
         do {
-            let refreshed = try await worktreeStore.refreshFromGit(project: project)
+            let refreshed = try await worktreeStore.refreshWorktrees(project: project)
             let refreshedIDs = Set(refreshed.map(\.id))
             let replacement = appState.activeWorktreeID[project.id].flatMap { activeID in
                 refreshed.first { $0.id == activeID }

--- a/Muxy/Views/VCS/WorktreeBranchPicker.swift
+++ b/Muxy/Views/VCS/WorktreeBranchPicker.swift
@@ -129,7 +129,7 @@ struct WorktreeBranchPicker: View {
                 case .worktrees:
                     WorktreePopover(
                         project: project,
-                        isGitRepo: isGitRepo,
+                        isVCSRepo: isGitRepo,
                         onDismiss: { showPopover = false },
                         onRequestCreate: {
                             showPopover = false

--- a/Tests/MuxyTests/Models/VCSKindTests.swift
+++ b/Tests/MuxyTests/Models/VCSKindTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("VCSKind")
+struct VCSKindTests {
+    @Test("detect returns git for a directory containing only .git")
+    func detectGitOnly() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeDirectory(at: tempDir.appendingPathComponent(".git"))
+
+        let kind = await VCSKind.detect(at: tempDir.path)
+
+        #expect(kind == .git)
+    }
+
+    @Test("detect returns jjNative for a directory containing only .jj")
+    func detectJJNative() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeDirectory(at: tempDir.appendingPathComponent(".jj"))
+
+        let kind = await VCSKind.detect(at: tempDir.path)
+
+        #expect(kind == .jjNative)
+    }
+
+    @Test("detect returns jjColocated for a directory containing both .jj and .git")
+    func detectJJColocated() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeDirectory(at: tempDir.appendingPathComponent(".jj"))
+        try makeDirectory(at: tempDir.appendingPathComponent(".git"))
+
+        let kind = await VCSKind.detect(at: tempDir.path)
+
+        #expect(kind == .jjColocated)
+    }
+
+    @Test("detect returns nil for a directory with no VCS markers")
+    func detectNilForNonRepo() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let kind = await VCSKind.detect(at: tempDir.path)
+
+        #expect(kind == nil)
+    }
+
+    @Test("detect finds VCS from a nested subdirectory")
+    func detectFromNestedSubdirectory() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeDirectory(at: tempDir.appendingPathComponent(".git"))
+        let nested = tempDir.appendingPathComponent("src/nested", isDirectory: true)
+        try makeDirectory(at: nested)
+
+        let kind = await VCSKind.detect(at: nested.path)
+
+        #expect(kind == .git)
+    }
+
+    @Test("detect prefers jj over git when both are present at the same level")
+    func detectPrefersJJWhenBothPresent() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try makeDirectory(at: tempDir.appendingPathComponent(".jj"))
+        try makeDirectory(at: tempDir.appendingPathComponent(".git"))
+
+        let kind = await VCSKind.detect(at: tempDir.path)
+
+        #expect(kind == .jjColocated)
+    }
+
+    @Test("isJujutsu returns true for jjColocated and jjNative")
+    func isJujutsuForJJVariants() {
+        #expect(VCSKind.jjColocated.isJujutsu)
+        #expect(VCSKind.jjNative.isJujutsu)
+    }
+
+    @Test("isJujutsu returns false for git")
+    func isJujutsuForGit() {
+        #expect(!VCSKind.git.isJujutsu)
+    }
+
+    @Test("displayName returns correct values")
+    func displayNames() {
+        #expect(VCSKind.git.displayName == "Git")
+        #expect(VCSKind.jjColocated.displayName == "Jujutsu (colocated)")
+        #expect(VCSKind.jjNative.displayName == "Jujutsu")
+    }
+
+    @Test("allCases contains expected values")
+    func allCases() {
+        let cases = Set(VCSKind.allCases)
+        #expect(cases == [.git, .jjColocated, .jjNative])
+    }
+
+    @Test("rawValue round-trips correctly")
+    func rawValueRoundTrip() {
+        #expect(VCSKind.git.rawValue == "git")
+        #expect(VCSKind.jjColocated.rawValue == "jjColocated")
+        #expect(VCSKind.jjNative.rawValue == "jjNative")
+        #expect(VCSKind(rawValue: "git") == .git)
+        #expect(VCSKind(rawValue: "jjColocated") == .jjColocated)
+        #expect(VCSKind(rawValue: "jjNative") == .jjNative)
+        #expect(VCSKind(rawValue: "unknown") == nil)
+    }
+
+    private func makeTempDir() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("muxy-vcskind-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeDirectory(at url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+}

--- a/Tests/MuxyTests/Services/VCSWorktreeAutoRefresherTests.swift
+++ b/Tests/MuxyTests/Services/VCSWorktreeAutoRefresherTests.swift
@@ -7,19 +7,19 @@ import Testing
 @Suite("VCSWorktreeAutoRefresher")
 @MainActor
 struct VCSWorktreeAutoRefresherTests {
-    @Test(".vcsDidRefresh triggers refreshFromGit for the matching project")
+    @Test(".vcsDidRefresh triggers refreshWorktrees for the matching project")
     func vcsDidRefreshTriggersRefresh() async {
         let context = makeContext()
         await runRefresh(context: context, notification: .vcsDidRefresh)
-        await #expect(context.gitService.callCount(forRepoPath: context.project.path) == 1)
+        await #expect(context.listingService.callCount(forRepoPath: context.project.path) == 1)
         #expect(context.worktreeStore.list(for: context.project.id).contains { $0.path == context.featurePath })
     }
 
-    @Test(".vcsRepoDidChange triggers refreshFromGit for the matching project")
+    @Test(".vcsRepoDidChange triggers refreshWorktrees for the matching project")
     func vcsRepoDidChangeTriggersRefresh() async {
         let context = makeContext()
         await runRefresh(context: context, notification: .vcsRepoDidChange)
-        await #expect(context.gitService.callCount(forRepoPath: context.project.path) == 1)
+        await #expect(context.listingService.callCount(forRepoPath: context.project.path) == 1)
         #expect(context.worktreeStore.list(for: context.project.id).contains { $0.path == context.featurePath })
     }
 
@@ -32,7 +32,7 @@ struct VCSWorktreeAutoRefresherTests {
             userInfo: ["repoPath": "/tmp/muxy-test-unknown-\(UUID().uuidString)"]
         )
         await drainMainQueue()
-        await #expect(context.gitService.callCount(forRepoPath: context.project.path) == 0)
+        await #expect(context.listingService.callCount(forRepoPath: context.project.path) == 0)
         #expect(context.worktreeStore.list(for: context.project.id).count == 1)
     }
 
@@ -42,7 +42,7 @@ struct VCSWorktreeAutoRefresherTests {
             object: nil,
             userInfo: ["repoPath": context.project.path]
         )
-        await context.gitService.awaitCall(forRepoPath: context.project.path)
+        await context.listingService.awaitCall(forRepoPath: context.project.path)
         await drainMainQueue()
     }
 
@@ -62,16 +62,16 @@ struct VCSWorktreeAutoRefresherTests {
         let featurePath = "/tmp/muxy-test-repo-\(suffix)-feature-x"
         let project = Project(name: "Repo", path: projectPath)
         let projectStore = ProjectStore(persistence: ProjectPersistenceStub(initial: [project]))
-        let gitService = TrackingGitWorktreeListingStub(recordsByRepoPath: [
+        let listingService = TrackingWorktreeListingStub(recordsByRepoPath: [
             projectPath: [
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: projectPath,
                     branch: "main",
                     head: nil,
                     isBare: false,
                     isDetached: false
                 ),
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: featurePath,
                     branch: "feature-x",
                     head: nil,
@@ -84,7 +84,7 @@ struct VCSWorktreeAutoRefresherTests {
             persistence: WorktreePersistenceStub(initial: [
                 project.id: [Worktree(name: project.name, path: project.path, isPrimary: true)]
             ]),
-            listGitWorktrees: gitService.listWorktrees,
+            listWorktrees: listingService.listWorktrees,
             projects: [project]
         )
         let appState = AppState(
@@ -103,7 +103,7 @@ struct VCSWorktreeAutoRefresherTests {
             projectStore: projectStore,
             worktreeStore: worktreeStore,
             appState: appState,
-            gitService: gitService,
+            listingService: listingService,
             refresher: refresher
         )
     }
@@ -115,7 +115,7 @@ struct VCSWorktreeAutoRefresherTests {
         let projectStore: ProjectStore
         let worktreeStore: WorktreeStore
         let appState: AppState
-        let gitService: TrackingGitWorktreeListingStub
+        let listingService: TrackingWorktreeListingStub
         let refresher: VCSWorktreeAutoRefresher
 
         init(
@@ -124,7 +124,7 @@ struct VCSWorktreeAutoRefresherTests {
             projectStore: ProjectStore,
             worktreeStore: WorktreeStore,
             appState: AppState,
-            gitService: TrackingGitWorktreeListingStub,
+            listingService: TrackingWorktreeListingStub,
             refresher: VCSWorktreeAutoRefresher
         ) {
             self.project = project
@@ -132,22 +132,22 @@ struct VCSWorktreeAutoRefresherTests {
             self.projectStore = projectStore
             self.worktreeStore = worktreeStore
             self.appState = appState
-            self.gitService = gitService
+            self.listingService = listingService
             self.refresher = refresher
         }
     }
 }
 
-private actor GitWorktreeCallTracker {
-    private let recordsByRepoPath: [String: [GitWorktreeRecord]]
+private actor WorktreeCallTracker {
+    private let recordsByRepoPath: [String: [WorktreeRecord]]
     private var calls: [String: Int] = [:]
     private var pendingContinuations: [String: [CheckedContinuation<Void, Never>]] = [:]
 
-    init(recordsByRepoPath: [String: [GitWorktreeRecord]]) {
+    init(recordsByRepoPath: [String: [WorktreeRecord]]) {
         self.recordsByRepoPath = recordsByRepoPath
     }
 
-    func record(repoPath: String) -> [GitWorktreeRecord] {
+    func record(repoPath: String) -> [WorktreeRecord] {
         calls[repoPath, default: 0] += 1
         let waiters = pendingContinuations.removeValue(forKey: repoPath) ?? []
         for continuation in waiters {
@@ -168,15 +168,15 @@ private actor GitWorktreeCallTracker {
     }
 }
 
-private final class TrackingGitWorktreeListingStub: Sendable {
-    let tracker: GitWorktreeCallTracker
+private final class TrackingWorktreeListingStub: Sendable {
+    let tracker: WorktreeCallTracker
 
-    init(recordsByRepoPath: [String: [GitWorktreeRecord]]) {
-        self.tracker = GitWorktreeCallTracker(recordsByRepoPath: recordsByRepoPath)
+    init(recordsByRepoPath: [String: [WorktreeRecord]]) {
+        self.tracker = WorktreeCallTracker(recordsByRepoPath: recordsByRepoPath)
     }
 
     @Sendable
-    func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
+    func listWorktrees(repoPath: String) async throws -> [WorktreeRecord] {
         await tracker.record(repoPath: repoPath)
     }
 

--- a/Tests/MuxyTests/Services/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeStoreTests.swift
@@ -47,8 +47,8 @@ struct WorktreeStoreTests {
         #expect(worktree.canBeRemoved)
     }
 
-    @Test("refreshFromGit imports missing external worktrees and preserves existing IDs by path")
-    func refreshFromGitImportsAndPreservesIDs() async throws {
+    @Test("refreshWorktrees imports missing external worktrees and preserves existing IDs by path")
+    func refreshWorktreesImportsAndPreservesIDs() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")
         let existingID = UUID()
         let createdAt = Date(timeIntervalSince1970: 123)
@@ -73,23 +73,23 @@ struct WorktreeStoreTests {
                 ]
             ]
         )
-        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+        let listingStub = WorktreeListingStub(recordsByRepoPath: [
             project.path: [
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: project.path,
                     branch: "main",
                     head: nil,
                     isBare: false,
                     isDetached: false
                 ),
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: "/tmp/repo-feature-a",
                     branch: "feature-a",
                     head: nil,
                     isBare: false,
                     isDetached: false
                 ),
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: "/tmp/repo-feature-b",
                     branch: "feature-b",
                     head: nil,
@@ -100,11 +100,11 @@ struct WorktreeStoreTests {
         ])
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: gitService.listWorktrees,
+            listWorktrees: listingStub.listWorktrees,
             projects: [project]
         )
 
-        let worktrees = try await store.refreshFromGit(project: project)
+        let worktrees = try await store.refreshWorktrees(project: project)
 
         #expect(worktrees.count == 3)
         #expect(worktrees[0].isPrimary)
@@ -122,8 +122,8 @@ struct WorktreeStoreTests {
         #expect(imported.isExternallyManaged)
     }
 
-    @Test("refreshFromGit keeps missing Muxy-managed worktrees")
-    func refreshFromGitKeepsMissingMuxyManagedEntries() async throws {
+    @Test("refreshWorktrees keeps missing Muxy-managed worktrees")
+    func refreshWorktreesKeepsMissingMuxyManagedEntries() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")
         let persistence = WorktreePersistenceStub(
             initial: [
@@ -139,9 +139,9 @@ struct WorktreeStoreTests {
                 ]
             ]
         )
-        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+        let listingStub = WorktreeListingStub(recordsByRepoPath: [
             project.path: [
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: project.path,
                     branch: "main",
                     head: nil,
@@ -152,18 +152,18 @@ struct WorktreeStoreTests {
         ])
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: gitService.listWorktrees,
+            listWorktrees: listingStub.listWorktrees,
             projects: [project]
         )
 
-        let worktrees = try await store.refreshFromGit(project: project)
+        let worktrees = try await store.refreshWorktrees(project: project)
 
         #expect(worktrees.count == 2)
         #expect(worktrees.contains(where: { $0.path == "/tmp/repo-retained" }))
     }
 
-    @Test("refreshFromGit removes missing external worktrees")
-    func refreshFromGitRemovesMissingExternalEntries() async throws {
+    @Test("refreshWorktrees removes missing external worktrees")
+    func refreshWorktreesRemovesMissingExternalEntries() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")
         let persistence = WorktreePersistenceStub(
             initial: [
@@ -179,9 +179,9 @@ struct WorktreeStoreTests {
                 ]
             ]
         )
-        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+        let listingStub = WorktreeListingStub(recordsByRepoPath: [
             project.path: [
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: project.path,
                     branch: "main",
                     head: nil,
@@ -192,19 +192,19 @@ struct WorktreeStoreTests {
         ])
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: gitService.listWorktrees,
+            listWorktrees: listingStub.listWorktrees,
             projects: [project]
         )
 
-        let worktrees = try await store.refreshFromGit(project: project)
+        let worktrees = try await store.refreshWorktrees(project: project)
 
         #expect(worktrees.count == 1)
         #expect(worktrees.allSatisfy { !$0.isExternallyManaged })
         #expect(!worktrees.contains(where: { $0.path == "/tmp/repo-external" }))
     }
 
-    @Test("refreshFromGit ignores bare and prunable records")
-    func refreshFromGitIgnoresUnusableRecords() async throws {
+    @Test("refreshWorktrees ignores bare and prunable records")
+    func refreshWorktreesIgnoresUnusableRecords() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")
         let persistence = WorktreePersistenceStub(
             initial: [
@@ -213,23 +213,23 @@ struct WorktreeStoreTests {
                 ]
             ]
         )
-        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+        let listingStub = WorktreeListingStub(recordsByRepoPath: [
             project.path: [
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: project.path,
                     branch: "main",
                     head: nil,
                     isBare: false,
                     isDetached: false
                 ),
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: "/tmp/repo-bare",
                     branch: nil,
                     head: nil,
                     isBare: true,
                     isDetached: false
                 ),
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: "/tmp/repo-prunable",
                     branch: "feature-prunable",
                     head: nil,
@@ -237,7 +237,7 @@ struct WorktreeStoreTests {
                     isDetached: false,
                     isPrunable: true
                 ),
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: "/tmp/repo-live",
                     branch: "feature-live",
                     head: nil,
@@ -248,11 +248,11 @@ struct WorktreeStoreTests {
         ])
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: gitService.listWorktrees,
+            listWorktrees: listingStub.listWorktrees,
             projects: [project]
         )
 
-        let worktrees = try await store.refreshFromGit(project: project)
+        let worktrees = try await store.refreshWorktrees(project: project)
 
         #expect(worktrees.count == 2)
         #expect(worktrees.contains(where: { $0.path == "/tmp/repo-live" }))
@@ -260,8 +260,8 @@ struct WorktreeStoreTests {
         #expect(!worktrees.contains(where: { $0.path == "/tmp/repo-prunable" }))
     }
 
-    @Test("refreshFromGit tolerates duplicate persisted paths without trapping")
-    func refreshFromGitToleratesDuplicatePaths() async throws {
+    @Test("refreshWorktrees tolerates duplicate persisted paths without trapping")
+    func refreshWorktreesToleratesDuplicatePaths() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")
         let duplicatePath = "/tmp/repo-dupe"
         let persistence = WorktreePersistenceStub(
@@ -285,16 +285,16 @@ struct WorktreeStoreTests {
                 ]
             ]
         )
-        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+        let listingStub = WorktreeListingStub(recordsByRepoPath: [
             project.path: [
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: project.path,
                     branch: "main",
                     head: nil,
                     isBare: false,
                     isDetached: false
                 ),
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: duplicatePath,
                     branch: "updated",
                     head: nil,
@@ -305,19 +305,19 @@ struct WorktreeStoreTests {
         ])
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: gitService.listWorktrees,
+            listWorktrees: listingStub.listWorktrees,
             projects: [project]
         )
 
-        let worktrees = try await store.refreshFromGit(project: project)
+        let worktrees = try await store.refreshWorktrees(project: project)
 
         let atDuplicatePath = worktrees.filter { $0.path == duplicatePath }
         #expect(atDuplicatePath.count == 2)
         #expect(atDuplicatePath.contains(where: { $0.branch == "updated" }))
     }
 
-    @Test("refreshFromGit treats symlinked primary paths as the primary worktree")
-    func refreshFromGitResolvesSymlinkedPrimaryPath() async throws {
+    @Test("refreshWorktrees treats symlinked primary paths as the primary worktree")
+    func refreshWorktreesResolvesSymlinkedPrimaryPath() async throws {
         let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("muxy-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
@@ -336,9 +336,9 @@ struct WorktreeStoreTests {
                 ]
             ]
         )
-        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+        let listingStub = WorktreeListingStub(recordsByRepoPath: [
             project.path: [
-                GitWorktreeRecord(
+                WorktreeRecord(
                     path: realRepo.path,
                     branch: "feat/worktree-refresh",
                     head: nil,
@@ -349,11 +349,11 @@ struct WorktreeStoreTests {
         ])
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: gitService.listWorktrees,
+            listWorktrees: listingStub.listWorktrees,
             projects: [project]
         )
 
-        let worktrees = try await store.refreshFromGit(project: project)
+        let worktrees = try await store.refreshWorktrees(project: project)
 
         #expect(worktrees.count == 1)
         #expect(worktrees[0].isPrimary)
@@ -380,7 +380,7 @@ struct WorktreeStoreTests {
         )
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: GitWorktreeListingStub(recordsByRepoPath: [:]).listWorktrees,
+            listWorktrees: WorktreeListingStub(recordsByRepoPath: [:]).listWorktrees,
             projects: [project]
         )
         _ = VCSStateStore.shared.state(for: removable.path)
@@ -411,7 +411,7 @@ struct WorktreeStoreTests {
         )
         let store = WorktreeStore(
             persistence: persistence,
-            listGitWorktrees: GitWorktreeListingStub(recordsByRepoPath: [:]).listWorktrees,
+            listWorktrees: WorktreeListingStub(recordsByRepoPath: [:]).listWorktrees,
             projects: [project]
         )
 
@@ -465,10 +465,10 @@ private final class WorktreePersistenceStub: WorktreePersisting {
     }
 }
 
-private struct GitWorktreeListingStub: GitWorktreeListing {
-    let recordsByRepoPath: [String: [GitWorktreeRecord]]
+private struct WorktreeListingStub {
+    let recordsByRepoPath: [String: [WorktreeRecord]]
 
-    func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
+    func listWorktrees(repoPath: String) async throws -> [WorktreeRecord] {
         recordsByRepoPath[repoPath] ?? []
     }
 }


### PR DESCRIPTION




<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

This CL introduces support for jujutsu(VCS) workspaces, when a project is directly managed or colocated by jujtusu

The reason to start with workpaces is that a user can continue using the CLI for the rest of jujutsu actions (`jj diff`, `jj describe`,` jj new`, `jj abandon`, ... etc) while git worktrees cause interference with jujutsu standard workflows (in jujutsu workspaces are visible between each other and new changes can be applied by merging different workspaces)


## Changes

- Add VCS abstraction for worktrees/workspaces
- New workspaces are located as slibings of the root directory following the format `<rootDirName>-<workspaceName>`
- Git and Jujutsu vcs detection support via VCSKind

Disclaimer: AI assisted development was used with kimi k2.6

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

<!-- If applicable, add screenshots -->
