### PR TITLE
Add adjustable line height to the code editor

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -62,10 +62,6 @@ line_length:
   ignores_function_declarations: false
   ignores_comments: true
 
-function_parameter_count:
-  warning: 6
-  error: 8
-
 type_name:
   min_length: 2
   max_length: 60

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -62,6 +62,10 @@ line_length:
   ignores_function_declarations: false
   ignores_comments: true
 
+function_parameter_count:
+  warning: 6
+  error: 8
+
 type_name:
   min_length: 2
   max_length: 60

--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -32,6 +32,11 @@ final class EditorSettings {
     static let markdownPreviewBaseFontSize: CGFloat = 14
     static let markdownPreviewZoomStep: CGFloat = 0.1
 
+    static let defaultLineHeight: CGFloat = 1.2
+    static let minLineHeight: CGFloat = 1.0
+    static let maxLineHeight: CGFloat = 2.0
+    static let lineHeightStep: CGFloat = 0.1
+
     var fontSize: CGFloat = 13 { didSet { save() } }
     var fontFamily: String = "SF Mono" { didSet { save() } }
     var defaultEditor: DefaultEditor = .builtIn { didSet { save() } }
@@ -41,6 +46,17 @@ final class EditorSettings {
     var highlightCurrentLine: Bool = true { didSet { save() } }
     var lineWrapping: Bool = false { didSet { save() } }
     var showLineNumbers: Bool = true { didSet { save() } }
+    var lineHeight: CGFloat = EditorSettings.defaultLineHeight {
+        didSet {
+            let clamped = min(max(lineHeight, Self.minLineHeight), Self.maxLineHeight)
+            if clamped != lineHeight {
+                lineHeight = clamped
+                return
+            }
+            save()
+        }
+    }
+
     var richInputImageStrategy: RichInputImageStrategy = .clipboard { didSet { save() } }
 
     @ObservationIgnored private let store: CodableFileStore<Snapshot>
@@ -129,6 +145,7 @@ final class EditorSettings {
         highlightCurrentLine = true
         lineWrapping = false
         showLineNumbers = true
+        lineHeight = Self.defaultLineHeight
         richInputImageStrategy = .clipboard
         isBatchLoading = false
         save()
@@ -151,6 +168,8 @@ final class EditorSettings {
             highlightCurrentLine = snapshot.highlightCurrentLine ?? true
             lineWrapping = snapshot.lineWrapping ?? false
             showLineNumbers = snapshot.showLineNumbers ?? true
+            let loadedLineHeight = snapshot.lineHeight ?? Self.defaultLineHeight
+            lineHeight = min(max(loadedLineHeight, Self.minLineHeight), Self.maxLineHeight)
             richInputImageStrategy = snapshot.richInputImageStrategy ?? .clipboard
             isBatchLoading = false
         } catch {
@@ -172,6 +191,7 @@ final class EditorSettings {
                 highlightCurrentLine: highlightCurrentLine,
                 lineWrapping: lineWrapping,
                 showLineNumbers: showLineNumbers,
+                lineHeight: lineHeight,
                 richInputImageStrategy: richInputImageStrategy
             ))
         } catch {
@@ -191,5 +211,6 @@ private struct Snapshot: Codable {
     let highlightCurrentLine: Bool?
     let lineWrapping: Bool?
     let showLineNumbers: Bool?
+    let lineHeight: CGFloat?
     let richInputImageStrategy: RichInputImageStrategy?
 }

--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -32,10 +32,10 @@ final class EditorSettings {
     static let markdownPreviewBaseFontSize: CGFloat = 14
     static let markdownPreviewZoomStep: CGFloat = 0.1
 
-    static let defaultLineHeight: CGFloat = 1.2
-    static let minLineHeight: CGFloat = 1.0
-    static let maxLineHeight: CGFloat = 2.0
-    static let lineHeightStep: CGFloat = 0.1
+    static let defaultLineHeightMultiplier: CGFloat = 1.2
+    static let minLineHeightMultiplier: CGFloat = 1.1
+    static let maxLineHeightMultiplier: CGFloat = 2.0
+    static let lineHeightMultiplierStep: CGFloat = 0.1
 
     var fontSize: CGFloat = 13 { didSet { save() } }
     var fontFamily: String = "SF Mono" { didSet { save() } }
@@ -46,15 +46,9 @@ final class EditorSettings {
     var highlightCurrentLine: Bool = true { didSet { save() } }
     var lineWrapping: Bool = false { didSet { save() } }
     var showLineNumbers: Bool = true { didSet { save() } }
-    var lineHeight: CGFloat = EditorSettings.defaultLineHeight {
-        didSet {
-            let clamped = min(max(lineHeight, Self.minLineHeight), Self.maxLineHeight)
-            if clamped != lineHeight {
-                lineHeight = clamped
-                return
-            }
-            save()
-        }
+
+    var lineHeightMultiplier: CGFloat = EditorSettings.defaultLineHeightMultiplier {
+        didSet { save() }
     }
 
     var richInputImageStrategy: RichInputImageStrategy = .clipboard { didSet { save() } }
@@ -145,7 +139,7 @@ final class EditorSettings {
         highlightCurrentLine = true
         lineWrapping = false
         showLineNumbers = true
-        lineHeight = Self.defaultLineHeight
+        lineHeightMultiplier = Self.defaultLineHeightMultiplier
         richInputImageStrategy = .clipboard
         isBatchLoading = false
         save()
@@ -168,8 +162,11 @@ final class EditorSettings {
             highlightCurrentLine = snapshot.highlightCurrentLine ?? true
             lineWrapping = snapshot.lineWrapping ?? false
             showLineNumbers = snapshot.showLineNumbers ?? true
-            let loadedLineHeight = snapshot.lineHeight ?? Self.defaultLineHeight
-            lineHeight = min(max(loadedLineHeight, Self.minLineHeight), Self.maxLineHeight)
+            let loadedMultiplier = snapshot.lineHeightMultiplier ?? Self.defaultLineHeightMultiplier
+            lineHeightMultiplier = min(
+                max(loadedMultiplier, Self.minLineHeightMultiplier),
+                Self.maxLineHeightMultiplier
+            )
             richInputImageStrategy = snapshot.richInputImageStrategy ?? .clipboard
             isBatchLoading = false
         } catch {
@@ -191,7 +188,7 @@ final class EditorSettings {
                 highlightCurrentLine: highlightCurrentLine,
                 lineWrapping: lineWrapping,
                 showLineNumbers: showLineNumbers,
-                lineHeight: lineHeight,
+                lineHeightMultiplier: lineHeightMultiplier,
                 richInputImageStrategy: richInputImageStrategy
             ))
         } catch {
@@ -211,6 +208,6 @@ private struct Snapshot: Codable {
     let highlightCurrentLine: Bool?
     let lineWrapping: Bool?
     let showLineNumbers: Bool?
-    let lineHeight: CGFloat?
+    let lineHeightMultiplier: CGFloat?
     let richInputImageStrategy: RichInputImageStrategy?
 }

--- a/Muxy/Models/ViewportState.swift
+++ b/Muxy/Models/ViewportState.swift
@@ -41,9 +41,11 @@ final class ViewportState {
         rebuildEstimates()
     }
 
-    func updateEstimatedLineHeight(font: NSFont) {
-        let lineHeight = ceil(NSLayoutManager().defaultLineHeight(for: font))
-        oracle.updateLineHeight(lineHeight > 0 ? lineHeight : 16)
+    func updateEstimatedLineHeight(font: NSFont, lineHeightMultiplier: CGFloat = 1.0) {
+        let typographicHeight = font.ascender - font.descender
+        let multiplier = max(lineHeightMultiplier, 1.0)
+        let scaled = ceil(typographicHeight * multiplier)
+        oracle.updateLineHeight(scaled > 0 ? scaled : 16)
         oracle.updateCharWidth(estimatedCharWidth(for: font))
         rebuildEstimates()
     }

--- a/Muxy/Models/ViewportState.swift
+++ b/Muxy/Models/ViewportState.swift
@@ -43,8 +43,7 @@ final class ViewportState {
 
     func updateEstimatedLineHeight(font: NSFont, lineHeightMultiplier: CGFloat = 1.0) {
         let typographicHeight = font.ascender - font.descender
-        let multiplier = max(lineHeightMultiplier, 1.0)
-        let scaled = ceil(typographicHeight * multiplier)
+        let scaled = ceil(typographicHeight * lineHeightMultiplier)
         oracle.updateLineHeight(scaled > 0 ? scaled : 16)
         oracle.updateCharWidth(estimatedCharWidth(for: font))
         rebuildEstimates()

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -253,8 +253,8 @@ struct CodeEditorView: NSViewRepresentable {
         let textStorage = NSTextStorage()
         let layoutManager = CodeEditorLayoutManager()
         layoutManager.usesFontLeading = false
-        let lineHeightDelegate = LineHeightLayoutDelegate()
-        lineHeightDelegate.lineHeightMultiplier = editorSettings.lineHeight
+        let lineHeightDelegate = LineHeightLayoutDelegate(fallbackFont: editorSettings.resolvedFont)
+        lineHeightDelegate.lineHeightMultiplier = editorSettings.lineHeightMultiplier
         layoutManager.delegate = lineHeightDelegate
         textStorage.addLayoutManager(layoutManager)
 
@@ -298,7 +298,6 @@ struct CodeEditorView: NSViewRepresentable {
         textView.backgroundColor = palette.background
         textView.insertionPointColor = palette.foreground
         textView.textColor = palette.foreground
-
         textView.typingAttributes = [
             .font: font,
             .foregroundColor: palette.foreground,
@@ -433,10 +432,14 @@ struct CodeEditorView: NSViewRepresentable {
         let themeChanged = coordinator.lastThemeVersion != themeVersion
         let font = editorSettings.resolvedFont
         let fontChanged = textView.font != font
-        let lineHeightMultiplier = editorSettings.lineHeight
+        let lineHeightMultiplier = editorSettings.lineHeightMultiplier
         let lineHeightChanged = coordinator.lastLineHeightMultiplier != lineHeightMultiplier
 
         applyThemeAndFont(scrollView: scrollView, textView: textView, font: font)
+
+        if fontChanged {
+            coordinator.lineHeightDelegate?.fallbackFont = font
+        }
 
         if lineHeightChanged {
             coordinator.lineHeightDelegate?.lineHeightMultiplier = lineHeightMultiplier
@@ -479,11 +482,7 @@ struct CodeEditorView: NSViewRepresentable {
         }
     }
 
-    private func applyThemeAndFont(
-        scrollView: NSScrollView,
-        textView: NSTextView,
-        font: NSFont
-    ) {
+    private func applyThemeAndFont(scrollView: NSScrollView, textView: NSTextView, font: NSFont) {
         let palette = EditorThemePalette.active
         let fgColor = palette.foreground
         let bgColor = palette.background
@@ -842,7 +841,7 @@ struct CodeEditorView: NSViewRepresentable {
             let viewport = ViewportState(backingStore: store)
             viewport.updateEstimatedLineHeight(
                 font: editorSettings.resolvedFont,
-                lineHeightMultiplier: editorSettings.lineHeight
+                lineHeightMultiplier: editorSettings.lineHeightMultiplier
             )
             viewport.lineWrappingEnabled = lineWrappingEnabled
             viewportState = viewport

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -252,6 +252,10 @@ struct CodeEditorView: NSViewRepresentable {
 
         let textStorage = NSTextStorage()
         let layoutManager = CodeEditorLayoutManager()
+        layoutManager.usesFontLeading = false
+        let lineHeightDelegate = LineHeightLayoutDelegate()
+        lineHeightDelegate.lineHeightMultiplier = editorSettings.lineHeight
+        layoutManager.delegate = lineHeightDelegate
         textStorage.addLayoutManager(layoutManager)
 
         let textContainer = NSTextContainer(containerSize: NSSize(
@@ -294,6 +298,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.backgroundColor = palette.background
         textView.insertionPointColor = palette.foreground
         textView.textColor = palette.foreground
+
         textView.typingAttributes = [
             .font: font,
             .foregroundColor: palette.foreground,
@@ -318,6 +323,7 @@ struct CodeEditorView: NSViewRepresentable {
         coordinator.textView = textView
         coordinator.scrollView = scrollView
         coordinator.scrollContainer = container
+        coordinator.lineHeightDelegate = lineHeightDelegate
         textView.onUndoRequest = { [weak coordinator] in
             coordinator?.performUndoRequest() ?? false
         }
@@ -427,15 +433,28 @@ struct CodeEditorView: NSViewRepresentable {
         let themeChanged = coordinator.lastThemeVersion != themeVersion
         let font = editorSettings.resolvedFont
         let fontChanged = textView.font != font
+        let lineHeightMultiplier = editorSettings.lineHeight
+        let lineHeightChanged = coordinator.lastLineHeightMultiplier != lineHeightMultiplier
 
         applyThemeAndFont(scrollView: scrollView, textView: textView, font: font)
 
-        if fontChanged {
-            viewport.updateEstimatedLineHeight(font: font)
+        if lineHeightChanged {
+            coordinator.lineHeightDelegate?.lineHeightMultiplier = lineHeightMultiplier
+            if let layoutManager = textView.layoutManager, let textContainer = textView.textContainer {
+                let storage = textView.textStorage
+                let fullRange = NSRange(location: 0, length: storage?.length ?? 0)
+                layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
+                layoutManager.ensureLayout(for: textContainer)
+            }
+        }
+
+        if fontChanged || lineHeightChanged {
+            viewport.updateEstimatedLineHeight(font: font, lineHeightMultiplier: lineHeightMultiplier)
             viewport.updateDocumentPadding(
                 topInset: textView.textContainerInset.height,
                 bottomInset: textView.textContainerInset.height
             )
+            coordinator.lastLineHeightMultiplier = lineHeightMultiplier
             coordinator.updateContainerHeight()
             coordinator.updateMarkdownEditorScrollMetrics()
             coordinator.refreshViewport(force: true)
@@ -460,7 +479,11 @@ struct CodeEditorView: NSViewRepresentable {
         }
     }
 
-    private func applyThemeAndFont(scrollView: NSScrollView, textView: NSTextView, font: NSFont) {
+    private func applyThemeAndFont(
+        scrollView: NSScrollView,
+        textView: NSTextView,
+        font: NSFont
+    ) {
         let palette = EditorThemePalette.active
         let fgColor = palette.foreground
         let bgColor = palette.background
@@ -577,6 +600,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         weak var scrollView: NSScrollView?
         weak var scrollContainer: EditorScrollContainer?
+        var lineHeightDelegate: LineHeightLayoutDelegate?
         var viewportState: ViewportState?
         var containerView: ViewportContainerView?
         private(set) var lineWrappingEnabled: Bool = false
@@ -589,6 +613,7 @@ struct CodeEditorView: NSViewRepresentable {
         private var isWritingScrollProgrammatically = false
         var hasAppliedInitialContent = false
         var lastThemeVersion = -1
+        var lastLineHeightMultiplier: CGFloat = -1
         var lastSearchVisible = false
         var lastSearchNeedle = ""
         var lastSearchNavigationVersion = -1
@@ -815,7 +840,10 @@ struct CodeEditorView: NSViewRepresentable {
             clearViewportHistory()
 
             let viewport = ViewportState(backingStore: store)
-            viewport.updateEstimatedLineHeight(font: editorSettings.resolvedFont)
+            viewport.updateEstimatedLineHeight(
+                font: editorSettings.resolvedFont,
+                lineHeightMultiplier: editorSettings.lineHeight
+            )
             viewport.lineWrappingEnabled = lineWrappingEnabled
             viewportState = viewport
             invalidateRenderedViewportText()

--- a/Muxy/Views/Editor/LineHeightLayoutDelegate.swift
+++ b/Muxy/Views/Editor/LineHeightLayoutDelegate.swift
@@ -2,7 +2,14 @@ import AppKit
 
 final class LineHeightLayoutDelegate: NSObject, NSLayoutManagerDelegate {
     var lineHeightMultiplier: CGFloat = 1.0
+    var fallbackFont: NSFont
 
+    init(fallbackFont: NSFont) {
+        self.fallbackFont = fallbackFont
+        super.init()
+    }
+
+    // swiftlint:disable:next function_parameter_count
     func layoutManager(
         _ layoutManager: NSLayoutManager,
         shouldSetLineFragmentRect lineFragmentRect: UnsafeMutablePointer<NSRect>,
@@ -35,6 +42,6 @@ final class LineHeightLayoutDelegate: NSObject, NSLayoutManagerDelegate {
                 return font
             }
         }
-        return NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        return fallbackFont
     }
 }

--- a/Muxy/Views/Editor/LineHeightLayoutDelegate.swift
+++ b/Muxy/Views/Editor/LineHeightLayoutDelegate.swift
@@ -1,0 +1,40 @@
+import AppKit
+
+final class LineHeightLayoutDelegate: NSObject, NSLayoutManagerDelegate {
+    var lineHeightMultiplier: CGFloat = 1.0
+
+    func layoutManager(
+        _ layoutManager: NSLayoutManager,
+        shouldSetLineFragmentRect lineFragmentRect: UnsafeMutablePointer<NSRect>,
+        lineFragmentUsedRect: UnsafeMutablePointer<NSRect>,
+        baselineOffset: UnsafeMutablePointer<CGFloat>,
+        in textContainer: NSTextContainer,
+        forGlyphRange glyphRange: NSRange
+    ) -> Bool {
+        guard lineHeightMultiplier > 1.0 + .ulpOfOne else { return false }
+
+        let font = referenceFont(layoutManager: layoutManager, glyphRange: glyphRange)
+        let ascent = font.ascender
+        let descent = -font.descender
+        let typographicHeight = ascent + descent
+        let targetHeight = ceil(typographicHeight * lineHeightMultiplier)
+        let paddingTop = (targetHeight - typographicHeight) / 2
+
+        lineFragmentRect.pointee.size.height = targetHeight
+        lineFragmentUsedRect.pointee.size.height = targetHeight
+        baselineOffset.pointee = paddingTop + ascent
+        return true
+    }
+
+    private func referenceFont(layoutManager: NSLayoutManager, glyphRange: NSRange) -> NSFont {
+        if let storage = layoutManager.textStorage, glyphRange.length > 0 {
+            let charIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
+            if charIndex < storage.length,
+               let font = storage.attribute(.font, at: charIndex, effectiveRange: nil) as? NSFont
+            {
+                return font
+            }
+        }
+        return NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+    }
+}

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -186,6 +186,40 @@ struct EditorSettingsView: View {
                         .buttonStyle(.borderless)
                     }
                 }
+
+                SettingsRow("Line Height") {
+                    HStack(spacing: 8) {
+                        Button {
+                            settings.lineHeight = max(
+                                EditorSettings.minLineHeight,
+                                settings.lineHeight - EditorSettings.lineHeightStep
+                            )
+                        } label: {
+                            Image(systemName: "minus")
+                                .font(.system(size: 10, weight: .medium))
+                                .frame(width: 20, height: 20)
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(settings.lineHeight <= EditorSettings.minLineHeight + 0.001)
+
+                        Text(String(format: "%.1f×", settings.lineHeight))
+                            .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
+                            .frame(width: 44)
+
+                        Button {
+                            settings.lineHeight = min(
+                                EditorSettings.maxLineHeight,
+                                settings.lineHeight + EditorSettings.lineHeightStep
+                            )
+                        } label: {
+                            Image(systemName: "plus")
+                                .font(.system(size: 10, weight: .medium))
+                                .frame(width: 20, height: 20)
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(settings.lineHeight >= EditorSettings.maxLineHeight - 0.001)
+                    }
+                }
             }
         }
     }

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -190,9 +190,9 @@ struct EditorSettingsView: View {
                 SettingsRow("Line Height") {
                     HStack(spacing: 8) {
                         Button {
-                            settings.lineHeight = max(
-                                EditorSettings.minLineHeight,
-                                settings.lineHeight - EditorSettings.lineHeightStep
+                            settings.lineHeightMultiplier = max(
+                                EditorSettings.minLineHeightMultiplier,
+                                settings.lineHeightMultiplier - EditorSettings.lineHeightMultiplierStep
                             )
                         } label: {
                             Image(systemName: "minus")
@@ -200,16 +200,16 @@ struct EditorSettingsView: View {
                                 .frame(width: 20, height: 20)
                         }
                         .buttonStyle(.borderless)
-                        .disabled(settings.lineHeight <= EditorSettings.minLineHeight + 0.001)
+                        .disabled(settings.lineHeightMultiplier <= EditorSettings.minLineHeightMultiplier + 0.001)
 
-                        Text(String(format: "%.1f×", settings.lineHeight))
+                        Text(String(format: "%.1f×", settings.lineHeightMultiplier))
                             .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
                             .frame(width: 44)
 
                         Button {
-                            settings.lineHeight = min(
-                                EditorSettings.maxLineHeight,
-                                settings.lineHeight + EditorSettings.lineHeightStep
+                            settings.lineHeightMultiplier = min(
+                                EditorSettings.maxLineHeightMultiplier,
+                                settings.lineHeightMultiplier + EditorSettings.lineHeightMultiplierStep
                             )
                         } label: {
                             Image(systemName: "plus")
@@ -217,7 +217,7 @@ struct EditorSettingsView: View {
                                 .frame(width: 20, height: 20)
                         }
                         .buttonStyle(.borderless)
-                        .disabled(settings.lineHeight >= EditorSettings.maxLineHeight - 0.001)
+                        .disabled(settings.lineHeightMultiplier >= EditorSettings.maxLineHeightMultiplier - 0.001)
                     }
                 }
             }

--- a/Tests/MuxyTests/Models/ViewportStateTests.swift
+++ b/Tests/MuxyTests/Models/ViewportStateTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Testing
 
 @testable import Muxy
@@ -149,5 +150,32 @@ struct ViewportStateTests {
         let vp = makeViewport(lineCount: 100)
         #expect(vp.scrollY(forLine: 10) == 160)
         #expect(vp.scrollY(forLine: 0) == 0)
+    }
+
+    @Test("updateEstimatedLineHeight scales by multiplier")
+    func lineHeightMultiplierScales() {
+        let vp = makeViewport(lineCount: 10)
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        vp.updateEstimatedLineHeight(font: font, lineHeightMultiplier: 1.0)
+        let base = vp.estimatedLineHeight
+
+        vp.updateEstimatedLineHeight(font: font, lineHeightMultiplier: 2.0)
+        let doubled = vp.estimatedLineHeight
+
+        #expect(doubled >= base * 2 - 1)
+        #expect(doubled <= base * 2 + 1)
+    }
+
+    @Test("multiplier scales totalDocumentHeight")
+    func lineHeightMultiplierAffectsTotalHeight() {
+        let vp = makeViewport(lineCount: 100)
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        vp.updateEstimatedLineHeight(font: font, lineHeightMultiplier: 1.0)
+        let baseHeight = vp.totalDocumentHeight
+
+        vp.updateEstimatedLineHeight(font: font, lineHeightMultiplier: 1.5)
+        let taller = vp.totalDocumentHeight
+
+        #expect(taller > baseHeight)
     }
 }


### PR DESCRIPTION
- New Editor setting (1.0×–2.0×) to control line spacing, persisted across launches.
- Layout manager delegate scales line fragments and viewport estimates so scrolling and document height stay accurate.