### PR TITLE
Desktop notifications

### DIFF
--- a/Muxy/Models/NotificationSettings.swift
+++ b/Muxy/Models/NotificationSettings.swift
@@ -28,3 +28,77 @@ enum ToastPosition: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 }
+
+struct NotificationDeliveryPlan: Equatable {
+    let showToast: Bool
+    let showDesktop: Bool
+    let soundName: String?
+}
+
+enum NotificationSettings {
+    enum Key {
+        static let sound = "muxy.notifications.sound"
+        static let toastEnabled = "muxy.notifications.toastEnabled"
+        static let desktopEnabled = "muxy.notifications.desktopEnabled"
+        static let toastPosition = "muxy.notifications.toastPosition"
+    }
+
+    enum Default {
+        static let sound = NotificationSound.funk
+        static let toastEnabled = true
+        static let desktopEnabled = false
+        static let toastPosition = ToastPosition.topCenter
+        static let providerEnabled = true
+    }
+
+    static func providerEnabledKey(for providerID: String) -> String {
+        "muxy.notifications.provider.\(providerID).enabled"
+    }
+
+    static func toastEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: Key.toastEnabled, fallback: Default.toastEnabled)
+    }
+
+    static func desktopEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: Key.desktopEnabled, fallback: Default.desktopEnabled)
+    }
+
+    static func soundRawValue(defaults: UserDefaults = .standard) -> String {
+        defaults.string(forKey: Key.sound) ?? Default.sound.rawValue
+    }
+
+    static func sound(defaults: UserDefaults = .standard) -> NotificationSound? {
+        NotificationSound(rawValue: soundRawValue(defaults: defaults))
+    }
+
+    static func toastPositionRawValue(defaults: UserDefaults = .standard) -> String {
+        defaults.string(forKey: Key.toastPosition) ?? Default.toastPosition.rawValue
+    }
+
+    static func toastPosition(rawValue: String) -> ToastPosition {
+        ToastPosition(rawValue: rawValue) ?? Default.toastPosition
+    }
+
+    static func toastPosition(defaults: UserDefaults = .standard) -> ToastPosition {
+        toastPosition(rawValue: toastPositionRawValue(defaults: defaults))
+    }
+
+    static func providerEnabled(providerID: String, defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: providerEnabledKey(for: providerID), fallback: Default.providerEnabled)
+    }
+
+    static func deliveryPlan(defaults: UserDefaults = .standard) -> NotificationDeliveryPlan {
+        let sound = soundRawValue(defaults: defaults)
+        return NotificationDeliveryPlan(
+            showToast: toastEnabled(defaults: defaults),
+            showDesktop: desktopEnabled(defaults: defaults),
+            soundName: sound == NotificationSound.none.rawValue ? nil : sound
+        )
+    }
+}
+
+extension UserDefaults {
+    func bool(forKey key: String, fallback: Bool) -> Bool {
+        object(forKey: key) != nil ? bool(forKey: key) : fallback
+    }
+}

--- a/Muxy/Models/ToastState.swift
+++ b/Muxy/Models/ToastState.swift
@@ -1,23 +1,67 @@
 import Foundation
 
+struct ToastContent: Equatable {
+    let title: String
+    let body: String?
+    let isActionable: Bool
+
+    var accessibilityLabel: String {
+        guard let body else { return title }
+        return "\(title), \(body)"
+    }
+}
+
 @MainActor
 @Observable
 final class ToastState {
     static let shared = ToastState()
 
-    var message: String?
+    var content: ToastContent?
+
+    var message: String? {
+        content?.title
+    }
 
     @ObservationIgnored private var dismissTask: Task<Void, Never>?
+    @ObservationIgnored private var action: (@MainActor () -> Void)?
 
     private init() {}
 
     func show(_ message: String) {
-        self.message = message
+        show(title: message)
+    }
+
+    func show(title: String, body: String? = nil, action: (@MainActor () -> Void)? = nil) {
+        content = ToastContent(
+            title: title,
+            body: Self.normalizedBody(body),
+            isActionable: action != nil
+        )
+        self.action = action
         dismissTask?.cancel()
         dismissTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 3_000_000_000)
             guard !Task.isCancelled, let self else { return }
-            self.message = nil
+            dismiss()
         }
+    }
+
+    func performAction() {
+        let action = action
+        dismiss()
+        action?()
+    }
+
+    func dismiss() {
+        content = nil
+        action = nil
+        dismissTask?.cancel()
+        dismissTask = nil
+    }
+
+    private static func normalizedBody(_ body: String?) -> String? {
+        guard let body else { return nil }
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -54,6 +54,7 @@ struct MuxyApp: App {
                     NotificationStore.shared.appState = appState
                     NotificationStore.shared.worktreeStore = worktreeStore
                     NotificationStore.shared.markAllAsRead()
+                    DesktopNotificationService.shared.start(appState: appState)
                     MemoryDiagnostics.shared.configure(appState: appState)
                     TerminalProgressStore.shared.appState = appState
                     appDelegate.onTerminate = { [appState] in
@@ -232,6 +233,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         observeSystemAppearanceChanges()
         UpdateService.shared.start()
         ModifierKeyMonitor.shared.start()
+        DesktopNotificationService.shared.prepare()
         NotificationSocketServer.shared.start()
         AIProviderRegistry.shared.installAll()
         _ = AIUsageSettingsStore.isUsageEnabled()

--- a/Muxy/Services/AIProviderIntegration.swift
+++ b/Muxy/Services/AIProviderIntegration.swift
@@ -21,10 +21,10 @@ extension AIProviderIntegration {
 }
 
 extension AIProviderIntegration {
-    var settingsKey: String { "muxy.notifications.provider.\(id).enabled" }
+    var settingsKey: String { NotificationSettings.providerEnabledKey(for: id) }
 
     var isEnabled: Bool {
-        get { UserDefaults.standard.bool(forKey: settingsKey, fallback: true) }
+        get { NotificationSettings.providerEnabled(providerID: id) }
         nonmutating set { UserDefaults.standard.set(newValue, forKey: settingsKey) }
     }
 

--- a/Muxy/Services/DesktopNotificationService.swift
+++ b/Muxy/Services/DesktopNotificationService.swift
@@ -1,0 +1,257 @@
+import AppKit
+import Foundation
+import os
+import UserNotifications
+
+private let desktopNotificationLogger = Logger(subsystem: "app.muxy", category: "DesktopNotificationService")
+
+struct DesktopNotificationPayload: Equatable {
+    static let notificationIDUserInfoKey = "notificationID"
+
+    let notificationID: UUID
+    let title: String
+    let body: String
+
+    init(notification: MuxyNotification) {
+        notificationID = notification.id
+        title = notification.title
+        body = notification.body
+    }
+
+    var requestIdentifier: String {
+        notificationID.uuidString
+    }
+
+    func makeRequest() -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.userInfo = [Self.notificationIDUserInfoKey: notificationID.uuidString]
+        return UNNotificationRequest(identifier: requestIdentifier, content: content, trigger: nil)
+    }
+
+    static func notificationID(from userInfo: [AnyHashable: Any]) -> UUID? {
+        guard let rawValue = userInfo[notificationIDUserInfoKey] as? String else { return nil }
+        return UUID(uuidString: rawValue)
+    }
+}
+
+@MainActor
+protocol DesktopNotificationDelivering: AnyObject {
+    func deliver(_ notification: MuxyNotification)
+}
+
+protocol UserNotificationScheduling: AnyObject {
+    var delegate: (any UNUserNotificationCenterDelegate)? { get set }
+
+    func authorizationStatus(completionHandler: @escaping @Sendable (UNAuthorizationStatus) -> Void)
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping @Sendable (Bool, (any Error)?) -> Void
+    )
+    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: (@Sendable ((any Error)?) -> Void)?)
+}
+
+final class SystemUserNotificationScheduler: UserNotificationScheduling {
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    var delegate: (any UNUserNotificationCenterDelegate)? {
+        get { center.delegate }
+        set { center.delegate = newValue }
+    }
+
+    func authorizationStatus(completionHandler: @escaping @Sendable (UNAuthorizationStatus) -> Void) {
+        center.getNotificationSettings { settings in
+            completionHandler(settings.authorizationStatus)
+        }
+    }
+
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping @Sendable (Bool, (any Error)?) -> Void
+    ) {
+        center.requestAuthorization(options: options, completionHandler: completionHandler)
+    }
+
+    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: (@Sendable ((any Error)?) -> Void)?) {
+        center.add(request, withCompletionHandler: completionHandler)
+    }
+}
+
+@MainActor
+final class DesktopNotificationService: NSObject, DesktopNotificationDelivering {
+    static let shared = DesktopNotificationService()
+
+    private let scheduler: any UserNotificationScheduling
+    private var appState: AppState?
+    private var notificationStore: NotificationStore?
+    private var pendingNavigationIDs: [UUID] = []
+    private var isStarted = false
+
+    init(scheduler: any UserNotificationScheduling = SystemUserNotificationScheduler()) {
+        self.scheduler = scheduler
+        super.init()
+    }
+
+    func prepare() {
+        guard !isStarted else { return }
+        scheduler.delegate = self
+        isStarted = true
+    }
+
+    func start(appState: AppState, notificationStore: NotificationStore = .shared) {
+        prepare()
+        notificationStore.desktopNotifier = self
+        self.appState = appState
+        self.notificationStore = notificationStore
+        flushPendingNavigation()
+    }
+
+    func deliver(_ notification: MuxyNotification) {
+        schedule(DesktopNotificationPayload(notification: notification))
+    }
+
+    func requestAuthorizationIfNeeded(completion: (@MainActor (Bool) -> Void)? = nil) {
+        scheduler.authorizationStatus { [weak self] status in
+            Task { @MainActor in
+                self?.requestAuthorizationIfNeeded(status: status, completion: completion)
+            }
+        }
+    }
+
+    nonisolated func foregroundPresentationOptions() -> UNNotificationPresentationOptions {
+        []
+    }
+
+    nonisolated func notificationIDForResponse(actionIdentifier: String, from userInfo: [AnyHashable: Any]) -> UUID? {
+        guard actionIdentifier == UNNotificationDefaultActionIdentifier else { return nil }
+        return DesktopNotificationPayload.notificationID(from: userInfo)
+    }
+
+    nonisolated func handleNotificationResponse(
+        actionIdentifier: String,
+        userInfo: [AnyHashable: Any],
+        completionHandler: @escaping @Sendable () -> Void
+    ) {
+        guard let notificationID = notificationIDForResponse(actionIdentifier: actionIdentifier, from: userInfo) else {
+            completionHandler()
+            return
+        }
+        Task { @MainActor [weak self] in
+            self?.handleResponse(notificationID: notificationID)
+            completionHandler()
+        }
+    }
+
+    private func requestAuthorizationIfNeeded(
+        status: UNAuthorizationStatus,
+        completion: (@MainActor (Bool) -> Void)?
+    ) {
+        switch status {
+        case .authorized,
+             .provisional,
+             .ephemeral:
+            completion?(true)
+        case .notDetermined:
+            requestAuthorization(completion: completion)
+        case .denied:
+            completion?(false)
+        @unknown default:
+            completion?(false)
+        }
+    }
+
+    private func schedule(_ payload: DesktopNotificationPayload) {
+        scheduler.authorizationStatus { [weak self] status in
+            Task { @MainActor in
+                self?.schedule(payload, authorizationStatus: status)
+            }
+        }
+    }
+
+    private func schedule(_ payload: DesktopNotificationPayload, authorizationStatus: UNAuthorizationStatus) {
+        switch authorizationStatus {
+        case .authorized,
+             .provisional,
+             .ephemeral:
+            add(payload)
+        case .notDetermined:
+            desktopNotificationLogger.debug("Desktop notification skipped: authorization not determined")
+        case .denied:
+            desktopNotificationLogger.debug("Desktop notification skipped: authorization denied")
+        @unknown default:
+            desktopNotificationLogger.debug("Desktop notification skipped: unknown authorization status")
+        }
+    }
+
+    private func requestAuthorization(completion: (@MainActor (Bool) -> Void)? = nil) {
+        scheduler.requestAuthorization(options: [.alert]) { granted, error in
+            if let error {
+                desktopNotificationLogger.error("Desktop notification authorization failed: \(error.localizedDescription)")
+            }
+            Task { @MainActor in
+                completion?(granted)
+            }
+        }
+    }
+
+    private func add(_ payload: DesktopNotificationPayload) {
+        scheduler.add(payload.makeRequest()) { error in
+            if let error {
+                desktopNotificationLogger.error("Desktop notification scheduling failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func handleResponse(notificationID: UUID) {
+        guard let appState, let notificationStore else {
+            pendingNavigationIDs.append(notificationID)
+            return
+        }
+        NSApp.activate()
+        guard NotificationNavigator.navigate(
+            notificationID: notificationID,
+            appState: appState,
+            notificationStore: notificationStore
+        )
+        else {
+            desktopNotificationLogger.debug("Desktop notification response ignored: notification not found")
+            return
+        }
+    }
+
+    private func flushPendingNavigation() {
+        guard !pendingNavigationIDs.isEmpty else { return }
+        let ids = pendingNavigationIDs
+        pendingNavigationIDs.removeAll()
+        for id in ids {
+            handleResponse(notificationID: id)
+        }
+    }
+}
+
+extension DesktopNotificationService: UNUserNotificationCenterDelegate {
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping @Sendable (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler(foregroundPresentationOptions())
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping @Sendable () -> Void
+    ) {
+        handleNotificationResponse(
+            actionIdentifier: response.actionIdentifier,
+            userInfo: response.notification.request.content.userInfo,
+            completionHandler: completionHandler
+        )
+    }
+}

--- a/Muxy/Services/NotificationNavigator.swift
+++ b/Muxy/Services/NotificationNavigator.swift
@@ -37,6 +37,18 @@ enum NotificationNavigator {
     }
 
     static func navigate(
+        notificationID: UUID,
+        appState: AppState,
+        notificationStore: NotificationStore
+    ) -> Bool {
+        guard let notification = notificationStore.notifications.first(where: { $0.id == notificationID }) else {
+            return false
+        }
+        navigate(to: notification, appState: appState, notificationStore: notificationStore)
+        return true
+    }
+
+    static func navigate(
         to notification: MuxyNotification,
         appState: AppState,
         notificationStore: NotificationStore

--- a/Muxy/Services/NotificationStore.swift
+++ b/Muxy/Services/NotificationStore.swift
@@ -17,6 +17,7 @@ final class NotificationStore {
 
     private static let maxNotifications = 200
     private static let defaults = UserDefaults.standard
+    weak var desktopNotifier: (any DesktopNotificationDelivering)?
     private static let store = CodableFileStore<[MuxyNotification]>(
         fileURL: MuxyFileStorage.fileURL(filename: "notifications.json")
     )
@@ -138,15 +139,34 @@ final class NotificationStore {
     }
 
     private func deliverNotification(_ notification: MuxyNotification) {
-        if Self.defaults.bool(forKey: "muxy.notifications.toastEnabled", fallback: true) {
-            ToastState.shared.show(notification.title)
+        let plan = NotificationSettings.deliveryPlan(defaults: Self.defaults)
+        if plan.showToast {
+            ToastState.shared.show(title: notification.title, body: notification.body) { [weak self] in
+                self?.activate(notificationID: notification.id)
+            }
+        }
+        if plan.showDesktop {
+            desktopNotifier?.deliver(notification)
         }
         playSound()
     }
 
+    private func activate(notificationID: UUID) {
+        guard let appState else { return }
+        NSApp.activate()
+        guard NotificationNavigator.navigate(
+            notificationID: notificationID,
+            appState: appState,
+            notificationStore: self
+        )
+        else {
+            logger.debug("Toast notification response ignored: notification not found")
+            return
+        }
+    }
+
     private func playSound() {
-        let soundName = Self.defaults.string(forKey: "muxy.notifications.sound") ?? NotificationSound.funk.rawValue
-        guard soundName != NotificationSound.none.rawValue else { return }
+        guard let soundName = NotificationSettings.deliveryPlan(defaults: Self.defaults).soundName else { return }
         NSSound(named: .init(soundName))?.play()
     }
 
@@ -221,11 +241,5 @@ final class NotificationStore {
             logger.error("Failed to load notifications: \(error.localizedDescription)")
             return []
         }
-    }
-}
-
-extension UserDefaults {
-    func bool(forKey key: String, fallback: Bool) -> Bool {
-        object(forKey: key) != nil ? bool(forKey: key) : fallback
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -85,7 +85,8 @@ struct MainWindow: View {
     @State private var sidebarExpanded = UserDefaults.standard.bool(forKey: "muxy.sidebarExpanded")
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
-    @AppStorage("muxy.notifications.toastPosition") private var toastPositionRaw = ToastPosition.topCenter.rawValue
+    @AppStorage(NotificationSettings.Key.toastPosition)
+    private var toastPositionRaw = NotificationSettings.Default.toastPosition.rawValue
     @MainActor private var trafficLightWidth: CGFloat { UIMetrics.scaled(75) }
 
     var body: some View {
@@ -175,24 +176,38 @@ struct MainWindow: View {
         }
         .environment(\.overlayActive, showQuickOpen || showFindInFiles || showWorktreeSwitcher || overlayAnimatingOut)
         .overlay(alignment: toastAlignment) {
-            if let toast = ToastState.shared.message {
-                HStack(spacing: UIMetrics.spacing3) {
+            if let toast = ToastState.shared.content {
+                HStack(alignment: toast.body == nil ? .center : .top, spacing: UIMetrics.spacing3) {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                         .foregroundStyle(MuxyTheme.diffAddFg)
-                    Text(toast)
-                        .font(.system(size: UIMetrics.fontBody, weight: .medium))
-                        .foregroundStyle(MuxyTheme.fg)
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
+                        Text(toast.title)
+                            .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                            .foregroundStyle(MuxyTheme.fg)
+                            .lineLimit(1)
+                        if let body = toast.body {
+                            Text(body)
+                                .font(.system(size: UIMetrics.fontFootnote))
+                                .foregroundStyle(MuxyTheme.fgMuted)
+                                .lineLimit(2)
+                        }
+                    }
                 }
                 .padding(.horizontal, UIMetrics.scaled(14))
                 .padding(.vertical, UIMetrics.spacing4)
+                .frame(maxWidth: UIMetrics.scaled(360), alignment: .leading)
                 .background(MuxyTheme.bg, in: Capsule())
                 .overlay(Capsule().stroke(MuxyTheme.border, lineWidth: 1))
+                .contentShape(Capsule())
                 .padding(toastEdgePadding)
                 .transition(.move(edge: toastTransitionEdge).combined(with: .opacity))
-                .allowsHitTesting(false)
-                .accessibilityLabel(toast)
-                .accessibilityAddTraits(.isStaticText)
+                .allowsHitTesting(toast.isActionable)
+                .onTapGesture {
+                    ToastState.shared.performAction()
+                }
+                .accessibilityLabel(toast.accessibilityLabel)
+                .accessibilityAddTraits(toast.isActionable ? .isButton : .isStaticText)
             }
         }
         .overlay {
@@ -580,7 +595,7 @@ struct MainWindow: View {
     }
 
     private var toastPosition: ToastPosition {
-        ToastPosition(rawValue: toastPositionRaw) ?? .topCenter
+        NotificationSettings.toastPosition(rawValue: toastPositionRaw)
     }
 
     private var toastAlignment: Alignment {

--- a/Muxy/Views/Settings/NotificationSettingsView.swift
+++ b/Muxy/Views/Settings/NotificationSettingsView.swift
@@ -2,14 +2,19 @@ import AppKit
 import SwiftUI
 
 struct NotificationSettingsView: View {
-    @AppStorage("muxy.notifications.sound") private var sound = NotificationSound.funk.rawValue
-    @AppStorage("muxy.notifications.toastEnabled") private var toastEnabled = true
-    @AppStorage("muxy.notifications.toastPosition") private var toastPosition = ToastPosition.topCenter.rawValue
+    @AppStorage(NotificationSettings.Key.sound) private var sound = NotificationSettings.Default.sound.rawValue
+    @AppStorage(NotificationSettings.Key.toastEnabled) private var toastEnabled = NotificationSettings.Default.toastEnabled
+    @AppStorage(NotificationSettings.Key.desktopEnabled) private var desktopEnabled = NotificationSettings.Default.desktopEnabled
+    @AppStorage(NotificationSettings.Key.toastPosition) private var toastPosition = NotificationSettings.Default.toastPosition.rawValue
 
     var body: some View {
         SettingsContainer {
             SettingsSection("Delivery") {
                 SettingsToggleRow(label: "Toast", isOn: $toastEnabled)
+                SettingsToggleRow(label: "Desktop notifications", isOn: $desktopEnabled)
+                    .onChange(of: desktopEnabled) { _, newValue in
+                        requestDesktopNotificationAuthorizationIfNeeded(newValue)
+                    }
             }
 
             SettingsSection("Sound") {
@@ -42,6 +47,15 @@ struct NotificationSettingsView: View {
     private func previewSound(_ value: String) {
         guard let sound = NotificationSound(rawValue: value), sound != .none else { return }
         NSSound(named: .init(sound.rawValue))?.play()
+    }
+
+    private func requestDesktopNotificationAuthorizationIfNeeded(_ enabled: Bool) {
+        guard enabled else { return }
+        DesktopNotificationService.shared.requestAuthorizationIfNeeded { authorized in
+            if !authorized {
+                desktopEnabled = false
+            }
+        }
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -63,6 +63,7 @@ let package = Package(
                 .linkedFramework("Metal"),
                 .linkedFramework("MetalKit"),
                 .linkedFramework("QuartzCore"),
+                .linkedFramework("UserNotifications"),
                 .linkedLibrary("c++"),
             ]
         ),
@@ -88,6 +89,7 @@ let package = Package(
                 .linkedFramework("Metal"),
                 .linkedFramework("MetalKit"),
                 .linkedFramework("QuartzCore"),
+                .linkedFramework("UserNotifications"),
                 .linkedLibrary("c++"),
             ]
         ),

--- a/Tests/MuxyTests/Models/NotificationSettingsTests.swift
+++ b/Tests/MuxyTests/Models/NotificationSettingsTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("NotificationSettings")
+struct NotificationSettingsTests {
+    @Test("defaults preserve current toast and sound delivery while desktop is off")
+    func defaultDeliveryPlan() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(NotificationSettings.toastEnabled(defaults: defaults))
+        #expect(!NotificationSettings.desktopEnabled(defaults: defaults))
+        #expect(NotificationSettings.soundRawValue(defaults: defaults) == NotificationSound.funk.rawValue)
+        #expect(NotificationSettings.sound(defaults: defaults) == .funk)
+        #expect(NotificationSettings.toastPosition(defaults: defaults) == .topCenter)
+        #expect(NotificationSettings.providerEnabled(providerID: "codex", defaults: defaults))
+
+        let plan = NotificationSettings.deliveryPlan(defaults: defaults)
+        #expect(plan == NotificationDeliveryPlan(
+            showToast: true,
+            showDesktop: false,
+            soundName: NotificationSound.funk.rawValue
+        ))
+    }
+
+    @Test("stored delivery preferences override defaults")
+    func storedDeliveryPreferences() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: NotificationSettings.Key.toastEnabled)
+        defaults.set(true, forKey: NotificationSettings.Key.desktopEnabled)
+        defaults.set(NotificationSound.ping.rawValue, forKey: NotificationSettings.Key.sound)
+        defaults.set(ToastPosition.bottomRight.rawValue, forKey: NotificationSettings.Key.toastPosition)
+        defaults.set(false, forKey: NotificationSettings.providerEnabledKey(for: "codex"))
+
+        #expect(!NotificationSettings.toastEnabled(defaults: defaults))
+        #expect(NotificationSettings.desktopEnabled(defaults: defaults))
+        #expect(NotificationSettings.sound(defaults: defaults) == .ping)
+        #expect(NotificationSettings.toastPosition(defaults: defaults) == .bottomRight)
+        #expect(!NotificationSettings.providerEnabled(providerID: "codex", defaults: defaults))
+
+        let plan = NotificationSettings.deliveryPlan(defaults: defaults)
+        #expect(plan == NotificationDeliveryPlan(
+            showToast: false,
+            showDesktop: true,
+            soundName: NotificationSound.ping.rawValue
+        ))
+    }
+
+    @Test("None sound suppresses sound delivery")
+    func noneSoundSuppressesDelivery() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(NotificationSound.none.rawValue, forKey: NotificationSettings.Key.sound)
+
+        #expect(NotificationSettings.sound(defaults: defaults) == NotificationSound.none)
+        #expect(NotificationSettings.deliveryPlan(defaults: defaults).soundName == nil)
+    }
+
+    @Test("invalid stored sound raw value is preserved for delivery compatibility")
+    func invalidSoundRawValueIsPreserved() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("Custom", forKey: NotificationSettings.Key.sound)
+
+        #expect(NotificationSettings.sound(defaults: defaults) == nil)
+        #expect(NotificationSettings.deliveryPlan(defaults: defaults).soundName == "Custom")
+    }
+
+    @Test("invalid toast position falls back to default")
+    func invalidToastPositionFallsBack() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("Middle", forKey: NotificationSettings.Key.toastPosition)
+
+        #expect(NotificationSettings.toastPosition(defaults: defaults) == .topCenter)
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "NotificationSettingsTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            Issue.record("Unable to create isolated UserDefaults suite")
+            throw NotificationSettingsTestError.unavailableDefaults
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}
+
+private enum NotificationSettingsTestError: Error {
+    case unavailableDefaults
+}

--- a/Tests/MuxyTests/Models/ToastStateTests.swift
+++ b/Tests/MuxyTests/Models/ToastStateTests.swift
@@ -1,0 +1,43 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("ToastState", .serialized)
+@MainActor
+struct ToastStateTests {
+    @Test("plain toasts keep the existing one-line message behavior")
+    func plainToast() {
+        let toast = ToastState.shared
+        defer { toast.dismiss() }
+
+        toast.show("Copied")
+
+        #expect(toast.message == "Copied")
+        #expect(toast.content == ToastContent(title: "Copied", body: nil, isActionable: false))
+    }
+
+    @Test("notification toasts store title body and action")
+    func notificationToast() {
+        let toast = ToastState.shared
+        var didActivate = false
+        defer { toast.dismiss() }
+
+        toast.show(title: "Build finished", body: "All tests passed") {
+            didActivate = true
+        }
+        toast.performAction()
+
+        #expect(didActivate)
+        #expect(toast.content == nil)
+    }
+
+    @Test("blank toast bodies are omitted")
+    func blankBody() {
+        let toast = ToastState.shared
+        defer { toast.dismiss() }
+
+        toast.show(title: "Done", body: "  \n  ")
+
+        #expect(toast.content == ToastContent(title: "Done", body: nil, isActionable: false))
+    }
+}

--- a/Tests/MuxyTests/Services/DesktopNotificationServiceTests.swift
+++ b/Tests/MuxyTests/Services/DesktopNotificationServiceTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import Testing
+import UserNotifications
+
+@testable import Muxy
+
+@Suite("DesktopNotificationService")
+@MainActor
+struct DesktopNotificationServiceTests {
+    @Test("payload builds an immediate request with visible content and minimal userInfo")
+    func payloadBuildsRequest() {
+        let notification = makeNotification(title: "Build finished", body: "All tests passed")
+        let payload = DesktopNotificationPayload(notification: notification)
+        let request = payload.makeRequest()
+
+        #expect(request.identifier == notification.id.uuidString)
+        #expect(request.trigger == nil)
+        #expect(request.content.title == "Build finished")
+        #expect(request.content.body == "All tests passed")
+        #expect(request.content.userInfo.count == 1)
+        #expect(DesktopNotificationPayload.notificationID(from: request.content.userInfo) == notification.id)
+    }
+
+    @Test("invalid payload userInfo does not resolve a notification ID")
+    func invalidPayloadUserInfo() {
+        #expect(DesktopNotificationPayload.notificationID(from: [:]) == nil)
+        #expect(DesktopNotificationPayload.notificationID(from: [
+            DesktopNotificationPayload.notificationIDUserInfoKey: "not-a-uuid",
+        ]) == nil)
+    }
+
+    @Test("foreground presentation is suppressed while the app owns in-app notification UI")
+    func foregroundPresentationIsSuppressed() {
+        let service = DesktopNotificationService(scheduler: UserNotificationSchedulerSpy())
+
+        #expect(service.foregroundPresentationOptions().isEmpty)
+    }
+
+    @Test("response handling only accepts default actions with a valid notification ID")
+    func responseHandlingFiltersActionsAndPayloads() {
+        let service = DesktopNotificationService(scheduler: UserNotificationSchedulerSpy())
+        let notification = makeNotification()
+
+        #expect(service.notificationIDForResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            from: [
+                DesktopNotificationPayload.notificationIDUserInfoKey: notification.id.uuidString,
+            ]
+        ) == notification.id)
+        #expect(service.notificationIDForResponse(
+            actionIdentifier: UNNotificationDismissActionIdentifier,
+            from: [
+                DesktopNotificationPayload.notificationIDUserInfoKey: notification.id.uuidString,
+            ]
+        ) == nil)
+        #expect(service.notificationIDForResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            from: [
+                DesktopNotificationPayload.notificationIDUserInfoKey: "not-a-uuid",
+            ]
+        ) == nil)
+    }
+
+    @Test("notification responses always complete exactly once")
+    func notificationResponsesCompleteExactlyOnce() async {
+        let service = DesktopNotificationService(scheduler: UserNotificationSchedulerSpy())
+        let notification = makeNotification()
+        let validCompletion = CompletionRecorder()
+        let dismissedCompletion = CompletionRecorder()
+        let invalidCompletion = CompletionRecorder()
+
+        service.handleNotificationResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            userInfo: [
+                DesktopNotificationPayload.notificationIDUserInfoKey: notification.id.uuidString,
+            ]
+        ) {
+            validCompletion.record()
+        }
+        service.handleNotificationResponse(
+            actionIdentifier: UNNotificationDismissActionIdentifier,
+            userInfo: [
+                DesktopNotificationPayload.notificationIDUserInfoKey: notification.id.uuidString,
+            ]
+        ) {
+            dismissedCompletion.record()
+        }
+        service.handleNotificationResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            userInfo: [
+                DesktopNotificationPayload.notificationIDUserInfoKey: "not-a-uuid",
+            ]
+        ) {
+            invalidCompletion.record()
+        }
+        await waitUntil {
+            validCompletion.count == 1 &&
+                dismissedCompletion.count == 1 &&
+                invalidCompletion.count == 1
+        }
+
+        #expect(validCompletion.count == 1)
+        #expect(dismissedCompletion.count == 1)
+        #expect(invalidCompletion.count == 1)
+    }
+
+    @Test("prepare installs the notification center delegate once")
+    func prepareInstallsDelegate() {
+        let scheduler = UserNotificationSchedulerSpy()
+        let service = DesktopNotificationService(scheduler: scheduler)
+
+        service.prepare()
+        let firstDelegate = scheduler.delegate
+        service.prepare()
+
+        #expect(firstDelegate != nil)
+        #expect(scheduler.delegate === firstDelegate)
+    }
+
+    @Test("authorized delivery schedules one local notification")
+    func authorizedDeliverySchedulesRequest() async {
+        let scheduler = UserNotificationSchedulerSpy(authorizationStatus: .authorized)
+        let service = DesktopNotificationService(scheduler: scheduler)
+        let notification = makeNotification()
+
+        service.deliver(notification)
+        await Task.yield()
+
+        #expect(scheduler.requests.count == 1)
+        #expect(scheduler.requests.first?.identifier == notification.id.uuidString)
+        #expect(scheduler.authorizationRequests.isEmpty)
+    }
+
+    @Test("undetermined delivery waits for settings to request permission")
+    func undeterminedDeliveryWaitsForSettingsAuthorization() async {
+        let scheduler = UserNotificationSchedulerSpy(authorizationStatus: .notDetermined, grantsAuthorization: true)
+        let service = DesktopNotificationService(scheduler: scheduler)
+
+        service.deliver(makeNotification())
+        await Task.yield()
+
+        #expect(scheduler.authorizationRequests.isEmpty)
+        #expect(scheduler.requests.isEmpty)
+    }
+
+    @Test("denied delivery does not schedule")
+    func deniedDeliveryDoesNotSchedule() async {
+        let scheduler = UserNotificationSchedulerSpy(authorizationStatus: .denied)
+        let service = DesktopNotificationService(scheduler: scheduler)
+
+        service.deliver(makeNotification())
+        await Task.yield()
+
+        #expect(scheduler.requests.isEmpty)
+        #expect(scheduler.authorizationRequests.isEmpty)
+    }
+
+    @Test("settings authorization callback reports denied permission")
+    func settingsAuthorizationReportsDeniedPermission() async throws {
+        let scheduler = UserNotificationSchedulerSpy(authorizationStatus: .notDetermined, grantsAuthorization: false)
+        let service = DesktopNotificationService(scheduler: scheduler)
+        var result: Bool?
+
+        service.requestAuthorizationIfNeeded { authorized in
+            result = authorized
+        }
+        await waitUntil { result != nil }
+
+        #expect(scheduler.authorizationRequests == [.alert])
+        #expect(result == false)
+    }
+
+    private func waitUntil(_ predicate: () -> Bool) async {
+        for _ in 0 ..< 20 {
+            if predicate() { return }
+            await Task.yield()
+        }
+    }
+
+    private func makeNotification(title: String = "Task completed", body: String = "Done") -> MuxyNotification {
+        MuxyNotification(
+            paneID: UUID(),
+            projectID: UUID(),
+            worktreeID: UUID(),
+            areaID: UUID(),
+            tabID: UUID(),
+            worktreePath: "/tmp/muxy",
+            source: .socket,
+            title: title,
+            body: body
+        )
+    }
+}
+
+private final class CompletionRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCount = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedCount
+    }
+
+    func record() {
+        lock.lock()
+        storedCount += 1
+        lock.unlock()
+    }
+}
+
+private final class UserNotificationSchedulerSpy: UserNotificationScheduling {
+    var delegate: (any UNUserNotificationCenterDelegate)?
+    var authorizationStatus: UNAuthorizationStatus
+    var grantsAuthorization: Bool
+    var authorizationRequests: [UNAuthorizationOptions] = []
+    var requests: [UNNotificationRequest] = []
+
+    init(authorizationStatus: UNAuthorizationStatus = .authorized, grantsAuthorization: Bool = true) {
+        self.authorizationStatus = authorizationStatus
+        self.grantsAuthorization = grantsAuthorization
+    }
+
+    func authorizationStatus(completionHandler: @escaping @Sendable (UNAuthorizationStatus) -> Void) {
+        completionHandler(authorizationStatus)
+    }
+
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping @Sendable (Bool, (any Error)?) -> Void
+    ) {
+        authorizationRequests.append(options)
+        if grantsAuthorization {
+            authorizationStatus = .authorized
+        }
+        completionHandler(grantsAuthorization, nil)
+    }
+
+    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: (@Sendable ((any Error)?) -> Void)?) {
+        requests.append(request)
+        completionHandler?(nil)
+    }
+}

--- a/docs/developer/architecture/notifications.md
+++ b/docs/developer/architecture/notifications.md
@@ -16,6 +16,7 @@ flowchart TB
   Nav --> Store[NotificationStore.add]
   Store -->|focused + active| Drop[suppress]
   Store --> Toast[Toast + sound]
+  Store --> Desktop[DesktopNotificationService<br/>UserNotifications]
   Store --> Persist[notifications.json<br/>debounced]
   Store --> UI[badge + panel]
 ```
@@ -28,7 +29,7 @@ flowchart TB
 
 ## Click-to-navigate
 
-`NotificationNavigator.navigate(to:)` dispatches `selectProject` → `focusArea` → `selectTab` against `AppState`. System notifications encode the navigation context in `userInfo` and bring the app to front on click.
+`NotificationNavigator.navigate(to:)` dispatches `selectProject` → `focusArea` → `selectTab` against `AppState`. Toast and desktop notification clicks look up the persisted notification by UUID, navigate with the stored context, and mark it read. Desktop notifications keep only the notification UUID in `userInfo`.
 
 ## Pane environment
 

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -8,6 +8,7 @@ flowchart TB
   Sock --> Server[NotificationSocketServer]
   Server --> Store[NotificationStore]
   Store --> Toast[Toast + sound]
+  Store --> Desktop[macOS desktop notification]
   Store --> Panel[Notification panel]
 ```
 
@@ -115,4 +116,4 @@ The built-in integrations are good templates:
 
 ## Delivery settings
 
-Muxy respects user choices under **Settings → Notifications**: toast on/off, position (top/bottom), sound. A dot also appears on the project and worktree rows in the sidebar until the notification is read.
+Muxy respects user choices under **Settings → Notifications**: toast on/off, macOS desktop notifications on/off, toast position, sound, and per-provider hook toggles. Toasts and desktop notifications show the same title/body and click through to the originating pane. Desktop notifications ask for macOS notification permission when enabled and contain only the visible title/body plus an internal notification ID for click-to-navigate. A dot also appears on the project and worktree rows in the sidebar until the notification is read.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -32,10 +32,11 @@ See [Keyboard Shortcuts](keyboard-shortcuts.md).
 
 ## Notifications
 
-- **Enable notifications** — global toggle.
+- **Toast** — show an in-app toast on arrival.
+- **Desktop notifications** — show a macOS notification when Muxy is not frontmost.
 - **Toast position** — top or bottom of the window.
 - **Sound** — play a system sound on arrival.
-- **Per‑source delivery** — separate toggles for Claude Code, OpenCode, OSC sequences, and the socket API.
+- **AI Providers** — enable or disable each provider hook integration.
 
 See [Notifications](../features/notifications.md).
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -48,7 +48,7 @@ After authenticating, restart Muxy or click **Refresh** in the PR list.
 
 ## Notifications aren't showing
 
-- Check **Settings → Notifications** that the global toggle and the relevant per‑source toggle are on.
+- Check **Settings → Notifications** that Toast or Desktop notifications are enabled and that the relevant provider integration is on.
 - macOS may have suppressed Muxy's system notifications — check **System Settings → Notifications → Muxy**.
 - For socket‑based integrations, verify the socket exists: `ls -l ~/Library/Application\ Support/Muxy/muxy.sock`.
 


### PR DESCRIPTION
Hello again!

This is a small PR that adds desktop notifications. It also extends the existing toast notification to match:

- Adds a setting for desktop notifications
- Adds a subtitle to the existing in-app toast notifications, adding notification content (matching desktop notifs)
- Adds click handler to both types of notifications, that switches to the workspace that caused the notification

<img width="367" height="80" alt="Screenshot 2026-05-12 at 3 47 50 PM" src="https://github.com/user-attachments/assets/80a78198-c5b1-4f1e-8840-497f0a6dac5c" />

<img width="413" height="77" alt="Screenshot 2026-05-12 at 4 23 55 PM" src="https://github.com/user-attachments/assets/28defb82-6321-4fa1-aa2b-6f315d711d54" />

<img width="490" height="93" alt="Screenshot 2026-05-12 at 4 24 22 PM" src="https://github.com/user-attachments/assets/0525b14d-0bfe-4170-bdc9-cd6c0ceb1226" />

Please let me know if you have any questions or concerns, and thanks for your consideration!

Best,
Paul