### PR TITLE
Add font family and line height controls for rich input panel

### DIFF
--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -37,6 +37,9 @@ final class EditorSettings {
     static let maxLineHeightMultiplier: CGFloat = 2.0
     static let lineHeightMultiplierStep: CGFloat = 0.1
 
+    static let defaultRichInputFontFamily = "SF Mono"
+    static let defaultRichInputLineHeightMultiplier: CGFloat = 1.2
+
     var fontSize: CGFloat = 13 { didSet { save() } }
     var fontFamily: String = "SF Mono" { didSet { save() } }
     var defaultEditor: DefaultEditor = .builtIn { didSet { save() } }
@@ -48,6 +51,11 @@ final class EditorSettings {
     var showLineNumbers: Bool = true { didSet { save() } }
 
     var lineHeightMultiplier: CGFloat = EditorSettings.defaultLineHeightMultiplier {
+        didSet { save() }
+    }
+
+    var richInputFontFamily: String = EditorSettings.defaultRichInputFontFamily { didSet { save() } }
+    var richInputLineHeightMultiplier: CGFloat = EditorSettings.defaultRichInputLineHeightMultiplier {
         didSet { save() }
     }
 
@@ -140,6 +148,8 @@ final class EditorSettings {
         lineWrapping = false
         showLineNumbers = true
         lineHeightMultiplier = Self.defaultLineHeightMultiplier
+        richInputFontFamily = Self.defaultRichInputFontFamily
+        richInputLineHeightMultiplier = Self.defaultRichInputLineHeightMultiplier
         richInputImageStrategy = .clipboard
         isBatchLoading = false
         save()
@@ -167,6 +177,13 @@ final class EditorSettings {
                 max(loadedMultiplier, Self.minLineHeightMultiplier),
                 Self.maxLineHeightMultiplier
             )
+            richInputFontFamily = snapshot.richInputFontFamily ?? Self.defaultRichInputFontFamily
+            let loadedRichInputMultiplier = snapshot.richInputLineHeightMultiplier
+                ?? Self.defaultRichInputLineHeightMultiplier
+            richInputLineHeightMultiplier = min(
+                max(loadedRichInputMultiplier, Self.minLineHeightMultiplier),
+                Self.maxLineHeightMultiplier
+            )
             richInputImageStrategy = snapshot.richInputImageStrategy ?? .clipboard
             isBatchLoading = false
         } catch {
@@ -189,6 +206,8 @@ final class EditorSettings {
                 lineWrapping: lineWrapping,
                 showLineNumbers: showLineNumbers,
                 lineHeightMultiplier: lineHeightMultiplier,
+                richInputFontFamily: richInputFontFamily,
+                richInputLineHeightMultiplier: richInputLineHeightMultiplier,
                 richInputImageStrategy: richInputImageStrategy
             ))
         } catch {
@@ -209,5 +228,7 @@ private struct Snapshot: Codable {
     let lineWrapping: Bool?
     let showLineNumbers: Bool?
     let lineHeightMultiplier: CGFloat?
+    let richInputFontFamily: String?
+    let richInputLineHeightMultiplier: CGFloat?
     let richInputImageStrategy: RichInputImageStrategy?
 }

--- a/Muxy/Views/Editor/Markdown/MarkdownTextEditor.swift
+++ b/Muxy/Views/Editor/Markdown/MarkdownTextEditor.swift
@@ -9,6 +9,7 @@ struct MarkdownTextEditor: NSViewRepresentable {
         var allowsUndo: Bool = true
         var lineWrapping: Bool = true
         var grabsFirstResponderOnAppear: Bool = false
+        var lineHeightMultiplier: CGFloat = 1.0
     }
 
     struct Callbacks {
@@ -48,6 +49,11 @@ struct MarkdownTextEditor: NSViewRepresentable {
         textContainer.lineFragmentPadding = 0
 
         let layoutManager = NSLayoutManager()
+        layoutManager.usesFontLeading = false
+        let lineHeightDelegate = LineHeightLayoutDelegate(fallbackFont: configuration.font)
+        lineHeightDelegate.lineHeightMultiplier = configuration.lineHeightMultiplier
+        layoutManager.delegate = lineHeightDelegate
+        context.coordinator.lineHeightDelegate = lineHeightDelegate
         layoutManager.addTextContainer(textContainer)
 
         let textStorage = NSTextStorage()
@@ -126,6 +132,16 @@ struct MarkdownTextEditor: NSViewRepresentable {
         textView.textContainerInset = configuration.insets
         textView.textColor = MarkdownTextEditor.defaultForeground()
         textView.insertionPointColor = MarkdownTextEditor.defaultForeground()
+        if let lineHeightDelegate = context.coordinator.lineHeightDelegate {
+            lineHeightDelegate.fallbackFont = configuration.font
+            if abs(lineHeightDelegate.lineHeightMultiplier - configuration.lineHeightMultiplier) > .ulpOfOne {
+                lineHeightDelegate.lineHeightMultiplier = configuration.lineHeightMultiplier
+                textView.layoutManager?.invalidateLayout(
+                    forCharacterRange: NSRange(location: 0, length: textView.string.utf16.count),
+                    actualCharacterRange: nil
+                )
+            }
+        }
         if context.coordinator.lastFocusVersion != focusVersion {
             context.coordinator.lastFocusVersion = focusVersion
             textView.grabFirstResponder()
@@ -145,6 +161,7 @@ struct MarkdownTextEditor: NSViewRepresentable {
         var parent: MarkdownTextEditor
         weak var textView: MarkdownEditingTextView?
         var lastFocusVersion: Int = -1
+        var lineHeightDelegate: LineHeightLayoutDelegate?
         private var lastReportedHeight: CGFloat = -1
 
         init(parent: MarkdownTextEditor) {

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -137,6 +137,58 @@ struct EditorSettingsView: View {
             }
 
             SettingsToggleRow(label: "Floating Panel", isOn: $richInputFloating)
+
+            SettingsRow("Font Family") {
+                Picker("", selection: $settings.richInputFontFamily) {
+                    ForEach(monoFonts, id: \.self) { family in
+                        Text(family)
+                            .font(.custom(family, size: 12))
+                            .tag(family)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
+            }
+
+            SettingsRow("Line Height") {
+                HStack(spacing: 8) {
+                    Button {
+                        settings.richInputLineHeightMultiplier = max(
+                            EditorSettings.minLineHeightMultiplier,
+                            settings.richInputLineHeightMultiplier - EditorSettings.lineHeightMultiplierStep
+                        )
+                    } label: {
+                        Image(systemName: "minus")
+                            .font(.system(size: 10, weight: .medium))
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(
+                        settings.richInputLineHeightMultiplier
+                            <= EditorSettings.minLineHeightMultiplier + 0.001
+                    )
+
+                    Text(String(format: "%.1f×", settings.richInputLineHeightMultiplier))
+                        .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
+                        .frame(width: 44)
+
+                    Button {
+                        settings.richInputLineHeightMultiplier = min(
+                            EditorSettings.maxLineHeightMultiplier,
+                            settings.richInputLineHeightMultiplier + EditorSettings.lineHeightMultiplierStep
+                        )
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 10, weight: .medium))
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(
+                        settings.richInputLineHeightMultiplier
+                            >= EditorSettings.maxLineHeightMultiplier - 0.001
+                    )
+                }
+            }
         }
 
         if showsAppearanceSection {

--- a/Muxy/Views/Terminal/RichInputSidePanel.swift
+++ b/Muxy/Views/Terminal/RichInputSidePanel.swift
@@ -8,6 +8,7 @@ struct RichInputSidePanel: View {
     let onDismiss: () -> Void
     let onSubmit: (_ appendReturn: Bool) -> Void
 
+    @State private var editorSettings = EditorSettings.shared
     @AppStorage(RichInputPreferences.fontSizeKey) private var fontSize: Double = RichInputPreferences.defaultFontSize
     @AppStorage(RichInputPreferences.positionKey) private var position: RichInputPanelPosition = RichInputPreferences
         .defaultPosition
@@ -59,11 +60,17 @@ struct RichInputSidePanel: View {
 
     private var editorConfiguration: MarkdownTextEditor.Configuration {
         MarkdownTextEditor.Configuration(
-            font: .systemFont(ofSize: clampedFontSize),
+            font: resolvedFont,
             insets: NSSize(width: 12, height: 10),
             lineWrapping: true,
-            grabsFirstResponderOnAppear: true
+            grabsFirstResponderOnAppear: true,
+            lineHeightMultiplier: editorSettings.richInputLineHeightMultiplier
         )
+    }
+
+    private var resolvedFont: NSFont {
+        NSFont(name: editorSettings.richInputFontFamily, size: clampedFontSize)
+            ?? .monospacedSystemFont(ofSize: clampedFontSize, weight: .regular)
     }
 
     private var editorCallbacks: MarkdownTextEditor.Callbacks {


### PR DESCRIPTION
Lets users customize the rich input editor's font family and line height from Editor Settings, matching the existing code editor controls. Settings persist across launches and default to SF Mono at 1.2×.