### PR TITLE
Fix Cmd-click on file paths surfacing 'application can't be opened. -50'

### DIFF
--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -255,9 +255,8 @@ struct TerminalBridge: NSViewRepresentable {
             Self.resolveFilePath(token, projectPath: projectPath) != nil
         }
         view.onOpenURL = { url in
-            if let projectID, url.isFileURL {
-                let path = url.path
-                guard !path.isEmpty, FileManager.default.fileExists(atPath: path) else { return false }
+            if let path = Self.resolveLocalFilePath(from: url, projectPath: projectPath) {
+                guard let projectID else { return false }
                 Task { @MainActor in
                     NotificationStore.shared.appState?.openFile(path, projectID: projectID, preserveFocus: true)
                 }
@@ -280,6 +279,20 @@ struct TerminalBridge: NSViewRepresentable {
         guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory) else { return nil }
         guard !isDirectory.boolValue else { return nil }
         return candidate
+    }
+
+    static func resolveLocalFilePath(from url: URL, projectPath: String) -> String? {
+        if url.isFileURL {
+            let path = url.path
+            guard !path.isEmpty else { return nil }
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else { return nil }
+            guard !isDirectory.boolValue else { return nil }
+            return path
+        }
+        guard url.scheme == nil else { return nil }
+        let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
+        return resolveFilePath(raw, projectPath: projectPath)
     }
 
     private func configureProgressCallback(_ view: GhosttyTerminalNSView) {

--- a/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
+++ b/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
@@ -68,4 +68,40 @@ struct TerminalBridgeResolveFilePathTests {
         let resolved = TerminalBridge.resolveFilePath("~/\(name)", projectPath: "/unused")
         #expect(resolved == path)
     }
+
+    @Test func resolvesLocalFilePathFromFileURL() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "doc.md")
+        let url = URL(fileURLWithPath: file)
+        #expect(TerminalBridge.resolveLocalFilePath(from: url, projectPath: "/unused") == file)
+    }
+
+    @Test func resolvesLocalFilePathFromSchemelessAbsolutePath() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "notes.md")
+        let url = try #require(URL(string: file))
+        #expect(TerminalBridge.resolveLocalFilePath(from: url, projectPath: "/unused") == file)
+    }
+
+    @Test func resolvesLocalFilePathFromSchemelessRelativePath() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "readme.md")
+        let url = try #require(URL(string: "readme.md"))
+        #expect(TerminalBridge.resolveLocalFilePath(from: url, projectPath: dir.path) == file)
+    }
+
+    @Test func resolvesLocalFilePathRejectsHttpURL() throws {
+        let url = try #require(URL(string: "https://example.com/readme.md"))
+        #expect(TerminalBridge.resolveLocalFilePath(from: url, projectPath: "/tmp") == nil)
+    }
+
+    @Test func resolvesLocalFilePathRejectsDirectoryFileURL() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = URL(fileURLWithPath: dir.path)
+        #expect(TerminalBridge.resolveLocalFilePath(from: url, projectPath: "/unused") == nil)
+    }
 }


### PR DESCRIPTION
Ghostty's link auto-detection fires OPEN_URL with a raw absolute path (no file:// scheme), so URL.isFileURL was false and the handler fell through to NSWorkspace.open — macOS then showed 'application can't be opened. -50'.

Route schemeless local paths through AppState.openFile, same as raw-word Cmd-click. Tests added.