### PR TITLE
Add on-device voice dictation panel

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -22,6 +22,7 @@ extension Notification.Name {
     static let vcsDidRefresh = Notification.Name("MuxyVCSDidRefresh")
     static let externalDragHoverChanged = Notification.Name("MuxyExternalDragHoverChanged")
     static let toggleRichInput = Notification.Name("MuxyToggleRichInput")
+    static let toggleVoiceRecording = Notification.Name("MuxyToggleVoiceRecording")
 }
 
 enum ExternalDragHoverUserInfoKey {

--- a/Muxy/Info.plist
+++ b/Muxy/Info.plist
@@ -47,7 +47,7 @@
 	<key>NSLocationUsageDescription</key>
 	<string>A process running in Muxy's terminal would like to access your location information.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>A process running in Muxy's terminal would like to use your microphone.</string>
+	<string>Muxy uses the microphone to record voice notes that you can attach to your terminal sessions.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>A process running in Muxy's terminal would like to access motion data.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/Muxy/Info.plist
+++ b/Muxy/Info.plist
@@ -47,7 +47,7 @@
 	<key>NSLocationUsageDescription</key>
 	<string>A process running in Muxy's terminal would like to access your location information.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Muxy uses the microphone to record voice notes that you can attach to your terminal sessions.</string>
+	<string>Muxy uses the microphone to transcribe your speech into text and insert it where you're typing.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>A process running in Muxy's terminal would like to access motion data.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -62,6 +62,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case navigateBack
     case navigateForward
     case toggleMaximizePane
+    case toggleVoiceRecording
 
     static let allCases: [Self] = [
         .newTab,
@@ -117,6 +118,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .navigateBack,
         .navigateForward,
         .toggleMaximizePane,
+        .toggleVoiceRecording,
     ]
 
     var id: String { rawValue }
@@ -184,6 +186,11 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .toggleAIUsage: ShortcutMetadata(displayName: "Toggle AI Usage", category: "App", scope: .mainWindow)
         case .navigateBack: ShortcutMetadata(displayName: "Navigate Back", category: "Navigation", scope: .mainWindow)
         case .navigateForward: ShortcutMetadata(displayName: "Navigate Forward", category: "Navigation", scope: .mainWindow)
+        case .toggleVoiceRecording: ShortcutMetadata(
+                displayName: "Voice Recording",
+                category: "Rich Input",
+                scope: .mainWindow
+            )
         case .toggleThemePicker: ShortcutMetadata(displayName: "Theme Picker", category: "App", scope: .mainWindow)
         case .newProject: ShortcutMetadata(displayName: "New Project", category: "App", scope: .mainWindow)
         case .openProject: ShortcutMetadata(displayName: "Open Project", category: "App", scope: .mainWindow)
@@ -309,5 +316,6 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .navigateBack, combo: KeyCombo(key: KeyCombo.leftArrowKey, command: true, control: true)),
         Self(action: .navigateForward, combo: KeyCombo(key: KeyCombo.rightArrowKey, command: true, control: true)),
         Self(action: .toggleMaximizePane, combo: KeyCombo(key: KeyCombo.returnKey, command: true, option: true)),
+        Self(action: .toggleVoiceRecording, combo: KeyCombo(key: "i", command: true, shift: true)),
     ]
 }

--- a/Muxy/Models/RecordingPreferences.swift
+++ b/Muxy/Models/RecordingPreferences.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum RecordingPreferences {
+    static let autoSendKey = "muxy.recording.autoSend"
+    static let defaultAutoSend = false
+    static let languageKey = "muxy.recording.language"
+}

--- a/Muxy/Models/RecordingPreferences.swift
+++ b/Muxy/Models/RecordingPreferences.swift
@@ -4,4 +4,5 @@ enum RecordingPreferences {
     static let autoSendKey = "muxy.recording.autoSend"
     static let defaultAutoSend = false
     static let languageKey = "muxy.recording.language"
+    static let defaultLanguage = ""
 }

--- a/Muxy/Models/VoiceRecordingState.swift
+++ b/Muxy/Models/VoiceRecordingState.swift
@@ -1,0 +1,124 @@
+import AppKit
+import AVFoundation
+import Foundation
+import Speech
+
+enum VoicePermissionState: Equatable {
+    case unknown
+    case granted
+    case denied
+}
+
+@MainActor
+@Observable
+final class VoiceRecordingState {
+    static let shared = VoiceRecordingState()
+
+    var isPanelVisible = false
+    var permission: VoicePermissionState = .unknown
+    var errorMessage: String?
+    let recorder = VoiceRecorder()
+
+    @ObservationIgnored private weak var capturedResponder: NSResponder?
+
+    private init() {
+        refreshPermission()
+    }
+
+    func toggle(autoSend: Bool, languageIdentifier: String) {
+        guard !isPanelVisible else { return }
+        present(autoSend: autoSend, languageIdentifier: languageIdentifier)
+    }
+
+    func present(autoSend _: Bool, languageIdentifier: String) {
+        guard !isPanelVisible else { return }
+        errorMessage = nil
+        capturedResponder = NSApp.keyWindow?.firstResponder
+        isPanelVisible = true
+        let resolvedLocale = Self.resolveLocale(from: languageIdentifier)
+        guard let resolvedLocale else {
+            errorMessage = "No on-device speech language is installed. Add one in System Settings → Keyboard → Dictation."
+            return
+        }
+        Task { @MainActor in
+            let granted = await VoiceRecorder.requestPermissions()
+            permission = granted ? .granted : .denied
+            guard granted else {
+                errorMessage = "Microphone or speech recognition is denied. Enable both in System Settings."
+                return
+            }
+            do {
+                try recorder.start(locale: resolvedLocale)
+            } catch {
+                errorMessage = readableMessage(for: error)
+            }
+        }
+    }
+
+    func finish(autoSend: Bool) {
+        guard isPanelVisible else { return }
+        let final = recorder.transcript
+        guard !final.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            errorMessage = "No speech detected. Try again or press Esc to close."
+            return
+        }
+        let responder = capturedResponder
+        cleanup()
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(220))
+            _ = recorder.finish()
+        }
+        TranscriptInserter.insert(text: final, into: responder, appendReturn: autoSend)
+    }
+
+    func cancel() {
+        guard isPanelVisible else { return }
+        cleanup()
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(220))
+            recorder.cancel()
+        }
+    }
+
+    func togglePause() {
+        guard recorder.isRecording else { return }
+        if recorder.isPaused {
+            recorder.resume()
+        } else {
+            recorder.pause()
+        }
+    }
+
+    func refreshPermission() {
+        permission = VoiceRecorder.currentPermissionStatus() ? .granted : .unknown
+    }
+
+    private static func resolveLocale(from identifier: String) -> Locale? {
+        if !identifier.isEmpty, let locale = SpeechLanguageCatalog.locale(for: identifier) {
+            return locale
+        }
+        if let fallback = SpeechLanguageCatalog.defaultIdentifier() {
+            return Locale(identifier: fallback)
+        }
+        return nil
+    }
+
+    private func cleanup() {
+        isPanelVisible = false
+        errorMessage = nil
+        capturedResponder = nil
+    }
+
+    private func readableMessage(for error: Error) -> String {
+        switch error {
+        case VoiceRecorderError.permissionDenied:
+            "Microphone access is denied. Enable it in System Settings."
+        case VoiceRecorderError.recognizerUnavailable:
+            "Speech recognition is unavailable on this device."
+        case let VoiceRecorderError.engineFailure(message):
+            "Recording failed: \(message)"
+        default:
+            error.localizedDescription
+        }
+    }
+}

--- a/Muxy/Models/VoiceRecordingState.swift
+++ b/Muxy/Models/VoiceRecordingState.swift
@@ -12,7 +12,7 @@ final class VoiceRecordingState {
     var errorMessage: String?
     let recorder = VoiceRecorder()
 
-    @ObservationIgnored private weak var capturedResponder: NSResponder?
+    @ObservationIgnored private var capturedResponder: NSResponder?
 
     private init() {}
 

--- a/Muxy/Models/VoiceRecordingState.swift
+++ b/Muxy/Models/VoiceRecordingState.swift
@@ -3,34 +3,20 @@ import AVFoundation
 import Foundation
 import Speech
 
-enum VoicePermissionState: Equatable {
-    case unknown
-    case granted
-    case denied
-}
-
 @MainActor
 @Observable
 final class VoiceRecordingState {
     static let shared = VoiceRecordingState()
 
     var isPanelVisible = false
-    var permission: VoicePermissionState = .unknown
     var errorMessage: String?
     let recorder = VoiceRecorder()
 
     @ObservationIgnored private weak var capturedResponder: NSResponder?
 
-    private init() {
-        refreshPermission()
-    }
+    private init() {}
 
-    func toggle(autoSend: Bool, languageIdentifier: String) {
-        guard !isPanelVisible else { return }
-        present(autoSend: autoSend, languageIdentifier: languageIdentifier)
-    }
-
-    func present(autoSend _: Bool, languageIdentifier: String) {
+    func present(languageIdentifier: String) {
         guard !isPanelVisible else { return }
         errorMessage = nil
         capturedResponder = NSApp.keyWindow?.firstResponder
@@ -42,7 +28,6 @@ final class VoiceRecordingState {
         }
         Task { @MainActor in
             let granted = await VoiceRecorder.requestPermissions()
-            permission = granted ? .granted : .denied
             guard granted else {
                 errorMessage = "Microphone or speech recognition is denied. Enable both in System Settings."
                 return
@@ -57,27 +42,20 @@ final class VoiceRecordingState {
 
     func finish(autoSend: Bool) {
         guard isPanelVisible else { return }
-        let final = recorder.transcript
+        let final = recorder.finish()
         guard !final.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             errorMessage = "No speech detected. Try again or press Esc to close."
             return
         }
         let responder = capturedResponder
         cleanup()
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(220))
-            _ = recorder.finish()
-        }
         TranscriptInserter.insert(text: final, into: responder, appendReturn: autoSend)
     }
 
     func cancel() {
         guard isPanelVisible else { return }
+        recorder.cancel()
         cleanup()
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(220))
-            recorder.cancel()
-        }
     }
 
     func togglePause() {
@@ -87,10 +65,6 @@ final class VoiceRecordingState {
         } else {
             recorder.pause()
         }
-    }
-
-    func refreshPermission() {
-        permission = VoiceRecorder.currentPermissionStatus() ? .granted : .unknown
     }
 
     private static func resolveLocale(from identifier: String) -> Locale? {
@@ -111,8 +85,6 @@ final class VoiceRecordingState {
 
     private func readableMessage(for error: Error) -> String {
         switch error {
-        case VoiceRecorderError.permissionDenied:
-            "Microphone access is denied. Enable it in System Settings."
         case VoiceRecorderError.recognizerUnavailable:
             "Speech recognition is unavailable on this device."
         case let VoiceRecorderError.engineFailure(message):

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -174,6 +174,8 @@ struct ShortcutActionDispatcher {
             else { return false }
             appState.toggleMaximize(areaID: areaID, for: projectID)
             return true
+        case .toggleVoiceRecording:
+            return false
         case .selectTab1,
              .selectTab2,
              .selectTab3,

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -174,9 +174,8 @@ struct ShortcutActionDispatcher {
             else { return false }
             appState.toggleMaximize(areaID: areaID, for: projectID)
             return true
-        case .toggleVoiceRecording:
-            return false
-        case .selectTab1,
+        case .toggleVoiceRecording,
+             .selectTab1,
              .selectTab2,
              .selectTab3,
              .selectTab4,

--- a/Muxy/Services/SpeechLanguageCatalog.swift
+++ b/Muxy/Services/SpeechLanguageCatalog.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Speech
+
+struct SpeechLanguage: Identifiable, Hashable {
+    let identifier: String
+    let displayName: String
+
+    var id: String { identifier }
+}
+
+enum SpeechLanguageCatalog {
+    private static let cacheLock = NSLock()
+    nonisolated(unsafe) private static var cachedLanguages: [SpeechLanguage]?
+
+    static func onDeviceLanguages() -> [SpeechLanguage] {
+        cacheLock.lock()
+        if let cached = cachedLanguages {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        let computed = computeOnDeviceLanguages()
+
+        cacheLock.lock()
+        cachedLanguages = computed
+        cacheLock.unlock()
+        return computed
+    }
+
+    static func defaultIdentifier() -> String? {
+        let supported = onDeviceLanguages()
+        let current = Locale.current.identifier
+        if supported.contains(where: { $0.identifier == current }) { return current }
+        let language = Locale.current.language.languageCode?.identifier
+        if let language, let match = supported.first(where: { $0.identifier.hasPrefix(language) }) {
+            return match.identifier
+        }
+        return supported.first?.identifier
+    }
+
+    static func locale(for identifier: String) -> Locale? {
+        guard !identifier.isEmpty else { return nil }
+        return Locale(identifier: identifier)
+    }
+
+    private static func computeOnDeviceLanguages() -> [SpeechLanguage] {
+        let displayLocale = Locale.current
+        var seen = Set<String>()
+        let languages = SFSpeechRecognizer.supportedLocales()
+            .compactMap { locale -> SpeechLanguage? in
+                guard let recognizer = SFSpeechRecognizer(locale: locale),
+                      recognizer.supportsOnDeviceRecognition
+                else { return nil }
+                let identifier = locale.identifier
+                guard seen.insert(identifier).inserted else { return nil }
+                let name = displayLocale.localizedString(forIdentifier: identifier)
+                    ?? identifier
+                return SpeechLanguage(identifier: identifier, displayName: name)
+            }
+        return languages.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+}

--- a/Muxy/Services/SpeechLanguageCatalog.swift
+++ b/Muxy/Services/SpeechLanguageCatalog.swift
@@ -8,23 +8,14 @@ struct SpeechLanguage: Identifiable, Hashable {
     var id: String { identifier }
 }
 
+@MainActor
 enum SpeechLanguageCatalog {
-    private static let cacheLock = NSLock()
-    nonisolated(unsafe) private static var cachedLanguages: [SpeechLanguage]?
+    private static var cachedLanguages: [SpeechLanguage]?
 
     static func onDeviceLanguages() -> [SpeechLanguage] {
-        cacheLock.lock()
-        if let cached = cachedLanguages {
-            cacheLock.unlock()
-            return cached
-        }
-        cacheLock.unlock()
-
+        if let cachedLanguages { return cachedLanguages }
         let computed = computeOnDeviceLanguages()
-
-        cacheLock.lock()
         cachedLanguages = computed
-        cacheLock.unlock()
         return computed
     }
 
@@ -54,8 +45,7 @@ enum SpeechLanguageCatalog {
                 else { return nil }
                 let identifier = locale.identifier
                 guard seen.insert(identifier).inserted else { return nil }
-                let name = displayLocale.localizedString(forIdentifier: identifier)
-                    ?? identifier
+                let name = displayLocale.localizedString(forIdentifier: identifier) ?? identifier
                 return SpeechLanguage(identifier: identifier, displayName: name)
             }
         return languages.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }

--- a/Muxy/Services/TranscriptInserter.swift
+++ b/Muxy/Services/TranscriptInserter.swift
@@ -1,0 +1,117 @@
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+
+@MainActor
+enum TranscriptInserter {
+    static func insert(
+        text: String,
+        into responder: NSResponder?,
+        appendReturn: Bool
+    ) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        guard let responder, let window = window(for: responder) else {
+            copyToClipboardWithToast(trimmed)
+            return
+        }
+
+        window.makeKey()
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeFirstResponder(responder)
+
+        if let terminal = nearestGhosttyView(from: responder) {
+            sendToTerminal(text: trimmed, view: terminal, appendReturn: appendReturn)
+            return
+        }
+
+        if let textView = responder as? NSTextView {
+            textView.insertText(trimmed, replacementRange: textView.selectedRange())
+            if appendReturn {
+                postReturnKey()
+            }
+            return
+        }
+
+        if let control = responder as? NSTextField {
+            insert(text: trimmed, into: control, appendReturn: appendReturn)
+            return
+        }
+
+        if let textInput = responder as? NSTextInputClient {
+            textInput.insertText(trimmed, replacementRange: NSRange(location: NSNotFound, length: 0))
+            if appendReturn {
+                postReturnKey()
+            }
+            return
+        }
+
+        copyToClipboardWithToast(trimmed)
+    }
+
+    private static func window(for responder: NSResponder) -> NSWindow? {
+        if let view = responder as? NSView { return view.window }
+        if let viewController = responder as? NSViewController { return viewController.view.window }
+        if let window = responder as? NSWindow { return window }
+        return NSApp.keyWindow
+    }
+
+    private static func nearestGhosttyView(from responder: NSResponder) -> GhosttyTerminalNSView? {
+        var current: NSResponder? = responder
+        while let node = current {
+            if let view = node as? GhosttyTerminalNSView { return view }
+            current = node.nextResponder
+        }
+        if let view = responder as? NSView {
+            var ancestor: NSView? = view
+            while let node = ancestor {
+                if let view = node as? GhosttyTerminalNSView { return view }
+                ancestor = node.superview
+            }
+        }
+        return nil
+    }
+
+    private static func sendToTerminal(text: String, view: GhosttyTerminalNSView, appendReturn: Bool) {
+        let sanitized = text.replacingOccurrences(of: "\u{1B}[201~", with: "")
+        var payload = Data()
+        payload.append(TerminalControlBytes.bracketedPasteStart)
+        payload.append(Data(sanitized.utf8))
+        payload.append(TerminalControlBytes.bracketedPasteEnd)
+        if appendReturn {
+            payload.append(TerminalControlBytes.carriageReturn)
+        }
+        view.sendRemoteBytes(payload)
+        view.window?.makeFirstResponder(view)
+    }
+
+    private static func insert(text: String, into textField: NSTextField, appendReturn: Bool) {
+        if let editor = textField.currentEditor() as? NSTextView {
+            editor.insertText(text, replacementRange: editor.selectedRange())
+        } else {
+            let current = textField.stringValue
+            textField.stringValue = current + text
+        }
+        if appendReturn {
+            postReturnKey()
+        }
+    }
+
+    private static func postReturnKey() {
+        guard let source = CGEventSource(stateID: .combinedSessionState) else { return }
+        if let down = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(kVK_Return), keyDown: true) {
+            down.post(tap: .cghidEventTap)
+        }
+        if let up = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(kVK_Return), keyDown: false) {
+            up.post(tap: .cghidEventTap)
+        }
+    }
+
+    private static func copyToClipboardWithToast(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        ToastState.shared.show("Transcript copied to clipboard")
+    }
+}

--- a/Muxy/Services/TranscriptInserter.swift
+++ b/Muxy/Services/TranscriptInserter.swift
@@ -12,21 +12,22 @@ enum TranscriptInserter {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        guard let responder, let window = window(for: responder) else {
+        let target = resolveTarget(preferred: responder)
+        guard let target, let window = window(for: target) else {
             copyToClipboardWithToast(trimmed)
             return
         }
 
         window.makeKey()
         NSApp.activate(ignoringOtherApps: true)
-        window.makeFirstResponder(responder)
+        window.makeFirstResponder(target)
 
-        if let terminal = nearestGhosttyView(from: responder) {
+        if let terminal = nearestGhosttyView(from: target) {
             sendToTerminal(text: trimmed, view: terminal, appendReturn: appendReturn)
             return
         }
 
-        if let textView = responder as? NSTextView {
+        if let textView = target as? NSTextView {
             textView.insertText(trimmed, replacementRange: textView.selectedRange())
             if appendReturn {
                 postReturnKey()
@@ -34,12 +35,12 @@ enum TranscriptInserter {
             return
         }
 
-        if let control = responder as? NSTextField {
+        if let control = target as? NSTextField {
             insert(text: trimmed, into: control, appendReturn: appendReturn)
             return
         }
 
-        if let textInput = responder as? NSTextInputClient {
+        if let textInput = target as? NSTextInputClient {
             textInput.insertText(trimmed, replacementRange: NSRange(location: NSNotFound, length: 0))
             if appendReturn {
                 postReturnKey()
@@ -48,6 +49,27 @@ enum TranscriptInserter {
         }
 
         copyToClipboardWithToast(trimmed)
+    }
+
+    private static func resolveTarget(preferred: NSResponder?) -> NSResponder? {
+        if let preferred, window(for: preferred) != nil {
+            return preferred
+        }
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow,
+           let terminal = firstGhosttyView(in: window.contentView)
+        {
+            return terminal
+        }
+        return NSApp.keyWindow?.firstResponder
+    }
+
+    private static func firstGhosttyView(in root: NSView?) -> GhosttyTerminalNSView? {
+        guard let root else { return nil }
+        if let terminal = root as? GhosttyTerminalNSView { return terminal }
+        for subview in root.subviews {
+            if let terminal = firstGhosttyView(in: subview) { return terminal }
+        }
+        return nil
     }
 
     private static func window(for responder: NSResponder) -> NSWindow? {

--- a/Muxy/Services/TranscriptInserter.swift
+++ b/Muxy/Services/TranscriptInserter.swift
@@ -58,17 +58,11 @@ enum TranscriptInserter {
     }
 
     private static func nearestGhosttyView(from responder: NSResponder) -> GhosttyTerminalNSView? {
-        var current: NSResponder? = responder
-        while let node = current {
-            if let view = node as? GhosttyTerminalNSView { return view }
-            current = node.nextResponder
-        }
-        if let view = responder as? NSView {
-            var ancestor: NSView? = view
-            while let node = ancestor {
-                if let view = node as? GhosttyTerminalNSView { return view }
-                ancestor = node.superview
-            }
+        guard let view = responder as? NSView else { return nil }
+        var ancestor: NSView? = view
+        while let node = ancestor {
+            if let terminal = node as? GhosttyTerminalNSView { return terminal }
+            ancestor = node.superview
         }
         return nil
     }

--- a/Muxy/Services/VoiceRecorder.swift
+++ b/Muxy/Services/VoiceRecorder.swift
@@ -1,0 +1,289 @@
+import AVFoundation
+import Foundation
+import os
+import Speech
+
+private let logger = Logger(subsystem: "app.muxy", category: "VoiceRecorder")
+
+enum VoiceRecorderError: Error {
+    case permissionDenied
+    case recognizerUnavailable
+    case engineFailure(String)
+}
+
+@MainActor
+@Observable
+final class VoiceRecorder {
+    private(set) var isRecording = false
+    private(set) var isPaused = false
+    private(set) var elapsed: TimeInterval = 0
+    private(set) var level: Float = 0
+    private(set) var transcript: String = ""
+
+    @ObservationIgnored private let engine = AVAudioEngine()
+    @ObservationIgnored private var recognizer: SFSpeechRecognizer?
+    @ObservationIgnored private var request: SFSpeechAudioBufferRecognitionRequest?
+    @ObservationIgnored private var task: SFSpeechRecognitionTask?
+    @ObservationIgnored private var startedAt: Date?
+    @ObservationIgnored private var accumulatedBeforePause: TimeInterval = 0
+    @ObservationIgnored private var elapsedTimer: Timer?
+    @ObservationIgnored private var levelSink: LevelSink?
+    @ObservationIgnored private var transcriptSink: TranscriptSink?
+
+    func start(locale: Locale) throws {
+        guard let recognizer = SFSpeechRecognizer(locale: locale),
+              recognizer.isAvailable
+        else {
+            throw VoiceRecorderError.recognizerUnavailable
+        }
+        guard recognizer.supportsOnDeviceRecognition else {
+            throw VoiceRecorderError.engineFailure(
+                "On-device speech recognition is unavailable for this language. Open Settings → Recording to pick another."
+            )
+        }
+        self.recognizer = recognizer
+        recognizer.defaultTaskHint = .dictation
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        request.requiresOnDeviceRecognition = true
+        self.request = request
+
+        let levelSink = LevelSink { [weak self] normalized in
+            guard let self else { return }
+            self.level = normalized
+        }
+        self.levelSink = levelSink
+        Self.installTapNonisolated(on: engine.inputNode, request: request, sink: levelSink)
+
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            throw VoiceRecorderError.engineFailure(error.localizedDescription)
+        }
+
+        let transcriptSink = TranscriptSink { [weak self] text, _ in
+            guard let self else { return }
+            self.transcript = text
+        }
+        self.transcriptSink = transcriptSink
+        task = Self.startRecognitionTaskNonisolated(
+            recognizer: recognizer,
+            request: request,
+            sink: transcriptSink
+        )
+
+        startedAt = Date()
+        accumulatedBeforePause = 0
+        elapsed = 0
+        level = 0
+        transcript = ""
+        isRecording = true
+        isPaused = false
+        startElapsedTimer()
+    }
+
+    func pause() {
+        guard isRecording, !isPaused else { return }
+        engine.pause()
+        if let startedAt {
+            accumulatedBeforePause += Date().timeIntervalSince(startedAt)
+        }
+        startedAt = nil
+        isPaused = true
+        level = 0
+        stopElapsedTimer()
+    }
+
+    func resume() {
+        guard isRecording, isPaused else { return }
+        do {
+            try engine.start()
+        } catch {
+            logger.error("Failed to resume engine: \(error.localizedDescription)")
+            return
+        }
+        startedAt = Date()
+        isPaused = false
+        startElapsedTimer()
+    }
+
+    func finish() -> String {
+        let final = transcript
+        teardown()
+        return final
+    }
+
+    func cancel() {
+        teardown()
+    }
+
+    nonisolated static func requestPermissions() async -> Bool {
+        let mic = await withCheckedContinuation { continuation in
+            AVCaptureDevice.requestAccess(for: .audio) { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+        guard mic else { return false }
+        return await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+
+    nonisolated static func currentPermissionStatus() -> Bool {
+        let mic = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        let speech = SFSpeechRecognizer.authorizationStatus() == .authorized
+        return mic && speech
+    }
+
+    private func teardown() {
+        stopElapsedTimer()
+        engine.inputNode.removeTap(onBus: 0)
+        if engine.isRunning {
+            engine.stop()
+        }
+        request?.endAudio()
+        task?.cancel()
+        levelSink?.detach()
+        levelSink = nil
+        transcriptSink?.detach()
+        transcriptSink = nil
+        request = nil
+        task = nil
+        recognizer = nil
+        startedAt = nil
+        accumulatedBeforePause = 0
+        isRecording = false
+        isPaused = false
+        level = 0
+    }
+
+    private func startElapsedTimer() {
+        stopElapsedTimer()
+        let timer = Timer(timeInterval: 0.1, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        elapsedTimer = timer
+    }
+
+    private func stopElapsedTimer() {
+        elapsedTimer?.invalidate()
+        elapsedTimer = nil
+    }
+
+    private func tick() {
+        guard let startedAt else { return }
+        elapsed = accumulatedBeforePause + Date().timeIntervalSince(startedAt)
+    }
+
+    nonisolated static func averagePower(in buffer: AVAudioPCMBuffer) -> Float {
+        guard let channel = buffer.floatChannelData?[0] else { return -160 }
+        let frames = Int(buffer.frameLength)
+        guard frames > 0 else { return -160 }
+        var sum: Float = 0
+        for i in 0 ..< frames {
+            let sample = channel[i]
+            sum += sample * sample
+        }
+        let rms = sqrt(sum / Float(frames))
+        guard rms > 0 else { return -160 }
+        return 20 * log10(rms)
+    }
+
+    nonisolated static func startRecognitionTaskNonisolated(
+        recognizer: SFSpeechRecognizer,
+        request: SFSpeechAudioBufferRecognitionRequest,
+        sink: TranscriptSink
+    ) -> SFSpeechRecognitionTask {
+        let handler: @Sendable (SFSpeechRecognitionResult?, Error?) -> Void = { result, _ in
+            guard let result else { return }
+            let text = result.bestTranscription.formattedString
+            sink.publish(text, isFinal: result.isFinal)
+        }
+        return recognizer.recognitionTask(with: request, resultHandler: handler)
+    }
+
+    nonisolated static func installTapNonisolated(
+        on inputNode: AVAudioInputNode,
+        request: SFSpeechAudioBufferRecognitionRequest,
+        sink: LevelSink
+    ) {
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.removeTap(onBus: 0)
+        let requestBox = UncheckedBox(request)
+        let block: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void = { buffer, _ in
+            requestBox.value.append(buffer)
+            let normalized = normalize(power: averagePower(in: buffer))
+            sink.publish(normalized)
+        }
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format, block: block)
+    }
+
+    nonisolated static func normalize(power db: Float) -> Float {
+        let floor: Float = -50
+        guard db.isFinite else { return 0 }
+        let clamped = max(min(db, 0), floor)
+        return (clamped - floor) / -floor
+    }
+}
+
+struct UncheckedBox<T>: @unchecked Sendable {
+    let value: T
+    init(_ value: T) {
+        self.value = value
+    }
+}
+
+final class TranscriptSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handler: (@MainActor (String, Bool) -> Void)?
+
+    init(handler: @escaping @MainActor (String, Bool) -> Void) {
+        self.handler = handler
+    }
+
+    func publish(_ value: String, isFinal: Bool) {
+        lock.lock()
+        let current = handler
+        lock.unlock()
+        guard let current else { return }
+        Task { @MainActor in
+            current(value, isFinal)
+        }
+    }
+
+    func detach() {
+        lock.lock()
+        handler = nil
+        lock.unlock()
+    }
+}
+
+final class LevelSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handler: (@MainActor (Float) -> Void)?
+
+    init(handler: @escaping @MainActor (Float) -> Void) {
+        self.handler = handler
+    }
+
+    func publish(_ value: Float) {
+        lock.lock()
+        let current = handler
+        lock.unlock()
+        guard let current else { return }
+        Task { @MainActor in
+            current(value)
+        }
+    }
+
+    func detach() {
+        lock.lock()
+        handler = nil
+        lock.unlock()
+    }
+}

--- a/Muxy/Services/VoiceRecorder.swift
+++ b/Muxy/Services/VoiceRecorder.swift
@@ -59,6 +59,11 @@ final class VoiceRecorder {
         do {
             try engine.start()
         } catch {
+            engine.inputNode.removeTap(onBus: 0)
+            levelSink.detach()
+            self.levelSink = nil
+            self.request = nil
+            self.recognizer = nil
             throw VoiceRecorderError.engineFailure(error.localizedDescription)
         }
 
@@ -262,18 +267,25 @@ final class TranscriptSink: @unchecked Sendable {
 }
 
 final class LevelSink: @unchecked Sendable {
+    private static let minInterval: TimeInterval = 1.0 / 15.0
+
     private let lock = NSLock()
     private var handler: (@MainActor (Float) -> Void)?
+    private var lastPublishedAt: TimeInterval = 0
 
     init(handler: @escaping @MainActor (Float) -> Void) {
         self.handler = handler
     }
 
     func publish(_ value: Float) {
+        let now = ProcessInfo.processInfo.systemUptime
         lock.lock()
-        let current = handler
+        guard let current = handler, now - lastPublishedAt >= Self.minInterval else {
+            lock.unlock()
+            return
+        }
+        lastPublishedAt = now
         lock.unlock()
-        guard let current else { return }
         Task { @MainActor in
             current(value)
         }

--- a/Muxy/Services/VoiceRecorder.swift
+++ b/Muxy/Services/VoiceRecorder.swift
@@ -6,7 +6,6 @@ import Speech
 private let logger = Logger(subsystem: "app.muxy", category: "VoiceRecorder")
 
 enum VoiceRecorderError: Error {
-    case permissionDenied
     case recognizerUnavailable
     case engineFailure(String)
 }
@@ -63,7 +62,7 @@ final class VoiceRecorder {
             throw VoiceRecorderError.engineFailure(error.localizedDescription)
         }
 
-        let transcriptSink = TranscriptSink { [weak self] text, _ in
+        let transcriptSink = TranscriptSink { [weak self] text in
             guard let self else { return }
             self.transcript = text
         }
@@ -201,8 +200,7 @@ final class VoiceRecorder {
     ) -> SFSpeechRecognitionTask {
         let handler: @Sendable (SFSpeechRecognitionResult?, Error?) -> Void = { result, _ in
             guard let result else { return }
-            let text = result.bestTranscription.formattedString
-            sink.publish(text, isFinal: result.isFinal)
+            sink.publish(result.bestTranscription.formattedString)
         }
         return recognizer.recognitionTask(with: request, resultHandler: handler)
     }
@@ -240,19 +238,19 @@ struct UncheckedBox<T>: @unchecked Sendable {
 
 final class TranscriptSink: @unchecked Sendable {
     private let lock = NSLock()
-    private var handler: (@MainActor (String, Bool) -> Void)?
+    private var handler: (@MainActor (String) -> Void)?
 
-    init(handler: @escaping @MainActor (String, Bool) -> Void) {
+    init(handler: @escaping @MainActor (String) -> Void) {
         self.handler = handler
     }
 
-    func publish(_ value: String, isFinal: Bool) {
+    func publish(_ value: String) {
         lock.lock()
         let current = handler
         lock.unlock()
         guard let current else { return }
         Task { @MainActor in
-            current(value, isFinal)
+            current(value)
         }
     }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -86,6 +86,9 @@ struct MainWindow: View {
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage("muxy.notifications.toastPosition") private var toastPositionRaw = ToastPosition.topCenter.rawValue
+    @AppStorage(RecordingPreferences.autoSendKey) private var recordingAutoSend = RecordingPreferences.defaultAutoSend
+    @AppStorage(RecordingPreferences.languageKey) private var recordingLanguage = ""
+    @State private var voiceRecording = VoiceRecordingState.shared
     @MainActor private var trafficLightWidth: CGFloat { UIMetrics.scaled(75) }
 
     var body: some View {
@@ -174,6 +177,13 @@ struct MainWindow: View {
             }
         }
         .environment(\.overlayActive, showQuickOpen || showFindInFiles || showWorktreeSwitcher || overlayAnimatingOut)
+        .overlay(alignment: .bottom) {
+            if voiceRecording.isPanelVisible {
+                VoiceRecordingPanel(state: voiceRecording, autoSend: recordingAutoSend)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: voiceRecording.isPanelVisible)
         .overlay(alignment: toastAlignment) {
             if let toast = ToastState.shared.message {
                 HStack(spacing: UIMetrics.spacing3) {
@@ -283,7 +293,8 @@ struct MainWindow: View {
         .modifier(SidePanelNotificationListeners(
             onToggleAttachedVCS: { toggleAttachedVCSPanel() },
             onToggleFileTree: { toggleFileTreePanel() },
-            onToggleRichInput: { toggleRichInputPanel() }
+            onToggleRichInput: { toggleRichInputPanel() },
+            onToggleVoiceRecording: { _ = openVoiceRecorder() }
         ))
         .onChange(of: vcsPruneSignature) {
             pruneFileTreeStates()
@@ -683,9 +694,24 @@ struct MainWindow: View {
     }
 
     private func handleShortcutAction(_ action: ShortcutAction) -> Bool {
-        shortcutDispatcher.perform(action, activeProject: activeProject) { project in
+        if action == .toggleVoiceRecording {
+            return openVoiceRecorder()
+        }
+        return shortcutDispatcher.perform(action, activeProject: activeProject) { project in
             openVCS(for: project)
         }
+    }
+
+    private func openVoiceRecorder() -> Bool {
+        if voiceRecording.isPanelVisible {
+            voiceRecording.cancel()
+            return true
+        }
+        voiceRecording.present(
+            autoSend: recordingAutoSend,
+            languageIdentifier: recordingLanguage
+        )
+        return true
     }
 
     private func handleCommandShortcut(_ shortcut: CommandShortcut) -> Bool {
@@ -1406,6 +1432,7 @@ private struct SidePanelNotificationListeners: ViewModifier {
     let onToggleAttachedVCS: () -> Void
     let onToggleFileTree: () -> Void
     let onToggleRichInput: () -> Void
+    let onToggleVoiceRecording: () -> Void
 
     func body(content: Content) -> some View {
         content
@@ -1417,6 +1444,9 @@ private struct SidePanelNotificationListeners: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .toggleRichInput)) { _ in
                 onToggleRichInput()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .toggleVoiceRecording)) { _ in
+                onToggleVoiceRecording()
             }
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -707,10 +707,7 @@ struct MainWindow: View {
             voiceRecording.cancel()
             return true
         }
-        voiceRecording.present(
-            autoSend: recordingAutoSend,
-            languageIdentifier: recordingLanguage
-        )
+        voiceRecording.present(languageIdentifier: recordingLanguage)
         return true
     }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -87,7 +87,7 @@ struct MainWindow: View {
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage("muxy.notifications.toastPosition") private var toastPositionRaw = ToastPosition.topCenter.rawValue
     @AppStorage(RecordingPreferences.autoSendKey) private var recordingAutoSend = RecordingPreferences.defaultAutoSend
-    @AppStorage(RecordingPreferences.languageKey) private var recordingLanguage = ""
+    @AppStorage(RecordingPreferences.languageKey) private var recordingLanguage = RecordingPreferences.defaultLanguage
     @State private var voiceRecording = VoiceRecordingState.shared
     @MainActor private var trafficLightWidth: CGFloat { UIMetrics.scaled(75) }
 

--- a/Muxy/Views/Settings/RecordingSettingsView.swift
+++ b/Muxy/Views/Settings/RecordingSettingsView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct RecordingSettingsView: View {
+    @AppStorage(RecordingPreferences.autoSendKey) private var autoSend = RecordingPreferences.defaultAutoSend
+    @AppStorage(RecordingPreferences.languageKey) private var languageIdentifier = ""
+
+    @State private var languages: [SpeechLanguage] = []
+
+    var body: some View {
+        SettingsContainer {
+            SettingsSection(
+                "Voice Recording",
+                footer: "Press the Voice Recording shortcut to dictate. "
+                    + "Muxy transcribes your speech on-device and inserts it wherever your cursor was before "
+                    + "you opened the recorder. If that target is gone, the transcript lands on your clipboard."
+            ) {
+                SettingsToggleRow(
+                    label: "Press Return after inserting",
+                    isOn: $autoSend
+                )
+            }
+
+            SettingsSection(
+                "Language",
+                footer: languageFooter,
+                showsDivider: false
+            ) {
+                languagePicker
+            }
+        }
+        .onAppear(perform: loadLanguages)
+    }
+
+    private var languageFooter: String {
+        if languages.isEmpty {
+            return "No on-device speech models are installed. "
+                + "Add a dictation language in System Settings → Keyboard → Dictation, then return here."
+        }
+        return "Only languages with an on-device model are listed. Transcription never leaves your Mac."
+    }
+
+    @ViewBuilder
+    private var languagePicker: some View {
+        if languages.isEmpty {
+            SettingsRow("Language") {
+                Text("None available")
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            SettingsRow("Language") {
+                Picker("", selection: resolvedSelection) {
+                    ForEach(languages) { language in
+                        Text(language.displayName).tag(language.identifier)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
+            }
+        }
+    }
+
+    private var resolvedSelection: Binding<String> {
+        Binding(
+            get: {
+                if languages.contains(where: { $0.identifier == languageIdentifier }) {
+                    return languageIdentifier
+                }
+                return SpeechLanguageCatalog.defaultIdentifier() ?? languages.first?.identifier ?? ""
+            },
+            set: { languageIdentifier = $0 }
+        )
+    }
+
+    private func loadLanguages() {
+        languages = SpeechLanguageCatalog.onDeviceLanguages()
+        if languageIdentifier.isEmpty, let defaultIdentifier = SpeechLanguageCatalog.defaultIdentifier() {
+            languageIdentifier = defaultIdentifier
+        }
+    }
+}

--- a/Muxy/Views/Settings/RecordingSettingsView.swift
+++ b/Muxy/Views/Settings/RecordingSettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct RecordingSettingsView: View {
     @AppStorage(RecordingPreferences.autoSendKey) private var autoSend = RecordingPreferences.defaultAutoSend
-    @AppStorage(RecordingPreferences.languageKey) private var languageIdentifier = ""
+    @AppStorage(RecordingPreferences.languageKey) private var languageIdentifier = RecordingPreferences.defaultLanguage
 
     @State private var languages: [SpeechLanguage] = []
 

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -11,6 +11,8 @@ struct SettingsView: View {
                 .tabItem { Label("Editor", systemImage: "pencil.line") }
             KeyboardShortcutsSettingsView()
                 .tabItem { Label("Shortcuts", systemImage: "keyboard") }
+            RecordingSettingsView()
+                .tabItem { Label("Recording", systemImage: "mic") }
             NotificationSettingsView()
                 .tabItem { Label("Notifications", systemImage: "bell") }
             MobileSettingsView()

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -12,6 +12,10 @@ struct ProjectStatusBar: View {
         KeyBindingStore.shared.combo(for: .toggleRichInput).displayString
     }
 
+    private var voiceShortcutLabel: String {
+        KeyBindingStore.shared.combo(for: .toggleVoiceRecording).displayString
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             if let pane = activePane {
@@ -34,6 +38,8 @@ struct ProjectStatusBar: View {
             }
             if activePane != nil {
                 richInputToggleButton
+                separator
+                voiceRecordingButton
             }
         }
         .padding(.horizontal, 10)
@@ -122,6 +128,22 @@ struct ProjectStatusBar: View {
         .help("Toggle Rich Input")
     }
 
+    private var voiceRecordingButton: some View {
+        Button(action: handleToggleVoiceRecording) {
+            HStack(spacing: 4) {
+                Image(systemName: "mic")
+                    .font(.system(size: 11, weight: .semibold))
+                Text(voiceShortcutLabel)
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .foregroundStyle(MuxyTheme.fgDim)
+            }
+        }
+        .buttonStyle(RichInputToolbarButtonStyle())
+        .disabled(!isInteractive)
+        .accessibilityLabel("Start Voice Recording")
+        .help("Start Voice Recording")
+    }
+
     private var zoomControls: some View {
         HStack(spacing: 2) {
             Button(action: decreaseFontSize) {
@@ -188,6 +210,11 @@ struct ProjectStatusBar: View {
     private func handleToggleRichInput() {
         guard isInteractive else { return }
         NotificationCenter.default.post(name: .toggleRichInput, object: nil)
+    }
+
+    private func handleToggleVoiceRecording() {
+        guard isInteractive else { return }
+        NotificationCenter.default.post(name: .toggleVoiceRecording, object: nil)
     }
 
     private func revealInFinder(_ path: String) {

--- a/Muxy/Views/VoiceRecordingPanel.swift
+++ b/Muxy/Views/VoiceRecordingPanel.swift
@@ -1,0 +1,261 @@
+import AppKit
+import SwiftUI
+
+struct VoiceRecordingPanel: View {
+    @Bindable var state: VoiceRecordingState
+    let autoSend: Bool
+    @State private var isFocused = false
+    @State private var pulse = false
+
+    private let levelBarSpacing: CGFloat = 3
+
+    var body: some View {
+        VStack(spacing: UIMetrics.spacing3) {
+            transcriptChip
+            mainPanel
+            keyboardHints
+        }
+        .padding(.bottom, UIMetrics.scaled(48))
+        .background(VoicePanelFocusTrap(
+            isFocused: $isFocused,
+            onFinish: { state.finish(autoSend: autoSend) },
+            onCancel: { state.cancel() },
+            onTogglePause: { state.togglePause() }
+        ))
+        .onAppear { pulse = true }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Voice recording")
+    }
+
+    private var mainPanel: some View {
+        HStack(spacing: UIMetrics.spacing5) {
+            statusDot
+            timerLabel
+            levelMeter
+                .frame(maxWidth: .infinity)
+            controlButtons
+        }
+        .padding(.horizontal, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.spacing5)
+        .background(MuxyTheme.bg, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
+        .overlay(
+            RoundedRectangle(cornerRadius: UIMetrics.radiusLG)
+                .stroke(isFocused ? MuxyTheme.accent.opacity(0.6) : MuxyTheme.border, lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.22), radius: 14, x: 0, y: -6)
+        .frame(width: UIMetrics.scaled(280))
+    }
+
+    private var transcriptChip: some View {
+        secondaryRow
+            .padding(.horizontal, UIMetrics.spacing5)
+            .padding(.vertical, UIMetrics.spacing3)
+            .frame(width: UIMetrics.scaled(280), alignment: .leading)
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+    }
+
+    @ViewBuilder
+    private var secondaryRow: some View {
+        if let message = state.errorMessage {
+            Text(message)
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.diffRemoveFg)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else if !state.recorder.transcript.isEmpty {
+            Text(state.recorder.transcript)
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .lineLimit(4)
+                .truncationMode(.head)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            Text("Listening...")
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fgDim)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var statusDot: some View {
+        Circle()
+            .fill(state.recorder.isPaused ? MuxyTheme.warning : MuxyTheme.diffRemoveFg)
+            .frame(width: UIMetrics.iconSM, height: UIMetrics.iconSM)
+            .opacity(state.recorder.isPaused ? 1.0 : (pulse ? 1.0 : 0.4))
+            .animation(
+                state.recorder.isPaused
+                    ? .default
+                    : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                value: pulse
+            )
+    }
+
+    private var timerLabel: some View {
+        Text(Self.formatElapsed(state.recorder.elapsed))
+            .font(.system(size: UIMetrics.fontEmphasis, weight: .medium, design: .monospaced))
+            .foregroundStyle(MuxyTheme.fg)
+            .frame(width: UIMetrics.scaled(60), alignment: .leading)
+    }
+
+    private var levelMeter: some View {
+        GeometryReader { geometry in
+            let barCount = max(8, Int(geometry.size.width / UIMetrics.scaled(6)))
+            HStack(spacing: UIMetrics.scaled(levelBarSpacing)) {
+                ForEach(0 ..< barCount, id: \.self) { index in
+                    let threshold = Float(index + 1) / Float(barCount)
+                    let active = !state.recorder.isPaused && state.recorder.level >= threshold
+                    Capsule()
+                        .fill(active ? MuxyTheme.accent : MuxyTheme.surface)
+                        .frame(maxWidth: .infinity, maxHeight: barHeight(at: index, of: barCount))
+                }
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+        }
+        .frame(height: UIMetrics.scaled(24))
+        .accessibilityHidden(true)
+    }
+
+    private func barHeight(at index: Int, of total: Int) -> CGFloat {
+        let normalized = Double(index) / Double(max(1, total - 1))
+        let curve = 0.5 + 0.5 * sin(normalized * .pi)
+        return UIMetrics.scaled(10 + 14 * curve)
+    }
+
+    private var controlButtons: some View {
+        HStack(spacing: UIMetrics.spacing3) {
+            iconButton(systemName: "xmark", tint: MuxyTheme.fgMuted, accessibility: "Cancel") {
+                state.cancel()
+            }
+            iconButton(
+                systemName: state.recorder.isPaused ? "play.fill" : "pause.fill",
+                tint: MuxyTheme.fg,
+                accessibility: state.recorder.isPaused ? "Resume" : "Pause"
+            ) {
+                state.togglePause()
+            }
+            iconButton(
+                systemName: "circle.fill",
+                tint: MuxyTheme.diffRemoveFg,
+                accessibility: "Send"
+            ) {
+                state.finish(autoSend: autoSend)
+            }
+        }
+    }
+
+    private var keyboardHints: some View {
+        HStack(spacing: UIMetrics.spacing5) {
+            hint(key: "⎋", label: "Cancel")
+            hint(key: "Space", label: state.recorder.isPaused ? "Resume" : "Pause")
+            hint(key: "⏎", label: autoSend ? "Send" : "Insert")
+        }
+        .font(.system(size: UIMetrics.fontCaption))
+        .foregroundStyle(MuxyTheme.fgDim)
+        .padding(.horizontal, UIMetrics.spacing4)
+        .padding(.vertical, UIMetrics.scaled(3))
+        .background(MuxyTheme.bg.opacity(0.85), in: Capsule())
+        .overlay(Capsule().stroke(MuxyTheme.border, lineWidth: 1))
+        .opacity(isFocused ? 1 : 0.55)
+    }
+
+    private func hint(key: String, label: String) -> some View {
+        HStack(spacing: UIMetrics.spacing1) {
+            Text(key)
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
+                .foregroundStyle(MuxyTheme.fgMuted)
+            Text(label)
+        }
+    }
+
+    private func iconButton(
+        systemName: String,
+        tint: Color,
+        background: Color? = nil,
+        accessibility: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
+                .background(
+                    background ?? MuxyTheme.surface,
+                    in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibility)
+    }
+
+    nonisolated static func formatElapsed(_ elapsed: TimeInterval) -> String {
+        let total = max(0, Int(elapsed))
+        let minutes = total / 60
+        let seconds = total % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}
+
+private struct VoicePanelFocusTrap: NSViewRepresentable {
+    @Binding var isFocused: Bool
+    let onFinish: () -> Void
+    let onCancel: () -> Void
+    let onTogglePause: () -> Void
+
+    func makeNSView(context: Context) -> VoicePanelFocusTrapView {
+        let view = VoicePanelFocusTrapView()
+        view.onFinish = onFinish
+        view.onCancel = onCancel
+        view.onTogglePause = onTogglePause
+        view.onFocusChange = { focused in
+            DispatchQueue.main.async { isFocused = focused }
+        }
+        DispatchQueue.main.async {
+            view.window?.makeFirstResponder(view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: VoicePanelFocusTrapView, context _: Context) {
+        nsView.onFinish = onFinish
+        nsView.onCancel = onCancel
+        nsView.onTogglePause = onTogglePause
+    }
+}
+
+final class VoicePanelFocusTrapView: NSView {
+    var onFinish: (() -> Void)?
+    var onCancel: (() -> Void)?
+    var onTogglePause: (() -> Void)?
+    var onFocusChange: ((Bool) -> Void)?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result { onFocusChange?(true) }
+        return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        if result { onFocusChange?(false) }
+        return result
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 36,
+             76:
+            onFinish?()
+        case 53:
+            onCancel?()
+        case 49:
+            onTogglePause?()
+        default:
+            super.keyDown(with: event)
+        }
+    }
+}

--- a/Muxy/Views/VoiceRecordingPanel.swift
+++ b/Muxy/Views/VoiceRecordingPanel.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import SwiftUI
 
 struct VoiceRecordingPanel: View {
@@ -7,7 +8,7 @@ struct VoiceRecordingPanel: View {
     @State private var isFocused = false
     @State private var pulse = false
 
-    private let levelBarSpacing: CGFloat = 3
+    private static let levelBarSpacing: CGFloat = 3
 
     var body: some View {
         VStack(spacing: UIMetrics.spacing3) {
@@ -102,7 +103,7 @@ struct VoiceRecordingPanel: View {
     private var levelMeter: some View {
         GeometryReader { geometry in
             let barCount = max(8, Int(geometry.size.width / UIMetrics.scaled(6)))
-            HStack(spacing: UIMetrics.scaled(levelBarSpacing)) {
+            HStack(spacing: UIMetrics.scaled(Self.levelBarSpacing)) {
                 ForEach(0 ..< barCount, id: \.self) { index in
                     let threshold = Float(index + 1) / Float(barCount)
                     let active = !state.recorder.isPaused && state.recorder.level >= threshold
@@ -172,7 +173,6 @@ struct VoiceRecordingPanel: View {
     private func iconButton(
         systemName: String,
         tint: Color,
-        background: Color? = nil,
         accessibility: String,
         action: @escaping () -> Void
     ) -> some View {
@@ -181,10 +181,7 @@ struct VoiceRecordingPanel: View {
                 .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(tint)
                 .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
-                .background(
-                    background ?? MuxyTheme.surface,
-                    in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
-                )
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibility)
@@ -246,13 +243,13 @@ final class VoicePanelFocusTrapView: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
-        switch event.keyCode {
-        case 36,
-             76:
+        switch Int(event.keyCode) {
+        case kVK_Return,
+             kVK_ANSI_KeypadEnter:
             onFinish?()
-        case 53:
+        case kVK_Escape:
             onCancel?()
-        case 49:
+        case kVK_Space:
             onTogglePause?()
         default:
             super.keyDown(with: event)

--- a/Muxy/Views/VoiceRecordingPanel.swift
+++ b/Muxy/Views/VoiceRecordingPanel.swift
@@ -189,9 +189,7 @@ struct VoiceRecordingPanel: View {
 
     nonisolated static func formatElapsed(_ elapsed: TimeInterval) -> String {
         let total = max(0, Int(elapsed))
-        let minutes = total / 60
-        let seconds = total % 60
-        return String(format: "%02d:%02d", minutes, seconds)
+        return Duration.seconds(total).formatted(.time(pattern: .minuteSecond(padMinuteToLength: 2)))
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ let package = Package(
                     "GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
                 ]),
                 .linkedFramework("AppKit"),
+                .linkedFramework("AVFoundation"),
                 .linkedFramework("Carbon"),
                 .linkedFramework("CoreGraphics"),
                 .linkedFramework("CoreText"),
@@ -63,6 +64,7 @@ let package = Package(
                 .linkedFramework("Metal"),
                 .linkedFramework("MetalKit"),
                 .linkedFramework("QuartzCore"),
+                .linkedFramework("Speech"),
                 .linkedLibrary("c++"),
             ]
         ),
@@ -80,6 +82,7 @@ let package = Package(
                     "GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
                 ]),
                 .linkedFramework("AppKit"),
+                .linkedFramework("AVFoundation"),
                 .linkedFramework("Carbon"),
                 .linkedFramework("CoreGraphics"),
                 .linkedFramework("CoreText"),
@@ -88,6 +91,7 @@ let package = Package(
                 .linkedFramework("Metal"),
                 .linkedFramework("MetalKit"),
                 .linkedFramework("QuartzCore"),
+                .linkedFramework("Speech"),
                 .linkedLibrary("c++"),
             ]
         ),

--- a/Tests/MuxyTests/Models/VoiceRecordingTests.swift
+++ b/Tests/MuxyTests/Models/VoiceRecordingTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("VoiceRecorder helpers")
+struct VoiceRecorderHelperTests {
+    @Test("normalize clamps below floor to zero")
+    func normalizeBelowFloor() {
+        #expect(VoiceRecorder.normalize(power: -120) == 0)
+    }
+
+    @Test("normalize clamps at zero dB to one")
+    func normalizeAtCeiling() {
+        #expect(VoiceRecorder.normalize(power: 0) == 1)
+    }
+
+    @Test("normalize maps mid-range power smoothly")
+    func normalizeMidrange() {
+        let value = VoiceRecorder.normalize(power: -25)
+        #expect(value > 0.45 && value < 0.55)
+    }
+
+    @Test("normalize handles non-finite values")
+    func normalizeNonFinite() {
+        #expect(VoiceRecorder.normalize(power: .nan) == 0)
+        #expect(VoiceRecorder.normalize(power: -.infinity) == 0)
+    }
+}
+
+@Suite("VoiceRecordingPanel formatting")
+struct VoiceRecordingPanelTests {
+    @Test("Zero formats as 00:00")
+    func formatsZero() {
+        #expect(VoiceRecordingPanel.formatElapsed(0) == "00:00")
+    }
+
+    @Test("Sub-minute formats with leading zero")
+    func formatsSeconds() {
+        #expect(VoiceRecordingPanel.formatElapsed(7) == "00:07")
+    }
+
+    @Test("Multi-minute formats correctly")
+    func formatsMinutes() {
+        #expect(VoiceRecordingPanel.formatElapsed(125) == "02:05")
+    }
+
+    @Test("Negative input clamps to zero")
+    func clampsNegative() {
+        #expect(VoiceRecordingPanel.formatElapsed(-5) == "00:00")
+    }
+}


### PR DESCRIPTION
Press Cmd+Shift+I to open a bottom panel that transcribes speech on-device (Apple Speech, no network) and inserts the result into the previously focused responder — terminal, editor, or any text field — falling back to the clipboard with a toast if the target is gone. Language is configurable in Settings → Recording; status bar gains a mic button next to the rich-input toggle.