### PR TITLE
Advertise Bonjour + pairing QR with Tailscale support

### DIFF
--- a/Muxy/Services/MobilePairingService.swift
+++ b/Muxy/Services/MobilePairingService.swift
@@ -1,0 +1,97 @@
+import Darwin
+import Foundation
+import SystemConfiguration
+
+enum MobilePairingNetwork: String, CaseIterable, Identifiable {
+    case local
+    case tailscale
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .local: "Local"
+        case .tailscale: "Tailscale"
+        }
+    }
+}
+
+struct MobilePairingHost: Equatable {
+    let network: MobilePairingNetwork
+    let host: String
+    let serviceName: String?
+    let label: String?
+}
+
+enum MobilePairingService {
+    static func localHostName() -> String? {
+        guard let cfName = SCDynamicStoreCopyLocalHostName(nil) else { return nil }
+        let value = cfName as String
+        return value.isEmpty ? nil : value
+    }
+
+    static func availableHosts() -> [MobilePairingHost] {
+        let name = localHostName()
+        var hosts: [MobilePairingHost] = [
+            MobilePairingHost(
+                network: .local,
+                host: "\(name ?? "localhost").local",
+                serviceName: name,
+                label: name
+            ),
+        ]
+        if let tailscaleIP = tailscaleIPv4() {
+            hosts.append(MobilePairingHost(
+                network: .tailscale,
+                host: tailscaleIP,
+                serviceName: nil,
+                label: name
+            ))
+        }
+        return hosts
+    }
+
+    static func pairingURIString(for host: MobilePairingHost, port: UInt16) -> String? {
+        MobilePairingURI.makeString(
+            host: host.host,
+            port: port,
+            service: host.serviceName,
+            label: host.label
+        )
+    }
+
+    static func isTailscaleAddress(_ address: String) -> Bool {
+        let parts = address.split(separator: ".")
+        guard parts.count == 4 else { return false }
+        guard let first = UInt8(parts[0]),
+              let second = UInt8(parts[1]),
+              UInt8(parts[2]) != nil,
+              UInt8(parts[3]) != nil
+        else { return false }
+        return first == 100 && (64 ... 127).contains(second)
+    }
+
+    static func tailscaleIPv4() -> String? {
+        var head: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&head) == 0, let first = head else { return nil }
+        defer { freeifaddrs(head) }
+
+        var pointer: UnsafeMutablePointer<ifaddrs>? = first
+        while let current = pointer {
+            defer { pointer = current.pointee.ifa_next }
+            guard let addrPtr = current.pointee.ifa_addr,
+                  addrPtr.pointee.sa_family == sa_family_t(AF_INET)
+            else { continue }
+            let name = String(cString: current.pointee.ifa_name)
+            guard name.hasPrefix("utun") else { continue }
+            var storage = sockaddr_in()
+            memcpy(&storage, addrPtr, MemoryLayout<sockaddr_in>.size)
+            var raw = storage.sin_addr
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            guard inet_ntop(AF_INET, &raw, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else { continue }
+            let ip = String(cString: buffer)
+            if isTailscaleAddress(ip) { return ip }
+        }
+        return nil
+    }
+}

--- a/Muxy/Services/MobilePairingURI.swift
+++ b/Muxy/Services/MobilePairingURI.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum MobilePairingURI {
+    static let scheme = "muxy"
+    static let action = "pair"
+
+    static func makeString(
+        host: String,
+        port: UInt16,
+        service: String?,
+        label: String?
+    ) -> String? {
+        let trimmedHost = host.trimmingCharacters(in: .whitespaces)
+        guard !trimmedHost.isEmpty else { return nil }
+
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = action
+
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "host", value: trimmedHost),
+            URLQueryItem(name: "port", value: String(port)),
+        ]
+        if let service, !service.isEmpty {
+            items.append(URLQueryItem(name: "service", value: service))
+        }
+        if let label, !label.isEmpty {
+            items.append(URLQueryItem(name: "label", value: label))
+        }
+        components.queryItems = items
+
+        return components.url?.absoluteString
+    }
+}

--- a/Muxy/Views/Settings/MobilePairingQRView.swift
+++ b/Muxy/Views/Settings/MobilePairingQRView.swift
@@ -1,0 +1,60 @@
+import AppKit
+import CoreImage
+import SwiftUI
+
+struct MobilePairingQRView: View {
+    let uriString: String
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            if let image = Self.makeQRImage(uriString: uriString, size: size) {
+                Image(nsImage: image)
+                    .interpolation(.none)
+                    .resizable()
+                    .frame(width: size, height: size)
+                    .accessibilityLabel("Muxy pairing QR code")
+            } else {
+                placeholder
+            }
+        }
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
+        )
+    }
+
+    private var placeholder: some View {
+        ZStack {
+            Color.white
+            Image(systemName: "qrcode")
+                .resizable()
+                .scaledToFit()
+                .padding(size * 0.2)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(width: size, height: size)
+    }
+
+    private static func makeQRImage(uriString: String, size: CGFloat) -> NSImage? {
+        guard let data = uriString.data(using: .utf8) else { return nil }
+        guard let filter = CIFilter(name: "CIQRCodeGenerator") else { return nil }
+        filter.setValue(data, forKey: "inputMessage")
+        filter.setValue("M", forKey: "inputCorrectionLevel")
+
+        guard let baseImage = filter.outputImage else { return nil }
+        let extent = baseImage.extent
+        guard extent.width > 0, extent.height > 0 else { return nil }
+
+        let scale = max(1, size / extent.width)
+        let scaled = baseImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+
+        let context = CIContext(options: nil)
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+
+        let pixelSize = NSSize(width: scaled.extent.width, height: scaled.extent.height)
+        return NSImage(cgImage: cgImage, size: pixelSize)
+    }
+}

--- a/Muxy/Views/Settings/MobilePairingQRView.swift
+++ b/Muxy/Views/Settings/MobilePairingQRView.swift
@@ -6,9 +6,12 @@ struct MobilePairingQRView: View {
     let uriString: String
     let size: CGFloat
 
+    @State private var cachedImage: NSImage?
+    @State private var cacheKey: String?
+
     var body: some View {
         Group {
-            if let image = Self.makeQRImage(uriString: uriString, size: size) {
+            if let image = currentImage {
                 Image(nsImage: image)
                     .interpolation(.none)
                     .resizable()
@@ -24,6 +27,24 @@ struct MobilePairingQRView: View {
             RoundedRectangle(cornerRadius: 6, style: .continuous)
                 .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
         )
+        .onAppear(perform: rebuildIfNeeded)
+        .onChange(of: uriString) { _, _ in rebuildIfNeeded() }
+        .onChange(of: size) { _, _ in rebuildIfNeeded() }
+    }
+
+    private var currentImage: NSImage? {
+        cacheKey == Self.key(uriString: uriString, size: size) ? cachedImage : nil
+    }
+
+    private func rebuildIfNeeded() {
+        let key = Self.key(uriString: uriString, size: size)
+        guard cacheKey != key else { return }
+        cachedImage = Self.makeQRImage(uriString: uriString, size: size)
+        cacheKey = key
+    }
+
+    private static func key(uriString: String, size: CGFloat) -> String {
+        "\(Int(size.rounded()))|\(uriString)"
     }
 
     private var placeholder: some View {

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct MobileSettingsView: View {
@@ -7,6 +8,9 @@ struct MobileSettingsView: View {
     @State private var portText: String = ""
     @State private var portValidationError: String?
     @State private var showFreePortConfirmation = false
+    @State private var didCopyPairingLink = false
+    @State private var pairingHosts: [MobilePairingHost] = []
+    @State private var selectedNetwork: MobilePairingNetwork = .local
 
     private var enabledBinding: Binding<Bool> {
         Binding(
@@ -61,6 +65,15 @@ struct MobileSettingsView: View {
                 }
             }
 
+            if service.isEnabled, let selectedHost, let uri = pairingURI(for: selectedHost) {
+                SettingsSection(
+                    "Pair Mobile Device",
+                    footer: pairingFooter
+                ) {
+                    pairingCard(host: selectedHost, uri: uri)
+                }
+            }
+
             SettingsSection(
                 "Approved Devices",
                 footer: "Revoking removes the device's access. It will need to request approval again to reconnect.",
@@ -79,10 +92,16 @@ struct MobileSettingsView: View {
                 }
             }
         }
-        .onAppear { portText = String(service.port) }
+        .onAppear {
+            portText = String(service.port)
+            refreshPairingHosts()
+        }
         .onChange(of: service.port) { _, newValue in
             let text = String(newValue)
             if portText != text { portText = text }
+        }
+        .onChange(of: service.isEnabled) { _, _ in
+            refreshPairingHosts()
         }
         .alert(
             "Free port \(String(service.port))?",
@@ -122,6 +141,103 @@ struct MobileSettingsView: View {
         service.port = value
         portText = String(value)
         return true
+    }
+
+    private let pairingFooter = """
+    Scan this with the Muxy mobile app to add this Mac. \
+    The QR carries no token — first-time pairing still needs your approval.
+    """
+
+    private var selectedHost: MobilePairingHost? {
+        pairingHosts.first(where: { $0.network == selectedNetwork }) ?? pairingHosts.first
+    }
+
+    private func pairingURI(for host: MobilePairingHost) -> String? {
+        MobilePairingService.pairingURIString(for: host, port: service.port)
+    }
+
+    private func refreshPairingHosts() {
+        pairingHosts = MobilePairingService.availableHosts()
+        if !pairingHosts.contains(where: { $0.network == selectedNetwork }) {
+            selectedNetwork = pairingHosts.first?.network ?? .local
+        }
+    }
+
+    private func pairingCard(host: MobilePairingHost, uri: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if pairingHosts.count > 1 {
+                Picker("", selection: $selectedNetwork) {
+                    ForEach(pairingHosts, id: \.network) { option in
+                        Text(option.network.displayName).tag(option.network)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .fixedSize()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(alignment: .top, spacing: 14) {
+                MobilePairingQRView(uriString: uri, size: 132)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Open the Muxy mobile app, tap Add device, and scan this code.")
+                        .font(.system(size: SettingsMetrics.labelFontSize))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(host.host)
+                        .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
+                        .foregroundStyle(.primary)
+                        .textSelection(.enabled)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text("Port \(String(service.port))")
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+
+            pairingLinkRow(uri: uri)
+        }
+        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+    }
+
+    private func pairingLinkRow(uri: String) -> some View {
+        HStack(spacing: 8) {
+            Text(uri)
+                .font(.system(size: SettingsMetrics.footnoteFontSize, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button {
+                copyPairingLink(uri)
+            } label: {
+                Label(
+                    didCopyPairingLink ? "Copied" : "Copy",
+                    systemImage: didCopyPairingLink ? "checkmark" : "doc.on.doc"
+                )
+                .labelStyle(.titleAndIcon)
+                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(MuxyTheme.accent)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func copyPairingLink(_ uri: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(uri, forType: .string)
+        didCopyPairingLink = true
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            await MainActor.run { didCopyPairingLink = false }
+        }
     }
 
     private func deviceRow(_ device: ApprovedDevice) -> some View {

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -1,7 +1,13 @@
 import AppKit
+import Network
 import SwiftUI
 
 struct MobileSettingsView: View {
+    private static let pairingFooter = """
+    Scan this with the Muxy mobile app to add this Mac. \
+    The QR carries no token — first-time pairing still needs your approval.
+    """
+
     @Bindable private var service = MobileServerService.shared
     @Bindable private var devices = ApprovedDevicesStore.shared
     @State private var deviceToRevoke: ApprovedDevice?
@@ -11,6 +17,7 @@ struct MobileSettingsView: View {
     @State private var didCopyPairingLink = false
     @State private var pairingHosts: [MobilePairingHost] = []
     @State private var selectedNetwork: MobilePairingNetwork = .local
+    @State private var pathMonitor: NWPathMonitor?
 
     private var enabledBinding: Binding<Bool> {
         Binding(
@@ -68,7 +75,7 @@ struct MobileSettingsView: View {
             if service.isEnabled, let selectedHost, let uri = pairingURI(for: selectedHost) {
                 SettingsSection(
                     "Pair Mobile Device",
-                    footer: pairingFooter
+                    footer: Self.pairingFooter
                 ) {
                     pairingCard(host: selectedHost, uri: uri)
                 }
@@ -95,7 +102,9 @@ struct MobileSettingsView: View {
         .onAppear {
             portText = String(service.port)
             refreshPairingHosts()
+            startPathMonitor()
         }
+        .onDisappear { stopPathMonitor() }
         .onChange(of: service.port) { _, newValue in
             let text = String(newValue)
             if portText != text { portText = text }
@@ -143,11 +152,6 @@ struct MobileSettingsView: View {
         return true
     }
 
-    private let pairingFooter = """
-    Scan this with the Muxy mobile app to add this Mac. \
-    The QR carries no token — first-time pairing still needs your approval.
-    """
-
     private var selectedHost: MobilePairingHost? {
         pairingHosts.first(where: { $0.network == selectedNetwork }) ?? pairingHosts.first
     }
@@ -163,10 +167,25 @@ struct MobileSettingsView: View {
         }
     }
 
+    private func startPathMonitor() {
+        guard pathMonitor == nil else { return }
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { _ in
+            Task { @MainActor in refreshPairingHosts() }
+        }
+        monitor.start(queue: .global(qos: .utility))
+        pathMonitor = monitor
+    }
+
+    private func stopPathMonitor() {
+        pathMonitor?.cancel()
+        pathMonitor = nil
+    }
+
     private func pairingCard(host: MobilePairingHost, uri: String) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             if pairingHosts.count > 1 {
-                Picker("", selection: $selectedNetwork) {
+                Picker("Pairing network", selection: $selectedNetwork) {
                     ForEach(pairingHosts, id: \.network) { option in
                         Text(option.network.displayName).tag(option.network)
                     }
@@ -175,6 +194,7 @@ struct MobileSettingsView: View {
                 .pickerStyle(.segmented)
                 .fixedSize()
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityLabel("Pairing network")
             }
 
             HStack(alignment: .top, spacing: 14) {

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -72,6 +72,7 @@ public protocol MuxyRemoteServerDelegate: AnyObject {
 
 public final class MuxyRemoteServer: @unchecked Sendable {
     public static let defaultPort: UInt16 = 4865
+    public static let bonjourServiceType: String = "_muxy._tcp"
 
     private let port: UInt16
     private var listener: NWListener?
@@ -169,6 +170,7 @@ public final class MuxyRemoteServer: @unchecked Sendable {
             ws.autoReplyPing = true
             params.defaultProtocolStack.applicationProtocols.insert(ws, at: 0)
             listener = try NWListener(using: params, on: endpointPort)
+            listener?.service = NWListener.Service(name: nil, type: Self.bonjourServiceType)
         } catch {
             logger.error("Failed to create listener: \(error)")
             finishStart(.failure(error))

--- a/Tests/MuxyTests/Models/MobilePairingURITests.swift
+++ b/Tests/MuxyTests/Models/MobilePairingURITests.swift
@@ -51,6 +51,20 @@ struct MobilePairingURITests {
         #expect(!names.contains("label"))
     }
 
+    @Test("omits nil service and label")
+    func omitsNilOptionals() throws {
+        let uri = try #require(MobilePairingURI.makeString(
+            host: "host.local",
+            port: 4865,
+            service: nil,
+            label: nil
+        ))
+        let components = try #require(URLComponents(string: uri))
+        let names = (components.queryItems ?? []).map(\.name)
+        #expect(!names.contains("service"))
+        #expect(!names.contains("label"))
+    }
+
     @Test("rejects empty host")
     func rejectsEmptyHost() {
         #expect(MobilePairingURI.makeString(host: "  ", port: 4865, service: nil, label: nil) == nil)

--- a/Tests/MuxyTests/Models/MobilePairingURITests.swift
+++ b/Tests/MuxyTests/Models/MobilePairingURITests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("MobilePairingURI")
+struct MobilePairingURITests {
+    @Test("includes host and port with required params")
+    func basicURI() throws {
+        let uri = try #require(MobilePairingURI.makeString(
+            host: "Saeeds-MacBook-Pro.local",
+            port: 4865,
+            service: nil,
+            label: nil
+        ))
+        let components = try #require(URLComponents(string: uri))
+        #expect(components.scheme == "muxy")
+        #expect(components.host == "pair")
+        let items = components.queryItems ?? []
+        #expect(items.contains(URLQueryItem(name: "host", value: "Saeeds-MacBook-Pro.local")))
+        #expect(items.contains(URLQueryItem(name: "port", value: "4865")))
+        #expect(!items.contains(where: { $0.name == "service" }))
+        #expect(!items.contains(where: { $0.name == "label" }))
+    }
+
+    @Test("URL-encodes label with special characters")
+    func encodesLabel() throws {
+        let uri = try #require(MobilePairingURI.makeString(
+            host: "host.local",
+            port: 4865,
+            service: "Saeeds-MacBook-Pro",
+            label: "Saeed's Mac"
+        ))
+        #expect(uri.contains("label=Saeed"))
+        let components = try #require(URLComponents(string: uri))
+        let labelItem = components.queryItems?.first(where: { $0.name == "label" })
+        #expect(labelItem?.value == "Saeed's Mac")
+    }
+
+    @Test("omits empty service and label")
+    func omitsEmptyOptionals() throws {
+        let uri = try #require(MobilePairingURI.makeString(
+            host: "host.local",
+            port: 4865,
+            service: "",
+            label: ""
+        ))
+        let components = try #require(URLComponents(string: uri))
+        let names = (components.queryItems ?? []).map(\.name)
+        #expect(!names.contains("service"))
+        #expect(!names.contains("label"))
+    }
+
+    @Test("rejects empty host")
+    func rejectsEmptyHost() {
+        #expect(MobilePairingURI.makeString(host: "  ", port: 4865, service: nil, label: nil) == nil)
+    }
+}
+
+@Suite("MobilePairingService Tailscale detection")
+struct MobilePairingServiceTailscaleTests {
+    @Test("recognises CGNAT range as Tailscale")
+    func recognisesCGNATRange() {
+        #expect(MobilePairingService.isTailscaleAddress("100.64.0.1"))
+        #expect(MobilePairingService.isTailscaleAddress("100.96.10.20"))
+        #expect(MobilePairingService.isTailscaleAddress("100.127.255.254"))
+    }
+
+    @Test("rejects addresses outside CGNAT range")
+    func rejectsNonCGNAT() {
+        #expect(!MobilePairingService.isTailscaleAddress("100.63.0.1"))
+        #expect(!MobilePairingService.isTailscaleAddress("100.128.0.1"))
+        #expect(!MobilePairingService.isTailscaleAddress("192.168.1.1"))
+        #expect(!MobilePairingService.isTailscaleAddress("10.0.0.1"))
+    }
+
+    @Test("rejects malformed addresses")
+    func rejectsMalformed() {
+        #expect(!MobilePairingService.isTailscaleAddress(""))
+        #expect(!MobilePairingService.isTailscaleAddress("100.64.0"))
+        #expect(!MobilePairingService.isTailscaleAddress("100.64.0.1.1"))
+        #expect(!MobilePairingService.isTailscaleAddress("100.x.0.1"))
+        #expect(!MobilePairingService.isTailscaleAddress("256.64.0.1"))
+    }
+}


### PR DESCRIPTION
Adds _muxy._tcp Bonjour advertising for IP-resilient reconnects and a Settings → Mobile pairing card with a QR that
   prefills host/port/service/label in the mobile app. Auto-detects Tailscale (CGNAT 100.64/10) and exposes a
  Local/Tailscale picker when both networks are reachable.