### PR TITLE
Improve palette IME input and page navigation

### DIFF
--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -48,8 +48,8 @@ struct FindInFilesOverlay: View {
                 onEscape: { onDismiss() },
                 onArrowUp: { moveHighlight(-1) },
                 onArrowDown: { moveHighlight(1) },
-                onPageUp: { moveHighlight(-10) },
-                onPageDown: { moveHighlight(10) }
+                onPageUp: { moveHighlight(-PaletteSearchField.pageJump) },
+                onPageDown: { moveHighlight(PaletteSearchField.pageJump) }
             )
         }
         .padding(.horizontal, UIMetrics.spacing6)

--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -47,7 +47,9 @@ struct FindInFilesOverlay: View {
                 onSubmit: { confirmSelection() },
                 onEscape: { onDismiss() },
                 onArrowUp: { moveHighlight(-1) },
-                onArrowDown: { moveHighlight(1) }
+                onArrowDown: { moveHighlight(1) },
+                onPageUp: { moveHighlight(-10) },
+                onPageDown: { moveHighlight(10) }
             )
         }
         .padding(.horizontal, UIMetrics.spacing6)

--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -60,7 +60,9 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
                 onSubmit: { confirmSelection() },
                 onEscape: { onDismiss() },
                 onArrowUp: { moveHighlight(-1) },
-                onArrowDown: { moveHighlight(1) }
+                onArrowDown: { moveHighlight(1) },
+                onPageUp: { moveHighlight(-10) },
+                onPageDown: { moveHighlight(10) }
             )
         }
         .padding(.horizontal, UIMetrics.spacing6)
@@ -148,6 +150,8 @@ struct PaletteSearchField: NSViewRepresentable {
     let onEscape: () -> Void
     let onArrowUp: () -> Void
     let onArrowDown: () -> Void
+    var onPageUp: () -> Void = {}
+    var onPageDown: () -> Void = {}
 
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
@@ -164,6 +168,9 @@ struct PaletteSearchField: NSViewRepresentable {
         field.placeholderString = placeholder
         field.cell?.sendsActionOnEndEditing = false
         field.onEscape = onEscape
+        field.onTextChange = { field in
+            context.coordinator.syncText(from: field, skipsMarkedText: true)
+        }
         DispatchQueue.main.async {
             field.window?.makeFirstResponder(field)
         }
@@ -172,14 +179,18 @@ struct PaletteSearchField: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSTextField, context: Context) {
         context.coordinator.parent = self
-        if nsView.stringValue != text {
+        if nsView.currentEditor() == nil, nsView.stringValue != text {
             nsView.stringValue = text
         }
         if let field = nsView as? PaletteNSTextField {
             field.onEscape = onEscape
+            field.onTextChange = { field in
+                context.coordinator.syncText(from: field, skipsMarkedText: true)
+            }
         }
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: PaletteSearchField
 
@@ -189,15 +200,16 @@ struct PaletteSearchField: NSViewRepresentable {
 
         func controlTextDidChange(_ obj: Notification) {
             guard let field = obj.object as? NSTextField else { return }
-            parent.text = field.stringValue
+            syncText(from: field, skipsMarkedText: true)
         }
 
         func control(
             _ control: NSControl,
-            textView _: NSTextView,
+            textView: NSTextView,
             doCommandBy commandSelector: Selector
         ) -> Bool {
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                syncText(from: control, textView: textView, skipsMarkedText: false)
                 parent.onSubmit()
                 return true
             }
@@ -209,13 +221,49 @@ struct PaletteSearchField: NSViewRepresentable {
                 parent.onArrowDown()
                 return true
             }
+            if commandSelector == #selector(NSResponder.pageUp(_:))
+                || commandSelector == #selector(NSResponder.scrollPageUp(_:)) {
+                parent.onPageUp()
+                return true
+            }
+            if commandSelector == #selector(NSResponder.pageDown(_:))
+                || commandSelector == #selector(NSResponder.scrollPageDown(_:)) {
+                parent.onPageDown()
+                return true
+            }
             return false
+        }
+
+        func syncText(
+            from control: NSControl,
+            textView: NSTextView? = nil,
+            skipsMarkedText: Bool
+        ) {
+            if skipsMarkedText, textView?.hasMarkedText() == true {
+                return
+            }
+            if skipsMarkedText, (control.currentEditor() as? NSTextView)?.hasMarkedText() == true {
+                return
+            }
+
+            let currentText = textView?.string
+                ?? (control.currentEditor() as? NSTextView)?.string
+                ?? control.stringValue
+            if parent.text != currentText {
+                parent.text = currentText
+            }
         }
     }
 }
 
 private final class PaletteNSTextField: NSTextField {
     var onEscape: (() -> Void)?
+    var onTextChange: ((NSTextField) -> Void)?
+
+    override func textDidChange(_ notification: Notification) {
+        super.textDidChange(notification)
+        onTextChange?(self)
+    }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if event.keyCode == 53 {

--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -222,12 +222,14 @@ struct PaletteSearchField: NSViewRepresentable {
                 return true
             }
             if commandSelector == #selector(NSResponder.pageUp(_:))
-                || commandSelector == #selector(NSResponder.scrollPageUp(_:)) {
+                || commandSelector == #selector(NSResponder.scrollPageUp(_:))
+            {
                 parent.onPageUp()
                 return true
             }
             if commandSelector == #selector(NSResponder.pageDown(_:))
-                || commandSelector == #selector(NSResponder.scrollPageDown(_:)) {
+                || commandSelector == #selector(NSResponder.scrollPageDown(_:))
+            {
                 parent.onPageDown()
                 return true
             }

--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -61,8 +61,8 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
                 onEscape: { onDismiss() },
                 onArrowUp: { moveHighlight(-1) },
                 onArrowDown: { moveHighlight(1) },
-                onPageUp: { moveHighlight(-10) },
-                onPageDown: { moveHighlight(10) }
+                onPageUp: { moveHighlight(-PaletteSearchField.pageJump) },
+                onPageDown: { moveHighlight(PaletteSearchField.pageJump) }
             )
         }
         .padding(.horizontal, UIMetrics.spacing6)
@@ -143,6 +143,8 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
 }
 
 struct PaletteSearchField: NSViewRepresentable {
+    static let pageJump = 10
+
     @Binding var text: String
     let placeholder: String
     var fontSize: CGFloat = UIMetrics.fontEmphasis
@@ -168,9 +170,6 @@ struct PaletteSearchField: NSViewRepresentable {
         field.placeholderString = placeholder
         field.cell?.sendsActionOnEndEditing = false
         field.onEscape = onEscape
-        field.onTextChange = { field in
-            context.coordinator.syncText(from: field, skipsMarkedText: true)
-        }
         DispatchQueue.main.async {
             field.window?.makeFirstResponder(field)
         }
@@ -184,9 +183,6 @@ struct PaletteSearchField: NSViewRepresentable {
         }
         if let field = nsView as? PaletteNSTextField {
             field.onEscape = onEscape
-            field.onTextChange = { field in
-                context.coordinator.syncText(from: field, skipsMarkedText: true)
-            }
         }
     }
 
@@ -205,11 +201,11 @@ struct PaletteSearchField: NSViewRepresentable {
 
         func control(
             _ control: NSControl,
-            textView: NSTextView,
+            textView _: NSTextView,
             doCommandBy commandSelector: Selector
         ) -> Bool {
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
-                syncText(from: control, textView: textView, skipsMarkedText: false)
+                syncText(from: control, skipsMarkedText: false)
                 parent.onSubmit()
                 return true
             }
@@ -236,21 +232,12 @@ struct PaletteSearchField: NSViewRepresentable {
             return false
         }
 
-        func syncText(
-            from control: NSControl,
-            textView: NSTextView? = nil,
-            skipsMarkedText: Bool
-        ) {
-            if skipsMarkedText, textView?.hasMarkedText() == true {
+        func syncText(from control: NSControl, skipsMarkedText: Bool) {
+            let editor = control.currentEditor() as? NSTextView
+            if skipsMarkedText, editor?.hasMarkedText() == true {
                 return
             }
-            if skipsMarkedText, (control.currentEditor() as? NSTextView)?.hasMarkedText() == true {
-                return
-            }
-
-            let currentText = textView?.string
-                ?? (control.currentEditor() as? NSTextView)?.string
-                ?? control.stringValue
+            let currentText = editor?.string ?? control.stringValue
             if parent.text != currentText {
                 parent.text = currentText
             }
@@ -260,12 +247,6 @@ struct PaletteSearchField: NSViewRepresentable {
 
 private final class PaletteNSTextField: NSTextField {
     var onEscape: (() -> Void)?
-    var onTextChange: ((NSTextField) -> Void)?
-
-    override func textDidChange(_ notification: Notification) {
-        super.textDidChange(notification)
-        onTextChange?(self)
-    }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if event.keyCode == 53 {


### PR DESCRIPTION
## Summary
Stabilizes palette text-field sync during IME composition and adds PageUp/PageDown result navigation.

## Changes
- Avoid overwriting active field-editor text during input.
- Sync committed input before submit.
- Add PageUp/PageDown navigation through search results from the search field.

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Recordings
Before: Korean IME composition breaks in the search field.
<!-- If applicable, add screenshots -->

https://github.com/user-attachments/assets/7f883885-56d0-4680-abe4-f9c984aa5e38

After: Korean IME composition stays stable and PageUp/PageDown navigates results.

https://github.com/user-attachments/assets/1f04e90b-1059-46d1-bdfb-6029684a17fd

