### PR TITLE
Fix built-in editor replacing symlinks with regular files on save

### DIFF
--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -529,7 +529,8 @@ final class EditorTabState: Identifiable {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             DispatchQueue.global(qos: .utility).async {
                 do {
-                    try text.write(toFile: path, atomically: true, encoding: .utf8)
+                    let destination = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+                    try text.write(toFile: destination, atomically: true, encoding: .utf8)
                     continuation.resume()
                 } catch {
                     continuation.resume(throwing: error)

--- a/Tests/MuxyTests/Models/EditorTabStateTests.swift
+++ b/Tests/MuxyTests/Models/EditorTabStateTests.swift
@@ -43,6 +43,97 @@ struct EditorTabStateTests {
         #expect(state.previewRefreshVersion > initialPreviewVersion)
     }
 
+    @Test("saveFileAsync preserves a single-level symlink and writes through to target")
+    func saveFileAsyncPreservesSingleLevelSymlink() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        let realFile = tempDirectory.appendingPathComponent("real.txt")
+        let symlinkFile = tempDirectory.appendingPathComponent("link.txt")
+        try "original\n".write(to: realFile, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(at: symlinkFile, withDestinationURL: realFile)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let state = EditorTabState(projectPath: tempDirectory.path, filePath: symlinkFile.path)
+        try await waitForLoad(state)
+        state.backingStore?.loadFromText("updated\n")
+        state.markModified()
+        try await state.saveFileAsync()
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: symlinkFile.path)
+        #expect(attrs[.type] as? FileAttributeType == .typeSymbolicLink)
+        let dest = try FileManager.default.destinationOfSymbolicLink(atPath: symlinkFile.path)
+        #expect(dest == realFile.path)
+        #expect(try String(contentsOf: realFile, encoding: .utf8) == "updated\n")
+    }
+
+    @Test("saveFileAsync writes through a multi-level symlink chain")
+    func saveFileAsyncTraversesMultiLevelSymlinks() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        let realFile = tempDirectory.appendingPathComponent("c.txt")
+        let mid = tempDirectory.appendingPathComponent("b.txt")
+        let top = tempDirectory.appendingPathComponent("a.txt")
+        try "v1\n".write(to: realFile, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(at: mid, withDestinationURL: realFile)
+        try FileManager.default.createSymbolicLink(at: top, withDestinationURL: mid)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let state = EditorTabState(projectPath: tempDirectory.path, filePath: top.path)
+        try await waitForLoad(state)
+        state.backingStore?.loadFromText("v2\n")
+        state.markModified()
+        try await state.saveFileAsync()
+
+        let topAttrs = try FileManager.default.attributesOfItem(atPath: top.path)
+        let midAttrs = try FileManager.default.attributesOfItem(atPath: mid.path)
+        #expect(topAttrs[.type] as? FileAttributeType == .typeSymbolicLink)
+        #expect(midAttrs[.type] as? FileAttributeType == .typeSymbolicLink)
+        #expect(try String(contentsOf: realFile, encoding: .utf8) == "v2\n")
+    }
+
+    @Test("saveFileAsync resolves a relative symlink target")
+    func saveFileAsyncResolvesRelativeSymlink() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let subdir = tempDirectory.appendingPathComponent("sub")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+        let realFile = tempDirectory.appendingPathComponent("target.txt")
+        let link = subdir.appendingPathComponent("link.txt")
+        try "before\n".write(to: realFile, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: "../target.txt")
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let state = EditorTabState(projectPath: tempDirectory.path, filePath: link.path)
+        try await waitForLoad(state)
+        state.backingStore?.loadFromText("after\n")
+        state.markModified()
+        try await state.saveFileAsync()
+
+        let linkAttrs = try FileManager.default.attributesOfItem(atPath: link.path)
+        #expect(linkAttrs[.type] as? FileAttributeType == .typeSymbolicLink)
+        let dest = try FileManager.default.destinationOfSymbolicLink(atPath: link.path)
+        #expect(dest == "../target.txt")
+        #expect(try String(contentsOf: realFile, encoding: .utf8) == "after\n")
+    }
+
+    @Test("saveFileAsync writes through to a plain file as a regression guard")
+    func saveFileAsyncWritesPlainFileUnchanged() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        let fileURL = tempDirectory.appendingPathComponent("plain.txt")
+        try "first\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let state = EditorTabState(projectPath: tempDirectory.path, filePath: fileURL.path)
+        try await waitForLoad(state)
+        state.backingStore?.loadFromText("second\n")
+        state.markModified()
+        try await state.saveFileAsync()
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        #expect(attrs[.type] as? FileAttributeType == .typeRegular)
+        #expect(try String(contentsOf: fileURL, encoding: .utf8) == "second\n")
+    }
+
     private func waitForLoad(_ state: EditorTabState, timeout: TimeInterval = 2.0) async throws {
         let deadline = Date().addingTimeInterval(timeout)
         while state.isLoading || state.isIncrementalLoading {


### PR DESCRIPTION
<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

<!-- What does this PR do and why? Write this yourself — no AI-generated text. -->

Fixes #440.
Built-in editor was replacing symlinks with regular files on save due to `atomically: true`.

## Changes

<!-- List the key changes -->

- Resolve the write path via `resolvingSymlinksInPath()` before writing, so the real file is updated and the symlink is preserved.
- Tests added for single-level, multi-level, relative symlinks, and plain files

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

<!-- If applicable, add screenshots -->

https://github.com/user-attachments/assets/02dfac46-fd65-48cc-aa7a-a00f02fb5642



