### PR TITLE
fix: stop plain Backspace from triggering Go Back in project picker

### DIFF
--- a/Muxy/Views/Components/ProjectPickerPathField.swift
+++ b/Muxy/Views/Components/ProjectPickerPathField.swift
@@ -97,7 +97,6 @@ private enum ProjectPickerPathFieldCommandMapper {
         if selector == #selector(NSResponder.moveUp(_:)) { return .moveHighlightUp }
         if selector == #selector(NSResponder.moveDown(_:)) { return .moveHighlightDown }
         if selector == #selector(NSResponder.deleteWordBackward(_:)) { return shouldGoUpOnDeleteBackward ? .goBack : nil }
-        if selector == #selector(NSResponder.deleteBackward(_:)) { return shouldGoUpOnDeleteBackward ? .goBack : nil }
         return nil
     }
 


### PR DESCRIPTION
## Summary

Reported by @IlyaRastorguev in https://github.com/muxy-app/muxy/pull/441#issuecomment-4467586103: opening the project picker and pressing Backspace navigates to the parent directory instead of editing the path. The footer only advertises `Option+Delete` as Go back, so plain Backspace should perform normal text deletion.

## Changes

- Remove the plain `deleteBackward(_:)` → `.goBack` mapping in `ProjectPickerPathField`; only `deleteWordBackward(_:)` (Option+Backspace) maps to Go back, matching the footer hint.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots