### PR TITLE
Fix fork PR detection regression in VCS tab

### DIFF
--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -208,9 +208,9 @@ struct GitRepositoryService {
         return result
     }
 
-    private static let prInfoJSONFields =
+    static let prInfoJSONFields =
         "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository"
-    private static let prInfoJSONFieldsWithHeadRefOid = prInfoJSONFields + ",headRefOid"
+    static let prInfoJSONFieldsWithHeadRefOid = prInfoJSONFields + ",headRefOid,headRefName"
 
     func pullRequestInfo(repoPath: String, branch: String, headSha: String? = nil) async -> PRInfo? {
         if case let .found(info) = await pullRequestInfoResult(

--- a/Tests/MuxyTests/Git/GitPRParserTests.swift
+++ b/Tests/MuxyTests/Git/GitPRParserTests.swift
@@ -263,6 +263,12 @@ struct GitPRParserTests {
                 GitPRParser.parsePRInfoMatchingHeadSha("not-json", headSha: "x", branch: "y") == nil
             )
         }
+
+        @Test("head-SHA fallback JSON fields include headRefName so fork PRs can match by branch")
+        func sha_fallback_fields_include_headRefName() {
+            #expect(GitRepositoryService.prInfoJSONFieldsWithHeadRefOid.contains("headRefName"))
+            #expect(GitRepositoryService.prInfoJSONFieldsWithHeadRefOid.contains("headRefOid"))
+        }
     }
 
     @Suite("parseAheadBehind")


### PR DESCRIPTION
Fork PRs were undetectable because the SHA-fallback query omitted headRefName from the requested gh fields while
  the matcher required it. Adds headRefName so cross-repo PRs match again.