### PR TITLE
Fix GitHub push authentication

### DIFF
--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -60,12 +60,20 @@ enum GitProcessRunner {
         try await runProcess(
             ProcessSpec(
                 executable: "/usr/bin/env",
-                arguments: ["git", "-C", repoPath] + arguments,
+                arguments: ["git"] + gitHubCredentialHelperArgs() + ["-C", repoPath] + arguments,
                 workingDirectory: nil,
                 lineLimit: lineLimit,
                 signpostName: "git"
             )
         )
+    }
+
+    static func gitHubCredentialHelperArgs(ghResolver: (String) -> String? = resolveExecutable) -> [String] {
+        guard let ghPath = ghResolver("gh") else { return [] }
+        return [
+            "-c", "credential.helper=",
+            "-c", "credential.https://github.com.helper=!\(ghPath) auth git-credential",
+        ]
     }
 
     static func runCommand(

--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -37,7 +37,7 @@ enum UIMetrics {
     static var controlSmall: CGFloat { scaled(20) }
     static var controlMedium: CGFloat { scaled(24) }
     static var controlLarge: CGFloat { scaled(32) }
-    static var resizeHandleHitArea: CGFloat { scaled(12) }
+    static var resizeHandleHitArea: CGFloat { scaled(18) }
 
     static var radiusSM: CGFloat { scaled(4) }
     static var radiusMD: CGFloat { scaled(6) }

--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -37,6 +37,7 @@ enum UIMetrics {
     static var controlSmall: CGFloat { scaled(20) }
     static var controlMedium: CGFloat { scaled(24) }
     static var controlLarge: CGFloat { scaled(32) }
+    static var resizeHandleHitArea: CGFloat { scaled(12) }
 
     static var radiusSM: CGFloat { scaled(4) }
     static var radiusMD: CGFloat { scaled(6) }

--- a/Muxy/Views/Components/ResizeHandle.swift
+++ b/Muxy/Views/Components/ResizeHandle.swift
@@ -12,28 +12,33 @@ struct ResizeHandle: View {
     @State private var hovering = false
 
     var body: some View {
-        Color.clear
-            .frame(
-                width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
-                height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
-            )
-            .overlay(
-                Rectangle()
-                    .fill(hovering ? MuxyTheme.accent : MuxyTheme.border)
-                    .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
-            )
-            .contentShape(Rectangle())
-            .gesture(
-                DragGesture(minimumDistance: 1)
-                    .onChanged(onDrag)
-            )
-            .onHover { on in
-                hovering = on
-                if on {
-                    cursor.push()
-                } else {
-                    NSCursor.pop()
-                }
+        Rectangle()
+            .fill(hovering ? MuxyTheme.accent : MuxyTheme.border)
+            .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
+            .overlay {
+                Color.clear
+                    .frame(
+                        width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
+                        height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
+                    )
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 1)
+                            .onChanged(onDrag)
+                    )
+                    .onHover { on in
+                        hovering = on
+                        if on {
+                            cursor.set()
+                        } else {
+                            NSCursor.arrow.set()
+                        }
+                    }
+                    .onContinuousHover { phase in
+                        if hovering, case .active = phase {
+                            cursor.set()
+                        }
+                    }
             }
     }
 

--- a/Muxy/Views/Components/ResizeHandle.swift
+++ b/Muxy/Views/Components/ResizeHandle.swift
@@ -10,10 +10,13 @@ struct ResizeHandle: View {
     let axis: Axis
     let onDrag: (DragGesture.Value) -> Void
     @State private var hovering = false
+    @GestureState private var dragging = false
+
+    private var active: Bool { hovering || dragging }
 
     var body: some View {
         Rectangle()
-            .fill(hovering ? MuxyTheme.accent : MuxyTheme.border)
+            .fill(active ? MuxyTheme.accent : MuxyTheme.border)
             .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
             .overlay {
                 Color.clear
@@ -24,19 +27,18 @@ struct ResizeHandle: View {
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 1)
-                            .onChanged(onDrag)
+                            .updating($dragging) { _, state, _ in state = true }
+                            .onChanged { value in
+                                cursor.set()
+                                onDrag(value)
+                            }
                     )
                     .onHover { on in
                         hovering = on
                         if on {
                             cursor.set()
-                        } else {
+                        } else if !dragging {
                             NSCursor.arrow.set()
-                        }
-                    }
-                    .onContinuousHover { phase in
-                        if hovering, case .active = phase {
-                            cursor.set()
                         }
                     }
             }

--- a/Muxy/Views/Components/ResizeHandle.swift
+++ b/Muxy/Views/Components/ResizeHandle.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+
+struct ResizeHandle: View {
+    enum Axis {
+        case horizontal
+        case vertical
+    }
+
+    let axis: Axis
+    let onDrag: (DragGesture.Value) -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Color.clear
+            .frame(
+                width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
+                height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
+            )
+            .overlay(
+                Rectangle()
+                    .fill(hovering ? MuxyTheme.accent : MuxyTheme.border)
+                    .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
+            )
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged(onDrag)
+            )
+            .onHover { on in
+                hovering = on
+                if on {
+                    cursor.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+    }
+
+    private var cursor: NSCursor {
+        axis == .horizontal ? .resizeLeftRight : .resizeUpDown
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -964,7 +964,7 @@ struct MainWindow: View {
             .accessibilityHidden(true)
             .overlay {
                 Color.clear
-                    .frame(width: UIMetrics.scaled(5))
+                    .frame(width: UIMetrics.resizeHandleHitArea)
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 1)
@@ -981,7 +981,7 @@ struct MainWindow: View {
             .accessibilityHidden(true)
             .overlay {
                 Color.clear
-                    .frame(height: UIMetrics.scaled(5))
+                    .frame(height: UIMetrics.resizeHandleHitArea)
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 1)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -960,37 +960,17 @@ struct MainWindow: View {
     }
 
     private func sidePanelResizeHandle(onDrag: @escaping (CGFloat) -> Void) -> some View {
-        Rectangle().fill(MuxyTheme.border).frame(width: 1)
-            .accessibilityHidden(true)
-            .overlay {
-                Color.clear
-                    .frame(width: UIMetrics.resizeHandleHitArea)
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 1)
-                            .onChanged { v in onDrag(v.translation.width) }
-                    )
-                    .onHover { on in
-                        if on { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
-                    }
-            }
+        ResizeHandle(axis: .horizontal) { v in
+            onDrag(v.translation.width)
+        }
+        .accessibilityHidden(true)
     }
 
     private func bottomPanelResizeHandle(onDrag: @escaping (CGFloat) -> Void) -> some View {
-        Rectangle().fill(MuxyTheme.border).frame(height: 1)
-            .accessibilityHidden(true)
-            .overlay {
-                Color.clear
-                    .frame(height: UIMetrics.resizeHandleHitArea)
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 1)
-                            .onChanged { v in onDrag(v.translation.height) }
-                    )
-                    .onHover { on in
-                        if on { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
-                    }
-            }
+        ResizeHandle(axis: .vertical) { v in
+            onDrag(v.translation.height)
+        }
+        .accessibilityHidden(true)
     }
 
     private var activeFileTreeState: FileTreeState? {

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1340,47 +1340,35 @@ private struct SectionSplitLayout: View {
         totalHeight: CGFloat,
         allSections: [SectionKind]
     ) -> some View {
-        Rectangle().fill(MuxyTheme.border).frame(height: 1)
-            .overlay {
-                Color.clear
-                    .frame(height: UIMetrics.resizeHandleHitArea)
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 1)
-                            .onChanged { v in
-                                guard totalHeight > 0 else { return }
-                                let delta = v.translation.height / totalHeight
+        ResizeHandle(axis: .vertical) { v in
+            guard totalHeight > 0 else { return }
+            let delta = v.translation.height / totalHeight
 
-                                guard let aboveIdx = allSections.firstIndex(of: above),
-                                      let belowIdx = allSections.firstIndex(of: below)
-                                else { return }
+            guard let aboveIdx = allSections.firstIndex(of: above),
+                  let belowIdx = allSections.firstIndex(of: below)
+            else { return }
 
-                                var ratios = state.sectionRatios
-                                if ratios.count < allSections.count {
-                                    let fill = 1.0 / CGFloat(allSections.count)
-                                    ratios.append(contentsOf: Array(repeating: fill, count: allSections.count - ratios.count))
-                                }
-                                guard aboveIdx < ratios.count, belowIdx < ratios.count else { return }
-                                let minRatio: CGFloat = 0.08
-
-                                ratios[aboveIdx] += delta
-                                ratios[belowIdx] -= delta
-
-                                ratios[aboveIdx] = max(minRatio, ratios[aboveIdx])
-                                ratios[belowIdx] = max(minRatio, ratios[belowIdx])
-
-                                let sum = ratios.reduce(0, +)
-                                if sum > 0 {
-                                    ratios = ratios.map { $0 / sum }
-                                }
-
-                                state.sectionRatios = ratios
-                            }
-                    )
-                    .onHover { on in
-                        if on { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
-                    }
+            var ratios = state.sectionRatios
+            if ratios.count < allSections.count {
+                let fill = 1.0 / CGFloat(allSections.count)
+                ratios.append(contentsOf: Array(repeating: fill, count: allSections.count - ratios.count))
             }
+            guard aboveIdx < ratios.count, belowIdx < ratios.count else { return }
+            let minRatio: CGFloat = 0.08
+
+            ratios[aboveIdx] += delta
+            ratios[belowIdx] -= delta
+
+            ratios[aboveIdx] = max(minRatio, ratios[aboveIdx])
+            ratios[belowIdx] = max(minRatio, ratios[belowIdx])
+
+            let sum = ratios.reduce(0, +)
+            if sum > 0 {
+                ratios = ratios.map { $0 / sum }
+            }
+
+            state.sectionRatios = ratios
+        }
     }
 
     @ViewBuilder

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1343,7 +1343,7 @@ private struct SectionSplitLayout: View {
         Rectangle().fill(MuxyTheme.border).frame(height: 1)
             .overlay {
                 Color.clear
-                    .frame(height: UIMetrics.scaled(5))
+                    .frame(height: UIMetrics.resizeHandleHitArea)
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 1)

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -24,8 +24,9 @@ struct SplitContainer: View {
         GeometryReader { geo in
             let h = branch.direction == .horizontal
             let total = h ? geo.size.width : geo.size.height
-            let first = max(0, total * branch.ratio - 0.5)
-            let second = max(0, total * (1 - branch.ratio) - 0.5)
+            let handleSize = UIMetrics.resizeHandleHitArea
+            let first = max(0, total * branch.ratio - handleSize / 2)
+            let second = max(0, total * (1 - branch.ratio) - handleSize / 2)
 
             let layout = h ? AnyLayout(HStackLayout(spacing: 0)) : AnyLayout(VStackLayout(spacing: 0))
 
@@ -33,40 +34,26 @@ struct SplitContainer: View {
                 child(branch.first)
                     .frame(width: h ? first : nil, height: h ? nil : first)
 
-                Color.clear
-                    .frame(width: h ? 1 : nil, height: h ? nil : 1)
-                    .overlay(Rectangle().fill(MuxyTheme.border))
-                    .overlay {
-                        Color.clear
-                            .frame(width: h ? UIMetrics.resizeHandleHitArea : nil, height: h ? nil : UIMetrics.resizeHandleHitArea)
-                            .contentShape(Rectangle())
-                            .gesture(
-                                DragGesture(minimumDistance: 1)
-                                    .onChanged { v in
-                                        let pos = h ? v.location.x : v.location.y
-                                        let origin = h ? v.startLocation.x : v.startLocation.y
-                                        let startPos = total * branch.ratio
-                                        let newPos = startPos + (pos - origin)
-                                        branch.ratio = min(max(newPos / total, 0.15), 0.85)
-                                    }
-                            )
-                            .onHover { on in
-                                if on { (h ? NSCursor.resizeLeftRight : NSCursor.resizeUpDown).push() } else { NSCursor.pop() }
-                            }
+                ResizeHandle(axis: h ? .horizontal : .vertical) { v in
+                    let pos = h ? v.location.x : v.location.y
+                    let origin = h ? v.startLocation.x : v.startLocation.y
+                    let startPos = total * branch.ratio
+                    let newPos = startPos + (pos - origin)
+                    branch.ratio = min(max(newPos / total, 0.15), 0.85)
+                }
+                .accessibilityLabel(h ? "Horizontal Split Divider" : "Vertical Split Divider")
+                .accessibilityValue("Split ratio: \(Int(branch.ratio * 100))%")
+                .accessibilityAdjustableAction { direction in
+                    let step: CGFloat = 0.05
+                    switch direction {
+                    case .increment:
+                        branch.ratio = min(branch.ratio + step, 0.85)
+                    case .decrement:
+                        branch.ratio = max(branch.ratio - step, 0.15)
+                    @unknown default:
+                        break
                     }
-                    .accessibilityLabel(h ? "Horizontal Split Divider" : "Vertical Split Divider")
-                    .accessibilityValue("Split ratio: \(Int(branch.ratio * 100))%")
-                    .accessibilityAdjustableAction { direction in
-                        let step: CGFloat = 0.05
-                        switch direction {
-                        case .increment:
-                            branch.ratio = min(branch.ratio + step, 0.85)
-                        case .decrement:
-                            branch.ratio = max(branch.ratio - step, 0.15)
-                        @unknown default:
-                            break
-                        }
-                    }
+                }
 
                 child(branch.second)
                     .frame(width: h ? second : nil, height: h ? nil : second)

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -38,7 +38,7 @@ struct SplitContainer: View {
                     .overlay(Rectangle().fill(MuxyTheme.border))
                     .overlay {
                         Color.clear
-                            .frame(width: h ? UIMetrics.scaled(5) : nil, height: h ? nil : UIMetrics.scaled(5))
+                            .frame(width: h ? UIMetrics.resizeHandleHitArea : nil, height: h ? nil : UIMetrics.resizeHandleHitArea)
                             .contentShape(Rectangle())
                             .gesture(
                                 DragGesture(minimumDistance: 1)

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -24,9 +24,8 @@ struct SplitContainer: View {
         GeometryReader { geo in
             let h = branch.direction == .horizontal
             let total = h ? geo.size.width : geo.size.height
-            let handleSize = UIMetrics.resizeHandleHitArea
-            let first = max(0, total * branch.ratio - handleSize / 2)
-            let second = max(0, total * (1 - branch.ratio) - handleSize / 2)
+            let first = max(0, total * branch.ratio - 0.5)
+            let second = max(0, total * (1 - branch.ratio) - 0.5)
 
             let layout = h ? AnyLayout(HStackLayout(spacing: 0)) : AnyLayout(VStackLayout(spacing: 0))
 

--- a/Tests/MuxyTests/Git/GitProcessRunnerCredentialHelperTests.swift
+++ b/Tests/MuxyTests/Git/GitProcessRunnerCredentialHelperTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitProcessRunner.gitHubCredentialHelperArgs")
+struct GitProcessRunnerCredentialHelperTests {
+    @Test("returns empty when gh is not on disk")
+    func ghMissing() {
+        let args = GitProcessRunner.gitHubCredentialHelperArgs { _ in nil }
+        #expect(args.isEmpty)
+    }
+
+    @Test("resets inherited helper and scopes gh to github.com only")
+    func ghPresent() {
+        let args = GitProcessRunner.gitHubCredentialHelperArgs { _ in "/opt/homebrew/bin/gh" }
+        #expect(args == [
+            "-c", "credential.helper=",
+            "-c", "credential.https://github.com.helper=!/opt/homebrew/bin/gh auth git-credential",
+        ])
+    }
+
+    @Test("uses the absolute path returned by the resolver")
+    func usesResolvedPath() {
+        let args = GitProcessRunner.gitHubCredentialHelperArgs { _ in "/usr/local/bin/gh" }
+        #expect(args.contains("credential.https://github.com.helper=!/usr/local/bin/gh auth git-credential"))
+    }
+}


### PR DESCRIPTION
- Use GitHub CLI credentials for github.com git operations so pushes can authenticate reliably.
- Clear inherited credential helpers for these commands to avoid conflicting auth behavior.

Includes tests for missing and resolved `gh` paths.