### PR TITLE
Fix GitHub auth for fork PR pushes

### DIFF
--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -60,12 +60,20 @@ enum GitProcessRunner {
         try await runProcess(
             ProcessSpec(
                 executable: "/usr/bin/env",
-                arguments: ["git", "-C", repoPath] + arguments,
+                arguments: ["git"] + gitHubCredentialHelperArgs() + ["-C", repoPath] + arguments,
                 workingDirectory: nil,
                 lineLimit: lineLimit,
                 signpostName: "git"
             )
         )
+    }
+
+    static func gitHubCredentialHelperArgs(ghResolver: (String) -> String? = resolveExecutable) -> [String] {
+        guard let ghPath = ghResolver("gh") else { return [] }
+        return [
+            "-c", "credential.helper=",
+            "-c", "credential.https://github.com.helper=!\(ghPath) auth git-credential",
+        ]
     }
 
     static func runCommand(

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -87,11 +87,21 @@ actor GitWorktreeService: GitWorktreeListing {
         }
     }
 
-    func addWorktree(repoPath: String, path: String, branch: String, createBranch: Bool) async throws {
+    func addWorktree(
+        repoPath: String,
+        path: String,
+        branch: String,
+        createBranch: Bool,
+        baseBranch: String? = nil
+    ) async throws {
         try Self.validateBranchName(branch)
         var args: [String] = ["worktree", "add"]
         if createBranch {
-            args += ["-b", branch, "--", path]
+            args += ["-b", branch, path]
+            if let baseBranch {
+                try Self.validateBranchName(baseBranch)
+                args.append(baseBranch)
+            }
         } else {
             args += ["--", path, branch]
         }

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -521,7 +521,8 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         projectID: UUID,
         name: String,
         branch: String,
-        createBranch: Bool
+        createBranch: Bool,
+        baseBranch: String?
     ) async throws -> WorktreeDTO {
         guard let project = projectStore.projects.first(where: { $0.id == projectID }) else {
             throw RemoteVCSError.projectNotFound
@@ -534,6 +535,8 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         guard !trimmedBranch.isEmpty else {
             throw RemoteVCSError.invalidInput("Branch name is required.")
         }
+        let trimmedBase = baseBranch?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBase: String? = (createBranch && trimmedBase?.isEmpty == false) ? trimmedBase : nil
         let slug = Self.worktreeSlug(from: trimmedName)
         let worktreeDirectory = WorktreeLocationResolver.worktreeDirectory(for: project, slug: slug)
 
@@ -556,7 +559,8 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             repoPath: project.path,
             path: worktreeDirectory,
             branch: trimmedBranch,
-            createBranch: createBranch
+            createBranch: createBranch,
+            baseBranch: resolvedBase
         )
 
         let worktree = Worktree(

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -22,6 +22,8 @@ struct CreateWorktreeSheet: View {
     @State private var selectedParentPath: String?
     @State private var usesProjectLocation = false
     @State private var availableBranches: [String] = []
+    @State private var defaultBranch: String?
+    @State private var selectedBaseBranch: String = ""
     @State private var setupCommands: [String] = []
     @State private var runSetup = false
     @State private var inProgress = false
@@ -54,6 +56,16 @@ struct CreateWorktreeSheet: View {
                         .onChange(of: branchName) { _, newValue in
                             branchNameEdited = newValue != name
                         }
+                }
+                VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                    Text("Base Branch").font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
+                    Picker("", selection: $selectedBaseBranch) {
+                        ForEach(availableBranches, id: \.self) { branch in
+                            Text(branch).tag(branch)
+                        }
+                    }
+                    .labelsHidden()
+                    .disabled(availableBranches.isEmpty)
                 }
             } else {
                 VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
@@ -248,11 +260,22 @@ struct CreateWorktreeSheet: View {
 
     private func loadBranches() async {
         do {
-            let branches = try await gitRepository.listBranches(repoPath: project.path)
+            async let branchesValue = gitRepository.listBranches(repoPath: project.path)
+            async let defaultValue = gitRepository.defaultBranch(repoPath: project.path)
+            let branches = try await branchesValue
+            let resolvedDefault = await defaultValue
             await MainActor.run {
                 availableBranches = branches
+                defaultBranch = resolvedDefault
                 if selectedExistingBranch.isEmpty {
                     selectedExistingBranch = branches.first ?? ""
+                }
+                if selectedBaseBranch.isEmpty {
+                    if let resolvedDefault, branches.contains(resolvedDefault) {
+                        selectedBaseBranch = resolvedDefault
+                    } else {
+                        selectedBaseBranch = branches.first ?? ""
+                    }
                 }
             }
         } catch {
@@ -297,12 +320,16 @@ struct CreateWorktreeSheet: View {
             return
         }
 
+        let trimmedBase = selectedBaseBranch.trimmingCharacters(in: .whitespaces)
+        let baseBranch: String? = createNewBranch && !trimmedBase.isEmpty ? trimmedBase : nil
+
         do {
             try await gitWorktree.addWorktree(
                 repoPath: project.path,
                 path: worktreeDirectory,
                 branch: branch,
-                createBranch: createNewBranch
+                createBranch: createNewBranch,
+                baseBranch: baseBranch
             )
         } catch {
             inProgress = false

--- a/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Sidebar/CreateWorktreeSheet.swift
@@ -22,7 +22,6 @@ struct CreateWorktreeSheet: View {
     @State private var selectedParentPath: String?
     @State private var usesProjectLocation = false
     @State private var availableBranches: [String] = []
-    @State private var defaultBranch: String?
     @State private var selectedBaseBranch: String = ""
     @State private var setupCommands: [String] = []
     @State private var runSetup = false
@@ -266,7 +265,6 @@ struct CreateWorktreeSheet: View {
             let resolvedDefault = await defaultValue
             await MainActor.run {
                 availableBranches = branches
-                defaultBranch = resolvedDefault
                 if selectedExistingBranch.isEmpty {
                     selectedExistingBranch = branches.first ?? ""
                 }

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -63,7 +63,13 @@ public protocol MuxyRemoteServerDelegate: AnyObject {
     func vcsCreateBranch(projectID: UUID, name: String) async throws
     func vcsCreatePR(projectID: UUID, title: String, body: String, baseBranch: String?, draft: Bool) async throws -> VCSCreatePRResultDTO
     func vcsMergePullRequest(projectID: UUID, number: Int, method: VCSMergeMethodDTO, deleteBranch: Bool) async throws
-    func vcsAddWorktree(projectID: UUID, name: String, branch: String, createBranch: Bool) async throws -> WorktreeDTO
+    func vcsAddWorktree(
+        projectID: UUID,
+        name: String,
+        branch: String,
+        createBranch: Bool,
+        baseBranch: String?
+    ) async throws -> WorktreeDTO
     func vcsRemoveWorktree(projectID: UUID, worktreeID: UUID) async throws
     func getProjectLogo(projectID: UUID) -> ProjectLogoDTO?
     func listNotifications() -> [NotificationDTO]
@@ -605,7 +611,8 @@ public final class MuxyRemoteServer: @unchecked Sendable {
                     projectID: params.projectID,
                     name: params.name,
                     branch: params.branch,
-                    createBranch: params.createBranch
+                    createBranch: params.createBranch,
+                    baseBranch: params.baseBranch
                 )
                 return MuxyResponse(id: request.id, result: .worktrees([worktree]))
             } catch {

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -483,11 +483,19 @@ public struct VCSAddWorktreeParams: Codable, Sendable {
     public let name: String
     public let branch: String
     public let createBranch: Bool
-    public init(projectID: UUID, name: String, branch: String, createBranch: Bool) {
+    public let baseBranch: String?
+    public init(
+        projectID: UUID,
+        name: String,
+        branch: String,
+        createBranch: Bool,
+        baseBranch: String? = nil
+    ) {
         self.projectID = projectID
         self.name = name
         self.branch = branch
         self.createBranch = createBranch
+        self.baseBranch = baseBranch
     }
 }
 

--- a/Tests/MuxyTests/Git/GitProcessRunnerCredentialHelperTests.swift
+++ b/Tests/MuxyTests/Git/GitProcessRunnerCredentialHelperTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitProcessRunner.gitHubCredentialHelperArgs")
+struct GitProcessRunnerCredentialHelperTests {
+    @Test("returns empty when gh is not on disk")
+    func ghMissing() {
+        let args = GitProcessRunner.gitHubCredentialHelperArgs { _ in nil }
+        #expect(args.isEmpty)
+    }
+
+    @Test("resets inherited helper and scopes gh to github.com only")
+    func ghPresent() {
+        let args = GitProcessRunner.gitHubCredentialHelperArgs { _ in "/opt/homebrew/bin/gh" }
+        #expect(args == [
+            "-c", "credential.helper=",
+            "-c", "credential.https://github.com.helper=!/opt/homebrew/bin/gh auth git-credential",
+        ])
+    }
+
+    @Test("uses the absolute path returned by the resolver")
+    func usesResolvedPath() {
+        let args = GitProcessRunner.gitHubCredentialHelperArgs { _ in "/usr/local/bin/gh" }
+        #expect(args.contains("credential.https://github.com.helper=!/usr/local/bin/gh auth git-credential"))
+    }
+}

--- a/Tests/MuxyTests/Git/GitWorktreeServiceAddTests.swift
+++ b/Tests/MuxyTests/Git/GitWorktreeServiceAddTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitWorktreeService.addWorktree")
+struct GitWorktreeServiceAddTests {
+    @Test("new branch is created from the supplied base branch, not current HEAD")
+    func newBranchUsesBaseBranch() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        try repo.run("checkout", "-b", "release")
+        try repo.commit(file: "b.txt", contents: "2", message: "on release")
+        try repo.run("checkout", "main")
+
+        let worktreePath = repo.siblingPath("feature-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "feature",
+            createBranch: true,
+            baseBranch: "release"
+        )
+
+        let head = try repo.runCapturing(at: worktreePath, "rev-parse", "HEAD")
+        let releaseHead = try repo.runCapturing("rev-parse", "release")
+        #expect(head == releaseHead)
+
+        let bExists = FileManager.default.fileExists(atPath: "\(worktreePath)/b.txt")
+        #expect(bExists, "Expected file from release branch to be present in the new worktree")
+    }
+
+    @Test("omitting the base branch falls back to current HEAD")
+    func newBranchDefaultsToHEADWhenNoBase() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+
+        let worktreePath = repo.siblingPath("noBase-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        let head = try repo.runCapturing(at: worktreePath, "rev-parse", "HEAD")
+        let mainHead = try repo.runCapturing("rev-parse", "main")
+        #expect(head == mainHead)
+    }
+}
+
+private struct TempGitRepo {
+    let path: String
+    private let parent: String
+
+    init() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-worktree-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        parent = base.path
+        path = base.appendingPathComponent("repo", isDirectory: true).path
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        try run("init", "-q", "-b", "main")
+        try run("config", "user.email", "test@example.com")
+        try run("config", "user.name", "Test")
+        try run("config", "commit.gpgsign", "false")
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(atPath: parent)
+    }
+
+    func siblingPath(_ name: String) -> String {
+        URL(fileURLWithPath: parent).appendingPathComponent(name).path
+    }
+
+    func commit(file: String, contents: String, message: String) throws {
+        let fileURL = URL(fileURLWithPath: path).appendingPathComponent(file)
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        try run("add", file)
+        try run("commit", "-q", "-m", message)
+    }
+
+    func run(_ args: String...) throws {
+        _ = try runGit(at: path, args: args)
+    }
+
+    func runCapturing(_ args: String...) throws -> String {
+        try runGit(at: path, args: args)
+    }
+
+    func runCapturing(at workingDir: String, _ args: String...) throws -> String {
+        try runGit(at: workingDir, args: args)
+    }
+
+    private func runGit(at workingDir: String, args: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", workingDir] + args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        if process.terminationStatus != 0 {
+            throw NSError(
+                domain: "GitTestRepo",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: output]
+            )
+        }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
@@ -24,7 +24,7 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
     var vcsCreateBranchCalls: [(projectID: UUID, name: String)] = []
     var vcsCreatePRCalls: [(projectID: UUID, title: String, body: String, baseBranch: String?, draft: Bool)] = []
     var vcsMergePullRequestCalls: [(projectID: UUID, number: Int, method: VCSMergeMethodDTO, deleteBranch: Bool)] = []
-    var vcsAddWorktreeCalls: [(projectID: UUID, name: String, branch: String, createBranch: Bool)] = []
+    var vcsAddWorktreeCalls: [(projectID: UUID, name: String, branch: String, createBranch: Bool, baseBranch: String?)] = []
     var vcsRemoveWorktreeCalls: [(projectID: UUID, worktreeID: UUID)] = []
 
     var stubProjects: [ProjectDTO] = []
@@ -160,9 +160,10 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
         projectID: UUID,
         name: String,
         branch: String,
-        createBranch: Bool
+        createBranch: Bool,
+        baseBranch: String?
     ) async throws -> WorktreeDTO {
-        vcsAddWorktreeCalls.append((projectID, name, branch, createBranch))
+        vcsAddWorktreeCalls.append((projectID, name, branch, createBranch, baseBranch))
         return stubAddedWorktree
     }
 
@@ -563,8 +564,9 @@ struct MuxyRemoteServerRoutingTests {
                 params: .vcsAddWorktree(VCSAddWorktreeParams(
                     projectID: projectID,
                     name: "wt",
-                    branch: "main",
-                    createBranch: false
+                    branch: "feature",
+                    createBranch: true,
+                    baseBranch: "main"
                 ))
             ),
             clientID: clientID
@@ -580,8 +582,9 @@ struct MuxyRemoteServerRoutingTests {
 
         #expect(delegate.vcsAddWorktreeCalls.first?.projectID == projectID)
         #expect(delegate.vcsAddWorktreeCalls.first?.name == "wt")
-        #expect(delegate.vcsAddWorktreeCalls.first?.branch == "main")
-        #expect(delegate.vcsAddWorktreeCalls.first?.createBranch == false)
+        #expect(delegate.vcsAddWorktreeCalls.first?.branch == "feature")
+        #expect(delegate.vcsAddWorktreeCalls.first?.createBranch == true)
+        #expect(delegate.vcsAddWorktreeCalls.first?.baseBranch == "main")
         #expect(delegate.vcsRemoveWorktreeCalls.first?.projectID == projectID)
         #expect(delegate.vcsRemoveWorktreeCalls.first?.worktreeID == worktreeID)
         guard case let .worktrees(worktrees) = addResponse.result else {


### PR DESCRIPTION
- Use the GitHub CLI credential helper for GitHub git commands so fork PR pushes can authenticate reliably.
- Let new worktrees choose an explicit base branch, defaulting to the repo default branch when available.