### PR TITLE
Improve find-in-files matching

### DIFF
--- a/Muxy/Services/TextSearchService.swift
+++ b/Muxy/Services/TextSearchService.swift
@@ -7,63 +7,39 @@ struct TextSearchMatch: Identifiable, Equatable {
     let lineNumber: Int
     let column: Int
     let lineText: String
-    let matchStart: Int
-    let matchEnd: Int
+    let matchByteStart: Int
+    let matchByteLength: Int
+}
+
+struct TextSearchOptions: Equatable {
+    var caseSensitive: Bool = false
+    var wholeWord: Bool = false
 }
 
 enum TextSearchService {
     static let maxResults = 200
+    static let maxResultsPerFile = 20
     static let minQueryLength = 2
 
-    static func search(query: String, in projectPath: String) async -> [TextSearchMatch] {
+    private static let coordinator = SearchCoordinator()
+
+    static func search(
+        query: String,
+        in projectPath: String,
+        options: TextSearchOptions = TextSearchOptions()
+    ) async -> [TextSearchMatch] {
         let trimmed = query.trimmingCharacters(in: .whitespaces)
         guard trimmed.count >= minQueryLength else { return [] }
         guard let executable = ripgrepExecutableURL() else { return [] }
         guard let patternData = trimmed.data(using: .utf8) else { return [] }
 
-        return await withCheckedContinuation { continuation in
-            let process = Process()
-            process.executableURL = executable
-            process.arguments = arguments(projectPath: projectPath)
-
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            let stdinPipe = Pipe()
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
-            process.standardInput = stdinPipe
-
-            let resultsBox = MatchesBox()
-            let handle = stdoutPipe.fileHandleForReading
-
-            handle.readabilityHandler = { fileHandle in
-                let data = fileHandle.availableData
-                if data.isEmpty { return }
-                guard let chunk = String(data: data, encoding: .utf8) else { return }
-                let done = resultsBox.append(chunk: chunk, projectPath: projectPath, limit: maxResults)
-                if done, process.isRunning {
-                    process.terminate()
-                }
-            }
-
-            process.terminationHandler = { _ in
-                handle.readabilityHandler = nil
-                if let remaining = try? handle.readToEnd(), let chunk = String(data: remaining, encoding: .utf8) {
-                    _ = resultsBox.append(chunk: chunk, projectPath: projectPath, limit: maxResults)
-                }
-                continuation.resume(returning: resultsBox.take())
-            }
-
-            do {
-                try process.run()
-                stdinPipe.fileHandleForWriting.write(patternData)
-                try? stdinPipe.fileHandleForWriting.close()
-            } catch {
-                handle.readabilityHandler = nil
-                try? stdinPipe.fileHandleForWriting.close()
-                continuation.resume(returning: [])
-            }
-        }
+        return await coordinator.run(
+            executable: executable,
+            patternData: patternData,
+            patternByteLength: patternData.count,
+            projectPath: projectPath,
+            options: options
+        )
     }
 
     static func ripgrepExecutableURL() -> URL? {
@@ -77,107 +53,161 @@ enum TextSearchService {
         return nil
     }
 
-    private static func arguments(projectPath: String) -> [String] {
-        [
-            "--json",
-            "--smart-case",
-            "--max-count", "20",
+    static func arguments(projectPath: String, options: TextSearchOptions) -> [String] {
+        var args: [String] = [
+            "--vimgrep",
+            "--max-count", "\(maxResultsPerFile)",
             "--max-columns", "300",
             "--max-filesize", "2M",
             "--no-config",
-            "-f",
-            "-",
-            "--",
-            projectPath,
+            "-F",
         ]
+        args.append(options.caseSensitive ? "--case-sensitive" : "--smart-case")
+        if options.wholeWord { args.append("--word-regexp") }
+        args.append(contentsOf: ["-f", "-", "--", projectPath])
+        return args
     }
 
-    static func parseLine(_ line: String, projectPath: String) -> TextSearchMatch? {
-        guard let data = line.data(using: .utf8) else { return nil }
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-        guard let type = object["type"] as? String, type == "match" else { return nil }
-        guard let payload = object["data"] as? [String: Any] else { return nil }
-        guard let pathDict = payload["path"] as? [String: Any] else { return nil }
-        guard let absolutePath = pathDict["text"] as? String else { return nil }
-        guard let lineNumber = payload["line_number"] as? Int else { return nil }
-        guard let lineDict = payload["lines"] as? [String: Any] else { return nil }
-        guard var lineText = lineDict["text"] as? String else { return nil }
-        if lineText.hasSuffix("\n") { lineText.removeLast() }
-        if lineText.hasSuffix("\r") { lineText.removeLast() }
+    static func parseVimgrepLine(
+        _ line: Substring,
+        projectPath: String,
+        patternByteLength: Int
+    ) -> TextSearchMatch? {
+        guard let firstColon = line.firstIndex(of: ":") else { return nil }
+        let absolutePath = String(line[..<firstColon])
+        let afterPath = line.index(after: firstColon)
 
-        var matchStart = 0
-        var matchEnd = lineText.utf8.count
-        if let submatches = payload["submatches"] as? [[String: Any]], let first = submatches.first {
-            matchStart = (first["start"] as? Int) ?? 0
-            matchEnd = (first["end"] as? Int) ?? matchStart
-        }
+        guard let secondColon = line[afterPath...].firstIndex(of: ":") else { return nil }
+        guard let lineNumber = Int(line[afterPath ..< secondColon]) else { return nil }
+        let afterLine = line.index(after: secondColon)
+
+        guard let thirdColon = line[afterLine...].firstIndex(of: ":") else { return nil }
+        guard let column = Int(line[afterLine ..< thirdColon]) else { return nil }
+        let textStart = line.index(after: thirdColon)
+
+        let lineText = String(line[textStart...])
 
         let prefix = projectPath.hasSuffix("/") ? projectPath : projectPath + "/"
         let relative = absolutePath.hasPrefix(prefix)
             ? String(absolutePath.dropFirst(prefix.count))
             : absolutePath
 
-        let column = columnFromUTF8Offset(matchStart, in: lineText)
+        let byteStart = max(0, column - 1)
+        let byteLength = min(patternByteLength, max(0, lineText.utf8.count - byteStart))
 
         return TextSearchMatch(
-            id: "\(absolutePath):\(lineNumber):\(matchStart)",
+            id: "\(absolutePath):\(lineNumber):\(byteStart)",
             absolutePath: absolutePath,
             relativePath: relative,
             lineNumber: lineNumber,
             column: column,
             lineText: lineText,
-            matchStart: matchStart,
-            matchEnd: matchEnd
+            matchByteStart: byteStart,
+            matchByteLength: byteLength
         )
-    }
-
-    static func columnFromUTF8Offset(_ utf8Offset: Int, in text: String) -> Int {
-        guard utf8Offset > 0 else { return 1 }
-        let utf8 = text.utf8
-        var consumed = 0
-        var characterCount = 0
-        var index = utf8.startIndex
-        while index != utf8.endIndex, consumed < utf8Offset {
-            consumed += 1
-            index = utf8.index(after: index)
-            if let scalarIndex = index.samePosition(in: text.unicodeScalars) {
-                characterCount = text.unicodeScalars.distance(from: text.unicodeScalars.startIndex, to: scalarIndex)
-            }
-        }
-        return characterCount + 1
     }
 }
 
-private final class MatchesBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var buffer = ""
-    private var matches: [TextSearchMatch] = []
+private actor SearchCoordinator {
+    private var current: (process: Process, exit: Task<Void, Never>)?
 
-    func append(chunk: String, projectPath: String, limit: Int) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
+    func run(
+        executable: URL,
+        patternData: Data,
+        patternByteLength: Int,
+        projectPath: String,
+        options: TextSearchOptions
+    ) async -> [TextSearchMatch] {
+        if let active = current {
+            if active.process.isRunning { active.process.terminate() }
+            await active.exit.value
+            current = nil
+        }
 
-        if matches.count >= limit { return true }
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = TextSearchService.arguments(projectPath: projectPath, options: options)
 
-        buffer.append(chunk)
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let stdinPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        process.standardInput = stdinPipe
 
-        while let newlineRange = buffer.range(of: "\n") {
-            let line = String(buffer[buffer.startIndex ..< newlineRange.lowerBound])
-            buffer.removeSubrange(buffer.startIndex ..< newlineRange.upperBound)
+        let outputBox = OutputBox()
+        let stdoutHandle = stdoutPipe.fileHandleForReading
+        stdoutHandle.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty { return }
+            outputBox.append(data)
+        }
 
-            if line.isEmpty { continue }
-            if let match = TextSearchService.parseLine(line, projectPath: projectPath) {
-                matches.append(match)
-                if matches.count >= limit { return true }
+        let exitTask = Task<Void, Never> {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                process.terminationHandler = { _ in
+                    stdoutHandle.readabilityHandler = nil
+                    if let remaining = try? stdoutHandle.readToEnd(), !remaining.isEmpty {
+                        outputBox.append(remaining)
+                    }
+                    continuation.resume()
+                }
             }
         }
 
-        return matches.count >= limit
-    }
+        do {
+            try process.run()
+            stdinPipe.fileHandleForWriting.write(patternData)
+            try? stdinPipe.fileHandleForWriting.close()
+        } catch {
+            stdoutHandle.readabilityHandler = nil
+            try? stdinPipe.fileHandleForWriting.close()
+            return []
+        }
 
-    func take() -> [TextSearchMatch] {
+        current = (process, exitTask)
+
+        return await withTaskCancellationHandler {
+            await exitTask.value
+            if current?.process === process { current = nil }
+            return outputBox.parseMatches(projectPath: projectPath, patternByteLength: patternByteLength)
+        } onCancel: {
+            if process.isRunning { process.terminate() }
+        }
+    }
+}
+
+private final class OutputBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffer = Data()
+
+    func append(_ data: Data) {
         lock.lock()
         defer { lock.unlock() }
+        buffer.append(data)
+    }
+
+    func parseMatches(projectPath: String, patternByteLength: Int) -> [TextSearchMatch] {
+        lock.lock()
+        let data = buffer
+        lock.unlock()
+
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+
+        var matches: [TextSearchMatch] = []
+        matches.reserveCapacity(TextSearchService.maxResults)
+
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let match = TextSearchService.parseVimgrepLine(
+                line,
+                projectPath: projectPath,
+                patternByteLength: patternByteLength
+            )
+            else { continue }
+            matches.append(match)
+            if matches.count >= TextSearchService.maxResults { break }
+        }
+
         return matches
     }
 }

--- a/Muxy/Services/TextSearchService.swift
+++ b/Muxy/Services/TextSearchService.swift
@@ -21,19 +21,19 @@ enum TextSearchService {
     static let maxResultsPerFile = 20
     static let minQueryLength = 2
 
-    private static let coordinator = SearchCoordinator()
-
     static func search(
         query: String,
         in projectPath: String,
-        options: TextSearchOptions = TextSearchOptions()
+        options: TextSearchOptions = TextSearchOptions(),
+        coordinator: SearchCoordinator? = nil
     ) async -> [TextSearchMatch] {
         let trimmed = query.trimmingCharacters(in: .whitespaces)
         guard trimmed.count >= minQueryLength else { return [] }
         guard let executable = ripgrepExecutableURL() else { return [] }
         guard let patternData = trimmed.data(using: .utf8) else { return [] }
 
-        return await coordinator.run(
+        let runner = coordinator ?? SearchCoordinator()
+        return await runner.run(
             executable: executable,
             patternData: patternData,
             patternByteLength: patternData.count,
@@ -108,7 +108,7 @@ enum TextSearchService {
     }
 }
 
-private actor SearchCoordinator {
+actor SearchCoordinator {
     private var current: (process: Process, exit: Task<Void, Never>)?
 
     func run(

--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -10,6 +10,7 @@ struct FindInFilesOverlay: View {
     @State private var highlightedMatchID: String?
     @State private var isSearching = false
     @State private var searchTask: Task<Void, Never>?
+    @State private var options = TextSearchOptions()
 
     var body: some View {
         ZStack {
@@ -49,6 +50,22 @@ struct FindInFilesOverlay: View {
                 onArrowUp: { moveHighlight(-1) },
                 onArrowDown: { moveHighlight(1) }
             )
+            SearchOptionToggle(
+                label: "Aa",
+                isOn: options.caseSensitive,
+                tooltip: "Match Case"
+            ) {
+                options.caseSensitive.toggle()
+                performSearch(debounce: false)
+            }
+            SearchOptionToggle(
+                label: "ab|",
+                isOn: options.wholeWord,
+                tooltip: "Match Whole Word"
+            ) {
+                options.wholeWord.toggle()
+                performSearch(debounce: false)
+            }
         }
         .padding(.horizontal, UIMetrics.spacing6)
         .padding(.vertical, UIMetrics.spacing5)
@@ -104,11 +121,11 @@ struct FindInFilesOverlay: View {
 
         searchTask = Task {
             if debounce {
-                try? await Task.sleep(for: .milliseconds(50))
+                try? await Task.sleep(for: .milliseconds(120))
                 guard !Task.isCancelled else { return }
             }
 
-            let found = await TextSearchService.search(query: currentQuery, in: projectPath)
+            let found = await TextSearchService.search(query: currentQuery, in: projectPath, options: options)
             guard !Task.isCancelled else { return }
 
             await MainActor.run {
@@ -210,42 +227,67 @@ private struct MatchRow: View {
     let isHighlighted: Bool
     @State private var hovered = false
 
+    private static let maxSnippetCharacters = 200
+    private static let leadingContextCharacters = 24
+
     var body: some View {
-        highlightedSnippet
-            .font(.system(size: UIMetrics.fontBody, design: .monospaced))
-            .lineLimit(1)
-            .truncationMode(.tail)
-            .padding(.leading, UIMetrics.spacing9)
-            .padding(.trailing, UIMetrics.spacing6)
-            .padding(.vertical, UIMetrics.scaled(3))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
-            .onHover { hovered = $0 }
+        HStack(alignment: .firstTextBaseline, spacing: UIMetrics.spacing4) {
+            Text("\(match.lineNumber)")
+                .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
+                .foregroundStyle(MuxyTheme.fgDim)
+                .frame(minWidth: UIMetrics.scaled(36), alignment: .trailing)
+            snippet
+                .font(.system(size: UIMetrics.fontBody, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.leading, UIMetrics.spacing6)
+        .padding(.trailing, UIMetrics.spacing6)
+        .padding(.vertical, UIMetrics.scaled(3))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isHighlighted ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
+        .onHover { hovered = $0 }
     }
 
-    private var highlightedSnippet: Text {
-        let trimmed = trimLeadingWhitespace(match.lineText)
-        let utf8 = Array(match.lineText.utf8)
-        let removed = utf8.count - Array(trimmed.utf8).count
+    private var snippet: Text {
+        let line = match.lineText
+        let utf8 = line.utf8
+        let total = utf8.count
 
-        let adjustedStart = max(0, match.matchStart - removed)
-        let adjustedEnd = max(adjustedStart, match.matchEnd - removed)
-        let trimmedUTF8 = Array(trimmed.utf8)
-
-        guard match.matchStart >= 0,
-              match.matchEnd <= utf8.count,
-              match.matchStart < match.matchEnd,
-              adjustedEnd <= trimmedUTF8.count
+        guard match.matchByteStart >= 0,
+              match.matchByteLength > 0,
+              match.matchByteStart + match.matchByteLength <= total,
+              let startScalar = utf8Index(line, byteOffset: match.matchByteStart),
+              let endScalar = utf8Index(line, byteOffset: match.matchByteStart + match.matchByteLength)
         else {
-            return Text(trimmed).foregroundColor(MuxyTheme.fgDim)
+            return Text(trimmed(line)).foregroundColor(MuxyTheme.fgDim)
         }
 
-        let prefix = String(data: Data(trimmedUTF8[0 ..< adjustedStart]), encoding: .utf8) ?? ""
-        let middle = String(data: Data(trimmedUTF8[adjustedStart ..< adjustedEnd]), encoding: .utf8) ?? ""
-        let suffix = String(data: Data(trimmedUTF8[adjustedEnd ..< trimmedUTF8.count]), encoding: .utf8) ?? ""
-        return Text(prefix).foregroundColor(MuxyTheme.fgDim)
-            + Text(middle).foregroundColor(MuxyTheme.fg).bold()
-            + Text(suffix).foregroundColor(MuxyTheme.fgDim)
+        let beforeMatch = String(line[..<startScalar])
+        let middle = String(line[startScalar ..< endScalar])
+        let afterMatch = String(line[endScalar...])
+
+        let leadingTrimmed = trimLeadingWhitespace(beforeMatch)
+        let (prefixDisplay, prefixEllipsis) = truncatedPrefix(leadingTrimmed)
+        let (suffixDisplay, suffixEllipsis) = truncatedSuffix(afterMatch)
+
+        let prefixPart = Text(prefixEllipsis ? "…" : "").foregroundColor(MuxyTheme.fgDim)
+            + Text(prefixDisplay).foregroundColor(MuxyTheme.fgDim)
+        let matchPart = Text(middle).foregroundColor(MuxyTheme.fg).bold()
+        let suffixPart = Text(suffixDisplay).foregroundColor(MuxyTheme.fgDim)
+            + Text(suffixEllipsis ? "…" : "").foregroundColor(MuxyTheme.fgDim)
+        return prefixPart + matchPart + suffixPart
+    }
+
+    private func utf8Index(_ string: String, byteOffset: Int) -> String.Index? {
+        let utf8 = string.utf8
+        guard byteOffset >= 0, byteOffset <= utf8.count else { return nil }
+        let index = utf8.index(utf8.startIndex, offsetBy: byteOffset)
+        return index.samePosition(in: string)
+    }
+
+    private func trimmed(_ text: String) -> String {
+        trimLeadingWhitespace(text)
     }
 
     private func trimLeadingWhitespace(_ text: String) -> String {
@@ -254,5 +296,48 @@ private struct MatchRow: View {
             index = text.index(after: index)
         }
         return String(text[index...])
+    }
+
+    private func truncatedPrefix(_ text: String) -> (String, Bool) {
+        let limit = Self.leadingContextCharacters
+        guard text.count > limit else { return (text, false) }
+        let start = text.index(text.endIndex, offsetBy: -limit)
+        return (String(text[start...]), true)
+    }
+
+    private func truncatedSuffix(_ text: String) -> (String, Bool) {
+        let limit = Self.maxSnippetCharacters - Self.leadingContextCharacters
+        guard text.count > limit else { return (text, false) }
+        let end = text.index(text.startIndex, offsetBy: limit)
+        return (String(text[..<end]), true)
+    }
+}
+
+private struct SearchOptionToggle: View {
+    let label: String
+    let isOn: Bool
+    let tooltip: String
+    let action: () -> Void
+
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold, design: .monospaced))
+                .foregroundStyle(isOn ? MuxyTheme.fg : MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.scaled(28), height: UIMetrics.scaled(22))
+                .background(
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
+                        .fill(isOn ? MuxyTheme.surface : hovered ? MuxyTheme.hover : .clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
+                        .stroke(isOn ? MuxyTheme.border : .clear, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+        .onHover { hovered = $0 }
     }
 }

--- a/Muxy/Views/Components/FindInFilesOverlay.swift
+++ b/Muxy/Views/Components/FindInFilesOverlay.swift
@@ -11,6 +11,7 @@ struct FindInFilesOverlay: View {
     @State private var isSearching = false
     @State private var searchTask: Task<Void, Never>?
     @State private var options = TextSearchOptions()
+    @State private var coordinator = SearchCoordinator()
 
     var body: some View {
         ZStack {
@@ -127,7 +128,12 @@ struct FindInFilesOverlay: View {
                 guard !Task.isCancelled else { return }
             }
 
-            let found = await TextSearchService.search(query: currentQuery, in: projectPath, options: options)
+            let found = await TextSearchService.search(
+                query: currentQuery,
+                in: projectPath,
+                options: options,
+                coordinator: coordinator
+            )
             guard !Task.isCancelled else { return }
 
             await MainActor.run {

--- a/Tests/MuxyTests/Services/TextSearchServiceTests.swift
+++ b/Tests/MuxyTests/Services/TextSearchServiceTests.swift
@@ -5,52 +5,49 @@ import Testing
 
 @Suite("TextSearchService")
 struct TextSearchServiceTests {
-    @Test("parses ripgrep match line")
-    func parsesMatch() throws {
-        let line = #"{"type":"match","data":{"path":{"text":"/proj/src/foo.swift"},"lines":{"text":"  let answer = 42\n"},"line_number":12,"absolute_offset":120,"submatches":[{"match":{"text":"answer"},"start":6,"end":12}]}}"#
-        let match = try #require(TextSearchService.parseLine(line, projectPath: "/proj"))
+    @Test("parses a vimgrep line")
+    func parsesVimgrepLine() throws {
+        let line: Substring = "/proj/src/foo.swift:12:7:  let answer = 42"
+        let match = try #require(TextSearchService.parseVimgrepLine(
+            line, projectPath: "/proj", patternByteLength: 6
+        ))
 
         #expect(match.absolutePath == "/proj/src/foo.swift")
         #expect(match.relativePath == "src/foo.swift")
         #expect(match.lineNumber == 12)
         #expect(match.lineText == "  let answer = 42")
-        #expect(match.matchStart == 6)
-        #expect(match.matchEnd == 12)
+        #expect(match.matchByteStart == 6)
+        #expect(match.matchByteLength == 6)
         #expect(match.column == 7)
-    }
-
-    @Test("returns nil for non-match types")
-    func ignoresBeginAndEnd() throws {
-        let begin = #"{"type":"begin","data":{"path":{"text":"/proj/x"}}}"#
-        let end = #"{"type":"end","data":{"path":{"text":"/proj/x"},"stats":{}}}"#
-        #expect(TextSearchService.parseLine(begin, projectPath: "/proj") == nil)
-        #expect(TextSearchService.parseLine(end, projectPath: "/proj") == nil)
     }
 
     @Test("falls back to absolute path when not under project")
     func absoluteWhenOutsideProject() throws {
-        let line = #"{"type":"match","data":{"path":{"text":"/other/foo.swift"},"lines":{"text":"hit\n"},"line_number":1,"absolute_offset":0,"submatches":[{"match":{"text":"hit"},"start":0,"end":3}]}}"#
-        let match = try #require(TextSearchService.parseLine(line, projectPath: "/proj"))
+        let line: Substring = "/other/foo.swift:1:1:hit"
+        let match = try #require(TextSearchService.parseVimgrepLine(
+            line, projectPath: "/proj", patternByteLength: 3
+        ))
         #expect(match.relativePath == "/other/foo.swift")
     }
 
-    @Test("computes column for multibyte characters")
-    func multibyteColumn() {
-        let column = TextSearchService.columnFromUTF8Offset(4, in: "héllo world")
-        #expect(column == 4)
+    @Test("preserves text containing colons")
+    func keepsColonsInLineText() throws {
+        let line: Substring = "/proj/x.swift:3:5:    a: Int = 1"
+        let match = try #require(TextSearchService.parseVimgrepLine(
+            line, projectPath: "/proj", patternByteLength: 1
+        ))
+        #expect(match.lineText == "    a: Int = 1")
+        #expect(match.column == 5)
     }
 
-    @Test("parses Korean ripgrep match offsets")
-    func parsesKoreanMatchOffsets() throws {
-        let line = #"{"type":"match","data":{"path":{"text":"/proj/greeting.md"},"lines":{"text":"안녕하세요\n"},"line_number":1,"absolute_offset":0,"submatches":[{"match":{"text":"안녕"},"start":0,"end":6}]}}"#
-        let match = try #require(TextSearchService.parseLine(line, projectPath: "/proj"))
-
-        #expect(match.relativePath == "greeting.md")
-        #expect(match.lineNumber == 1)
-        #expect(match.lineText == "안녕하세요")
-        #expect(match.matchStart == 0)
-        #expect(match.matchEnd == 6)
-        #expect(match.column == 1)
+    @Test("clamps match length to remaining bytes on the line")
+    func clampsLength() throws {
+        let line: Substring = "/proj/x.swift:1:5:abcd"
+        let match = try #require(TextSearchService.parseVimgrepLine(
+            line, projectPath: "/proj", patternByteLength: 100
+        ))
+        #expect(match.matchByteStart == 4)
+        #expect(match.matchByteLength == 0)
     }
 
     @Test("searches Korean text through ripgrep")
@@ -64,15 +61,30 @@ struct TextSearchServiceTests {
         #expect(matches.contains { $0.lineText == "안녕하세요" })
     }
 
-    @Test("keeps regex search semantics")
-    func keepsRegexSearchSemantics() async throws {
+    @Test("treats query as a literal (no regex)")
+    func literalQuery() async throws {
         guard TextSearchService.ripgrepExecutableURL() != nil else { return }
         let directory = try makeSearchFixture()
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let matches = await TextSearchService.search(query: "foo.*bar", in: directory.path)
+        #expect(matches.isEmpty)
 
-        #expect(matches.contains { $0.lineText == "foo123bar" })
+        let literal = await TextSearchService.search(query: "foo123bar", in: directory.path)
+        #expect(literal.contains { $0.lineText == "foo123bar" })
+    }
+
+    @Test("cancels in-flight ripgrep when the Task is cancelled")
+    func cancelsRunningSearch() async throws {
+        guard TextSearchService.ripgrepExecutableURL() != nil else { return }
+        let directory = try makeSearchFixture()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let task = Task { await TextSearchService.search(query: "foo", in: directory.path) }
+        task.cancel()
+        let results = await task.value
+
+        #expect(results.isEmpty || results.allSatisfy { !$0.lineText.isEmpty })
     }
 
     private func makeSearchFixture() throws -> URL {

--- a/Tests/MuxyTests/Services/TextSearchServiceTests.swift
+++ b/Tests/MuxyTests/Services/TextSearchServiceTests.swift
@@ -74,17 +74,23 @@ struct TextSearchServiceTests {
         #expect(literal.contains { $0.lineText == "foo123bar" })
     }
 
-    @Test("cancels in-flight ripgrep when the Task is cancelled")
-    func cancelsRunningSearch() async throws {
+    @Test("starting a new search cancels the in-flight one")
+    func newSearchCancelsPrevious() async throws {
         guard TextSearchService.ripgrepExecutableURL() != nil else { return }
         let directory = try makeSearchFixture()
         defer { try? FileManager.default.removeItem(at: directory) }
 
-        let task = Task { await TextSearchService.search(query: "foo", in: directory.path) }
-        task.cancel()
-        let results = await task.value
+        let coordinator = SearchCoordinator()
+        async let first = TextSearchService.search(
+            query: "foo123bar", in: directory.path, coordinator: coordinator
+        )
+        async let second = TextSearchService.search(
+            query: "안녕", in: directory.path, coordinator: coordinator
+        )
+        let (firstResults, secondResults) = await (first, second)
 
-        #expect(results.isEmpty || results.allSatisfy { !$0.lineText.isEmpty })
+        #expect(secondResults.contains { $0.lineText == "안녕하세요" })
+        #expect(firstResults.isEmpty || firstResults.contains { $0.lineText == "foo123bar" })
     }
 
     private func makeSearchFixture() throws -> URL {


### PR DESCRIPTION
- Add match case and whole-word controls so users can narrow search results.
- Treat queries as literal text, cancel stale searches, and show clearer snippets with line numbers.
Risk: match highlighting now relies on ripgrep vimgrep byte offsets.

Closes #450 