### PR TITLE
Add Droid (Factory CLI) notifications provider

### DIFF
--- a/Muxy/Resources/scripts/muxy-droid-hook.sh
+++ b/Muxy/Resources/scripts/muxy-droid-hook.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${MUXY_SOCKET_PATH:-}" ] || [ -z "${MUXY_PANE_ID:-}" ]; then
+    exit 0
+fi
+
+event="${1:-}"
+input=$(cat)
+
+send_notification() {
+    local type="$1"
+    local title="$2"
+    local body="$3"
+    printf '%s|%s|%s|%s' "$type" "$MUXY_PANE_ID" "$title" "$body" \
+        | nc -U "$MUXY_SOCKET_PATH" 2>/dev/null || true
+}
+
+extract_last_message() {
+    local msg=""
+    msg=$(printf '%s' "$input" | grep -o '"last_assistant_message":"[^"]*"' | head -1 | cut -d'"' -f4)
+    if [ -n "$msg" ]; then
+        printf '%s' "$msg" | tr '|' ' ' | head -c 200
+        return
+    fi
+    printf 'Session completed'
+}
+
+case "$event" in
+    notification)
+        send_notification "droid_hook" "Droid" "Needs attention"
+        ;;
+    stop)
+        body=$(extract_last_message)
+        send_notification "droid_hook" "Droid" "$body"
+        ;;
+esac

--- a/Muxy/Services/AIProviderIntegration.swift
+++ b/Muxy/Services/AIProviderIntegration.swift
@@ -49,12 +49,14 @@ final class AIProviderRegistry {
     private let openCodeProvider = OpenCodeProvider()
     private let codexProvider = CodexProvider()
     private let cursorProvider = CursorProvider()
+    private let droidProvider = DroidProvider()
 
     lazy var providers: [AIProviderIntegration] = [
         claudeCodeProvider,
         openCodeProvider,
         codexProvider,
         cursorProvider,
+        droidProvider,
     ]
 
     lazy var usageProviders: [any AIUsageProvider] = [

--- a/Muxy/Services/Providers/DroidProvider.swift
+++ b/Muxy/Services/Providers/DroidProvider.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+struct DroidProvider: AIProviderIntegration {
+    let id = "droid"
+    let displayName = "Droid"
+    let socketTypeKey = "droid_hook"
+    let iconName = "factory"
+    let executableNames = ["droid"]
+    let hookScriptName = "muxy-droid-hook"
+
+    private static let settingsPath = NSHomeDirectory() + "/.factory/settings.json"
+    private static let muxyMarker = "muxy-notification-hook"
+    private static let installedEvents = ["Stop", "Notification"]
+
+    func isToolInstalled() -> Bool {
+        let home = NSHomeDirectory()
+        let paths = [
+            "\(home)/.factory/bin/droid",
+            "\(home)/.local/bin/droid",
+            "/usr/local/bin/droid",
+            "/opt/homebrew/bin/droid",
+        ]
+        return paths.contains { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    func install(hookScriptPath: String) throws {
+        let settings = try Self.readSettings()
+        let hooks = settings["hooks"] as? [String: Any] ?? [:]
+
+        var allMatch = true
+        for event in Self.installedEvents {
+            let expected = Self.hookCommand(hookScript: hookScriptPath, event: event.lowercased())
+            if !Self.muxyHookMatches(entries: hooks[event] as? [[String: Any]], expectedCommand: expected) {
+                allMatch = false
+                break
+            }
+        }
+        guard !allMatch else { return }
+
+        var updatedSettings = settings
+        var updatedHooks = hooks
+        for event in Self.installedEvents {
+            let command = Self.hookCommand(hookScript: hookScriptPath, event: event.lowercased())
+            let entry = Self.buildHookEntry(command: command)
+            updatedHooks[event] = Self.mergeHookArray(existing: hooks[event] as? [[String: Any]], muxyHook: entry)
+        }
+        updatedSettings["hooks"] = updatedHooks
+        try Self.writeSettings(updatedSettings)
+    }
+
+    func uninstall() throws {
+        guard FileManager.default.fileExists(atPath: Self.settingsPath) else { return }
+        var settings = try Self.readSettings()
+        guard var hooks = settings["hooks"] as? [String: Any] else { return }
+
+        for key in Self.installedEvents {
+            guard var entries = hooks[key] as? [[String: Any]] else { continue }
+            entries.removeAll { Self.isMuxyHookEntry($0) }
+            if entries.isEmpty {
+                hooks.removeValue(forKey: key)
+            } else {
+                hooks[key] = entries
+            }
+        }
+
+        if hooks.isEmpty {
+            settings.removeValue(forKey: "hooks")
+        } else {
+            settings["hooks"] = hooks
+        }
+        try Self.writeSettings(settings)
+    }
+
+    private static func hookCommand(hookScript: String, event: String) -> String {
+        "'\(hookScript)' \(event) # \(muxyMarker)"
+    }
+
+    private static func buildHookEntry(command: String) -> [String: Any] {
+        [
+            "matcher": "",
+            "hooks": [
+                [
+                    "type": "command",
+                    "command": command,
+                    "timeout": 10,
+                ] as [String: Any],
+            ],
+        ]
+    }
+
+    private static func muxyHookMatches(entries: [[String: Any]]?, expectedCommand: String) -> Bool {
+        guard let entries else { return false }
+        return entries.contains { entry in
+            guard let hooks = entry["hooks"] as? [[String: Any]] else { return false }
+            return hooks.contains { hook in
+                guard let command = hook["command"] as? String else { return false }
+                return command == expectedCommand
+            }
+        }
+    }
+
+    private static func mergeHookArray(
+        existing: [[String: Any]]?,
+        muxyHook: [String: Any]
+    ) -> [[String: Any]] {
+        var entries = existing ?? []
+        entries.removeAll { isMuxyHookEntry($0) }
+        entries.append(muxyHook)
+        return entries
+    }
+
+    private static func isMuxyHookEntry(_ entry: [String: Any]) -> Bool {
+        guard let hooks = entry["hooks"] as? [[String: Any]] else { return false }
+        return hooks.contains { hook in
+            guard let command = hook["command"] as? String else { return false }
+            return command.contains(muxyMarker)
+        }
+    }
+
+    private static func readSettings() throws -> [String: Any] {
+        guard FileManager.default.fileExists(atPath: settingsPath) else { return [:] }
+        let data = try Data(contentsOf: URL(fileURLWithPath: settingsPath))
+        guard !data.isEmpty else { return [:] }
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [:] }
+        return json
+    }
+
+    private static func writeSettings(_ settings: [String: Any]) throws {
+        let dirPath = (settingsPath as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
+
+        let fileURL = URL(fileURLWithPath: settingsPath)
+        if FileManager.default.fileExists(atPath: settingsPath) {
+            let backupPath = settingsPath + ".muxy-backup"
+            let backupURL = URL(fileURLWithPath: backupPath)
+            try? FileManager.default.removeItem(at: backupURL)
+            try FileManager.default.copyItem(at: fileURL, to: backupURL)
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: fileURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.privateFile],
+            ofItemAtPath: settingsPath
+        )
+    }
+}

--- a/docs/developer/architecture/notifications.md
+++ b/docs/developer/architecture/notifications.md
@@ -7,7 +7,7 @@ Notifications alert users when terminal events occur (command completion, AI age
 ```mermaid
 flowchart TB
   OSC[OSC 9/777<br/>terminal escape] --> Adapter[GhosttyRuntimeEventAdapter]
-  Claude[Claude Code hooks] --> Sock[Unix socket<br/>muxy.sock]
+  Claude[Agent CLI hooks<br/>Claude / Codex / Cursor / Droid / OpenCode] --> Sock[Unix socket<br/>muxy.sock]
   External[External tools] --> Sock
   Sock --> Server[NotificationSocketServer]
   Adapter --> Lookup[TerminalViewRegistry<br/>paneID lookup]
@@ -23,7 +23,7 @@ flowchart TB
 | Source | Mechanism |
 | --- | --- |
 | OSC 9 / 777 | `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` in `GhosttyRuntimeEventAdapter`. |
-| Claude Code | Wrapper script injects `--hooks` to route lifecycle events through the socket. |
+| Agent CLIs (Claude Code, Codex, Cursor, Droid, OpenCode) | `AIProviderRegistry` installs per-tool hook scripts that route lifecycle events through the socket. |
 | Unix socket | `~/Library/Application Support/Muxy/muxy.sock`, pipe-delimited messages with paneID. |
 
 ## Click-to-navigate

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -1,6 +1,6 @@
 # Notification Setup
 
-Muxy ships built-in integrations for **Claude Code** and **OpenCode** — toggle them under **Settings → Notifications**. This page is for everything else: sending notifications into Muxy from any other tool (a custom CLI, a build script, a different AI agent, …).
+Muxy ships built-in integrations for **Claude Code**, **Codex**, **Cursor**, **Droid**, and **OpenCode** — toggle them under **Settings → Notifications**. This page is for everything else: sending notifications into Muxy from any other tool (a custom CLI, a build script, a different AI agent, …).
 
 ```mermaid
 flowchart TB
@@ -31,7 +31,7 @@ One message per connection: a single UTF-8 line with four pipe-separated fields:
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `type` | yes | Source identifier. Unknown values are accepted and shown generically. Built-in: `claude_hook`, `opencode`. |
+| `type` | yes | Source identifier. Unknown values are accepted and shown generically. Built-in: `claude_hook`, `codex_hook`, `cursor_hook`, `droid_hook`, `opencode`. |
 | `paneID` | yes | Pane the event belongs to. Use `$MUXY_PANE_ID` from inside a Muxy terminal. Leave empty to attach to the active pane. |
 | `title` | yes | Notification title. Empty falls back to `Task completed!`. |
 | `body` | no | Body. Must not contain `\|` or newlines — replace them first. |


### PR DESCRIPTION
Wires Droid's `Stop` and `Notification` hooks (in `~/.factory/settings.json`) into Muxy's notification socket so session-finished and needs-attention events surface as toasts and tab unread dots.

Toggle under Settings → Notifications. Auto-installs when the `droid` binary is found in `~/.factory/bin`, `~/.local/bin`, `/usr/local/bin`, or `/opt/homebrew/bin`.