### PR TITLE
Update base branches after merging PRs

### DIFF
--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -1008,6 +1008,31 @@ struct GitRepositoryService {
         GitMetadataCache.shared.invalidatePRInfo(repoPath: repoPath)
     }
 
+    @discardableResult
+    func fastForwardBranch(repoPath: String, branch: String) async -> Bool {
+        let trimmed = branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.unicodeScalars.allSatisfy({ Self.allowedBranchCharacters.contains($0) })
+        else { return false }
+
+        let headResult = try? await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["symbolic-ref", "--quiet", "--short", "HEAD"]
+        )
+        let currentBranch = headResult?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        let arguments: [String] = currentBranch == trimmed
+            ? ["pull", "--ff-only"]
+            : ["fetch", "origin", "\(trimmed):\(trimmed)"]
+
+        let result = try? await GitProcessRunner.runGit(repoPath: repoPath, arguments: arguments)
+        let success = result?.status == 0
+        if success {
+            GitMetadataCache.shared.invalidatePRInfo(repoPath: repoPath, branch: trimmed)
+        }
+        return success
+    }
+
     func listBranches(repoPath: String) async throws -> [String] {
         let result = try await GitProcessRunner.runGit(
             repoPath: repoPath,

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -1021,16 +1021,45 @@ struct GitRepositoryService {
         )
         let currentBranch = headResult?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-        let arguments: [String] = currentBranch == trimmed
-            ? ["pull", "--ff-only"]
-            : ["fetch", "origin", "\(trimmed):\(trimmed)"]
-
-        let result = try? await GitProcessRunner.runGit(repoPath: repoPath, arguments: arguments)
-        let success = result?.status == 0
+        let success: Bool
+        if currentBranch == trimmed {
+            let result = try? await GitProcessRunner.runGit(repoPath: repoPath, arguments: ["pull", "--ff-only"])
+            success = result?.status == 0
+        } else {
+            success = await fastForwardInactiveBranch(repoPath: repoPath, branch: trimmed)
+        }
         if success {
             GitMetadataCache.shared.invalidatePRInfo(repoPath: repoPath, branch: trimmed)
         }
         return success
+    }
+
+    private func fastForwardInactiveBranch(repoPath: String, branch: String) async -> Bool {
+        let localRef = "refs/heads/\(branch)"
+        let remoteRef = "refs/remotes/origin/\(branch)"
+        let fetchResult = try? await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["fetch", "origin", "refs/heads/\(branch):\(remoteRef)"]
+        )
+        guard fetchResult?.status == 0 else { return false }
+
+        let localExistsResult = try? await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["show-ref", "--verify", "--quiet", localRef]
+        )
+        if localExistsResult?.status == 0 {
+            let ancestorResult = try? await GitProcessRunner.runGit(
+                repoPath: repoPath,
+                arguments: ["merge-base", "--is-ancestor", branch, remoteRef]
+            )
+            guard ancestorResult?.status == 0 else { return false }
+        }
+
+        let updateResult = try? await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["update-ref", localRef, remoteRef]
+        )
+        return updateResult?.status == 0
     }
 
     func listBranches(repoPath: String) async throws -> [String] {

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -312,11 +312,14 @@ struct VCSTabView: View {
         if let defaultBranch, defaultBranch != mergedBranch {
             await state.switchBranchAndRefresh(defaultBranch)
         }
-        await Self.fastForwardAfterMerge(
+        let pulled = await Self.fastForwardAfterMerge(
             repoPath: state.projectPath,
             defaultBranch: defaultBranch,
             baseBranch: baseBranch
         )
+        if !pulled.isEmpty {
+            state.refresh()
+        }
     }
 
     private func removeWorktreeAfterMerge(
@@ -352,11 +355,12 @@ struct VCSTabView: View {
         }
     }
 
+    @discardableResult
     private static func fastForwardAfterMerge(
         repoPath: String,
         defaultBranch: String?,
         baseBranch: String
-    ) async {
+    ) async -> [String] {
         let git = GitRepositoryService()
         var pulled: [String] = []
         if let defaultBranch, !defaultBranch.isEmpty,
@@ -375,6 +379,7 @@ struct VCSTabView: View {
                 ToastState.shared.show("Pulled \(pulled.joined(separator: ", "))")
             }
         }
+        return pulled
     }
 
     private func presentClosePRConfirmation(prInfo: GitRepositoryService.PRInfo) {

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -243,6 +243,7 @@ struct VCSTabView: View {
         let worktree = activeWorktreeForTab
         let defaultBranch = state.defaultBranch
         let isWorktreeMerge = worktree.map { !$0.isPrimary } ?? false
+        let baseBranch = prInfo.baseBranch
         state.mergePullRequest(method: method, deleteBranch: !isWorktreeMerge) { _, mergedBranch in
             ToastState.shared.show("Merged PR #\(prInfo.number)")
             Task { @MainActor in
@@ -250,7 +251,8 @@ struct VCSTabView: View {
                     mergedBranch: mergedBranch,
                     project: project,
                     worktree: worktree,
-                    defaultBranch: defaultBranch
+                    defaultBranch: defaultBranch,
+                    baseBranch: baseBranch
                 )
             }
         }
@@ -293,19 +295,37 @@ struct VCSTabView: View {
         mergedBranch: String,
         project: Project?,
         worktree: Worktree?,
-        defaultBranch: String?
+        defaultBranch: String?,
+        baseBranch: String
     ) async {
         if let project, let worktree, worktree.canBeRemoved {
-            removeWorktreeAfterMerge(project: project, worktree: worktree, mergedBranch: mergedBranch)
+            removeWorktreeAfterMerge(
+                project: project,
+                worktree: worktree,
+                mergedBranch: mergedBranch,
+                defaultBranch: defaultBranch,
+                baseBranch: baseBranch
+            )
             return
         }
 
         if let defaultBranch, defaultBranch != mergedBranch {
             await state.switchBranchAndRefresh(defaultBranch)
         }
+        await fastForwardAfterMerge(
+            repoPath: state.projectPath,
+            defaultBranch: defaultBranch,
+            baseBranch: baseBranch
+        )
     }
 
-    private func removeWorktreeAfterMerge(project: Project, worktree: Worktree, mergedBranch: String) {
+    private func removeWorktreeAfterMerge(
+        project: Project,
+        worktree: Worktree,
+        mergedBranch: String,
+        defaultBranch: String?,
+        baseBranch: String
+    ) {
         let repoPath = project.path
         let remaining = worktreeStore.list(for: project.id).filter { $0.id != worktree.id }
         let replacement = remaining.first(where: { $0.isPrimary }) ?? remaining.first
@@ -324,6 +344,48 @@ struct VCSTabView: View {
                 repoPath: repoPath,
                 branch: mergedBranch
             )
+            await Self.fastForwardAfterMerge(
+                repoPath: repoPath,
+                defaultBranch: defaultBranch,
+                baseBranch: baseBranch
+            )
+        }
+    }
+
+    private func fastForwardAfterMerge(
+        repoPath: String,
+        defaultBranch: String?,
+        baseBranch: String
+    ) async {
+        await Self.fastForwardAfterMerge(
+            repoPath: repoPath,
+            defaultBranch: defaultBranch,
+            baseBranch: baseBranch
+        )
+    }
+
+    private static func fastForwardAfterMerge(
+        repoPath: String,
+        defaultBranch: String?,
+        baseBranch: String
+    ) async {
+        let git = GitRepositoryService()
+        var pulled: [String] = []
+        if let defaultBranch, !defaultBranch.isEmpty,
+           await git.fastForwardBranch(repoPath: repoPath, branch: defaultBranch)
+        {
+            pulled.append(defaultBranch)
+        }
+        let trimmedBase = baseBranch.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedBase.isEmpty, trimmedBase != defaultBranch,
+           await git.fastForwardBranch(repoPath: repoPath, branch: trimmedBase)
+        {
+            pulled.append(trimmedBase)
+        }
+        if !pulled.isEmpty {
+            await MainActor.run {
+                ToastState.shared.show("Pulled \(pulled.joined(separator: ", "))")
+            }
         }
     }
 

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -312,7 +312,7 @@ struct VCSTabView: View {
         if let defaultBranch, defaultBranch != mergedBranch {
             await state.switchBranchAndRefresh(defaultBranch)
         }
-        await fastForwardAfterMerge(
+        await Self.fastForwardAfterMerge(
             repoPath: state.projectPath,
             defaultBranch: defaultBranch,
             baseBranch: baseBranch
@@ -350,18 +350,6 @@ struct VCSTabView: View {
                 baseBranch: baseBranch
             )
         }
-    }
-
-    private func fastForwardAfterMerge(
-        repoPath: String,
-        defaultBranch: String?,
-        baseBranch: String
-    ) async {
-        await Self.fastForwardAfterMerge(
-            repoPath: repoPath,
-            defaultBranch: defaultBranch,
-            baseBranch: baseBranch
-        )
     }
 
     private static func fastForwardAfterMerge(

--- a/Tests/MuxyTests/Git/GitRepositoryServiceFastForwardTests.swift
+++ b/Tests/MuxyTests/Git/GitRepositoryServiceFastForwardTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitRepositoryService.fastForwardBranch")
+struct GitRepositoryServiceFastForwardTests {
+    @Test("inactive branch fast-forward refreshes remote tracking ref")
+    func inactiveBranchRefreshesRemoteTrackingRef() async throws {
+        let repo = try TempRemoteGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "main.txt", contents: "1", message: "main")
+        try repo.run("push", "-u", "origin", "main")
+        try repo.run("checkout", "-b", "release")
+        try repo.commit(file: "release.txt", contents: "1", message: "release")
+        try repo.run("push", "-u", "origin", "release")
+        try repo.run("checkout", "main")
+
+        try repo.cloneToUpstream()
+        try repo.runUpstream("checkout", "release")
+        try repo.commitUpstream(file: "release.txt", contents: "2", message: "advance release")
+        try repo.runUpstream("push", "origin", "release")
+
+        let succeeded = await GitRepositoryService().fastForwardBranch(repoPath: repo.path, branch: "release")
+
+        #expect(succeeded)
+        let localRelease = try repo.runCapturing("rev-parse", "release")
+        let trackingRelease = try repo.runCapturing("rev-parse", "origin/release")
+        #expect(localRelease == trackingRelease)
+    }
+}
+
+private struct TempRemoteGitRepo {
+    let path: String
+    private let parent: String
+    private let remotePath: String
+    private let upstreamPath: String
+
+    init() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-git-service-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        parent = base.path
+        remotePath = base.appendingPathComponent("remote.git", isDirectory: true).path
+        path = base.appendingPathComponent("repo", isDirectory: true).path
+        upstreamPath = base.appendingPathComponent("upstream", isDirectory: true).path
+        try Self.runGit(at: parent, args: ["init", "-q", "--bare", "-b", "main", remotePath])
+        try Self.runGit(at: parent, args: ["clone", "-q", remotePath, path])
+        try configureRepository(at: path)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(atPath: parent)
+    }
+
+    func cloneToUpstream() throws {
+        try Self.runGit(at: parent, args: ["clone", "-q", remotePath, upstreamPath])
+        try configureRepository(at: upstreamPath)
+    }
+
+    func commit(file: String, contents: String, message: String) throws {
+        try commit(at: path, file: file, contents: contents, message: message)
+    }
+
+    func commitUpstream(file: String, contents: String, message: String) throws {
+        try commit(at: upstreamPath, file: file, contents: contents, message: message)
+    }
+
+    func run(_ args: String...) throws {
+        try Self.runGit(at: path, args: args)
+    }
+
+    func runUpstream(_ args: String...) throws {
+        try Self.runGit(at: upstreamPath, args: args)
+    }
+
+    func runCapturing(_ args: String...) throws -> String {
+        try Self.runGit(at: path, args: args)
+    }
+
+    private func configureRepository(at path: String) throws {
+        try Self.runGit(at: path, args: ["config", "user.email", "test@example.com"])
+        try Self.runGit(at: path, args: ["config", "user.name", "Test"])
+        try Self.runGit(at: path, args: ["config", "commit.gpgsign", "false"])
+    }
+
+    private func commit(at path: String, file: String, contents: String, message: String) throws {
+        let fileURL = URL(fileURLWithPath: path).appendingPathComponent(file)
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        try Self.runGit(at: path, args: ["add", file])
+        try Self.runGit(at: path, args: ["commit", "-q", "-m", message])
+    }
+
+    @discardableResult
+    private static func runGit(at workingDir: String, args: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", workingDir] + args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        if process.terminationStatus != 0 {
+            throw NSError(
+                domain: "GitTestRepo",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: output]
+            )
+        }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
- Fast-forwards the default and PR base branches after a successful merge so local branch state reflects GitHub.
- Keeps worktree cleanup behavior while still refreshing the repo branch metadata.