### PR TITLE
Expose file diffs over the remote API

### DIFF
--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -441,6 +441,16 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             await state.refreshAndWait()
         }
         let file = state.files.first { $0.path == filePath }
+        if file?.isBinary == true {
+            return VCSDiffDTO(
+                filePath: filePath,
+                rows: [],
+                additions: 0,
+                deletions: 0,
+                truncated: false,
+                isBinary: true
+            )
+        }
         let hints: GitRepositoryService.DiffHints = if let file {
             GitRepositoryService.DiffHints(
                 hasStaged: file.isStaged,
@@ -463,7 +473,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             additions: result.additions,
             deletions: result.deletions,
             truncated: result.truncated,
-            isBinary: file?.isBinary ?? false
+            isBinary: false
         )
     }
 
@@ -479,6 +489,8 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             kind: kind,
             oldLineNumber: row.oldLineNumber,
             newLineNumber: row.newLineNumber,
+            oldText: row.oldText,
+            newText: row.newText,
             text: row.text
         )
     }

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -434,6 +434,55 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         notifyRepoDidChange(repoPath: repoPath)
     }
 
+    func vcsGetDiff(projectID: UUID, filePath: String, forceFull: Bool) async throws -> VCSDiffDTO {
+        let repoPath = try repoPath(projectID: projectID)
+        let state = VCSStateStore.shared.state(for: repoPath)
+        if !state.hasCompletedInitialLoad {
+            await state.refreshAndWait()
+        }
+        let file = state.files.first { $0.path == filePath }
+        let hints: GitRepositoryService.DiffHints = if let file {
+            GitRepositoryService.DiffHints(
+                hasStaged: file.isStaged,
+                hasUnstaged: file.isUnstaged,
+                isUntrackedOrNew: file.xStatus == "?" && file.yStatus == "?"
+            )
+        } else {
+            .unknown
+        }
+        let lineLimit = forceFull ? nil : DiffLoader.previewLineLimit
+        let result = try await gitService.patchAndCompare(
+            repoPath: repoPath,
+            filePath: filePath,
+            lineLimit: lineLimit,
+            hints: hints
+        )
+        return VCSDiffDTO(
+            filePath: filePath,
+            rows: result.rows.map(Self.toDiffRowDTO),
+            additions: result.additions,
+            deletions: result.deletions,
+            truncated: result.truncated,
+            isBinary: file?.isBinary ?? false
+        )
+    }
+
+    private static func toDiffRowDTO(_ row: DiffDisplayRow) -> VCSDiffRowDTO {
+        let kind: VCSDiffRowKindDTO = switch row.kind {
+        case .hunk: .hunk
+        case .context: .context
+        case .addition: .addition
+        case .deletion: .deletion
+        case .collapsed: .collapsed
+        }
+        return VCSDiffRowDTO(
+            kind: kind,
+            oldLineNumber: row.oldLineNumber,
+            newLineNumber: row.newLineNumber,
+            text: row.text
+        )
+    }
+
     func vcsListBranches(projectID: UUID) async throws -> VCSBranchesDTO {
         let repoPath = try repoPath(projectID: projectID)
         let state = VCSStateStore.shared.state(for: repoPath)

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -71,6 +71,7 @@ public protocol MuxyRemoteServerDelegate: AnyObject {
         baseBranch: String?
     ) async throws -> WorktreeDTO
     func vcsRemoveWorktree(projectID: UUID, worktreeID: UUID) async throws
+    func vcsGetDiff(projectID: UUID, filePath: String, forceFull: Bool) async throws -> VCSDiffDTO
     func getProjectLogo(projectID: UUID) -> ProjectLogoDTO?
     func listNotifications() -> [NotificationDTO]
     func markNotificationRead(_ notificationID: UUID)
@@ -626,6 +627,21 @@ public final class MuxyRemoteServer: @unchecked Sendable {
             do {
                 try await delegate.vcsRemoveWorktree(projectID: params.projectID, worktreeID: params.worktreeID)
                 return MuxyResponse(id: request.id, result: .ok)
+            } catch {
+                return MuxyResponse(id: request.id, error: MuxyError(code: 500, message: error.localizedDescription))
+            }
+
+        case .vcsGetDiff:
+            guard case let .vcsGetDiff(params) = request.params else {
+                return MuxyResponse(id: request.id, error: .invalidParams)
+            }
+            do {
+                let diff = try await delegate.vcsGetDiff(
+                    projectID: params.projectID,
+                    filePath: params.filePath,
+                    forceFull: params.forceFull
+                )
+                return MuxyResponse(id: request.id, result: .vcsDiff(diff))
             } catch {
                 return MuxyResponse(id: request.id, error: MuxyError(code: 500, message: error.localizedDescription))
             }

--- a/MuxyShared/MuxyProtocol.swift
+++ b/MuxyShared/MuxyProtocol.swift
@@ -93,6 +93,7 @@ public enum MuxyMethod: String, Codable, Sendable {
     case vcsMergePullRequest
     case vcsAddWorktree
     case vcsRemoveWorktree
+    case vcsGetDiff
     case getProjectLogo
     case listNotifications
     case markNotificationRead
@@ -135,6 +136,7 @@ public enum MuxyParams: Codable, Sendable {
     case vcsMergePullRequest(VCSMergePullRequestParams)
     case vcsAddWorktree(VCSAddWorktreeParams)
     case vcsRemoveWorktree(VCSRemoveWorktreeParams)
+    case vcsGetDiff(VCSGetDiffParams)
     case getProjectLogo(GetProjectLogoParams)
     case markNotificationRead(MarkNotificationReadParams)
     case subscribe(SubscribeParams)
@@ -183,6 +185,7 @@ public enum MuxyParams: Codable, Sendable {
         case "vcsMergePullRequest": self = try .vcsMergePullRequest(container.decode(VCSMergePullRequestParams.self, forKey: .value))
         case "vcsAddWorktree": self = try .vcsAddWorktree(container.decode(VCSAddWorktreeParams.self, forKey: .value))
         case "vcsRemoveWorktree": self = try .vcsRemoveWorktree(container.decode(VCSRemoveWorktreeParams.self, forKey: .value))
+        case "vcsGetDiff": self = try .vcsGetDiff(container.decode(VCSGetDiffParams.self, forKey: .value))
         case "getProjectLogo": self = try .getProjectLogo(container.decode(GetProjectLogoParams.self, forKey: .value))
         case "markNotificationRead": self = try .markNotificationRead(container.decode(MarkNotificationReadParams.self, forKey: .value))
         case "subscribe": self = try .subscribe(container.decode(SubscribeParams.self, forKey: .value))
@@ -262,6 +265,8 @@ public enum MuxyParams: Codable, Sendable {
             try container.encode(v, forKey: .value)
         case let .vcsRemoveWorktree(v): try container.encode("vcsRemoveWorktree", forKey: .type)
             try container.encode(v, forKey: .value)
+        case let .vcsGetDiff(v): try container.encode("vcsGetDiff", forKey: .type)
+            try container.encode(v, forKey: .value)
         case let .getProjectLogo(v): try container.encode("getProjectLogo", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .markNotificationRead(v): try container.encode("markNotificationRead", forKey: .type)
@@ -287,6 +292,7 @@ public enum MuxyResult: Codable, Sendable {
     case vcsStatus(VCSStatusDTO)
     case vcsBranches(VCSBranchesDTO)
     case vcsPRCreated(VCSCreatePRResultDTO)
+    case vcsDiff(VCSDiffDTO)
     case projectLogo(ProjectLogoDTO)
     case notifications([NotificationDTO])
     case ok
@@ -312,6 +318,7 @@ public enum MuxyResult: Codable, Sendable {
         case "vcsStatus": self = try .vcsStatus(container.decode(VCSStatusDTO.self, forKey: .value))
         case "vcsBranches": self = try .vcsBranches(container.decode(VCSBranchesDTO.self, forKey: .value))
         case "vcsPRCreated": self = try .vcsPRCreated(container.decode(VCSCreatePRResultDTO.self, forKey: .value))
+        case "vcsDiff": self = try .vcsDiff(container.decode(VCSDiffDTO.self, forKey: .value))
         case "projectLogo": self = try .projectLogo(container.decode(ProjectLogoDTO.self, forKey: .value))
         case "notifications": self = try .notifications(container.decode([NotificationDTO].self, forKey: .value))
         case "ok": self = .ok
@@ -345,6 +352,8 @@ public enum MuxyResult: Codable, Sendable {
         case let .vcsBranches(v): try container.encode("vcsBranches", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .vcsPRCreated(v): try container.encode("vcsPRCreated", forKey: .type)
+            try container.encode(v, forKey: .value)
+        case let .vcsDiff(v): try container.encode("vcsDiff", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .projectLogo(v): try container.encode("projectLogo", forKey: .type)
             try container.encode(v, forKey: .value)

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -508,6 +508,18 @@ public struct VCSRemoveWorktreeParams: Codable, Sendable {
     }
 }
 
+public struct VCSGetDiffParams: Codable, Sendable {
+    public let projectID: UUID
+    public let filePath: String
+    public let forceFull: Bool
+
+    public init(projectID: UUID, filePath: String, forceFull: Bool = false) {
+        self.projectID = projectID
+        self.filePath = filePath
+        self.forceFull = forceFull
+    }
+}
+
 public struct GetProjectLogoParams: Codable, Sendable {
     public let projectID: UUID
     public init(projectID: UUID) {

--- a/MuxyShared/VCSDiffDTO.swift
+++ b/MuxyShared/VCSDiffDTO.swift
@@ -12,12 +12,23 @@ public struct VCSDiffRowDTO: Codable, Sendable, Hashable {
     public let kind: VCSDiffRowKindDTO
     public let oldLineNumber: Int?
     public let newLineNumber: Int?
+    public let oldText: String?
+    public let newText: String?
     public let text: String
 
-    public init(kind: VCSDiffRowKindDTO, oldLineNumber: Int?, newLineNumber: Int?, text: String) {
+    public init(
+        kind: VCSDiffRowKindDTO,
+        oldLineNumber: Int?,
+        newLineNumber: Int?,
+        oldText: String?,
+        newText: String?,
+        text: String
+    ) {
         self.kind = kind
         self.oldLineNumber = oldLineNumber
         self.newLineNumber = newLineNumber
+        self.oldText = oldText
+        self.newText = newText
         self.text = text
     }
 }

--- a/MuxyShared/VCSDiffDTO.swift
+++ b/MuxyShared/VCSDiffDTO.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public enum VCSDiffRowKindDTO: String, Codable, Sendable {
+    case hunk
+    case context
+    case addition
+    case deletion
+    case collapsed
+}
+
+public struct VCSDiffRowDTO: Codable, Sendable, Hashable {
+    public let kind: VCSDiffRowKindDTO
+    public let oldLineNumber: Int?
+    public let newLineNumber: Int?
+    public let text: String
+
+    public init(kind: VCSDiffRowKindDTO, oldLineNumber: Int?, newLineNumber: Int?, text: String) {
+        self.kind = kind
+        self.oldLineNumber = oldLineNumber
+        self.newLineNumber = newLineNumber
+        self.text = text
+    }
+}
+
+public struct VCSDiffDTO: Codable, Sendable {
+    public let filePath: String
+    public let rows: [VCSDiffRowDTO]
+    public let additions: Int
+    public let deletions: Int
+    public let truncated: Bool
+    public let isBinary: Bool
+
+    public init(
+        filePath: String,
+        rows: [VCSDiffRowDTO],
+        additions: Int,
+        deletions: Int,
+        truncated: Bool,
+        isBinary: Bool
+    ) {
+        self.filePath = filePath
+        self.rows = rows
+        self.additions = additions
+        self.deletions = deletions
+        self.truncated = truncated
+        self.isBinary = isBinary
+    }
+}

--- a/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
@@ -170,6 +170,11 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
     func vcsRemoveWorktree(projectID: UUID, worktreeID: UUID) async throws {
         vcsRemoveWorktreeCalls.append((projectID, worktreeID))
     }
+
+    func vcsGetDiff(projectID _: UUID, filePath: String, forceFull _: Bool) async throws -> VCSDiffDTO {
+        VCSDiffDTO(filePath: filePath, rows: [], additions: 0, deletions: 0, truncated: false, isBinary: false)
+    }
+
     func getProjectLogo(projectID _: UUID) -> ProjectLogoDTO? { nil }
     func listNotifications() -> [NotificationDTO] { [] }
 


### PR DESCRIPTION
- Add a `vcsGetDiff` route so clients can request preview or full diffs for a project file.
- Return structured rows, counts, truncation, and binary metadata for rendering file changes remotely.