### PR TITLE
feat: add project groups to organize projects in sidebar

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -135,7 +135,7 @@ jobs:
             --version "${{ needs.validate.outputs.version }}" \
             --sign-identity "${{ steps.identity.outputs.name }}" \
             --sparkle-public-key "${{ steps.sparkle.outputs.public_key }}" \
-            --sparkle-feed-url "https://github.com/muxy-app/muxy/releases/download/beta-channel/appcast-beta-${{ matrix.arch }}.xml"
+            --sparkle-feed-url "https://github.com/ejklock/muxy/releases/download/beta-channel/appcast-beta-${{ matrix.arch }}.xml"
 
       - name: Notarize DMG
         env:
@@ -192,7 +192,7 @@ jobs:
         run: |
           mkdir -p prev
           for ARCH in arm64 x86_64; do
-            URL="https://github.com/muxy-app/muxy/releases/download/beta-channel/appcast-beta-${ARCH}.xml"
+            URL="https://github.com/ejklock/muxy/releases/download/beta-channel/appcast-beta-${ARCH}.xml"
             if curl -fsSL "$URL" -o "prev/appcast-beta-${ARCH}.xml"; then
               echo "Fetched previous beta appcast for $ARCH"
             else
@@ -265,42 +265,3 @@ jobs:
               appcast-beta-arm64.xml appcast-beta-x86_64.xml
           fi
 
-      - name: Notify Discord
-        continue-on-error: true
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.validate.outputs.tag }}
-          VERSION: ${{ needs.validate.outputs.version }}
-          REPO: ${{ github.repository }}
-        run: |
-          if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
-            echo "DISCORD_WEBHOOK_URL not set, skipping Discord notification"
-            exit 0
-          fi
-          NOTES=$(gh release view "$TAG" --repo "$REPO" --json body --jq .body \
-            | sed -E 's# by @[A-Za-z0-9_-]+ in https://github\.com/[^ ]+/pull/[0-9]+##g')
-          if [[ ${#NOTES} -gt 3800 ]]; then
-            NOTES="${NOTES:0:3800}…"
-          fi
-          URL="https://github.com/${REPO}/releases/tag/${TAG}"
-          PAYLOAD=$(jq -n \
-            --arg title "Muxy ${VERSION} (beta) released" \
-            --arg url "$URL" \
-            --arg notes "$NOTES" \
-            --arg footer "Beta channel" \
-            '{
-              username: "Muxy Releases",
-              embeds: [{
-                title: $title,
-                url: $url,
-                description: $notes,
-                color: 15844367,
-                footer: { text: $footer },
-                timestamp: (now | todate)
-              }]
-            }')
-          if ! curl -fsSL -H "Content-Type: application/json" \
-            -X POST -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"; then
-            echo "Discord notification failed; release succeeded regardless"
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
             --version "${{ needs.validate.outputs.version }}" \
             --sign-identity "${{ steps.identity.outputs.name }}" \
             --sparkle-public-key "${{ steps.sparkle.outputs.public_key }}" \
-            --sparkle-feed-url "https://github.com/muxy-app/muxy/releases/latest/download/appcast-${{ matrix.arch }}.xml"
+            --sparkle-feed-url "https://github.com/ejklock/muxy/releases/latest/download/appcast-${{ matrix.arch }}.xml"
 
       - name: Notarize DMG
         env:
@@ -197,7 +197,7 @@ jobs:
         run: |
           mkdir -p prev
           for ARCH in arm64 x86_64; do
-            URL="https://github.com/muxy-app/muxy/releases/latest/download/appcast-${ARCH}.xml"
+            URL="https://github.com/ejklock/muxy/releases/latest/download/appcast-${ARCH}.xml"
             if curl -fsSL "$URL" -o "prev/appcast-${ARCH}.xml"; then
               echo "Fetched previous stable appcast for $ARCH"
             else
@@ -269,106 +269,3 @@ jobs:
           git commit -m "Bump BETA_VERSION to $NEXT"
           git push origin main
 
-      - name: Notify Discord
-        continue-on-error: true
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.validate.outputs.version }}
-          REPO: ${{ github.repository }}
-        run: |
-          if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
-            echo "DISCORD_WEBHOOK_URL not set, skipping Discord notification"
-            exit 0
-          fi
-          TAG="v${VERSION}"
-          NOTES=$(gh release view "$TAG" --repo "$REPO" --json body --jq .body \
-            | sed -E 's# by @[A-Za-z0-9_-]+ in https://github\.com/[^ ]+/pull/[0-9]+##g')
-          if [[ ${#NOTES} -gt 3800 ]]; then
-            NOTES="${NOTES:0:3800}…"
-          fi
-          URL="https://github.com/${REPO}/releases/tag/${TAG}"
-          PAYLOAD=$(jq -n \
-            --arg title "Muxy ${TAG} released" \
-            --arg url "$URL" \
-            --arg notes "$NOTES" \
-            --arg footer "Stable channel" \
-            '{
-              username: "Muxy Releases",
-              embeds: [{
-                title: $title,
-                url: $url,
-                description: $notes,
-                color: 3066993,
-                footer: { text: $footer },
-                timestamp: (now | todate)
-              }]
-            }')
-          if ! curl -fsSL -H "Content-Type: application/json" \
-            -X POST -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"; then
-            echo "Discord notification failed; release succeeded regardless"
-          fi
-
-  update-homebrew-tap:
-    needs: [validate, release]
-    runs-on: macos-26
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Compute SHA256 checksums
-        id: sha256
-        run: |
-          ARM64_SHA=$(shasum -a 256 artifacts/dmg-arm64/Muxy-${{ needs.validate.outputs.version }}-arm64.dmg | awk '{print $1}')
-          X86_64_SHA=$(shasum -a 256 artifacts/dmg-x86_64/Muxy-${{ needs.validate.outputs.version }}-x86_64.dmg | awk '{print $1}')
-          echo "arm64=$ARM64_SHA" >> "$GITHUB_OUTPUT"
-          echo "x86_64=$X86_64_SHA" >> "$GITHUB_OUTPUT"
-
-      - name: Update Homebrew tap
-        env:
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          VERSION: ${{ needs.validate.outputs.version }}
-          SHA256_ARM64: ${{ steps.sha256.outputs.arm64 }}
-          SHA256_X86_64: ${{ steps.sha256.outputs.x86_64 }}
-        run: |
-          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/muxy-app/homebrew-tap.git tap
-          mkdir -p tap/Casks
-          cat > tap/Casks/muxy.rb <<EOF
-          cask "muxy" do
-            version "${VERSION}"
-
-            on_arm do
-              sha256 "${SHA256_ARM64}"
-              url "https://github.com/muxy-app/muxy/releases/download/v#{version}/Muxy-#{version}-arm64.dmg"
-            end
-
-            on_intel do
-              sha256 "${SHA256_X86_64}"
-              url "https://github.com/muxy-app/muxy/releases/download/v#{version}/Muxy-#{version}-x86_64.dmg"
-            end
-
-            name "Muxy"
-            desc "Terminal multiplexer for macOS"
-            homepage "https://github.com/muxy-app/muxy"
-
-            livecheck do
-              url :url
-              strategy :github_latest
-            end
-
-            app "Muxy.app"
-
-            zap trash: [
-              "~/Library/Application Support/Muxy",
-              "~/Library/Preferences/app.muxy.Muxy.plist",
-              "~/Library/Saved Application State/app.muxy.Muxy.savedState",
-            ]
-          end
-          EOF
-          cd tap
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/muxy.rb
-          git commit -m "Update Muxy to v${VERSION}"
-          git push

--- a/Muxy/Extensions/DTOConversions.swift
+++ b/Muxy/Extensions/DTOConversions.swift
@@ -88,6 +88,7 @@ extension TerminalTab.Kind {
         case .vcs: .vcs
         case .editor: .editor
         case .diffViewer: .diffViewer
+        case .webView: .webView
         }
     }
 }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -38,6 +38,7 @@ final class AppState {
         case createExternalEditorTab(projectID: UUID, areaID: UUID?, filePath: String, command: String)
         case createDiffViewerTab(projectID: UUID, areaID: UUID?, request: DiffViewerRequest)
         case restoreClosedTerminalTab(projectID: UUID, areaID: UUID?, snapshot: ClosedTerminalTabSnapshot)
+        case createWebViewTab(projectID: UUID, areaID: UUID?)
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTabByIndex(projectID: UUID, index: Int)

--- a/Muxy/Models/ProjectGroup.swift
+++ b/Muxy/Models/ProjectGroup.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct ProjectGroup: Identifiable, Codable, Hashable {
+    let id: UUID
+    var name: String
+    var sortOrder: Int
+    var isExpanded: Bool
+    var projectIDs: [UUID]
+
+    init(name: String, sortOrder: Int = 0, isExpanded: Bool = true, projectIDs: [UUID] = []) {
+        self.id = UUID()
+        self.name = name
+        self.sortOrder = sortOrder
+        self.isExpanded = isExpanded
+        self.projectIDs = projectIDs
+    }
+}

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -41,7 +41,7 @@ final class TabArea: Identifiable {
     }
 
     func snapshot() -> TabAreaSnapshot {
-        let persistedTabs = tabs.filter { $0.kind != .diffViewer }
+        let persistedTabs = tabs.filter { $0.kind != .diffViewer && $0.kind != .webView }
         let activeIndex = persistedTabs.firstIndex(where: { $0.id == activeTabID })
         return TabAreaSnapshot(
             id: id,
@@ -109,6 +109,10 @@ final class TabArea: Identifiable {
         let editorState = EditorTabState(projectPath: projectPath, filePath: filePath)
         editorState.suppressInitialFocus = suppressInitialFocus
         insertTab(TerminalTab(editorState: editorState))
+    }
+
+    func createWebViewTab() {
+        insertTab(TerminalTab(webViewState: WebViewTabState(projectPath: projectPath)))
     }
 
     func createDiffViewerTab(vcs: VCSTabState, filePath: String, isStaged: Bool) {

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -8,6 +8,7 @@ final class TerminalTab: Identifiable {
         case vcs
         case editor
         case diffViewer
+        case webView
     }
 
     enum Content {
@@ -15,6 +16,7 @@ final class TerminalTab: Identifiable {
         case vcs(VCSTabState)
         case editor(EditorTabState)
         case diffViewer(DiffViewerTabState)
+        case webView(WebViewTabState)
 
         var kind: Kind {
             switch self {
@@ -22,6 +24,7 @@ final class TerminalTab: Identifiable {
             case .vcs: .vcs
             case .editor: .editor
             case .diffViewer: .diffViewer
+            case .webView: .webView
             }
         }
 
@@ -45,12 +48,18 @@ final class TerminalTab: Identifiable {
             return state
         }
 
+        var webViewState: WebViewTabState? {
+            guard case let .webView(state) = self else { return nil }
+            return state
+        }
+
         var projectPath: String {
             switch self {
             case let .terminal(pane): pane.projectPath
             case let .vcs(state): state.projectPath
             case let .editor(state): state.projectPath
             case let .diffViewer(state): state.projectPath
+            case let .webView(state): state.projectPath
             }
         }
     }
@@ -76,6 +85,8 @@ final class TerminalTab: Identifiable {
             return state.displayTitle
         case let .diffViewer(state):
             return state.displayTitle
+        case let .webView(state):
+            return state.displayTitle
         }
     }
 
@@ -97,6 +108,11 @@ final class TerminalTab: Identifiable {
     init(diffViewerState: DiffViewerTabState) {
         id = UUID()
         content = .diffViewer(diffViewerState)
+    }
+
+    init(webViewState: WebViewTabState) {
+        id = UUID()
+        content = .webView(webViewState)
     }
 
     init(restoring snapshot: TerminalTabSnapshot, restoredSession: TerminalSessionSnapshot? = nil) {
@@ -122,6 +138,8 @@ final class TerminalTab: Identifiable {
                 content = .terminal(TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle))
             }
         case .diffViewer:
+            content = .terminal(TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle))
+        case .webView:
             content = .terminal(TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle))
         }
     }

--- a/Muxy/Models/WebViewTabState.swift
+++ b/Muxy/Models/WebViewTabState.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+@MainActor
+@Observable
+final class WebViewTabState: Identifiable {
+    let id = UUID()
+    let projectPath: String
+    var urlString: String
+    var displayTitle: String
+    var isLoading = false
+    var canGoBack = false
+    var canGoForward = false
+    var loadVersion = 0
+
+    init(projectPath: String, urlString: String = "https://www.google.com") {
+        self.projectPath = projectPath
+        self.urlString = urlString
+        displayTitle = "Browser"
+    }
+
+    func requestLoad(_ urlString: String) {
+        self.urlString = urlString
+        loadVersion &+= 1
+    }
+}

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -134,6 +134,9 @@ enum WorkspaceReducer {
                 state: &state
             )
 
+        case let .createWebViewTab(projectID, areaID):
+            TabReducer.createWebViewTab(projectID: projectID, areaID: areaID, state: &state)
+
         case let .closeTab(projectID, areaID, tabID):
             guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { break }
             TabReducer.closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -73,6 +73,14 @@ enum TabReducer {
         area.createExternalEditorTab(filePath: filePath, command: command)
     }
 
+    static func createWebViewTab(projectID: UUID, areaID: UUID?, state: inout WorkspaceState) {
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
+              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
+        else { return }
+        FocusReducer.focusArea(area.id, key: key, state: &state)
+        area.createWebViewTab()
+    }
+
     static func createDiffViewerTab(
         projectID: UUID,
         areaID: UUID?,

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -9,6 +9,7 @@ struct MuxyApp: App {
     @State private var appState: AppState
     @State private var projectStore: ProjectStore
     @State private var worktreeStore: WorktreeStore
+    @State private var groupStore: ProjectGroupStore
     @State private var vcsWorktreeAutoRefresher: VCSWorktreeAutoRefresher
     private let updateService = UpdateService.shared
 
@@ -29,6 +30,10 @@ struct MuxyApp: App {
             projects: projectStore.projects,
             worktrees: worktreeStore.worktrees
         )
+        let groupStore = ProjectGroupStore(
+            persistence: environment.groupPersistence,
+            existingProjectIDs: projectStore.projects.map(\.id)
+        )
         let vcsWorktreeAutoRefresher = VCSWorktreeAutoRefresher(
             appState: appState,
             projectStore: projectStore,
@@ -37,6 +42,7 @@ struct MuxyApp: App {
         _appState = State(initialValue: appState)
         _projectStore = State(initialValue: projectStore)
         _worktreeStore = State(initialValue: worktreeStore)
+        _groupStore = State(initialValue: groupStore)
         _vcsWorktreeAutoRefresher = State(initialValue: vcsWorktreeAutoRefresher)
     }
 
@@ -46,6 +52,7 @@ struct MuxyApp: App {
                 .environment(appState)
                 .environment(projectStore)
                 .environment(worktreeStore)
+                .environment(groupStore)
                 .environment(GhosttyService.shared)
                 .environment(MuxyConfig.shared)
                 .environment(ThemeService.shared)
@@ -86,7 +93,7 @@ struct MuxyApp: App {
                         delegate.server = server
                         return delegate
                     }
-                    appState.onProjectsEmptied = { [projectStore, worktreeStore] projectIDs in
+                    appState.onProjectsEmptied = { [projectStore, worktreeStore, groupStore] projectIDs in
                         for id in projectIDs {
                             if let project = projectStore.projects.first(where: { $0.id == id }) {
                                 let knownWorktrees = worktreeStore.list(for: id)
@@ -99,7 +106,14 @@ struct MuxyApp: App {
                             }
                             projectStore.remove(id: id)
                             worktreeStore.removeProject(id)
+                            groupStore.removeProjectFromAllGroups(projectID: id)
                         }
+                    }
+                    projectStore.onProjectAdded = { [groupStore] project in
+                        groupStore.addProjectToFirstGroupOrDefault(projectID: project.id)
+                    }
+                    projectStore.onProjectRemoved = { [groupStore] projectID in
+                        groupStore.removeProjectFromAllGroups(projectID: projectID)
                     }
                 }
         }
@@ -123,6 +137,7 @@ struct MuxyApp: App {
                 .environment(appState)
                 .environment(projectStore)
                 .environment(worktreeStore)
+                .environment(groupStore)
                 .environment(GhosttyService.shared)
                 .preferredColorScheme(MuxyTheme.colorScheme)
         }

--- a/Muxy/Services/AppEnvironment.swift
+++ b/Muxy/Services/AppEnvironment.swift
@@ -15,12 +15,14 @@ struct AppEnvironment {
     let projectPersistence: any ProjectPersisting
     let workspacePersistence: any WorkspacePersisting
     let worktreePersistence: any WorktreePersisting
+    let groupPersistence: any ProjectGroupPersisting
 
     static let live = Self(
         selectionStore: UserDefaultsActiveProjectSelectionStore(),
         terminalViews: TerminalViewRegistry.shared,
         projectPersistence: FileProjectPersistence(),
         workspacePersistence: FileWorkspacePersistence(),
-        worktreePersistence: FileWorktreePersistence()
+        worktreePersistence: FileWorktreePersistence(),
+        groupPersistence: FileProjectGroupPersistence()
     )
 }

--- a/Muxy/Services/ProjectGroupPersistence.swift
+++ b/Muxy/Services/ProjectGroupPersistence.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+protocol ProjectGroupPersisting {
+    func loadGroups() throws -> [ProjectGroup]
+    func saveGroups(_ groups: [ProjectGroup]) throws
+}
+
+final class FileProjectGroupPersistence: ProjectGroupPersisting {
+    private let store: CodableFileStore<[ProjectGroup]>
+
+    init(fileURL: URL = MuxyFileStorage.fileURL(filename: "project-groups.json")) {
+        store = CodableFileStore(fileURL: fileURL)
+    }
+
+    func loadGroups() throws -> [ProjectGroup] {
+        try store.load() ?? []
+    }
+
+    func saveGroups(_ groups: [ProjectGroup]) throws {
+        try store.save(groups)
+    }
+}

--- a/Muxy/Services/ProjectGroupStore.swift
+++ b/Muxy/Services/ProjectGroupStore.swift
@@ -1,0 +1,114 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "ProjectGroupStore")
+
+@MainActor
+@Observable
+final class ProjectGroupStore {
+    private(set) var groups: [ProjectGroup] = []
+    private let persistence: any ProjectGroupPersisting
+
+    init(persistence: any ProjectGroupPersisting, existingProjectIDs: [UUID] = []) {
+        self.persistence = persistence
+        load(existingProjectIDs: existingProjectIDs)
+    }
+
+    func addGroup(name: String) {
+        let sortOrder = groups.count
+        let group = ProjectGroup(name: name, sortOrder: sortOrder)
+        groups.append(group)
+        save()
+    }
+
+    func removeGroup(id: UUID) {
+        groups.removeAll { $0.id == id }
+        save()
+    }
+
+    func renameGroup(id: UUID, to newName: String) {
+        guard let index = groups.firstIndex(where: { $0.id == id }) else { return }
+        groups[index].name = newName
+        save()
+    }
+
+    func addProject(projectID: UUID, toGroup groupID: UUID) {
+        guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
+        guard !groups[index].projectIDs.contains(projectID) else { return }
+        groups[index].projectIDs.append(projectID)
+        save()
+    }
+
+    func removeProject(projectID: UUID, fromGroup groupID: UUID) {
+        guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
+        groups[index].projectIDs.removeAll { $0 == projectID }
+        save()
+    }
+
+    func moveProject(projectID: UUID, fromGroup sourceGroupID: UUID, toGroup destinationGroupID: UUID) {
+        guard sourceGroupID != destinationGroupID else { return }
+        removeProject(projectID: projectID, fromGroup: sourceGroupID)
+        addProject(projectID: projectID, toGroup: destinationGroupID)
+    }
+
+    func removeProjectFromAllGroups(projectID: UUID) {
+        for index in groups.indices {
+            groups[index].projectIDs.removeAll { $0 == projectID }
+        }
+        save()
+    }
+
+    func addProjectToFirstGroupOrDefault(projectID: UUID) {
+        if let firstGroup = groups.first {
+            addProject(projectID: projectID, toGroup: firstGroup.id)
+            return
+        }
+        let defaultGroup = ProjectGroup(name: "Default", sortOrder: 0)
+        groups.append(defaultGroup)
+        groups[groups.count - 1].projectIDs.append(projectID)
+        save()
+    }
+
+    func reorderGroups(fromOffsets source: IndexSet, toOffset destination: Int) {
+        groups.move(fromOffsets: source, toOffset: destination)
+        for index in groups.indices {
+            groups[index].sortOrder = index
+        }
+        save()
+    }
+
+    func reorderProjects(inGroup groupID: UUID, fromOffsets source: IndexSet, toOffset destination: Int) {
+        guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
+        groups[index].projectIDs.move(fromOffsets: source, toOffset: destination)
+        save()
+    }
+
+    func toggleExpanded(groupID: UUID) {
+        guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
+        groups[index].isExpanded.toggle()
+        save()
+    }
+
+    func save() {
+        do {
+            try persistence.saveGroups(groups)
+        } catch {
+            logger.error("Failed to save project groups: \(error)")
+        }
+    }
+
+    private func load(existingProjectIDs: [UUID]) {
+        do {
+            let loaded = try persistence.loadGroups()
+            if loaded.isEmpty && !existingProjectIDs.isEmpty {
+                let defaultGroup = ProjectGroup(name: "Default", sortOrder: 0, projectIDs: existingProjectIDs)
+                groups = [defaultGroup]
+                save()
+                return
+            }
+            groups = loaded.sorted { $0.sortOrder < $1.sortOrder }
+        } catch {
+            logger.error("Failed to load project groups: \(error)")
+        }
+    }
+}

--- a/Muxy/Services/ProjectStore.swift
+++ b/Muxy/Services/ProjectStore.swift
@@ -8,6 +8,8 @@ private let logger = Logger(subsystem: "app.muxy", category: "ProjectStore")
 final class ProjectStore {
     private(set) var projects: [Project] = []
     private let persistence: any ProjectPersisting
+    var onProjectAdded: ((Project) -> Void)?
+    var onProjectRemoved: ((UUID) -> Void)?
 
     init(persistence: any ProjectPersisting) {
         self.persistence = persistence
@@ -17,6 +19,7 @@ final class ProjectStore {
     func add(_ project: Project) {
         projects.append(project)
         save()
+        onProjectAdded?(project)
     }
 
     func remove(id: UUID) {
@@ -25,6 +28,7 @@ final class ProjectStore {
         }
         projects.removeAll { $0.id == id }
         save()
+        onProjectRemoved?(id)
     }
 
     func rename(id: UUID, to newName: String) {

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -153,6 +153,8 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             appState.dispatch(.createTab(projectID: projectID, areaID: areaID))
         case .diffViewer:
             appState.dispatch(.createTab(projectID: projectID, areaID: areaID))
+        case .webView:
+            appState.dispatch(.createWebViewTab(projectID: projectID, areaID: areaID))
         }
 
         guard let area = appState.focusedArea(for: projectID),

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -496,6 +496,9 @@ struct MainWindow: View {
                 onCreateVCSTab: {
                     openVCS(for: project, preferredAreaID: area.id)
                 },
+                onCreateWebViewTab: {
+                    appState.dispatch(.createWebViewTab(projectID: project.id, areaID: area.id))
+                },
                 onCloseTab: { tabID in
                     appState.closeTab(tabID, areaID: area.id, projectID: project.id)
                 },

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -29,6 +29,7 @@ enum SidebarLayout {
 struct Sidebar: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
+    @Environment(ProjectGroupStore.self) private var groupStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @State private var dragState = ProjectDragState()
     let expanded: Bool
@@ -78,47 +79,54 @@ struct Sidebar: View {
         .help(shortcutTooltip("Add Project", for: .openProject))
     }
 
+    private var groupedProjects: [(group: ProjectGroup, projects: [Project])] {
+        groupStore.groups.map { group in
+            let projects = group.projectIDs.compactMap { id in
+                projectStore.projects.first { $0.id == id }
+            }
+            return (group, projects)
+        }
+    }
+
+    private var ungroupedProjects: [Project] {
+        let assignedIDs = Set(groupStore.groups.flatMap(\.projectIDs))
+        return projectStore.projects.filter { !assignedIDs.contains($0.id) }
+    }
+
+    private func globalIndexOffset(forGroupIndex groupIndex: Int) -> Int {
+        groupedProjects.prefix(groupIndex).reduce(0) { $0 + $1.projects.count }
+    }
+
     private var projectList: some View {
         ScrollView(.vertical, showsIndicators: false) {
             LazyVStack(spacing: UIMetrics.spacing2) {
-                ForEach(Array(projectStore.projects.enumerated()), id: \.element.id) { index, project in
-                    Group {
-                        if isWide {
-                            ExpandedProjectRow(
-                                project: project,
-                                shortcutIndex: index < 9 ? index + 1 : nil,
-                                isAnyDragging: dragState.draggedID != nil,
-                                onSelect: { select(project) },
-                                onRemove: { remove(project) },
-                                onRename: { projectStore.rename(id: project.id, to: $0) },
-                                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
-                                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
+                ForEach(Array(groupedProjects.enumerated()), id: \.element.group.id) { groupIndex, entry in
+                    ProjectGroupSection(
+                        group: entry.group,
+                        projects: entry.projects,
+                        isWide: isWide,
+                        draggedID: dragState.draggedID,
+                        globalIndexOffset: globalIndexOffset(forGroupIndex: groupIndex),
+                        onSelect: { select($0) },
+                        onRemove: { remove($0) },
+                        onRename: { project, name in projectStore.rename(id: project.id, to: name) },
+                        onSetLogo: { project, logo in projectStore.setLogo(id: project.id, to: logo) },
+                        onSetIconColor: { project, color in projectStore.setIconColor(id: project.id, to: color) },
+                        onRenameGroup: { groupStore.renameGroup(id: entry.group.id, to: $0) },
+                        onDeleteGroup: { deleteGroup(entry.group) },
+                        onAddGroup: { addNewGroup() },
+                        onMoveProject: { project, targetGroupID in
+                            groupStore.moveProject(
+                                projectID: project.id,
+                                fromGroup: entry.group.id,
+                                toGroup: targetGroupID
                             )
-                        } else {
-                            ProjectRow(
-                                project: project,
-                                shortcutIndex: index < 9 ? index + 1 : nil,
-                                isAnyDragging: dragState.draggedID != nil,
-                                onSelect: { select(project) },
-                                onRemove: { remove(project) },
-                                onRename: { projectStore.rename(id: project.id, to: $0) },
-                                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
-                                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
-                            )
-                        }
-                    }
-                    .background {
-                        if dragState.draggedID != nil {
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: UUIDFramePreferenceKey<SidebarFrameTag>.self,
-                                    value: [project.id: geo.frame(in: .named("sidebar"))]
-                                )
-                            }
-                        }
-                    }
-                    .gesture(projectDragGesture(for: project))
+                        },
+                        allGroups: groupStore.groups,
+                        projectDragGesture: { projectDragGesture(for: $0) }
+                    )
                 }
+                ungroupedSection
                 addButton
             }
             .padding(.horizontal, isWide ? UIMetrics.spacing3 : UIMetrics.spacing4)
@@ -131,26 +139,75 @@ struct Sidebar: View {
         .coordinateSpace(name: "sidebar")
     }
 
+    @ViewBuilder
+    private var ungroupedSection: some View {
+        let projects = ungroupedProjects
+        if !projects.isEmpty {
+            let ungroupedOffset = groupedProjects.reduce(0) { $0 + $1.projects.count }
+            ForEach(Array(projects.enumerated()), id: \.element.id) { offset, project in
+                let shortcutIndex = ungroupedOffset + offset
+                Group {
+                    if isWide {
+                        ExpandedProjectRow(
+                            project: project,
+                            shortcutIndex: shortcutIndex < 9 ? shortcutIndex + 1 : nil,
+                            isAnyDragging: dragState.draggedID != nil,
+                            onSelect: { select(project) },
+                            onRemove: { remove(project) },
+                            onRename: { projectStore.rename(id: project.id, to: $0) },
+                            onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
+                            onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
+                        )
+                    } else {
+                        ProjectRow(
+                            project: project,
+                            shortcutIndex: shortcutIndex < 9 ? shortcutIndex + 1 : nil,
+                            isAnyDragging: dragState.draggedID != nil,
+                            onSelect: { select(project) },
+                            onRemove: { remove(project) },
+                            onRename: { projectStore.rename(id: project.id, to: $0) },
+                            onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
+                            onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
+                        )
+                    }
+                }
+                .background {
+                    if dragState.draggedID != nil {
+                        GeometryReader { geo in
+                            Color.clear.preference(
+                                key: UUIDFramePreferenceKey<SidebarFrameTag>.self,
+                                value: [project.id: geo.frame(in: .named("sidebar"))]
+                            )
+                        }
+                    }
+                }
+                .gesture(projectDragGesture(for: project))
+            }
+        }
+    }
+
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {
         "\(name) (\(KeyBindingStore.shared.combo(for: action).displayString))"
     }
 
-    private func projectDragGesture(for project: Project) -> some Gesture {
-        DragGesture(minimumDistance: 6, coordinateSpace: .named("sidebar"))
-            .onChanged { value in
-                if dragState.draggedID == nil {
-                    dragState.draggedID = project.id
-                    dragState.lastReorderTargetID = nil
+    private func projectDragGesture(for project: Project) -> AnyGesture<DragGesture.Value> {
+        AnyGesture(
+            DragGesture(minimumDistance: 6, coordinateSpace: .named("sidebar"))
+                .onChanged { value in
+                    if dragState.draggedID == nil {
+                        dragState.draggedID = project.id
+                        dragState.lastReorderTargetID = nil
+                    }
+                    reorderIfNeeded(at: value.location)
                 }
-                reorderIfNeeded(at: value.location)
-            }
-            .onEnded { _ in
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    dragState.draggedID = nil
-                    dragState.frames = [:]
-                    dragState.lastReorderTargetID = nil
+                .onEnded { _ in
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        dragState.draggedID = nil
+                        dragState.frames = [:]
+                        dragState.lastReorderTargetID = nil
+                    }
                 }
-            }
+        )
     }
 
     private func select(_ project: Project) {
@@ -172,6 +229,14 @@ struct Sidebar: View {
         appState.removeProject(project.id)
         projectStore.remove(id: project.id)
         worktreeStore.removeProject(project.id)
+    }
+
+    private func deleteGroup(_ group: ProjectGroup) {
+        groupStore.removeGroup(id: group.id)
+    }
+
+    private func addNewGroup() {
+        groupStore.addGroup(name: "New Group")
     }
 
     private func reorderIfNeeded(at location: CGPoint) {

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -99,7 +99,7 @@ struct Sidebar: View {
 
     private var projectList: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            LazyVStack(spacing: UIMetrics.spacing2) {
+            LazyVStack(spacing: UIMetrics.spacing3) {
                 ForEach(Array(groupedProjects.enumerated()), id: \.element.group.id) { groupIndex, entry in
                     ProjectGroupSection(
                         group: entry.group,

--- a/Muxy/Views/Sidebar/ProjectGroupSection.swift
+++ b/Muxy/Views/Sidebar/ProjectGroupSection.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+struct ProjectGroupSection: View {
+    let group: ProjectGroup
+    let projects: [Project]
+    let isWide: Bool
+    let draggedID: UUID?
+    let globalIndexOffset: Int
+    let onSelect: (Project) -> Void
+    let onRemove: (Project) -> Void
+    let onRename: (Project, String) -> Void
+    let onSetLogo: (Project, String?) -> Void
+    let onSetIconColor: (Project, String?) -> Void
+    let onRenameGroup: (String) -> Void
+    let onDeleteGroup: () -> Void
+    let onAddGroup: () -> Void
+    let onMoveProject: (Project, UUID) -> Void
+    let allGroups: [ProjectGroup]
+    let projectDragGesture: (Project) -> AnyGesture<DragGesture.Value>
+
+    @Environment(ProjectGroupStore.self) private var groupStore
+
+    @State private var isRenaming = false
+    @State private var renameText = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            groupHeader
+            if group.isExpanded {
+                projectRows
+            }
+        }
+    }
+
+    private var isAnyDragging: Bool { draggedID != nil }
+
+    private var groupHeader: some View {
+        HStack(spacing: UIMetrics.spacing2) {
+            if isWide {
+                wideGroupHeader
+            } else {
+                collapsedGroupHeader
+            }
+        }
+    }
+
+    private var wideGroupHeader: some View {
+        HStack(spacing: UIMetrics.spacing2) {
+            if isRenaming {
+                TextField("Group name", text: $renameText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    .onSubmit { commitRename() }
+                    .onExitCommand { cancelRename() }
+            } else {
+                Text(group.name.uppercased())
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Image(systemName: group.isExpanded ? "chevron.down" : "chevron.right")
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+        }
+        .padding(.horizontal, UIMetrics.spacing2)
+        .padding(.vertical, UIMetrics.spacing1)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                groupStore.toggleExpanded(groupID: group.id)
+            }
+        }
+        .contextMenu { groupContextMenu }
+    }
+
+    private var collapsedGroupHeader: some View {
+        Image(systemName: group.isExpanded ? "chevron.down" : "chevron.right")
+            .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+            .foregroundStyle(MuxyTheme.fgMuted)
+            .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconSM)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    groupStore.toggleExpanded(groupID: group.id)
+                }
+            }
+            .contextMenu { groupContextMenu }
+    }
+
+    @ViewBuilder
+    private var groupContextMenu: some View {
+        Button("Add New Group") { onAddGroup() }
+        Divider()
+        Button("Rename Group") { startRename() }
+        Button("Delete Group", role: .destructive) { onDeleteGroup() }
+    }
+
+    @ViewBuilder
+    private var projectRows: some View {
+        ForEach(Array(projects.enumerated()), id: \.element.id) { offset, project in
+            let shortcutIndex = globalIndexOffset + offset
+            Group {
+                if isWide {
+                    ExpandedProjectRow(
+                        project: project,
+                        shortcutIndex: shortcutIndex < 9 ? shortcutIndex + 1 : nil,
+                        isAnyDragging: isAnyDragging,
+                        onSelect: { onSelect(project) },
+                        onRemove: { onRemove(project) },
+                        onRename: { onRename(project, $0) },
+                        onSetLogo: { onSetLogo(project, $0) },
+                        onSetIconColor: { onSetIconColor(project, $0) }
+                    )
+                    .contextMenu { moveToGroupMenu(for: project) }
+                } else {
+                    ProjectRow(
+                        project: project,
+                        shortcutIndex: shortcutIndex < 9 ? shortcutIndex + 1 : nil,
+                        isAnyDragging: isAnyDragging,
+                        onSelect: { onSelect(project) },
+                        onRemove: { onRemove(project) },
+                        onRename: { onRename(project, $0) },
+                        onSetLogo: { onSetLogo(project, $0) },
+                        onSetIconColor: { onSetIconColor(project, $0) }
+                    )
+                    .contextMenu { moveToGroupMenu(for: project) }
+                }
+            }
+            .background {
+                if draggedID != nil {
+                    GeometryReader { geo in
+                        Color.clear.preference(
+                            key: UUIDFramePreferenceKey<SidebarFrameTag>.self,
+                            value: [project.id: geo.frame(in: .named("sidebar"))]
+                        )
+                    }
+                }
+            }
+            .gesture(projectDragGesture(project))
+        }
+    }
+
+    @ViewBuilder
+    private func moveToGroupMenu(for project: Project) -> some View {
+        let otherGroups = allGroups.filter { $0.id != group.id }
+        if !otherGroups.isEmpty {
+            Menu("Move to Group") {
+                ForEach(otherGroups) { targetGroup in
+                    Button(targetGroup.name) {
+                        onMoveProject(project, targetGroup.id)
+                    }
+                }
+            }
+        }
+    }
+
+    private func startRename() {
+        renameText = group.name
+        isRenaming = true
+    }
+
+    private func commitRename() {
+        let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            cancelRename()
+            return
+        }
+        onRenameGroup(trimmed)
+        isRenaming = false
+    }
+
+    private func cancelRename() {
+        renameText = ""
+        isRenaming = false
+    }
+}

--- a/Muxy/Views/Sidebar/ProjectGroupSection.swift
+++ b/Muxy/Views/Sidebar/ProjectGroupSection.swift
@@ -30,6 +30,11 @@ struct ProjectGroupSection: View {
                 projectRows
             }
         }
+        .padding(UIMetrics.spacing1)
+        .overlay(
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
+                .stroke(MuxyTheme.border, lineWidth: 1)
+        )
     }
 
     private var isAnyDragging: Bool { draggedID != nil }
@@ -76,17 +81,24 @@ struct ProjectGroupSection: View {
     }
 
     private var collapsedGroupHeader: some View {
-        Image(systemName: group.isExpanded ? "chevron.down" : "chevron.right")
-            .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
-            .foregroundStyle(MuxyTheme.fgMuted)
-            .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconSM)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    groupStore.toggleExpanded(groupID: group.id)
-                }
+        VStack(spacing: UIMetrics.spacing1) {
+            Text(group.name.prefix(1).uppercased())
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.iconXXL)
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            Image(systemName: group.isExpanded ? "chevron.down" : "chevron.right")
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconSM)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                groupStore.toggleExpanded(groupID: group.id)
             }
-            .contextMenu { groupContextMenu }
+        }
+        .contextMenu { groupContextMenu }
     }
 
     @ViewBuilder

--- a/Muxy/Views/WebViewPane.swift
+++ b/Muxy/Views/WebViewPane.swift
@@ -1,0 +1,167 @@
+import AppKit
+import SwiftUI
+import WebKit
+
+struct WebViewPane: View {
+    @Bindable var state: WebViewTabState
+    let focused: Bool
+    let onFocus: () -> Void
+    @State private var addressText: String = ""
+    @State private var coordinator = WebViewCoordinator()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Rectangle().fill(MuxyTheme.border).frame(height: 1)
+            WebViewBridge(state: state, coordinator: coordinator)
+                .background(MuxyTheme.bg)
+        }
+        .background(MuxyTheme.bg)
+        .contentShape(Rectangle())
+        .onTapGesture { onFocus() }
+        .onAppear {
+            addressText = state.urlString
+        }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 6) {
+            IconButton(symbol: "chevron.left", size: 12, accessibilityLabel: "Back") {
+                coordinator.webView?.goBack()
+            }
+            .disabled(!state.canGoBack)
+            .opacity(state.canGoBack ? 1 : 0.4)
+
+            IconButton(symbol: "chevron.right", size: 12, accessibilityLabel: "Forward") {
+                coordinator.webView?.goForward()
+            }
+            .disabled(!state.canGoForward)
+            .opacity(state.canGoForward ? 1 : 0.4)
+
+            IconButton(
+                symbol: state.isLoading ? "xmark" : "arrow.clockwise",
+                size: 12,
+                accessibilityLabel: state.isLoading ? "Stop" : "Reload"
+            ) {
+                if state.isLoading {
+                    coordinator.webView?.stopLoading()
+                } else {
+                    coordinator.webView?.reload()
+                }
+            }
+
+            TextField("Enter URL or search", text: $addressText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(MuxyTheme.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(MuxyTheme.border, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .onSubmit {
+                    state.requestLoad(Self.normalize(addressText))
+                }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(height: 36)
+        .background(MuxyTheme.bg)
+    }
+
+    static func normalize(_ input: String) -> String {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "about:blank" }
+        if trimmed.contains("://") { return trimmed }
+        if trimmed.contains(" ") || !trimmed.contains(".") {
+            let query = trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? trimmed
+            return "https://www.google.com/search?q=\(query)"
+        }
+        return "https://\(trimmed)"
+    }
+}
+
+@MainActor
+@Observable
+final class WebViewCoordinator: NSObject, WKNavigationDelegate {
+    var webView: WKWebView?
+    weak var state: WebViewTabState?
+    private var lastLoadedVersion = -1
+
+    func bind(webView: WKWebView, state: WebViewTabState) {
+        self.webView = webView
+        self.state = state
+        webView.navigationDelegate = self
+        loadIfNeeded(force: true)
+    }
+
+    func loadIfNeeded(force: Bool = false) {
+        guard let webView, let state else { return }
+        if !force, lastLoadedVersion == state.loadVersion { return }
+        lastLoadedVersion = state.loadVersion
+        guard let url = URL(string: state.urlString) else { return }
+        webView.load(URLRequest(url: url))
+    }
+
+    nonisolated func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+        Task { @MainActor in
+            state?.isLoading = true
+            updateNavigationState(webView)
+        }
+    }
+
+    nonisolated func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+        Task { @MainActor in
+            state?.isLoading = false
+            if let title = webView.title, !title.isEmpty {
+                state?.displayTitle = title
+            }
+            updateNavigationState(webView)
+        }
+    }
+
+    nonisolated func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+        Task { @MainActor in
+            state?.isLoading = false
+            updateNavigationState(webView)
+        }
+    }
+
+    nonisolated func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation _: WKNavigation!,
+        withError _: Error
+    ) {
+        Task { @MainActor in
+            state?.isLoading = false
+            updateNavigationState(webView)
+        }
+    }
+
+    @MainActor
+    private func updateNavigationState(_ webView: WKWebView) {
+        state?.canGoBack = webView.canGoBack
+        state?.canGoForward = webView.canGoForward
+    }
+}
+
+private struct WebViewBridge: NSViewRepresentable {
+    let state: WebViewTabState
+    let coordinator: WebViewCoordinator
+
+    func makeNSView(context _: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .default()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.allowsBackForwardNavigationGestures = true
+        webView.allowsMagnification = true
+        coordinator.bind(webView: webView, state: state)
+        return webView
+    }
+
+    func updateNSView(_: WKWebView, context _: Context) {
+        coordinator.loadIfNeeded()
+    }
+}

--- a/Muxy/Views/Workspace/PaneNode.swift
+++ b/Muxy/Views/Workspace/PaneNode.swift
@@ -12,6 +12,7 @@ struct PaneNode: View {
     let onSelectTab: (UUID, UUID) -> Void
     let onCreateTab: (UUID) -> Void
     let onCreateVCSTab: (UUID) -> Void
+    let onCreateWebViewTab: (UUID) -> Void
     let onCloseTab: (UUID, UUID) -> Void
     let onForceCloseTab: (UUID, UUID) -> Void
     let onSplit: (UUID, SplitDirection) -> Void
@@ -35,6 +36,7 @@ struct PaneNode: View {
                 onSelectTab: { tabID in onSelectTab(area.id, tabID) },
                 onCreateTab: { onCreateTab(area.id) },
                 onCreateVCSTab: { onCreateVCSTab(area.id) },
+                onCreateWebViewTab: { onCreateWebViewTab(area.id) },
                 onCloseTab: { tabID in onCloseTab(area.id, tabID) },
                 onForceCloseTab: { tabID in onForceCloseTab(area.id, tabID) },
                 onSplit: { dir in onSplit(area.id, dir) },
@@ -54,6 +56,7 @@ struct PaneNode: View {
                 onSelectTab: onSelectTab,
                 onCreateTab: onCreateTab,
                 onCreateVCSTab: onCreateVCSTab,
+                onCreateWebViewTab: onCreateWebViewTab,
                 onCloseTab: onCloseTab,
                 onForceCloseTab: onForceCloseTab,
                 onSplit: onSplit,

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -12,6 +12,7 @@ struct SplitContainer: View {
     let onSelectTab: (UUID, UUID) -> Void
     let onCreateTab: (UUID) -> Void
     let onCreateVCSTab: (UUID) -> Void
+    let onCreateWebViewTab: (UUID) -> Void
     let onCloseTab: (UUID, UUID) -> Void
     let onForceCloseTab: (UUID, UUID) -> Void
     let onSplit: (UUID, SplitDirection) -> Void
@@ -72,6 +73,7 @@ struct SplitContainer: View {
             onSelectTab: onSelectTab,
             onCreateTab: onCreateTab,
             onCreateVCSTab: onCreateVCSTab,
+            onCreateWebViewTab: onCreateWebViewTab,
             onCloseTab: onCloseTab,
             onForceCloseTab: onForceCloseTab,
             onSplit: onSplit,

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -12,6 +12,7 @@ struct TabAreaView: View {
     let onSelectTab: (UUID) -> Void
     let onCreateTab: () -> Void
     let onCreateVCSTab: () -> Void
+    let onCreateWebViewTab: () -> Void
     let onCloseTab: (UUID) -> Void
     let onForceCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
@@ -46,6 +47,7 @@ struct TabAreaView: View {
                     onSelectTab: onSelectTab,
                     onCreateTab: onCreateTab,
                     onCreateVCSTab: onCreateVCSTab,
+                    onCreateWebViewTab: onCreateWebViewTab,
                     onCloseTab: onCloseTab,
                     onCloseOtherTabs: { tabID in
                         closeTabs(area.tabs.filter { $0.id != tabID && !$0.isPinned }.map(\.id))
@@ -218,6 +220,8 @@ private struct TabContentView: View {
             EditorPane(state: editorState, focused: focused, onFocus: onFocus)
         case let .diffViewer(diffState):
             DiffViewerPane(state: diffState, focused: focused, onFocus: onFocus)
+        case let .webView(webState):
+            WebViewPane(state: webState, focused: focused, onFocus: onFocus)
         }
     }
 }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -656,14 +656,10 @@ private struct TabCell: View {
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))
         } else if tab.kind == .diffViewer {
             Image(systemName: "rectangle.split.2x1")
-<<<<<<< HEAD
                 .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
-=======
-                .font(.system(size: 11, weight: .semibold))
         } else if tab.kind == .webView {
             Image(systemName: "globe")
-                .font(.system(size: 12, weight: .semibold))
->>>>>>> 2e520d5 (Add in-app browser tab)
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
         } else {
             Image(systemName: "terminal")
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -28,6 +28,7 @@ struct PaneTabStrip: View {
     let onSelectTab: (UUID) -> Void
     let onCreateTab: () -> Void
     let onCreateVCSTab: () -> Void
+    let onCreateWebViewTab: () -> Void
     let onCloseTab: (UUID) -> Void
     let onCloseOtherTabs: (UUID) -> Void
     let onCloseTabsToLeft: (UUID) -> Void
@@ -98,6 +99,10 @@ struct PaneTabStrip: View {
                     IconButton(symbol: symbol, accessibilityLabel: label, action: onToggleMaximize)
                         .help(shortcutTooltip("Toggle Maximize Pane", for: .toggleMaximizePane))
                 }
+                IconButton(symbol: "globe", size: 12, accessibilityLabel: "Open Browser") {
+                    onCreateWebViewTab()
+                }
+                .help("Open Browser")
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
                     .help(shortcutTooltip("Split Right", for: .splitRight))
                 IconButton(symbol: "square.split.1x2", accessibilityLabel: "Split Down") { onSplit(.vertical) }
@@ -626,6 +631,7 @@ private struct TabCell: View {
         case .vcs: label += ", Source Control"
         case .editor: label += ", Editor"
         case .diffViewer: label += ", Diff Viewer"
+        case .webView: label += ", Browser"
         }
         if tab.isPinned { label += ", Pinned" }
         if hasUnread { label += ", Unread" }
@@ -650,7 +656,14 @@ private struct TabCell: View {
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))
         } else if tab.kind == .diffViewer {
             Image(systemName: "rectangle.split.2x1")
+<<<<<<< HEAD
                 .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+=======
+                .font(.system(size: 11, weight: .semibold))
+        } else if tab.kind == .webView {
+            Image(systemName: "globe")
+                .font(.system(size: 12, weight: .semibold))
+>>>>>>> 2e520d5 (Add in-app browser tab)
         } else {
             Image(systemName: "terminal")
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -62,6 +62,9 @@ struct TerminalArea: View {
                         attached: { NotificationCenter.default.post(name: .toggleAttachedVCS, object: nil) }
                     )
                 },
+                onCreateWebViewTab: {
+                    appState.dispatch(.createWebViewTab(projectID: project.id, areaID: area.id))
+                },
                 onCloseTab: { tabID in
                     appState.closeTab(tabID, areaID: area.id, projectID: project.id)
                 },
@@ -146,6 +149,7 @@ private struct MaximizedAreaView: View {
     let onSelectTab: (UUID) -> Void
     let onCreateTab: () -> Void
     let onCreateVCSTab: () -> Void
+    let onCreateWebViewTab: () -> Void
     let onCloseTab: (UUID) -> Void
     let onForceCloseTab: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
@@ -164,6 +168,7 @@ private struct MaximizedAreaView: View {
             onSelectTab: onSelectTab,
             onCreateTab: onCreateTab,
             onCreateVCSTab: onCreateVCSTab,
+            onCreateWebViewTab: onCreateWebViewTab,
             onCloseTab: onCloseTab,
             onForceCloseTab: onForceCloseTab,
             onSplit: onSplit,

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -106,6 +106,9 @@ struct TerminalArea: View {
                         attached: { NotificationCenter.default.post(name: .toggleAttachedVCS, object: nil) }
                     )
                 },
+                onCreateWebViewTab: { areaID in
+                    appState.dispatch(.createWebViewTab(projectID: project.id, areaID: areaID))
+                },
                 onCloseTab: { areaID, tabID in
                     appState.closeTab(tabID, areaID: areaID, projectID: project.id)
                 },

--- a/MuxyShared/WorkspaceDTO.swift
+++ b/MuxyShared/WorkspaceDTO.swift
@@ -131,4 +131,5 @@ public enum TabKindDTO: String, Codable, Sendable {
     case vcs
     case editor
     case diffViewer
+    case webView
 }

--- a/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProjectGroupStore")
+@MainActor
+struct ProjectGroupStoreTests {
+    @Test("addGroup appends a new group and persists it")
+    func addGroup() {
+        let persistence = ProjectGroupPersistenceStub()
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addGroup(name: "Work")
+
+        #expect(store.groups.count == 1)
+        #expect(store.groups.first?.name == "Work")
+        #expect(persistence.savedGroups?.count == 1)
+    }
+
+    @Test("removeGroup deletes the group and persists")
+    func removeGroup() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.removeGroup(id: group.id)
+
+        #expect(store.groups.isEmpty)
+        #expect(persistence.savedGroups?.isEmpty == true)
+    }
+
+    @Test("renameGroup updates the name and persists")
+    func renameGroup() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.renameGroup(id: group.id, to: "Personal")
+
+        #expect(store.groups.first?.name == "Personal")
+        #expect(persistence.savedGroups?.first?.name == "Personal")
+    }
+
+    @Test("renameGroup with unknown id is a no-op")
+    func renameGroupUnknownID() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.renameGroup(id: UUID(), to: "Other")
+
+        #expect(store.groups.first?.name == "Work")
+    }
+
+    @Test("addProject adds projectID to the group and persists")
+    func addProject() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+        let projectID = UUID()
+
+        store.addProject(projectID: projectID, toGroup: group.id)
+
+        #expect(store.groups.first?.projectIDs == [projectID])
+        #expect(persistence.savedGroups?.first?.projectIDs == [projectID])
+    }
+
+    @Test("addProject ignores duplicate projectID")
+    func addProjectDuplicate() {
+        let projectID = UUID()
+        let group = ProjectGroup(name: "Work", projectIDs: [projectID])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addProject(projectID: projectID, toGroup: group.id)
+
+        #expect(store.groups.first?.projectIDs.count == 1)
+    }
+
+    @Test("removeProject removes projectID from the group and persists")
+    func removeProject() {
+        let projectID = UUID()
+        let group = ProjectGroup(name: "Work", projectIDs: [projectID])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.removeProject(projectID: projectID, fromGroup: group.id)
+
+        #expect(store.groups.first?.projectIDs.isEmpty == true)
+        #expect(persistence.savedGroups?.first?.projectIDs.isEmpty == true)
+    }
+
+    @Test("moveProject transfers projectID between groups and persists")
+    func moveProject() {
+        let projectID = UUID()
+        let source = ProjectGroup(name: "Work", sortOrder: 0, projectIDs: [projectID])
+        let destination = ProjectGroup(name: "Personal", sortOrder: 1)
+        let persistence = ProjectGroupPersistenceStub(initial: [source, destination])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.moveProject(projectID: projectID, fromGroup: source.id, toGroup: destination.id)
+
+        let updatedSource = store.groups.first(where: { $0.id == source.id })
+        let updatedDestination = store.groups.first(where: { $0.id == destination.id })
+        #expect(updatedSource?.projectIDs.isEmpty == true)
+        #expect(updatedDestination?.projectIDs == [projectID])
+    }
+
+    @Test("moveProject with same source and destination is a no-op")
+    func moveProjectSameGroup() {
+        let projectID = UUID()
+        let group = ProjectGroup(name: "Work", projectIDs: [projectID])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.moveProject(projectID: projectID, fromGroup: group.id, toGroup: group.id)
+
+        #expect(store.groups.first?.projectIDs == [projectID])
+    }
+
+    @Test("reorderGroups updates sortOrder and persists")
+    func reorderGroups() {
+        let first = ProjectGroup(name: "A", sortOrder: 0)
+        let second = ProjectGroup(name: "B", sortOrder: 1)
+        let persistence = ProjectGroupPersistenceStub(initial: [first, second])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.reorderGroups(fromOffsets: IndexSet(integer: 0), toOffset: 2)
+
+        #expect(store.groups.first?.name == "B")
+        #expect(store.groups.last?.name == "A")
+        #expect(persistence.savedGroups?.first?.name == "B")
+    }
+
+    @Test("reorderProjects moves projectIDs within group and persists")
+    func reorderProjects() {
+        let idA = UUID()
+        let idB = UUID()
+        let group = ProjectGroup(name: "Work", projectIDs: [idA, idB])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.reorderProjects(inGroup: group.id, fromOffsets: IndexSet(integer: 0), toOffset: 2)
+
+        #expect(store.groups.first?.projectIDs == [idB, idA])
+        #expect(persistence.savedGroups?.first?.projectIDs == [idB, idA])
+    }
+
+    @Test("toggleExpanded flips isExpanded and persists")
+    func toggleExpanded() {
+        let group = ProjectGroup(name: "Work", isExpanded: true)
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.toggleExpanded(groupID: group.id)
+
+        #expect(store.groups.first?.isExpanded == false)
+        #expect(persistence.savedGroups?.first?.isExpanded == false)
+
+        store.toggleExpanded(groupID: group.id)
+
+        #expect(store.groups.first?.isExpanded == true)
+    }
+
+    @Test("toggleExpanded with unknown id is a no-op")
+    func toggleExpandedUnknownID() {
+        let group = ProjectGroup(name: "Work", isExpanded: true)
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.toggleExpanded(groupID: UUID())
+
+        #expect(store.groups.first?.isExpanded == true)
+    }
+
+    @Test("migration creates Default group when store is empty and projects exist")
+    func migrationCreatesDefaultGroup() {
+        let projectIDs = [UUID(), UUID()]
+        let persistence = ProjectGroupPersistenceStub(initial: [])
+        let store = ProjectGroupStore(persistence: persistence, existingProjectIDs: projectIDs)
+
+        #expect(store.groups.count == 1)
+        #expect(store.groups.first?.name == "Default")
+        #expect(store.groups.first?.projectIDs == projectIDs)
+        #expect(persistence.savedGroups?.count == 1)
+    }
+
+    @Test("migration does not create Default group when projects are empty")
+    func migrationSkipsWhenNoProjects() {
+        let persistence = ProjectGroupPersistenceStub(initial: [])
+        let store = ProjectGroupStore(persistence: persistence, existingProjectIDs: [])
+
+        #expect(store.groups.isEmpty)
+    }
+
+    @Test("migration does not create Default group when groups already exist")
+    func migrationSkipsWhenGroupsExist() {
+        let existingGroup = ProjectGroup(name: "Existing")
+        let persistence = ProjectGroupPersistenceStub(initial: [existingGroup])
+        let store = ProjectGroupStore(persistence: persistence, existingProjectIDs: [UUID()])
+
+        #expect(store.groups.count == 1)
+        #expect(store.groups.first?.name == "Existing")
+    }
+
+    @Test("load sorts groups by sortOrder")
+    func loadSortsByOrder() {
+        let second = ProjectGroup(name: "B", sortOrder: 1)
+        let first = ProjectGroup(name: "A", sortOrder: 0)
+        let persistence = ProjectGroupPersistenceStub(initial: [second, first])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        #expect(store.groups.first?.name == "A")
+        #expect(store.groups.last?.name == "B")
+    }
+
+    @Test("addGroup assigns sequential sortOrder")
+    func addGroupSortOrder() {
+        let persistence = ProjectGroupPersistenceStub(initial: [])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addGroup(name: "First")
+        store.addGroup(name: "Second")
+
+        #expect(store.groups[0].sortOrder == 0)
+        #expect(store.groups[1].sortOrder == 1)
+    }
+}
+
+private final class ProjectGroupPersistenceStub: ProjectGroupPersisting {
+    var groups: [ProjectGroup]
+    var savedGroups: [ProjectGroup]?
+
+    init(initial: [ProjectGroup] = []) {
+        groups = initial
+    }
+
+    func loadGroups() throws -> [ProjectGroup] {
+        groups
+    }
+
+    func saveGroups(_ groups: [ProjectGroup]) throws {
+        savedGroups = groups
+    }
+}

--- a/Tests/MuxyTests/Views/SidebarGroupTests.swift
+++ b/Tests/MuxyTests/Views/SidebarGroupTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Sidebar group integration")
+@MainActor
+struct SidebarGroupTests {
+    @Test("removeProjectFromAllGroups removes project from every group that contains it")
+    func removeProjectFromAllGroups() {
+        let projectID = UUID()
+        let groupA = ProjectGroup(name: "A", projectIDs: [projectID])
+        let groupB = ProjectGroup(name: "B", projectIDs: [UUID()])
+        let persistence = ProjectGroupPersistenceStub(initial: [groupA, groupB])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.removeProjectFromAllGroups(projectID: projectID)
+
+        #expect(store.groups.first(where: { $0.id == groupA.id })?.projectIDs.isEmpty == true)
+        #expect(store.groups.first(where: { $0.id == groupB.id })?.projectIDs.count == 1)
+    }
+
+    @Test("removeProjectFromAllGroups on unknown projectID is a no-op")
+    func removeProjectFromAllGroupsUnknown() {
+        let projectID = UUID()
+        let group = ProjectGroup(name: "A", projectIDs: [projectID])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.removeProjectFromAllGroups(projectID: UUID())
+
+        #expect(store.groups.first?.projectIDs == [projectID])
+    }
+
+    @Test("addProjectToFirstGroupOrDefault adds to first group when groups exist")
+    func addProjectToFirstGroupWhenGroupsExist() {
+        let newProjectID = UUID()
+        let group = ProjectGroup(name: "Default")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addProjectToFirstGroupOrDefault(projectID: newProjectID)
+
+        #expect(store.groups.first?.projectIDs == [newProjectID])
+        #expect(persistence.savedGroups?.first?.projectIDs == [newProjectID])
+    }
+
+    @Test("addProjectToFirstGroupOrDefault creates Default group when no groups exist")
+    func addProjectToFirstGroupCreatesDefault() {
+        let newProjectID = UUID()
+        let persistence = ProjectGroupPersistenceStub(initial: [])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addProjectToFirstGroupOrDefault(projectID: newProjectID)
+
+        #expect(store.groups.count == 1)
+        #expect(store.groups.first?.name == "Default")
+        #expect(store.groups.first?.projectIDs == [newProjectID])
+    }
+
+    @Test("ProjectStore onProjectAdded callback fires after add")
+    func projectStoreAddCallbackFires() {
+        let project = Project(name: "Test", path: "/tmp/test")
+        let persistence = ProjectPersistenceStub(initial: [])
+        let store = ProjectStore(persistence: persistence)
+        var received: Project?
+
+        store.onProjectAdded = { received = $0 }
+        store.add(project)
+
+        #expect(received?.id == project.id)
+    }
+
+    @Test("ProjectStore onProjectRemoved callback fires after remove")
+    func projectStoreRemoveCallbackFires() {
+        let project = Project(name: "Test", path: "/tmp/test")
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let store = ProjectStore(persistence: persistence)
+        var receivedID: UUID?
+
+        store.onProjectRemoved = { receivedID = $0 }
+        store.remove(id: project.id)
+
+        #expect(receivedID == project.id)
+    }
+
+    @Test("ProjectStore onProjectAdded is nil-safe when no callback set")
+    func projectStoreAddNoCallback() {
+        let project = Project(name: "Test", path: "/tmp/test")
+        let persistence = ProjectPersistenceStub(initial: [])
+        let store = ProjectStore(persistence: persistence)
+
+        store.add(project)
+
+        #expect(store.projects.count == 1)
+    }
+
+    @Test("ProjectStore onProjectRemoved is nil-safe when no callback set")
+    func projectStoreRemoveNoCallback() {
+        let project = Project(name: "Test", path: "/tmp/test")
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let store = ProjectStore(persistence: persistence)
+
+        store.remove(id: project.id)
+
+        #expect(store.projects.isEmpty)
+    }
+
+    @Test("ProjectGroupStore init with existing IDs triggers migration to Default group")
+    func initWithExistingIDsCreatesMigration() {
+        let ids = [UUID(), UUID(), UUID()]
+        let persistence = ProjectGroupPersistenceStub(initial: [])
+        let store = ProjectGroupStore(persistence: persistence, existingProjectIDs: ids)
+
+        #expect(store.groups.count == 1)
+        #expect(store.groups.first?.name == "Default")
+        #expect(store.groups.first?.projectIDs == ids)
+    }
+
+    @Test("removeProjectFromAllGroups persists changes")
+    func removeProjectFromAllGroupsPersists() {
+        let projectID = UUID()
+        let group = ProjectGroup(name: "Work", projectIDs: [projectID])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.removeProjectFromAllGroups(projectID: projectID)
+
+        #expect(persistence.savedGroups?.first?.projectIDs.isEmpty == true)
+    }
+
+    @Test("addProjectToFirstGroupOrDefault persists Default group creation")
+    func addProjectPersistsDefaultGroupCreation() {
+        let newProjectID = UUID()
+        let persistence = ProjectGroupPersistenceStub(initial: [])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addProjectToFirstGroupOrDefault(projectID: newProjectID)
+
+        #expect(persistence.savedGroups?.count == 1)
+        #expect(persistence.savedGroups?.first?.name == "Default")
+        #expect(persistence.savedGroups?.first?.projectIDs == [newProjectID])
+    }
+}
+
+private final class ProjectGroupPersistenceStub: ProjectGroupPersisting {
+    var groups: [ProjectGroup]
+    var savedGroups: [ProjectGroup]?
+
+    init(initial: [ProjectGroup] = []) {
+        groups = initial
+    }
+
+    func loadGroups() throws -> [ProjectGroup] {
+        groups
+    }
+
+    func saveGroups(_ groups: [ProjectGroup]) throws {
+        savedGroups = groups
+        self.groups = groups
+    }
+}
+
+private final class ProjectPersistenceStub: ProjectPersisting {
+    var projects: [Project]
+
+    init(initial: [Project]) {
+        projects = initial
+    }
+
+    func loadProjects() throws -> [Project] {
+        projects
+    }
+
+    func saveProjects(_ projects: [Project]) throws {
+        self.projects = projects
+    }
+}


### PR DESCRIPTION
## Summary
- Adds project group model, store, and persistence layer for organizing projects into named groups
- Sidebar renders groups as collapsible sections with context menus (add/rename/delete group, move project between groups)
- Collapsed sidebar shows initial letter badge per group with rounded rectangle borders delimiting each group

## Test plan
- [ ] Verify groups persist across app restarts
- [ ] Verify collapsed sidebar shows group initial letter badge
- [ ] Verify rounded border wraps each group section in both sidebar states
- [ ] Verify context menu: add/rename/delete group, move project between groups
- [ ] Verify Ctrl+1-9 shortcuts still work with sequential indexing across groups