### PR TITLE
Let file tree follow the active terminal directory

### DIFF
--- a/Muxy/Models/FileTreeSourcePreference.swift
+++ b/Muxy/Models/FileTreeSourcePreference.swift
@@ -13,13 +13,5 @@ enum FileTreeSourcePreference: String, CaseIterable, Identifiable {
         }
     }
 
-    static let storageKey = "muxy.fileTreeSource"
     static let defaultValue: FileTreeSourcePreference = .projectBase
-
-    static var current: FileTreeSourcePreference {
-        guard let raw = UserDefaults.standard.string(forKey: storageKey),
-              let value = FileTreeSourcePreference(rawValue: raw)
-        else { return defaultValue }
-        return value
-    }
 }

--- a/Muxy/Models/FileTreeSourcePreference.swift
+++ b/Muxy/Models/FileTreeSourcePreference.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum FileTreeSourcePreference: String, CaseIterable, Identifiable {
+    case projectBase
+    case activeTerminal
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .projectBase: "Project base"
+        case .activeTerminal: "Active terminal directory"
+        }
+    }
+
+    static let storageKey = "muxy.fileTreeSource"
+    static let defaultValue: FileTreeSourcePreference = .projectBase
+
+    static var current: FileTreeSourcePreference {
+        guard let raw = UserDefaults.standard.string(forKey: storageKey),
+              let value = FileTreeSourcePreference(rawValue: raw)
+        else { return defaultValue }
+        return value
+    }
+}

--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -22,7 +22,7 @@ final class FileTreeState {
         let token: UUID
     }
 
-    let rootPath: String
+    private(set) var rootPath: String
     private(set) var rootEntries: [FileTreeEntry] = []
     private(set) var children: [String: [FileTreeEntry]] = [:]
     private(set) var expanded: Set<String> = []
@@ -63,6 +63,24 @@ final class FileTreeState {
         hasLoadedRoot = true
         reloadRoot()
         refreshStatuses()
+    }
+
+    func setRootPath(_ newPath: String) {
+        guard newPath != rootPath else { return }
+        rootPath = newPath
+        rootEntries = []
+        children = [:]
+        expanded = []
+        loadingPaths = []
+        statuses = [:]
+        dirHasChange = []
+        selectedFilePath = nil
+        selectedPaths = []
+        selectionAnchorPath = nil
+        pendingScrollTarget = nil
+        hasLoadedRoot = false
+        installWatcher()
+        loadRootIfNeeded()
     }
 
     func refresh() {

--- a/Muxy/Models/GeneralSettingsKeys.swift
+++ b/Muxy/Models/GeneralSettingsKeys.swift
@@ -1,4 +1,5 @@
 enum GeneralSettingsKeys {
     static let autoExpandWorktreesOnProjectSwitch = "muxy.general.autoExpandWorktreesOnProjectSwitch"
     static let defaultWorktreeParentPath = "muxy.general.defaultWorktreeParentPath"
+    static let fileTreeSource = "muxy.general.fileTreeSource"
 }

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -11,6 +11,7 @@ struct FileTreeView: View {
     @State private var commands: FileTreeCommands
     @State private var hasKeyboardFocus = false
     @State private var focusToken = 0
+    @State private var hasRequestedInitialFocus = false
 
     init(
         state: FileTreeState,
@@ -84,7 +85,10 @@ struct FileTreeView: View {
         .contentShape(Rectangle())
         .task(id: state.rootPath) {
             state.loadRootIfNeeded()
-            requestKeyboardFocus()
+            if !hasRequestedInitialFocus {
+                hasRequestedInitialFocus = true
+                requestKeyboardFocus()
+            }
         }
         .alert(
             "Move \(commands.deleteAlertKind()) to Trash?",

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -91,6 +91,8 @@ struct MainWindow: View {
     @State private var fileTreePanelVisible = false
     @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
     @State private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
+    @State private var fileTreeLastTerminalPaths: [WorktreeKey: String] = [:]
+    @AppStorage(FileTreeSourcePreference.storageKey) private var fileTreeSourceRaw = FileTreeSourcePreference.defaultValue.rawValue
     @State private var richInputPanelVisible = false
     @State private var panelToRestoreAfterRichInput: SidePanelKind?
     @AppStorage("muxy.richInputPanelWidth") private var richInputPanelWidth: Double = .init(RichInputPanelLayout.defaultWidth)
@@ -285,6 +287,16 @@ struct MainWindow: View {
                 ensureFileTreeState(for: project)
             }
         }
+        .modifier(FileTreeSourceObserver(
+            activeTerminalCWD: activeTerminalPane?.currentWorkingDirectory,
+            activeTerminalID: activeTerminalPane?.id,
+            sourceRaw: fileTreeSourceRaw,
+            onTerminalChange: refreshFileTreeRootForActiveTerminal,
+            onSourceChange: {
+                guard let project = activeProject else { return }
+                ensureFileTreeState(for: project)
+            }
+        ))
         .modifier(FileTreeSelectionSync(
             filePath: activeEditorFilePath,
             panelVisible: fileTreePanelVisible,
@@ -984,7 +996,7 @@ struct MainWindow: View {
                         appState.handleFileMoved(from: oldPath, to: newPath)
                     }
                 )
-                .id(treeState.rootPath)
+                .id(activeFileTreeIdentity)
                 .frame(width: CGFloat(fileTreePanelWidth))
             }
         }
@@ -1011,11 +1023,41 @@ struct MainWindow: View {
         return fileTreeStates[key]
     }
 
+    private var activeFileTreeIdentity: WorktreeKey? {
+        guard let project = activeProject else { return nil }
+        return appState.activeWorktreeKey(for: project.id)
+    }
+
     private func ensureFileTreeState(for project: Project) {
         guard let key = appState.activeWorktreeKey(for: project.id) else { return }
-        let path = activeWorktreePath(for: project)
-        if let existing = fileTreeStates[key], existing.rootPath == path { return }
+        let path = resolvedFileTreeRoot(for: project, key: key)
+        if let existing = fileTreeStates[key] {
+            existing.setRootPath(path)
+            return
+        }
         fileTreeStates[key] = FileTreeState(rootPath: path)
+    }
+
+    private var fileTreeSource: FileTreeSourcePreference {
+        FileTreeSourcePreference(rawValue: fileTreeSourceRaw) ?? .projectBase
+    }
+
+    private func resolvedFileTreeRoot(for project: Project, key: WorktreeKey) -> String {
+        let base = activeWorktreePath(for: project)
+        guard fileTreeSource == .activeTerminal else { return base }
+        if let cwd = appState.activeTab(for: project.id)?.content.pane?.currentWorkingDirectory {
+            fileTreeLastTerminalPaths[key] = cwd
+            return cwd
+        }
+        return fileTreeLastTerminalPaths[key] ?? base
+    }
+
+    private func refreshFileTreeRootForActiveTerminal() {
+        guard fileTreeSource == .activeTerminal,
+              fileTreePanelVisible,
+              let project = activeProject
+        else { return }
+        ensureFileTreeState(for: project)
     }
 
     private var activeEditorState: EditorTabState? {
@@ -1048,6 +1090,7 @@ struct MainWindow: View {
     private func pruneFileTreeStates() {
         let validKeys = validVCSKeys()
         fileTreeStates = fileTreeStates.filter { validKeys.contains($0.key) }
+        fileTreeLastTerminalPaths = fileTreeLastTerminalPaths.filter { validKeys.contains($0.key) }
         richInputStates = richInputStates.filter { validKeys.contains($0.key) }
     }
 
@@ -1382,6 +1425,21 @@ private struct FileTreeSelectionSync: ViewModifier {
                 guard visible else { return }
                 sync(filePath)
             }
+    }
+}
+
+private struct FileTreeSourceObserver: ViewModifier {
+    let activeTerminalCWD: String?
+    let activeTerminalID: UUID?
+    let sourceRaw: String
+    let onTerminalChange: () -> Void
+    let onSourceChange: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: activeTerminalCWD) { _, _ in onTerminalChange() }
+            .onChange(of: activeTerminalID) { _, _ in onTerminalChange() }
+            .onChange(of: sourceRaw) { _, _ in onSourceChange() }
     }
 }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -92,7 +92,7 @@ struct MainWindow: View {
     @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
     @State private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
     @State private var fileTreeLastTerminalPaths: [WorktreeKey: String] = [:]
-    @AppStorage(FileTreeSourcePreference.storageKey) private var fileTreeSourceRaw = FileTreeSourcePreference.defaultValue.rawValue
+    @AppStorage(GeneralSettingsKeys.fileTreeSource) private var fileTreeSourceRaw = FileTreeSourcePreference.defaultValue.rawValue
     @State private var richInputPanelVisible = false
     @State private var panelToRestoreAfterRichInput: SidePanelKind?
     @AppStorage("muxy.richInputPanelWidth") private var richInputPanelWidth: Double = .init(RichInputPanelLayout.defaultWidth)

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -6,6 +6,8 @@ struct GeneralSettingsView: View {
     private var autoExpandWorktrees = false
     @AppStorage(GeneralSettingsKeys.defaultWorktreeParentPath)
     private var defaultWorktreeParentPath = ""
+    @AppStorage(FileTreeSourcePreference.storageKey)
+    private var fileTreeSourceRaw = FileTreeSourcePreference.defaultValue.rawValue
     @AppStorage(TabCloseConfirmationPreferences.confirmRunningProcessKey)
     private var confirmRunningProcess = true
     @AppStorage(ProjectLifecyclePreferences.keepOpenWhenNoTabsKey)
@@ -45,6 +47,22 @@ struct GeneralSettingsView: View {
                     label: "Auto-expand worktrees on project switch",
                     isOn: $autoExpandWorktrees
                 )
+            }
+
+            SettingsSection(
+                "File Tree",
+                footer: "When set to the active terminal, the file tree follows the working directory of "
+                    + "the active terminal tab. If there is no active terminal, it keeps the last known path."
+            ) {
+                SettingsRow("Root directory") {
+                    Picker("", selection: $fileTreeSourceRaw) {
+                        ForEach(FileTreeSourcePreference.allCases) { source in
+                            Text(source.title).tag(source.rawValue)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
+                }
             }
 
             SettingsSection(

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -6,7 +6,7 @@ struct GeneralSettingsView: View {
     private var autoExpandWorktrees = false
     @AppStorage(GeneralSettingsKeys.defaultWorktreeParentPath)
     private var defaultWorktreeParentPath = ""
-    @AppStorage(FileTreeSourcePreference.storageKey)
+    @AppStorage(GeneralSettingsKeys.fileTreeSource)
     private var fileTreeSourceRaw = FileTreeSourcePreference.defaultValue.rawValue
     @AppStorage(TabCloseConfirmationPreferences.confirmRunningProcessKey)
     private var confirmRunningProcess = true


### PR DESCRIPTION
- Adds a General setting to choose whether the file tree roots at the project base or active terminal CWD.
- Updates the tree as terminal focus or directories change, while preserving the last terminal path when no terminal is active.