### PR TITLE
fix(pairing): bound first-time pairing requests

### DIFF
--- a/Muxy/Services/PairingRequestCoordinator.swift
+++ b/Muxy/Services/PairingRequestCoordinator.swift
@@ -17,14 +17,45 @@ struct PairingRequest: Identifiable, Equatable {
 final class PairingRequestCoordinator {
     static let shared = PairingRequestCoordinator()
 
+    nonisolated static let tokenLengthRange: ClosedRange<Int> = 8 ... 256
+    nonisolated static let deviceNameLengthRange: ClosedRange<Int> = 1 ... 128
+    static let maxPendingQueue: Int = 4
+    static let denialCooldownSeconds: TimeInterval = 30
+    static let pairingTimeoutSeconds: TimeInterval = 60
+
     private(set) var pendingRequest: PairingRequest?
 
     private var continuations: [UUID: CheckedContinuation<Bool, Never>] = [:]
     private var queue: [PairingRequest] = []
+    private var deniedAt: [UUID: Date] = [:]
+    private var timeoutTasks: [UUID: Task<Void, Never>] = [:]
 
     private init() {}
 
+    nonisolated static func isValidRequest(deviceName: String, token: String) -> Bool {
+        deviceNameLengthRange.contains(deviceName.count) && tokenLengthRange.contains(token.count)
+    }
+
     func requestApproval(deviceID: UUID, deviceName: String, token: String) async -> Bool {
+        guard Self.isValidRequest(deviceName: deviceName, token: token) else {
+            logger.warning("Rejected pairing request: invalid payload length deviceID=\(deviceID)")
+            return false
+        }
+        if let lastDenial = deniedAt[deviceID],
+           Date().timeIntervalSince(lastDenial) < Self.denialCooldownSeconds
+        {
+            logger.info("Rejected pairing request: cooldown deviceID=\(deviceID)")
+            return false
+        }
+        if pendingRequest?.deviceID == deviceID || queue.contains(where: { $0.deviceID == deviceID }) {
+            logger.info("Rejected pairing request: duplicate deviceID=\(deviceID)")
+            return false
+        }
+        if pendingRequest != nil, queue.count >= Self.maxPendingQueue {
+            logger.warning("Rejected pairing request: queue full deviceID=\(deviceID)")
+            return false
+        }
+
         let request = PairingRequest(
             deviceID: deviceID,
             deviceName: deviceName,
@@ -33,6 +64,7 @@ final class PairingRequestCoordinator {
         )
         return await withCheckedContinuation { continuation in
             continuations[request.id] = continuation
+            scheduleTimeout(for: request)
             if pendingRequest == nil {
                 present(request)
             } else {
@@ -47,14 +79,20 @@ final class PairingRequestCoordinator {
             name: request.deviceName,
             token: request.token
         )
-        finish(request, approved: true)
+        finish(request, approved: true, recordDenial: false)
     }
 
     func deny(_ request: PairingRequest) {
-        finish(request, approved: false)
+        finish(request, approved: false, recordDenial: true)
     }
 
-    private func finish(_ request: PairingRequest, approved: Bool) {
+    private func finish(_ request: PairingRequest, approved: Bool, recordDenial: Bool) {
+        timeoutTasks[request.id]?.cancel()
+        timeoutTasks.removeValue(forKey: request.id)
+        if recordDenial {
+            deniedAt[request.deviceID] = Date()
+            pruneStaleDenials()
+        }
         guard let continuation = continuations.removeValue(forKey: request.id) else { return }
         continuation.resume(returning: approved)
         if pendingRequest?.id == request.id {
@@ -70,10 +108,42 @@ final class PairingRequestCoordinator {
 
     private func present(_ request: PairingRequest) {
         pendingRequest = request
-        NSApp.activate(ignoringOtherApps: true)
+        if !hasRecentDenial() {
+            NSApp.activate(ignoringOtherApps: true)
+        }
         DispatchQueue.main.async { [weak self] in
             self?.runAlert(for: request)
         }
+    }
+
+    private func hasRecentDenial() -> Bool {
+        let now = Date()
+        return deniedAt.values.contains { now.timeIntervalSince($0) < Self.denialCooldownSeconds }
+    }
+
+    private func pruneStaleDenials() {
+        let now = Date()
+        deniedAt = deniedAt.filter { now.timeIntervalSince($0.value) < Self.denialCooldownSeconds * 2 }
+    }
+
+    private func scheduleTimeout(for request: PairingRequest) {
+        let task = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Self.pairingTimeoutSeconds))
+            guard !Task.isCancelled, let self else { return }
+            self.handleTimeout(for: request)
+        }
+        timeoutTasks[request.id] = task
+    }
+
+    private func handleTimeout(for request: PairingRequest) {
+        let isPending = pendingRequest?.id == request.id
+        let inQueue = queue.contains { $0.id == request.id }
+        guard isPending || inQueue else { return }
+        logger.info("Pairing request timed out deviceID=\(request.deviceID)")
+        if isPending {
+            NSApp.abortModal()
+        }
+        finish(request, approved: false, recordDenial: true)
     }
 
     private func runAlert(for request: PairingRequest) {

--- a/Tests/MuxyTests/Services/PairingRequestCoordinatorTests.swift
+++ b/Tests/MuxyTests/Services/PairingRequestCoordinatorTests.swift
@@ -1,0 +1,15 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("PairingRequestCoordinator")
+struct PairingRequestCoordinatorTests {
+    @Test("validates token and device name lengths before queuing")
+    func validatesRequestLengths() {
+        #expect(PairingRequestCoordinator.isValidRequest(deviceName: "iPhone", token: String(repeating: "a", count: 8)))
+        #expect(!PairingRequestCoordinator.isValidRequest(deviceName: "", token: String(repeating: "a", count: 8)))
+        #expect(!PairingRequestCoordinator.isValidRequest(deviceName: String(repeating: "d", count: 129), token: String(repeating: "a", count: 8)))
+        #expect(!PairingRequestCoordinator.isValidRequest(deviceName: "iPhone", token: String(repeating: "a", count: 7)))
+        #expect(!PairingRequestCoordinator.isValidRequest(deviceName: "iPhone", token: String(repeating: "a", count: 257)))
+    }
+}


### PR DESCRIPTION
## Description

This came up while looking into long timeouts and app hangs...

Currently the first-time pairing flow accepts malformed or repeated requests, and timed-out requests can keep pulling the app forward.

This changes pairing approval so:

- Pairing tokens and device names are length-checked before queuing.
- Duplicate requests and an already-full pending queue are rejected.
- Denied or timed-out requests get a short per-device cooldown.
- Timed-out requests are auto-denied.
- The app avoids repeated activation after a recent denial.

## Related Issue

N/A

## Potential Risk & Impact

Overlong, duplicate, or repeated pairing attempts are rejected sooner. A legitimate device may need to retry after the cooldown if a request was denied or timed out.

## How Has This Been Tested?

- `swift test --filter PairingRequestCoordinatorTests`
- `PATH="$PWD/.build/tools/bin:$PATH" scripts/checks.sh --fix`
