### PR TITLE
fix(process): add timeouts for Git and helper subprocesses

### DIFF
--- a/Muxy/Services/AIUsageTokenReader.swift
+++ b/Muxy/Services/AIUsageTokenReader.swift
@@ -56,9 +56,11 @@ enum AIUsageTokenReader {
             return nil
         }
 
+        let watcher = ProcessTimeoutWatcher.install(on: process, timeout: 5)
         let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
         _ = stderr.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
+        watcher.cancel()
 
         guard process.terminationStatus == 0,
               let output = String(data: outputData, encoding: .utf8)

--- a/Muxy/Services/FileSearchService.swift
+++ b/Muxy/Services/FileSearchService.swift
@@ -78,6 +78,7 @@ enum FileSearchService {
 
             do {
                 try process.run()
+                ProcessTimeoutWatcher.install(on: process, timeout: 30)
             } catch {
                 handle.readabilityHandler = nil
                 continuation.resume(returning: [])

--- a/Muxy/Services/FileTreeService.swift
+++ b/Muxy/Services/FileTreeService.swift
@@ -108,6 +108,7 @@ enum FileTreeService {
         } catch {
             return []
         }
+        let watcher = ProcessTimeoutWatcher.install(on: process, timeout: 5)
 
         var payload = Data()
         for name in candidates {
@@ -122,6 +123,7 @@ enum FileTreeService {
         let outData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
         _ = try? stderrPipe.fileHandleForReading.readToEnd()
         process.waitUntilExit()
+        watcher.cancel()
 
         var result: Set<String> = []
         var current = Data()

--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -10,6 +10,52 @@ struct GitProcessResult {
 
 enum GitProcessError: Error {
     case launchFailed(String)
+    case timedOut(TimeInterval)
+}
+
+enum GitCommandClass {
+    case fastMetadata
+    case statusDiff
+    case network
+
+    var defaultTimeout: TimeInterval {
+        switch self {
+        case .fastMetadata: 5
+        case .statusDiff: 20
+        case .network: 60
+        }
+    }
+
+    static func classifyGit(arguments: [String]) -> GitCommandClass {
+        guard let command = primarySubcommand(in: arguments) else { return .statusDiff }
+        if ["fetch", "pull", "push", "ls-remote", "clone", "submodule"].contains(command) {
+            return .network
+        }
+        if ["rev-parse", "branch", "config", "symbolic-ref", "merge-base", "remote", "tag", "worktree"].contains(command) {
+            return .fastMetadata
+        }
+        if ["status", "diff", "log", "show", "rev-list"].contains(command) {
+            return .statusDiff
+        }
+        return .statusDiff
+    }
+
+    private static func primarySubcommand(in arguments: [String]) -> String? {
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            if ["-c", "-C", "--git-dir", "--work-tree", "--namespace"].contains(argument) {
+                index += 2
+                continue
+            }
+            if argument.hasPrefix("-") {
+                index += 1
+                continue
+            }
+            return argument
+        }
+        return nil
+    }
 }
 
 enum GitProcessRunner {
@@ -49,13 +95,15 @@ enum GitProcessRunner {
         let arguments: [String]
         let workingDirectory: String?
         let lineLimit: Int?
+        let timeout: TimeInterval?
         let signpostName: StaticString
     }
 
     static func runGit(
         repoPath: String,
         arguments: [String],
-        lineLimit: Int? = nil
+        lineLimit: Int? = nil,
+        timeout: TimeInterval? = nil
     ) async throws -> GitProcessResult {
         try await runProcess(
             ProcessSpec(
@@ -63,8 +111,23 @@ enum GitProcessRunner {
                 arguments: ["git"] + gitHubCredentialHelperArgs() + ["-C", repoPath] + arguments,
                 workingDirectory: nil,
                 lineLimit: lineLimit,
+                timeout: timeout ?? GitCommandClass.classifyGit(arguments: arguments).defaultTimeout,
                 signpostName: "git"
             )
+        )
+    }
+
+    static func runGit(
+        repoPath: String,
+        arguments: [String],
+        commandClass: GitCommandClass,
+        lineLimit: Int? = nil
+    ) async throws -> GitProcessResult {
+        try await runGit(
+            repoPath: repoPath,
+            arguments: arguments,
+            lineLimit: lineLimit,
+            timeout: commandClass.defaultTimeout
         )
     }
 
@@ -79,7 +142,8 @@ enum GitProcessRunner {
     static func runCommand(
         executable: String,
         arguments: [String],
-        workingDirectory: String
+        workingDirectory: String,
+        timeout: TimeInterval? = nil
     ) async throws -> GitProcessResult {
         try await runProcess(
             ProcessSpec(
@@ -87,9 +151,14 @@ enum GitProcessRunner {
                 arguments: arguments,
                 workingDirectory: workingDirectory,
                 lineLimit: nil,
+                timeout: timeout ?? defaultCommandTimeout(executable: executable),
                 signpostName: "command"
             )
         )
+    }
+
+    private static func defaultCommandTimeout(executable: String) -> TimeInterval? {
+        URL(fileURLWithPath: executable).lastPathComponent == "gh" ? GitCommandClass.network.defaultTimeout : nil
     }
 
     private static func runProcess(_ spec: ProcessSpec) async throws -> GitProcessResult {
@@ -180,6 +249,17 @@ enum GitProcessRunner {
         }
         defer { handle.detach() }
 
+        let timeoutFiredBox = TimeoutFlag()
+        let timeoutWatcher: DispatchWorkItem? = if let timeout = spec.timeout {
+            ProcessTimeoutWatcher.install(on: process, timeout: timeout) { [timeoutFiredBox, spec] in
+                timeoutFiredBox.fire()
+                GitSignpost.event(spec.signpostName, "timeout")
+            }
+        } else {
+            nil
+        }
+        defer { timeoutWatcher?.cancel() }
+
         let stderrCollector = AsyncDataCollector()
         stderrCollector.start(reading: stderrPipe.fileHandleForReading, on: stderrDrainQueue)
 
@@ -199,6 +279,10 @@ enum GitProcessRunner {
 
         process.waitUntilExit()
         let stderrData = stderrCollector.wait()
+
+        if timeoutFiredBox.didFire, let timeout = spec.timeout {
+            throw GitProcessError.timedOut(timeout)
+        }
 
         let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
         let stderr = String(data: stderrData, encoding: .utf8) ?? ""
@@ -248,6 +332,23 @@ enum GitProcessRunner {
                 return collected
             }
         }
+    }
+}
+
+private final class TimeoutFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+
+    func fire() {
+        lock.lock()
+        fired = true
+        lock.unlock()
+    }
+
+    var didFire: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return fired
     }
 }
 

--- a/Muxy/Services/MobileServerService.swift
+++ b/Muxy/Services/MobileServerService.swift
@@ -221,10 +221,12 @@ final class MobileServerService {
         process.standardError = FileHandle.nullDevice
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return []
         }
+        let watcher = ProcessTimeoutWatcher.install(on: process, timeout: 5)
+        process.waitUntilExit()
+        watcher.cancel()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let output = String(data: data, encoding: .utf8) else { return [] }
         return output

--- a/Muxy/Services/ProcessTimeoutWatcher.swift
+++ b/Muxy/Services/ProcessTimeoutWatcher.swift
@@ -1,0 +1,45 @@
+import Darwin
+import Foundation
+import os
+
+private let processTimeoutLogger = Logger(subsystem: "app.muxy", category: "ProcessTimeout")
+
+enum ProcessTimeoutWatcher {
+    private static let timerQueue = DispatchQueue(
+        label: "app.muxy.process-timeout-watcher",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
+    static let graceBeforeKillSeconds: TimeInterval = 2.0
+
+    @discardableResult
+    static func install(
+        on process: Process,
+        timeout: TimeInterval,
+        onFire: (() -> Void)? = nil
+    ) -> DispatchWorkItem {
+        let item = DispatchWorkItem { [weak process] in
+            guard let process, process.isRunning else { return }
+            onFire?()
+            let pid = process.processIdentifier
+            if !signalProcessGroup(pid: pid, signal: SIGTERM) {
+                processTimeoutLogger.debug("Process group SIGTERM unavailable pid=\(pid)")
+                process.terminate()
+            }
+            timerQueue.asyncAfter(deadline: .now() + graceBeforeKillSeconds) { [weak process] in
+                guard let process, process.isRunning, pid > 0 else { return }
+                if !signalProcessGroup(pid: pid, signal: SIGKILL) {
+                    kill(pid, SIGKILL)
+                }
+            }
+        }
+        timerQueue.asyncAfter(deadline: .now() + timeout, execute: item)
+        return item
+    }
+
+    private static func signalProcessGroup(pid: pid_t, signal: Int32) -> Bool {
+        guard pid > 0 else { return false }
+        return kill(-pid, signal) == 0
+    }
+}

--- a/Muxy/Services/TextSearchService.swift
+++ b/Muxy/Services/TextSearchService.swift
@@ -157,6 +157,7 @@ actor SearchCoordinator {
 
         do {
             try process.run()
+            ProcessTimeoutWatcher.install(on: process, timeout: 30)
             stdinPipe.fileHandleForWriting.write(patternData)
             try? stdinPipe.fileHandleForWriting.close()
         } catch {

--- a/Tests/MuxyTests/Git/GitProcessRunnerCredentialHelperTests.swift
+++ b/Tests/MuxyTests/Git/GitProcessRunnerCredentialHelperTests.swift
@@ -25,4 +25,14 @@ struct GitProcessRunnerCredentialHelperTests {
         let args = GitProcessRunner.gitHubCredentialHelperArgs { _ in "/usr/local/bin/gh" }
         #expect(args.contains("credential.https://github.com.helper=!/usr/local/bin/gh auth git-credential"))
     }
+
+    @Test("classifies git commands by timeout budget")
+    func classifiesGitCommandTimeouts() {
+        #expect(GitCommandClass.classifyGit(arguments: ["rev-parse", "--abbrev-ref", "HEAD"]) == .fastMetadata)
+        #expect(GitCommandClass.classifyGit(arguments: ["-c", "core.quotepath=false", "status", "--porcelain=1"]) == .statusDiff)
+        #expect(GitCommandClass.classifyGit(arguments: ["diff", "--cached"]) == .statusDiff)
+        #expect(GitCommandClass.classifyGit(arguments: ["fetch", "origin"]) == .network)
+        #expect(GitCommandClass.classifyGit(arguments: ["push"]) == .network)
+        #expect(GitCommandClass.classifyGit(arguments: ["add", "--", "README.md"]) == .statusDiff)
+    }
 }

--- a/Tests/MuxyTests/Services/TextSearchServiceTests.swift
+++ b/Tests/MuxyTests/Services/TextSearchServiceTests.swift
@@ -76,21 +76,36 @@ struct TextSearchServiceTests {
 
     @Test("starting a new search cancels the in-flight one")
     func newSearchCancelsPrevious() async throws {
-        guard TextSearchService.ripgrepExecutableURL() != nil else { return }
         let directory = try makeSearchFixture()
         defer { try? FileManager.default.removeItem(at: directory) }
+        let executable = try makeFakeRipgrep()
+        defer { try? FileManager.default.removeItem(at: executable.deletingLastPathComponent()) }
 
         let coordinator = SearchCoordinator()
-        async let first = TextSearchService.search(
-            query: "foo123bar", in: directory.path, coordinator: coordinator
+        let firstPattern = Data("slow".utf8)
+        let secondPattern = Data("안녕".utf8)
+        let first = Task {
+            await coordinator.run(
+                executable: executable,
+                patternData: firstPattern,
+                patternByteLength: firstPattern.count,
+                projectPath: directory.path,
+                options: TextSearchOptions()
+            )
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        let secondResults = await coordinator.run(
+            executable: executable,
+            patternData: secondPattern,
+            patternByteLength: secondPattern.count,
+            projectPath: directory.path,
+            options: TextSearchOptions()
         )
-        async let second = TextSearchService.search(
-            query: "안녕", in: directory.path, coordinator: coordinator
-        )
-        let (firstResults, secondResults) = await (first, second)
+        let firstResults = await first.value
 
         #expect(secondResults.contains { $0.lineText == "안녕하세요" })
-        #expect(firstResults.isEmpty || firstResults.contains { $0.lineText == "foo123bar" })
+        #expect(firstResults.isEmpty)
     }
 
     private func makeSearchFixture() throws -> URL {
@@ -103,5 +118,28 @@ struct TextSearchServiceTests {
         foo123bar
         """.write(to: file, atomically: true, encoding: .utf8)
         return directory
+    }
+
+    private func makeFakeRipgrep() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-fake-rg-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("rg")
+        try """
+        #!/bin/sh
+        project=""
+        for arg in "$@"; do
+          project="$arg"
+        done
+        pattern="$(cat)"
+        if [ "$pattern" = "slow" ]; then
+          sleep 2
+          printf "%s/test.md:2:1:foo123bar\\n" "$project"
+        else
+          printf "%s/test.md:1:1:안녕하세요\\n" "$project"
+        fi
+        """.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
     }
 }


### PR DESCRIPTION
## Description

This came up while looking into app instability...

Currently a hung helper subprocess can leave the app in indefinite wait (and the user lol).

This adds bounded subprocess handling for:

- Git commands, with timeout budgets for metadata, status/diff, and network operations.
- File search and text search helpers.
- AI usage token reads.
- Mobile `lsof` discovery.
- File-tree ignore checks.

A shared timeout watcher sends best-effort process-group termination first, then force-kills if the process is still running.

## Related Issue

N/A

## Potential Risk & Impact

Very slow helper commands may now be terminated instead of running indefinitely. Git network operations have the longest timeout budget, but unusually slow networks may need a retry.

## How Has This Been Tested?

- `swift test --filter 'GitProcessRunnerCredentialHelperTests|TextSearchServiceTests'`
- `PATH="$PWD/.build/tools/bin:$PATH" scripts/checks.sh --fix`
