### PR TITLE
Clarify PR mergeability status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ appcast*.xml
 .plans/
 .muxy/
 /muxy-markdown-remote-image-urlcache
+.opencode/

--- a/Muxy/Views/VCS/PRMergeabilityPresentation.swift
+++ b/Muxy/Views/VCS/PRMergeabilityPresentation.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct PRMergeabilityPresentation: Equatable {
+    enum Tone {
+        case positive
+        case negative
+        case warning
+        case muted
+    }
+
+    let text: String
+    let tone: Tone
+
+    @MainActor var color: Color {
+        switch tone {
+        case .positive: MuxyTheme.diffAddFg
+        case .negative: MuxyTheme.diffRemoveFg
+        case .warning: MuxyTheme.warning
+        case .muted: MuxyTheme.fgMuted
+        }
+    }
+
+    static func make(info: GitRepositoryService.PRInfo) -> PRMergeabilityPresentation? {
+        switch info.mergeStateStatus {
+        case .dirty:
+            PRMergeabilityPresentation(text: "Conflicts", tone: .negative)
+        case .behind:
+            PRMergeabilityPresentation(text: "Behind base", tone: .negative)
+        case .blocked:
+            PRMergeabilityPresentation(text: "Blocked", tone: .negative)
+        case .draft:
+            PRMergeabilityPresentation(text: "Draft", tone: .muted)
+        case .clean,
+             .hasHooks:
+            PRMergeabilityPresentation(text: "Yes", tone: .positive)
+        case .unstable:
+            unstablePresentation(checks: info.checks)
+        case .unknown:
+            unknownPresentation(mergeable: info.mergeable)
+        }
+    }
+
+    private static func unstablePresentation(checks: GitRepositoryService.PRChecks) -> PRMergeabilityPresentation {
+        switch checks.status {
+        case .failure:
+            PRMergeabilityPresentation(text: "Yes (checks failing)", tone: .warning)
+        case .pending:
+            PRMergeabilityPresentation(text: "Yes (checks running)", tone: .positive)
+        case .none,
+             .success:
+            PRMergeabilityPresentation(text: "Yes", tone: .positive)
+        }
+    }
+
+    private static func unknownPresentation(mergeable: Bool?) -> PRMergeabilityPresentation? {
+        switch mergeable {
+        case true: PRMergeabilityPresentation(text: "Yes", tone: .positive)
+        case false: PRMergeabilityPresentation(text: "Conflicts", tone: .negative)
+        default: nil
+        }
+    }
+}

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1001,59 +1001,6 @@ struct PRPill: View {
     }
 }
 
-struct PRMergeabilityPresentation: Equatable {
-    enum Tone {
-        case positive
-        case negative
-        case muted
-    }
-
-    let text: String
-    let tone: Tone
-
-    @MainActor var color: Color {
-        switch tone {
-        case .positive: MuxyTheme.diffAddFg
-        case .negative: MuxyTheme.diffRemoveFg
-        case .muted: MuxyTheme.fgMuted
-        }
-    }
-
-    static func make(info: GitRepositoryService.PRInfo) -> PRMergeabilityPresentation? {
-        switch info.mergeStateStatus {
-        case .dirty:
-            return PRMergeabilityPresentation(text: "Conflicts", tone: .negative)
-        case .behind:
-            return PRMergeabilityPresentation(text: "Behind base", tone: .negative)
-        case .blocked:
-            return PRMergeabilityPresentation(text: "Blocked", tone: .negative)
-        case .draft:
-            return PRMergeabilityPresentation(text: "Draft", tone: .muted)
-        case .clean,
-             .hasHooks:
-            return PRMergeabilityPresentation(text: "Yes", tone: .positive)
-        case .unstable:
-            return unstablePresentation(checks: info.checks)
-        case .unknown:
-            if info.mergeable == true { return PRMergeabilityPresentation(text: "Yes", tone: .positive) }
-            if info.mergeable == false { return PRMergeabilityPresentation(text: "Conflicts", tone: .negative) }
-            return nil
-        }
-    }
-
-    private static func unstablePresentation(checks: GitRepositoryService.PRChecks) -> PRMergeabilityPresentation {
-        switch checks.status {
-        case .failure:
-            PRMergeabilityPresentation(text: "Yes (checks failing)", tone: .positive)
-        case .pending:
-            PRMergeabilityPresentation(text: "Yes (checks running)", tone: .positive)
-        case .none,
-             .success:
-            PRMergeabilityPresentation(text: "Yes", tone: .positive)
-        }
-    }
-}
-
 struct PRPopover: View {
     @Bindable var state: VCSTabState
     let info: GitRepositoryService.PRInfo

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1001,6 +1001,59 @@ struct PRPill: View {
     }
 }
 
+struct PRMergeabilityPresentation: Equatable {
+    enum Tone {
+        case positive
+        case negative
+        case muted
+    }
+
+    let text: String
+    let tone: Tone
+
+    @MainActor var color: Color {
+        switch tone {
+        case .positive: MuxyTheme.diffAddFg
+        case .negative: MuxyTheme.diffRemoveFg
+        case .muted: MuxyTheme.fgMuted
+        }
+    }
+
+    static func make(info: GitRepositoryService.PRInfo) -> PRMergeabilityPresentation? {
+        switch info.mergeStateStatus {
+        case .dirty:
+            return PRMergeabilityPresentation(text: "Conflicts", tone: .negative)
+        case .behind:
+            return PRMergeabilityPresentation(text: "Behind base", tone: .negative)
+        case .blocked:
+            return PRMergeabilityPresentation(text: "Blocked", tone: .negative)
+        case .draft:
+            return PRMergeabilityPresentation(text: "Draft", tone: .muted)
+        case .clean,
+             .hasHooks:
+            return PRMergeabilityPresentation(text: "Yes", tone: .positive)
+        case .unstable:
+            return unstablePresentation(checks: info.checks)
+        case .unknown:
+            if info.mergeable == true { return PRMergeabilityPresentation(text: "Yes", tone: .positive) }
+            if info.mergeable == false { return PRMergeabilityPresentation(text: "Conflicts", tone: .negative) }
+            return nil
+        }
+    }
+
+    private static func unstablePresentation(checks: GitRepositoryService.PRChecks) -> PRMergeabilityPresentation {
+        switch checks.status {
+        case .failure:
+            PRMergeabilityPresentation(text: "Yes (checks failing)", tone: .positive)
+        case .pending:
+            PRMergeabilityPresentation(text: "Yes (checks running)", tone: .positive)
+        case .none,
+             .success:
+            PRMergeabilityPresentation(text: "Yes", tone: .positive)
+        }
+    }
+}
+
 struct PRPopover: View {
     @Bindable var state: VCSTabState
     let info: GitRepositoryService.PRInfo
@@ -1046,7 +1099,7 @@ struct PRPopover: View {
 
             VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
                 infoRow(label: "Base", value: info.baseBranch)
-                if let label = mergeableLabel {
+                if let label = PRMergeabilityPresentation.make(info: info) {
                     infoRow(
                         label: "Mergeable",
                         value: label.text,
@@ -1168,28 +1221,6 @@ struct PRPopover: View {
                 return "Checks are still running. You will be asked to confirm before merging."
             }
             return "Merge PR #\(info.number)"
-        }
-    }
-
-    private var mergeableLabel: (text: String, color: Color)? {
-        switch info.mergeStateStatus {
-        case .dirty:
-            return ("Conflicts", MuxyTheme.diffRemoveFg)
-        case .behind:
-            return ("Behind base", MuxyTheme.diffRemoveFg)
-        case .blocked:
-            return ("Blocked", MuxyTheme.diffRemoveFg)
-        case .draft:
-            return ("Draft", MuxyTheme.fgMuted)
-        case .clean,
-             .hasHooks:
-            return ("Yes", MuxyTheme.diffAddFg)
-        case .unstable:
-            return ("Yes (checks failing)", MuxyTheme.diffAddFg)
-        case .unknown:
-            if info.mergeable == true { return ("Yes", MuxyTheme.diffAddFg) }
-            if info.mergeable == false { return ("Conflicts", MuxyTheme.diffRemoveFg) }
-            return nil
         }
     }
 

--- a/Tests/MuxyTests/Views/PRMergeabilityPresentationTests.swift
+++ b/Tests/MuxyTests/Views/PRMergeabilityPresentationTests.swift
@@ -1,0 +1,63 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("PRMergeabilityPresentation")
+struct PRMergeabilityPresentationTests {
+    @Test("unstable PR with pending checks reports checks running")
+    func unstablePendingChecks() throws {
+        let presentation = try #require(PRMergeabilityPresentation.make(info: prInfo(
+            mergeStateStatus: .unstable,
+            checks: GitRepositoryService.PRChecks(status: .pending, passing: 1, failing: 0, pending: 1, total: 2)
+        )))
+
+        #expect(presentation.text == "Yes (checks running)")
+        #expect(presentation.tone == .positive)
+    }
+
+    @Test("unstable PR with failing checks reports checks failing")
+    func unstableFailingChecks() throws {
+        let presentation = try #require(PRMergeabilityPresentation.make(info: prInfo(
+            mergeStateStatus: .unstable,
+            checks: GitRepositoryService.PRChecks(status: .failure, passing: 1, failing: 1, pending: 0, total: 2)
+        )))
+
+        #expect(presentation.text == "Yes (checks failing)")
+        #expect(presentation.tone == .positive)
+    }
+
+    @Test("unknown merge state falls back to mergeable value")
+    func unknownMergeStateFallsBackToMergeableValue() throws {
+        let presentation = try #require(PRMergeabilityPresentation.make(info: prInfo(
+            mergeable: false,
+            mergeStateStatus: .unknown
+        )))
+
+        #expect(presentation.text == "Conflicts")
+        #expect(presentation.tone == .negative)
+    }
+
+    private func prInfo(
+        mergeable: Bool? = true,
+        mergeStateStatus: GitRepositoryService.PRMergeStateStatus,
+        checks: GitRepositoryService.PRChecks = GitRepositoryService.PRChecks(
+            status: .none,
+            passing: 0,
+            failing: 0,
+            pending: 0,
+            total: 0
+        )
+    ) -> GitRepositoryService.PRInfo {
+        GitRepositoryService.PRInfo(
+            url: "https://github.com/acme/app/pull/1",
+            number: 1,
+            state: .open,
+            isDraft: false,
+            baseBranch: "main",
+            mergeable: mergeable,
+            mergeStateStatus: mergeStateStatus,
+            checks: checks,
+            isCrossRepository: false
+        )
+    }
+}

--- a/Tests/MuxyTests/Views/PRMergeabilityPresentationTests.swift
+++ b/Tests/MuxyTests/Views/PRMergeabilityPresentationTests.swift
@@ -23,7 +23,7 @@ struct PRMergeabilityPresentationTests {
         )))
 
         #expect(presentation.text == "Yes (checks failing)")
-        #expect(presentation.tone == .positive)
+        #expect(presentation.tone == .warning)
     }
 
     @Test("unknown merge state falls back to mergeable value")


### PR DESCRIPTION
Show running checks separately from failing checks when a PR is otherwise mergeable, so reviewers can tell whether status is still pending or needs attention. Adds focused coverage for mergeability labels.