### PR TITLE
Reuse existing VCS tabs

### DIFF
--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -39,8 +39,16 @@ enum TabReducer {
 
     static func createVCSTab(projectID: UUID, areaID: UUID?, state: inout WorkspaceState) {
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
+              let root = state.workspaceRoots[key],
               let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
         else { return }
+        for existingArea in root.allAreas() {
+            if let existing = existingArea.tabs.first(where: { $0.kind == .vcs }) {
+                FocusReducer.focusArea(existingArea.id, key: key, state: &state)
+                existingArea.selectTab(existing.id)
+                return
+            }
+        }
         FocusReducer.focusArea(area.id, key: key, state: &state)
         area.createVCSTab()
     }

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -178,6 +178,27 @@ struct WorkspaceReducerTests {
         #expect(area?.activeTab?.kind == .vcs)
     }
 
+    @Test("createVCSTab focuses existing VCS tab instead of adding a duplicate")
+    func createVCSTabReusesExisting() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+
+        let action = AppState.Action.createVCSTab(projectID: projectID, areaID: nil)
+        _ = WorkspaceReducer.reduce(action: action, state: &state)
+        let firstArea = focusedArea(in: state, projectID: projectID)
+        let firstTabID = firstArea?.activeTabID
+
+        firstArea?.createTab()
+        #expect(firstArea?.activeTab?.kind == .terminal)
+
+        _ = WorkspaceReducer.reduce(action: action, state: &state)
+
+        let area = focusedArea(in: state, projectID: projectID)
+        #expect(area?.tabs.filter { $0.kind == .vcs }.count == 1)
+        #expect(area?.activeTabID == firstTabID)
+    }
+
     @Test("createEditorTab adds editor tab")
     func createEditorTab() {
         let projectID = UUID()


### PR DESCRIPTION
- Prevent duplicate VCS tabs by focusing the existing one when users open VCS again.
- Keeps tab state cleaner and preserves the user's current VCS context.