### PR TITLE
Fix crash when starting voice recording

### DIFF
--- a/Muxy/Services/VoiceRecorder.swift
+++ b/Muxy/Services/VoiceRecorder.swift
@@ -215,7 +215,6 @@ final class VoiceRecorder {
         request: SFSpeechAudioBufferRecognitionRequest,
         sink: LevelSink
     ) {
-        let format = inputNode.outputFormat(forBus: 0)
         inputNode.removeTap(onBus: 0)
         let requestBox = UncheckedBox(request)
         let block: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void = { buffer, _ in
@@ -223,7 +222,7 @@ final class VoiceRecorder {
             let normalized = normalize(power: averagePower(in: buffer))
             sink.publish(normalized)
         }
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format, block: block)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: nil, block: block)
     }
 
     nonisolated static func normalize(power db: Float) -> Float {


### PR DESCRIPTION
Let the audio input tap use the recorder's active hardware format so recording can start reliably.
- Prevents crashes caused by installing the tap with a stale or incompatible format.