### PR TITLE
Add terminal selection auto-copy

### DIFF
--- a/Muxy/Models/GeneralSettingsKeys.swift
+++ b/Muxy/Models/GeneralSettingsKeys.swift
@@ -2,4 +2,5 @@ enum GeneralSettingsKeys {
     static let autoExpandWorktreesOnProjectSwitch = "muxy.general.autoExpandWorktreesOnProjectSwitch"
     static let defaultWorktreeParentPath = "muxy.general.defaultWorktreeParentPath"
     static let fileTreeSource = "muxy.general.fileTreeSource"
+    static let autoCopyTerminalSelection = "muxy.general.autoCopyTerminalSelection"
 }

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -18,6 +18,8 @@ struct GeneralSettingsView: View {
     private var updateChannelRaw = UpdateChannel.stable.rawValue
     @AppStorage(QuitConfirmationPreferences.confirmQuitKey)
     private var confirmQuit = true
+    @AppStorage(GeneralSettingsKeys.autoCopyTerminalSelection)
+    private var autoCopyTerminalSelection = false
     @State private var projectPickerDefaultLocationSettings = ProjectPickerDefaultLocationSettingsModel()
     @State private var sentry = SentryService.shared
 
@@ -98,6 +100,16 @@ struct GeneralSettingsView: View {
                     + "Projects can still override this from the new worktree dialog."
             ) {
                 worktreeLocationControl
+            }
+
+            SettingsSection(
+                "Terminal",
+                footer: "When enabled, releasing the mouse after selecting text in the terminal copies it to the clipboard."
+            ) {
+                SettingsToggleRow(
+                    label: "Auto-copy selected text",
+                    isOn: $autoCopyTerminalSelection
+                )
             }
 
             SettingsSection("Tabs") {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -605,6 +605,16 @@ final class GhosttyTerminalNSView: NSView {
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
+        autoCopySelectionIfEnabled()
+    }
+
+    private func autoCopySelectionIfEnabled() {
+        guard UserDefaults.standard.bool(forKey: GeneralSettingsKeys.autoCopyTerminalSelection) else { return }
+        guard let selection = readSelectionText(), !selection.isEmpty else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(selection, forType: .string)
+        ToastState.shared.show("Copied")
     }
 
     override func mouseDragged(with event: NSEvent) {


### PR DESCRIPTION
- Let users opt into copying selected terminal text on mouse release.
- Adds a General setting so the behavior stays disabled by default.