### PR TITLE
Update behind pull request branches

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -83,6 +83,7 @@ final class VCSTabState {
     var isMergingPullRequest = false
     var isClosingPullRequest = false
     var isRefreshingPullRequest = false
+    var isUpdatingPullRequestBranch = false
     var hasFetchedPullRequestInfo = false
     private(set) var isGitRepo = false
     private(set) var remoteWebURL: URL?
@@ -1139,6 +1140,24 @@ final class VCSTabState {
                 pullRequestInfo = nil
                 ToastState.shared.show("Closed PR #\(info.number)")
                 onSuccess()
+            } catch {
+                guard !Task.isCancelled else { return }
+                showStatus(errorText(error), isError: true)
+            }
+        }
+    }
+
+    func updatePullRequestBranch() {
+        guard let info = pullRequestInfo, !isUpdatingPullRequestBranch else { return }
+        isUpdatingPullRequestBranch = true
+        Task { [weak self] in
+            guard let self else { return }
+            defer { isUpdatingPullRequestBranch = false }
+            do {
+                try await git.mergeBaseIntoCurrentBranch(repoPath: projectPath, baseBranch: info.baseBranch)
+                guard !Task.isCancelled else { return }
+                ToastState.shared.show("Updated branch with \(info.baseBranch)")
+                refreshPullRequest()
             } catch {
                 guard !Task.isCancelled else { return }
                 showStatus(errorText(error), isError: true)

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -1149,14 +1149,19 @@ final class VCSTabState {
 
     func updatePullRequestBranch() {
         guard let info = pullRequestInfo, !isUpdatingPullRequestBranch else { return }
+        guard !info.isCrossRepository else {
+            showStatus("Branch lives on a fork — update it locally.", isError: true)
+            return
+        }
+        guard let branch = branchName else { return }
         isUpdatingPullRequestBranch = true
         Task { [weak self] in
             guard let self else { return }
             defer { isUpdatingPullRequestBranch = false }
             do {
                 try await git.mergeBaseIntoCurrentBranch(repoPath: projectPath, baseBranch: info.baseBranch)
-                guard !Task.isCancelled else { return }
-                ToastState.shared.show("Updated branch with \(info.baseBranch)")
+                guard !Task.isCancelled, branchName == branch else { return }
+                ToastState.shared.show("Merged \(info.baseBranch) into \(branch)")
                 refreshPullRequest()
             } catch {
                 guard !Task.isCancelled else { return }

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -1016,6 +1016,16 @@ struct GitRepositoryService {
             throw GitError.commandFailed("Invalid base branch name.")
         }
 
+        let statusResult = try await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["status", "--porcelain=1", "--untracked-files=no"]
+        )
+        if statusResult.status == 0,
+           !statusResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            throw GitError.commandFailed("Commit or stash your changes before updating the branch.")
+        }
+
         let fetchResult = try await GitProcessRunner.runGit(
             repoPath: repoPath,
             arguments: ["fetch", "origin", trimmed]

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -1008,6 +1008,48 @@ struct GitRepositoryService {
         GitMetadataCache.shared.invalidatePRInfo(repoPath: repoPath)
     }
 
+    func mergeBaseIntoCurrentBranch(repoPath: String, baseBranch: String) async throws {
+        let trimmed = baseBranch.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.unicodeScalars.allSatisfy({ Self.allowedBranchCharacters.contains($0) })
+        else {
+            throw GitError.commandFailed("Invalid base branch name.")
+        }
+
+        let fetchResult = try await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["fetch", "origin", trimmed]
+        )
+        guard fetchResult.status == 0 else {
+            throw GitError.commandFailed(
+                fetchResult.stderr.isEmpty ? "Failed to fetch origin/\(trimmed)." : fetchResult.stderr
+            )
+        }
+
+        let mergeResult = try await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["merge", "--no-edit", "origin/\(trimmed)"]
+        )
+        guard mergeResult.status == 0 else {
+            _ = try? await GitProcessRunner.runGit(repoPath: repoPath, arguments: ["merge", "--abort"])
+            let detail = mergeResult.stderr.isEmpty ? mergeResult.stdout : mergeResult.stderr
+            let trimmedDetail = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw GitError.commandFailed(
+                trimmedDetail.isEmpty
+                    ? "Could not merge origin/\(trimmed) — resolve conflicts manually."
+                    : "Could not merge origin/\(trimmed): \(trimmedDetail)"
+            )
+        }
+
+        let pushResult = try await GitProcessRunner.runGit(repoPath: repoPath, arguments: ["push"])
+        guard pushResult.status == 0 else {
+            throw GitError.commandFailed(
+                pushResult.stderr.isEmpty ? "Merged locally but failed to push." : pushResult.stderr
+            )
+        }
+        GitMetadataCache.shared.invalidatePRInfo(repoPath: repoPath)
+    }
+
     @discardableResult
     func fastForwardBranch(repoPath: String, branch: String) async -> Bool {
         let trimmed = branch.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -935,6 +935,9 @@ struct PRPill: View {
                 },
                 onRefresh: {
                     state.refreshPullRequest()
+                },
+                onUpdateBranch: {
+                    state.updatePullRequestBranch()
                 }
             )
         }
@@ -1008,6 +1011,7 @@ struct PRPopover: View {
     let onClose: () -> Void
     let onOpenInBrowser: () -> Void
     let onRefresh: () -> Void
+    let onUpdateBranch: () -> Void
 
     @State private var mergeMethod: GitRepositoryService.PRMergeMethod = .squash
 
@@ -1075,6 +1079,30 @@ struct PRPopover: View {
             .buttonStyle(.plain)
 
             if info.state == .open {
+                if info.mergeStateStatus == .behind {
+                    Button(action: onUpdateBranch) {
+                        HStack(spacing: UIMetrics.spacing3) {
+                            if state.isUpdatingPullRequestBranch {
+                                ProgressView().controlSize(.mini)
+                            } else {
+                                Image(systemName: "arrow.down.circle")
+                                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                            }
+                            Text(state.isUpdatingPullRequestBranch ? "Updating…" : "Update branch")
+                                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                            Spacer(minLength: 0)
+                        }
+                        .foregroundStyle(MuxyTheme.fg)
+                        .padding(.horizontal, UIMetrics.spacing4)
+                        .padding(.vertical, UIMetrics.spacing3)
+                        .frame(maxWidth: .infinity)
+                        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(state.isUpdatingPullRequestBranch)
+                    .help("Merge \(info.baseBranch) into this branch")
+                }
+
                 SegmentedPicker(
                     selection: $mergeMethod,
                     options: GitRepositoryService.PRMergeMethod.allCases.map { ($0, $0.shortLabel) }

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1079,7 +1079,7 @@ struct PRPopover: View {
             .buttonStyle(.plain)
 
             if info.state == .open {
-                if info.mergeStateStatus == .behind {
+                if info.mergeStateStatus == .behind, !info.isCrossRepository {
                     Button(action: onUpdateBranch) {
                         HStack(spacing: UIMetrics.spacing3) {
                             if state.isUpdatingPullRequestBranch {


### PR DESCRIPTION
Let users bring a behind PR branch up to date from the PR popover, with progress and failure feedback.
Conflicting merges are aborted and surfaced for manual resolution.