### PR TITLE
Manage pull request labels from the PR popover

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -83,6 +83,10 @@ final class VCSTabState {
     var isMergingPullRequest = false
     var isClosingPullRequest = false
     var isRefreshingPullRequest = false
+    var availableRepositoryLabels: [GitRepositoryService.PRLabel] = []
+    var isLoadingRepositoryLabels = false
+    var repositoryLabelsError: String?
+    var pendingLabelUpdates: Set<String> = []
     var hasFetchedPullRequestInfo = false
     private(set) var isGitRepo = false
     private(set) var remoteWebURL: URL?
@@ -1139,6 +1143,70 @@ final class VCSTabState {
                 pullRequestInfo = nil
                 ToastState.shared.show("Closed PR #\(info.number)")
                 onSuccess()
+            } catch {
+                guard !Task.isCancelled else { return }
+                showStatus(errorText(error), isError: true)
+            }
+        }
+    }
+
+    func loadRepositoryLabels(force: Bool = false) {
+        if !force, !availableRepositoryLabels.isEmpty { return }
+        if isLoadingRepositoryLabels { return }
+        isLoadingRepositoryLabels = true
+        repositoryLabelsError = nil
+        Task { [weak self] in
+            guard let self else { return }
+            defer { isLoadingRepositoryLabels = false }
+            do {
+                let labels = try await git.listRepositoryLabels(repoPath: projectPath)
+                guard !Task.isCancelled else { return }
+                availableRepositoryLabels = labels
+            } catch {
+                guard !Task.isCancelled else { return }
+                repositoryLabelsError = errorText(error)
+            }
+        }
+    }
+
+    func addLabel(_ name: String) {
+        guard let info = pullRequestInfo else { return }
+        guard !pendingLabelUpdates.contains(name) else { return }
+        guard !info.labels.contains(where: { $0.name == name }) else { return }
+        pendingLabelUpdates.insert(name)
+        Task { [weak self] in
+            guard let self else { return }
+            defer { pendingLabelUpdates.remove(name) }
+            do {
+                try await git.addLabelsToPullRequest(
+                    repoPath: projectPath,
+                    number: info.number,
+                    labels: [name]
+                )
+                guard !Task.isCancelled else { return }
+                refreshPullRequest()
+            } catch {
+                guard !Task.isCancelled else { return }
+                showStatus(errorText(error), isError: true)
+            }
+        }
+    }
+
+    func removeLabel(_ name: String) {
+        guard let info = pullRequestInfo else { return }
+        guard !pendingLabelUpdates.contains(name) else { return }
+        pendingLabelUpdates.insert(name)
+        Task { [weak self] in
+            guard let self else { return }
+            defer { pendingLabelUpdates.remove(name) }
+            do {
+                try await git.removeLabelFromPullRequest(
+                    repoPath: projectPath,
+                    number: info.number,
+                    label: name
+                )
+                guard !Task.isCancelled else { return }
+                refreshPullRequest()
             } catch {
                 guard !Task.isCancelled else { return }
                 showStatus(errorText(error), isError: true)

--- a/Muxy/Services/Git/GitPRParser.swift
+++ b/Muxy/Services/Git/GitPRParser.swift
@@ -27,6 +27,7 @@ enum GitPRParser {
         ) ?? .unknown
         let rollup = json["statusCheckRollup"] as? [[String: Any]] ?? []
         let isCrossRepository = json["isCrossRepository"] as? Bool ?? false
+        let labels = parseLabels(json["labels"] as? [[String: Any]] ?? [])
 
         return GitRepositoryService.PRInfo(
             url: url,
@@ -37,8 +38,18 @@ enum GitPRParser {
             mergeable: mergeable,
             mergeStateStatus: mergeStateStatus,
             checks: parseStatusChecks(rollup),
-            isCrossRepository: isCrossRepository
+            isCrossRepository: isCrossRepository,
+            labels: labels
         )
+    }
+
+    static func parseLabels(_ rawLabels: [[String: Any]]) -> [GitRepositoryService.PRLabel] {
+        rawLabels.compactMap { entry -> GitRepositoryService.PRLabel? in
+            guard let name = entry["name"] as? String, !name.isEmpty else { return nil }
+            let color = (entry["color"] as? String) ?? ""
+            let description = (entry["description"] as? String) ?? ""
+            return GitRepositoryService.PRLabel(name: name, color: color, description: description)
+        }
     }
 
     static func parseStatusChecks(_ rollup: [[String: Any]]) -> GitRepositoryService.PRChecks {

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -35,6 +35,15 @@ struct GitRepositoryService {
         let mergeStateStatus: PRMergeStateStatus
         let checks: PRChecks
         let isCrossRepository: Bool
+        let labels: [PRLabel]
+    }
+
+    struct PRLabel: Equatable, Hashable, Identifiable {
+        let name: String
+        let color: String
+        let description: String
+
+        var id: String { name }
     }
 
     struct PRListItem: Equatable, Identifiable {
@@ -209,7 +218,7 @@ struct GitRepositoryService {
     }
 
     static let prInfoJSONFields =
-        "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository"
+        "url,number,state,isDraft,baseRefName,mergeable,mergeStateStatus,statusCheckRollup,isCrossRepository,labels"
     static let prInfoJSONFieldsWithHeadRefOid = prInfoJSONFields + ",headRefOid,headRefName"
 
     func pullRequestInfo(repoPath: String, branch: String, headSha: String? = nil) async -> PRInfo? {
@@ -639,6 +648,64 @@ struct GitRepositoryService {
                 result.stderr.isEmpty ? "Failed to delete remote branch \(branch)." : result.stderr
             )
         }
+    }
+
+    func listRepositoryLabels(repoPath: String) async throws -> [PRLabel] {
+        guard let ghPath = GitProcessRunner.resolveExecutable("gh") else {
+            throw PRCreateError.ghNotInstalled
+        }
+        let result = try await GitProcessRunner.runCommand(
+            executable: ghPath,
+            arguments: ["label", "list", "--limit", "200", "--json", "name,color,description"],
+            workingDirectory: repoPath
+        )
+        guard result.status == 0 else {
+            let message = result.stderr.isEmpty ? result.stdout : result.stderr
+            throw PRCreateError.commandFailed(
+                message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? "Failed to list repository labels."
+                    : message.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+        guard let data = result.stdout.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+        return GitPRParser.parseLabels(array)
+    }
+
+    func addLabelsToPullRequest(repoPath: String, number: Int, labels: [String]) async throws {
+        try await editPullRequestLabels(repoPath: repoPath, number: number, flag: "--add-label", labels: labels)
+    }
+
+    func removeLabelFromPullRequest(repoPath: String, number: Int, label: String) async throws {
+        try await editPullRequestLabels(repoPath: repoPath, number: number, flag: "--remove-label", labels: [label])
+    }
+
+    private func editPullRequestLabels(
+        repoPath: String,
+        number: Int,
+        flag: String,
+        labels: [String]
+    ) async throws {
+        guard let ghPath = GitProcessRunner.resolveExecutable("gh") else {
+            throw PRCreateError.ghNotInstalled
+        }
+        guard !labels.isEmpty else { return }
+        let joined = labels.joined(separator: ",")
+        let result = try await GitProcessRunner.runCommand(
+            executable: ghPath,
+            arguments: ["pr", "edit", String(number), flag, joined],
+            workingDirectory: repoPath
+        )
+        guard result.status == 0 else {
+            let message = result.stderr.isEmpty ? result.stdout : result.stderr
+            throw PRCreateError.commandFailed(
+                message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? "Failed to update labels."
+                    : message.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+        GitMetadataCache.shared.invalidatePRInfo(repoPath: repoPath)
     }
 
     func closePullRequest(repoPath: String, number: Int) async throws {

--- a/Muxy/Views/VCS/PRLabelsSection.swift
+++ b/Muxy/Views/VCS/PRLabelsSection.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+
+struct PRLabelsSection: View {
+    @Bindable var state: VCSTabState
+    let info: GitRepositoryService.PRInfo
+
+    @State private var showAddLabelPopover = false
+
+    private var canEditLabels: Bool {
+        info.state == .open
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+            HStack(spacing: UIMetrics.spacing3) {
+                Text("Labels")
+                    .font(.system(size: UIMetrics.fontFootnote))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                Spacer(minLength: 0)
+                if canEditLabels {
+                    addLabelButton
+                }
+            }
+
+            if info.labels.isEmpty {
+                Text("No labels")
+                    .font(.system(size: UIMetrics.fontFootnote))
+                    .foregroundStyle(MuxyTheme.fgDim)
+            } else {
+                LabelFlowLayout(spacing: UIMetrics.spacing2, lineSpacing: UIMetrics.spacing2) {
+                    ForEach(info.labels) { label in
+                        labelBadge(label)
+                    }
+                }
+            }
+        }
+    }
+
+    private var addLabelButton: some View {
+        Button {
+            showAddLabelPopover = true
+            state.loadRepositoryLabels()
+        } label: {
+            HStack(spacing: UIMetrics.spacing1) {
+                Image(systemName: "plus")
+                    .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+                Text("Add")
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+            }
+            .foregroundStyle(MuxyTheme.fgMuted)
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.scaled(2))
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showAddLabelPopover, arrowEdge: .trailing) {
+            AddLabelPopover(
+                state: state,
+                appliedNames: Set(info.labels.map(\.name)),
+                onSelect: { name in
+                    showAddLabelPopover = false
+                    state.addLabel(name)
+                }
+            )
+        }
+    }
+
+    private func labelBadge(_ label: GitRepositoryService.PRLabel) -> some View {
+        let bg = Color(hex: label.color) ?? MuxyTheme.surface
+        let fg = LabelColorMath.foreground(forHex: label.color)
+        let isPending = state.pendingLabelUpdates.contains(label.name)
+
+        return HStack(spacing: UIMetrics.spacing2) {
+            Text(label.name)
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .foregroundStyle(fg)
+                .lineLimit(1)
+            if canEditLabels {
+                Button {
+                    state.removeLabel(label.name)
+                } label: {
+                    if isPending {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .scaleEffect(0.6)
+                    } else {
+                        Image(systemName: "xmark")
+                            .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+                            .foregroundStyle(fg.opacity(0.75))
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(isPending)
+                .help("Remove \(label.name)")
+            }
+        }
+        .padding(.horizontal, UIMetrics.spacing3)
+        .padding(.vertical, UIMetrics.scaled(2))
+        .background(bg, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+        .help(label.description.isEmpty ? label.name : "\(label.name) — \(label.description)")
+    }
+}
+
+private struct AddLabelPopover: View {
+    @Bindable var state: VCSTabState
+    let appliedNames: Set<String>
+    let onSelect: (String) -> Void
+
+    @State private var searchText = ""
+
+    private var filtered: [GitRepositoryService.PRLabel] {
+        let unapplied = state.availableRepositoryLabels.filter { !appliedNames.contains($0.name) }
+        guard !searchText.isEmpty else { return unapplied }
+        return unapplied.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: UIMetrics.spacing3) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: UIMetrics.fontFootnote))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                TextField("Search labels", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: UIMetrics.fontFootnote))
+            }
+            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.spacing3)
+
+            Divider().overlay(MuxyTheme.border)
+
+            content
+        }
+        .frame(width: UIMetrics.scaled(240))
+        .frame(maxHeight: UIMetrics.scaled(280))
+        .background(MuxyTheme.bg)
+        .task { state.loadRepositoryLabels() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if state.isLoadingRepositoryLabels, state.availableRepositoryLabels.isEmpty {
+            VStack {
+                Spacer()
+                ProgressView().controlSize(.small)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .padding(UIMetrics.spacing5)
+        } else if let error = state.repositoryLabelsError {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                Text(error)
+                    .font(.system(size: UIMetrics.fontFootnote))
+                    .foregroundStyle(MuxyTheme.diffRemoveFg)
+                Button("Retry") { state.loadRepositoryLabels(force: true) }
+                    .font(.system(size: UIMetrics.fontFootnote))
+            }
+            .padding(UIMetrics.spacing5)
+        } else if filtered.isEmpty {
+            Text(searchText.isEmpty ? "No labels available" : "No matches")
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .padding(UIMetrics.spacing5)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(filtered) { label in
+                        labelRow(label)
+                    }
+                }
+                .padding(.vertical, UIMetrics.spacing2)
+            }
+        }
+    }
+
+    private func labelRow(_ label: GitRepositoryService.PRLabel) -> some View {
+        let pending = state.pendingLabelUpdates.contains(label.name)
+        return Button {
+            guard !pending else { return }
+            onSelect(label.name)
+        } label: {
+            HStack(spacing: UIMetrics.spacing3) {
+                Circle()
+                    .fill(Color(hex: label.color) ?? MuxyTheme.surface)
+                    .frame(width: UIMetrics.scaled(10), height: UIMetrics.scaled(10))
+                Text(label.name)
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                if pending {
+                    ProgressView().controlSize(.mini)
+                }
+            }
+            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.vertical, UIMetrics.spacing3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(pending)
+    }
+}
+
+enum LabelColorMath {
+    static func foreground(forHex hex: String) -> Color {
+        var trimmed = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("#") { trimmed.removeFirst() }
+        guard trimmed.count == 6, let value = UInt32(trimmed, radix: 16) else { return .white }
+        let red = Double((value >> 16) & 0xFF) / 255.0
+        let green = Double((value >> 8) & 0xFF) / 255.0
+        let blue = Double(value & 0xFF) / 255.0
+        let luminance = 0.299 * red + 0.587 * green + 0.114 * blue
+        return luminance > 0.6 ? .black : .white
+    }
+}
+
+struct LabelFlowLayout: Layout {
+    var spacing: CGFloat
+    var lineSpacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let arrangement = arrange(subviews: subviews, maxWidth: maxWidth)
+        return CGSize(width: arrangement.width, height: arrangement.height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        let arrangement = arrange(subviews: subviews, maxWidth: proposal.width ?? bounds.width)
+        for placement in arrangement.placements {
+            subviews[placement.index].place(
+                at: CGPoint(x: bounds.minX + placement.origin.x, y: bounds.minY + placement.origin.y),
+                proposal: ProposedViewSize(placement.size)
+            )
+        }
+    }
+
+    private struct Placement {
+        let index: Int
+        let origin: CGPoint
+        let size: CGSize
+    }
+
+    private struct Arrangement {
+        let placements: [Placement]
+        let width: CGFloat
+        let height: CGFloat
+    }
+
+    private func arrange(subviews: Subviews, maxWidth: CGFloat) -> Arrangement {
+        var placements: [Placement] = []
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var maxRowWidth: CGFloat = 0
+        var cursorY: CGFloat = 0
+
+        for (index, subview) in subviews.enumerated() {
+            let size = subview.sizeThatFits(.unspecified)
+            let needsNewLine = rowWidth > 0 && rowWidth + spacing + size.width > maxWidth
+            if needsNewLine {
+                maxRowWidth = max(maxRowWidth, rowWidth)
+                cursorY += rowHeight + lineSpacing
+                totalHeight = cursorY
+                rowWidth = 0
+                rowHeight = 0
+            }
+            let x = rowWidth == 0 ? 0 : rowWidth + spacing
+            placements.append(Placement(index: index, origin: CGPoint(x: x, y: cursorY), size: size))
+            rowWidth = x + size.width
+            rowHeight = max(rowHeight, size.height)
+        }
+        maxRowWidth = max(maxRowWidth, rowWidth)
+        totalHeight = cursorY + rowHeight
+        return Arrangement(placements: placements, width: maxRowWidth, height: totalHeight)
+    }
+}

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -1056,6 +1056,8 @@ struct PRPopover: View {
                 checksRow
             }
 
+            PRLabelsSection(state: state, info: info)
+
             Divider()
 
             Button(action: onOpenInBrowser) {

--- a/Tests/MuxyTests/Git/GitPRParserTests.swift
+++ b/Tests/MuxyTests/Git/GitPRParserTests.swift
@@ -188,6 +188,54 @@ struct GitPRParserTests {
             let info = GitPRParser.parsePRInfo(json)
             #expect(info?.isCrossRepository == false)
         }
+
+        @Test("labels parse with name, color, and description")
+        func labelsParse() {
+            let json = """
+            {
+              "url": "u",
+              "number": 1,
+              "state": "OPEN",
+              "labels": [
+                {"name": "bug", "color": "d73a4a", "description": "Something broken"},
+                {"name": "feature", "color": "0e8a16", "description": ""}
+              ]
+            }
+            """
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.labels.count == 2)
+            #expect(info?.labels[0].name == "bug")
+            #expect(info?.labels[0].color == "d73a4a")
+            #expect(info?.labels[0].description == "Something broken")
+            #expect(info?.labels[1].name == "feature")
+            #expect(info?.labels[1].description == "")
+        }
+
+        @Test("missing labels defaults to empty array")
+        func labelsMissing() {
+            let json = #"{"url":"u","number":1,"state":"OPEN"}"#
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.labels.isEmpty == true)
+        }
+
+        @Test("label entries without a name are skipped")
+        func labelsSkipInvalid() {
+            let json = """
+            {
+              "url": "u",
+              "number": 1,
+              "state": "OPEN",
+              "labels": [
+                {"color": "ffffff"},
+                {"name": "", "color": "ffffff"},
+                {"name": "kept", "color": "ffffff"}
+              ]
+            }
+            """
+            let info = GitPRParser.parsePRInfo(json)
+            #expect(info?.labels.count == 1)
+            #expect(info?.labels.first?.name == "kept")
+        }
     }
 
     @Suite("parsePRInfoMatchingHeadSha")


### PR DESCRIPTION
- Show current PR labels in the popover and allow adding or removing labels on open PRs.
- Fetch repository labels from GitHub so users can choose existing labels without leaving Muxy.