### PR TITLE
Prevent release build number regressions

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release-beta
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -47,7 +47,8 @@ jobs:
             echo "Error: BETA_VERSION must be X.Y.Z, got '$BETA_BASE'"
             exit 1
           fi
-          BUILD_NUMBER=$(git rev-list --count HEAD)
+          chmod +x scripts/compute-build-number.sh
+          BUILD_NUMBER=$(REPO="${{ github.repository }}" scripts/compute-build-number.sh)
           VERSION="${BETA_BASE}-beta.${BUILD_NUMBER}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
@@ -133,6 +134,7 @@ jobs:
           scripts/build-release.sh \
             --arch "${{ matrix.arch }}" \
             --version "${{ needs.validate.outputs.version }}" \
+            --build-number "${{ needs.validate.outputs.build_number }}" \
             --sign-identity "${{ steps.identity.outputs.name }}" \
             --sparkle-public-key "${{ steps.sparkle.outputs.public_key }}" \
             --sparkle-feed-url "https://github.com/muxy-app/muxy/releases/download/beta-channel/appcast-beta-${{ matrix.arch }}.xml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   validate:
     runs-on: macos-26
@@ -50,7 +54,8 @@ jobs:
             echo "Error: tag $BETA_TAG not found"
             exit 1
           fi
-          BUILD_NUMBER=$(git rev-list --count "$BETA_TAG")
+          chmod +x scripts/compute-build-number.sh
+          BUILD_NUMBER=$(REPO="${{ github.repository }}" scripts/compute-build-number.sh --ref "$BETA_TAG")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "next_beta_version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
@@ -136,6 +141,7 @@ jobs:
           scripts/build-release.sh \
             --arch "${{ matrix.arch }}" \
             --version "${{ needs.validate.outputs.version }}" \
+            --build-number "${{ needs.validate.outputs.build_number }}" \
             --sign-identity "${{ steps.identity.outputs.name }}" \
             --sparkle-public-key "${{ steps.sparkle.outputs.public_key }}" \
             --sparkle-feed-url "https://github.com/muxy-app/muxy/releases/latest/download/appcast-${{ matrix.arch }}.xml"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -7,6 +7,7 @@ BUILD_DIR="$PROJECT_ROOT/build"
 
 ARCH=""
 VERSION=""
+BUILD_NUMBER_OVERRIDE=""
 SIGN_IDENTITY=""
 SPARKLE_PUBLIC_KEY=""
 SPARKLE_FEED_URL=""
@@ -22,6 +23,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --version)
             VERSION="$2"
+            shift 2
+            ;;
+        --build-number)
+            BUILD_NUMBER_OVERRIDE="$2"
             shift 2
             ;;
         --sign)
@@ -52,7 +57,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$ARCH" || -z "$VERSION" ]]; then
-    echo "Usage: $0 --arch <arm64|x86_64> --version <X.Y.Z[-beta.N]> [--sign | --sign-identity <identity>] [--sparkle-public-key <key>] [--sparkle-feed-url <url>] [--sentry-dsn <dsn>]"
+    echo "Usage: $0 --arch <arm64|x86_64> --version <X.Y.Z[-beta.N]> [--build-number <N>] [--sign | --sign-identity <identity>] [--sparkle-public-key <key>] [--sparkle-feed-url <url>] [--sentry-dsn <dsn>]"
+    exit 1
+fi
+
+if [[ -n "$BUILD_NUMBER_OVERRIDE" && ! "$BUILD_NUMBER_OVERRIDE" =~ ^[0-9]+$ ]]; then
+    echo "Error: --build-number must be a positive integer"
     exit 1
 fi
 
@@ -84,7 +94,11 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then
 fi
 
 TRIPLE="${ARCH}-apple-macosx14.0"
-BUILD_NUMBER=$(git -C "$PROJECT_ROOT" rev-list --count HEAD)
+if [[ -n "$BUILD_NUMBER_OVERRIDE" ]]; then
+    BUILD_NUMBER="$BUILD_NUMBER_OVERRIDE"
+else
+    BUILD_NUMBER=$(git -C "$PROJECT_ROOT" rev-list --count HEAD)
+fi
 APP_BUNDLE="$BUILD_DIR/Muxy.app"
 DMG_NAME="Muxy-${VERSION}-${ARCH}.dmg"
 

--- a/scripts/compute-build-number.sh
+++ b/scripts/compute-build-number.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REF="HEAD"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --ref)
+      REF="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+REPO="${REPO:-muxy-app/muxy}"
+STABLE_APPCAST_URL="${STABLE_APPCAST_URL:-https://github.com/${REPO}/releases/latest/download/appcast-arm64.xml}"
+BETA_APPCAST_URL="${BETA_APPCAST_URL:-https://github.com/${REPO}/releases/download/beta-channel/appcast-beta-arm64.xml}"
+
+max_sparkle_version_in_url() {
+  local url="$1"
+  local body
+  body=$(curl -fsSL "$url" 2>/dev/null || true)
+  if [[ -z "$body" ]]; then
+    echo 0
+    return
+  fi
+  local versions
+  versions=$(printf '%s' "$body" | grep -oE '<sparkle:version>[0-9]+</sparkle:version>' | grep -oE '[0-9]+' || true)
+  if [[ -z "$versions" ]]; then
+    echo 0
+    return
+  fi
+  printf '%s\n' "$versions" | sort -n | tail -1
+}
+
+REV_COUNT=$(git -C "$PROJECT_ROOT" rev-list --count "$REF")
+STABLE_MAX=$(max_sparkle_version_in_url "$STABLE_APPCAST_URL")
+BETA_MAX=$(max_sparkle_version_in_url "$BETA_APPCAST_URL")
+
+NEXT=$REV_COUNT
+[[ $STABLE_MAX -ge $NEXT ]] && NEXT=$((STABLE_MAX + 1))
+[[ $BETA_MAX -ge $NEXT ]] && NEXT=$((BETA_MAX + 1))
+
+echo "$NEXT"


### PR DESCRIPTION
- Keep beta and stable releases on one build-number sequence so Sparkle updates stay monotonic.
- Pass the validated build number into packaging instead of recomputing per job.
Risk: release numbering now depends on reading existing appcasts successfully.