### PR TITLE
Allow external worktrees to be removed

### DIFF
--- a/Muxy/Models/Worktree.swift
+++ b/Muxy/Models/Worktree.swift
@@ -40,7 +40,7 @@ struct Worktree: Identifiable, Codable, Hashable {
     }
 
     var canBeRemoved: Bool {
-        !isPrimary && !isExternallyManaged
+        !isPrimary
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -643,11 +643,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             throw RemoteVCSError.worktreeNotFound
         }
         guard worktree.canBeRemoved else {
-            throw RemoteVCSError.invalidInput(
-                worktree.isPrimary
-                    ? "The primary worktree cannot be removed."
-                    : "This worktree is managed outside Muxy and cannot be removed here."
-            )
+            throw RemoteVCSError.invalidInput("The primary worktree cannot be removed.")
         }
 
         await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: project.path)

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -184,11 +184,12 @@ final class WorktreeStore {
         }
 
         try? FileManager.default.removeItem(atPath: worktree.path)
+        guard !worktree.isExternallyManaged else { return }
         removeParentDirectoryIfEmpty(for: worktree.path)
     }
 
     static func cleanupOnDisk(for project: Project, knownWorktrees: [Worktree]) async {
-        let secondaryWorktrees = knownWorktrees.filter(\.canBeRemoved)
+        let secondaryWorktrees = knownWorktrees.filter { $0.canBeRemoved && !$0.isExternallyManaged }
         for worktree in secondaryWorktrees {
             await cleanupOnDisk(worktree: worktree, repoPath: project.path)
         }

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -220,8 +220,6 @@ private struct WorktreePopoverRow: View {
                 Button("Remove", role: .destructive, action: onRemove)
             } else {
                 Button("Rename") { startRename() }
-                Divider()
-                Text("External worktree").font(.system(size: UIMetrics.fontFootnote))
             }
         }
     }

--- a/Tests/MuxyTests/Services/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeStoreTests.swift
@@ -391,8 +391,8 @@ struct WorktreeStoreTests {
         #expect(VCSStateStore.shared.cachedState(for: removable.path) == nil)
     }
 
-    @Test("remove does not delete externally managed worktrees")
-    func removeDoesNotDeleteExternalWorktree() {
+    @Test("remove deletes externally managed worktrees")
+    func removeDeletesExternalWorktree() {
         let project = Project(name: "Repo", path: "/tmp/repo")
         let external = Worktree(
             name: "feature-b",
@@ -417,8 +417,8 @@ struct WorktreeStoreTests {
 
         store.remove(worktreeID: external.id, from: project.id)
 
-        #expect(store.list(for: project.id).contains(external))
-        #expect(external.canBeRemoved == false)
+        #expect(!store.list(for: project.id).contains(external))
+        #expect(external.canBeRemoved)
     }
 
     @Test("WorktreeDTO preserves removal capability")
@@ -440,7 +440,7 @@ struct WorktreeStoreTests {
         )
 
         #expect(primary.toDTO().canBeRemoved == false)
-        #expect(external.toDTO().canBeRemoved == false)
+        #expect(external.toDTO().canBeRemoved)
         #expect(managed.toDTO().canBeRemoved)
     }
 }


### PR DESCRIPTION
External (manually-imported) worktrees were blocked from removal by canBeRemoved. They can now be removed from the
  sidebar and remote API, while leaving parent directories Muxy doesn't own untouched.