### PR TITLE
feat: Add Open on GitHub option to commit history context menu

### DIFF
--- a/Muxy/Views/VCS/CommitHistoryView.swift
+++ b/Muxy/Views/VCS/CommitHistoryView.swift
@@ -37,6 +37,7 @@ struct CommitHistoryView: View {
                 CommitRow(
                     commit: commit,
                     currentBranch: state.branchName,
+                    remoteWebURL: state.remoteWebURL,
                     onCheckout: { state.switchBranch($0) },
                     onCheckoutDetached: { state.checkoutDetached($0) },
                     onCherryPick: { state.cherryPick($0) },
@@ -119,6 +120,7 @@ private struct NamePrompt: Identifiable {
 private struct CommitRow: View {
     let commit: GitCommit
     let currentBranch: String?
+    let remoteWebURL: URL?
     let onCheckout: (String) -> Void
     let onCheckoutDetached: (String) -> Void
     let onCherryPick: (String) -> Void
@@ -254,6 +256,13 @@ private struct CommitRow: View {
         Button("Copy Commit Message") {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(commit.subject, forType: .string)
+        }
+
+        if let remoteWebURL {
+            Button("Open on GitHub") {
+                let url = remoteWebURL.appendingPathComponent("commit/\(commit.hash)")
+                NSWorkspace.shared.open(url)
+            }
         }
 
         Divider()


### PR DESCRIPTION
Adds an "Open on GitHub" button to the commit context menu that opens the commit page on GitHub using the repository's remote web URL.

## Testing

- [x] `All checks passed` in `./scripts/checks.sh` 
- [x] Manually tested

## Preview

<img width="1006" height="912" alt="Screenshot 2026-05-20 at 17 14 45" src="https://github.com/user-attachments/assets/e51265b0-b65d-4460-b28c-b6c142ec8f5e" />
