### PR TITLE
Check out pull requests in new worktrees

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -1211,7 +1211,7 @@ final class VCSTabState {
         }
     }
 
-    private func showStatus(_ message: String, isError: Bool) {
+    func showStatus(_ message: String, isError: Bool) {
         if isError {
             statusMessage = message
             statusIsError = true
@@ -1322,6 +1322,84 @@ final class VCSTabState {
                 showStatus(errorText(error), isError: true)
             }
         }
+    }
+
+    func createWorktreeForPullRequest(
+        _ item: GitRepositoryService.PRListItem,
+        project: Project,
+        defaultParentPath: String?
+    ) async throws -> Worktree {
+        guard checkingOutPRNumber == nil else {
+            throw PRCheckoutError.alreadyInProgress
+        }
+        checkingOutPRNumber = item.number
+        defer { checkingOutPRNumber = nil }
+
+        let localBranch = item.headBranch.isEmpty ? "pr-\(item.number)" : item.headBranch
+        let slug = Self.directorySlug(from: localBranch)
+        let worktreeDirectory = WorktreeLocationResolver.worktreeDirectory(
+            for: project,
+            slug: slug,
+            defaultParentPath: defaultParentPath
+        )
+        let parentDirectory = URL(fileURLWithPath: worktreeDirectory)
+            .deletingLastPathComponent()
+            .path
+
+        try await GitProcessRunner.offMainThrowing {
+            if FileManager.default.fileExists(atPath: worktreeDirectory) {
+                throw PRCheckoutError.worktreeExists(path: worktreeDirectory)
+            }
+            try FileManager.default.createDirectory(
+                atPath: parentDirectory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
+
+        try await git.fetchPullRequestRef(
+            repoPath: project.path,
+            number: item.number,
+            localBranch: localBranch
+        )
+
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: project.path,
+            path: worktreeDirectory,
+            branch: localBranch,
+            createBranch: false
+        )
+
+        return Worktree(
+            name: localBranch,
+            path: worktreeDirectory,
+            branch: localBranch,
+            ownsBranch: true,
+            isPrimary: false
+        )
+    }
+
+    enum PRCheckoutError: LocalizedError {
+        case alreadyInProgress
+        case worktreeExists(path: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .alreadyInProgress:
+                "Another PR checkout is already in progress."
+            case let .worktreeExists(path):
+                "A worktree already exists at \(path)."
+            }
+        }
+    }
+
+    private static func directorySlug(from name: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = name.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let collapsed = String(scalars)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+        return collapsed.isEmpty ? UUID().uuidString : collapsed
     }
 
     private func rescheduleAutoSync() {

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -1312,7 +1312,11 @@ final class VCSTabState {
             guard let self else { return }
             defer { checkingOutPRNumber = nil }
             do {
-                try await git.checkoutPullRequest(repoPath: projectPath, number: item.number)
+                try await git.checkoutPullRequest(
+                    repoPath: projectPath,
+                    number: item.number,
+                    headBranch: item.headBranch
+                )
                 guard !Task.isCancelled else { return }
                 ToastState.shared.show("Checked out PR #\(item.number)")
                 commits = []
@@ -1324,10 +1328,11 @@ final class VCSTabState {
         }
     }
 
-    func createWorktreeForPullRequest(
+    func checkoutPullRequestInNewWorktree(
         _ item: GitRepositoryService.PRListItem,
         project: Project,
-        defaultParentPath: String?
+        defaultParentPath: String?,
+        worktreeStore: WorktreeStore
     ) async throws -> Worktree {
         guard checkingOutPRNumber == nil else {
             throw PRCheckoutError.alreadyInProgress
@@ -1357,26 +1362,33 @@ final class VCSTabState {
             )
         }
 
-        try await git.fetchPullRequestRef(
-            repoPath: project.path,
-            number: item.number,
-            localBranch: localBranch
-        )
-
-        try await GitWorktreeService.shared.addWorktree(
-            repoPath: project.path,
-            path: worktreeDirectory,
-            branch: localBranch,
-            createBranch: false
-        )
-
-        return Worktree(
+        let worktree = Worktree(
             name: localBranch,
             path: worktreeDirectory,
             branch: localBranch,
             ownsBranch: true,
             isPrimary: false
         )
+        worktreeStore.add(worktree, to: project.id)
+
+        do {
+            try await git.fetchPullRequestRef(
+                repoPath: project.path,
+                number: item.number,
+                localBranch: localBranch
+            )
+            try await GitWorktreeService.shared.addWorktree(
+                repoPath: project.path,
+                path: worktreeDirectory,
+                branch: localBranch,
+                createBranch: false
+            )
+        } catch {
+            worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+            throw error
+        }
+
+        return worktree
     }
 
     enum PRCheckoutError: LocalizedError {

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -357,7 +357,7 @@ struct GitRepositoryService {
         return GitPRParser.parsePRList(result.stdout)
     }
 
-    func checkoutPullRequest(repoPath: String, number: Int) async throws {
+    func checkoutPullRequest(repoPath: String, number: Int, headBranch: String? = nil) async throws {
         guard let ghPath = GitProcessRunner.resolveExecutable("gh") else {
             throw PRCreateError.ghNotInstalled
         }
@@ -370,7 +370,8 @@ struct GitRepositoryService {
             return
         }
 
-        let localBranch = "pr-\(number)"
+        let trimmedHead = headBranch?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let localBranch = trimmedHead.isEmpty ? "pr-\(number)" : trimmedHead
         try await fetchPullRequestRef(repoPath: repoPath, number: number, localBranch: localBranch)
         let checkoutResult = try await GitProcessRunner.runGit(
             repoPath: repoPath,

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -371,19 +371,7 @@ struct GitRepositoryService {
         }
 
         let localBranch = "pr-\(number)"
-        let refspec = "refs/pull/\(number)/head:\(localBranch)"
-        let fetchResult = try await GitProcessRunner.runGit(
-            repoPath: repoPath,
-            arguments: ["fetch", "origin", refspec, "--force"]
-        )
-        if fetchResult.status != 0 {
-            let message = ghResult.stderr.isEmpty ? ghResult.stdout : ghResult.stderr
-            throw PRCreateError.commandFailed(
-                message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ? "Failed to checkout pull request."
-                    : message.trimmingCharacters(in: .whitespacesAndNewlines)
-            )
-        }
+        try await fetchPullRequestRef(repoPath: repoPath, number: number, localBranch: localBranch)
         let checkoutResult = try await GitProcessRunner.runGit(
             repoPath: repoPath,
             arguments: ["checkout", localBranch]
@@ -393,6 +381,22 @@ struct GitRepositoryService {
             throw PRCreateError.commandFailed(
                 message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ? "Failed to checkout pull request."
+                    : message.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+    }
+
+    func fetchPullRequestRef(repoPath: String, number: Int, localBranch: String) async throws {
+        let refspec = "refs/pull/\(number)/head:\(localBranch)"
+        let fetchResult = try await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["fetch", "origin", refspec, "--force"]
+        )
+        guard fetchResult.status == 0 else {
+            let message = fetchResult.stderr.isEmpty ? fetchResult.stdout : fetchResult.stderr
+            throw PRCreateError.commandFailed(
+                message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? "Failed to fetch pull request ref."
                     : message.trimmingCharacters(in: .whitespacesAndNewlines)
             )
         }

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -47,14 +47,18 @@ actor GitWorktreeService: GitWorktreeListing {
     }
 
     func isGitRepository(_ path: String) async -> Bool {
-        guard let result = try? runGit(repoPath: path, arguments: ["rev-parse", "--is-inside-work-tree"]) else {
+        guard let result = try? await GitProcessRunner.runGit(
+            repoPath: path,
+            arguments: ["rev-parse", "--is-inside-work-tree"]
+        )
+        else {
             return false
         }
         return result.status == 0 && result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true"
     }
 
     func hasUncommittedChanges(worktreePath: String) async -> Bool {
-        guard let result = try? runGit(
+        guard let result = try? await GitProcessRunner.runGit(
             repoPath: worktreePath,
             arguments: ["status", "--porcelain=1", "--untracked-files=all"]
         )
@@ -66,7 +70,10 @@ actor GitWorktreeService: GitWorktreeListing {
     }
 
     func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
-        let result = try runGit(repoPath: repoPath, arguments: ["worktree", "list", "--porcelain"])
+        let result = try await GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["worktree", "list", "--porcelain"]
+        )
         guard result.status == 0 else {
             throw GitWorktreeError.commandFailed(
                 result.stderr.isEmpty ? "Failed to list worktrees." : result.stderr
@@ -105,7 +112,7 @@ actor GitWorktreeService: GitWorktreeListing {
         } else {
             args += ["--", path, branch]
         }
-        let result = try runGit(repoPath: repoPath, arguments: args)
+        let result = try await GitProcessRunner.runGit(repoPath: repoPath, arguments: args)
         guard result.status == 0 else {
             throw GitWorktreeError.commandFailed(
                 result.stderr.isEmpty ? "Failed to add worktree." : result.stderr
@@ -117,7 +124,7 @@ actor GitWorktreeService: GitWorktreeListing {
         var args: [String] = ["worktree", "remove"]
         if force { args.append("--force") }
         args += ["--", path]
-        let result = try runGit(repoPath: repoPath, arguments: args)
+        let result = try await GitProcessRunner.runGit(repoPath: repoPath, arguments: args)
         guard result.status == 0 else {
             throw GitWorktreeError.commandFailed(
                 result.stderr.isEmpty ? "Failed to remove worktree." : result.stderr
@@ -128,7 +135,7 @@ actor GitWorktreeService: GitWorktreeListing {
     func deleteBranch(repoPath: String, branch: String, force: Bool = true) async throws {
         try Self.validateBranchName(branch)
         let args = ["branch", force ? "-D" : "-d", "--", branch]
-        let result = try runGit(repoPath: repoPath, arguments: args)
+        let result = try await GitProcessRunner.runGit(repoPath: repoPath, arguments: args)
         guard result.status == 0 else {
             throw GitWorktreeError.commandFailed(
                 result.stderr.isEmpty ? "Failed to delete branch \(branch)." : result.stderr
@@ -188,31 +195,5 @@ actor GitWorktreeService: GitWorktreeListing {
         }
         flush()
         return records
-    }
-
-    private struct GitRunResult {
-        let status: Int32
-        let stdout: String
-        let stderr: String
-    }
-
-    private func runGit(repoPath: String, arguments: [String]) throws -> GitRunResult {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["git", "-C", repoPath] + arguments
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        try process.run()
-        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
-        return GitRunResult(status: process.terminationStatus, stdout: stdout, stderr: stderr)
     }
 }

--- a/Muxy/Views/VCS/PullRequestsListView.swift
+++ b/Muxy/Views/VCS/PullRequestsListView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct PullRequestsListView: View {
     @Bindable var state: VCSTabState
     let onCheckout: (GitRepositoryService.PRListItem) -> Void
+    let onCheckoutInNewWorktree: (GitRepositoryService.PRListItem) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -112,7 +113,8 @@ struct PullRequestsListView: View {
                         PullRequestRow(
                             pr: pr,
                             isCheckingOut: state.checkingOutPRNumber == pr.number,
-                            onCheckout: { onCheckout(pr) }
+                            onCheckout: { onCheckout(pr) },
+                            onCheckoutInNewWorktree: { onCheckoutInNewWorktree(pr) }
                         )
                         Rectangle().fill(MuxyTheme.border).frame(height: 1)
                     }
@@ -165,6 +167,7 @@ struct PullRequestRow: View {
     let pr: GitRepositoryService.PRListItem
     let isCheckingOut: Bool
     let onCheckout: () -> Void
+    let onCheckoutInNewWorktree: () -> Void
 
     @State private var hovered = false
 
@@ -253,7 +256,18 @@ struct PullRequestRow: View {
     }
 
     private var checkoutButton: some View {
-        Button(action: onCheckout) {
+        Menu {
+            Button {
+                onCheckout()
+            } label: {
+                Label("Checkout here", systemImage: "arrow.down.to.line")
+            }
+            Button {
+                onCheckoutInNewWorktree()
+            } label: {
+                Label("Checkout in new worktree", systemImage: "square.stack.3d.up")
+            }
+        } label: {
             HStack(spacing: UIMetrics.scaled(3)) {
                 if isCheckingOut {
                     ProgressView().controlSize(.mini)
@@ -263,6 +277,8 @@ struct PullRequestRow: View {
                 }
                 Text("Checkout")
                     .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: UIMetrics.fontMicro, weight: .bold))
             }
             .foregroundStyle(MuxyTheme.fg)
             .padding(.horizontal, UIMetrics.spacing4)
@@ -270,7 +286,9 @@ struct PullRequestRow: View {
             .background(MuxyTheme.bg, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(MuxyTheme.border, lineWidth: 1))
         }
-        .buttonStyle(.plain)
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
         .disabled(isCheckingOut)
     }
 }

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -14,6 +14,9 @@ struct VCSTabView: View {
     @State private var showCreateBranchSheet = false
     @State private var pendingClosePR: GitRepositoryService.PRInfo?
     @State private var pendingCheckoutPR: GitRepositoryService.PRListItem?
+    @State private var pendingCheckoutPRInNewWorktree: GitRepositoryService.PRListItem?
+    @AppStorage(GeneralSettingsKeys.defaultWorktreeParentPath)
+    private var defaultWorktreeParentPath = ""
     private var commitEnabled: Bool {
         state.hasStagedChanges && !state.commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -86,6 +89,11 @@ struct VCSTabView: View {
             guard number != nil, let pr = pendingCheckoutPR else { return }
             pendingCheckoutPR = nil
             presentCheckoutPRConfirmation(pr: pr)
+        }
+        .onChange(of: pendingCheckoutPRInNewWorktree?.number) { _, number in
+            guard number != nil, let pr = pendingCheckoutPRInNewWorktree else { return }
+            pendingCheckoutPRInNewWorktree = nil
+            checkoutPRInNewWorktree(pr: pr)
         }
         .alert(
             "Error",
@@ -510,6 +518,7 @@ struct VCSTabView: View {
                     showDiscardAllConfirmation: $showDiscardAllConfirmation,
                     pendingDiscardPath: $pendingDiscardPath,
                     pendingCheckoutPR: $pendingCheckoutPR,
+                    pendingCheckoutPRInNewWorktree: $pendingCheckoutPRInNewWorktree,
                     onOpenInEditor: openFileInEditor,
                     onOpenDiff: openDiffInTab
                 )
@@ -834,6 +843,28 @@ struct VCSTabView: View {
         alert.beginSheetModal(for: window) { response in
             if response == .alertFirstButtonReturn {
                 state.checkoutPullRequest(pr)
+            }
+        }
+    }
+
+    private func checkoutPRInNewWorktree(pr: GitRepositoryService.PRListItem) {
+        guard let project = owningProject else {
+            state.showStatus("Project not found for this worktree.", isError: true)
+            return
+        }
+        let parentPath = defaultWorktreeParentPath
+        Task { @MainActor in
+            do {
+                let worktree = try await state.createWorktreeForPullRequest(
+                    pr,
+                    project: project,
+                    defaultParentPath: parentPath
+                )
+                worktreeStore.add(worktree, to: project.id)
+                appState.selectWorktree(projectID: project.id, worktree: worktree)
+                ToastState.shared.show("Checked out PR #\(pr.number) in new worktree")
+            } catch {
+                state.showStatus(error.localizedDescription, isError: true)
             }
         }
     }
@@ -1379,6 +1410,7 @@ private struct SectionSplitLayout: View {
     @Binding var showDiscardAllConfirmation: Bool
     @Binding var pendingDiscardPath: String?
     @Binding var pendingCheckoutPR: GitRepositoryService.PRListItem?
+    @Binding var pendingCheckoutPRInNewWorktree: GitRepositoryService.PRListItem?
     let onOpenInEditor: (String) -> Void
     let onOpenDiff: (String, Bool) -> Void
 
@@ -1572,7 +1604,8 @@ private struct SectionSplitLayout: View {
                 sectionHeader(for: .pullRequests, collapsed: false)
                 PullRequestsListView(
                     state: state,
-                    onCheckout: { pr in pendingCheckoutPR = pr }
+                    onCheckout: { pr in pendingCheckoutPR = pr },
+                    onCheckoutInNewWorktree: { pr in pendingCheckoutPRInNewWorktree = pr }
                 )
             }
             .frame(height: height)

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -855,12 +855,12 @@ struct VCSTabView: View {
         let parentPath = defaultWorktreeParentPath
         Task { @MainActor in
             do {
-                let worktree = try await state.createWorktreeForPullRequest(
+                let worktree = try await state.checkoutPullRequestInNewWorktree(
                     pr,
                     project: project,
-                    defaultParentPath: parentPath
+                    defaultParentPath: parentPath,
+                    worktreeStore: worktreeStore
                 )
-                worktreeStore.add(worktree, to: project.id)
                 appState.selectWorktree(projectID: project.id, worktree: worktree)
                 ToastState.shared.show("Checked out PR #\(pr.number) in new worktree")
             } catch {


### PR DESCRIPTION
- Let reviewers open a PR in an isolated worktree without disturbing the current checkout.
- Reuses PR ref fetching and switches to async git execution for worktree operations.