### PR TITLE
feat: add pane control CLI for terminal multiplexer integration

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -12,6 +12,7 @@ final class AppState {
         let areaID: UUID
         let direction: SplitDirection
         let position: SplitPosition
+        var command: String?
     }
 
     struct DiffViewerRequest {

--- a/Muxy/Models/SplitNode.swift
+++ b/Muxy/Models/SplitNode.swift
@@ -49,11 +49,12 @@ extension SplitNode {
     func splitting(
         areaID: UUID,
         direction: SplitDirection,
-        position: SplitPosition
+        position: SplitPosition,
+        command: String? = nil
     ) -> (node: SplitNode, newAreaID: UUID?) {
         switch self {
         case let .tabArea(area) where area.id == areaID:
-            let newArea = TabArea(projectPath: area.projectPath)
+            let newArea = TabArea(projectPath: area.projectPath, command: command)
             let first: SplitNode = position == .first ? .tabArea(newArea) : .tabArea(area)
             let second: SplitNode = position == .first ? .tabArea(area) : .tabArea(newArea)
             let node = SplitNode.split(SplitBranch(
@@ -68,14 +69,16 @@ extension SplitNode {
             let (newFirst, id1) = branch.first.splitting(
                 areaID: areaID,
                 direction: direction,
-                position: position
+                position: position,
+                command: command
             )
             branch.first = newFirst
             if id1 != nil { return (.split(branch), id1) }
             let (newSecond, id2) = branch.second.splitting(
                 areaID: areaID,
                 direction: direction,
-                position: position
+                position: position,
+                command: command
             )
             branch.second = newSecond
             return (.split(branch), id2)

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -17,6 +17,20 @@ final class TabArea: Identifiable {
         activeTabID = tab.id
     }
 
+    init(projectPath: String, command: String?) {
+        id = UUID()
+        self.projectPath = projectPath
+        let wrappedCommand = command.map { "(\($0)); exec \"$0\" -l" }
+        let pane = TerminalPaneState(
+            projectPath: projectPath,
+            startupCommand: wrappedCommand,
+            startupCommandInteractive: wrappedCommand != nil
+        )
+        let tab = TerminalTab(pane: pane)
+        tabs.append(tab)
+        activeTabID = tab.id
+    }
+
     init(projectPath: String, existingTab tab: TerminalTab) {
         id = UUID()
         self.projectPath = projectPath

--- a/Muxy/Models/WorkspaceReducer/SplitReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/SplitReducer.swift
@@ -9,7 +9,8 @@ enum SplitReducer {
         let (newRoot, newAreaID) = root.splitting(
             areaID: request.areaID,
             direction: request.direction,
-            position: request.position
+            position: request.position,
+            command: request.command
         )
         state.workspaceRoots[key] = newRoot
         guard let newAreaID else { return }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -77,6 +77,19 @@ struct MuxyApp: App {
                             appDelegate.handleOpenProjectPath(path)
                         }
                     }
+                    NotificationSocketServer.shared.splitActionHandler = { [appState, projectStore, worktreeStore] direction, command in
+                        Task { @MainActor in
+                            guard let projectID = appState.activeProjectID else { return }
+                            guard let area = appState.focusedArea(for: projectID) else { return }
+                            appState.dispatch(.splitArea(.init(
+                                projectID: projectID,
+                                areaID: area.id,
+                                direction: direction,
+                                position: .second,
+                                command: command
+                            )))
+                        }
+                    }
                     MobileServerService.shared.configure { server in
                         let delegate = RemoteServerDelegate(
                             appState: appState,

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -90,6 +90,9 @@ struct MuxyApp: App {
                             )))
                         }
                     }
+                    NotificationSocketServer.shared.jsonRequestHandler = { [appState] requestData in
+                        await SocketCommandHandler.handleRequest(requestData, appState: appState)
+                    }
                     MobileServerService.shared.configure { server in
                         let delegate = RemoteServerDelegate(
                             appState: appState,

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -1,17 +1,23 @@
 #!/bin/bash
 # Muxy CLI wrapper
 # Usage:
-#   muxy <path>              - Open a folder in Muxy
-#   muxy split-right [cmd]   - Split the focused pane horizontally, optionally run a command
-#   muxy split-down [cmd]    - Split the focused pane vertically, optionally run a command
+#   muxy <path>                        - Open a folder in Muxy
+#   muxy split-right [cmd]             - Split horizontally, optionally run a command (returns pane ID)
+#   muxy split-down [cmd]              - Split vertically, optionally run a command (returns pane ID)
+#   muxy send --pane <id> <text>       - Send text to a pane (use \n for newline)
+#   muxy send-keys --pane <id> <key>   - Send special key (Escape, Enter, Tab, Ctrl+C, etc.)
+#   muxy read-screen --pane <id> [--lines N] - Read terminal content
+#   muxy close-pane --pane <id>        - Close a pane
+#   muxy rename-pane --pane <id> <title> - Rename a pane tab
+#   muxy list-panes [--json]           - List all panes
 
 COMMAND="$1"
+SOCKET="$HOME/Library/Application Support/Muxy/muxy.sock"
 
 send_socket_message() {
     local message="$1"
-    local socket="$HOME/Library/Application Support/Muxy/muxy.sock"
-    if [ ! -e "$socket" ]; then
-        echo "Error: Muxy is not running"
+    if [ ! -e "$SOCKET" ]; then
+        echo "Error: Muxy is not running" >&2
         exit 1
     fi
     python3 -c "
@@ -21,33 +27,180 @@ s.connect(sys.argv[1])
 s.sendall((sys.argv[2] + '\\n').encode())
 s.shutdown(socket.SHUT_WR)
 s.close()
-" "$socket" "$message" 2>/dev/null
+" "$SOCKET" "$message" 2>/dev/null
+}
+
+send_json_request() {
+    local json="$1"
+    if [ ! -e "$SOCKET" ]; then
+        echo "Error: Muxy is not running" >&2
+        exit 1
+    fi
+    python3 -c "
+import socket, sys, json
+
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(sys.argv[1])
+s.sendall(sys.argv[2].encode())
+s.shutdown(socket.SHUT_WR)
+
+response = b''
+while True:
+    chunk = s.recv(4096)
+    if not chunk:
+        break
+    response += chunk
+s.close()
+
+if not response:
+    print(json.dumps({'ok': False, 'error': 'No response from Muxy'}))
+    sys.exit(1)
+
+try:
+    data = json.loads(response)
+    if not data.get('ok', False):
+        print(data.get('error', 'Unknown error'), file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(data))
+except json.JSONDecodeError:
+    print('Error: Invalid response from Muxy', file=sys.stderr)
+    sys.exit(1)
+" "$SOCKET" "$json" 2>/dev/null
 }
 
 case "$COMMAND" in
     split-right)
-        if [ -n "$2" ]; then
-            shift
-            send_socket_message "split-right|$*"
+        shift
+        if [ -n "$1" ]; then
+            CMD_ESCAPED=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$*")
+            RESP=$(send_json_request "{\"cmd\":\"split\",\"direction\":\"right\",\"command\":$CMD_ESCAPED}")
         else
-            send_socket_message "split-right"
+            RESP=$(send_json_request '{"cmd":"split","direction":"right"}')
         fi
+        echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('paneID',''))" 2>/dev/null
         exit 0
         ;;
     split-down)
-        if [ -n "$2" ]; then
-            shift
-            send_socket_message "split-down|$*"
+        shift
+        if [ -n "$1" ]; then
+            CMD_ESCAPED=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$*")
+            RESP=$(send_json_request "{\"cmd\":\"split\",\"direction\":\"down\",\"command\":$CMD_ESCAPED}")
         else
-            send_socket_message "split-down"
+            RESP=$(send_json_request '{"cmd":"split","direction":"down"}')
+        fi
+        echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('paneID',''))" 2>/dev/null
+        exit 0
+        ;;
+    send)
+        shift
+        PANE_ID=""
+        TEXT=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) TEXT="$1"; shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ] || [ -z "$TEXT" ]; then
+            echo "Usage: muxy send --pane <id> <text>" >&2
+            exit 1
+        fi
+        TEXT_ESCAPED=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$TEXT")
+        send_json_request "{\"cmd\":\"send\",\"pane\":\"$PANE_ID\",\"text\":$TEXT_ESCAPED}" > /dev/null
+        exit 0
+        ;;
+    send-keys)
+        shift
+        PANE_ID=""
+        KEY=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) KEY="$1"; shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ] || [ -z "$KEY" ]; then
+            echo "Usage: muxy send-keys --pane <id> <key>" >&2
+            exit 1
+        fi
+        KEY_ESCAPED=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$KEY")
+        send_json_request "{\"cmd\":\"send-keys\",\"pane\":\"$PANE_ID\",\"key\":$KEY_ESCAPED}" > /dev/null
+        exit 0
+        ;;
+    read-screen)
+        shift
+        PANE_ID=""
+        LINES=50
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                --lines) LINES="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ]; then
+            echo "Usage: muxy read-screen --pane <id> [--lines N]" >&2
+            exit 1
+        fi
+        RESP=$(send_json_request "{\"cmd\":\"read-screen\",\"pane\":\"$PANE_ID\",\"lines\":$LINES}")
+        echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('content',''))" 2>/dev/null
+        exit 0
+        ;;
+    close-pane)
+        shift
+        PANE_ID=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ]; then
+            echo "Usage: muxy close-pane --pane <id>" >&2
+            exit 1
+        fi
+        send_json_request "{\"cmd\":\"close-pane\",\"pane\":\"$PANE_ID\"}" > /dev/null
+        exit 0
+        ;;
+    rename-pane)
+        shift
+        PANE_ID=""
+        TITLE=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) TITLE="$1"; shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ] || [ -z "$TITLE" ]; then
+            echo "Usage: muxy rename-pane --pane <id> <title>" >&2
+            exit 1
+        fi
+        TITLE_ESCAPED=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$TITLE")
+        send_json_request "{\"cmd\":\"rename-pane\",\"pane\":\"$PANE_ID\",\"title\":$TITLE_ESCAPED}" > /dev/null
+        exit 0
+        ;;
+    list-panes)
+        shift
+        RESP=$(send_json_request '{"cmd":"list-panes"}')
+        if [ "$1" = "--json" ] || [ "${PREV_ARG:-}" = "--json" ]; then
+            echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('panes',[]),indent=2))" 2>/dev/null
+        else
+            echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('panes',[]),indent=2))" 2>/dev/null
         fi
         exit 0
         ;;
     ""|--help|-h)
         echo "Usage:"
-        echo "  muxy <path>              Open a folder in Muxy (e.g. muxy .)"
-        echo "  muxy split-right [cmd]   Split the focused pane horizontally, optionally run a command"
-        echo "  muxy split-down [cmd]    Split the focused pane vertically, optionally run a command"
+        echo "  muxy <path>                        Open a folder in Muxy"
+        echo "  muxy split-right [cmd]             Split horizontally (returns pane ID)"
+        echo "  muxy split-down [cmd]              Split vertically (returns pane ID)"
+        echo "  muxy send --pane <id> <text>       Send text to a pane"
+        echo "  muxy send-keys --pane <id> <key>   Send special key (Escape, Enter, Tab, Ctrl+C)"
+        echo "  muxy read-screen --pane <id> [--lines N]  Read terminal content"
+        echo "  muxy close-pane --pane <id>        Close a pane"
+        echo "  muxy rename-pane --pane <id> <title>  Rename a pane tab"
+        echo "  muxy list-panes [--json]           List all panes"
         exit 1
         ;;
 esac
@@ -81,7 +234,6 @@ ENCODED_PATH="$(percent_encode "$TARGET_DIR")"
 open "muxy://open?path=${ENCODED_PATH}" 2>/dev/null \
     || open -b com.muxy.app "$TARGET_DIR" 2>/dev/null \
     || {
-        SOCKET="$HOME/Library/Application Support/Muxy/muxy.sock"
         if [ -e "$SOCKET" ]; then
             printf 'open-project|%s\n' "$TARGET_DIR" | nc -U "$SOCKET" 2>/dev/null
         fi

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -1,14 +1,58 @@
 #!/bin/bash
-# Muxy CLI wrapper - Usage: muxy /path/to/project
-# Opens a folder in Muxy app
+# Muxy CLI wrapper
+# Usage:
+#   muxy <path>              - Open a folder in Muxy
+#   muxy split-right [cmd]   - Split the focused pane horizontally, optionally run a command
+#   muxy split-down [cmd]    - Split the focused pane vertically, optionally run a command
 
-TARGET_DIR="$1"
+COMMAND="$1"
 
-if [ -z "$TARGET_DIR" ]; then
-    echo "Usage: muxy <path>"
-    echo "       muxy ."
-    exit 1
-fi
+send_socket_message() {
+    local message="$1"
+    local socket="$HOME/Library/Application Support/Muxy/muxy.sock"
+    if [ ! -e "$socket" ]; then
+        echo "Error: Muxy is not running"
+        exit 1
+    fi
+    python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(sys.argv[1])
+s.sendall((sys.argv[2] + '\\n').encode())
+s.shutdown(socket.SHUT_WR)
+s.close()
+" "$socket" "$message" 2>/dev/null
+}
+
+case "$COMMAND" in
+    split-right)
+        if [ -n "$2" ]; then
+            shift
+            send_socket_message "split-right|$*"
+        else
+            send_socket_message "split-right"
+        fi
+        exit 0
+        ;;
+    split-down)
+        if [ -n "$2" ]; then
+            shift
+            send_socket_message "split-down|$*"
+        else
+            send_socket_message "split-down"
+        fi
+        exit 0
+        ;;
+    ""|--help|-h)
+        echo "Usage:"
+        echo "  muxy <path>              Open a folder in Muxy (e.g. muxy .)"
+        echo "  muxy split-right [cmd]   Split the focused pane horizontally, optionally run a command"
+        echo "  muxy split-down [cmd]    Split the focused pane vertically, optionally run a command"
+        exit 1
+        ;;
+esac
+
+TARGET_DIR="$COMMAND"
 
 case "$TARGET_DIR" in
     ~*) TARGET_DIR="${HOME}${TARGET_DIR:1}" ;;

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -10,6 +10,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "app.muxy.notificationSocket")
     var openProjectHandler: (@Sendable (String) -> Void)?
+    var splitActionHandler: (@Sendable (SplitDirection, String?) -> Void)?
 
     static var socketPath: String {
         MuxyFileStorage.appSupportDirectory()
@@ -133,6 +134,20 @@ final class NotificationSocketServer: @unchecked Sendable {
             }
             logger.info("Received open-project request via socket")
             openProjectHandler?(path)
+            return
+        }
+
+        if message == "split-right" || message.hasPrefix("split-right|") {
+            let command = message.hasPrefix("split-right|") ? String(message.dropFirst("split-right|".count)) : nil
+            logger.info("Received split-right request via socket")
+            splitActionHandler?(.horizontal, command)
+            return
+        }
+
+        if message == "split-down" || message.hasPrefix("split-down|") {
+            let command = message.hasPrefix("split-down|") ? String(message.dropFirst("split-down|".count)) : nil
+            logger.info("Received split-down request via socket")
+            splitActionHandler?(.vertical, command)
             return
         }
 

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -11,6 +11,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private let queue = DispatchQueue(label: "app.muxy.notificationSocket")
     var openProjectHandler: (@Sendable (String) -> Void)?
     var splitActionHandler: (@Sendable (SplitDirection, String?) -> Void)?
+    var jsonRequestHandler: (@Sendable (Data) async -> Data)?
 
     static var socketPath: String {
         MuxyFileStorage.appSupportDirectory()
@@ -114,9 +115,49 @@ final class NotificationSocketServer: @unchecked Sendable {
 
         guard !data.isEmpty else { return }
 
+        let trimmed = data.trimmingWhitespace()
+        if trimmed.first == UInt8(ascii: "{") {
+            let response = processJSONRequest(trimmed)
+            writeResponse(fd: fd, data: response)
+            return
+        }
+
         for line in data.split(separator: UInt8(ascii: "\n")) {
             processMessage(Data(line))
         }
+    }
+
+    private func processJSONRequest(_ data: Data) -> Data {
+        guard let handler = jsonRequestHandler else {
+            return Self.jsonResponse(["ok": false, "error": "No handler registered"])
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var responseData = Self.jsonResponse(["ok": false, "error": "Timeout"])
+
+        Task { @Sendable in
+            responseData = await handler(data)
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return responseData
+    }
+
+    private func writeResponse(fd: Int32, data: Data) {
+        data.withUnsafeBytes { buffer in
+            guard let ptr = buffer.baseAddress else { return }
+            var offset = 0
+            while offset < buffer.count {
+                let written = Darwin.write(fd, ptr.advanced(by: offset), buffer.count - offset)
+                if written <= 0 { break }
+                offset += written
+            }
+        }
+    }
+
+    static func jsonResponse(_ dict: [String: Any]) -> Data {
+        (try? JSONSerialization.data(withJSONObject: dict)) ?? Data("{\"ok\":false}".utf8)
     }
 
     private func processMessage(_ data: Data) {
@@ -227,5 +268,20 @@ final class NotificationSocketServer: @unchecked Sendable {
     private func cleanup() {
         acceptSource?.cancel()
         acceptSource = nil
+    }
+}
+
+private extension Data {
+    func trimmingWhitespace() -> Data {
+        var start = startIndex
+        var end = endIndex
+        let whitespace: Set<UInt8> = [0x20, 0x09, 0x0A, 0x0D]
+        while start < end, whitespace.contains(self[start]) {
+            start += 1
+        }
+        while end > start, whitespace.contains(self[end - 1]) {
+            end -= 1
+        }
+        return subdata(in: start ..< end)
     }
 }

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -1,0 +1,248 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "SocketCommandHandler")
+
+@MainActor
+enum SocketCommandHandler {
+    static func handleRequest(_ data: Data, appState: AppState) async -> Data {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let cmd = json["cmd"] as? String
+        else {
+            return NotificationSocketServer.jsonResponse(["ok": false, "error": "Invalid JSON request"])
+        }
+        let result = handle(cmd: cmd, params: json, appState: appState)
+        return NotificationSocketServer.jsonResponse(result)
+    }
+
+    static func handle(
+        cmd: String,
+        params: [String: Any],
+        appState: AppState
+    ) -> [String: Any] {
+        switch cmd {
+        case "split":
+            handleSplit(params: params, appState: appState)
+        case "send":
+            handleSend(params: params)
+        case "send-keys":
+            handleSendKeys(params: params)
+        case "read-screen":
+            handleReadScreen(params: params)
+        case "close-pane":
+            handleClosePane(params: params, appState: appState)
+        case "rename-pane":
+            handleRenamePane(params: params, appState: appState)
+        case "list-panes":
+            handleListPanes(appState: appState)
+        default:
+            ["ok": false, "error": "Unknown command: \(cmd)"]
+        }
+    }
+
+    private static func handleSplit(params: [String: Any], appState: AppState) -> [String: Any] {
+        guard let projectID = appState.activeProjectID else {
+            return ["ok": false, "error": "No active project"]
+        }
+        guard let area = appState.focusedArea(for: projectID) else {
+            return ["ok": false, "error": "No focused area"]
+        }
+
+        let directionStr = params["direction"] as? String ?? "right"
+        let direction: SplitDirection = directionStr == "down" ? .vertical : .horizontal
+        let command = params["command"] as? String
+
+        let existingPaneIDs = collectAllPaneIDs(appState: appState)
+
+        appState.dispatch(.splitArea(.init(
+            projectID: projectID,
+            areaID: area.id,
+            direction: direction,
+            position: .second,
+            command: command
+        )))
+
+        let newPaneIDs = collectAllPaneIDs(appState: appState)
+        let added = newPaneIDs.subtracting(existingPaneIDs)
+
+        guard let newPaneID = added.first else {
+            return ["ok": false, "error": "Split succeeded but could not determine new pane ID"]
+        }
+
+        return ["ok": true, "paneID": newPaneID.uuidString]
+    }
+
+    private static func handleSend(params: [String: Any]) -> [String: Any] {
+        guard let paneIDStr = params["pane"] as? String,
+              let paneID = UUID(uuidString: paneIDStr)
+        else {
+            return ["ok": false, "error": "Invalid or missing pane ID"]
+        }
+        guard let text = params["text"] as? String else {
+            return ["ok": false, "error": "Missing text parameter"]
+        }
+        guard let view = TerminalViewRegistry.shared.existingView(for: paneID) else {
+            return ["ok": false, "error": "Pane not found: \(paneIDStr)"]
+        }
+
+        let parts = text.components(separatedBy: "\n")
+        for (index, part) in parts.enumerated() {
+            if !part.isEmpty {
+                view.sendText(part)
+            }
+            if index < parts.count - 1 {
+                view.sendRemoteBytes(Data([0x0D]))
+            }
+        }
+        return ["ok": true]
+    }
+
+    private static func handleSendKeys(params: [String: Any]) -> [String: Any] {
+        guard let paneIDStr = params["pane"] as? String,
+              let paneID = UUID(uuidString: paneIDStr)
+        else {
+            return ["ok": false, "error": "Invalid or missing pane ID"]
+        }
+        guard let key = params["key"] as? String else {
+            return ["ok": false, "error": "Missing key parameter"]
+        }
+        guard let view = TerminalViewRegistry.shared.existingView(for: paneID) else {
+            return ["ok": false, "error": "Pane not found: \(paneIDStr)"]
+        }
+
+        let bytes: Data
+        switch key.lowercased() {
+        case "escape",
+             "esc":
+            bytes = Data([0x1B])
+        case "enter",
+             "return":
+            bytes = Data([0x0D])
+        case "tab":
+            bytes = Data([0x09])
+        case "ctrl+c",
+             "ctrl-c":
+            bytes = Data([0x03])
+        case "ctrl+d",
+             "ctrl-d":
+            bytes = Data([0x04])
+        case "ctrl+z",
+             "ctrl-z":
+            bytes = Data([0x1A])
+        case "backspace":
+            bytes = Data([0x7F])
+        default:
+            return ["ok": false, "error": "Unsupported key: \(key)"]
+        }
+
+        view.sendRemoteBytes(bytes)
+        return ["ok": true]
+    }
+
+    private static func handleReadScreen(params: [String: Any]) -> [String: Any] {
+        guard let paneIDStr = params["pane"] as? String,
+              let paneID = UUID(uuidString: paneIDStr)
+        else {
+            return ["ok": false, "error": "Invalid or missing pane ID"]
+        }
+        let lines = params["lines"] as? Int ?? 50
+        let clampedLines = min(max(lines, 1), 500)
+
+        guard let view = TerminalViewRegistry.shared.existingView(for: paneID) else {
+            return ["ok": false, "error": "Pane not found: \(paneIDStr)"]
+        }
+
+        let content = view.readScreenText(lastLines: clampedLines)
+        return ["ok": true, "content": content]
+    }
+
+    private static func handleClosePane(params: [String: Any], appState: AppState) -> [String: Any] {
+        guard let paneIDStr = params["pane"] as? String,
+              let paneID = UUID(uuidString: paneIDStr)
+        else {
+            return ["ok": false, "error": "Invalid or missing pane ID"]
+        }
+
+        guard let loc = locateTab(paneID: paneID, appState: appState) else {
+            return ["ok": false, "error": "Pane not found: \(paneIDStr)"]
+        }
+
+        appState.dispatch(.closeTab(projectID: loc.key.projectID, areaID: loc.areaID, tabID: loc.tabID))
+        return ["ok": true]
+    }
+
+    private static func handleRenamePane(params: [String: Any], appState: AppState) -> [String: Any] {
+        guard let paneIDStr = params["pane"] as? String,
+              let paneID = UUID(uuidString: paneIDStr)
+        else {
+            return ["ok": false, "error": "Invalid or missing pane ID"]
+        }
+        guard let title = params["title"] as? String else {
+            return ["ok": false, "error": "Missing title parameter"]
+        }
+
+        guard let loc = locateTab(paneID: paneID, appState: appState) else {
+            return ["ok": false, "error": "Pane not found: \(paneIDStr)"]
+        }
+
+        for (_, root) in appState.workspaceRoots {
+            guard let area = root.findArea(id: loc.areaID) else { continue }
+            area.setCustomTitle(loc.tabID, title: title)
+            return ["ok": true]
+        }
+
+        return ["ok": false, "error": "Could not rename pane"]
+    }
+
+    private static func handleListPanes(appState: AppState) -> [String: Any] {
+        var panes: [[String: Any]] = []
+        for (key, root) in appState.workspaceRoots {
+            let focusedAreaID = appState.focusedAreaID(for: key.projectID)
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    guard let pane = tab.content.pane else { continue }
+                    let isFocused = area.id == focusedAreaID && tab.id == area.activeTabID
+                    panes.append([
+                        "id": pane.id.uuidString,
+                        "title": tab.customTitle ?? pane.title,
+                        "cwd": pane.currentWorkingDirectory ?? pane.projectPath,
+                        "projectID": key.projectID.uuidString,
+                        "focused": isFocused,
+                    ])
+                }
+            }
+        }
+        return ["ok": true, "panes": panes]
+    }
+
+    private static func collectAllPaneIDs(appState: AppState) -> Set<UUID> {
+        var ids = Set<UUID>()
+        for (_, root) in appState.workspaceRoots {
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    if let pane = tab.content.pane {
+                        ids.insert(pane.id)
+                    }
+                }
+            }
+        }
+        return ids
+    }
+
+    private struct PaneLocation {
+        let key: WorktreeKey
+        let areaID: UUID
+        let tabID: UUID
+    }
+
+    private static func locateTab(paneID: UUID, appState: AppState) -> PaneLocation? {
+        for (key, root) in appState.workspaceRoots {
+            for area in root.allAreas() {
+                for tab in area.tabs where tab.content.pane?.id == paneID {
+                    return PaneLocation(key: key, areaID: area.id, tabID: tab.id)
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1040,6 +1040,42 @@ final class GhosttyTerminalNSView: NSView {
         }
     }
 
+    func readScreenText(lastLines: Int = 50) -> String {
+        guard let surface else { return "" }
+        var out = ghostty_cells_s()
+        guard ghostty_surface_read_cells(surface, &out) else { return "" }
+        defer { ghostty_surface_free_cells(surface, &out) }
+
+        let cols = Int(out.cols)
+        let rows = Int(out.rows)
+        guard cols > 0, rows > 0, let cells = out.cells else { return "" }
+
+        var lines: [String] = []
+        for row in 0 ..< rows {
+            var line = ""
+            for col in 0 ..< cols {
+                let cell = cells[row * cols + col]
+                let cp = cell.codepoint
+                if cp == 0 {
+                    line.append(" ")
+                } else if let scalar = Unicode.Scalar(cp) {
+                    line.append(Character(scalar))
+                } else {
+                    line.append(" ")
+                }
+            }
+            lines.append(line)
+        }
+
+        while lines.last?.allSatisfy({ $0 == " " }) == true {
+            lines.removeLast()
+        }
+
+        let trimmed = lines.map { $0.replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression) }
+        let result = trimmed.suffix(lastLines)
+        return result.joined(separator: "\n")
+    }
+
     func submitRichInput(text: String) {
         guard !text.isEmpty else { return }
         let sanitized = text.replacingOccurrences(of: "\u{1B}[201~", with: "")

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("SocketCommandHandler")
+@MainActor
+struct SocketCommandHandlerTests {
+    private let testPath = "/tmp/test"
+
+    @Test("unknown command returns error")
+    func unknownCommand() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(cmd: "bogus", params: [:], appState: appState)
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Unknown command") == true)
+    }
+
+    @Test("split returns new pane ID")
+    func splitReturnsNewPaneID() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+
+        let result = SocketCommandHandler.handle(
+            cmd: "split",
+            params: ["direction": "right"],
+            appState: appState
+        )
+
+        #expect(result["ok"] as? Bool == true)
+        let paneIDStr = result["paneID"] as? String
+        #expect(paneIDStr != nil)
+        #expect(UUID(uuidString: paneIDStr!) != nil)
+    }
+
+    @Test("split down returns new pane ID")
+    func splitDownReturnsNewPaneID() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+
+        let result = SocketCommandHandler.handle(
+            cmd: "split",
+            params: ["direction": "down"],
+            appState: appState
+        )
+
+        #expect(result["ok"] as? Bool == true)
+        #expect(result["paneID"] as? String != nil)
+    }
+
+    @Test("split fails without active project")
+    func splitFailsWithoutActiveProject() {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+
+        let result = SocketCommandHandler.handle(
+            cmd: "split",
+            params: ["direction": "right"],
+            appState: appState
+        )
+
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("No active project") == true)
+    }
+
+    @Test("send fails with missing pane ID")
+    func sendFailsMissingPaneID() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "send",
+            params: ["text": "hello"],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("pane ID") == true)
+    }
+
+    @Test("send fails with invalid pane ID")
+    func sendFailsInvalidPaneID() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "send",
+            params: ["pane": "not-a-uuid", "text": "hello"],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+    }
+
+    @Test("send fails with nonexistent pane")
+    func sendFailsNonexistentPane() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "send",
+            params: ["pane": UUID().uuidString, "text": "hello"],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Pane not found") == true)
+    }
+
+    @Test("send fails with missing text")
+    func sendFailsMissingText() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "send",
+            params: ["pane": UUID().uuidString],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Missing text") == true)
+    }
+
+    @Test("send-keys fails with unsupported key")
+    func sendKeysFailsUnsupportedKey() {
+        let appState = makeAppState()
+        let paneID = UUID()
+        let result = SocketCommandHandler.handle(
+            cmd: "send-keys",
+            params: ["pane": paneID.uuidString, "key": "F13"],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+    }
+
+    @Test("send-keys fails with missing key")
+    func sendKeysFailsMissingKey() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "send-keys",
+            params: ["pane": UUID().uuidString],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Missing key") == true)
+    }
+
+    @Test("read-screen fails with nonexistent pane")
+    func readScreenFailsNonexistentPane() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "read-screen",
+            params: ["pane": UUID().uuidString],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Pane not found") == true)
+    }
+
+    @Test("close-pane fails with nonexistent pane")
+    func closePaneFailsNonexistentPane() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "close-pane",
+            params: ["pane": UUID().uuidString],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Pane not found") == true)
+    }
+
+    @Test("close-pane fails with missing pane ID")
+    func closePaneFailsMissingPaneID() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "close-pane",
+            params: [:],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("pane ID") == true)
+    }
+
+    @Test("rename-pane fails with nonexistent pane")
+    func renamePaneFailsNonexistentPane() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "rename-pane",
+            params: ["pane": UUID().uuidString, "title": "Test"],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Pane not found") == true)
+    }
+
+    @Test("rename-pane fails with missing title")
+    func renamePaneFailsMissingTitle() {
+        let appState = makeAppState()
+        let result = SocketCommandHandler.handle(
+            cmd: "rename-pane",
+            params: ["pane": UUID().uuidString],
+            appState: appState
+        )
+        #expect(result["ok"] as? Bool == false)
+        #expect((result["error"] as? String)?.contains("Missing title") == true)
+    }
+
+    @Test("list-panes returns empty array when no panes")
+    func listPanesEmpty() {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+
+        let result = SocketCommandHandler.handle(
+            cmd: "list-panes",
+            params: [:],
+            appState: appState
+        )
+
+        #expect(result["ok"] as? Bool == true)
+        let panes = result["panes"] as? [[String: Any]]
+        #expect(panes != nil)
+        #expect(panes?.isEmpty == true)
+    }
+
+    @Test("list-panes returns panes from workspace")
+    func listPanesReturnsWorkspacePanes() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = makeAppState(projectID: projectID, worktreeID: worktreeID)
+
+        let result = SocketCommandHandler.handle(
+            cmd: "list-panes",
+            params: [:],
+            appState: appState
+        )
+
+        #expect(result["ok"] as? Bool == true)
+        let panes = result["panes"] as? [[String: Any]]
+        #expect(panes != nil)
+        #expect(panes!.count >= 1)
+
+        let firstPane = panes!.first!
+        #expect(firstPane["id"] as? String != nil)
+        #expect(firstPane["projectID"] as? String == projectID.uuidString)
+    }
+
+    @Test("handleRequest parses valid JSON")
+    func handleRequestParsesValidJSON() async {
+        let appState = makeAppState()
+        let json = "{\"cmd\":\"list-panes\"}"
+        let data = Data(json.utf8)
+
+        let response = await SocketCommandHandler.handleRequest(data, appState: appState)
+        let parsed = try? JSONSerialization.jsonObject(with: response) as? [String: Any]
+
+        #expect(parsed != nil)
+        #expect(parsed?["ok"] as? Bool == true)
+    }
+
+    @Test("handleRequest returns error for invalid JSON")
+    func handleRequestReturnsErrorForInvalidJSON() async {
+        let appState = makeAppState()
+        let data = Data("not json".utf8)
+
+        let response = await SocketCommandHandler.handleRequest(data, appState: appState)
+        let parsed = try? JSONSerialization.jsonObject(with: response) as? [String: Any]
+
+        #expect(parsed != nil)
+        #expect(parsed?["ok"] as? Bool == false)
+        #expect((parsed?["error"] as? String)?.contains("Invalid JSON") == true)
+    }
+
+    @Test("handleRequest returns error for missing cmd")
+    func handleRequestReturnsErrorForMissingCmd() async {
+        let appState = makeAppState()
+        let json = "{\"foo\":\"bar\"}"
+        let data = Data(json.utf8)
+
+        let response = await SocketCommandHandler.handleRequest(data, appState: appState)
+        let parsed = try? JSONSerialization.jsonObject(with: response) as? [String: Any]
+
+        #expect(parsed != nil)
+        #expect(parsed?["ok"] as? Bool == false)
+    }
+
+    private func makeAppState(
+        projectID: UUID = UUID(),
+        worktreeID: UUID = UUID()
+    ) -> AppState {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: testPath)
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        return appState
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}


### PR DESCRIPTION
Add CLI commands for programmatic pane control, enabling terminal multiplexer plugins to manage panes by UUID.

**Changes:**
- Extend socket protocol with JSON request-response mode (backward compatible)
- Add split-right/down with optional startup command
- Add send, send-keys, read-screen, close-pane, rename-pane, list-panes commands
- Replace nc with python3 for CLI socket communication
- Add 20 unit tests for SocketCommandHandler