### PR TITLE
Fix Git panel flicker on non-git projects

### DIFF
--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -308,7 +308,6 @@ final class VCSTabState {
         }
         isRefreshing = true
         pendingRefresh = false
-        errorMessage = nil
 
         let refreshSignpost = GitSignpost.begin("performRefresh", incremental ? "incremental" : "full")
 
@@ -413,6 +412,9 @@ final class VCSTabState {
                 let listChanged = files.map(\.path) != newFiles.map(\.path) || !changedPaths.isEmpty
                 if listChanged {
                     files = newFiles
+                }
+                if errorMessage != nil {
+                    errorMessage = nil
                 }
                 isLoadingFiles = false
                 hasCompletedInitialLoad = true


### PR DESCRIPTION
## Summary
Opening the Git panel on a non-git folder made it flicker between the "not a git repository" message and a blank git UI. `performRefresh` cleared `errorMessage` synchronously but only restored it after the async git lookup failed, so every file-system event briefly rendered the full git UI. `errorMessage` is now cleared only when a refresh completes successfully.

Closes #506

## Testing
`scripts/checks.sh` passes — formatting, linting, build, and the full test suite. Verified manually on a non-git folder: the Git panel stays on the error message instead of flickering.

## Screenshots / Recording
Before: the panel flickers between the error message and an empty git UI on a non-git folder.
After: the panel stays on the "not a git repository" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)