### PR TITLE
Fix Ghostty terminal focus crash

### DIFF
--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 
 final class GhosttyTerminalNSView: NSView {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
+    private var surfaceFocused: Bool?
     private let workingDirectory: String
     private let command: String?
     private let commandInteractive: Bool
@@ -163,7 +164,7 @@ final class GhosttyTerminalNSView: NSView {
             ghostty_surface_set_display_id(surface, displayID)
         }
 
-        ghostty_surface_set_focus(surface, isFocused)
+        syncSurfaceFocus()
 
         if let paneID = TerminalViewRegistry.shared.paneID(for: self) {
             RemoteTerminalStreamer.shared.attach(paneID: paneID, surface: surface)
@@ -180,6 +181,7 @@ final class GhosttyTerminalNSView: NSView {
             ghostty_surface_free(surface)
         }
         surface = nil
+        surfaceFocused = nil
     }
 
     func tearDown() {
@@ -377,13 +379,25 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     func notifySurfaceFocused() {
-        guard let surface else { return }
-        ghostty_surface_set_focus(surface, true)
+        setSurfaceFocused(true)
     }
 
     func notifySurfaceUnfocused() {
-        guard let surface else { return }
-        ghostty_surface_set_focus(surface, false)
+        setSurfaceFocused(false)
+    }
+
+    private func syncSurfaceFocus() {
+        setSurfaceFocused(!overlayActive && (window?.firstResponder === self || window?.firstResponder === inputContext))
+    }
+
+    private func setSurfaceFocused(_ focused: Bool) {
+        guard let surface else {
+            surfaceFocused = nil
+            return
+        }
+        guard surfaceFocused != focused else { return }
+        ghostty_surface_set_focus(surface, focused)
+        surfaceFocused = focused
     }
 
     override var acceptsFirstResponder: Bool { !overlayActive }
@@ -391,9 +405,7 @@ final class GhosttyTerminalNSView: NSView {
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         if result {
-            if let surface {
-                ghostty_surface_set_focus(surface, true)
-            }
+            setSurfaceFocused(true)
             if !isFocused {
                 DispatchQueue.main.async { [weak self] in
                     self?.onFocus?()
@@ -405,8 +417,8 @@ final class GhosttyTerminalNSView: NSView {
 
     override func resignFirstResponder() -> Bool {
         let result = super.resignFirstResponder()
-        if result, let surface {
-            ghostty_surface_set_focus(surface, false)
+        if result {
+            setSurfaceFocused(false)
         }
         return result
     }
@@ -575,7 +587,7 @@ final class GhosttyTerminalNSView: NSView {
         let alreadyFirstResponder = window?.firstResponder === self
         window?.makeFirstResponder(self)
         if alreadyFirstResponder {
-            ghostty_surface_set_focus(surface, true)
+            setSurfaceFocused(true)
             DispatchQueue.main.async { [weak self] in
                 self?.onFocus?()
             }
@@ -1231,7 +1243,6 @@ extension GhosttyTerminalNSView {
                 NSApp.activate()
                 self.window?.makeKeyAndOrderFront(nil)
                 self.window?.makeFirstResponder(self)
-                self.notifySurfaceFocused()
                 self.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
             }
         }

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -24,7 +24,7 @@ struct TerminalPane: View {
             .onReceive(NotificationCenter.default.publisher(for: .refocusActiveTerminal)) { _ in
                 guard focused, visible else { return }
                 let view = TerminalViewRegistry.shared.existingView(for: state.id)
-                DispatchQueue.main.async {
+                DispatchQueue.main.async { [weak view] in
                     view?.window?.makeFirstResponder(view)
                 }
             }
@@ -68,7 +68,7 @@ struct TerminalPane: View {
                     onClose: {
                         let view = TerminalViewRegistry.shared.existingView(for: state.id)
                         view?.endSearch()
-                        DispatchQueue.main.async {
+                        DispatchQueue.main.async { [weak view] in
                             view?.window?.makeFirstResponder(view)
                         }
                     }
@@ -170,8 +170,8 @@ struct TerminalBridge: NSViewRepresentable {
         configureProgressCallback(view)
         context.coordinator.wasFocused = focused
         if focused, !overlayActive {
-            view.notifySurfaceFocused()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak view] in
+                guard let view else { return }
                 view.window?.makeFirstResponder(view)
             }
         } else {
@@ -220,8 +220,8 @@ struct TerminalBridge: NSViewRepresentable {
                 nsView.notifySurfaceUnfocused()
             }
         } else if focused, !wasFocused || wasOverlayActive {
-            nsView.notifySurfaceFocused()
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak nsView] in
+                guard let nsView else { return }
                 nsView.window?.makeFirstResponder(nsView)
             }
         } else if !focused, wasFocused {


### PR DESCRIPTION
Deduplicates native Ghostty focus updates and lets AppKit responder changes drive terminal focus to avoid ghostty_surface_set_focus crashes.