### PR TITLE
Upload release dSYMs to Sentry

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -137,6 +137,20 @@ jobs:
             --sparkle-public-key "${{ steps.sparkle.outputs.public_key }}" \
             --sparkle-feed-url "https://github.com/muxy-app/muxy/releases/download/beta-channel/appcast-beta-${{ matrix.arch }}.xml"
 
+      - name: Upload dSYM to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
+            echo "SENTRY_AUTH_TOKEN is not set; skipping Sentry dSYM upload"
+            exit 0
+          fi
+          npm install --global @sentry/cli
+          sentry-cli debug-files upload \
+            --org muxy-4d \
+            --project muxy-desktop \
+            "build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.app.dSYM"
+
       - name: Notarize DMG
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -166,7 +180,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dmg-${{ matrix.arch }}
-          path: build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg
+          path: |
+            build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg
+            build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.app.dSYM
 
   release:
     needs: [validate, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,20 @@ jobs:
             --sparkle-public-key "${{ steps.sparkle.outputs.public_key }}" \
             --sparkle-feed-url "https://github.com/muxy-app/muxy/releases/latest/download/appcast-${{ matrix.arch }}.xml"
 
+      - name: Upload dSYM to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
+            echo "SENTRY_AUTH_TOKEN is not set; skipping Sentry dSYM upload"
+            exit 0
+          fi
+          npm install --global @sentry/cli
+          sentry-cli debug-files upload \
+            --org muxy-4d \
+            --project muxy-desktop \
+            "build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.app.dSYM"
+
       - name: Notarize DMG
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -169,7 +183,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dmg-${{ matrix.arch }}
-          path: build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg
+          path: |
+            build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.dmg
+            build/Muxy-${{ needs.validate.outputs.version }}-${{ matrix.arch }}.app.dSYM
 
   release:
     needs: [validate, build]

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -86,9 +86,11 @@ fi
 TRIPLE="${ARCH}-apple-macosx14.0"
 BUILD_NUMBER=$(git -C "$PROJECT_ROOT" rev-list --count HEAD)
 APP_BUNDLE="$BUILD_DIR/Muxy.app"
+DSYM_BUNDLE="$BUILD_DIR/Muxy-${VERSION}-${ARCH}.app.dSYM"
 DMG_NAME="Muxy-${VERSION}-${ARCH}.dmg"
 
 rm -rf "$APP_BUNDLE"
+rm -rf "$DSYM_BUNDLE"
 
 echo "==> Building for $ARCH ($TRIPLE)"
 cd "$PROJECT_ROOT"
@@ -102,6 +104,9 @@ mkdir -p "$APP_BUNDLE/Contents/Resources"
 
 cp "$SPM_BUILD_DIR/Muxy" "$APP_BUNDLE/Contents/MacOS/Muxy"
 install_name_tool -add_rpath @executable_path/../Frameworks "$APP_BUNDLE/Contents/MacOS/Muxy"
+
+echo "==> Generating dSYM"
+xcrun dsymutil "$APP_BUNDLE/Contents/MacOS/Muxy" -o "$DSYM_BUNDLE"
 
 echo "==> Stripping local and debug symbols"
 strip -Sx "$APP_BUNDLE/Contents/MacOS/Muxy"


### PR DESCRIPTION
Generate dSYMs before stripping release binaries and upload them in stable/beta workflows so native crashes are symbolicated in Sentry.