### PR TITLE
Fix editor undo crash in viewport mode

### DIFF
--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -10,6 +10,11 @@ private final class CodeEditorTextView: NSTextView {
     var onRedoRequest: (() -> Bool)?
     var canUndoRequest: (() -> Bool)?
     var canRedoRequest: (() -> Bool)?
+    var usesNativeUndo = true
+
+    override var undoManager: UndoManager? {
+        usesNativeUndo ? super.undoManager : nil
+    }
 
     override func paste(_ sender: Any?) {
         pasteAsPlainText(sender)
@@ -833,8 +838,11 @@ struct CodeEditorView: NSViewRepresentable {
 
         func enterViewportMode(scrollView: NSScrollView) {
             guard let store = state.backingStore, let textView else { return }
-            textView.allowsUndo = false
             textView.undoManager?.removeAllActions()
+            textView.allowsUndo = false
+            if let codeTextView = textView as? CodeEditorTextView {
+                codeTextView.usesNativeUndo = false
+            }
             textView.usesFindBar = false
             clearViewportHistory()
 


### PR DESCRIPTION
Disable native text undo for virtualized editor content.
Routes undo/redo through viewport history to avoid stale AppKit ranges.