### PR TITLE
Fix voice transcript buffering across pauses

### DIFF
--- a/Muxy/Services/VoiceRecorder.swift
+++ b/Muxy/Services/VoiceRecorder.swift
@@ -11,6 +11,12 @@ enum VoiceRecorderError: Error {
     case engineFailure(String)
 }
 
+struct TranscriptMergeResult {
+    let committed: String
+    let partial: String
+    let transcript: String
+}
+
 @MainActor
 @Observable
 final class VoiceRecorder {
@@ -33,6 +39,8 @@ final class VoiceRecorder {
     @ObservationIgnored private var transcriptSink: TranscriptSink?
     @ObservationIgnored private var inputDeviceObserver: AudioInputDeviceObserver?
     @ObservationIgnored private var captureSink: AudioCaptureSink?
+    @ObservationIgnored private var committedTranscript = ""
+    @ObservationIgnored private var currentPartialTranscript = ""
 
     func start(locale: Locale) throws {
         guard let recognizer = SFSpeechRecognizer(locale: locale),
@@ -68,7 +76,7 @@ final class VoiceRecorder {
         observeInputDeviceChanges()
         let transcriptSink = TranscriptSink { [weak self] text in
             guard let self else { return }
-            self.transcript = text
+            self.updateTranscript(with: text)
         }
         self.transcriptSink = transcriptSink
         task = Self.startRecognitionTaskNonisolated(
@@ -89,6 +97,8 @@ final class VoiceRecorder {
         accumulatedBeforePause = 0
         elapsed = 0
         level = 0
+        committedTranscript = ""
+        currentPartialTranscript = ""
         transcript = ""
         isRecording = true
         isPaused = false
@@ -237,6 +247,61 @@ final class VoiceRecorder {
     private func tick() {
         guard let startedAt else { return }
         elapsed = accumulatedBeforePause + Date().timeIntervalSince(startedAt)
+    }
+
+    private func updateTranscript(with text: String) {
+        let updated = Self.mergeTranscript(
+            committed: committedTranscript,
+            partial: currentPartialTranscript,
+            incoming: text
+        )
+        committedTranscript = updated.committed
+        currentPartialTranscript = updated.partial
+        transcript = updated.transcript
+    }
+
+    nonisolated static func mergeTranscript(committed: String, partial: String, incoming: String) -> TranscriptMergeResult {
+        let cleanedIncoming = incoming.trimmingCharacters(in: .whitespacesAndNewlines)
+        var updatedCommitted = committed
+        var updatedPartial = partial
+
+        if cleanedIncoming.isEmpty {
+            updatedCommitted = joinedTranscript(committed, partial)
+            updatedPartial = ""
+        } else if shouldCommitPartial(partial, before: cleanedIncoming) {
+            updatedCommitted = joinedTranscript(committed, partial)
+            updatedPartial = cleanedIncoming
+        } else {
+            updatedPartial = cleanedIncoming
+        }
+
+        return TranscriptMergeResult(
+            committed: updatedCommitted,
+            partial: updatedPartial,
+            transcript: joinedTranscript(updatedCommitted, updatedPartial)
+        )
+    }
+
+    nonisolated private static func joinedTranscript(_ leading: String, _ trailing: String) -> String {
+        let cleanedLeading = leading.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanedTrailing = trailing.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedLeading.isEmpty else { return cleanedTrailing }
+        guard !cleanedTrailing.isEmpty else { return cleanedLeading }
+        return "\(cleanedLeading) \(cleanedTrailing)"
+    }
+
+    nonisolated private static func shouldCommitPartial(_ partial: String, before incoming: String) -> Bool {
+        guard !partial.isEmpty, !incoming.hasPrefix(partial) else { return false }
+        let partialWords = words(in: partial)
+        let incomingWords = words(in: incoming)
+        guard partialWords.count > 1 else { return false }
+        return partialWords.first != incomingWords.first
+    }
+
+    nonisolated private static func words(in text: String) -> [String] {
+        text.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
     }
 
     nonisolated static func averagePower(in samples: UnsafeBufferPointer<Float>) -> Float {

--- a/Muxy/Services/VoiceRecorder.swift
+++ b/Muxy/Services/VoiceRecorder.swift
@@ -294,8 +294,10 @@ final class VoiceRecorder {
         guard !partial.isEmpty, !incoming.hasPrefix(partial) else { return false }
         let partialWords = words(in: partial)
         let incomingWords = words(in: incoming)
-        guard partialWords.count > 1 else { return false }
-        return partialWords.first != incomingWords.first
+        guard partialWords.count > 1, !incomingWords.isEmpty else { return false }
+        guard partialWords.first == incomingWords.first else { return true }
+        guard partialWords.count > 2, incomingWords.count > 1 else { return false }
+        return partialWords[1] != incomingWords[1]
     }
 
     nonisolated private static func words(in text: String) -> [String] {

--- a/Tests/MuxyTests/Models/VoiceRecordingTests.swift
+++ b/Tests/MuxyTests/Models/VoiceRecordingTests.swift
@@ -64,6 +64,18 @@ struct VoiceRecorderHelperTests {
         #expect(second.transcript == "Open the file and add tests")
     }
 
+    @Test("Transcript merge appends reset phrase with same first word")
+    func transcriptMergeAppendsResetPhraseWithSameFirstWord() {
+        let first = VoiceRecorder.mergeTranscript(committed: "", partial: "", incoming: "Open the file")
+        let second = VoiceRecorder.mergeTranscript(
+            committed: first.committed,
+            partial: first.partial,
+            incoming: "Open settings"
+        )
+
+        #expect(second.transcript == "Open the file Open settings")
+    }
+
     @Test("Transcript merge replaces early corrected partials")
     func transcriptMergeReplacesEarlyCorrectedPartials() {
         let first = VoiceRecorder.mergeTranscript(committed: "", partial: "", incoming: "The more")

--- a/Tests/MuxyTests/Models/VoiceRecordingTests.swift
+++ b/Tests/MuxyTests/Models/VoiceRecordingTests.swift
@@ -34,6 +34,52 @@ struct VoiceRecorderHelperTests {
 
         #expect(power > -7 && power < -5)
     }
+
+    @Test("Transcript merge keeps earlier text when recognition restarts")
+    func transcriptMergeKeepsEarlierTextWhenRecognitionRestarts() {
+        let first = VoiceRecorder.mergeTranscript(committed: "", partial: "", incoming: "Open the file")
+        let pause = VoiceRecorder.mergeTranscript(
+            committed: first.committed,
+            partial: first.partial,
+            incoming: ""
+        )
+        let second = VoiceRecorder.mergeTranscript(
+            committed: pause.committed,
+            partial: pause.partial,
+            incoming: "and add tests"
+        )
+
+        #expect(second.transcript == "Open the file and add tests")
+    }
+
+    @Test("Transcript merge appends a new phrase after partial reset")
+    func transcriptMergeAppendsNewPhraseAfterPartialReset() {
+        let first = VoiceRecorder.mergeTranscript(committed: "", partial: "", incoming: "Open the file")
+        let second = VoiceRecorder.mergeTranscript(
+            committed: first.committed,
+            partial: first.partial,
+            incoming: "and add tests"
+        )
+
+        #expect(second.transcript == "Open the file and add tests")
+    }
+
+    @Test("Transcript merge replaces early corrected partials")
+    func transcriptMergeReplacesEarlyCorrectedPartials() {
+        let first = VoiceRecorder.mergeTranscript(committed: "", partial: "", incoming: "The more")
+        let second = VoiceRecorder.mergeTranscript(
+            committed: first.committed,
+            partial: first.partial,
+            incoming: "The more I continue"
+        )
+        let third = VoiceRecorder.mergeTranscript(
+            committed: second.committed,
+            partial: second.partial,
+            incoming: "The more I continue the stable sounds like"
+        )
+
+        #expect(third.transcript == "The more I continue the stable sounds like")
+    }
 }
 
 @Suite("VoiceRecordingPanel formatting")


### PR DESCRIPTION
Preserve prior voice transcript segments across natural pauses while avoiding duplicate early partials. Adds regression coverage for transcript merge behavior