### PR TITLE
Disable session restore by default

### DIFF
--- a/Muxy/Models/SessionRestorePreferences.swift
+++ b/Muxy/Models/SessionRestorePreferences.swift
@@ -5,11 +5,12 @@ enum SessionRestorePreferences {
     static let excludedCommandsKey = "muxy.sessionRestore.excludedCommands"
 
     static let maxSnapshots = 200
+    static let defaultIsEnabled = false
 
     static var isEnabled: Bool {
         get {
             let defaults = UserDefaults.standard
-            if defaults.object(forKey: enabledKey) == nil { return true }
+            if defaults.object(forKey: enabledKey) == nil { return defaultIsEnabled }
             return defaults.bool(forKey: enabledKey)
         }
         set { UserDefaults.standard.set(newValue, forKey: enabledKey) }

--- a/Muxy/Views/Settings/SessionRestoreSettingsView.swift
+++ b/Muxy/Views/Settings/SessionRestoreSettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SessionRestoreSettingsView: View {
-    @AppStorage(SessionRestorePreferences.enabledKey) private var enabled = true
+    @AppStorage(SessionRestorePreferences.enabledKey) private var enabled = SessionRestorePreferences.defaultIsEnabled
     @State private var excludedCommands = SessionRestorePreferences.excludedCommandsText
 
     var body: some View {

--- a/Tests/MuxyTests/Models/TerminalSessionRestorePolicyTests.swift
+++ b/Tests/MuxyTests/Models/TerminalSessionRestorePolicyTests.swift
@@ -83,6 +83,14 @@ struct TerminalSessionRestorePolicyTests {
         #expect(snapshot.commandToRestore == nil)
     }
 
+    @Test("session restore is disabled by default")
+    func sessionRestoreIsDisabledByDefault() {
+        UserDefaults.standard.removeObject(forKey: SessionRestorePreferences.enabledKey)
+        let snapshot = makeSnapshot(startupCommand: nil, lastSubmittedCommand: "nvim main.swift", activity: .running)
+        #expect(SessionRestorePreferences.isEnabled == false)
+        #expect(TerminalSessionRestorePolicy.decision(for: snapshot) == .none)
+    }
+
     @Test("decision returns command when safe and enabled")
     func decisionReturnsCommandWhenSafe() {
         SessionRestorePreferences.isEnabled = true


### PR DESCRIPTION
- Keep session restore off for fresh installs so the app does not resume terminal commands unexpectedly.
- Preserve the toggle in Settings, while still letting existing users opt back in.
- Added coverage for the default-disabled behavior.