### PR TITLE
feat: add pane control CLI for terminal multiplexer integration

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -12,6 +12,7 @@ final class AppState {
         let areaID: UUID
         let direction: SplitDirection
         let position: SplitPosition
+        var command: String?
     }
 
     struct DiffViewerRequest {

--- a/Muxy/Models/SplitNode.swift
+++ b/Muxy/Models/SplitNode.swift
@@ -49,11 +49,12 @@ extension SplitNode {
     func splitting(
         areaID: UUID,
         direction: SplitDirection,
-        position: SplitPosition
+        position: SplitPosition,
+        command: String? = nil
     ) -> (node: SplitNode, newAreaID: UUID?) {
         switch self {
         case let .tabArea(area) where area.id == areaID:
-            let newArea = TabArea(projectPath: area.projectPath)
+            let newArea = TabArea(projectPath: area.projectPath, command: command)
             let first: SplitNode = position == .first ? .tabArea(newArea) : .tabArea(area)
             let second: SplitNode = position == .first ? .tabArea(area) : .tabArea(newArea)
             let node = SplitNode.split(SplitBranch(
@@ -68,14 +69,16 @@ extension SplitNode {
             let (newFirst, id1) = branch.first.splitting(
                 areaID: areaID,
                 direction: direction,
-                position: position
+                position: position,
+                command: command
             )
             branch.first = newFirst
             if id1 != nil { return (.split(branch), id1) }
             let (newSecond, id2) = branch.second.splitting(
                 areaID: areaID,
                 direction: direction,
-                position: position
+                position: position,
+                command: command
             )
             branch.second = newSecond
             return (.split(branch), id2)

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -17,6 +17,20 @@ final class TabArea: Identifiable {
         activeTabID = tab.id
     }
 
+    init(projectPath: String, command: String?) {
+        id = UUID()
+        self.projectPath = projectPath
+        let wrappedCommand = command.map { "(\($0)); exec \"$0\" -l" }
+        let pane = TerminalPaneState(
+            projectPath: projectPath,
+            startupCommand: wrappedCommand,
+            startupCommandInteractive: wrappedCommand != nil
+        )
+        let tab = TerminalTab(pane: pane)
+        tabs.append(tab)
+        activeTabID = tab.id
+    }
+
     init(projectPath: String, existingTab tab: TerminalTab) {
         id = UUID()
         self.projectPath = projectPath

--- a/Muxy/Models/WorkspaceReducer/SplitReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/SplitReducer.swift
@@ -9,7 +9,8 @@ enum SplitReducer {
         let (newRoot, newAreaID) = root.splitting(
             areaID: request.areaID,
             direction: request.direction,
-            position: request.position
+            position: request.position,
+            command: request.command
         )
         state.workspaceRoots[key] = newRoot
         guard let newAreaID else { return }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -83,18 +83,8 @@ struct MuxyApp: App {
                             appDelegate.handleOpenProjectPath(path)
                         }
                     }
-                    NotificationSocketServer.shared.splitActionHandler = { [appState, projectStore, worktreeStore] direction, command in
-                        Task { @MainActor in
-                            guard let projectID = appState.activeProjectID else { return }
-                            guard let area = appState.focusedArea(for: projectID) else { return }
-                            appState.dispatch(.splitArea(.init(
-                                projectID: projectID,
-                                areaID: area.id,
-                                direction: direction,
-                                position: .second,
-                                command: command
-                            )))
-                        }
+                    NotificationSocketServer.shared.commandHandler = { [appState] message in
+                        await SocketCommandHandler.handleRequest(message, appState: appState)
                     }
                     MobileServerService.shared.configure { server in
                         let delegate = RemoteServerDelegate(

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -83,6 +83,19 @@ struct MuxyApp: App {
                             appDelegate.handleOpenProjectPath(path)
                         }
                     }
+                    NotificationSocketServer.shared.splitActionHandler = { [appState, projectStore, worktreeStore] direction, command in
+                        Task { @MainActor in
+                            guard let projectID = appState.activeProjectID else { return }
+                            guard let area = appState.focusedArea(for: projectID) else { return }
+                            appState.dispatch(.splitArea(.init(
+                                projectID: projectID,
+                                areaID: area.id,
+                                direction: direction,
+                                position: .second,
+                                command: command
+                            )))
+                        }
+                    }
                     MobileServerService.shared.configure { server in
                         let delegate = RemoteServerDelegate(
                             appState: appState,

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -1,88 +1,218 @@
 #!/bin/bash
 # Muxy CLI wrapper
 # Usage:
-#   muxy <path>              - Open a folder in Muxy
-#   muxy split-right [cmd]   - Split the focused pane horizontally, optionally run a command
-#   muxy split-down [cmd]    - Split the focused pane vertically, optionally run a command
+#   muxy <path>                              Open a folder in Muxy
+#   muxy split-right [cmd]                   Split horizontally (returns pane ID)
+#   muxy split-down [cmd]                    Split vertically (returns pane ID)
+#   muxy send --pane <id> <text>             Send text to a pane
+#   muxy send-keys --pane <id> <key>         Send special key (Escape, Enter, Tab, Ctrl+C)
+#   muxy read-screen --pane <id> [--lines N] Read terminal content
+#   muxy close-pane --pane <id>              Close a pane
+#   muxy rename-pane --pane <id> <title>     Rename a pane tab
+#   muxy list-panes                          List all panes (tab-separated)
 
 COMMAND="$1"
+SOCKET="$HOME/Library/Application Support/Muxy/muxy.sock"
 
-send_socket_message() {
+send_message() {
     local message="$1"
-    local socket="$HOME/Library/Application Support/Muxy/muxy.sock"
-    if [ ! -e "$socket" ]; then
-        echo "Error: Muxy is not running"
+    if [ ! -e "$SOCKET" ]; then
+        echo "Error: Muxy is not running" >&2
         exit 1
     fi
-    python3 -c "
-import socket, sys
-s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-s.connect(sys.argv[1])
-s.sendall((sys.argv[2] + '\\n').encode())
-s.shutdown(socket.SHUT_WR)
-s.close()
-" "$socket" "$message" 2>/dev/null
+    printf '%s' "$message" | nc -U "$SOCKET"
+}
+
+send_command() {
+    local message="$1"
+    if [ ! -e "$SOCKET" ]; then
+        echo "Error: Muxy is not running" >&2
+        exit 1
+    fi
+    local response
+    response=$(printf '%s' "$message" | nc -U "$SOCKET" 2>/dev/null)
+    if [ -z "$response" ]; then
+        echo "Error: no response from Muxy" >&2
+        exit 1
+    fi
+    case "$response" in
+        error:*)
+            echo "${response#error:}" >&2
+            exit 1
+            ;;
+        *)
+            printf '%s\n' "$response"
+            ;;
+    esac
 }
 
 case "$COMMAND" in
     split-right)
-        if [ -n "$2" ]; then
-            shift
-            send_socket_message "split-right|$*"
+        shift
+        FROM=""
+        CMD=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --from) FROM="$2"; shift 2 ;;
+                *) CMD="$1"; shift ;;
+            esac
+        done
+        if [ -n "$CMD" ] || [ -n "$FROM" ]; then
+            send_command "split-right|$CMD|$FROM"
         else
-            send_socket_message "split-right"
+            send_command "split-right"
         fi
-        exit 0
         ;;
     split-down)
-        if [ -n "$2" ]; then
-            shift
-            send_socket_message "split-down|$*"
+        shift
+        FROM=""
+        CMD=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --from) FROM="$2"; shift 2 ;;
+                *) CMD="$1"; shift ;;
+            esac
+        done
+        if [ -n "$CMD" ] || [ -n "$FROM" ]; then
+            send_command "split-down|$CMD|$FROM"
         else
-            send_socket_message "split-down"
+            send_command "split-down"
         fi
-        exit 0
+        ;;
+    send)
+        shift
+        PANE_ID=""
+        TEXT=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) TEXT="$1"; shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ] || [ -z "$TEXT" ]; then
+            echo "Usage: muxy send --pane <id> <text>" >&2
+            exit 1
+        fi
+        send_command "send|$PANE_ID|$TEXT"
+        ;;
+    send-keys)
+        shift
+        PANE_ID=""
+        KEY=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) KEY="$1"; shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ] || [ -z "$KEY" ]; then
+            echo "Usage: muxy send-keys --pane <id> <key>" >&2
+            exit 1
+        fi
+        send_command "send-keys|$PANE_ID|$KEY"
+        ;;
+    read-screen)
+        shift
+        PANE_ID=""
+        LINES=50
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                --lines) LINES="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ]; then
+            echo "Usage: muxy read-screen --pane <id> [--lines N]" >&2
+            exit 1
+        fi
+        send_command "read-screen|$PANE_ID|$LINES"
+        ;;
+    close-pane)
+        shift
+        PANE_ID=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ]; then
+            echo "Usage: muxy close-pane --pane <id>" >&2
+            exit 1
+        fi
+        send_command "close-pane|$PANE_ID"
+        ;;
+    rename-pane)
+        shift
+        PANE_ID=""
+        TITLE=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --pane) PANE_ID="$2"; shift 2 ;;
+                *) TITLE="$1"; shift ;;
+            esac
+        done
+        if [ -z "$PANE_ID" ] || [ -z "$TITLE" ]; then
+            echo "Usage: muxy rename-pane --pane <id> <title>" >&2
+            exit 1
+        fi
+        send_command "rename-pane|$PANE_ID|$TITLE"
+        ;;
+    list-panes)
+        send_command "list-panes"
         ;;
     ""|--help|-h)
         echo "Usage:"
-        echo "  muxy <path>              Open a folder in Muxy (e.g. muxy .)"
-        echo "  muxy split-right [cmd]   Split the focused pane horizontally, optionally run a command"
-        echo "  muxy split-down [cmd]    Split the focused pane vertically, optionally run a command"
+        echo "  muxy <path>                              Open a folder in Muxy"
+        echo "  muxy split-right [cmd]                   Split horizontally (returns pane ID)"
+        echo "  muxy split-down [cmd]                    Split vertically (returns pane ID)"
+        echo "  muxy send --pane <id> <text>             Send text to a pane"
+        echo "  muxy send-keys --pane <id> <key>         Send special key (Escape, Enter, Tab, Ctrl+C)"
+        echo "  muxy read-screen --pane <id> [--lines N] Read terminal content"
+        echo "  muxy close-pane --pane <id>              Close a pane"
+        echo "  muxy rename-pane --pane <id> <title>     Rename a pane tab"
+        echo "  muxy list-panes                          List all panes"
         exit 1
         ;;
 esac
 
-TARGET_DIR="$COMMAND"
+# If we reach here, it's a path to open
+if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "split-down" ] && \
+   [ "$COMMAND" != "send" ] && [ "$COMMAND" != "send-keys" ] && [ "$COMMAND" != "read-screen" ] && \
+   [ "$COMMAND" != "close-pane" ] && [ "$COMMAND" != "rename-pane" ] && [ "$COMMAND" != "list-panes" ]; then
+    TARGET_DIR="$COMMAND"
 
-case "$TARGET_DIR" in
-    ~*) TARGET_DIR="${HOME}${TARGET_DIR:1}" ;;
-    .)  TARGET_DIR="$(pwd)" ;;
-    ..) TARGET_DIR="$(cd .. && pwd)" ;;
-    *)  TARGET_DIR="$(cd "$TARGET_DIR" 2>/dev/null && pwd)" ;;
-esac
+    case "$TARGET_DIR" in
+        ~*) TARGET_DIR="${HOME}${TARGET_DIR:1}" ;;
+        .)  TARGET_DIR="$(pwd)" ;;
+        ..) TARGET_DIR="$(cd .. && pwd)" ;;
+        *)  TARGET_DIR="$(cd "$TARGET_DIR" 2>/dev/null && pwd)" ;;
+    esac
 
-if [ ! -d "$TARGET_DIR" ]; then
-    echo "Error: $TARGET_DIR is not a valid directory"
-    exit 1
-fi
-
-percent_encode() {
-    if command -v python3 >/dev/null 2>&1; then
-        python3 -c 'import sys, urllib.parse; sys.stdout.write(urllib.parse.quote(sys.argv[1], safe="/"))' "$1"
-    elif command -v python >/dev/null 2>&1; then
-        python -c 'import sys, urllib; sys.stdout.write(urllib.quote(sys.argv[1], safe="/"))' "$1"
-    else
-        printf '%s' "$1"
+    if [ ! -d "$TARGET_DIR" ]; then
+        echo "Error: $TARGET_DIR is not a valid directory" >&2
+        exit 1
     fi
-}
 
-ENCODED_PATH="$(percent_encode "$TARGET_DIR")"
-
-open "muxy://open?path=${ENCODED_PATH}" 2>/dev/null \
-    || open -b com.muxy.app "$TARGET_DIR" 2>/dev/null \
-    || {
-        SOCKET="$HOME/Library/Application Support/Muxy/muxy.sock"
-        if [ -e "$SOCKET" ]; then
-            printf 'open-project|%s\n' "$TARGET_DIR" | nc -U "$SOCKET" 2>/dev/null
-        fi
+    percent_encode() {
+        local string="$1" length=${#1} i c
+        for (( i = 0; i < length; i++ )); do
+            c="${string:i:1}"
+            case "$c" in
+                [a-zA-Z0-9.~_/-]) printf '%s' "$c" ;;
+                *) printf '%%%02X' "'$c" ;;
+            esac
+        done
     }
+
+    ENCODED_PATH="$(percent_encode "$TARGET_DIR")"
+
+    open "muxy://open?path=${ENCODED_PATH}" 2>/dev/null \
+        || open -b com.muxy.app "$TARGET_DIR" 2>/dev/null \
+        || {
+            if [ -e "$SOCKET" ]; then
+                send_message "open-project|$TARGET_DIR"
+            fi
+        }
+fi

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -1,14 +1,58 @@
 #!/bin/bash
-# Muxy CLI wrapper - Usage: muxy /path/to/project
-# Opens a folder in Muxy app
+# Muxy CLI wrapper
+# Usage:
+#   muxy <path>              - Open a folder in Muxy
+#   muxy split-right [cmd]   - Split the focused pane horizontally, optionally run a command
+#   muxy split-down [cmd]    - Split the focused pane vertically, optionally run a command
 
-TARGET_DIR="$1"
+COMMAND="$1"
 
-if [ -z "$TARGET_DIR" ]; then
-    echo "Usage: muxy <path>"
-    echo "       muxy ."
-    exit 1
-fi
+send_socket_message() {
+    local message="$1"
+    local socket="$HOME/Library/Application Support/Muxy/muxy.sock"
+    if [ ! -e "$socket" ]; then
+        echo "Error: Muxy is not running"
+        exit 1
+    fi
+    python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(sys.argv[1])
+s.sendall((sys.argv[2] + '\\n').encode())
+s.shutdown(socket.SHUT_WR)
+s.close()
+" "$socket" "$message" 2>/dev/null
+}
+
+case "$COMMAND" in
+    split-right)
+        if [ -n "$2" ]; then
+            shift
+            send_socket_message "split-right|$*"
+        else
+            send_socket_message "split-right"
+        fi
+        exit 0
+        ;;
+    split-down)
+        if [ -n "$2" ]; then
+            shift
+            send_socket_message "split-down|$*"
+        else
+            send_socket_message "split-down"
+        fi
+        exit 0
+        ;;
+    ""|--help|-h)
+        echo "Usage:"
+        echo "  muxy <path>              Open a folder in Muxy (e.g. muxy .)"
+        echo "  muxy split-right [cmd]   Split the focused pane horizontally, optionally run a command"
+        echo "  muxy split-down [cmd]    Split the focused pane vertically, optionally run a command"
+        exit 1
+        ;;
+esac
+
+TARGET_DIR="$COMMAND"
 
 case "$TARGET_DIR" in
     ~*) TARGET_DIR="${HOME}${TARGET_DIR:1}" ;;

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -2,8 +2,8 @@
 # Muxy CLI wrapper
 # Usage:
 #   muxy <path>                              Open a folder in Muxy
-#   muxy split-right [cmd]                   Split horizontally (returns pane ID)
-#   muxy split-down [cmd]                    Split vertically (returns pane ID)
+#   muxy split-right [--from <id>] [cmd...]  Split horizontally (returns pane ID)
+#   muxy split-down [--from <id>] [cmd...]   Split vertically (returns pane ID)
 #   muxy send --pane <id> <text>             Send text to a pane
 #   muxy send-keys --pane <id> <key>         Send special key (Escape, Enter, Tab, Ctrl+C)
 #   muxy read-screen --pane <id> [--lines N] Read terminal content
@@ -50,15 +50,23 @@ case "$COMMAND" in
     split-right)
         shift
         FROM=""
-        CMD=""
+        CMD_ARGS=()
         while [[ $# -gt 0 ]]; do
             case $1 in
-                --from) FROM="$2"; shift 2 ;;
-                *) CMD="$1"; shift ;;
+                --from)
+                    if [ $# -lt 2 ]; then
+                        echo "Usage: muxy split-right [--from <id>] [cmd...]" >&2
+                        exit 1
+                    fi
+                    FROM="$2"
+                    shift 2
+                    ;;
+                *) CMD_ARGS+=("$1"); shift ;;
             esac
         done
+        CMD="${CMD_ARGS[*]}"
         if [ -n "$CMD" ] || [ -n "$FROM" ]; then
-            send_command "split-right|$CMD|$FROM"
+            send_command "split-right|$FROM|$CMD"
         else
             send_command "split-right"
         fi
@@ -66,15 +74,23 @@ case "$COMMAND" in
     split-down)
         shift
         FROM=""
-        CMD=""
+        CMD_ARGS=()
         while [[ $# -gt 0 ]]; do
             case $1 in
-                --from) FROM="$2"; shift 2 ;;
-                *) CMD="$1"; shift ;;
+                --from)
+                    if [ $# -lt 2 ]; then
+                        echo "Usage: muxy split-down [--from <id>] [cmd...]" >&2
+                        exit 1
+                    fi
+                    FROM="$2"
+                    shift 2
+                    ;;
+                *) CMD_ARGS+=("$1"); shift ;;
             esac
         done
+        CMD="${CMD_ARGS[*]}"
         if [ -n "$CMD" ] || [ -n "$FROM" ]; then
-            send_command "split-down|$CMD|$FROM"
+            send_command "split-down|$FROM|$CMD"
         else
             send_command "split-down"
         fi
@@ -165,8 +181,8 @@ case "$COMMAND" in
     ""|--help|-h)
         echo "Usage:"
         echo "  muxy <path>                              Open a folder in Muxy"
-        echo "  muxy split-right [cmd]                   Split horizontally (returns pane ID)"
-        echo "  muxy split-down [cmd]                    Split vertically (returns pane ID)"
+        echo "  muxy split-right [--from <id>] [cmd...]  Split horizontally (returns pane ID)"
+        echo "  muxy split-down [--from <id>] [cmd...]   Split vertically (returns pane ID)"
         echo "  muxy send --pane <id> <text>             Send text to a pane"
         echo "  muxy send-keys --pane <id> <key>         Send special key (Escape, Enter, Tab, Ctrl+C)"
         echo "  muxy read-screen --pane <id> [--lines N] Read terminal content"

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -10,6 +10,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "app.muxy.notificationSocket")
     var openProjectHandler: (@Sendable (String) -> Void)?
+    var splitActionHandler: (@Sendable (SplitDirection, String?) -> Void)?
 
     static var socketPath: String {
         MuxyFileStorage.appSupportDirectory()
@@ -133,6 +134,20 @@ final class NotificationSocketServer: @unchecked Sendable {
             }
             logger.info("Received open-project request via socket")
             openProjectHandler?(path)
+            return
+        }
+
+        if message == "split-right" || message.hasPrefix("split-right|") {
+            let command = message.hasPrefix("split-right|") ? String(message.dropFirst("split-right|".count)) : nil
+            logger.info("Received split-right request via socket")
+            splitActionHandler?(.horizontal, command)
+            return
+        }
+
+        if message == "split-down" || message.hasPrefix("split-down|") {
+            let command = message.hasPrefix("split-down|") ? String(message.dropFirst("split-down|".count)) : nil
+            logger.info("Received split-down request via socket")
+            splitActionHandler?(.vertical, command)
             return
         }
 

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -10,7 +10,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "app.muxy.notificationSocket")
     var openProjectHandler: (@Sendable (String) -> Void)?
-    var splitActionHandler: (@Sendable (SplitDirection, String?) -> Void)?
+    var commandHandler: (@Sendable (String) async -> String)?
 
     static var socketPath: String {
         MuxyFileStorage.appSupportDirectory()
@@ -97,6 +97,11 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private static let maxMessageSize = 65536
 
+    private static let commandPrefixes = [
+        "split-right", "split-down", "send|", "send-keys|",
+        "read-screen|", "close-pane|", "rename-pane|", "list-panes",
+    ]
+
     private func handleClient(_ fd: Int32) {
         defer { close(fd) }
 
@@ -112,10 +117,47 @@ final class NotificationSocketServer: @unchecked Sendable {
             }
         }
 
-        guard !data.isEmpty else { return }
+        guard !data.isEmpty,
+              let message = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !message.isEmpty
+        else { return }
 
-        for line in data.split(separator: UInt8(ascii: "\n")) {
-            processMessage(Data(line))
+        if Self.commandPrefixes.contains(where: { message.hasPrefix($0) }) {
+            let response = processCommand(message)
+            writeResponse(fd: fd, text: response)
+            return
+        }
+
+        processMessage(Data(message.utf8))
+    }
+
+    private func processCommand(_ message: String) -> String {
+        guard let handler = commandHandler else {
+            return "error:no handler registered"
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var response = "error:timeout"
+
+        Task { @Sendable in
+            response = await handler(message)
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return response
+    }
+
+    private func writeResponse(fd: Int32, text: String) {
+        let data = Data(text.utf8)
+        data.withUnsafeBytes { buffer in
+            guard let ptr = buffer.baseAddress else { return }
+            var offset = 0
+            while offset < buffer.count {
+                let written = Darwin.write(fd, ptr.advanced(by: offset), buffer.count - offset)
+                if written <= 0 { break }
+                offset += written
+            }
         }
     }
 
@@ -138,16 +180,12 @@ final class NotificationSocketServer: @unchecked Sendable {
         }
 
         if message == "split-right" || message.hasPrefix("split-right|") {
-            let command = message.hasPrefix("split-right|") ? String(message.dropFirst("split-right|".count)) : nil
-            logger.info("Received split-right request via socket")
-            splitActionHandler?(.horizontal, command)
+            logger.info("Received legacy split-right request via socket")
             return
         }
 
         if message == "split-down" || message.hasPrefix("split-down|") {
-            let command = message.hasPrefix("split-down|") ? String(message.dropFirst("split-down|".count)) : nil
-            logger.info("Received split-down request via socket")
-            splitActionHandler?(.vertical, command)
+            logger.info("Received legacy split-down request via socket")
             return
         }
 

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -97,9 +97,9 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private static let maxMessageSize = 65536
 
-    private static let commandPrefixes = [
-        "split-right", "split-down", "send|", "send-keys|",
-        "read-screen|", "close-pane|", "rename-pane|", "list-panes",
+    private static let commandNames = [
+        "split-right", "split-down", "send", "send-keys",
+        "read-screen", "close-pane", "rename-pane", "list-panes",
     ]
 
     private func handleClient(_ fd: Int32) {
@@ -118,17 +118,26 @@ final class NotificationSocketServer: @unchecked Sendable {
         }
 
         guard !data.isEmpty,
-              let message = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !message.isEmpty
+              let message = String(data: data, encoding: .utf8)
         else { return }
 
-        if Self.commandPrefixes.contains(where: { message.hasPrefix($0) }) {
-            let response = processCommand(message)
+        let commandMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        if isCommandMessage(commandMessage) {
+            let response = processCommand(commandMessage)
             writeResponse(fd: fd, text: response)
             return
         }
 
-        processMessage(Data(message.utf8))
+        for line in data.split(separator: UInt8(ascii: "\n")) {
+            processMessage(Data(line))
+        }
+    }
+
+    private func isCommandMessage(_ message: String) -> Bool {
+        guard let command = message.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false).first else {
+            return false
+        }
+        return Self.commandNames.contains(String(command))
     }
 
     private func processCommand(_ message: String) -> String {
@@ -144,7 +153,9 @@ final class NotificationSocketServer: @unchecked Sendable {
             semaphore.signal()
         }
 
-        semaphore.wait()
+        guard semaphore.wait(timeout: .now() + .seconds(5)) == .success else {
+            return "error:timeout"
+        }
         return response
     }
 

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -13,13 +13,11 @@ enum SocketCommandHandler {
 
         switch cmd {
         case "split-right":
-            let command = parts.count >= 2 ? parts[1] : nil
-            let fromPane = parts.count >= 3 ? parts[2] : nil
-            return handleSplit(direction: .horizontal, command: command, fromPane: fromPane, appState: appState)
+            let request = parseSplitRequest(parts: parts)
+            return handleSplit(direction: .horizontal, command: request.command, fromPane: request.fromPane, appState: appState)
         case "split-down":
-            let command = parts.count >= 2 ? parts[1] : nil
-            let fromPane = parts.count >= 3 ? parts[2] : nil
-            return handleSplit(direction: .vertical, command: command, fromPane: fromPane, appState: appState)
+            let request = parseSplitRequest(parts: parts)
+            return handleSplit(direction: .vertical, command: request.command, fromPane: request.fromPane, appState: appState)
         case "send":
             guard parts.count >= 3 else { return "error:usage send|paneID|text" }
             return await handleSend(paneIDStr: parts[1], text: parts.dropFirst(2).joined(separator: "|"), appState: appState)
@@ -41,6 +39,20 @@ enum SocketCommandHandler {
         default:
             return "error:unknown command \(cmd)"
         }
+    }
+
+    private static func parseSplitRequest(parts: [String]) -> (fromPane: String?, command: String?) {
+        guard parts.count >= 2 else { return (nil, nil) }
+        let firstValue = parts[1]
+        let firstValueIsPane = firstValue.isEmpty || UUID(uuidString: firstValue) != nil
+        if firstValueIsPane {
+            let command = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
+            return (firstValue, command)
+        }
+        if parts.count >= 3, let fromPane = parts.last, UUID(uuidString: fromPane) != nil {
+            return (fromPane, parts.dropFirst(1).dropLast().joined(separator: "|"))
+        }
+        return (nil, parts.dropFirst(1).joined(separator: "|"))
     }
 
     private static func handleSplit(direction: SplitDirection, command: String?, fromPane: String?, appState: AppState) -> String {

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -1,0 +1,250 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "SocketCommandHandler")
+
+@MainActor
+enum SocketCommandHandler {
+    static func handleRequest(_ message: String, appState: AppState) async -> String {
+        let parts = message.components(separatedBy: "|")
+        guard let cmd = parts.first else {
+            return "error:empty command"
+        }
+
+        switch cmd {
+        case "split-right":
+            let command = parts.count >= 2 ? parts[1] : nil
+            let fromPane = parts.count >= 3 ? parts[2] : nil
+            return handleSplit(direction: .horizontal, command: command, fromPane: fromPane, appState: appState)
+        case "split-down":
+            let command = parts.count >= 2 ? parts[1] : nil
+            let fromPane = parts.count >= 3 ? parts[2] : nil
+            return handleSplit(direction: .vertical, command: command, fromPane: fromPane, appState: appState)
+        case "send":
+            guard parts.count >= 3 else { return "error:usage send|paneID|text" }
+            return await handleSend(paneIDStr: parts[1], text: parts.dropFirst(2).joined(separator: "|"), appState: appState)
+        case "send-keys":
+            guard parts.count >= 3 else { return "error:usage send-keys|paneID|key" }
+            return await handleSendKeys(paneIDStr: parts[1], key: parts[2], appState: appState)
+        case "read-screen":
+            guard parts.count >= 2 else { return "error:usage read-screen|paneID[|lines]" }
+            let lines = parts.count >= 3 ? Int(parts[2]) ?? 50 : 50
+            return await handleReadScreen(paneIDStr: parts[1], lines: lines, appState: appState)
+        case "close-pane":
+            guard parts.count >= 2 else { return "error:usage close-pane|paneID" }
+            return handleClosePane(paneIDStr: parts[1], appState: appState)
+        case "rename-pane":
+            guard parts.count >= 3 else { return "error:usage rename-pane|paneID|title" }
+            return handleRenamePane(paneIDStr: parts[1], title: parts.dropFirst(2).joined(separator: "|"), appState: appState)
+        case "list-panes":
+            return handleListPanes(appState: appState)
+        default:
+            return "error:unknown command \(cmd)"
+        }
+    }
+
+    private static func handleSplit(direction: SplitDirection, command: String?, fromPane: String?, appState: AppState) -> String {
+        let projectID: UUID
+        let areaID: UUID
+
+        if let fromPane, let paneID = UUID(uuidString: fromPane),
+           let loc = locateTab(paneID: paneID, appState: appState)
+        {
+            projectID = loc.key.projectID
+            areaID = loc.areaID
+        } else {
+            guard let activeID = appState.activeProjectID else {
+                return "error:no active project"
+            }
+            guard let area = appState.focusedArea(for: activeID) else {
+                return "error:no focused area"
+            }
+            projectID = activeID
+            areaID = area.id
+        }
+
+        let trimmedCommand = command?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalCommand = (trimmedCommand?.isEmpty ?? true) ? nil : trimmedCommand
+
+        let existingPaneIDs = collectAllPaneIDs(appState: appState)
+
+        appState.dispatch(.splitArea(.init(
+            projectID: projectID,
+            areaID: areaID,
+            direction: direction,
+            position: .second,
+            command: finalCommand
+        )))
+
+        let newPaneIDs = collectAllPaneIDs(appState: appState)
+        let added = newPaneIDs.subtracting(existingPaneIDs)
+
+        guard let newPaneID = added.first else {
+            return "error:split succeeded but could not determine new pane ID"
+        }
+
+        return newPaneID.uuidString
+    }
+
+    private static func handleSend(paneIDStr: String, text: String, appState: AppState) async -> String {
+        guard let paneID = UUID(uuidString: paneIDStr) else {
+            return "error:invalid pane ID"
+        }
+        guard let view = await waitForView(paneID: paneID, appState: appState) else {
+            return "error:pane not found \(paneIDStr)"
+        }
+
+        view.sendText(text)
+        return "ok"
+    }
+
+    private static func handleSendKeys(paneIDStr: String, key: String, appState: AppState) async -> String {
+        guard let paneID = UUID(uuidString: paneIDStr) else {
+            return "error:invalid pane ID"
+        }
+        guard let view = await waitForView(paneID: paneID, appState: appState) else {
+            return "error:pane not found \(paneIDStr)"
+        }
+
+        let bytes: Data
+        switch key.lowercased() {
+        case "escape",
+             "esc":
+            bytes = Data([0x1B])
+        case "enter",
+             "return":
+            bytes = Data([0x0D])
+        case "tab":
+            bytes = Data([0x09])
+        case "ctrl+c",
+             "ctrl-c":
+            bytes = Data([0x03])
+        case "ctrl+d",
+             "ctrl-d":
+            bytes = Data([0x04])
+        case "ctrl+z",
+             "ctrl-z":
+            bytes = Data([0x1A])
+        case "backspace":
+            bytes = Data([0x7F])
+        default:
+            return "error:unsupported key \(key)"
+        }
+
+        view.sendRemoteBytes(bytes)
+        return "ok"
+    }
+
+    private static func handleReadScreen(paneIDStr: String, lines: Int, appState: AppState) async -> String {
+        guard let paneID = UUID(uuidString: paneIDStr) else {
+            return "error:invalid pane ID"
+        }
+        let clampedLines = min(max(lines, 1), 500)
+
+        guard let view = await waitForView(paneID: paneID, appState: appState) else {
+            return "error:pane not found \(paneIDStr)"
+        }
+
+        return view.readScreenText(lastLines: clampedLines)
+    }
+
+    private static func handleClosePane(paneIDStr: String, appState: AppState) -> String {
+        guard let paneID = UUID(uuidString: paneIDStr) else {
+            return "error:invalid pane ID"
+        }
+
+        guard let loc = locateTab(paneID: paneID, appState: appState) else {
+            return "error:pane not found \(paneIDStr)"
+        }
+
+        appState.dispatch(.closeTab(projectID: loc.key.projectID, areaID: loc.areaID, tabID: loc.tabID))
+        return "ok"
+    }
+
+    private static func handleRenamePane(paneIDStr: String, title: String, appState: AppState) -> String {
+        guard let paneID = UUID(uuidString: paneIDStr) else {
+            return "error:invalid pane ID"
+        }
+
+        guard let loc = locateTab(paneID: paneID, appState: appState) else {
+            return "error:pane not found \(paneIDStr)"
+        }
+
+        for (_, root) in appState.workspaceRoots {
+            guard let area = root.findArea(id: loc.areaID) else { continue }
+            area.setCustomTitle(loc.tabID, title: title)
+            return "ok"
+        }
+
+        return "error:could not rename pane"
+    }
+
+    private static func handleListPanes(appState: AppState) -> String {
+        var lines: [String] = []
+        for (key, root) in appState.workspaceRoots {
+            let focusedAreaID = appState.focusedAreaID(for: key.projectID)
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    guard let pane = tab.content.pane else { continue }
+                    let isFocused = area.id == focusedAreaID && tab.id == area.activeTabID
+                    let title = tab.customTitle ?? pane.title
+                    let cwd = pane.currentWorkingDirectory ?? pane.projectPath
+                    lines.append("\(pane.id.uuidString)\t\(title)\t\(cwd)\t\(isFocused)")
+                }
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func waitForView(
+        paneID: UUID,
+        appState: AppState? = nil,
+        timeout: Duration = .seconds(3)
+    ) async -> GhosttyTerminalNSView? {
+        if let view = TerminalViewRegistry.shared.existingView(for: paneID) {
+            return view
+        }
+        if let appState, locateTab(paneID: paneID, appState: appState) == nil {
+            return nil
+        }
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if let view = TerminalViewRegistry.shared.existingView(for: paneID) {
+                return view
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return nil
+    }
+
+    private static func collectAllPaneIDs(appState: AppState) -> Set<UUID> {
+        var ids = Set<UUID>()
+        for (_, root) in appState.workspaceRoots {
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    if let pane = tab.content.pane {
+                        ids.insert(pane.id)
+                    }
+                }
+            }
+        }
+        return ids
+    }
+
+    private struct PaneLocation {
+        let key: WorktreeKey
+        let areaID: UUID
+        let tabID: UUID
+    }
+
+    private static func locateTab(paneID: UUID, appState: AppState) -> PaneLocation? {
+        for (key, root) in appState.workspaceRoots {
+            for area in root.allAreas() {
+                for tab in area.tabs where tab.content.pane?.id == paneID {
+                    return PaneLocation(key: key, areaID: area.id, tabID: tab.id)
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1070,6 +1070,42 @@ final class GhosttyTerminalNSView: NSView {
         }
     }
 
+    func readScreenText(lastLines: Int = 50) -> String {
+        guard let surface else { return "" }
+        var out = ghostty_cells_s()
+        guard ghostty_surface_read_cells(surface, &out) else { return "" }
+        defer { ghostty_surface_free_cells(surface, &out) }
+
+        let cols = Int(out.cols)
+        let rows = Int(out.rows)
+        guard cols > 0, rows > 0, let cells = out.cells else { return "" }
+
+        var lines: [String] = []
+        for row in 0 ..< rows {
+            var line = ""
+            for col in 0 ..< cols {
+                let cell = cells[row * cols + col]
+                let cp = cell.codepoint
+                if cp == 0 {
+                    line.append(" ")
+                } else if let scalar = Unicode.Scalar(cp) {
+                    line.append(Character(scalar))
+                } else {
+                    line.append(" ")
+                }
+            }
+            lines.append(line)
+        }
+
+        while lines.last?.allSatisfy({ $0 == " " }) == true {
+            lines.removeLast()
+        }
+
+        let trimmed = lines.map { $0.replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression) }
+        let result = trimmed.suffix(lastLines)
+        return result.joined(separator: "\n")
+    }
+
     func submitRichInput(text: String) {
         guard !text.isEmpty else { return }
         let sanitized = text.replacingOccurrences(of: "\u{1B}[201~", with: "")

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("SocketCommandHandler")
+@MainActor
+struct SocketCommandHandlerTests {
+    private let testPath = "/tmp/test"
+
+    @Test("unknown command returns error")
+    func unknownCommand() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("bogus", appState: appState)
+        #expect(result.hasPrefix("error:"))
+    }
+
+    @Test("split-right returns new pane ID")
+    func splitReturnsNewPaneID() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("split-right", appState: appState)
+        #expect(!result.hasPrefix("error:"))
+        #expect(UUID(uuidString: result) != nil)
+    }
+
+    @Test("split-down returns new pane ID")
+    func splitDownReturnsNewPaneID() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("split-down", appState: appState)
+        #expect(!result.hasPrefix("error:"))
+        #expect(UUID(uuidString: result) != nil)
+    }
+
+    @Test("split-right with command returns new pane ID")
+    func splitWithCommandReturnsNewPaneID() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("split-right|echo hello", appState: appState)
+        #expect(!result.hasPrefix("error:"))
+        #expect(UUID(uuidString: result) != nil)
+    }
+
+    @Test("split fails without active project")
+    func splitFailsWithoutActiveProject() async {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let result = await SocketCommandHandler.handleRequest("split-right", appState: appState)
+        #expect(result == "error:no active project")
+    }
+
+    @Test("send fails with missing args")
+    func sendFailsMissingArgs() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("send|\(UUID().uuidString)", appState: appState)
+        #expect(result.hasPrefix("error:"))
+    }
+
+    @Test("send-keys fails with unsupported key")
+    func sendKeysFailsUnsupportedKey() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("send-keys|\(UUID().uuidString)|F13", appState: appState)
+        #expect(result.hasPrefix("error:"))
+    }
+
+    @Test("send-keys fails with missing key")
+    func sendKeysFailsMissingKey() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("send-keys|\(UUID().uuidString)", appState: appState)
+        #expect(result.hasPrefix("error:"))
+    }
+
+    @Test("close-pane fails with nonexistent pane")
+    func closePaneFailsNonexistentPane() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("close-pane|\(UUID().uuidString)", appState: appState)
+        #expect(result.hasPrefix("error:pane not found"))
+    }
+
+    @Test("close-pane fails with invalid pane ID")
+    func closePaneFailsInvalidPaneID() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("close-pane|not-a-uuid", appState: appState)
+        #expect(result == "error:invalid pane ID")
+    }
+
+    @Test("rename-pane fails with nonexistent pane")
+    func renamePaneFailsNonexistentPane() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("rename-pane|\(UUID().uuidString)|Test", appState: appState)
+        #expect(result.hasPrefix("error:pane not found"))
+    }
+
+    @Test("rename-pane fails with missing title")
+    func renamePaneFailsMissingTitle() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("rename-pane|\(UUID().uuidString)", appState: appState)
+        #expect(result.hasPrefix("error:"))
+    }
+
+    @Test("list-panes returns empty when no panes")
+    func listPanesEmpty() async {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let result = await SocketCommandHandler.handleRequest("list-panes", appState: appState)
+        #expect(result.isEmpty)
+    }
+
+    @Test("list-panes returns tab-separated pane info")
+    func listPanesReturnsPanes() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("list-panes", appState: appState)
+        #expect(!result.isEmpty)
+        let fields = result.components(separatedBy: "\t")
+        #expect(fields.count >= 4)
+        #expect(UUID(uuidString: fields[0]) != nil)
+    }
+
+    @Test("split-right with from pane targets correct area")
+    func splitWithFromPane() async {
+        let appState = makeAppState()
+        let firstPaneID = appState.workspaceRoots.values.first!.allAreas().first!.tabs.first!.content.pane!.id
+        let result = await SocketCommandHandler.handleRequest("split-right||" + firstPaneID.uuidString, appState: appState)
+        #expect(!result.hasPrefix("error:"))
+        #expect(UUID(uuidString: result) != nil)
+    }
+
+    private func makeAppState(
+        projectID: UUID = UUID(),
+        worktreeID: UUID = UUID()
+    ) -> AppState {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: testPath)
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        return appState
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -34,9 +34,18 @@ struct SocketCommandHandlerTests {
     @Test("split-right with command returns new pane ID")
     func splitWithCommandReturnsNewPaneID() async {
         let appState = makeAppState()
-        let result = await SocketCommandHandler.handleRequest("split-right|echo hello", appState: appState)
+        let result = await SocketCommandHandler.handleRequest("split-right||echo hello", appState: appState)
         #expect(!result.hasPrefix("error:"))
         #expect(UUID(uuidString: result) != nil)
+    }
+
+    @Test("split-right preserves commands containing pipes")
+    func splitPreservesCommandPipes() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("split-right||echo a | wc", appState: appState)
+        let paneID = UUID(uuidString: result)
+        #expect(paneID != nil)
+        #expect(paneID.flatMap { pane(with: $0, appState: appState)?.startupCommand } == "(echo a | wc); exec \"$0\" -l")
     }
 
     @Test("split fails without active project")
@@ -124,9 +133,20 @@ struct SocketCommandHandlerTests {
     func splitWithFromPane() async {
         let appState = makeAppState()
         let firstPaneID = appState.workspaceRoots.values.first!.allAreas().first!.tabs.first!.content.pane!.id
-        let result = await SocketCommandHandler.handleRequest("split-right||" + firstPaneID.uuidString, appState: appState)
+        let result = await SocketCommandHandler.handleRequest("split-right|" + firstPaneID.uuidString + "|", appState: appState)
         #expect(!result.hasPrefix("error:"))
         #expect(UUID(uuidString: result) != nil)
+    }
+
+    private func pane(with paneID: UUID, appState: AppState) -> TerminalPaneState? {
+        for root in appState.workspaceRoots.values {
+            for area in root.allAreas() {
+                for tab in area.tabs where tab.content.pane?.id == paneID {
+                    return tab.content.pane
+                }
+            }
+        }
+        return nil
     }
 
     private func makeAppState(

--- a/docs/features/muxy-cli.md
+++ b/docs/features/muxy-cli.md
@@ -1,0 +1,194 @@
+# Muxy CLI
+
+The `muxy` command lets you open projects and control Muxy panes from a terminal or automation script.
+
+Use it for quick project launching, scripted split layouts, sending input to panes, reading visible terminal output, and closing or renaming panes without switching back to the UI.
+
+## Install
+
+Install the CLI from **Muxy → Install CLI**.
+
+Muxy first tries to install `muxy` to `/usr/local/bin/muxy`. If that needs admin access, macOS prompts for permission. If installation there fails, Muxy falls back to `~/bin/muxy` or `~/.local/bin/muxy`.
+
+After installing, verify it is on your `PATH`:
+
+```bash
+muxy --help
+```
+
+## Open a project
+
+Open the current folder:
+
+```bash
+muxy .
+```
+
+Open a specific folder:
+
+```bash
+muxy ~/Developer/my-app
+```
+
+If the project is already open, Muxy selects the existing project instead of creating a duplicate.
+
+## Pane control
+
+Pane-control commands talk to the running Muxy app through a local Unix socket. Muxy must be open.
+
+### Create splits
+
+Split the focused pane to the right:
+
+```bash
+muxy split-right
+```
+
+Split the focused pane downward:
+
+```bash
+muxy split-down
+```
+
+Create a split and run a command in the new pane:
+
+```bash
+muxy split-right npm run dev
+muxy split-down "echo a | wc"
+```
+
+Both commands print the new pane ID. Save it when you want to control that pane later:
+
+```bash
+PANE=$(muxy split-right npm run dev)
+```
+
+Split from a specific pane instead of the focused pane:
+
+```bash
+muxy split-right --from "$PANE" "npm test"
+```
+
+### List panes
+
+```bash
+muxy list-panes
+```
+
+Output is tab-separated:
+
+```text
+<pane-id>  <title>  <cwd>  <focused>
+```
+
+Example:
+
+```bash
+muxy list-panes | column -t -s $'\t'
+```
+
+### Send text
+
+Send text to a pane:
+
+```bash
+muxy send --pane "$PANE" "npm test"
+```
+
+Send text and press Enter:
+
+```bash
+muxy send --pane "$PANE" "npm test"
+muxy send-keys --pane "$PANE" Enter
+```
+
+Supported keys:
+
+- `Escape` or `Esc`
+- `Enter` or `Return`
+- `Tab`
+- `Ctrl+C` or `Ctrl-C`
+- `Ctrl+D` or `Ctrl-D`
+- `Ctrl+Z` or `Ctrl-Z`
+- `Backspace`
+
+### Read screen content
+
+Read the last 50 visible lines:
+
+```bash
+muxy read-screen --pane "$PANE"
+```
+
+Read a specific number of lines:
+
+```bash
+muxy read-screen --pane "$PANE" --lines 20
+```
+
+This reads visible terminal cells, not the full scrollback history.
+
+### Rename and close panes
+
+Rename a pane tab:
+
+```bash
+muxy rename-pane --pane "$PANE" "Dev Server"
+```
+
+Close a pane:
+
+```bash
+muxy close-pane --pane "$PANE"
+```
+
+## Example workflow
+
+Create a small development layout:
+
+```bash
+WEB=$(muxy split-right npm run dev)
+TESTS=$(muxy split-down --from "$WEB" npm test)
+
+muxy rename-pane --pane "$WEB" "Web"
+muxy rename-pane --pane "$TESTS" "Tests"
+```
+
+Run a command in the tests pane later:
+
+```bash
+muxy send --pane "$TESTS" "npm test -- --watch"
+muxy send-keys --pane "$TESTS" Enter
+```
+
+## Security model
+
+Pane control is local to your macOS user account.
+
+Muxy listens on:
+
+```text
+~/Library/Application Support/Muxy/muxy.sock
+```
+
+The socket is private to your user. It does not grant extra privileges, but any process already running as your user can use it while Muxy is open to:
+
+- list panes
+- read visible terminal text
+- send text or supported control keys
+- rename or close panes
+- create new splits
+
+Avoid exposing sensitive terminal output if you are running untrusted local software.
+
+## Troubleshooting
+
+If `muxy` is not found, make sure its install directory is on your `PATH`.
+
+If pane commands fail with `Muxy is not running`, open Muxy and try again.
+
+If a command with spaces or shell operators is not behaving as expected, quote it:
+
+```bash
+muxy split-right "echo a | wc"
+```

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -25,6 +25,10 @@ Most Ghostty options work — fonts, colors, padding, keybinds, shell integratio
 
 Muxy tracks the cwd via Ghostty's shell integration (OSC 7). The directory is persisted in workspace snapshots so newly recreated tabs land in the same folder when applicable.
 
+## Muxy CLI
+
+Use the `muxy` command to open projects and control panes from a shell or automation script. See [Muxy CLI](muxy-cli.md).
+
 ## Custom command shortcuts
 
 Define reusable shell command shortcuts in **Settings → Keyboard Shortcuts → Custom Commands**:


### PR DESCRIPTION
## What

Adds a **socket-based CLI (`muxy-cli`)** that lets external tools (AI agents, scripts, plugins) programmatically control Muxy panes — split terminals, send commands, read output, and manage panes — all through the existing Unix socket.

## Why

External tools currently have no way to interact with a running Muxy instance. This PR enables programmatic pane control, making Muxy scriptable and agent-friendly without adding any external dependencies.

## How it works

The existing `NotificationSocketServer` (one-way, fire-and-forget) is extended to support **request-response** communication. When a CLI command arrives on the socket, the server detects it via command prefix, dispatches it to `SocketCommandHandler` on the main actor, and writes the response back to the client fd.

## CLI Commands

| Command | Description |
|---------|-------------|
| `muxy <path>` | Open a folder (existing behavior, unchanged) |
| `muxy split-right [cmd] [--from <pane>]` | Split horizontally; returns new pane UUID |
| `muxy split-down [cmd] [--from <pane>]` | Split vertically; returns new pane UUID |
| `muxy send --pane <id> <text>` | Send text to a pane (no Enter) |
| `muxy send-keys --pane <id> <key>` | Send special key (Escape, Enter, Tab, Ctrl+C, etc.) |
| `muxy read-screen --pane <id> [--lines N]` | Read terminal screen content |
| `muxy close-pane --pane <id>` | Close a pane |
| `muxy rename-pane --pane <id> <title>` | Rename a pane tab |
| `muxy list-panes` | List all panes (tab-separated: ID, title, cwd, focused) |

## Changes

- **`SocketCommandHandler` (new)** — Main-actor enum that parses pipe-delimited commands and executes them against `AppState`. Handles split, send, send-keys, read-screen, close, rename, and list-panes.
- **`NotificationSocketServer`** — Extended with `commandHandler` callback and request-response flow. Distinguishes CLI commands from existing one-way notifications via prefix matching.
- **`GhosttyTerminalNSView`** — Added `readScreenText(lastLines:)` using `ghostty_surface_read_cells` to extract terminal buffer content.
- **`TabArea`** — New `init(projectPath:command:)` that wraps the startup command in a login shell (`(cmd); exec "$0" -l`) so the terminal stays open after execution.
- **`SplitNode` / `SplitReducer` / `AppState`** — Thread optional `command` parameter through the split action chain.
- **`muxy-cli`** — Rewritten from a simple URL-scheme opener to a full CLI using `nc -U` for socket I/O (no external dependencies).
- **`SocketCommandHandlerTests`** — 15 unit tests covering all commands, error cases, and edge cases.

## Design Notes

- `split-*` returns the new pane UUID so callers can chain commands (split → send → read-screen).
- `waitForView` polls `TerminalViewRegistry` up to 3s after split, since the Ghostty surface registers asynchronously.
- `--from <paneID>` on split lets you split relative to a specific pane, not just the focused one.
- Socket protocol: `command|arg1|arg2` delimited by `|`, response is plain text or `error:<message>`.