### PR TITLE
Fix Antigravity IDE bundle id after Google product split

### DIFF
--- a/Muxy/Services/IDEIntegrationService.swift
+++ b/Muxy/Services/IDEIntegrationService.swift
@@ -523,7 +523,7 @@ final class IDEIntegrationService: ObservableObject {
     nonisolated private static let aiCompanionBundleIdentifiers: Set<String> = [
         "com.openai.codex",
         "ai.opencode.desktop",
-        "com.google.antigravity",
+        "com.google.antigravity-ide",
         "com.jetbrains.air",
     ]
 
@@ -577,7 +577,7 @@ final class IDEIntegrationService: ObservableObject {
         "org.aquamacs.Aquamacs": .init(symbolName: "text.cursor", rank: 33, group: .editor),
         "com.openai.codex": .init(symbolName: "sparkles.rectangle.stack", rank: 80, group: .otherTool),
         "ai.opencode.desktop": .init(symbolName: "chevron.left.forwardslash.chevron.right", rank: 81, group: .otherTool),
-        "com.google.antigravity": .init(symbolName: "sparkles", rank: 82, group: .otherTool),
+        "com.google.antigravity-ide": .init(symbolName: "sparkles", rank: 82, group: .otherTool),
         "com.jetbrains.air": .init(symbolName: "sparkles", rank: 84, group: .otherTool),
     ]
 

--- a/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
+++ b/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
@@ -342,6 +342,35 @@ struct IDEIntegrationServiceTests {
         #expect(app?.group == .editor)
     }
 
+    @Test("classifies Antigravity IDE by curated bundle identifier")
+    func classifiesAntigravityIDEByCuratedBundleIdentifier() {
+        let metadata = IDEIntegrationService.AppMetadata(
+            bundleIdentifier: "com.google.antigravity-ide",
+            displayName: "Antigravity IDE",
+            executableName: "Antigravity IDE",
+            category: nil,
+            appURL: URL(fileURLWithPath: "/Applications/Antigravity IDE.app")
+        )
+
+        let app = IDEIntegrationService.ideApplication(from: metadata)
+
+        #expect(app?.displayName == "Antigravity IDE")
+        #expect(app?.group == .otherTool)
+    }
+
+    @Test("does not classify standalone Antigravity product as an IDE target")
+    func doesNotClassifyStandaloneAntigravityProduct() {
+        let metadata = IDEIntegrationService.AppMetadata(
+            bundleIdentifier: "com.google.antigravity",
+            displayName: "Antigravity",
+            executableName: "Antigravity",
+            category: nil,
+            appURL: URL(fileURLWithPath: "/Applications/Antigravity.app")
+        )
+
+        #expect(IDEIntegrationService.ideApplication(from: metadata) == nil)
+    }
+
     @Test("does not classify JetBrains Toolbox as an IDE target")
     func doesNotClassifyJetBrainsToolbox() {
         let metadata = IDEIntegrationService.AppMetadata(
@@ -383,9 +412,9 @@ struct IDEIntegrationServiceTests {
             group: .editor
             ),
             IDEIntegrationService.IDEApplication(
-                bundleIdentifier: "com.google.antigravity",
-                displayName: "Antigravity",
-                appURL: URL(fileURLWithPath: "/Applications/Antigravity.app"),
+                bundleIdentifier: "com.google.antigravity-ide",
+                displayName: "Antigravity IDE",
+                appURL: URL(fileURLWithPath: "/Applications/Antigravity IDE.app"),
                 symbolName: "sparkles",
                 rank: 82,
                 group: .otherTool
@@ -394,6 +423,6 @@ struct IDEIntegrationServiceTests {
 
         let sorted = apps.sorted(by: IDEIntegrationService.compareInstalledApps)
 
-        #expect(sorted.map(\.displayName) == ["VS Code", "PhpStorm", "Antigravity", "Air"])
+        #expect(sorted.map(\.displayName) == ["VS Code", "PhpStorm", "Antigravity IDE", "Air"])
     }
 }


### PR DESCRIPTION
Google split Antigravity into two apps: `com.google.antigravity-ide` (the IDE) and `com.google.antigravity` (the standalone product).
Updates the curated bundle id so the IDE menu targets the actual IDE and excludes the non-IDE app.
Adds tests covering both classifications.