### PR TITLE
Filter AppKit modal false-positive hangs

### DIFF
--- a/Muxy/Services/SentryService.swift
+++ b/Muxy/Services/SentryService.swift
@@ -133,21 +133,22 @@ final class SentryService {
             return false
         }
         let frames = exceptions.flatMap { $0.stacktrace?.frames ?? [] }
-        if frames.contains(where: { isModalAlertFrame($0) }) {
+        if frames.contains(where: { isAppKitModalFrame($0) }) {
             return true
         }
         return !frames.contains(where: { $0.inApp?.boolValue == true })
     }
 
-    nonisolated private static func isModalAlertFrame(_ frame: Frame) -> Bool {
+    nonisolated private static func isAppKitModalFrame(_ frame: Frame) -> Bool {
         guard let function = frame.function else { return false }
-        return modalAlertFrameSignatures.contains { function.contains($0) }
+        return appKitModalFrameSignatures.contains { function.contains($0) }
     }
 
-    nonisolated private static let modalAlertFrameSignatures: [String] = [
+    nonisolated private static let appKitModalFrameSignatures: [String] = [
         "runModal",
         "_NSTryRunModal",
         "_doModalLoop",
+        "NSAlert",
         "NSOpenPanel",
         "NSSavePanel",
     ]

--- a/Tests/MuxyTests/Services/SentryServiceTests.swift
+++ b/Tests/MuxyTests/Services/SentryServiceTests.swift
@@ -144,6 +144,24 @@ struct SentryServiceTests {
         #expect(SentryService.shouldDropAppHang(event))
     }
 
+    @Test("shouldDropAppHang drops NSSavePanel modal frames")
+    func shouldDropAppHangDropsSavePanel() {
+        let event = makeEvent(
+            type: "App Hanging",
+            frames: [("ProjectOpenService.openProject", true), ("-[NSSavePanel runModal]", false)]
+        )
+        #expect(SentryService.shouldDropAppHang(event))
+    }
+
+    @Test("shouldDropAppHang drops NSAlert frames without runModal")
+    func shouldDropAppHangDropsAlertFrameWithoutRunModal() {
+        let event = makeEvent(
+            type: "App Hanging",
+            frames: [("CLIAccessor.alert", true), ("-[NSAlert layout]", false)]
+        )
+        #expect(SentryService.shouldDropAppHang(event))
+    }
+
     @Test("shouldDropAppHang drops modal loop frames")
     func shouldDropAppHangDropsDoModalLoop() {
         let event = makeEvent(


### PR DESCRIPTION
Drops Sentry app-hang events caused by expected NSAlert/OpenPanel modal waits.
Adds regression coverage for the observed 0.28.0 hang reports.