### PR TITLE
Fix Ghostty initial focus crash

### DIFF
--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -413,9 +413,16 @@ final class GhosttyTerminalNSView: NSView {
             surfaceFocused = nil
             return
         }
-        guard surfaceFocused != focused else { return }
+        guard Self.shouldApplySurfaceFocusChange(previous: surfaceFocused, next: focused) else {
+            surfaceFocused = focused
+            return
+        }
         ghostty_surface_set_focus(surface, focused)
         surfaceFocused = focused
+    }
+
+    static func shouldApplySurfaceFocusChange(previous: Bool?, next: Bool) -> Bool {
+        previous != next && (next || previous != nil)
     }
 
     override var acceptsFirstResponder: Bool { !overlayActive }

--- a/Tests/MuxyTests/Views/TerminalTextInputClientTests.swift
+++ b/Tests/MuxyTests/Views/TerminalTextInputClientTests.swift
@@ -5,6 +5,21 @@ import Testing
 @Suite("GhosttyTerminalNSView NSTextInputClient")
 @MainActor
 struct TerminalTextInputClientTests {
+    @Test func initialUnfocusedSurfaceDoesNotNeedNativeFocusUpdate() {
+        #expect(GhosttyTerminalNSView.shouldApplySurfaceFocusChange(previous: nil, next: false) == false)
+    }
+
+    @Test func focusTransitionsNeedNativeFocusUpdates() {
+        #expect(GhosttyTerminalNSView.shouldApplySurfaceFocusChange(previous: nil, next: true))
+        #expect(GhosttyTerminalNSView.shouldApplySurfaceFocusChange(previous: true, next: false))
+        #expect(GhosttyTerminalNSView.shouldApplySurfaceFocusChange(previous: false, next: true))
+    }
+
+    @Test func duplicateFocusStateDoesNotNeedNativeFocusUpdate() {
+        #expect(GhosttyTerminalNSView.shouldApplySurfaceFocusChange(previous: true, next: true) == false)
+        #expect(GhosttyTerminalNSView.shouldApplySurfaceFocusChange(previous: false, next: false) == false)
+    }
+
     @Test func selectedRangeDefaultsToValidInsertionPoint() {
         let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
 


### PR DESCRIPTION
Fixes the Ghostty focus crash by skipping the initial native unfocus call for newly created unfocused surfaces.
Adds regression coverage for focus transition gating.
Tested with scripts/checks.sh --fix.