### PR TITLE
Add project command management to sidebar

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -20,6 +20,12 @@ final class AppState {
         let isStaged: Bool
     }
 
+    struct CreatedCommandTab: Equatable {
+        let tabID: UUID
+        let areaID: UUID
+        let paneID: UUID
+    }
+
     enum Action {
         case selectProject(projectID: UUID, worktreeID: UUID, worktreePath: String)
         case selectWorktree(projectID: UUID, worktreeID: UUID, worktreePath: String)
@@ -65,6 +71,7 @@ final class AppState {
     private let workspacePersistence: any WorkspacePersisting
     private let terminalSessions: any TerminalSessionStoring
     var onProjectsEmptied: (([UUID]) -> Void)?
+    var onPaneClosed: ((UUID) -> Void)?
 
     var activeProjectID: UUID?
 
@@ -278,6 +285,54 @@ final class AppState {
             name: shortcut.displayName,
             command: shortcut.trimmedCommand
         ))
+    }
+
+    func createProjectCommandTab(projectID: UUID, name: String, command: String) -> CreatedCommandTab? {
+        dispatch(.createCommandTab(projectID: projectID, areaID: nil, name: name, command: command))
+        guard let key = activeWorktreeKey(for: projectID),
+              let areaID = focusedAreaID[key],
+              let area = workspaceRoots[key]?.findArea(id: areaID),
+              let tab = area.activeTab,
+              let pane = tab.content.pane
+        else { return nil }
+        return CreatedCommandTab(tabID: tab.id, areaID: area.id, paneID: pane.id)
+    }
+
+    func selectTab(projectID: UUID, areaID: UUID, tabID: UUID) {
+        dispatch(.selectTab(projectID: projectID, areaID: areaID, tabID: tabID))
+    }
+
+    func interruptCommandTab(paneID: UUID) {
+        TerminalViewRegistry.shared.view(for: paneID)?.sendRemoteBytes(TerminalControlBytes.interrupt)
+    }
+
+    func restartCommandTab(_ run: ProjectCommandRun, command: ProjectCommand) -> ProjectCommandRun? {
+        selectTab(projectID: run.projectID, areaID: run.areaID, tabID: run.tabID)
+        guard let view = TerminalViewRegistry.shared.view(for: run.paneID) else {
+            return createProjectCommandTab(projectID: run.projectID, name: command.name, command: command.command).map {
+                ProjectCommandRun(
+                    commandID: command.id,
+                    projectID: run.projectID,
+                    tabID: $0.tabID,
+                    areaID: $0.areaID,
+                    paneID: $0.paneID,
+                    state: .running
+                )
+            }
+        }
+        view.sendRemoteBytes(TerminalControlBytes.interrupt)
+        view.sendText("clear")
+        view.sendReturnKey()
+        view.sendText(command.command)
+        view.sendReturnKey()
+        return ProjectCommandRun(
+            commandID: command.id,
+            projectID: run.projectID,
+            tabID: run.tabID,
+            areaID: run.areaID,
+            paneID: run.paneID,
+            state: .running
+        )
     }
 
     func createVCSTab(projectID: UUID) {
@@ -772,6 +827,7 @@ final class AppState {
         for paneID in effects.paneIDsToRemove {
             terminalViews.removeView(for: paneID)
             TerminalProgressStore.shared.resetPane(paneID)
+            onPaneClosed?(paneID)
         }
 
         if !effects.projectIDsToRemove.isEmpty {

--- a/Muxy/Models/ProjectCommand.swift
+++ b/Muxy/Models/ProjectCommand.swift
@@ -21,6 +21,11 @@ struct ProjectCommand: Codable, Identifiable, Equatable, Hashable {
     var source: Source
 }
 
+struct ProjectCommandRunKey: Equatable, Hashable {
+    let projectID: UUID
+    let commandID: String
+}
+
 struct ProjectCommandRun: Equatable {
     enum State: Equatable {
         case running

--- a/Muxy/Models/ProjectCommand.swift
+++ b/Muxy/Models/ProjectCommand.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct ProjectCommand: Codable, Identifiable, Equatable, Hashable {
+    enum Source: String, Codable, CaseIterable {
+        case npm
+        case composer
+        case manual
+
+        var title: String {
+            switch self {
+            case .npm: "npm"
+            case .composer: "composer"
+            case .manual: "manual"
+            }
+        }
+    }
+
+    let id: String
+    var name: String
+    var command: String
+    var source: Source
+}
+
+struct ProjectCommandRun: Equatable {
+    enum State: Equatable {
+        case running
+        case stopped
+    }
+
+    let commandID: String
+    let projectID: UUID
+    let tabID: UUID
+    let areaID: UUID
+    let paneID: UUID
+    var state: State
+}

--- a/Muxy/Models/TerminalControlBytes.swift
+++ b/Muxy/Models/TerminalControlBytes.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum TerminalControlBytes {
     static let carriageReturn = Data([0x0D])
+    static let interrupt = Data([0x03])
     static let killLineToCursor = Data([0x15])
     static let pasteShortcut = Data([0x16])
     static let bracketedPasteStart = Data([0x1B, 0x5B, 0x32, 0x30, 0x30, 0x7E])

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -10,6 +10,7 @@ struct MuxyApp: App {
     @State private var projectStore: ProjectStore
     @State private var worktreeStore: WorktreeStore
     @State private var projectGroupStore: ProjectGroupStore
+    @State private var projectCommandStore: ProjectCommandStore
     @State private var vcsWorktreeAutoRefresher: VCSWorktreeAutoRefresher
     private let updateService = UpdateService.shared
 
@@ -33,6 +34,9 @@ struct MuxyApp: App {
         let projectGroupStore = ProjectGroupStore(
             persistence: environment.projectGroupPersistence
         )
+        let projectCommandStore = ProjectCommandStore(
+            persistence: environment.projectCommandPersistence
+        )
         let vcsWorktreeAutoRefresher = VCSWorktreeAutoRefresher(
             appState: appState,
             projectStore: projectStore,
@@ -42,6 +46,7 @@ struct MuxyApp: App {
         _projectStore = State(initialValue: projectStore)
         _worktreeStore = State(initialValue: worktreeStore)
         _projectGroupStore = State(initialValue: projectGroupStore)
+        _projectCommandStore = State(initialValue: projectCommandStore)
         _vcsWorktreeAutoRefresher = State(initialValue: vcsWorktreeAutoRefresher)
     }
 
@@ -52,6 +57,7 @@ struct MuxyApp: App {
                 .environment(projectStore)
                 .environment(worktreeStore)
                 .environment(projectGroupStore)
+                .environment(projectCommandStore)
                 .environment(GhosttyService.shared)
                 .environment(MuxyConfig.shared)
                 .environment(ThemeService.shared)
@@ -106,6 +112,9 @@ struct MuxyApp: App {
                             projectStore.remove(id: id)
                             worktreeStore.removeProject(id)
                         }
+                    }
+                    appState.onPaneClosed = { [projectCommandStore] paneID in
+                        projectCommandStore.removeRun(paneID: paneID)
                     }
                     projectStore.onProjectRemoved = { [projectGroupStore] projectID in
                         projectGroupStore.removeProjectFromAllGroups(projectID: projectID)

--- a/Muxy/Services/AppEnvironment.swift
+++ b/Muxy/Services/AppEnvironment.swift
@@ -16,6 +16,7 @@ struct AppEnvironment {
     let workspacePersistence: any WorkspacePersisting
     let worktreePersistence: any WorktreePersisting
     let projectGroupPersistence: any ProjectGroupPersisting
+    let projectCommandPersistence: any ProjectCommandPersisting
 
     static let live = Self(
         selectionStore: UserDefaultsActiveProjectSelectionStore(),
@@ -23,6 +24,7 @@ struct AppEnvironment {
         projectPersistence: FileProjectPersistence(),
         workspacePersistence: FileWorkspacePersistence(),
         worktreePersistence: FileWorktreePersistence(),
-        projectGroupPersistence: FileProjectGroupPersistence()
+        projectGroupPersistence: FileProjectGroupPersistence(),
+        projectCommandPersistence: FileProjectCommandPersistence()
     )
 }

--- a/Muxy/Services/ProjectCommandDiscovery.swift
+++ b/Muxy/Services/ProjectCommandDiscovery.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+protocol ProjectCommandProviding {
+    func commands(projectPath: String) -> [ProjectCommand]
+}
+
+struct ProjectCommandDiscovery {
+    var providers: [any ProjectCommandProviding]
+
+    init(providers: [any ProjectCommandProviding] = [NPMProjectCommandProvider(), ComposerProjectCommandProvider()]) {
+        self.providers = providers
+    }
+
+    func commands(projectPath: String) -> [ProjectCommand] {
+        providers.flatMap { $0.commands(projectPath: projectPath) }
+            .sorted { lhs, rhs in
+                if lhs.source != rhs.source { return lhs.source.title < rhs.source.title }
+                return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+            }
+    }
+}
+
+struct NPMProjectCommandProvider: ProjectCommandProviding {
+    func commands(projectPath: String) -> [ProjectCommand] {
+        let url = URL(fileURLWithPath: projectPath).appendingPathComponent("package.json")
+        guard let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let scripts = object["scripts"] as? [String: String]
+        else { return [] }
+
+        return scripts.keys.sorted().map { script in
+            ProjectCommand(
+                id: "npm:\(script)",
+                name: script,
+                command: "npm run \(ShellEscaper.escape(script))",
+                source: .npm
+            )
+        }
+    }
+}
+
+struct ComposerProjectCommandProvider: ProjectCommandProviding {
+    func commands(projectPath: String) -> [ProjectCommand] {
+        let url = URL(fileURLWithPath: projectPath).appendingPathComponent("composer.json")
+        guard let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let scripts = object["scripts"] as? [String: Any]
+        else { return [] }
+
+        return scripts.keys.sorted().map { script in
+            ProjectCommand(
+                id: "composer:\(script)",
+                name: script,
+                command: "composer run-script \(ShellEscaper.escape(script))",
+                source: .composer
+            )
+        }
+    }
+}

--- a/Muxy/Services/ProjectCommandPersistence.swift
+++ b/Muxy/Services/ProjectCommandPersistence.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+protocol ProjectCommandPersisting {
+    func loadManualCommands() throws -> [UUID: [ProjectCommand]]
+    func saveManualCommands(_ commands: [UUID: [ProjectCommand]]) throws
+    func loadHiddenDiscoveredCommandIDs() throws -> [UUID: Set<String>]
+    func saveHiddenDiscoveredCommandIDs(_ ids: [UUID: Set<String>]) throws
+}
+
+final class FileProjectCommandPersistence: ProjectCommandPersisting {
+    private let manualStore: CodableFileStore<[UUID: [ProjectCommand]]>
+    private let hiddenDiscoveredStore: CodableFileStore<[UUID: Set<String>]>
+
+    init(
+        fileURL: URL = MuxyFileStorage.fileURL(filename: "project-commands.json"),
+        hiddenDiscoveredFileURL: URL = MuxyFileStorage.fileURL(filename: "hidden-project-commands.json")
+    ) {
+        manualStore = CodableFileStore(fileURL: fileURL, options: .pretty)
+        hiddenDiscoveredStore = CodableFileStore(fileURL: hiddenDiscoveredFileURL, options: .pretty)
+    }
+
+    func loadManualCommands() throws -> [UUID: [ProjectCommand]] {
+        try manualStore.load() ?? [:]
+    }
+
+    func saveManualCommands(_ commands: [UUID: [ProjectCommand]]) throws {
+        try manualStore.save(commands)
+    }
+
+    func loadHiddenDiscoveredCommandIDs() throws -> [UUID: Set<String>] {
+        try hiddenDiscoveredStore.load() ?? [:]
+    }
+
+    func saveHiddenDiscoveredCommandIDs(_ ids: [UUID: Set<String>]) throws {
+        try hiddenDiscoveredStore.save(ids)
+    }
+}

--- a/Muxy/Services/ProjectCommandStore.swift
+++ b/Muxy/Services/ProjectCommandStore.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Observation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "ProjectCommandStore")
 
 @MainActor
 @Observable
@@ -8,7 +11,7 @@ final class ProjectCommandStore {
     private let discovery: ProjectCommandDiscovery
     private var manualCommands: [UUID: [ProjectCommand]]
     private var hiddenDiscoveredCommandIDs: [UUID: Set<String>]
-    private(set) var runs: [String: ProjectCommandRun] = [:]
+    private(set) var runs: [ProjectCommandRunKey: ProjectCommandRun] = [:]
 
     init(
         persistence: any ProjectCommandPersisting = FileProjectCommandPersistence(),
@@ -51,7 +54,7 @@ final class ProjectCommandStore {
             hiddenDiscoveredCommandIDs[projectID, default: []].insert(command.id)
             saveHiddenDiscoveredCommandIDs()
         }
-        runs.removeValue(forKey: command.id)
+        runs.removeValue(forKey: ProjectCommandRunKey(projectID: projectID, commandID: command.id))
     }
 
     func loadDiscoveredCommands(from project: Project) {
@@ -64,7 +67,7 @@ final class ProjectCommandStore {
     }
 
     func run(_ command: ProjectCommand, projectID: UUID, tabID: UUID, areaID: UUID, paneID: UUID) {
-        runs[command.id] = ProjectCommandRun(
+        runs[ProjectCommandRunKey(projectID: projectID, commandID: command.id)] = ProjectCommandRun(
             commandID: command.id,
             projectID: projectID,
             tabID: tabID,
@@ -74,18 +77,23 @@ final class ProjectCommandStore {
         )
     }
 
+    func run(for commandID: String, projectID: UUID) -> ProjectCommandRun? {
+        runs[ProjectCommandRunKey(projectID: projectID, commandID: commandID)]
+    }
+
     func replaceRun(_ run: ProjectCommandRun) {
-        runs[run.commandID] = run
+        runs[ProjectCommandRunKey(projectID: run.projectID, commandID: run.commandID)] = run
     }
 
-    func markStopped(_ commandID: String) {
-        guard var run = runs[commandID] else { return }
+    func markStopped(_ commandID: String, projectID: UUID) {
+        let key = ProjectCommandRunKey(projectID: projectID, commandID: commandID)
+        guard var run = runs[key] else { return }
         run.state = .stopped
-        runs[commandID] = run
+        runs[key] = run
     }
 
-    func removeRun(_ commandID: String) {
-        runs.removeValue(forKey: commandID)
+    func removeRun(_ commandID: String, projectID: UUID) {
+        runs.removeValue(forKey: ProjectCommandRunKey(projectID: projectID, commandID: commandID))
     }
 
     func removeRun(paneID: UUID) {
@@ -94,11 +102,19 @@ final class ProjectCommandStore {
     }
 
     private func saveManualCommands() {
-        try? persistence.saveManualCommands(manualCommands)
+        do {
+            try persistence.saveManualCommands(manualCommands)
+        } catch {
+            logger.error("Failed to save manual project commands: \(error)")
+        }
     }
 
     private func saveHiddenDiscoveredCommandIDs() {
-        try? persistence.saveHiddenDiscoveredCommandIDs(hiddenDiscoveredCommandIDs)
+        do {
+            try persistence.saveHiddenDiscoveredCommandIDs(hiddenDiscoveredCommandIDs)
+        } catch {
+            logger.error("Failed to save hidden discovered project commands: \(error)")
+        }
     }
 }
 

--- a/Muxy/Services/ProjectCommandStore.swift
+++ b/Muxy/Services/ProjectCommandStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ProjectCommandStore {
+    private let persistence: any ProjectCommandPersisting
+    private let discovery: ProjectCommandDiscovery
+    private var manualCommands: [UUID: [ProjectCommand]]
+    private var hiddenDiscoveredCommandIDs: [UUID: Set<String>]
+    private(set) var runs: [String: ProjectCommandRun] = [:]
+
+    init(
+        persistence: any ProjectCommandPersisting = FileProjectCommandPersistence(),
+        discovery: ProjectCommandDiscovery = ProjectCommandDiscovery()
+    ) {
+        self.persistence = persistence
+        self.discovery = discovery
+        manualCommands = (try? persistence.loadManualCommands()) ?? [:]
+        hiddenDiscoveredCommandIDs = (try? persistence.loadHiddenDiscoveredCommandIDs()) ?? [:]
+    }
+
+    func commands(for project: Project) -> [ProjectCommand] {
+        let hiddenIDs = hiddenDiscoveredCommandIDs[project.id] ?? []
+        let discoveredCommands = discovery.commands(projectPath: project.path)
+            .filter { !hiddenIDs.contains($0.id) }
+        return discoveredCommands + (manualCommands[project.id] ?? [])
+    }
+
+    func addManualCommand(name: String, command: String, to projectID: UUID) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCommand.isEmpty else { return }
+        let command = ProjectCommand(
+            id: "manual:\(UUID().uuidString)",
+            name: trimmedName.isEmpty ? trimmedCommand : trimmedName,
+            command: trimmedCommand,
+            source: .manual
+        )
+        manualCommands[projectID, default: []].append(command)
+        saveManualCommands()
+    }
+
+    func delete(_ command: ProjectCommand, from projectID: UUID) {
+        switch command.source {
+        case .manual:
+            manualCommands[projectID, default: []].removeAll { $0.id == command.id }
+            saveManualCommands()
+        case .npm,
+             .composer:
+            hiddenDiscoveredCommandIDs[projectID, default: []].insert(command.id)
+            saveHiddenDiscoveredCommandIDs()
+        }
+        runs.removeValue(forKey: command.id)
+    }
+
+    func loadDiscoveredCommands(from project: Project) {
+        let discoveredCommands = discovery.commands(projectPath: project.path)
+        let discoveredSignatures = Set(discoveredCommands.map(ProjectCommandSignature.init))
+        manualCommands[project.id, default: []].removeAll { discoveredSignatures.contains(ProjectCommandSignature($0)) }
+        hiddenDiscoveredCommandIDs[project.id] = []
+        saveManualCommands()
+        saveHiddenDiscoveredCommandIDs()
+    }
+
+    func run(_ command: ProjectCommand, projectID: UUID, tabID: UUID, areaID: UUID, paneID: UUID) {
+        runs[command.id] = ProjectCommandRun(
+            commandID: command.id,
+            projectID: projectID,
+            tabID: tabID,
+            areaID: areaID,
+            paneID: paneID,
+            state: .running
+        )
+    }
+
+    func replaceRun(_ run: ProjectCommandRun) {
+        runs[run.commandID] = run
+    }
+
+    func markStopped(_ commandID: String) {
+        guard var run = runs[commandID] else { return }
+        run.state = .stopped
+        runs[commandID] = run
+    }
+
+    func removeRun(_ commandID: String) {
+        runs.removeValue(forKey: commandID)
+    }
+
+    func removeRun(paneID: UUID) {
+        guard let commandID = runs.first(where: { $0.value.paneID == paneID })?.key else { return }
+        runs.removeValue(forKey: commandID)
+    }
+
+    private func saveManualCommands() {
+        try? persistence.saveManualCommands(manualCommands)
+    }
+
+    private func saveHiddenDiscoveredCommandIDs() {
+        try? persistence.saveHiddenDiscoveredCommandIDs(hiddenDiscoveredCommandIDs)
+    }
+}
+
+private struct ProjectCommandSignature: Hashable {
+    let name: String
+    let command: String
+
+    init(_ command: ProjectCommand) {
+        name = command.name
+        self.command = command.command
+    }
+}

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -61,18 +61,18 @@ struct ExpandedProjectRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             projectHeader
-            if worktreesExpanded, isGitRepo {
+            if worktreesExpanded {
                 expandedSections
             }
         }
         .task(id: project.path) {
             isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path)
-            if autoExpandWorktrees, isActive, isGitRepo {
+            if autoExpandWorktrees, isActive {
                 worktreesExpanded = true
             }
         }
         .onChange(of: isActive) { _, active in
-            guard autoExpandWorktrees, active, isGitRepo else { return }
+            guard autoExpandWorktrees, active else { return }
             withAnimation(.easeInOut(duration: 0.15)) {
                 worktreesExpanded = true
             }
@@ -168,9 +168,7 @@ struct ExpandedProjectRow: View {
 
             Spacer(minLength: UIMetrics.spacing2)
 
-            if isGitRepo {
-                worktreeChevron
-            }
+            projectChevron
         }
         .padding(UIMetrics.spacing2)
         .background(headerBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
@@ -188,7 +186,7 @@ struct ExpandedProjectRow: View {
         }
         .onTapGesture {
             guard !isAnyDragging else { return }
-            if isActive, isGitRepo {
+            if isActive {
                 withAnimation(.easeInOut(duration: 0.15)) {
                     worktreesExpanded.toggle()
                 }
@@ -205,7 +203,7 @@ struct ExpandedProjectRow: View {
         }
     }
 
-    private var worktreeChevron: some View {
+    private var projectChevron: some View {
         Button {
             withAnimation(.easeInOut(duration: 0.15)) {
                 worktreesExpanded.toggle()
@@ -220,7 +218,7 @@ struct ExpandedProjectRow: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(worktreesExpanded ? "Collapse Worktrees" : "Expand Worktrees")
+        .accessibilityLabel(worktreesExpanded ? "Collapse Project" : "Expand Project")
     }
 
     private var projectIcon: some View {
@@ -300,7 +298,9 @@ struct ExpandedProjectRow: View {
     private var expandedSections: some View {
         VStack(spacing: 0) {
             commandList
-            worktreeList
+            if isGitRepo {
+                worktreeList
+            }
         }
         .padding(.top, UIMetrics.spacing2)
     }
@@ -317,7 +317,7 @@ struct ExpandedProjectRow: View {
                 ForEach(projectCommands) { command in
                     ProjectCommandRow(
                         command: command,
-                        run: projectCommandStore.runs[command.id],
+                        run: projectCommandStore.run(for: command.id, projectID: project.id),
                         active: activeCommandID == command.id,
                         onActivate: { activate(command) },
                         onRun: { run(command) },
@@ -505,12 +505,12 @@ struct ExpandedProjectRow: View {
 
     private func activate(_ command: ProjectCommand) {
         activeCommandID = command.id
-        guard let run = projectCommandStore.runs[command.id] else { return }
+        guard let run = projectCommandStore.run(for: command.id, projectID: project.id) else { return }
         appState.selectTab(projectID: run.projectID, areaID: run.areaID, tabID: run.tabID)
     }
 
     private func restart(_ command: ProjectCommand) {
-        guard let run = projectCommandStore.runs[command.id] else {
+        guard let run = projectCommandStore.run(for: command.id, projectID: project.id) else {
             run(command)
             return
         }
@@ -519,9 +519,9 @@ struct ExpandedProjectRow: View {
     }
 
     private func requestStop(_ command: ProjectCommand) {
-        guard let run = projectCommandStore.runs[command.id] else { return }
+        guard let run = projectCommandStore.run(for: command.id, projectID: project.id) else { return }
         appState.interruptCommandTab(paneID: run.paneID)
-        projectCommandStore.markStopped(command.id)
+        projectCommandStore.markStopped(command.id, projectID: project.id)
     }
 
     private func delete(_ command: ProjectCommand) {
@@ -610,7 +610,7 @@ private struct ProjectCommandRow: View {
             Button("Restart", action: onRestart)
                 .disabled(run == nil)
             Button("Stop", action: onStop)
-                .disabled(run == nil)
+                .disabled(!isRunning)
             Divider()
             Button("Delete", role: .destructive, action: onDelete)
         }

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -15,6 +15,7 @@ struct ExpandedProjectRow: View {
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
+    @Environment(ProjectCommandStore.self) private var projectCommandStore
 
     @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
     private var autoExpandWorktrees = false
@@ -28,6 +29,10 @@ struct ExpandedProjectRow: View {
     @State private var worktreesExpanded = false
     @State private var isRefreshingWorktrees = false
     @State private var showColorPicker = false
+    @State private var showAddCommandSheet = false
+    @State private var commandsSectionExpanded = true
+    @State private var worktreesSectionExpanded = true
+    @State private var activeCommandID: String?
 
     private var isActive: Bool {
         appState.activeProjectID == project.id
@@ -45,6 +50,10 @@ struct ExpandedProjectRow: View {
         worktrees.first { $0.id == activeWorktreeID }
     }
 
+    private var projectCommands: [ProjectCommand] {
+        projectCommandStore.commands(for: project)
+    }
+
     private var displayLetter: String {
         String(project.name.prefix(1)).uppercased()
     }
@@ -53,7 +62,7 @@ struct ExpandedProjectRow: View {
         VStack(alignment: .leading, spacing: 0) {
             projectHeader
             if worktreesExpanded, isGitRepo {
-                worktreeList
+                expandedSections
             }
         }
         .task(id: project.path) {
@@ -95,6 +104,17 @@ struct ExpandedProjectRow: View {
             CreateWorktreeSheet(project: project) { result in
                 showCreateWorktreeSheet = false
                 handleCreateWorktreeResult(result)
+            }
+        }
+        .sheet(isPresented: $showAddCommandSheet) {
+            AddProjectCommandSheet { name, command in
+                showAddCommandSheet = false
+                projectCommandStore.addManualCommand(name: name, command: command, to: project.id)
+            } onLoadFromProject: {
+                showAddCommandSheet = false
+                projectCommandStore.loadDiscoveredCommands(from: project)
+            } onCancel: {
+                showAddCommandSheet = false
             }
         }
         .sheet(item: $logoCropImage) { item in
@@ -239,34 +259,76 @@ struct ExpandedProjectRow: View {
 
     private var worktreeList: some View {
         VStack(spacing: UIMetrics.scaled(1)) {
-            ForEach(worktrees) { worktree in
-                ExpandedWorktreeRow(
-                    projectID: project.id,
-                    worktree: worktree,
-                    selected: worktree.id == activeWorktreeID,
-                    projectActive: isActive,
-                    onSelect: {
-                        appState.selectWorktree(projectID: project.id, worktree: worktree)
-                    },
-                    onRename: { newName in
-                        worktreeStore.rename(
-                            worktreeID: worktree.id,
-                            in: project.id,
-                            to: newName
-                        )
-                    },
-                    onRemove: worktree.canBeRemoved ? {
-                        Task { await requestRemove(worktree: worktree) }
-                    } : nil
-                )
-            }
+            SidebarSectionHeader(
+                title: "Worktrees",
+                symbol: "square.stack.3d.up",
+                expanded: worktreesSectionExpanded,
+                onToggle: { worktreesSectionExpanded.toggle() }
+            )
 
-            ExpandedNewWorktreeButton {
-                showCreateWorktreeSheet = true
+            if worktreesSectionExpanded {
+                ForEach(worktrees) { worktree in
+                    ExpandedWorktreeRow(
+                        projectID: project.id,
+                        worktree: worktree,
+                        selected: worktree.id == activeWorktreeID,
+                        onSelect: {
+                            appState.selectWorktree(projectID: project.id, worktree: worktree)
+                        },
+                        onRename: { newName in
+                            worktreeStore.rename(
+                                worktreeID: worktree.id,
+                                in: project.id,
+                                to: newName
+                            )
+                        },
+                        onRemove: worktree.canBeRemoved ? {
+                            Task { await requestRemove(worktree: worktree) }
+                        } : nil
+                    )
+                }
+
+                ExpandedNewWorktreeButton {
+                    showCreateWorktreeSheet = true
+                }
             }
         }
         .padding(.top, UIMetrics.spacing1)
-        .padding(.bottom, UIMetrics.spacing2)
+        .padding(.bottom, UIMetrics.spacing1)
+    }
+
+    private var expandedSections: some View {
+        VStack(spacing: 0) {
+            commandList
+            worktreeList
+        }
+        .padding(.top, UIMetrics.spacing2)
+    }
+
+    private var commandList: some View {
+        VStack(spacing: UIMetrics.scaled(1)) {
+            SidebarSectionHeader(
+                title: "Commands",
+                symbol: "command",
+                expanded: commandsSectionExpanded,
+                onToggle: { commandsSectionExpanded.toggle() }
+            )
+            if commandsSectionExpanded {
+                ForEach(projectCommands) { command in
+                    ProjectCommandRow(
+                        command: command,
+                        run: projectCommandStore.runs[command.id],
+                        active: activeCommandID == command.id,
+                        onActivate: { activate(command) },
+                        onRun: { run(command) },
+                        onRestart: { restart(command) },
+                        onStop: { requestStop(command) },
+                        onDelete: { delete(command) }
+                    )
+                }
+                ExpandedAddCommandButton { showAddCommandSheet = true }
+            }
+        }
     }
 
     private var projectHeaderAccessibilityLabel: String {
@@ -423,13 +485,276 @@ struct ExpandedProjectRow: View {
             isRefreshing: $isRefreshingWorktrees
         )
     }
+
+    private func run(_ command: ProjectCommand) {
+        guard let created = appState.createProjectCommandTab(
+            projectID: project.id,
+            name: command.name,
+            command: command.command
+        )
+        else { return }
+        activeCommandID = command.id
+        projectCommandStore.run(
+            command,
+            projectID: project.id,
+            tabID: created.tabID,
+            areaID: created.areaID,
+            paneID: created.paneID
+        )
+    }
+
+    private func activate(_ command: ProjectCommand) {
+        activeCommandID = command.id
+        guard let run = projectCommandStore.runs[command.id] else { return }
+        appState.selectTab(projectID: run.projectID, areaID: run.areaID, tabID: run.tabID)
+    }
+
+    private func restart(_ command: ProjectCommand) {
+        guard let run = projectCommandStore.runs[command.id] else {
+            run(command)
+            return
+        }
+        guard let replacement = appState.restartCommandTab(run, command: command) else { return }
+        projectCommandStore.replaceRun(replacement)
+    }
+
+    private func requestStop(_ command: ProjectCommand) {
+        guard let run = projectCommandStore.runs[command.id] else { return }
+        appState.interruptCommandTab(paneID: run.paneID)
+        projectCommandStore.markStopped(command.id)
+    }
+
+    private func delete(_ command: ProjectCommand) {
+        if activeCommandID == command.id {
+            activeCommandID = nil
+        }
+        projectCommandStore.delete(command, from: project.id)
+    }
+}
+
+private struct SidebarSectionHeader: View {
+    let title: String
+    let symbol: String
+    let expanded: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: UIMetrics.spacing3) {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fgMuted.opacity(0.75))
+                    .rotationEffect(.degrees(expanded ? 0 : -90))
+                    .animation(.easeInOut(duration: 0.15), value: expanded)
+                    .frame(width: UIMetrics.iconXS)
+
+                Image(systemName: symbol)
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    .frame(width: UIMetrics.iconMD)
+
+                Text(title.uppercased())
+                    .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+                    .tracking(1.4)
+                    .foregroundStyle(MuxyTheme.fgMuted)
+
+                Rectangle()
+                    .fill(MuxyTheme.border.opacity(0.8))
+                    .frame(height: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.leading, UIMetrics.spacing3)
+        .padding(.trailing, UIMetrics.spacing4)
+        .padding(.top, UIMetrics.spacing2)
+        .padding(.bottom, expanded ? UIMetrics.spacing3 : UIMetrics.spacing2)
+        .accessibilityLabel(expanded ? "Collapse \(title)" : "Expand \(title)")
+    }
+}
+
+private struct ProjectCommandRow: View {
+    let command: ProjectCommand
+    let run: ProjectCommandRun?
+    let active: Bool
+    let onActivate: () -> Void
+    let onRun: () -> Void
+    let onRestart: () -> Void
+    let onStop: () -> Void
+    let onDelete: () -> Void
+    @State private var hovered = false
+
+    private var isRunning: Bool {
+        run?.state == .running
+    }
+
+    var body: some View {
+        ProjectItem(
+            title: command.name,
+            color: active || isRunning ? MuxyTheme.accent : MuxyTheme.fg,
+            onTap: onActivate,
+            trailing: { hovered in
+                Button(action: isRunning ? onStop : onRun) {
+                    Image(systemName: isRunning ? "stop.fill" : "play.fill")
+                        .font(.system(size: UIMetrics.fontMicro, weight: .semibold))
+                        .foregroundStyle(isRunning ? MuxyTheme.fg : MuxyTheme.accent)
+                        .frame(width: UIMetrics.scaled(18), height: UIMetrics.scaled(18))
+                }
+                .buttonStyle(.plain)
+                .opacity(hovered || isRunning ? 1 : 0)
+                .accessibilityHidden(!hovered && !isRunning)
+                .accessibilityLabel(isRunning ? "Stop Command" : "Run Command")
+            }
+        )
+        .contextMenu {
+            Button("Run", action: onRun)
+            Button("Restart", action: onRestart)
+                .disabled(run == nil)
+            Button("Stop", action: onStop)
+                .disabled(run == nil)
+            Divider()
+            Button("Delete", role: .destructive, action: onDelete)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(command.name)
+    }
+}
+
+@MainActor
+private enum ProjectItemLayout {
+    static var leadingPadding: CGFloat { UIMetrics.spacing9 }
+    static var trailingPadding: CGFloat { UIMetrics.spacing4 }
+}
+
+private struct ProjectItem<Trailing: View>: View {
+    let title: String
+    var badge: String?
+    var color: Color
+    let onTap: () -> Void
+    @ViewBuilder let trailing: (Bool) -> Trailing
+    @State private var hovered = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: UIMetrics.spacing3) {
+            HStack(spacing: UIMetrics.spacing2) {
+                Text(title)
+                    .font(.system(size: UIMetrics.fontBody, weight: .regular))
+                    .foregroundStyle(color)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                if let badge {
+                    ProjectItemBadge(title: badge)
+                }
+            }
+
+            Spacer(minLength: UIMetrics.spacing1)
+
+            trailing(hovered)
+        }
+        .padding(.leading, ProjectItemLayout.leadingPadding)
+        .padding(.trailing, ProjectItemLayout.trailingPadding)
+        .padding(.vertical, UIMetrics.scaled(5))
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+        .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+        .onHover { hovered = $0 }
+        .onTapGesture(perform: onTap)
+    }
+
+    private var rowBackground: AnyShapeStyle {
+        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        return AnyShapeStyle(Color.clear)
+    }
+}
+
+private struct ProjectItemBadge: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+            .tracking(0.4)
+            .foregroundStyle(MuxyTheme.fg)
+            .padding(.horizontal, UIMetrics.spacing2)
+            .padding(.vertical, UIMetrics.scaled(1))
+            .background(MuxyTheme.surface, in: Capsule())
+    }
+}
+
+private struct ExpandedAddCommandButton: View {
+    let action: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: UIMetrics.spacing3) {
+                Image(systemName: "plus")
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
+                    .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
+                Text("Add Command")
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
+                Spacer()
+            }
+            .padding(.leading, ProjectItemLayout.leadingPadding)
+            .padding(.trailing, ProjectItemLayout.trailingPadding)
+            .padding(.vertical, UIMetrics.scaled(5))
+            .background(hovered ? MuxyTheme.hover : Color.clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .accessibilityLabel("Add Command")
+    }
+}
+
+private struct AddProjectCommandSheet: View {
+    let onAdd: (String, String) -> Void
+    let onLoadFromProject: () -> Void
+    let onCancel: () -> Void
+    @State private var name = ""
+    @State private var command = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing4) {
+            Text("Add Command")
+                .font(.system(size: UIMetrics.fontTitle, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+
+            TextField("Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+
+            TextField("Command", text: $command)
+                .textFieldStyle(.roundedBorder)
+                .focused($focused)
+                .onSubmit { submit() }
+
+            HStack {
+                Button("Load from Project", action: onLoadFromProject)
+
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Add", action: submit)
+                    .disabled(command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(360))
+        .onAppear { focused = true }
+    }
+
+    private func submit() {
+        guard !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        onAdd(name, command)
+    }
 }
 
 private struct ExpandedWorktreeRow: View {
     let projectID: UUID
     let worktree: Worktree
     let selected: Bool
-    let projectActive: Bool
     let onSelect: () -> Void
     let onRename: (String) -> Void
     let onRemove: (() -> Void)?
@@ -452,51 +777,35 @@ private struct ExpandedWorktreeRow: View {
     }
 
     var body: some View {
-        HStack(spacing: UIMetrics.spacing3) {
-            leadingIndicator
-
+        Group {
             if isRenaming {
-                TextField("", text: $renameText)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
-                    .foregroundStyle(MuxyTheme.fg)
-                    .focused($renameFieldFocused)
-                    .onSubmit { commitRename() }
-                    .onExitCommand { cancelRename() }
-            } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: UIMetrics.spacing2) {
-                        Text(displayName)
-                            .font(.system(size: UIMetrics.fontBody, weight: activeStyle ? .semibold : .regular))
-                            .foregroundStyle(MuxyTheme.fg)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                HStack(spacing: UIMetrics.spacing3) {
+                    leadingIndicator
 
-                        if worktree.isPrimary {
-                            PrimaryBadge()
-                        }
-                    }
+                    TextField("", text: $renameText)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .focused($renameFieldFocused)
+                        .onSubmit { commitRename() }
+                        .onExitCommand { cancelRename() }
 
-                    if let branch = branchLabel {
-                        Text(branch)
-                            .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
-                            .foregroundStyle(MuxyTheme.fg)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
+                    Spacer(minLength: UIMetrics.spacing1)
                 }
+                .padding(.horizontal, UIMetrics.spacing4)
+                .padding(.vertical, UIMetrics.scaled(7))
+                .background(rowBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                .onHover { hovered = $0 }
+            } else {
+                ProjectItem(
+                    title: displayName,
+                    color: itemColor,
+                    onTap: onSelect,
+                    trailing: { _ in EmptyView() }
+                )
+                .onHover { hovered = $0 }
             }
-
-            Spacer(minLength: UIMetrics.spacing1)
-        }
-        .padding(.horizontal, UIMetrics.spacing4)
-        .padding(.vertical, UIMetrics.scaled(7))
-        .background(rowBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
-        .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
-        .onHover { hovered = $0 }
-        .onTapGesture {
-            guard !isRenaming else { return }
-            onSelect()
         }
         .contextMenu {
             if worktree.isPrimary {
@@ -537,10 +846,12 @@ private struct ExpandedWorktreeRow: View {
         .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
     }
 
-    private var activeStyle: Bool { selected && projectActive }
+    private var itemColor: Color {
+        if selected { return MuxyTheme.accent }
+        return MuxyTheme.fg
+    }
 
     private var rowBackground: AnyShapeStyle {
-        if activeStyle { return AnyShapeStyle(MuxyTheme.accentSoft) }
         if hovered { return AnyShapeStyle(MuxyTheme.hover) }
         return AnyShapeStyle(Color.clear)
     }
@@ -571,31 +882,22 @@ private struct ExpandedNewWorktreeButton: View {
             HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "plus")
                     .font(.system(size: UIMetrics.fontCaption, weight: .medium))
-                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fg)
+                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
                     .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
                 Text("New Worktree")
                     .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
-                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fg)
+                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
                 Spacer()
             }
-            .padding(.horizontal, UIMetrics.spacing4)
+            .padding(.leading, ProjectItemLayout.leadingPadding)
+            .padding(.trailing, ProjectItemLayout.trailingPadding)
             .padding(.vertical, UIMetrics.scaled(5))
+            .background(hovered ? MuxyTheme.hover : Color.clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .contentShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
         .accessibilityLabel("New Worktree")
-    }
-}
-
-private struct PrimaryBadge: View {
-    var body: some View {
-        Text("PRIMARY")
-            .font(.system(size: UIMetrics.fontMicro, weight: .bold))
-            .tracking(0.4)
-            .foregroundStyle(MuxyTheme.fg)
-            .padding(.horizontal, UIMetrics.spacing2)
-            .padding(.vertical, UIMetrics.scaled(1))
-            .background(MuxyTheme.surface, in: Capsule())
     }
 }
 

--- a/Tests/MuxyTests/Services/ProjectCommandDiscoveryTests.swift
+++ b/Tests/MuxyTests/Services/ProjectCommandDiscoveryTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProjectCommandDiscovery")
+struct ProjectCommandDiscoveryTests {
+    @Test("discovers npm scripts")
+    func discoversNPMScripts() throws {
+        let directory = try temporaryDirectory()
+        try #"{"scripts":{"dev":"vite","test":"vitest"}}"#.write(
+            to: directory.appendingPathComponent("package.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let commands = NPMProjectCommandProvider().commands(projectPath: directory.path)
+
+        #expect(commands.map(\.name) == ["dev", "test"])
+        #expect(commands.first?.command == "npm run dev")
+        #expect(commands.first?.source == .npm)
+    }
+
+    @Test("discovers composer scripts")
+    func discoversComposerScripts() throws {
+        let directory = try temporaryDirectory()
+        try #"{"scripts":{"analyse":"phpstan","test":["phpunit"]}}"#.write(
+            to: directory.appendingPathComponent("composer.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let commands = ComposerProjectCommandProvider().commands(projectPath: directory.path)
+
+        #expect(commands.map(\.name) == ["analyse", "test"])
+        #expect(commands.first?.command == "composer run-script analyse")
+        #expect(commands.first?.source == .composer)
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}

--- a/Tests/MuxyTests/Services/ProjectCommandStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectCommandStoreTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProjectCommandStore")
+@MainActor
+struct ProjectCommandStoreTests {
+    @Test("removeRun by paneID clears linked command")
+    func removeRunByPaneID() {
+        let store = ProjectCommandStore(
+            persistence: ProjectCommandPersistenceStub(),
+            discovery: ProjectCommandDiscovery(providers: [])
+        )
+        let command = ProjectCommand(id: "manual:test", name: "Test", command: "npm test", source: .manual)
+        let projectID = UUID()
+        let paneID = UUID()
+
+        store.run(command, projectID: projectID, tabID: UUID(), areaID: UUID(), paneID: paneID)
+        store.removeRun(paneID: paneID)
+
+        #expect(store.runs[command.id] == nil)
+    }
+
+    @Test("delete hides discovered command")
+    func deleteHidesDiscoveredCommand() {
+        let command = ProjectCommand(id: "npm:test", name: "test", command: "npm run test", source: .npm)
+        let project = Project(name: "App", path: "/tmp/app")
+        let persistence = ProjectCommandPersistenceStub()
+        let store = ProjectCommandStore(
+            persistence: persistence,
+            discovery: ProjectCommandDiscovery(providers: [ProjectCommandProviderStub(commands: [command])])
+        )
+
+        store.delete(command, from: project.id)
+
+        #expect(store.commands(for: project).isEmpty)
+        #expect(persistence.savedHiddenDiscoveredCommandIDs[project.id] == [command.id])
+    }
+
+    @Test("loadDiscoveredCommands restores hidden project commands")
+    func loadDiscoveredCommandsRestoresHiddenCommands() {
+        let command = ProjectCommand(id: "npm:test", name: "test", command: "npm run test", source: .npm)
+        let project = Project(name: "App", path: "/tmp/app")
+        let persistence = ProjectCommandPersistenceStub()
+        let store = ProjectCommandStore(
+            persistence: persistence,
+            discovery: ProjectCommandDiscovery(providers: [ProjectCommandProviderStub(commands: [command])])
+        )
+
+        store.delete(command, from: project.id)
+        store.loadDiscoveredCommands(from: project)
+
+        #expect(store.commands(for: project) == [command])
+        #expect((persistence.savedHiddenDiscoveredCommandIDs[project.id] ?? []) == [])
+    }
+
+    @Test("loadDiscoveredCommands removes matching manual duplicate")
+    func loadDiscoveredCommandsRemovesMatchingManualDuplicate() {
+        let command = ProjectCommand(id: "npm:test", name: "test", command: "npm run test", source: .npm)
+        let project = Project(name: "App", path: "/tmp/app")
+        let persistence = ProjectCommandPersistenceStub()
+        let store = ProjectCommandStore(
+            persistence: persistence,
+            discovery: ProjectCommandDiscovery(providers: [ProjectCommandProviderStub(commands: [command])])
+        )
+
+        store.addManualCommand(name: command.name, command: command.command, to: project.id)
+        store.loadDiscoveredCommands(from: project)
+
+        #expect(store.commands(for: project) == [command])
+        #expect((persistence.savedManualCommands[project.id] ?? []) == [])
+    }
+}
+
+private final class ProjectCommandPersistenceStub: ProjectCommandPersisting {
+    var savedManualCommands: [UUID: [ProjectCommand]] = [:]
+    var savedHiddenDiscoveredCommandIDs: [UUID: Set<String>] = [:]
+
+    func loadManualCommands() throws -> [UUID: [ProjectCommand]] { savedManualCommands }
+    func saveManualCommands(_ commands: [UUID: [ProjectCommand]]) throws {
+        savedManualCommands = commands
+    }
+
+    func loadHiddenDiscoveredCommandIDs() throws -> [UUID: Set<String>] { savedHiddenDiscoveredCommandIDs }
+    func saveHiddenDiscoveredCommandIDs(_ ids: [UUID: Set<String>]) throws {
+        savedHiddenDiscoveredCommandIDs = ids
+    }
+}
+
+private struct ProjectCommandProviderStub: ProjectCommandProviding {
+    let commands: [ProjectCommand]
+
+    func commands(projectPath: String) -> [ProjectCommand] {
+        commands
+    }
+}

--- a/Tests/MuxyTests/Services/ProjectCommandStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectCommandStoreTests.swift
@@ -19,7 +19,26 @@ struct ProjectCommandStoreTests {
         store.run(command, projectID: projectID, tabID: UUID(), areaID: UUID(), paneID: paneID)
         store.removeRun(paneID: paneID)
 
-        #expect(store.runs[command.id] == nil)
+        #expect(store.run(for: command.id, projectID: projectID) == nil)
+    }
+
+    @Test("runs are scoped by project and command")
+    func runsAreScopedByProjectAndCommand() {
+        let store = ProjectCommandStore(
+            persistence: ProjectCommandPersistenceStub(),
+            discovery: ProjectCommandDiscovery(providers: [])
+        )
+        let command = ProjectCommand(id: "npm:test", name: "test", command: "npm run test", source: .npm)
+        let firstProjectID = UUID()
+        let secondProjectID = UUID()
+        let firstPaneID = UUID()
+        let secondPaneID = UUID()
+
+        store.run(command, projectID: firstProjectID, tabID: UUID(), areaID: UUID(), paneID: firstPaneID)
+        store.run(command, projectID: secondProjectID, tabID: UUID(), areaID: UUID(), paneID: secondPaneID)
+
+        #expect(store.run(for: command.id, projectID: firstProjectID)?.paneID == firstPaneID)
+        #expect(store.run(for: command.id, projectID: secondProjectID)?.paneID == secondPaneID)
     }
 
     @Test("delete hides discovered command")


### PR DESCRIPTION
Adds project command discovery, manual commands, linked command tabs, delete support, and reload-from-project behavior.
Updates the expanded project sidebar with collapsible Commands and Worktrees sections.
Includes tests for command discovery, persistence, and run cleanup.