### PR TITLE
Redesign settings with themed modal and JSON editor

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -96,6 +96,15 @@ struct MuxyCommands: Commands {
     }
 
     var body: some Commands {
+        CommandGroup(replacing: .appSettings) {
+            Button {
+                NotificationCenter.default.post(name: .openSettingsModal, object: nil)
+            } label: {
+                Label("Settings...", systemImage: "gearshape")
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
+
         CommandGroup(after: .appSettings) {
             Button {
                 NSWorkspace.shared.open(

--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -14,6 +14,7 @@ extension Notification.Name {
     static let findInFiles = Notification.Name("MuxyFindInFiles")
     static let switchWorktree = Notification.Name("MuxySwitchWorktree")
     static let openProjectPicker = Notification.Name("MuxyOpenProjectPicker")
+    static let openSettingsModal = Notification.Name("MuxyOpenSettingsModal")
     static let focusProjectPickerDefaultLocation = Notification.Name("MuxyFocusProjectPickerDefaultLocation")
     static let saveActiveEditor = Notification.Name("MuxySaveActiveEditor")
     static let windowFullScreenDidChange = Notification.Name("MuxyWindowFullScreenDidChange")

--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -215,6 +215,7 @@ final class EditorSettings {
                 richInputLineHeightMultiplier: richInputLineHeightMultiplier,
                 richInputImageStrategy: richInputImageStrategy
             ))
+            SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         } catch {
             logger.error("Failed to save editor settings: \(error.localizedDescription)")
         }

--- a/Muxy/Models/ProjectPickerDefaultLocation.swift
+++ b/Muxy/Models/ProjectPickerDefaultLocation.swift
@@ -37,7 +37,7 @@ struct ProjectPickerDefaultLocationState: Equatable {
 }
 
 enum ProjectPickerDefaultLocation {
-    private static let storageKey = "muxy.projectPicker.defaultDirectory"
+    static let storageKey = "muxy.projectPicker.defaultDirectory"
 
     static var path: String { path(defaults: .standard) }
     static var displayPath: String { displayPath(defaults: .standard) }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -43,6 +43,7 @@ struct MuxyApp: App {
         _worktreeStore = State(initialValue: worktreeStore)
         _projectGroupStore = State(initialValue: projectGroupStore)
         _vcsWorktreeAutoRefresher = State(initialValue: vcsWorktreeAutoRefresher)
+        SettingsJSONStore.beginAutomaticUserSettingsSync()
     }
 
     var body: some Scene {
@@ -144,22 +145,20 @@ struct MuxyApp: App {
                 .preferredColorScheme(MuxyTheme.colorScheme)
         }
         .defaultSize(width: 820, height: 580)
-
-        Settings {
-            SettingsView()
-                .preferredColorScheme(MuxyTheme.colorScheme)
-        }
     }
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var onTerminate: (() -> Void)?
     var hasUnsavedEditorTabs: (() -> [EditorTabState])?
     var openProjectFromPath: ((String) -> Void)?
 
     private var pendingOpenPaths: [String] = []
     private var systemAppearanceObserver: NSObjectProtocol?
+    private var settingsObserver: NSObjectProtocol?
+    private var settingsThemeObserver: NSObjectProtocol?
+    private weak var settingsWindow: NSWindow?
 
     @MainActor
     func handleOpenProjectPath(_ path: String) {
@@ -249,6 +248,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AIProviderRegistry.shared.installAll()
         _ = AIUsageSettingsStore.isUsageEnabled()
         DiagnosticsMenuController.shared.install()
+        observeSettingsRequests()
 
         consumeLaunchArguments()
     }
@@ -353,6 +353,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             DistributedNotificationCenter.default().removeObserver(observer)
             systemAppearanceObserver = nil
         }
+        if let settingsObserver {
+            NotificationCenter.default.removeObserver(settingsObserver)
+            self.settingsObserver = nil
+        }
+        if let settingsThemeObserver {
+            NotificationCenter.default.removeObserver(settingsThemeObserver)
+            self.settingsThemeObserver = nil
+        }
         onTerminate?()
         NotificationStore.shared.saveToDisk()
         NotificationSocketServer.shared.stop()
@@ -360,6 +368,58 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             MobileServerService.shared.stopForTermination()
             RichInputDraftStore.shared.flush()
         }
+    }
+
+    @MainActor
+    private func observeSettingsRequests() {
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: .openSettingsModal,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.presentSettingsModal()
+            }
+        }
+        settingsThemeObserver = NotificationCenter.default.addObserver(
+            forName: .themeDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.settingsWindow?.backgroundColor = MuxyTheme.nsBg
+            }
+        }
+    }
+
+    @MainActor
+    private func presentSettingsModal() {
+        if let settingsWindow {
+            settingsWindow.makeKeyAndOrderFront(nil)
+            return
+        }
+        guard let parent = NSApp.keyWindow ?? NSApp.mainWindow else { return }
+        let host = NSHostingController(
+            rootView: SettingsView()
+                .frame(width: 980, height: 680)
+                .preferredColorScheme(MuxyTheme.colorScheme)
+        )
+        let window = SettingsModalWindow(contentViewController: host)
+        window.title = "Settings"
+        window.styleMask = [.titled, .closable]
+        window.isOpaque = true
+        window.backgroundColor = MuxyTheme.nsBg
+        window.delegate = self
+        settingsWindow = window
+        parent.beginSheet(window) { [weak self, weak window] _ in
+            guard self?.settingsWindow === window else { return }
+            self?.settingsWindow = nil
+        }
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard notification.object as? NSWindow === settingsWindow else { return }
+        settingsWindow = nil
     }
 
     @MainActor
@@ -391,6 +451,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
+    }
+}
+
+private final class SettingsModalWindow: NSWindow {
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.charactersIgnoringModifiers?.lowercased() == "w"
+        {
+            close()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        close()
+    }
+
+    override func close() {
+        guard let sheetParent else {
+            super.close()
+            return
+        }
+        sheetParent.endSheet(self)
     }
 }
 

--- a/Muxy/Services/ApprovedDevicesStore.swift
+++ b/Muxy/Services/ApprovedDevicesStore.swift
@@ -82,6 +82,11 @@ final class ApprovedDevicesStore {
         onRevoke?(deviceID)
     }
 
+    func replaceDevices(_ newDevices: [ApprovedDevice]) {
+        devices = newDevices
+        save()
+    }
+
     static func hash(_ token: String) -> String {
         let digest = SHA256.hash(data: Data(token.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()
@@ -101,6 +106,7 @@ final class ApprovedDevicesStore {
     private func save() {
         do {
             try Self.store.save(devices)
+            SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         } catch {
             logger.error("Failed to save approved devices: \(error)")
         }

--- a/Muxy/Services/CommandShortcutStore.swift
+++ b/Muxy/Services/CommandShortcutStore.swift
@@ -125,6 +125,12 @@ final class CommandShortcutStore {
         updatePrefixCombo(CommandShortcutConfiguration().prefixCombo)
     }
 
+    func replaceConfiguration(_ configuration: CommandShortcutConfiguration) {
+        prefixCombo = configuration.prefixCombo
+        shortcuts = configuration.shortcuts.map(shortcutWithDefaultModifier)
+        save()
+    }
+
     func activateLayer() {
         isLayerActive = true
         layerResetTask?.cancel()
@@ -202,6 +208,7 @@ final class CommandShortcutStore {
                 prefixCombo: prefixCombo,
                 shortcuts: shortcuts
             ))
+            SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         } catch {
             commandShortcutLogger.error("Failed to save command shortcuts: \(error.localizedDescription)")
         }

--- a/Muxy/Services/KeyBindingStore.swift
+++ b/Muxy/Services/KeyBindingStore.swift
@@ -37,6 +37,11 @@ final class KeyBindingStore {
         save()
     }
 
+    func replaceBindings(_ newBindings: [KeyBinding]) {
+        bindings = newBindings
+        save()
+    }
+
     func resetBinding(action: ShortcutAction) {
         guard let defaultBinding = KeyBinding.defaults.first(where: { $0.action == action }) else { return }
         updateBinding(action: defaultBinding.action, combo: defaultBinding.combo)
@@ -84,6 +89,7 @@ final class KeyBindingStore {
     private func save() {
         do {
             try persistence.saveBindings(bindings)
+            SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         } catch {
             logger.error("Failed to save key bindings: \(error.localizedDescription)")
         }

--- a/Muxy/Services/MobileServerService.swift
+++ b/Muxy/Services/MobileServerService.swift
@@ -16,13 +16,13 @@ final class MobileServerService {
     static let minPort: UInt16 = 1024
     static let maxPort: UInt16 = 65535
 
-    private static var enabledKey: String {
+    static var enabledKey: String {
         AppEnvironment.isDevelopment
             ? "app.muxy.mobile.serverEnabled.dev"
             : "app.muxy.mobile.serverEnabled"
     }
 
-    private static var portKey: String {
+    static var portKey: String {
         AppEnvironment.isDevelopment
             ? "app.muxy.mobile.serverPort.dev"
             : "app.muxy.mobile.serverPort"

--- a/Muxy/Services/SettingsJSONStore.swift
+++ b/Muxy/Services/SettingsJSONStore.swift
@@ -1,0 +1,485 @@
+import Foundation
+import os
+
+private let settingsJSONLogger = Logger(subsystem: "app.muxy", category: "SettingsJSONStore")
+
+@MainActor
+enum SettingsJSONStore {
+    private static var defaultsObserver: NSObjectProtocol?
+    private static var isApplyingSettings = false
+    private static var isSyncingFile = false
+
+    static var userSettingsURL: URL {
+        MuxyFileStorage.fileURL(filename: SettingsCatalog.userSettingsFilename)
+    }
+
+    static var systemSettingsText: String {
+        prettyJSONString(defaultSettingsDictionary())
+    }
+
+    static func loadUserSettingsText() -> String {
+        ensureUserSettingsFileExists()
+        let text = (try? String(contentsOf: userSettingsURL, encoding: .utf8)) ?? "{}"
+        return (try? prettifiedSettingsText(text)) ?? text
+    }
+
+    static func saveUserSettingsText(_ text: String) throws {
+        let data = Data(text.utf8)
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let dictionary = object as? [String: Any] else {
+            throw SettingsJSONError.topLevelObjectRequired
+        }
+        let settings = try validatedSettings(from: dictionary)
+        try Data(prettyJSONString(dictionary).utf8).write(to: userSettingsURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: FilePermissions.privateFile], ofItemAtPath: userSettingsURL.path)
+        isApplyingSettings = true
+        apply(settings)
+        isApplyingSettings = false
+        syncUserSettingsFileWithCurrentSettings()
+    }
+
+    static func prettifiedSettingsText(_ text: String) throws -> String {
+        let data = Data(text.utf8)
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let dictionary = object as? [String: Any] else {
+            throw SettingsJSONError.topLevelObjectRequired
+        }
+        return prettyJSONString(dictionary)
+    }
+
+    static func resetUserSettingsFile() {
+        let current = currentSettingsDictionary()
+        let text = prettyJSONString(current)
+        do {
+            try text.write(to: userSettingsURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: FilePermissions.privateFile], ofItemAtPath: userSettingsURL.path)
+        } catch {
+            settingsJSONLogger.error("Failed to reset user settings file: \(error.localizedDescription)")
+        }
+    }
+
+    static func beginAutomaticUserSettingsSync() {
+        guard defaultsObserver == nil else { return }
+        defaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                guard !isApplyingSettings else { return }
+                syncUserSettingsFileWithCurrentSettings()
+            }
+        }
+        syncUserSettingsFileWithCurrentSettings()
+    }
+
+    static func syncUserSettingsFileWithCurrentSettings() {
+        guard !isApplyingSettings, !isSyncingFile else { return }
+        isSyncingFile = true
+        defer { isSyncingFile = false }
+        var dictionary = existingUserSettingsDictionary()
+        for (key, value) in currentSettingsDictionary() {
+            dictionary[key] = value
+        }
+        do {
+            try Data(prettyJSONString(dictionary).utf8).write(to: userSettingsURL, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: FilePermissions.privateFile], ofItemAtPath: userSettingsURL.path)
+        } catch {
+            settingsJSONLogger.error("Failed to sync user settings file: \(error.localizedDescription)")
+        }
+    }
+
+    private static func ensureUserSettingsFileExists() {
+        guard !FileManager.default.fileExists(atPath: userSettingsURL.path) else { return }
+        resetUserSettingsFile()
+    }
+
+    private static func defaultSettingsDictionary() -> [String: Any] {
+        var dictionary: [String: Any] = Dictionary(uniqueKeysWithValues: SettingsCatalog.jsonEditableItems.compactMap { item in
+            guard let value = item.defaultValue else { return nil }
+            return (item.key, jsonValue(value))
+        })
+        dictionary["shortcuts.app"] = keyBindingsJSONObject(KeyBinding.defaults)
+        dictionary["shortcuts.customCommands"] = commandShortcutsJSONObject(CommandShortcutConfiguration())
+        dictionary["ai.providers"] = notificationProviderSettings(defaultValue: true)
+        dictionary["aiUsage.providers"] = aiUsageProviderSettings(defaultValue: false)
+        dictionary["mobile.approvedDevices"] = []
+        return dictionary
+    }
+
+    private static func currentSettingsDictionary() -> [String: Any] {
+        var dictionary = Dictionary(uniqueKeysWithValues: SettingsCatalog.jsonEditableItems.map { item in
+            let value = currentValue(for: item) ?? item.defaultValue.map(jsonValue) ?? NSNull()
+            return (item.key, value)
+        })
+        dictionary["shortcuts.app"] = keyBindingsJSONObject(KeyBindingStore.shared.bindings)
+        dictionary["shortcuts.customCommands"] = commandShortcutsJSONObject(CommandShortcutConfiguration(
+            prefixCombo: CommandShortcutStore.shared.prefixCombo,
+            shortcuts: CommandShortcutStore.shared.shortcuts
+        ))
+        dictionary["ai.providers"] = notificationProviderSettings()
+        dictionary["aiUsage.providers"] = aiUsageProviderSettings()
+        dictionary["mobile.approvedDevices"] = codableJSONObject(ApprovedDevicesStore.shared.devices) ?? []
+        return dictionary
+    }
+
+    private static func validatedSettings(from dictionary: [String: Any]) throws -> [String: Any] {
+        let itemsByKey = Dictionary(uniqueKeysWithValues: SettingsCatalog.jsonEditableItems.map { ($0.key, $0) })
+        var settings: [String: Any] = [:]
+        for (key, value) in dictionary {
+            if isSpecialJSONSetting(key) {
+                settings[key] = value
+                continue
+            }
+            guard let item = itemsByKey[key] else { continue }
+            settings[key] = try validatedValue(value, for: item)
+        }
+        return settings
+    }
+
+    private static func apply(_ dictionary: [String: Any]) {
+        for (key, value) in dictionary {
+            if applySpecialSetting(key: key, value: value) {
+                continue
+            }
+            if applyEditorSetting(key: key, value: value) {
+                continue
+            }
+            if value is NSNull {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else {
+                UserDefaults.standard.set(value, forKey: key)
+            }
+        }
+    }
+
+    private static func existingUserSettingsDictionary() -> [String: Any] {
+        guard let data = try? Data(contentsOf: userSettingsURL),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = object as? [String: Any]
+        else { return [:] }
+        return dictionary
+    }
+
+    private static func validatedValue(_ value: Any, for item: SettingsCatalogItem) throws -> Any {
+        guard !(value is NSNull) else { return value }
+        guard let defaultValue = item.defaultValue?.base else { throw SettingsJSONError.unsupportedValue(item.key) }
+        if defaultValue is Bool, value is Bool { return value }
+        if defaultValue is String, let string = value as? String {
+            try validateAllowedString(string, key: item.key)
+            return string
+        }
+        if defaultValue is Int, let int = value as? Int {
+            try validateAllowedInt(int, key: item.key)
+            return int
+        }
+        if defaultValue is UInt16, let int = value as? Int {
+            try validateAllowedInt(int, key: item.key)
+            return int
+        }
+        if defaultValue is Double, let number = value as? NSNumber {
+            let double = number.doubleValue
+            try validateAllowedDouble(double, key: item.key)
+            return double
+        }
+        if defaultValue is CGFloat, let number = value as? NSNumber {
+            let double = number.doubleValue
+            try validateAllowedDouble(double, key: item.key)
+            return double
+        }
+        if defaultValue is [String], let strings = value as? [String] { return strings }
+        throw SettingsJSONError.invalidValue(item.key)
+    }
+
+    private static func validateAllowedString(_ value: String, key: String) throws {
+        let allowedValues: [String: Set<String>] = [
+            UpdateChannel.storageKey: Set(UpdateChannel.allCases.map(\.rawValue)),
+            GeneralSettingsKeys.fileTreeSource: Set(FileTreeSourcePreference.allCases.map(\.rawValue)),
+            ProjectPickerPreferences.storageKey: Set(ProjectPickerMode.allCases.map(\.rawValue)),
+            SentryConsent.storageKey: Set(["", SentryConsent.allowed.rawValue, SentryConsent.denied.rawValue]),
+            "muxy.ui.scale": Set(UIScale.Preset.allCases.map(\.rawValue)),
+            SidebarCollapsedStyle.storageKey: Set(SidebarCollapsedStyle.allCases.map(\.rawValue)),
+            SidebarExpandedStyle.storageKey: Set(SidebarExpandedStyle.allCases.map(\.rawValue)),
+            "muxy.vcsDisplayMode": Set(VCSDisplayMode.allCases.map(\.rawValue)),
+            RichInputPreferences.positionKey: Set(RichInputPanelPosition.allCases.map(\.rawValue)),
+            "editor.defaultEditor": Set(EditorSettings.DefaultEditor.allCases.map(\.rawValue)),
+            "editor.htmlDefaultViewMode": Set(EditorMarkdownViewMode.allCases.map(\.rawValue)),
+            "editor.richInputImageStrategy": Set(RichInputImageStrategy.allCases.map(\.rawValue)),
+            "muxy.notifications.sound": Set(NotificationSound.allCases.map(\.rawValue)),
+            "muxy.notifications.toastPosition": Set(ToastPosition.allCases.map(\.rawValue)),
+            AIAssistantSettings.providerKey: Set(AIAssistantProvider.allCases.map(\.rawValue)),
+            AIUsageSettingsStore.usageDisplayModeKey: Set(AIUsageDisplayMode.allCases.map(\.rawValue)),
+        ]
+        guard let allowed = allowedValues[key] else { return }
+        guard allowed.contains(value) else { throw SettingsJSONError.invalidValue(key) }
+    }
+
+    private static func validateAllowedInt(_ value: Int, key: String) throws {
+        if key == MobileServerService.portKey {
+            guard let port = UInt16(exactly: value), MobileServerService.isValid(port: port) else {
+                throw SettingsJSONError.invalidValue(key)
+            }
+            return
+        }
+        if key == AIUsageSettingsStore.autoRefreshIntervalKey {
+            guard AIUsageAutoRefreshInterval(rawValue: value) != nil else { throw SettingsJSONError.invalidValue(key) }
+        }
+    }
+
+    private static func validateAllowedDouble(_ value: Double, key: String) throws {
+        switch key {
+        case "editor.fontSize":
+            guard (8 ... 36).contains(value) else { throw SettingsJSONError.invalidValue(key) }
+        case "editor.markdownPreviewFontScale":
+            guard (Double(EditorSettings.minMarkdownPreviewFontScale) ... Double(EditorSettings.maxMarkdownPreviewFontScale))
+                .contains(value)
+            else { throw SettingsJSONError.invalidValue(key) }
+        case "editor.lineHeightMultiplier",
+             "editor.richInputLineHeightMultiplier":
+            guard (Double(EditorSettings.minLineHeightMultiplier) ... Double(EditorSettings.maxLineHeightMultiplier))
+                .contains(value)
+            else { throw SettingsJSONError.invalidValue(key) }
+        default:
+            return
+        }
+    }
+
+    private static func currentValue(for item: SettingsCatalogItem) -> Any? {
+        let settings = EditorSettings.shared
+        return switch item.key {
+        case SentryConsent.storageKey: SentryService.shared.consent?.rawValue ?? ""
+        case "muxy.ui.scale": UIScale.shared.preset.rawValue
+        case "muxy.theme.light": ThemeService.shared.currentLightThemeName() ?? ThemeService.defaultThemeName
+        case "muxy.theme.dark": ThemeService.shared.currentDarkThemeName() ?? ThemeService.defaultThemeName
+        case ProjectPickerDefaultLocation.storageKey: UserDefaults.standard.string(forKey: item.key) ?? ""
+        case "editor.defaultEditor": settings.defaultEditor.rawValue
+        case "editor.externalEditorCommand": settings.externalEditorCommand
+        case "editor.markdownPreviewFontFamily": settings.markdownPreviewFontFamily
+        case "editor.markdownPreviewFontScale": Double(settings.markdownPreviewFontScale)
+        case "editor.htmlDefaultViewMode": settings.htmlDefaultViewMode.rawValue
+        case "editor.richInputImageStrategy": settings.richInputImageStrategy.rawValue
+        case "editor.richInputFontFamily": settings.richInputFontFamily
+        case "editor.richInputLineHeightMultiplier": Double(settings.richInputLineHeightMultiplier)
+        case "editor.highlightCurrentLine": settings.highlightCurrentLine
+        case "editor.showLineNumbers": settings.showLineNumbers
+        case "editor.lineWrapping": settings.lineWrapping
+        case "editor.fontFamily": settings.fontFamily
+        case "editor.fontSize": Double(settings.fontSize)
+        case "editor.lineHeightMultiplier": Double(settings.lineHeightMultiplier)
+        default: UserDefaults.standard.object(forKey: item.key)
+        }
+    }
+
+    private static func isSpecialJSONSetting(_ key: String) -> Bool {
+        switch key {
+        case "shortcuts.app",
+             "shortcuts.customCommands",
+             "ai.providers",
+             "aiUsage.providers",
+             "mobile.approvedDevices":
+            true
+        default:
+            false
+        }
+    }
+
+    private static func applySpecialSetting(key: String, value: Any) -> Bool {
+        switch key {
+        case SentryConsent.storageKey:
+            guard let rawValue = value as? String else { return false }
+            if rawValue.isEmpty {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else if let consent = SentryConsent(rawValue: rawValue) {
+                SentryService.shared.setConsent(consent)
+            }
+        case "muxy.ui.scale":
+            guard let rawValue = value as? String, let preset = UIScale.Preset(rawValue: rawValue) else { return false }
+            UIScale.shared.preset = preset
+        case "muxy.theme.light":
+            guard let value = value as? String else { return false }
+            ThemeService.shared.applyLightTheme(value)
+        case "muxy.theme.dark":
+            guard let value = value as? String else { return false }
+            ThemeService.shared.applyDarkTheme(value)
+        case ProjectPickerDefaultLocation.storageKey:
+            guard let value = value as? String else { return false }
+            if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                ProjectPickerDefaultLocation.resetToAppDefault()
+            } else {
+                ProjectPickerDefaultLocation.setCustomPath(value)
+            }
+        case "shortcuts.app":
+            guard let bindings = keyBindings(from: value) else { return false }
+            KeyBindingStore.shared.replaceBindings(bindings)
+        case "shortcuts.customCommands":
+            guard let configuration = commandShortcutConfiguration(from: value) else { return false }
+            CommandShortcutStore.shared.replaceConfiguration(configuration)
+        case "ai.providers":
+            guard let values = value as? [String: Any] else { return false }
+            for provider in AIProviderRegistry.shared.providers {
+                guard let enabled = values[provider.id] as? Bool else { continue }
+                provider.isEnabled = enabled
+            }
+            AIProviderRegistry.shared.installAll()
+        case "aiUsage.providers":
+            guard let values = value as? [String: Any] else { return false }
+            for provider in AIUsageProviderCatalog.providers {
+                guard let enabled = values[provider.id] as? Bool else { continue }
+                AIUsageProviderTrackingStore.setTracked(enabled, providerID: provider.id)
+            }
+            AIUsageService.shared.recomposeSnapshots()
+        case "mobile.approvedDevices":
+            guard let devices: [ApprovedDevice] = codableValue(from: value) else { return false }
+            ApprovedDevicesStore.shared.replaceDevices(devices)
+        default:
+            return false
+        }
+        return true
+    }
+
+    private static func applyEditorSetting(key: String, value: Any) -> Bool {
+        guard !(value is NSNull) else { return false }
+        let settings = EditorSettings.shared
+        switch key {
+        case "editor.defaultEditor":
+            guard let rawValue = value as? String, let editor = EditorSettings.DefaultEditor(rawValue: rawValue) else { return false }
+            settings.defaultEditor = editor
+        case "editor.externalEditorCommand":
+            guard let value = value as? String else { return false }
+            settings.externalEditorCommand = value
+        case "editor.markdownPreviewFontFamily":
+            guard let value = value as? String else { return false }
+            settings.markdownPreviewFontFamily = value
+        case "editor.markdownPreviewFontScale":
+            guard let value = doubleValue(value) else { return false }
+            settings.markdownPreviewFontScale = CGFloat(value)
+        case "editor.htmlDefaultViewMode":
+            guard let rawValue = value as? String, let mode = EditorMarkdownViewMode(rawValue: rawValue) else { return false }
+            settings.htmlDefaultViewMode = mode
+        case "editor.richInputImageStrategy":
+            guard let rawValue = value as? String, let strategy = RichInputImageStrategy(rawValue: rawValue) else { return false }
+            settings.richInputImageStrategy = strategy
+        case "editor.richInputFontFamily":
+            guard let value = value as? String else { return false }
+            settings.richInputFontFamily = value
+        case "editor.richInputLineHeightMultiplier":
+            guard let value = doubleValue(value) else { return false }
+            settings.richInputLineHeightMultiplier = CGFloat(value)
+        case "editor.highlightCurrentLine":
+            guard let value = value as? Bool else { return false }
+            settings.highlightCurrentLine = value
+        case "editor.showLineNumbers":
+            guard let value = value as? Bool else { return false }
+            settings.showLineNumbers = value
+        case "editor.lineWrapping":
+            guard let value = value as? Bool else { return false }
+            settings.lineWrapping = value
+        case "editor.fontFamily":
+            guard let value = value as? String else { return false }
+            settings.fontFamily = value
+        case "editor.fontSize":
+            guard let value = doubleValue(value) else { return false }
+            settings.fontSize = CGFloat(value)
+        case "editor.lineHeightMultiplier":
+            guard let value = doubleValue(value) else { return false }
+            settings.lineHeightMultiplier = CGFloat(value)
+        default:
+            return false
+        }
+        return true
+    }
+
+    private static func doubleValue(_ value: Any) -> Double? {
+        if let value = value as? Double { return value }
+        if let value = value as? Int { return Double(value) }
+        if let value = value as? NSNumber { return value.doubleValue }
+        return nil
+    }
+
+    private static func keyBindingsJSONObject(_ bindings: [KeyBinding]) -> Any {
+        Dictionary(uniqueKeysWithValues: bindings.map { binding in
+            (binding.action.rawValue, codableJSONObject(binding.combo) ?? [:])
+        })
+    }
+
+    private static func keyBindings(from value: Any) -> [KeyBinding]? {
+        guard let dictionary = value as? [String: Any] else { return nil }
+        return dictionary.compactMap { key, value in
+            guard let action = ShortcutAction(rawValue: key), let combo: KeyCombo = codableValue(from: value) else { return nil }
+            return KeyBinding(action: action, combo: combo)
+        }
+    }
+
+    private static func commandShortcutsJSONObject(_ configuration: CommandShortcutConfiguration) -> Any {
+        codableJSONObject(StoredCommandShortcutJSON(
+            prefixCombo: configuration.prefixCombo,
+            shortcuts: configuration.shortcuts
+        )) ?? [:]
+    }
+
+    private static func commandShortcutConfiguration(from value: Any) -> CommandShortcutConfiguration? {
+        guard let stored: StoredCommandShortcutJSON = codableValue(from: value) else { return nil }
+        return CommandShortcutConfiguration(prefixCombo: stored.prefixCombo, shortcuts: stored.shortcuts)
+    }
+
+    private static func notificationProviderSettings(defaultValue: Bool? = nil) -> [String: Bool] {
+        Dictionary(uniqueKeysWithValues: AIProviderRegistry.shared.providers.map { provider in
+            (provider.id, defaultValue ?? provider.isEnabled)
+        })
+    }
+
+    private static func aiUsageProviderSettings(defaultValue: Bool? = nil) -> [String: Bool] {
+        Dictionary(uniqueKeysWithValues: AIUsageProviderCatalog.providers.map { provider in
+            (provider.id, defaultValue ?? AIUsageProviderTrackingStore.isTracked(providerID: provider.id))
+        })
+    }
+
+    private static func codableJSONObject(_ value: some Encodable) -> Any? {
+        guard let data = try? JSONEncoder().encode(value) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data)
+    }
+
+    private static func codableValue<Value: Decodable>(from value: Any) -> Value? {
+        guard JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value)
+        else { return nil }
+        return try? JSONDecoder().decode(Value.self, from: data)
+    }
+
+    private static func jsonValue(_ value: AnyHashable) -> Any {
+        if let array = value.base as? [String] { return array }
+        if let value = value.base as? UInt16 { return Int(value) }
+        return value.base
+    }
+
+    private static func prettyJSONString(_ dictionary: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: dictionary,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        ), let text = String(data: data, encoding: .utf8)
+        else { return "{}" }
+        return text + "\n"
+    }
+}
+
+private struct StoredCommandShortcutJSON: Codable {
+    let prefixCombo: KeyCombo
+    let shortcuts: [CommandShortcut]
+}
+
+enum SettingsJSONError: LocalizedError {
+    case topLevelObjectRequired
+    case unsupportedValue(String)
+    case invalidValue(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .topLevelObjectRequired:
+            "Settings JSON must be an object."
+        case let .unsupportedValue(key):
+            "Unsupported JSON value for \"\(key)\"."
+        case let .invalidValue(key):
+            "Invalid JSON value for \"\(key)\"."
+        }
+    }
+}

--- a/Muxy/Services/SettingsJSONStore.swift
+++ b/Muxy/Services/SettingsJSONStore.swift
@@ -128,7 +128,7 @@ enum SettingsJSONStore {
         var settings: [String: Any] = [:]
         for (key, value) in dictionary {
             if isSpecialJSONSetting(key) {
-                settings[key] = value
+                settings[key] = try validatedSpecialValue(value, key: key)
                 continue
             }
             guard let item = itemsByKey[key] else { continue }
@@ -283,6 +283,27 @@ enum SettingsJSONStore {
         }
     }
 
+    private static func validatedSpecialValue(_ value: Any, key: String) throws -> Any {
+        switch key {
+        case "shortcuts.app":
+            guard let bindings = keyBindings(from: value), !bindings.isEmpty else { throw SettingsJSONError.invalidValue(key) }
+        case "shortcuts.customCommands":
+            guard let configuration = commandShortcutConfiguration(from: value), isValidKeyCombo(configuration.prefixCombo),
+                  configuration.shortcuts.allSatisfy({ isValidKeyCombo($0.combo) })
+            else { throw SettingsJSONError.invalidValue(key) }
+        case "ai.providers",
+             "aiUsage.providers":
+            guard let values = value as? [String: Any], values.values.allSatisfy({ $0 is Bool }) else {
+                throw SettingsJSONError.invalidValue(key)
+            }
+        case "mobile.approvedDevices":
+            guard (codableValue(from: value) as [ApprovedDevice]?) != nil else { throw SettingsJSONError.invalidValue(key) }
+        default:
+            throw SettingsJSONError.invalidValue(key)
+        }
+        return value
+    }
+
     private static func applySpecialSetting(key: String, value: Any) -> Bool {
         switch key {
         case SentryConsent.storageKey:
@@ -309,27 +330,27 @@ enum SettingsJSONStore {
                 ProjectPickerDefaultLocation.setCustomPath(value)
             }
         case "shortcuts.app":
-            guard let bindings = keyBindings(from: value) else { return false }
+            guard let bindings = keyBindings(from: value) else { return true }
             KeyBindingStore.shared.replaceBindings(bindings)
         case "shortcuts.customCommands":
-            guard let configuration = commandShortcutConfiguration(from: value) else { return false }
+            guard let configuration = commandShortcutConfiguration(from: value) else { return true }
             CommandShortcutStore.shared.replaceConfiguration(configuration)
         case "ai.providers":
-            guard let values = value as? [String: Any] else { return false }
+            guard let values = value as? [String: Any] else { return true }
             for provider in AIProviderRegistry.shared.providers {
                 guard let enabled = values[provider.id] as? Bool else { continue }
                 provider.isEnabled = enabled
             }
             AIProviderRegistry.shared.installAll()
         case "aiUsage.providers":
-            guard let values = value as? [String: Any] else { return false }
+            guard let values = value as? [String: Any] else { return true }
             for provider in AIUsageProviderCatalog.providers {
                 guard let enabled = values[provider.id] as? Bool else { continue }
                 AIUsageProviderTrackingStore.setTracked(enabled, providerID: provider.id)
             }
             AIUsageService.shared.recomposeSnapshots()
         case "mobile.approvedDevices":
-            guard let devices: [ApprovedDevice] = codableValue(from: value) else { return false }
+            guard let devices: [ApprovedDevice] = codableValue(from: value) else { return true }
             ApprovedDevicesStore.shared.replaceDevices(devices)
         default:
             return false
@@ -404,10 +425,20 @@ enum SettingsJSONStore {
 
     private static func keyBindings(from value: Any) -> [KeyBinding]? {
         guard let dictionary = value as? [String: Any] else { return nil }
-        return dictionary.compactMap { key, value in
-            guard let action = ShortcutAction(rawValue: key), let combo: KeyCombo = codableValue(from: value) else { return nil }
-            return KeyBinding(action: action, combo: combo)
+        var bindings: [KeyBinding] = []
+        for (key, value) in dictionary {
+            guard let action = ShortcutAction(rawValue: key), let combo: KeyCombo = codableValue(from: value), isValidKeyCombo(combo) else {
+                return nil
+            }
+            bindings.append(KeyBinding(action: action, combo: combo))
         }
+        return bindings
+    }
+
+    private static func isValidKeyCombo(_ combo: KeyCombo) -> Bool {
+        !combo.key.isEmpty
+            && KeyCombo.normalized(key: combo.key) == combo.key
+            && KeyCombo.normalized(modifiers: combo.modifiers) == combo.modifiers
     }
 
     private static func commandShortcutsJSONObject(_ configuration: CommandShortcutConfiguration) -> Any {

--- a/Muxy/Services/ThemeService.swift
+++ b/Muxy/Services/ThemeService.swift
@@ -155,6 +155,7 @@ final class ThemeService {
         config.updateConfigValue("theme", value: "\"\(sanitized)\"")
         cachedColors = nil
         ghostty.reloadConfig()
+        SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         NotificationCenter.default.post(name: .themeDidChange, object: nil)
     }
 
@@ -164,6 +165,7 @@ final class ThemeService {
         config.updateConfigValue("theme", value: "dark:\"\(dark)\",light:\"\(light)\"")
         cachedColors = nil
         ghostty.reloadConfig()
+        SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         NotificationCenter.default.post(name: .themeDidChange, object: nil)
     }
 

--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -4,6 +4,8 @@ import SwiftUI
 enum MuxyTheme {
     @MainActor static var bg: Color { snapshot.bg }
     @MainActor static var nsBg: NSColor { snapshot.nsBg }
+    @MainActor static var nsFg: NSColor { snapshot.nsFg }
+    @MainActor static var nsFgMuted: NSColor { snapshot.nsFgMuted }
     @MainActor static var fg: Color { snapshot.fg }
     @MainActor static var fgMuted: Color { snapshot.fgMuted }
     @MainActor static var fgDim: Color { snapshot.fgDim }
@@ -53,6 +55,8 @@ extension MuxyTheme {
     struct Snapshot {
         let palette: EditorThemePalette
         let nsBg: NSColor
+        let nsFg: NSColor
+        let nsFgMuted: NSColor
         let bg: Color
         let fg: Color
         let fgMuted: Color
@@ -92,6 +96,8 @@ extension MuxyTheme {
 
             palette = resolvedPalette
             nsBg = bgColor
+            nsFg = fgColor
+            nsFgMuted = fgColor.withAlphaComponent(0.65)
             bg = Color(nsColor: bgColor)
             fg = Color(nsColor: fgColor)
             fgMuted = Color(nsColor: fgColor.withAlphaComponent(0.65))

--- a/Muxy/Theme/UIScale.swift
+++ b/Muxy/Theme/UIScale.swift
@@ -70,6 +70,7 @@ final class UIScale {
         guard !isLoading else { return }
         do {
             try store.save(Snapshot(preset: preset))
+            SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         } catch {
             logger.error("Failed to save UI scale settings: \(error.localizedDescription)")
         }

--- a/Muxy/Views/Components/ProjectPickerOverlay.swift
+++ b/Muxy/Views/Components/ProjectPickerOverlay.swift
@@ -7,7 +7,6 @@ struct ProjectPickerOverlay: View {
     let onChooseFinder: () -> Void
     let onDismiss: () -> Void
 
-    @Environment(\.openSettings) private var openSettings
     @State private var workflow: ProjectPickerWorkflow
 
     init(
@@ -268,8 +267,8 @@ struct ProjectPickerOverlay: View {
             DispatchQueue.main.async { onChooseFinder() }
         case .openSettingsFocusedOnDefaultLocation:
             DispatchQueue.main.async {
-                openSettings()
                 SettingsFocusCoordinator.shared.request(.projectPickerDefaultLocation)
+                NotificationCenter.default.post(name: .openSettingsModal, object: nil)
             }
         case .dismiss:
             onDismiss()

--- a/Muxy/Views/Settings/AIAssistantSettingsView.swift
+++ b/Muxy/Views/Settings/AIAssistantSettingsView.swift
@@ -47,8 +47,7 @@ struct AIAssistantSettingsView: View {
                 if provider != .custom {
                     SettingsRow("Model (optional)") {
                         TextField("Default", text: modelBinding)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: SettingsMetrics.controlWidth)
+                            .settingsTextInput(width: SettingsMetrics.controlWidth)
                     }
                 } else {
                     customCommandRow
@@ -91,8 +90,7 @@ struct AIAssistantSettingsView: View {
         VStack(alignment: .leading, spacing: 6) {
             SettingsRow("Command") {
                 TextField("e.g. mytool --quiet", text: $customCommand)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: SettingsMetrics.controlWidth)
+                    .settingsTextInput(width: SettingsMetrics.controlWidth)
             }
             Text(
                 "Runs through your interactive login shell so PATH and aliases resolve. "
@@ -100,7 +98,7 @@ struct AIAssistantSettingsView: View {
                     + "Provide arguments that make the tool emit only the response (no banners or progress)."
             )
             .font(.system(size: SettingsMetrics.footnoteFontSize))
-            .foregroundStyle(.secondary)
+            .foregroundStyle(SettingsStyle.mutedForeground)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, SettingsMetrics.horizontalPadding)
             .padding(.bottom, 4)
@@ -115,10 +113,7 @@ struct AIAssistantSettingsView: View {
             TextEditor(text: text)
                 .font(.system(size: SettingsMetrics.footnoteFontSize))
                 .scrollContentBackground(.hidden)
-                .padding(.horizontal, 4)
-                .padding(.vertical, 2)
-                .frame(height: 120)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                .settingsTextInput(minHeight: 120)
                 .padding(.horizontal, SettingsMetrics.horizontalPadding)
 
             HStack {

--- a/Muxy/Views/Settings/AIUsageSettingsView.swift
+++ b/Muxy/Views/Settings/AIUsageSettingsView.swift
@@ -34,7 +34,7 @@ struct AIUsageSettingsView: View {
             .padding(.top, 8)
             .padding(.bottom, 6)
 
-            Divider().padding(.horizontal, 12)
+            SettingsDivider().padding(.horizontal, 12)
 
             ScrollView {
                 if usageEnabled {
@@ -65,7 +65,7 @@ struct AIUsageSettingsView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Enable AI Usage to show the usage board in the sidebar.")
                 .font(.system(size: 12))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 10)
         }
@@ -91,7 +91,7 @@ struct AIUsageSettingsView: View {
             .padding(.top, 8)
             .padding(.bottom, 6)
 
-            Divider().padding(.horizontal, 12)
+            SettingsDivider().padding(.horizontal, 12)
 
             HStack(spacing: 8) {
                 Text("Auto Refresh")
@@ -112,7 +112,7 @@ struct AIUsageSettingsView: View {
             .padding(.top, 8)
             .padding(.bottom, 6)
 
-            Divider().padding(.horizontal, 12)
+            SettingsDivider().padding(.horizontal, 12)
 
             HStack(spacing: 8) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -120,7 +120,7 @@ struct AIUsageSettingsView: View {
                         .font(.system(size: 12, weight: .medium))
                     Text("Display weekly and monthly quotas alongside the primary session usage.")
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SettingsStyle.mutedForeground)
                 }
 
                 Spacer()
@@ -134,12 +134,12 @@ struct AIUsageSettingsView: View {
             .padding(.top, 8)
             .padding(.bottom, 6)
 
-            Divider().padding(.horizontal, 12)
+            SettingsDivider().padding(.horizontal, 12)
 
             HStack(spacing: 8) {
                 Text("Choose which providers appear on the usage board.")
                     .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SettingsStyle.mutedForeground)
 
                 Spacer()
 
@@ -159,7 +159,7 @@ struct AIUsageSettingsView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
 
-            Divider().padding(.horizontal, 12)
+            SettingsDivider().padding(.horizontal, 12)
 
             LazyVGrid(columns: gridColumns, spacing: 8) {
                 ForEach(providers) { provider in
@@ -173,7 +173,7 @@ struct AIUsageSettingsView: View {
 
     private func providerCell(_ provider: AIUsageProviderCatalogEntry) -> some View {
         HStack(spacing: 8) {
-            ProviderIconView(iconName: provider.iconName, size: 16, style: .monochrome(.primary))
+            ProviderIconView(iconName: provider.iconName, size: 16, style: .monochrome(SettingsStyle.foreground))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(provider.displayName)
@@ -183,7 +183,7 @@ struct AIUsageSettingsView: View {
                 if provider.hasNotificationIntegration {
                     Text("Integrated")
                         .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SettingsStyle.mutedForeground)
                 }
             }
 
@@ -196,7 +196,7 @@ struct AIUsageSettingsView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+        .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 8))
     }
 
     private func providerToggleBinding(for provider: AIUsageProviderCatalogEntry) -> Binding<Bool> {

--- a/Muxy/Views/Settings/AppearanceSettingsView.swift
+++ b/Muxy/Views/Settings/AppearanceSettingsView.swift
@@ -116,7 +116,8 @@ struct AppearanceSettingsView: View {
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
-            .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+            .foregroundStyle(SettingsStyle.foreground)
+            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
         .popover(isPresented: isPresented) {

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -24,7 +24,7 @@ struct EditorSettingsView: View {
                 }
                 .font(.system(size: SettingsMetrics.footnoteFontSize))
                 .buttonStyle(.borderless)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
             }
             .padding(.horizontal, SettingsMetrics.horizontalPadding)
             .padding(.bottom, SettingsMetrics.verticalPadding)
@@ -51,9 +51,8 @@ struct EditorSettingsView: View {
             if settings.defaultEditor == .terminalCommand {
                 SettingsRow("Editor Command") {
                     TextField("vim", text: $settings.externalEditorCommand)
-                        .textFieldStyle(.roundedBorder)
                         .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
-                        .frame(width: SettingsMetrics.controlWidth)
+                        .settingsTextInput(width: SettingsMetrics.controlWidth)
                 }
             }
         }

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -204,12 +204,12 @@ struct GeneralSettingsView: View {
         HStack(spacing: 7) {
             Image(systemName: defaultWorktreeParentPath.isEmpty ? "internaldrive" : "folder")
                 .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
                 .frame(width: 15)
 
             Text(defaultWorktreeLocationText)
                 .font(.system(size: SettingsMetrics.footnoteFontSize, design: .monospaced))
-                .foregroundStyle(defaultWorktreeParentPath.isEmpty ? .secondary : .primary)
+                .foregroundStyle(defaultWorktreeParentPath.isEmpty ? SettingsStyle.mutedForeground : SettingsStyle.foreground)
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .textSelection(.enabled)
@@ -218,10 +218,10 @@ struct GeneralSettingsView: View {
         .padding(.horizontal, 9)
         .frame(minWidth: 170, maxWidth: .infinity, alignment: .leading)
         .frame(height: 22)
-        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 6))
+        .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
         .overlay(
             RoundedRectangle(cornerRadius: 6)
-                .stroke(.quaternary.opacity(0.7), lineWidth: 1)
+                .stroke(SettingsStyle.border, lineWidth: 1)
         )
     }
 

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct KeyboardShortcutsSettingsView: View {
+    @Environment(\.settingsSearchQuery) private var settingsSearchQuery
+
     private enum ListSection: String, CaseIterable, Identifiable {
         case app
         case custom
@@ -40,13 +42,16 @@ struct KeyboardShortcutsSettingsView: View {
     var body: some View {
         VStack(spacing: 0) {
             sectionPicker
-            Divider()
+            SettingsDivider()
             header
-            Divider()
+            SettingsDivider()
             switch section {
             case .app: appShortcutsList
             case .custom: customShortcutsList
             }
+        }
+        .onChange(of: settingsSearchQuery) { _, query in
+            applyGlobalSearchSection(query)
         }
     }
 
@@ -77,15 +82,16 @@ struct KeyboardShortcutsSettingsView: View {
         HStack(spacing: 8) {
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SettingsStyle.mutedForeground)
                     .font(.system(size: SettingsMetrics.labelFontSize))
                 TextField(section.searchPlaceholder, text: $searchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: SettingsMetrics.labelFontSize))
+                    .foregroundStyle(SettingsStyle.foreground)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 6)
-            .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
 
             switch section {
             case .app:
@@ -96,7 +102,7 @@ struct KeyboardShortcutsSettingsView: View {
                 }
                 .buttonStyle(.plain)
                 .font(.system(size: SettingsMetrics.footnoteFontSize))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
             case .custom:
                 Button {
                     searchText = ""
@@ -163,6 +169,7 @@ struct KeyboardShortcutsSettingsView: View {
                 )
             }
         }
+        .environment(\.settingsSearchQuery, "")
     }
 
     private func filteredActions(for category: String) -> [ShortcutAction] {
@@ -183,14 +190,14 @@ struct KeyboardShortcutsSettingsView: View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Custom Commands")
                 .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
                 .padding(.horizontal, SettingsMetrics.horizontalPadding)
                 .padding(.top, SettingsMetrics.sectionHeaderTopPadding)
                 .padding(.bottom, 2)
 
             Text("Press the command layer shortcut, then a command key to open a new terminal tab.")
                 .font(.system(size: SettingsMetrics.footnoteFontSize))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, SettingsMetrics.horizontalPadding)
                 .padding(.bottom, SettingsMetrics.sectionHeaderBottomPadding)
@@ -274,6 +281,14 @@ struct KeyboardShortcutsSettingsView: View {
         store.updateBinding(action: action, combo: combo)
         recordingAction = nil
         conflictWarning = nil
+    }
+
+    private func applyGlobalSearchSection(_ query: String) {
+        let sections = SettingsCatalog.matchingItems(query: query)
+            .filter { $0.category == .shortcuts }
+            .map(\.section)
+        guard sections.contains("Custom Commands") else { return }
+        section = .custom
     }
 
     private func handleRecord(prefixCombo combo: KeyCombo) {
@@ -390,12 +405,12 @@ private struct ShortcutRow: View {
             if let conflictAction {
                 Text("Conflicts with \"\(conflictAction.displayName)\" — press a different shortcut or Esc to cancel")
                     .font(.system(size: 10))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(SettingsStyle.warning)
             }
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
-        .background(hovered ? Color.primary.opacity(0.04) : .clear)
+        .background(hovered ? SettingsStyle.hover : .clear)
         .onHover { hovered = $0 }
     }
 
@@ -405,7 +420,7 @@ private struct ShortcutRow: View {
                 Button(action: onReset) {
                     Image(systemName: "arrow.counterclockwise")
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SettingsStyle.mutedForeground)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Reset Shortcut")
@@ -414,10 +429,10 @@ private struct ShortcutRow: View {
             Button(action: onStartRecording) {
                 Text(combo.displayString)
                     .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(SettingsStyle.foreground)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
             }
             .buttonStyle(.plain)
         }
@@ -431,10 +446,10 @@ private struct ShortcutRow: View {
 
             Text("Press shortcut…")
                 .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                .foregroundStyle(.orange)
+                .foregroundStyle(SettingsStyle.warning)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
-                .background(.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
+                .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
         }
     }
 }
@@ -466,12 +481,12 @@ private struct CommandPrefixRow: View {
             if let conflictMessage {
                 Text("\(conflictMessage) — press a different shortcut or Esc to cancel")
                     .font(.system(size: 10))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(SettingsStyle.warning)
             }
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
-        .background(hovered ? Color.primary.opacity(0.04) : .clear)
+        .background(hovered ? SettingsStyle.hover : .clear)
         .onHover { hovered = $0 }
     }
 
@@ -481,7 +496,7 @@ private struct CommandPrefixRow: View {
                 Button(action: onReset) {
                     Image(systemName: "arrow.counterclockwise")
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SettingsStyle.mutedForeground)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Reset Shortcut")
@@ -490,10 +505,10 @@ private struct CommandPrefixRow: View {
             Button(action: onStartRecording) {
                 Text(combo.displayString)
                     .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(SettingsStyle.foreground)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
             }
             .buttonStyle(.plain)
         }
@@ -507,10 +522,10 @@ private struct CommandPrefixRow: View {
 
             Text("Press shortcut…")
                 .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                .foregroundStyle(.orange)
+                .foregroundStyle(SettingsStyle.warning)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
-                .background(.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
+                .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
         }
     }
 }
@@ -536,14 +551,12 @@ private struct CommandShortcutRow: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 TextField("Name", text: $shortcut.name)
-                    .textFieldStyle(.roundedBorder)
                     .font(.system(size: SettingsMetrics.labelFontSize))
-                    .frame(width: 120)
+                    .settingsTextInput(width: 120)
 
                 TextField("Command", text: $shortcut.command)
-                    .textFieldStyle(.roundedBorder)
                     .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
-                    .frame(maxWidth: .infinity)
+                    .settingsTextInput(maxWidth: .infinity)
 
                 if isRecording {
                     recordingView
@@ -555,12 +568,12 @@ private struct CommandShortcutRow: View {
             if let conflictMessage {
                 Text("\(conflictMessage) — press a different shortcut or Esc to cancel")
                     .font(.system(size: 10))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(SettingsStyle.warning)
             }
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
-        .background(hovered ? Color.primary.opacity(0.04) : .clear)
+        .background(hovered ? SettingsStyle.hover : .clear)
         .onHover { hovered = $0 }
     }
 
@@ -569,10 +582,10 @@ private struct CommandShortcutRow: View {
             Button(action: onStartRecording) {
                 Text("\(prefixCombo.displayString) \(shortcut.combo.displayString)")
                     .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(SettingsStyle.foreground)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
             }
             .buttonStyle(.plain)
 
@@ -580,13 +593,13 @@ private struct CommandShortcutRow: View {
                 Image(systemName: "trash")
                     .font(.system(size: 10))
                     .foregroundStyle(
-                        deleteButtonHovered ? AnyShapeStyle(MuxyTheme.diffRemoveFg) : AnyShapeStyle(.secondary)
+                        deleteButtonHovered ? AnyShapeStyle(SettingsStyle.destructive) : AnyShapeStyle(SettingsStyle.mutedForeground)
                     )
                     .frame(width: Metrics.deleteButtonSize, height: Metrics.deleteButtonSize)
             }
             .buttonStyle(.plain)
             .background(
-                deleteButtonHovered ? AnyShapeStyle(MuxyTheme.diffRemoveBg) : AnyShapeStyle(.quaternary),
+                deleteButtonHovered ? AnyShapeStyle(SettingsStyle.destructiveSoft) : AnyShapeStyle(SettingsStyle.surface),
                 in: RoundedRectangle(cornerRadius: 5)
             )
             .onHover { isHovering in
@@ -605,10 +618,10 @@ private struct CommandShortcutRow: View {
 
             Text("Press key…")
                 .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                .foregroundStyle(.orange)
+                .foregroundStyle(SettingsStyle.warning)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
-                .background(.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
+                .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
         }
     }
 }
@@ -628,7 +641,7 @@ private struct DeleteAllCommandShortcutsRow: View {
             Button(action: action) {
                 Text(title)
                     .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                    .foregroundStyle(isConfirming ? MuxyTheme.diffRemoveFg : .secondary)
+                    .foregroundStyle(isConfirming ? SettingsStyle.destructive : SettingsStyle.mutedForeground)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
                     .background(backgroundStyle, in: RoundedRectangle(cornerRadius: 5))
@@ -648,6 +661,6 @@ private struct DeleteAllCommandShortcutsRow: View {
     }
 
     private var backgroundStyle: AnyShapeStyle {
-        isConfirming ? AnyShapeStyle(MuxyTheme.diffRemoveBg) : AnyShapeStyle(.quaternary)
+        isConfirming ? AnyShapeStyle(SettingsStyle.destructiveSoft) : AnyShapeStyle(SettingsStyle.surface)
     }
 }

--- a/Muxy/Views/Settings/MobilePairingQRView.swift
+++ b/Muxy/Views/Settings/MobilePairingQRView.swift
@@ -25,7 +25,7 @@ struct MobilePairingQRView: View {
         .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
+                .strokeBorder(SettingsStyle.border, lineWidth: 1)
         )
         .onAppear(perform: rebuildIfNeeded)
         .onChange(of: uriString) { _, _ in rebuildIfNeeded() }
@@ -54,7 +54,7 @@ struct MobilePairingQRView: View {
                 .resizable()
                 .scaledToFit()
                 .padding(size * 0.2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(SettingsStyle.dimForeground)
         }
         .frame(width: size, height: size)
     }

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -39,9 +39,8 @@ struct MobileSettingsView: View {
 
                 SettingsRow("Port") {
                     TextField("\(MobileServerService.defaultPort)", text: $portText)
-                        .textFieldStyle(.roundedBorder)
                         .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
-                        .frame(width: SettingsMetrics.controlWidth)
+                        .settingsTextInput(width: SettingsMetrics.controlWidth)
                         .onChange(of: portText) { _, _ in
                             guard portText != String(service.port) else { return }
                             portValidationError = nil
@@ -56,7 +55,7 @@ struct MobileSettingsView: View {
                     HStack(spacing: 6) {
                         Text(error)
                             .font(.system(size: SettingsMetrics.footnoteFontSize))
-                            .foregroundStyle(.red)
+                            .foregroundStyle(SettingsStyle.destructive)
                             .fixedSize(horizontal: false, vertical: true)
                         if service.isPortInUse {
                             Button("Free Port") {
@@ -89,7 +88,7 @@ struct MobileSettingsView: View {
                 if devices.devices.isEmpty {
                     Text("No devices approved yet.")
                         .font(.system(size: SettingsMetrics.labelFontSize))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SettingsStyle.mutedForeground)
                         .padding(.horizontal, SettingsMetrics.horizontalPadding)
                         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
                 } else {
@@ -205,13 +204,13 @@ struct MobileSettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     Text(host.host)
                         .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(SettingsStyle.foreground)
                         .textSelection(.enabled)
                         .lineLimit(1)
                         .truncationMode(.middle)
                     Text("Port \(String(service.port))")
                         .font(.system(size: SettingsMetrics.footnoteFontSize))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(SettingsStyle.mutedForeground)
                 }
                 Spacer(minLength: 0)
             }
@@ -226,7 +225,7 @@ struct MobileSettingsView: View {
         HStack(spacing: 8) {
             Text(uri)
                 .font(.system(size: SettingsMetrics.footnoteFontSize, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
                 .textSelection(.enabled)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -246,7 +245,7 @@ struct MobileSettingsView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+        .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
     }
 
     private func copyPairingLink(_ uri: String) {
@@ -267,7 +266,7 @@ struct MobileSettingsView: View {
                     .font(.system(size: SettingsMetrics.labelFontSize))
                 Text(lastSeenText(device))
                     .font(.system(size: SettingsMetrics.footnoteFontSize))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SettingsStyle.mutedForeground)
             }
             Spacer()
             Button("Revoke", role: .destructive) {
@@ -275,7 +274,7 @@ struct MobileSettingsView: View {
             }
             .buttonStyle(.borderless)
             .font(.system(size: SettingsMetrics.footnoteFontSize))
-            .foregroundStyle(.red)
+            .foregroundStyle(SettingsStyle.destructive)
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
         .padding(.vertical, SettingsMetrics.rowVerticalPadding)

--- a/Muxy/Views/Settings/NotificationSettingsView.swift
+++ b/Muxy/Views/Settings/NotificationSettingsView.swift
@@ -58,7 +58,7 @@ private struct ProviderToggleRow: View {
         HStack {
             Image(systemName: provider.iconName)
                 .font(.system(size: 10))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(SettingsStyle.mutedForeground)
                 .frame(width: 16)
             Text(provider.displayName)
                 .font(.system(size: SettingsMetrics.labelFontSize))
@@ -80,7 +80,7 @@ private struct ProviderToggleRow: View {
                 }
                 .buttonStyle(.plain)
                 .font(.system(size: SettingsMetrics.footnoteFontSize))
-                .foregroundStyle(refreshed ? .green : Color.accentColor)
+                .foregroundStyle(refreshed ? MuxyTheme.diffAddFg : SettingsStyle.accent)
                 .disabled(refreshed)
             }
             Toggle("", isOn: $enabled)

--- a/Muxy/Views/Settings/RecordingSettingsView.swift
+++ b/Muxy/Views/Settings/RecordingSettingsView.swift
@@ -45,7 +45,7 @@ struct RecordingSettingsView: View {
             SettingsRow("Language") {
                 Text("None available")
                     .font(.system(size: SettingsMetrics.labelFontSize))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SettingsStyle.mutedForeground)
             }
         } else {
             SettingsRow("Language") {

--- a/Muxy/Views/Settings/SessionRestoreSettingsView.swift
+++ b/Muxy/Views/Settings/SessionRestoreSettingsView.swift
@@ -34,14 +34,7 @@ struct SessionRestoreSettingsView: View {
                 TextEditor(text: $excludedCommands)
                     .font(.system(size: 12, design: .monospaced))
                     .scrollContentBackground(.hidden)
-                    .frame(minHeight: 180)
-                    .padding(8)
-                    .background(MuxyTheme.bg)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(MuxyTheme.border, lineWidth: 1)
-                    )
+                    .settingsTextInput(minHeight: 180)
                     .padding(.horizontal, SettingsMetrics.horizontalPadding)
                     .padding(.vertical, SettingsMetrics.rowVerticalPadding)
                     .onChange(of: excludedCommands) { _, value in

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -1,0 +1,612 @@
+import Foundation
+import SwiftUI
+
+enum SettingsCategory: String, CaseIterable, Identifiable {
+    case general
+    case appearance
+    case editor
+    case sessions
+    case shortcuts
+    case recording
+    case notifications
+    case mobile
+    case ai
+    case aiUsage
+    case json
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .appearance: "Appearance"
+        case .editor: "Editor"
+        case .sessions: "Sessions"
+        case .shortcuts: "Shortcuts"
+        case .recording: "Recording"
+        case .notifications: "Notifications"
+        case .mobile: "Mobile"
+        case .ai: "AI Assistant"
+        case .aiUsage: "AI Usage"
+        case .json: "JSON"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .general: "gearshape"
+        case .appearance: "paintbrush"
+        case .editor: "pencil.line"
+        case .sessions: "clock.arrow.circlepath"
+        case .shortcuts: "keyboard"
+        case .recording: "mic"
+        case .notifications: "bell"
+        case .mobile: "iphone"
+        case .ai: "sparkles"
+        case .aiUsage: "chart.bar"
+        case .json: "curlybraces"
+        }
+    }
+}
+
+struct SettingsCatalogItem: Identifiable, Equatable {
+    let key: String
+    let title: String
+    let description: String
+    let category: SettingsCategory
+    let section: String
+    let defaultValue: AnyHashable?
+    let searchableText: String
+
+    var id: String { key }
+
+    init(
+        key: String,
+        title: String,
+        description: String,
+        category: SettingsCategory,
+        section: String,
+        defaultValue: AnyHashable? = nil,
+        aliases: [String] = []
+    ) {
+        self.key = key
+        self.title = title
+        self.description = description
+        self.category = category
+        self.section = section
+        self.defaultValue = defaultValue
+        searchableText = ([key, title, description, category.title, section] + aliases)
+            .joined(separator: " ")
+            .lowercased()
+    }
+}
+
+@MainActor
+enum SettingsCatalog {
+    static let userSettingsFilename = "settings.json"
+    static let systemSettingsFilename = "default-settings.json"
+
+    static let categories = SettingsCategory.allCases
+
+    static let items: [SettingsCatalogItem] = [
+        SettingsCatalogItem(
+            key: UpdateChannel.storageKey,
+            title: "Update Channel",
+            description: "Controls whether Muxy receives stable releases or beta builds.",
+            category: .general,
+            section: "Updates",
+            defaultValue: UpdateChannel.stable.rawValue,
+            aliases: ["release", "beta"]
+        ),
+        SettingsCatalogItem(
+            key: GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch,
+            title: "Auto-expand Worktrees",
+            description: "Automatically reveals worktrees when switching projects.",
+            category: .general,
+            section: "Sidebar",
+            defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: GeneralSettingsKeys.fileTreeSource,
+            title: "File Tree Root Directory",
+            description: "Controls whether the file tree follows the project or active terminal.",
+            category: .general,
+            section: "File Tree",
+            defaultValue: FileTreeSourcePreference.defaultValue.rawValue
+        ),
+        SettingsCatalogItem(
+            key: ProjectPickerPreferences.storageKey,
+            title: "Project Picker",
+            description: "Chooses the picker used when opening projects.",
+            category: .general,
+            section: "Projects",
+            defaultValue: ProjectPickerMode.custom.rawValue
+        ),
+        SettingsCatalogItem(
+            key: ProjectPickerDefaultLocation.storageKey,
+            title: "Project Picker Default Path",
+            description: "Sets the default folder for Muxy's project picker.",
+            category: .general,
+            section: "Projects",
+            defaultValue: "",
+            aliases: ["folder", "path", "directory"]
+        ),
+        SettingsCatalogItem(
+            key: ProjectLifecyclePreferences.keepOpenWhenNoTabsKey,
+            title: "Keep Projects Open",
+            description: "Keeps projects in the sidebar after closing the last tab.",
+            category: .general,
+            section: "Projects",
+            defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: GeneralSettingsKeys.defaultWorktreeParentPath,
+            title: "Default Worktree Path",
+            description: "Sets the parent folder for new worktrees.",
+            category: .general,
+            section: "Worktrees",
+            defaultValue: "",
+            aliases: ["folder", "path"]
+        ),
+        SettingsCatalogItem(
+            key: GeneralSettingsKeys.autoCopyTerminalSelection,
+            title: "Auto-copy Terminal Selection",
+            description: "Copies terminal selections when the mouse is released.",
+            category: .general,
+            section: "Terminal",
+            defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: TabCloseConfirmationPreferences.confirmRunningProcessKey,
+            title: "Confirm Running Process Tab Close",
+            description: "Asks before closing a terminal tab with a running process.",
+            category: .general,
+            section: "Tabs",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
+            key: QuitConfirmationPreferences.confirmQuitKey,
+            title: "Confirm Quit",
+            description: "Asks before quitting Muxy.",
+            category: .general,
+            section: "Quit",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
+            key: "muxy.sentry.consent",
+            title: "Crash Reports",
+            description: "Controls anonymous crash report consent when diagnostics are available.",
+            category: .general,
+            section: "Diagnostics",
+            defaultValue: ""
+        ),
+
+        SettingsCatalogItem(
+            key: "muxy.ui.scale",
+            title: "Interface Size",
+            description: "Controls the scale of the app interface.",
+            category: .appearance,
+            section: "Interface",
+            defaultValue: UIScale.defaultPreset.rawValue,
+            aliases: ["zoom", "density"]
+        ),
+        SettingsCatalogItem(
+            key: "muxy.showStatusBar",
+            title: "Show Status Bar",
+            description: "Shows or hides the status bar.",
+            category: .appearance,
+            section: "Interface",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
+            key: "muxy.theme.light",
+            title: "Light Terminal Theme",
+            description: "Chooses the terminal theme for light appearance.",
+            category: .appearance,
+            section: "Terminal",
+            defaultValue: ThemeService.defaultThemeName
+        ),
+        SettingsCatalogItem(
+            key: "muxy.theme.dark",
+            title: "Dark Terminal Theme",
+            description: "Chooses the terminal theme for dark appearance.",
+            category: .appearance,
+            section: "Terminal",
+            defaultValue: ThemeService.defaultThemeName
+        ),
+        SettingsCatalogItem(
+            key: SidebarCollapsedStyle.storageKey,
+            title: "Collapsed Sidebar Style",
+            description: "Controls the sidebar appearance when collapsed.",
+            category: .appearance,
+            section: "Sidebar",
+            defaultValue: SidebarCollapsedStyle.defaultValue.rawValue
+        ),
+        SettingsCatalogItem(
+            key: SidebarExpandedStyle.storageKey,
+            title: "Expanded Sidebar Style",
+            description: "Controls the sidebar appearance when expanded.",
+            category: .appearance,
+            section: "Sidebar",
+            defaultValue: SidebarExpandedStyle.defaultValue.rawValue
+        ),
+        SettingsCatalogItem(
+            key: "muxy.vcsDisplayMode",
+            title: "Source Control Display Mode",
+            description: "Controls how source control is shown.",
+            category: .appearance,
+            section: "Source Control",
+            defaultValue: VCSDisplayMode.attached.rawValue
+        ),
+
+        SettingsCatalogItem(
+            key: "editor.defaultEditor",
+            title: "Default Editor",
+            description: "Chooses between Muxy's editor and a terminal editor command.",
+            category: .editor,
+            section: "Editor",
+            defaultValue: EditorSettings.DefaultEditor.builtIn.rawValue
+        ),
+        SettingsCatalogItem(
+            key: "editor.externalEditorCommand",
+            title: "Editor Command",
+            description: "Runs this command when the terminal editor is selected.",
+            category: .editor,
+            section: "Editor",
+            defaultValue: "vim"
+        ),
+        SettingsCatalogItem(
+            key: MarkdownPreviewPreferences.allowRemoteImagesKey,
+            title: "Allow Remote Images",
+            description: "Allows HTTPS images in Markdown preview.",
+            category: .editor,
+            section: "Markdown Preview",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
+            key: "editor.markdownPreviewFontFamily",
+            title: "Markdown Preview Font Family",
+            description: "Controls the Markdown preview font.",
+            category: .editor,
+            section: "Markdown Preview",
+            defaultValue: EditorSettings.defaultMarkdownPreviewFontFamily
+        ),
+        SettingsCatalogItem(
+            key: "editor.markdownPreviewFontScale",
+            title: "Markdown Preview Zoom",
+            description: "Controls Markdown preview zoom.",
+            category: .editor,
+            section: "Markdown Preview",
+            defaultValue: Double(EditorSettings.defaultMarkdownPreviewFontScale)
+        ),
+        SettingsCatalogItem(
+            key: "editor.htmlDefaultViewMode",
+            title: "HTML Default View",
+            description: "Chooses the default view mode for HTML files.",
+            category: .editor,
+            section: "HTML",
+            defaultValue: EditorSettings.defaultHTMLViewMode.rawValue
+        ),
+        SettingsCatalogItem(
+            key: "editor.richInputImageStrategy",
+            title: "Rich Input Image Submission",
+            description: "Chooses how rich input submits images.",
+            category: .editor,
+            section: "Rich Input",
+            defaultValue: RichInputImageStrategy.clipboard.rawValue
+        ),
+        SettingsCatalogItem(
+            key: RichInputPreferences.positionKey,
+            title: "Rich Input Position",
+            description: "Controls where the rich input panel appears.",
+            category: .editor,
+            section: "Rich Input",
+            defaultValue: RichInputPreferences.defaultPosition.rawValue
+        ),
+        SettingsCatalogItem(
+            key: RichInputPreferences.floatingKey,
+            title: "Floating Rich Input",
+            description: "Shows rich input as a floating panel.",
+            category: .editor,
+            section: "Rich Input",
+            defaultValue: RichInputPreferences.defaultFloating
+        ),
+        SettingsCatalogItem(
+            key: "editor.richInputFontFamily",
+            title: "Rich Input Font Family",
+            description: "Controls the rich input editor font family.",
+            category: .editor,
+            section: "Rich Input",
+            defaultValue: EditorSettings.defaultRichInputFontFamily
+        ),
+        SettingsCatalogItem(
+            key: "editor.richInputLineHeightMultiplier",
+            title: "Rich Input Line Height",
+            description: "Controls line height in rich input.",
+            category: .editor,
+            section: "Rich Input",
+            defaultValue: Double(EditorSettings.defaultRichInputLineHeightMultiplier)
+        ),
+        SettingsCatalogItem(
+            key: "editor.highlightCurrentLine",
+            title: "Highlight Current Line",
+            description: "Highlights the active line in the built-in editor.",
+            category: .editor,
+            section: "Appearance",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
+            key: "editor.showLineNumbers",
+            title: "Show Line Numbers",
+            description: "Shows line numbers in the built-in editor.",
+            category: .editor,
+            section: "Appearance",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
+            key: "editor.lineWrapping",
+            title: "Wrap Lines",
+            description: "Wraps long lines in the built-in editor.",
+            category: .editor,
+            section: "Appearance",
+            defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: "editor.fontFamily",
+            title: "Editor Font Family",
+            description: "Controls the built-in editor font family.",
+            category: .editor,
+            section: "Appearance",
+            defaultValue: "SF Mono"
+        ),
+        SettingsCatalogItem(
+            key: "editor.fontSize",
+            title: "Editor Font Size",
+            description: "Controls the built-in editor font size.",
+            category: .editor,
+            section: "Appearance",
+            defaultValue: 13
+        ),
+        SettingsCatalogItem(
+            key: "editor.lineHeightMultiplier",
+            title: "Editor Line Height",
+            description: "Controls line height in the built-in editor.",
+            category: .editor,
+            section: "Appearance",
+            defaultValue: Double(EditorSettings.defaultLineHeightMultiplier)
+        ),
+
+        SettingsCatalogItem(
+            key: SessionRestorePreferences.enabledKey,
+            title: "Restore Terminal Sessions",
+            description: "Restores terminal sessions when a project opens.",
+            category: .sessions,
+            section: "Restore",
+            defaultValue: SessionRestorePreferences.defaultIsEnabled
+        ),
+        SettingsCatalogItem(
+            key: SessionRestorePreferences.excludedCommandsKey,
+            title: "Blocked Commands",
+            description: "Commands that are never restored automatically.",
+            category: .sessions,
+            section: "Blocked Commands",
+            defaultValue: SessionRestorePreferences.defaultExcludedCommands
+        ),
+        SettingsCatalogItem(
+            key: "shortcuts.app",
+            title: "App Shortcuts",
+            description: "Configures Muxy keyboard shortcuts.",
+            category: .shortcuts,
+            section: "App Shortcuts",
+            aliases: ["keybindings", "hotkeys"]
+        ),
+        SettingsCatalogItem(
+            key: "shortcuts.customCommands",
+            title: "Custom Commands",
+            description: "Configures shortcuts that open command tabs.",
+            category: .shortcuts,
+            section: "Custom Commands",
+            aliases: ["command layer"]
+        ),
+        SettingsCatalogItem(
+            key: RecordingPreferences.autoSendKey,
+            title: "Press Return After Inserting",
+            description: "Presses Return after voice transcription is inserted.",
+            category: .recording,
+            section: "Voice Recording",
+            defaultValue: RecordingPreferences.defaultAutoSend
+        ),
+        SettingsCatalogItem(
+            key: RecordingPreferences.languageKey,
+            title: "Recording Language",
+            description: "Chooses the on-device speech recognition language.",
+            category: .recording,
+            section: "Language",
+            defaultValue: RecordingPreferences.defaultLanguage
+        ),
+        SettingsCatalogItem(
+            key: "muxy.notifications.toastEnabled",
+            title: "Toast Notifications",
+            description: "Shows toast notifications.",
+            category: .notifications,
+            section: "Delivery",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
+            key: "muxy.notifications.sound",
+            title: "Notification Sound",
+            description: "Chooses the notification sound.",
+            category: .notifications,
+            section: "Sound",
+            defaultValue: NotificationSound.funk.rawValue
+        ),
+        SettingsCatalogItem(
+            key: "muxy.notifications.toastPosition",
+            title: "Toast Position",
+            description: "Controls where toast notifications appear.",
+            category: .notifications,
+            section: "Toast",
+            defaultValue: ToastPosition.topCenter.rawValue
+        ),
+        SettingsCatalogItem(
+            key: "ai.providers",
+            title: "AI Provider Notifications",
+            description: "Controls AI provider notification integrations.",
+            category: .notifications,
+            section: "AI Providers"
+        ),
+
+        SettingsCatalogItem(
+            key: MobileServerService.enabledKey,
+            title: "Allow Mobile Connections",
+            description: "Allows mobile devices to connect to this Mac.",
+            category: .mobile,
+            section: "Mobile",
+            defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: MobileServerService.portKey,
+            title: "Mobile Port",
+            description: "Controls the local server port for mobile pairing.",
+            category: .mobile,
+            section: "Mobile",
+            defaultValue: MobileServerService.defaultPort
+        ),
+        SettingsCatalogItem(
+            key: "mobile.pairing",
+            title: "Pair Mobile Device",
+            description: "Shows the QR code used to pair a mobile device.",
+            category: .mobile,
+            section: "Pair Mobile Device"
+        ),
+        SettingsCatalogItem(
+            key: "mobile.approvedDevices",
+            title: "Approved Devices",
+            description: "Manages mobile devices that can connect.",
+            category: .mobile,
+            section: "Approved Devices"
+        ),
+
+        SettingsCatalogItem(
+            key: AIAssistantSettings.providerKey,
+            title: "AI Assistant Tool",
+            description: "Chooses the CLI tool used for commit and PR generation.",
+            category: .ai,
+            section: "Provider",
+            defaultValue: AIAssistantProvider.claude.rawValue
+        ),
+        SettingsCatalogItem(
+            key: AIAssistantSettings.claudeModelKey,
+            title: "Claude Model",
+            description: "Optional Claude model override.",
+            category: .ai,
+            section: "Provider",
+            defaultValue: ""
+        ),
+        SettingsCatalogItem(
+            key: AIAssistantSettings.codexModelKey,
+            title: "Codex Model",
+            description: "Optional Codex model override.",
+            category: .ai,
+            section: "Provider",
+            defaultValue: ""
+        ),
+        SettingsCatalogItem(
+            key: AIAssistantSettings.opencodeModelKey,
+            title: "OpenCode Model",
+            description: "Optional OpenCode model override.",
+            category: .ai,
+            section: "Provider",
+            defaultValue: ""
+        ),
+        SettingsCatalogItem(
+            key: AIAssistantSettings.customCommandKey,
+            title: "Custom AI Command",
+            description: "Command used when the custom AI provider is selected.",
+            category: .ai,
+            section: "Provider",
+            defaultValue: ""
+        ),
+        SettingsCatalogItem(
+            key: AIAssistantSettings.commitPromptKey,
+            title: "Commit Prompt",
+            description: "Prompt used to generate commit messages.",
+            category: .ai,
+            section: "Commit Prompt",
+            defaultValue: ""
+        ),
+        SettingsCatalogItem(
+            key: AIAssistantSettings.prPromptKey,
+            title: "Pull Request Prompt",
+            description: "Prompt used to generate pull request drafts.",
+            category: .ai,
+            section: "Pull Request Prompt",
+            defaultValue: ""
+        ),
+
+        SettingsCatalogItem(
+            key: AIUsageSettingsStore.usageEnabledKey,
+            title: "Enable AI Usage",
+            description: "Shows the AI usage board in the sidebar.",
+            category: .aiUsage,
+            section: "AI Usage",
+            defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: AIUsageSettingsStore.usageDisplayModeKey,
+            title: "Usage Display Mode",
+            description: "Shows used or remaining AI quota.",
+            category: .aiUsage,
+            section: "Show",
+            defaultValue: AIUsageSettingsStore.defaultUsageDisplayMode.rawValue
+        ),
+        SettingsCatalogItem(
+            key: AIUsageSettingsStore.autoRefreshIntervalKey,
+            title: "Auto Refresh",
+            description: "Controls how often AI usage data refreshes.",
+            category: .aiUsage,
+            section: "Auto Refresh",
+            defaultValue: AIUsageSettingsStore.defaultAutoRefreshInterval.rawValue
+        ),
+        SettingsCatalogItem(
+            key: AIUsageSettingsStore.showSecondaryLimitsKey,
+            title: "Show Secondary Limits",
+            description: "Shows weekly and monthly quotas next to primary usage.",
+            category: .aiUsage,
+            section: "Show Secondary Limits",
+            defaultValue: AIUsageSettingsStore.defaultShowSecondaryLimits
+        ),
+        SettingsCatalogItem(
+            key: "aiUsage.providers",
+            title: "Tracked Usage Providers",
+            description: "Chooses which providers appear on the usage board.",
+            category: .aiUsage,
+            section: "Providers"
+        ),
+    ]
+
+    static let jsonEditableItems = items.filter { item in
+        item.defaultValue != nil
+    }
+
+    static func matchingItems(query: String) -> [SettingsCatalogItem] {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return items }
+        return items.filter { $0.searchableText.contains(normalized) }
+    }
+
+    static func categoryMatches(_ category: SettingsCategory, query: String) -> Bool {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return true }
+        return category.title.localizedCaseInsensitiveContains(normalized)
+            || matchingItems(query: normalized).contains { $0.category == category }
+    }
+
+    static func sectionMatches(query: String, category: SettingsCategory?, section: String) -> Bool {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return true }
+        return matchingItems(query: normalized).contains { item in
+            item.section == section && (category == nil || item.category == category)
+        }
+    }
+}

--- a/Muxy/Views/Settings/SettingsComponents.swift
+++ b/Muxy/Views/Settings/SettingsComponents.swift
@@ -1,6 +1,12 @@
 import AppKit
 import SwiftUI
 
+extension EnvironmentValues {
+    @Entry var settingsSearchQuery: String = ""
+
+    @Entry var settingsCategory: SettingsCategory?
+}
+
 enum SettingsMetrics {
     static let horizontalPadding: CGFloat = 12
     static let verticalPadding: CGFloat = 12
@@ -14,6 +20,37 @@ enum SettingsMetrics {
     static let controlWidth: CGFloat = 210
 }
 
+enum SettingsStyle {
+    @MainActor static var background: Color { MuxyTheme.bg }
+    @MainActor static var foreground: Color { MuxyTheme.fg }
+    @MainActor static var mutedForeground: Color { MuxyTheme.fgMuted }
+    @MainActor static var dimForeground: Color { MuxyTheme.fgDim }
+    @MainActor static var surface: Color { MuxyTheme.surface }
+    @MainActor static var elevatedSurface: Color { MuxyTheme.surface.opacity(1.45) }
+    @MainActor static var sidebarBackground: Color {
+        Color(nsColor: MuxyTheme.nsBg.blended(withFraction: 0.08, of: .black) ?? MuxyTheme.nsBg)
+    }
+
+    @MainActor static var hover: Color { MuxyTheme.hover }
+    @MainActor static var border: Color { MuxyTheme.border }
+    @MainActor static var accent: Color { MuxyTheme.accent }
+    @MainActor static var accentSoft: Color { MuxyTheme.accentSoft }
+    @MainActor static var warning: Color { MuxyTheme.warning }
+    @MainActor static var destructive: Color { MuxyTheme.diffRemoveFg }
+    @MainActor static var destructiveSoft: Color { MuxyTheme.diffRemoveBg }
+    @MainActor static var nsBackground: NSColor { MuxyTheme.nsBg }
+    @MainActor static var nsForeground: NSColor { MuxyTheme.nsFg }
+    @MainActor static var mutedNSForeground: NSColor { MuxyTheme.nsFgMuted }
+}
+
+struct SettingsDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(SettingsStyle.border)
+            .frame(height: 1)
+    }
+}
+
 struct SettingsContainer<Content: View>: View {
     @ViewBuilder var content: Content
 
@@ -24,10 +61,14 @@ struct SettingsContainer<Content: View>: View {
             }
             .frame(maxWidth: .infinity, alignment: .top)
         }
+        .background(SettingsStyle.background)
     }
 }
 
 struct SettingsSection<Content: View>: View {
+    @Environment(\.settingsSearchQuery) private var searchQuery
+    @Environment(\.settingsCategory) private var category
+
     let title: String
     let footer: String?
     let showsDivider: Bool
@@ -46,28 +87,30 @@ struct SettingsSection<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, SettingsMetrics.horizontalPadding)
-                .padding(.top, SettingsMetrics.sectionHeaderTopPadding)
-                .padding(.bottom, SettingsMetrics.sectionHeaderBottomPadding)
-
-            content
-
-            if let footer {
-                Text(footer)
-                    .font(.system(size: SettingsMetrics.footnoteFontSize))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+        if SettingsCatalog.sectionMatches(query: searchQuery, category: category, section: title) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(title)
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
                     .padding(.horizontal, SettingsMetrics.horizontalPadding)
-                    .padding(.top, SettingsMetrics.sectionFooterTopPadding)
-                    .padding(.bottom, SettingsMetrics.sectionFooterBottomPadding)
-            }
+                    .padding(.top, SettingsMetrics.sectionHeaderTopPadding)
+                    .padding(.bottom, SettingsMetrics.sectionHeaderBottomPadding)
 
-            if showsDivider {
-                Divider().padding(.horizontal, SettingsMetrics.horizontalPadding)
+                content
+
+                if let footer {
+                    Text(footer)
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                        .padding(.top, SettingsMetrics.sectionFooterTopPadding)
+                        .padding(.bottom, SettingsMetrics.sectionFooterBottomPadding)
+                }
+
+                if showsDivider {
+                    SettingsDivider().padding(.horizontal, SettingsMetrics.horizontalPadding)
+                }
             }
         }
     }
@@ -86,6 +129,7 @@ struct SettingsRow<Content: View>: View {
         HStack {
             Text(label)
                 .font(.system(size: SettingsMetrics.labelFontSize))
+                .foregroundStyle(SettingsStyle.foreground)
             Spacer()
             content
         }
@@ -129,6 +173,20 @@ struct SettingsPickerRow<Option: CaseIterable & Identifiable & RawRepresentable>
 }
 
 extension View {
+    func settingsTextInput(width: CGFloat? = nil, maxWidth: CGFloat? = nil, minHeight: CGFloat? = nil) -> some View {
+        textFieldStyle(.plain)
+            .foregroundStyle(SettingsStyle.foreground)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .frame(width: width)
+            .frame(maxWidth: maxWidth, minHeight: minHeight)
+            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(SettingsStyle.border, lineWidth: 1)
+            )
+    }
+
     func resetsSettingsFocusOnOutsideClick() -> some View {
         background(SettingsFocusResetView())
     }

--- a/Muxy/Views/Settings/SettingsJSONEditorView.swift
+++ b/Muxy/Views/Settings/SettingsJSONEditorView.swift
@@ -1,0 +1,508 @@
+import AppKit
+import SwiftUI
+
+struct SettingsJSONEditorView: View {
+    private enum Source: String, CaseIterable, Identifiable {
+        case user
+        case system
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .user: "User"
+            case .system: "System Defaults"
+            }
+        }
+    }
+
+    @State private var source: Source = .user
+    @State private var text = ""
+    @State private var status: String?
+    @State private var errorMessage: String?
+    @State private var isSearchVisible = false
+    @State private var searchText = ""
+    @State private var selectedSearchMatchIndex = 0
+    @State private var searchMatchCount = 0
+    @FocusState private var isSearchFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            SettingsDivider()
+            editor
+            footer
+        }
+        .onAppear(perform: reload)
+        .onChange(of: source) { _, _ in reload() }
+        .onChange(of: searchText) { _, _ in selectedSearchMatchIndex = 0 }
+        .overlay(alignment: .topTrailing) {
+            Button("Find") {
+                showSearch()
+            }
+            .keyboardShortcut("f", modifiers: .command)
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
+        }
+    }
+
+    private var editor: some View {
+        VStack(spacing: 0) {
+            if isSearchVisible {
+                searchBar
+            }
+
+            SettingsJSONTextView(
+                text: editorText,
+                isEditable: source == .user,
+                searchText: searchText,
+                selectedSearchMatchIndex: selectedSearchMatchIndex,
+                searchMatchCount: $searchMatchCount,
+                onFindRequested: showSearch
+            )
+            .background(SettingsStyle.background)
+            .overlay(alignment: .topLeading) {
+                if text.isEmpty {
+                    Text("{}")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                        .padding(16)
+                        .allowsHitTesting(false)
+                }
+            }
+        }
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+
+            TextField("Search JSON", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: SettingsMetrics.labelFontSize))
+                .focused($isSearchFocused)
+                .onSubmit { selectNextSearchMatch() }
+                .onExitCommand(perform: hideSearch)
+
+            Text(searchStatusText)
+                .font(.system(size: SettingsMetrics.footnoteFontSize, design: .monospaced))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+                .frame(width: 56, alignment: .trailing)
+
+            Button {
+                selectPreviousSearchMatch()
+            } label: {
+                Image(systemName: "chevron.up")
+            }
+            .jsonSearchArrowButton()
+            .disabled(searchMatchCount == 0)
+
+            Button {
+                selectNextSearchMatch()
+            } label: {
+                Image(systemName: "chevron.down")
+            }
+            .jsonSearchArrowButton()
+            .disabled(searchMatchCount == 0)
+
+            Button {
+                hideSearch()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(SettingsStyle.sidebarBackground)
+        .overlay(alignment: .bottom) {
+            SettingsDivider()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Text("JSON Settings")
+                    .font(.system(size: 20, weight: .semibold))
+                Spacer()
+                Picker("Source", selection: $source) {
+                    ForEach(Source.allCases) { source in
+                        Text(source.title).tag(source)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 220)
+                .tint(SettingsStyle.accent)
+            }
+
+            Text(description)
+                .font(.system(size: SettingsMetrics.labelFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .background(SettingsStyle.background)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.system(size: SettingsMetrics.footnoteFontSize))
+                    .foregroundStyle(SettingsStyle.destructive)
+                    .lineLimit(2)
+            } else if let status {
+                Label(status, systemImage: "checkmark.circle")
+                    .font(.system(size: SettingsMetrics.footnoteFontSize))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+            } else {
+                Text(SettingsJSONStore.userSettingsURL.path)
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, design: .monospaced))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+
+            Spacer()
+
+            Button("Reload") {
+                reload()
+            }
+            .controlSize(.small)
+
+            if source == .user {
+                Button("Prettify") {
+                    prettify()
+                }
+                .controlSize(.small)
+
+                Button("Reset from Current Settings") {
+                    SettingsJSONStore.resetUserSettingsFile()
+                    reload()
+                }
+                .controlSize(.small)
+
+                Button("Apply") {
+                    apply()
+                }
+                .controlSize(.small)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(12)
+        .background(SettingsStyle.sidebarBackground)
+        .overlay(alignment: .top) {
+            SettingsDivider()
+        }
+    }
+
+    private var editorText: Binding<String> {
+        Binding(
+            get: { text },
+            set: { newValue in
+                guard source == .user else { return }
+                text = newValue
+                errorMessage = nil
+                status = nil
+            }
+        )
+    }
+
+    private var description: String {
+        switch source {
+        case .user:
+            "Edit user settings as JSON. Present keys are applied as user overrides for known Muxy settings. "
+                + "Unknown keys are preserved in the file but ignored by Muxy."
+        case .system:
+            "Read-only reference of the built-in defaults supported by the JSON editor. "
+                + "Copy keys into User JSON to override them."
+        }
+    }
+
+    private var searchStatusText: String {
+        guard !searchText.isEmpty else { return "" }
+        guard searchMatchCount > 0 else { return "0/0" }
+        return "\(selectedSearchMatchIndex + 1)/\(searchMatchCount)"
+    }
+
+    private func reload() {
+        switch source {
+        case .user:
+            text = SettingsJSONStore.loadUserSettingsText()
+        case .system:
+            text = SettingsJSONStore.systemSettingsText
+        }
+        status = nil
+        errorMessage = nil
+        selectedSearchMatchIndex = 0
+    }
+
+    private func apply() {
+        do {
+            try SettingsJSONStore.saveUserSettingsText(text)
+            text = SettingsJSONStore.loadUserSettingsText()
+            status = "Settings applied"
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            status = nil
+        }
+    }
+
+    private func prettify() {
+        do {
+            text = try SettingsJSONStore.prettifiedSettingsText(text)
+            status = "JSON prettified"
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+            status = nil
+        }
+    }
+
+    private func showSearch() {
+        isSearchVisible = true
+        DispatchQueue.main.async {
+            isSearchFocused = true
+        }
+    }
+
+    private func hideSearch() {
+        isSearchVisible = false
+        searchText = ""
+        selectedSearchMatchIndex = 0
+        isSearchFocused = false
+    }
+
+    private func selectNextSearchMatch() {
+        guard searchMatchCount > 0 else { return }
+        selectedSearchMatchIndex = (selectedSearchMatchIndex + 1) % searchMatchCount
+    }
+
+    private func selectPreviousSearchMatch() {
+        guard searchMatchCount > 0 else { return }
+        selectedSearchMatchIndex = (selectedSearchMatchIndex + searchMatchCount - 1) % searchMatchCount
+    }
+}
+
+private extension View {
+    func jsonSearchArrowButton() -> some View {
+        buttonStyle(.plain)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(SettingsStyle.foreground)
+            .frame(width: 22, height: 20)
+            .background(SettingsStyle.sidebarBackground, in: RoundedRectangle(cornerRadius: 5))
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(SettingsStyle.border, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 5))
+    }
+}
+
+private struct SettingsJSONTextView: NSViewRepresentable {
+    @Binding var text: String
+    let isEditable: Bool
+    let searchText: String
+    let selectedSearchMatchIndex: Int
+    @Binding var searchMatchCount: Int
+    let onFindRequested: () -> Void
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = SettingsStyle.nsBackground
+
+        let textView = JSONHighlightingTextView()
+        textView.delegate = context.coordinator
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.usesFindBar = false
+        textView.allowsUndo = true
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = false
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.textColor = SettingsStyle.nsForeground
+        textView.insertionPointColor = SettingsStyle.nsForeground
+        textView.backgroundColor = SettingsStyle.nsBackground
+        textView.onFindRequested = onFindRequested
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        context.coordinator.apply(
+            text: text,
+            isEditable: isEditable,
+            searchText: searchText,
+            selectedSearchMatchIndex: selectedSearchMatchIndex
+        )
+
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        scrollView.backgroundColor = SettingsStyle.nsBackground
+        context.coordinator.apply(
+            text: text,
+            isEditable: isEditable,
+            searchText: searchText,
+            selectedSearchMatchIndex: selectedSearchMatchIndex
+        )
+        let count = context.coordinator.searchMatchCount
+        if searchMatchCount != count {
+            DispatchQueue.main.async {
+                searchMatchCount = count
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        @Binding private var text: String
+        weak var textView: JSONHighlightingTextView?
+        private var isApplying = false
+        private(set) var searchMatchCount = 0
+
+        init(text: Binding<String>) {
+            _text = text
+        }
+
+        func apply(text newText: String, isEditable: Bool, searchText: String, selectedSearchMatchIndex: Int) {
+            guard let textView else { return }
+            isApplying = true
+            textView.isEditable = isEditable
+            textView.isSelectable = true
+            textView.backgroundColor = SettingsStyle.nsBackground
+            textView.textColor = SettingsStyle.nsForeground
+            textView.insertionPointColor = SettingsStyle.nsForeground
+            if textView.string != newText {
+                let selectedRanges = textView.selectedRanges
+                textView.string = newText
+                textView.selectedRanges = selectedRanges
+            }
+            JSONSyntaxHighlighter.apply(to: textView)
+            let matches = JSONSearchHighlighter.apply(to: textView, query: searchText, selectedIndex: selectedSearchMatchIndex)
+            searchMatchCount = matches
+            isApplying = false
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard !isApplying, let textView = notification.object as? NSTextView else { return }
+            text = textView.string
+            JSONSyntaxHighlighter.apply(to: textView)
+        }
+    }
+}
+
+private final class JSONHighlightingTextView: NSTextView {
+    var onFindRequested: (() -> Void)?
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.charactersIgnoringModifiers?.lowercased() == "f"
+        {
+            onFindRequested?()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+}
+
+private enum JSONSyntaxHighlighter {
+    private static let tokenPattern = [
+        #"("(?:\\.|[^"\\])*"\s*:)|("(?:\\.|[^"\\])*")"#,
+        #"\b(true|false)\b|\bnull\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|([{}\[\]:,])"#,
+    ].joined()
+
+    @MainActor
+    static func apply(to textView: NSTextView) {
+        let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+        guard let storage = textView.textStorage else { return }
+        storage.beginEditing()
+        storage.setAttributes(baseAttributes, range: fullRange)
+        guard let regex = try? NSRegularExpression(pattern: tokenPattern) else {
+            storage.endEditing()
+            return
+        }
+        regex.enumerateMatches(in: textView.string, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            let attributes = attributesForMatch(match)
+            storage.addAttributes(attributes, range: match.range)
+        }
+        storage.endEditing()
+    }
+
+    @MainActor
+    private static var baseAttributes: [NSAttributedString.Key: Any] {
+        [
+            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular),
+            .foregroundColor: SettingsStyle.nsForeground,
+            .backgroundColor: SettingsStyle.nsBackground,
+        ]
+    }
+
+    @MainActor
+    private static func attributesForMatch(_ match: NSTextCheckingResult) -> [NSAttributedString.Key: Any] {
+        if match.range(at: 1).location != NSNotFound { return [.foregroundColor: NSColor(MuxyTheme.accent)] }
+        if match.range(at: 2).location != NSNotFound { return [.foregroundColor: NSColor.systemGreen] }
+        if match.range(at: 3).location != NSNotFound { return [.foregroundColor: NSColor.systemOrange] }
+        if match.range(at: 4).location != NSNotFound { return [.foregroundColor: NSColor.systemPurple] }
+        if match.range(at: 5).location != NSNotFound { return [.foregroundColor: NSColor.systemBlue] }
+        return [.foregroundColor: SettingsStyle.mutedNSForeground]
+    }
+}
+
+private enum JSONSearchHighlighter {
+    @MainActor
+    static func apply(to textView: NSTextView, query: String, selectedIndex: Int) -> Int {
+        let layoutManager = textView.layoutManager
+        let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+        layoutManager?.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
+
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return 0 }
+
+        let ranges = matchRanges(in: textView.string, query: normalized)
+        for (index, range) in ranges.enumerated() {
+            let color = index == selectedIndex ? NSColor.systemYellow.withAlphaComponent(0.55) : NSColor.systemYellow
+                .withAlphaComponent(0.22)
+            layoutManager?.addTemporaryAttribute(.backgroundColor, value: color, forCharacterRange: range)
+        }
+        if ranges.indices.contains(selectedIndex) {
+            textView.scrollRangeToVisible(ranges[selectedIndex])
+        }
+        return ranges.count
+    }
+
+    private static func matchRanges(in text: String, query: String) -> [NSRange] {
+        let haystack = text as NSString
+        var ranges: [NSRange] = []
+        var searchRange = NSRange(location: 0, length: haystack.length)
+        while searchRange.length > 0 {
+            let range = haystack.range(of: query, options: [.caseInsensitive], range: searchRange)
+            guard range.location != NSNotFound else { break }
+            ranges.append(range)
+            let nextLocation = range.location + max(range.length, 1)
+            searchRange = NSRange(location: nextLocation, length: haystack.length - nextLocation)
+        }
+        return ranges
+    }
+}

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -1,53 +1,194 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @State private var selectedCategory: SettingsCategory = .general
+    @State private var searchText = ""
+    @State private var themeRefreshID = 0
+
+    private var visibleCategories: [SettingsCategory] {
+        SettingsCatalog.categories.filter { SettingsCatalog.categoryMatches($0, query: searchText) }
+    }
+
     var body: some View {
-        TabView {
-            GeneralSettingsView()
-                .tabItem { Label("General", systemImage: "gearshape") }
-            AppearanceSettingsView()
-                .tabItem { Label("Appearance", systemImage: "paintbrush") }
-            EditorSettingsView()
-                .tabItem { Label("Editor", systemImage: "pencil.line") }
-            SessionRestoreSettingsView()
-                .tabItem { Label("Sessions", systemImage: "clock.arrow.circlepath") }
-            KeyboardShortcutsSettingsView()
-                .tabItem { Label("Shortcuts", systemImage: "keyboard") }
-            RecordingSettingsView()
-                .tabItem { Label("Recording", systemImage: "mic") }
-            NotificationSettingsView()
-                .tabItem { Label("Notifications", systemImage: "bell") }
-            MobileSettingsView()
-                .tabItem { Label("Mobile", systemImage: "iphone") }
-            AIAssistantSettingsView()
-                .tabItem { Label("AI", systemImage: "sparkles") }
-            AIUsageSettingsView()
-                .tabItem { Label("AI Usage", systemImage: "chart.bar") }
+        VStack(spacing: 0) {
+            SettingsHeader(searchText: $searchText)
+            SettingsDivider()
+            HStack(spacing: 0) {
+                SettingsSidebar(
+                    categories: visibleCategories,
+                    selectedCategory: $selectedCategory,
+                    searchText: searchText
+                )
+                Rectangle()
+                    .fill(SettingsStyle.border)
+                    .frame(width: 1)
+                settingsContent
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .environment(\.settingsSearchQuery, searchText)
+                    .environment(\.settingsCategory, selectedCategory)
+            }
         }
-        .frame(minWidth: 720, minHeight: 560)
-        .background(SettingsWindowConfigurator(minSize: NSSize(width: 720, height: 560)))
+        .frame(minWidth: 860, minHeight: 620)
+        .background(SettingsStyle.background)
+        .foregroundStyle(SettingsStyle.foreground)
+        .tint(SettingsStyle.accent)
+        .preferredColorScheme(MuxyTheme.colorScheme)
         .resetsSettingsFocusOnOutsideClick()
+        .onChange(of: searchText) { _, _ in
+            guard !visibleCategories.contains(selectedCategory), let first = visibleCategories.first else { return }
+            selectedCategory = first
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .focusProjectPickerDefaultLocation)) { _ in
+            searchText = ""
+            selectedCategory = .general
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .themeDidChange)) { _ in
+            themeRefreshID += 1
+        }
+    }
+
+    @ViewBuilder
+    private var settingsContent: some View {
+        switch selectedCategory {
+        case .general:
+            GeneralSettingsView()
+        case .appearance:
+            AppearanceSettingsView()
+        case .editor:
+            EditorSettingsView()
+        case .sessions:
+            SessionRestoreSettingsView()
+        case .shortcuts:
+            KeyboardShortcutsSettingsView()
+        case .recording:
+            RecordingSettingsView()
+        case .notifications:
+            NotificationSettingsView()
+        case .mobile:
+            MobileSettingsView()
+        case .ai:
+            AIAssistantSettingsView()
+        case .aiUsage:
+            AIUsageSettingsView()
+        case .json:
+            SettingsJSONEditorView()
+        }
     }
 }
 
-private struct SettingsWindowConfigurator: NSViewRepresentable {
-    let minSize: NSSize
+private struct SettingsHeader: View {
+    @Binding var searchText: String
 
-    func makeNSView(context _: Context) -> NSView {
-        let view = NSView()
-        DispatchQueue.main.async { [weak view] in
-            guard let window = view?.window else { return }
-            window.styleMask.insert(.resizable)
-            window.minSize = minSize
-            if window.frame.width < minSize.width || window.frame.height < minSize.height {
-                var frame = window.frame
-                frame.size.width = max(frame.size.width, minSize.width)
-                frame.size.height = max(frame.size.height, minSize.height)
-                window.setFrame(frame, display: true)
+    var body: some View {
+        HStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: "slider.horizontal.3")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+
+                Text("Settings")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(SettingsStyle.foreground)
             }
+            .padding(.horizontal, 16)
+            .frame(width: 210, alignment: .leading)
+
+            Rectangle()
+                .fill(SettingsStyle.border)
+                .frame(width: 1, height: 56)
+
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 12))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                TextField("Search settings", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
+                    .foregroundStyle(SettingsStyle.foreground)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(SettingsStyle.mutedForeground)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(SettingsStyle.accent.opacity(searchText.isEmpty ? 0 : 0.55), lineWidth: 1)
+            )
+            .frame(maxWidth: .infinity)
+            .padding(.leading, 8)
+            .padding(.trailing, 16)
         }
-        return view
+        .padding(.vertical, 12)
+        .frame(height: 56)
+        .background(SettingsStyle.background)
+    }
+}
+
+private struct SettingsSidebar: View {
+    let categories: [SettingsCategory]
+    @Binding var selectedCategory: SettingsCategory
+    let searchText: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if categories.isEmpty {
+                Text("No settings found")
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                    .padding(SettingsMetrics.horizontalPadding)
+            } else {
+                ForEach(categories) { category in
+                    Button {
+                        selectedCategory = category
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: category.symbolName)
+                                .font(.system(size: 12, weight: .medium))
+                                .frame(width: 16)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(category.title)
+                                    .font(.system(size: 12, weight: selectedCategory == category ? .semibold : .regular))
+                                    .foregroundStyle(SettingsStyle.foreground)
+                                if !searchText.isEmpty {
+                                    Text(matchCountText(for: category))
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(SettingsStyle.mutedForeground)
+                                }
+                            }
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                        .background(
+                            selectedCategory == category ? SettingsStyle.accentSoft : .clear,
+                            in: RoundedRectangle(cornerRadius: 8)
+                        )
+                        .foregroundStyle(selectedCategory == category ? SettingsStyle.accent : SettingsStyle.mutedForeground)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            Spacer()
+        }
+        .padding(10)
+        .frame(width: 210)
+        .background(SettingsStyle.sidebarBackground)
     }
 
-    func updateNSView(_: NSView, context _: Context) {}
+    private func matchCountText(for category: SettingsCategory) -> String {
+        let count = SettingsCatalog.matchingItems(query: searchText).count(where: { $0.category == category })
+        guard count != 1 else { return "1 match" }
+        return "\(count) matches"
+    }
 }

--- a/Muxy/Views/Settings/ShortcutBadge.swift
+++ b/Muxy/Views/Settings/ShortcutBadge.swift
@@ -7,13 +7,13 @@ struct ShortcutBadge: View {
     var body: some View {
         Text(label)
             .font(.system(size: compact ? UIMetrics.fontXS : UIMetrics.fontFootnote, weight: .medium, design: .rounded))
-            .foregroundStyle(.white)
+            .foregroundStyle(SettingsStyle.foreground)
             .padding(.horizontal, compact ? UIMetrics.spacing2 : UIMetrics.spacing3)
             .padding(.vertical, compact ? UIMetrics.scaled(1) : UIMetrics.scaled(3))
-            .background(.ultraThinMaterial, in: Capsule())
-            .overlay(Capsule().strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
+            .background(SettingsStyle.surface, in: Capsule())
+            .overlay(Capsule().strokeBorder(SettingsStyle.border, lineWidth: 0.5))
             .shadow(
-                color: .black.opacity(0.25),
+                color: SettingsStyle.background.opacity(0.25),
                 radius: UIMetrics.scaled(compact ? 2 : 4),
                 y: UIMetrics.scaled(compact ? 1 : 2)
             )

--- a/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("SettingsJSONStore", .serialized)
+@MainActor
+struct SettingsJSONStoreTests {
+    @Test
+    func saveAppliesKnownSettingsAndPreservesUnknownKeys() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
+        defer { snapshot.restore() }
+
+        try SettingsJSONStore.saveUserSettingsText("{\"unknown.setting\":{\"nested\":true},\"\(MobileServerService.portKey)\":4242}")
+
+        let savedText = try String(contentsOf: SettingsJSONStore.userSettingsURL, encoding: .utf8)
+
+        #expect(UserDefaults.standard.integer(forKey: MobileServerService.portKey) == 4242)
+        #expect(savedText.contains("\"unknown.setting\""))
+        #expect(savedText.contains("  \"nested\" : true"))
+        #expect(savedText.hasSuffix("\n"))
+    }
+
+    @Test
+    func invalidKnownValueDoesNotWriteOrApplySettings() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
+        defer { snapshot.restore() }
+        let originalText = "{\"unchanged\":true}\n"
+
+        try originalText.write(to: SettingsJSONStore.userSettingsURL, atomically: true, encoding: .utf8)
+        UserDefaults.standard.set(4242, forKey: MobileServerService.portKey)
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "\(MobileServerService.portKey)": 0
+            }
+            """)
+        }
+
+        let savedText = try String(contentsOf: SettingsJSONStore.userSettingsURL, encoding: .utf8)
+
+        #expect(savedText == originalText)
+        #expect(UserDefaults.standard.integer(forKey: MobileServerService.portKey) == 4242)
+    }
+
+    @Test
+    func omittedKnownSettingsRemainUnchanged() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
+        defer { snapshot.restore() }
+
+        UserDefaults.standard.set(4242, forKey: MobileServerService.portKey)
+
+        try SettingsJSONStore.saveUserSettingsText("""
+        {
+          "unknown.setting": true
+        }
+        """)
+
+        #expect(UserDefaults.standard.integer(forKey: MobileServerService.portKey) == 4242)
+    }
+
+    @Test
+    func prettifiedSettingsTextSortsAndFormatsJSONObject() throws {
+        let text = try SettingsJSONStore.prettifiedSettingsText("{\"z\":1,\"a\":{\"b\":true}}")
+
+        #expect(text == """
+        {
+          "a" : {
+            "b" : true
+          },
+          "z" : 1
+        }
+
+        """)
+    }
+
+    @Test
+    func saveAppliesEditorSettings() throws {
+        let settings = EditorSettings.shared
+        let originalDefaultEditor = settings.defaultEditor
+        let originalFontSize = settings.fontSize
+        let originalLineWrapping = settings.lineWrapping
+        defer {
+            settings.defaultEditor = originalDefaultEditor
+            settings.fontSize = originalFontSize
+            settings.lineWrapping = originalLineWrapping
+        }
+
+        try SettingsJSONStore.saveUserSettingsText("""
+        {
+          "editor.defaultEditor": "terminalCommand",
+          "editor.fontSize": 18,
+          "editor.lineWrapping": true
+        }
+        """)
+
+        #expect(settings.defaultEditor == .terminalCommand)
+        #expect(settings.fontSize == 18)
+        #expect(settings.lineWrapping)
+    }
+
+    @Test
+    func systemSettingsIncludeAllBackedSettings() throws {
+        let data = Data(SettingsJSONStore.systemSettingsText.utf8)
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        for item in SettingsCatalog.jsonEditableItems {
+            #expect(object.keys.contains(item.key))
+        }
+        #expect(object.keys.contains("shortcuts.app"))
+        #expect(object.keys.contains("shortcuts.customCommands"))
+        #expect(object.keys.contains("ai.providers"))
+        #expect(object.keys.contains("aiUsage.providers"))
+        #expect(object.keys.contains("mobile.approvedDevices"))
+    }
+
+    @Test
+    func syncWritesCurrentSettingsToUserJSON() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
+        defer { snapshot.restore() }
+
+        UserDefaults.standard.set(4242, forKey: MobileServerService.portKey)
+        SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
+
+        let data = try Data(contentsOf: SettingsJSONStore.userSettingsURL)
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(object[MobileServerService.portKey] as? Int == 4242)
+        #expect(object.keys.contains("shortcuts.app"))
+    }
+}
+
+private struct SettingsJSONStoreSnapshot {
+    let data: Data?
+    let defaults: [String: Any]
+
+    @MainActor
+    static func capture(keys: [String]) -> SettingsJSONStoreSnapshot {
+        SettingsJSONStoreSnapshot(
+            data: try? Data(contentsOf: SettingsJSONStore.userSettingsURL),
+            defaults: Dictionary(uniqueKeysWithValues: keys.map { key in
+                (key, UserDefaults.standard.object(forKey: key) ?? NSNull())
+            })
+        )
+    }
+
+    @MainActor
+    func restore() {
+        if let data {
+            try? data.write(to: SettingsJSONStore.userSettingsURL, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: SettingsJSONStore.userSettingsURL)
+        }
+
+        for (key, value) in defaults {
+            if value is NSNull {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else {
+                UserDefaults.standard.set(value, forKey: key)
+            }
+        }
+    }
+}

--- a/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
@@ -45,6 +45,53 @@ struct SettingsJSONStoreTests {
     }
 
     @Test
+    func invalidSpecialValueDoesNotWriteSettings() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [])
+        defer { snapshot.restore() }
+        let originalText = "{\"unchanged\":true}\n"
+
+        try originalText.write(to: SettingsJSONStore.userSettingsURL, atomically: true, encoding: .utf8)
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "ai.providers": []
+            }
+            """)
+        }
+
+        let savedText = try String(contentsOf: SettingsJSONStore.userSettingsURL, encoding: .utf8)
+
+        #expect(savedText == originalText)
+    }
+
+    @Test
+    func invalidAppShortcutsDoNotReplaceBindings() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [])
+        let originalBindings = KeyBindingStore.shared.bindings
+        defer {
+            KeyBindingStore.shared.replaceBindings(originalBindings)
+            snapshot.restore()
+        }
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "shortcuts.app": {
+                "unknownAction": {}
+              }
+            }
+            """)
+        }
+
+        #expect(KeyBindingStore.shared.bindings.count == originalBindings.count)
+        for binding in originalBindings {
+            let current = KeyBindingStore.shared.bindings.first { $0.action == binding.action }
+            #expect(current?.combo == binding.combo)
+        }
+    }
+
+    @Test
     func omittedKnownSettingsRemainUnchanged() throws {
         let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
         defer { snapshot.restore() }

--- a/Tests/MuxyTests/Views/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/SettingsCatalogTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import Muxy
+
+@Suite("SettingsCatalog")
+@MainActor
+struct SettingsCatalogTests {
+    @Test
+    func searchFindsSettingsByAliasAndDescription() {
+        let results = SettingsCatalog.matchingItems(query: "hotkeys")
+
+        #expect(results.contains { $0.category == .shortcuts && $0.title == "App Shortcuts" })
+    }
+
+    @Test
+    func categoryMatchingUsesCatalogItems() {
+        #expect(SettingsCatalog.categoryMatches(.editor, query: "line numbers"))
+        #expect(!SettingsCatalog.categoryMatches(.mobile, query: "line numbers"))
+    }
+
+    @Test
+    func jsonEditableItemsHaveDefaults() {
+        #expect(!SettingsCatalog.jsonEditableItems.isEmpty)
+        #expect(SettingsCatalog.jsonEditableItems.allSatisfy { $0.defaultValue != nil })
+    }
+
+    @Test
+    func jsonEditableItemsIncludeEditorSettings() {
+        #expect(SettingsCatalog.items.contains { $0.key.hasPrefix("editor.") })
+        #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == "editor.defaultEditor" })
+        #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == "editor.richInputLineHeightMultiplier" })
+    }
+}


### PR DESCRIPTION
Redesigns Settings as a searchable themed in-app modal.
Adds full JSON-backed settings export/import with validation, sync, prettify, highlighting, and search.
Polishes sidebar/header layout, keyboard closing behavior, and settings control theming.