### PR TITLE
Add Markdown frontmatter preview panel

### DIFF
--- a/Muxy/Models/MarkdownAnchorParser.swift
+++ b/Muxy/Models/MarkdownAnchorParser.swift
@@ -6,7 +6,7 @@ enum MarkdownAnchorParser {
         guard !lines.isEmpty else { return [] }
 
         var anchors: [MarkdownSyncAnchor] = []
-        var index = 0
+        var index = frontmatterEndIndex(in: lines).map { $0 + 1 } ?? 0
 
         while index < lines.count {
             let line = lines[index]
@@ -99,6 +99,20 @@ enum MarkdownAnchorParser {
             startLine: startIndex + 1,
             endLine: endIndex + 1
         )
+    }
+
+    private static func frontmatterEndIndex(in lines: [String]) -> Int? {
+        guard lines.count >= 3 else { return nil }
+        guard lines[0].trimmingCharacters(in: .whitespaces) == "---" else { return nil }
+
+        for index in 1 ..< lines.count {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" {
+                return index
+            }
+        }
+
+        return nil
     }
 
     private static func fenceStart(in trimmed: String) -> FenceStart? {

--- a/Muxy/Models/MarkdownRenderer.swift
+++ b/Muxy/Models/MarkdownRenderer.swift
@@ -201,6 +201,44 @@ enum MarkdownRenderer {
                 .markdown-body ul, .markdown-body ol { padding-left: 2em; margin: 16px 0; }
                 .markdown-body li { margin: 4px 0; }
                 .markdown-body hr { border: none; border-top: 1px solid var(--border); margin: 24px 0; }
+                .muxy-frontmatter {
+                    border: 1px solid var(--border);
+                    border-radius: 6px;
+                    background: var(--code-bg);
+                    margin: 0 0 20px 0;
+                    overflow: hidden;
+                }
+                .muxy-frontmatter summary {
+                    cursor: pointer;
+                    color: var(--fg);
+                    font-weight: 600;
+                    padding: 8px 12px;
+                    user-select: none;
+                }
+                .muxy-frontmatter-grid {
+                    display: grid;
+                    grid-template-columns: minmax(120px, 0.32fr) minmax(0, 1fr);
+                    border-top: 1px solid var(--border);
+                }
+                .muxy-frontmatter-key,
+                .muxy-frontmatter-value {
+                    padding: 7px 12px;
+                    border-bottom: 1px solid var(--border);
+                    min-width: 0;
+                    overflow-wrap: anywhere;
+                }
+                .muxy-frontmatter-key {
+                    color: var(--muted);
+                    font-weight: 600;
+                    background: var(--row-alt);
+                }
+                .muxy-frontmatter-value {
+                    color: var(--fg);
+                    white-space: pre-wrap;
+                }
+                .muxy-frontmatter-grid :nth-last-child(-n + 2) {
+                    border-bottom: none;
+                }
                 .mermaid {
                     width: 100%;
                     margin: 16px 0;

--- a/Muxy/Resources/markdown-assets/markdown-renderer.js
+++ b/Muxy/Resources/markdown-assets/markdown-renderer.js
@@ -61,6 +61,93 @@
             .replace(/'/g, '&#39;');
     }
 
+    function extractFrontmatter(content) {
+        var normalized = String(content || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+        var lines = normalized.split('\n');
+        if (lines.length < 3 || lines[0].trim() !== '---') {
+            return {
+                frontmatter: null,
+                body: content,
+                lineOffset: 0
+            };
+        }
+        for (var i = 1; i < lines.length; i++) {
+            if (lines[i].trim() === '---') {
+                return {
+                    frontmatter: parseFrontmatterRows(lines.slice(1, i)),
+                    body: lines.slice(i + 1).join('\n'),
+                    lineOffset: i + 1
+                };
+            }
+        }
+        return {
+            frontmatter: null,
+            body: content,
+            lineOffset: 0
+        };
+    }
+
+    function parseFrontmatterRows(lines) {
+        var rows = [];
+        var pending = null;
+        lines.forEach(function (line) {
+            if (!line.trim()) {
+                return;
+            }
+            var match = line.match(/^([^:#][^:]*):\s*(.*)$/);
+            if (match) {
+                pending = {
+                    key: match[1].trim(),
+                    value: normalizeFrontmatterValue(match[2].trim())
+                };
+                rows.push(pending);
+                return;
+            }
+            if (pending && /^\s+/.test(line)) {
+                pending.value = pending.value ? pending.value + '\n' + line.trim() : line.trim();
+                return;
+            }
+            rows.push({
+                key: '',
+                value: line.trim()
+            });
+            pending = null;
+        });
+        return rows;
+    }
+
+    function normalizeFrontmatterValue(value) {
+        return String(value || '')
+            .replace(/^['"]|['"]$/g, '')
+            .trim();
+    }
+
+    function renderFrontmatter(frontmatter) {
+        if (!frontmatter || !frontmatter.length) {
+            return null;
+        }
+        var details = document.createElement('details');
+        details.className = 'muxy-frontmatter';
+        details.open = true;
+        var summary = document.createElement('summary');
+        summary.textContent = 'Frontmatter';
+        details.appendChild(summary);
+        var grid = document.createElement('div');
+        grid.className = 'muxy-frontmatter-grid';
+        frontmatter.forEach(function (row) {
+            var key = document.createElement('div');
+            key.className = 'muxy-frontmatter-key';
+            key.textContent = row.key || 'Raw';
+            var value = document.createElement('div');
+            value.className = 'muxy-frontmatter-value';
+            value.textContent = row.value || '';
+            grid.appendChild(key);
+            grid.appendChild(value);
+        });
+        details.appendChild(grid);
+        return details;
+    }
+
     function sanitizeURL(rawValue, options) {
         var value = String(rawValue || '').trim();
         if (!value) {
@@ -409,11 +496,12 @@
         return i;
     }
 
-    function parseSyncAnchors(content) {
+    function parseSyncAnchors(content, lineOffset) {
         var lines = content.split(/\r?\n/);
         var anchors = [];
         var i = 0;
         var sequence = 0;
+        var offset = Number(lineOffset || 0);
         while (i < lines.length) {
             if (!(lines[i] || '').trim()) {
                 i += 1;
@@ -426,8 +514,8 @@
             anchors.push({
                 id: 'muxy-anchor-' + String(sequence),
                 kind: kind,
-                startLine: startLine,
-                endLine: Math.max(startLine, endLine)
+                startLine: startLine + offset,
+                endLine: Math.max(startLine, endLine) + offset
             });
             sequence += 1;
             i = end + 1;
@@ -667,7 +755,8 @@
     }
 
     async function renderMarkdown(content) {
-        var anchors = parseSyncAnchors(content);
+        var preparedMarkdown = extractFrontmatter(content);
+        var anchors = parseSyncAnchors(preparedMarkdown.body, preparedMarkdown.lineOffset);
         if (!_markedConfigured) {
             marked.use({
                 walkTokens: function (token) {
@@ -700,7 +789,7 @@
         });
 
         var diagramMap = {};
-        content = content.replace(/```mermaid\s*\r?\n([\s\S]*?)```/g, function (match, code) {
+        content = preparedMarkdown.body.replace(/```mermaid\s*\r?\n([\s\S]*?)```/g, function (match, code) {
             var id = 'mermaid-' + Object.keys(diagramMap).length;
             diagramMap[id] = code.trim();
             return '<div class="mermaid" id="' + id + '" data-muxy-mermaid="true"></div>';
@@ -716,6 +805,10 @@
         preserveExistingImages(markdownRoot, nextRoot);
 
         var fragment = document.createDocumentFragment();
+        var frontmatterElement = renderFrontmatter(preparedMarkdown.frontmatter);
+        if (frontmatterElement) {
+            fragment.appendChild(frontmatterElement);
+        }
         while (nextRoot.firstChild) {
             fragment.appendChild(nextRoot.firstChild);
         }

--- a/Tests/MuxyTests/Models/MarkdownAnchorParserTests.swift
+++ b/Tests/MuxyTests/Models/MarkdownAnchorParserTests.swift
@@ -89,6 +89,41 @@ struct MarkdownAnchorParserTests {
         #expect(anchors.map(\.endLine) == [3, 5, 7])
     }
 
+    @Test("skips document frontmatter")
+    func skipsDocumentFrontmatter() {
+        let markdown = """
+        ---
+        name: my-awesome-skill
+        description: Use when you want to become more awesome
+        ---
+
+        # Start here
+
+        Install the awesominator from npm.
+        """
+
+        let anchors = MarkdownAnchorParser.parseAnchors(in: markdown)
+
+        #expect(anchors.map(\.kind) == [.heading, .paragraph])
+        #expect(anchors.map(\.startLine) == [6, 8])
+        #expect(anchors.map(\.endLine) == [6, 8])
+    }
+
+    @Test("keeps unterminated frontmatter as markdown")
+    func keepsUnterminatedFrontmatterAsMarkdown() {
+        let markdown = """
+        ---
+        name: draft
+
+        # Start here
+        """
+
+        let anchors = MarkdownAnchorParser.parseAnchors(in: markdown)
+
+        #expect(anchors.map(\.kind) == [.thematicBreak, .paragraph, .heading])
+        #expect(anchors.map(\.startLine) == [1, 2, 4])
+    }
+
     @Test("parses blockquotes and html blocks")
     func parsesBlockquotesAndHTMLBlocks() {
         let markdown = """

--- a/Tests/MuxyTests/Models/MermaidCodeBlockNormalizerTests.swift
+++ b/Tests/MuxyTests/Models/MermaidCodeBlockNormalizerTests.swift
@@ -91,6 +91,15 @@ struct MermaidCodeBlockNormalizerTests {
         #expect(html.contains(".markdown-body a { color: var(--accent); cursor: pointer; text-decoration: none; }"))
     }
 
+    @Test("MarkdownRenderer shell styles frontmatter panel")
+    @MainActor
+    func markdownRendererShellStylesFrontmatterPanel() {
+        let html = MarkdownRenderer.html(filePath: nil)
+
+        #expect(html.contains(".muxy-frontmatter"))
+        #expect(html.contains(".muxy-frontmatter-grid"))
+    }
+
     @Test("MarkdownRenderer themeApplyScript emits Mermaid theme variables")
     @MainActor
     func themeApplyScriptEmitsMermaidThemeVariables() {


### PR DESCRIPTION
Render leading Markdown frontmatter as a collapsible key-value panel.
  Keep scroll sync aligned by skipping frontmatter anchors.
  Add tests for frontmatter parsing and preview styling.

Closes #372