### PR TITLE
Route CLI project opens to the running app

### DIFF
--- a/Muxy/Info.plist
+++ b/Muxy/Info.plist
@@ -22,6 +22,8 @@
 	<string>6.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
+	<key>LSMultipleInstancesProhibited</key>
+	<true/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -85,11 +85,6 @@ struct MuxyApp: App {
                         )
                     }
                     appDelegate.flushPendingOpens()
-                    NotificationSocketServer.shared.openProjectHandler = { [appDelegate] path in
-                        Task { @MainActor in
-                            appDelegate.handleOpenProjectPath(path)
-                        }
-                    }
                     NotificationSocketServer.shared.commandHandler = { [appState] message in
                         await SocketCommandHandler.handleRequest(message, appState: appState)
                     }
@@ -256,12 +251,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         observeSystemAppearanceChanges()
         UpdateService.shared.start()
         ModifierKeyMonitor.shared.start()
+        NotificationSocketServer.shared.openProjectHandler = { [weak self] path in
+            Task { @MainActor [weak self] in
+                self?.handleOpenProjectPath(path)
+            }
+        }
         NotificationSocketServer.shared.start()
         AIProviderRegistry.shared.installAll()
         _ = AIUsageSettingsStore.isUsageEnabled()
         DiagnosticsMenuController.shared.install()
         observeSettingsRequests()
-
         consumeLaunchArguments()
     }
 

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -224,11 +224,10 @@ if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "spli
 
     ENCODED_PATH="$(percent_encode "$TARGET_DIR")"
 
+    if [ -e "$SOCKET" ] && printf '%s' "open-project|$TARGET_DIR" | nc -U "$SOCKET" 2>/dev/null; then
+        exit 0
+    fi
+
     open "muxy://open?path=${ENCODED_PATH}" 2>/dev/null \
-        || open -b com.muxy.app "$TARGET_DIR" 2>/dev/null \
-        || {
-            if [ -e "$SOCKET" ]; then
-                send_message "open-project|$TARGET_DIR"
-            fi
-        }
+        || open -b com.muxy.app "$TARGET_DIR" 2>/dev/null
 fi

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -54,6 +54,40 @@ struct AppDelegateResolveProjectPathTests {
     }
 }
 
+@Suite("Muxy CLI launch resources")
+struct MuxyCLILaunchResourceTests {
+    @Test("CLI sends project opens to the running app before using macOS open")
+    func cliPrefersRunningAppSocket() throws {
+        let script = try String(
+            contentsOf: Self.repositoryRoot
+                .appendingPathComponent("Muxy/Resources/scripts/muxy-cli"),
+            encoding: .utf8
+        )
+        let socketRange = try #require(script.range(of: "open-project|$TARGET_DIR"))
+        let openRange = try #require(script.range(of: "open \"muxy://open?path="))
+        #expect(socketRange.lowerBound < openRange.lowerBound)
+    }
+
+    @Test("app bundle prohibits multiple running instances")
+    func appProhibitsMultipleInstances() throws {
+        let plistData = try Data(
+            contentsOf: Self.repositoryRoot
+                .appendingPathComponent("Muxy/Info.plist")
+        )
+        let plist = try #require(PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any])
+        #expect(plist["LSMultipleInstancesProhibited"] as? Bool == true)
+    }
+
+    private static var repositoryRoot: URL {
+        var url = URL(fileURLWithPath: #filePath)
+        url.deleteLastPathComponent()
+        url.deleteLastPathComponent()
+        url.deleteLastPathComponent()
+        url.deleteLastPathComponent()
+        return url
+    }
+}
+
 @Suite("CLIAccessor.openProjectFromPath")
 @MainActor
 struct CLIAccessorOpenProjectFromPathTests {

--- a/docs/architecture/cli-and-url-scheme.md
+++ b/docs/architecture/cli-and-url-scheme.md
@@ -24,7 +24,7 @@ flowchart TB
 
 | Path | Behavior |
 | --- | --- |
-| `muxy` shell wrapper | `Muxy/Resources/scripts/muxy-cli`, installed to `/usr/local/bin/muxy` via `CLIAccessor.installCLI`. Resolves to an absolute directory and tries, in order via `\|\|` chaining: open `muxy://open?path=<percent-encoded>`, fall back to `open -b com.muxy.app`, finally pipe `open-project\|<path>` to the Unix socket. A small `python3`/`python` percent-encoder runs without taking a `jq` dependency. |
+| `muxy` shell wrapper | `Muxy/Resources/scripts/muxy-cli`, installed to `/usr/local/bin/muxy` via `CLIAccessor.installCLI`. Resolves to an absolute directory and sends `open-project\|<path>` to the Unix socket when Muxy is already running. If no running app accepts the socket request, it opens `muxy://open?path=<percent-encoded>` and falls back to `open -b com.muxy.app`. |
 | `muxy://` URL scheme | `AppDelegate.application(_:open:)`. `resolveProjectPath(from:)` parses with `URLComponents`, prefers a `path` query item, falls back to `host + path`, percent-decodes, and standardizes via `URL(fileURLWithPath:).standardizedFileURL.path`. File URLs are accepted; foreign schemes rejected. |
 | Launch arguments | `applicationDidFinishLaunching` reads `CommandLine.arguments[1]` only when the candidate begins with `/` or `~` and resolves to an existing directory — Xcode/test runner flags are not treated as project paths. |
 | Notification socket | `NotificationSocketServer` accepts `open-project\|<path>` in addition to its notification format. It validates the path is an existing directory and dispatches via an injected `openProjectHandler` closure (wired in `MainWindow.onAppear`). |


### PR DESCRIPTION
- Prefer the Unix socket when Muxy is already open, so directory launches target the existing session instead of spawning duplicates.
- Mark the app as single-instance to keep open requests and state in one place.
- Falls back to the existing URL/open flow when the socket path is not available.