### PR TITLE
Change Source Control shortcut to Cmd+Y

### DIFF
--- a/Muxy/Extensions/View+KeyboardShortcut.swift
+++ b/Muxy/Extensions/View+KeyboardShortcut.swift
@@ -1,8 +1,13 @@
 import SwiftUI
 
 extension View {
+    @ViewBuilder
     func shortcut(for action: ShortcutAction, store: KeyBindingStore) -> some View {
         let combo = store.combo(for: action)
-        return keyboardShortcut(combo.swiftUIKeyEquivalent, modifiers: combo.swiftUIModifiers)
+        if combo.isAssigned {
+            keyboardShortcut(combo.swiftUIKeyEquivalent, modifiers: combo.swiftUIModifiers)
+        } else {
+            self
+        }
     }
 }

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -285,7 +285,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .cycleNextTabAcrossPanes, combo: KeyCombo(key: KeyCombo.tabKey, control: true)),
         Self(action: .cyclePreviousTabAcrossPanes, combo: KeyCombo(key: KeyCombo.tabKey, shift: true, control: true)),
         Self(action: .toggleThemePicker, combo: KeyCombo(key: "k", command: true, shift: true)),
-        Self(action: .openVCSTab, combo: KeyCombo(key: "k", command: true)),
+        Self(action: .openVCSTab, combo: KeyCombo(key: "y", command: true)),
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),
         Self(action: .reloadConfig, combo: KeyCombo(key: "r", command: true, shift: true)),
         Self(action: .nextTab, combo: KeyCombo(key: "]", command: true)),

--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -140,6 +140,10 @@ struct KeyCombo: Codable, Equatable, Hashable {
         }
     }
 
+    var isAssigned: Bool {
+        !key.isEmpty
+    }
+
     var swiftUIModifiers: SwiftUI.EventModifiers {
         var result: SwiftUI.EventModifiers = []
         let flags = nsModifierFlags

--- a/Muxy/Services/KeyBindingStore.swift
+++ b/Muxy/Services/KeyBindingStore.swift
@@ -27,7 +27,11 @@ final class KeyBindingStore {
     }
 
     func updateBinding(action: ShortcutAction, combo: KeyCombo) {
-        guard let index = bindings.firstIndex(where: { $0.action == action }) else { return }
+        guard let index = bindings.firstIndex(where: { $0.action == action }) else {
+            bindings.append(KeyBinding(action: action, combo: combo))
+            save()
+            return
+        }
         bindings[index].combo = combo
         save()
     }
@@ -43,7 +47,11 @@ final class KeyBindingStore {
     }
 
     func resetBinding(action: ShortcutAction) {
-        guard let defaultBinding = KeyBinding.defaults.first(where: { $0.action == action }) else { return }
+        guard let defaultBinding = KeyBinding.defaults.first(where: { $0.action == action }) else {
+            bindings.removeAll { $0.action == action }
+            save()
+            return
+        }
         updateBinding(action: defaultBinding.action, combo: defaultBinding.combo)
     }
 
@@ -60,6 +68,7 @@ final class KeyBindingStore {
         return ShortcutAction.allCases.first { action in
             guard scopes.contains(action.scope) else { return false }
             let combo = combo(for: action)
+            guard combo.isAssigned else { return false }
             return combo.key == normalizedKey && combo.modifiers == flags
         }
     }
@@ -70,6 +79,7 @@ final class KeyBindingStore {
 
     func conflictingAction(for combo: KeyCombo, excluding: ShortcutAction?) -> ShortcutAction? {
         bindings.first { binding in
+            guard binding.combo.isAssigned else { return false }
             if let excluding {
                 return binding.combo == combo && binding.action != excluding
             }

--- a/Muxy/Views/Help/HelpView.swift
+++ b/Muxy/Views/Help/HelpView.swift
@@ -97,7 +97,7 @@ private struct HelpQuickStart: View {
         Step(title: "Add a project", detail: "Click + in the sidebar, or use File → Open Project…", shortcut: "⌘O"),
         Step(title: "Open a new tab", detail: "Each tab is a terminal by default.", shortcut: "⌘T"),
         Step(title: "Split a pane", detail: "Split right or down to multiplex within one tab.", shortcut: "⌘D"),
-        Step(title: "Open Source Control", detail: "Stage, commit, push, and review diffs.", shortcut: "⌘K"),
+        Step(title: "Open Source Control", detail: "Stage, commit, push, and review diffs.", shortcut: "⌘Y"),
         Step(title: "Quick‑open a file", detail: "Fuzzy‑search files in the active worktree.", shortcut: "⌘P"),
     ]
 

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -427,7 +427,7 @@ private struct ShortcutRow: View {
             }
 
             Button(action: onStartRecording) {
-                Text(combo.displayString)
+                Text(combo.isAssigned ? combo.displayString : "Unassigned")
                     .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
                     .foregroundStyle(SettingsStyle.foreground)
                     .padding(.horizontal, 8)

--- a/Tests/MuxyTests/Models/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/KeyBindingTests.swift
@@ -101,6 +101,14 @@ struct KeyBindingTests {
         #expect(combos[.renameTab] == KeyCombo(key: "t", shift: true, option: true))
     }
 
+    @Test("Source Control uses Cmd+Y by default")
+    func sourceControlUsesCommandYByDefault() {
+        let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
+        #expect(combos[.openVCSTab] == KeyCombo(key: "y", command: true))
+        #expect(!KeyBinding.defaults.contains { $0.combo == KeyCombo(key: "k", command: true) })
+        #expect(!KeyBinding.defaults.contains { $0.combo == KeyCombo(key: "j", command: true) })
+    }
+
     @Test("KeyBinding Codable round-trip")
     func codableRoundTrip() throws {
         let binding = KeyBinding(

--- a/Tests/MuxyTests/Services/KeyBindingStoreTests.swift
+++ b/Tests/MuxyTests/Services/KeyBindingStoreTests.swift
@@ -38,6 +38,23 @@ struct KeyBindingStoreTests {
         #expect(store.action(for: event, scopes: [.mainWindow]) == nil)
     }
 
+    @Test("action can be assigned and reset")
+    func actionCanBeAssignedAndReset() {
+        let persistence = StubKeyBindingPersistence(bindings: KeyBinding.defaults)
+        let store = KeyBindingStore(persistence: persistence)
+        let combo = KeyCombo(key: "u", command: true)
+
+        #expect(store.combo(for: .openVCSTab) == KeyCombo(key: "y", command: true))
+
+        store.updateBinding(action: .openVCSTab, combo: combo)
+
+        #expect(store.combo(for: .openVCSTab) == combo)
+
+        store.resetBinding(action: .openVCSTab)
+
+        #expect(store.combo(for: .openVCSTab) == KeyCombo(key: "y", command: true))
+    }
+
     private func keyEvent(
         characters: String,
         charactersIgnoringModifiers: String,


### PR DESCRIPTION
Replaces the default Source Control shortcut so Cmd+K remains available for terminal scrollback clearing.
Updates help text and shortcut tests.

Closes #383