### PR TITLE
Fix asymmetric resize handle hit area

### DIFF
--- a/Muxy/Views/Components/ResizeHandle.swift
+++ b/Muxy/Views/Components/ResizeHandle.swift
@@ -42,6 +42,7 @@ struct ResizeHandle: View {
                         }
                     }
             }
+            .zIndex(1)
     }
 
     private var cursor: NSCursor {


### PR DESCRIPTION
Ensures split resize handles stay above adjacent panes so the grab area works equally from both sides.