### PR TITLE
Fix empty status bar on non-terminal tabs

### DIFF
--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -386,6 +386,7 @@ struct MainWindow: View {
                 ProjectStatusBar(
                     activePane: activeTerminalPane,
                     activeWorktree: activeProject.flatMap { resolvedActiveWorktree(for: $0) },
+                    fallbackProjectPath: activeProject.map { activeWorktreePath(for: $0) },
                     isInteractive: activeTerminalPane != nil && !overlayAnimatingOut,
                     richInputVisible: richInputPanelVisible,
                     richInputFontSize: $richInputFontSize

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -2,8 +2,15 @@ import AppKit
 import SwiftUI
 
 struct ProjectStatusBar: View {
+    struct StatusContext: Equatable {
+        let path: String
+        let worktreeName: String?
+        let branch: String?
+    }
+
     let activePane: TerminalPaneState?
     let activeWorktree: Worktree?
+    let fallbackProjectPath: String?
     let isInteractive: Bool
     let richInputVisible: Bool
     @Binding var richInputFontSize: Double
@@ -18,13 +25,13 @@ struct ProjectStatusBar: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            if let pane = activePane {
-                pathButton(pane)
-                if let worktree = activeWorktree {
+            if let statusContext {
+                pathButton(statusContext.path)
+                if let worktreeName = statusContext.worktreeName {
                     separator
-                    worktreeLabel(worktree)
+                    worktreeLabel(worktreeName)
                 }
-                if let branch = pane.branchObserver.branch {
+                if let branch = statusContext.branch {
                     separator
                     branchLabel(branch)
                 }
@@ -53,8 +60,39 @@ struct ProjectStatusBar: View {
         .accessibilityLabel("Status bar")
     }
 
-    private func pathButton(_ pane: TerminalPaneState) -> some View {
-        let fullPath = pane.currentWorkingDirectory ?? pane.projectPath
+    private var statusContext: StatusContext? {
+        Self.statusContext(
+            activePane: activePane,
+            activeWorktree: activeWorktree,
+            fallbackProjectPath: fallbackProjectPath
+        )
+    }
+
+    static func statusContext(
+        activePane: TerminalPaneState?,
+        activeWorktree: Worktree?,
+        fallbackProjectPath: String?
+    ) -> StatusContext? {
+        guard let path = activePane?.currentWorkingDirectory
+            ?? activePane?.projectPath
+            ?? activeWorktree?.path
+            ?? fallbackProjectPath
+        else { return nil }
+        return StatusContext(
+            path: path,
+            worktreeName: activeWorktree?.name,
+            branch: nonEmpty(activePane?.branchObserver.branch) ?? nonEmpty(activeWorktree?.branch)
+        )
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+
+    private func pathButton(_ fullPath: String) -> some View {
         let displayPath = abbreviatePath(fullPath)
         let truncated = ProjectStatusBar.truncatePath(displayPath, maxCharacters: ProjectStatusBar.pathMaxCharacters)
         return Button {
@@ -78,17 +116,17 @@ struct ProjectStatusBar: View {
         }
     }
 
-    private func worktreeLabel(_ worktree: Worktree) -> some View {
+    private func worktreeLabel(_ worktreeName: String) -> some View {
         HStack(spacing: 4) {
             Image(systemName: "square.stack.3d.up")
                 .font(.system(size: 10, weight: .semibold))
-            Text(worktree.name)
+            Text(worktreeName)
                 .font(.system(size: 11, weight: .medium))
                 .lineLimit(1)
                 .truncationMode(.tail)
         }
         .foregroundStyle(MuxyTheme.fgMuted)
-        .help("Worktree: \(worktree.name)")
+        .help("Worktree: \(worktreeName)")
     }
 
     private func branchLabel(_ branch: String) -> some View {

--- a/Tests/MuxyTests/Views/ProjectStatusBarTests.swift
+++ b/Tests/MuxyTests/Views/ProjectStatusBarTests.swift
@@ -25,4 +25,45 @@ struct ProjectStatusBarTests {
         let path = String(repeating: "a", count: 40)
         #expect(ProjectStatusBar.truncatePath(path, maxCharacters: 40) == path)
     }
+
+    @Test("non terminal tabs use active worktree context")
+    func fallbackContextUsesActiveWorktree() {
+        let worktree = Worktree(
+            name: "feature",
+            path: "/Projects/muxy-worktrees/feature",
+            branch: "feature/status-bar",
+            isPrimary: false
+        )
+
+        let context = ProjectStatusBar.statusContext(
+            activePane: nil,
+            activeWorktree: worktree,
+            fallbackProjectPath: "/Projects/muxy"
+        )
+
+        #expect(context?.path == "/Projects/muxy-worktrees/feature")
+        #expect(context?.worktreeName == "feature")
+        #expect(context?.branch == "feature/status-bar")
+    }
+
+    @Test("terminal tabs prefer pane path")
+    func terminalContextPrefersPanePath() {
+        let pane = TerminalPaneState(projectPath: "/Projects/muxy", initialWorkingDirectory: "/Projects/muxy/Muxy")
+        let worktree = Worktree(
+            name: "feature",
+            path: "/Projects/muxy-worktrees/feature",
+            branch: "feature/status-bar",
+            isPrimary: false
+        )
+
+        let context = ProjectStatusBar.statusContext(
+            activePane: pane,
+            activeWorktree: worktree,
+            fallbackProjectPath: nil
+        )
+
+        #expect(context?.path == "/Projects/muxy/Muxy")
+        #expect(context?.worktreeName == "feature")
+        #expect(context?.branch == "feature/status-bar")
+    }
 }


### PR DESCRIPTION
Show active project/worktree context in the footer when the selected tab is not a terminal.
  Keeps terminal cwd behavior unchanged and covers fallback status context with tests.