### PR TITLE
Add syntax highlighting to diff viewer

### DIFF
--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -208,6 +208,7 @@ final class EditorTabState: Identifiable {
         isReadOnly = true
         self.diffLineKinds = diffLineKinds
         self.diffGutterLines = diffGutterLines
+        syntaxHighlighter = Self.makeSyntaxHighlighter(for: filePath)
         let store = TextBackingStore()
         store.loadFromText(readOnlyText)
         store.finishLoading()
@@ -232,7 +233,7 @@ final class EditorTabState: Identifiable {
         awaitingLargeFileConfirmation = false
         hasExternalChange = false
         errorMessage = nil
-        syntaxHighlighter = nil
+        syntaxHighlighter = Self.makeSyntaxHighlighter(for: filePath)
         let store = backingStore ?? TextBackingStore()
         store.loadFromText(text)
         store.finishLoading()

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -740,6 +740,9 @@ struct CodeEditorView: NSViewRepresentable {
             var loaded: [EditorExtension] = []
             if state.diffLineKinds != nil {
                 loaded.append(DiffGutterExtension(host: self))
+                if state.syntaxHighlighter != nil {
+                    loaded.append(SyntaxHighlightExtension(coordinator: self))
+                }
                 loaded.append(DiffLineStyleExtension())
             } else {
                 loaded.append(SyntaxHighlightExtension(coordinator: self))

--- a/Muxy/Views/Editor/Extensions/DiffLineStyleExtension.swift
+++ b/Muxy/Views/Editor/Extensions/DiffLineStyleExtension.swift
@@ -291,8 +291,11 @@ final class DiffLineStyleExtension: EditorExtension {
         guard storageLength > 0 else { return }
 
         let fullRange = NSRange(location: 0, length: storageLength)
-        context.layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: fullRange)
         context.layoutManager.removeTemporaryAttribute(.backgroundColor, forCharacterRange: fullRange)
+        let preservesSyntaxForeground = context.state.syntaxHighlighter != nil
+        if !preservesSyntaxForeground {
+            context.layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: fullRange)
+        }
 
         let viewportStart = context.viewport.viewportStartLine
         var runKind: DiffDisplayRow.Kind?
@@ -315,39 +318,73 @@ final class DiffLineStyleExtension: EditorExtension {
                 continue
             }
 
-            flushRun(kind: runKind, start: runStart, end: runEnd, layoutManager: context.layoutManager)
+            flushRun(
+                kind: runKind,
+                start: runStart,
+                end: runEnd,
+                preservesSyntaxForeground: preservesSyntaxForeground,
+                layoutManager: context.layoutManager
+            )
             runKind = kind
             runStart = start
             runEnd = end
         }
 
-        flushRun(kind: runKind, start: runStart, end: runEnd, layoutManager: context.layoutManager)
+        flushRun(
+            kind: runKind,
+            start: runStart,
+            end: runEnd,
+            preservesSyntaxForeground: preservesSyntaxForeground,
+            layoutManager: context.layoutManager
+        )
     }
 
-    private func flushRun(kind: DiffDisplayRow.Kind?, start: Int?, end: Int, layoutManager: NSLayoutManager) {
+    private func flushRun(
+        kind: DiffDisplayRow.Kind?,
+        start: Int?,
+        end: Int,
+        preservesSyntaxForeground: Bool,
+        layoutManager: NSLayoutManager
+    ) {
         guard let kind, let start, end > start else { return }
         applyStyle(
             kind: kind,
             range: NSRange(location: start, length: end - start),
+            preservesSyntaxForeground: preservesSyntaxForeground,
             layoutManager: layoutManager
         )
     }
 
-    private func applyStyle(kind: DiffDisplayRow.Kind, range: NSRange, layoutManager: NSLayoutManager) {
+    private func applyStyle(
+        kind: DiffDisplayRow.Kind,
+        range: NSRange,
+        preservesSyntaxForeground: Bool,
+        layoutManager: NSLayoutManager
+    ) {
         switch kind {
         case .addition:
-            layoutManager.addTemporaryAttribute(.foregroundColor, value: MuxyTheme.nsDiffAdd, forCharacterRange: range)
             layoutManager.addTemporaryAttribute(
                 .backgroundColor,
                 value: MuxyTheme.nsDiffAdd.withAlphaComponent(0.14),
                 forCharacterRange: range
             )
+            applyFallbackForeground(
+                MuxyTheme.nsDiffAdd,
+                range: range,
+                preservesSyntaxForeground: preservesSyntaxForeground,
+                layoutManager: layoutManager
+            )
         case .deletion:
-            layoutManager.addTemporaryAttribute(.foregroundColor, value: MuxyTheme.nsDiffRemove, forCharacterRange: range)
             layoutManager.addTemporaryAttribute(
                 .backgroundColor,
                 value: MuxyTheme.nsDiffRemove.withAlphaComponent(0.14),
                 forCharacterRange: range
+            )
+            applyFallbackForeground(
+                MuxyTheme.nsDiffRemove,
+                range: range,
+                preservesSyntaxForeground: preservesSyntaxForeground,
+                layoutManager: layoutManager
             )
         case .hunk:
             layoutManager.addTemporaryAttribute(.foregroundColor, value: MuxyTheme.nsDiffHunk, forCharacterRange: range)
@@ -370,5 +407,15 @@ final class DiffLineStyleExtension: EditorExtension {
         case .context:
             break
         }
+    }
+
+    private func applyFallbackForeground(
+        _ color: NSColor,
+        range: NSRange,
+        preservesSyntaxForeground: Bool,
+        layoutManager: NSLayoutManager
+    ) {
+        guard !preservesSyntaxForeground else { return }
+        layoutManager.addTemporaryAttribute(.foregroundColor, value: color, forCharacterRange: range)
     }
 }

--- a/Tests/MuxyTests/Models/EditorTabStateDiffSyntaxTests.swift
+++ b/Tests/MuxyTests/Models/EditorTabStateDiffSyntaxTests.swift
@@ -1,0 +1,51 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("EditorTabState diff syntax")
+@MainActor
+struct EditorTabStateDiffSyntaxTests {
+    @Test("read only diff state creates syntax highlighter from file path")
+    func readOnlyDiffStateCreatesSyntaxHighlighterFromFilePath() {
+        let state = EditorTabState(
+            projectPath: "/tmp/project",
+            filePath: "/tmp/project/Sources/App.swift",
+            readOnlyText: "let value = 1",
+            diffLineKinds: [.addition],
+            diffGutterLines: [DiffEditorGutterLine(kind: .addition, oldLineNumber: nil, newLineNumber: 1)]
+        )
+
+        #expect(state.syntaxHighlighter?.grammar.name == "Swift")
+    }
+
+    @Test("replace read only text refreshes syntax highlighter when file path changes")
+    func replaceReadOnlyTextRefreshesSyntaxHighlighterWhenFilePathChanges() {
+        let state = EditorTabState(
+            projectPath: "/tmp/project",
+            filePath: "/tmp/project/Sources/App.swift",
+            readOnlyText: "let value = 1",
+            diffLineKinds: [.addition]
+        )
+
+        state.replaceReadOnlyText(
+            "const value = 1",
+            filePath: "/tmp/project/web/app.ts",
+            diffLineKinds: [.addition],
+            diffGutterLines: [DiffEditorGutterLine(kind: .addition, oldLineNumber: nil, newLineNumber: 1)]
+        )
+
+        #expect(state.syntaxHighlighter?.grammar.name == "TypeScript")
+    }
+
+    @Test("read only diff state leaves syntax highlighter empty for unsupported files")
+    func readOnlyDiffStateLeavesSyntaxHighlighterEmptyForUnsupportedFiles() {
+        let state = EditorTabState(
+            projectPath: "/tmp/project",
+            filePath: "/tmp/project/file.unknownext",
+            readOnlyText: "plain text",
+            diffLineKinds: [.context]
+        )
+
+        #expect(state.syntaxHighlighter == nil)
+    }
+}


### PR DESCRIPTION
Enables existing syntax highlighting for diff buffers while preserving diff row styling.
  Adds tests for read-only diff syntax highlighter setup.