### PR TITLE
Improve diff viewer performance and behavior

### DIFF
--- a/Muxy/Models/DiffCache.swift
+++ b/Muxy/Models/DiffCache.swift
@@ -91,6 +91,7 @@ final class DiffCache {
     }
 
     func registerTask(_ task: Task<Void, Never>, for filePath: String) {
+        tasks[filePath]?.cancel()
         tasks[filePath] = task
     }
 
@@ -113,6 +114,12 @@ final class DiffCache {
 
     nonisolated func cancelAll() {
         tasks.values.forEach { $0.cancel() }
+    }
+
+    func cancelAndClearLoading() {
+        tasks.values.forEach { $0.cancel() }
+        tasks.removeAll()
+        loadingPaths.removeAll()
     }
 
     private func enforceCap(pinnedPaths: Set<String>) {

--- a/Muxy/Models/DiffCollapsePolicy.swift
+++ b/Muxy/Models/DiffCollapsePolicy.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum DiffCollapsePolicy {
+    private static let largeChangedLineThreshold = 1000
+    private static let noisyChangedLineThreshold = 200
+
+    private static let lockFileNames: Set<String> = [
+        "Cargo.lock",
+        "Gemfile.lock",
+        "Package.resolved",
+        "Podfile.lock",
+        "composer.lock",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+    ]
+
+    static func shouldCollapseByDefault(_ file: GitStatusFile) -> Bool {
+        file.isBinary
+            || isDeleted(file)
+            || changedLines(file) >= largeChangedLineThreshold
+            || isNoisyPath(file.path) && changedLines(file) >= noisyChangedLineThreshold
+    }
+
+    static func shouldCollapseByDefault(_ file: GitStatusFile, isStaged: Bool) -> Bool {
+        file.isBinary
+            || isDeleted(file)
+            || changedLines(file, isStaged: isStaged) >= largeChangedLineThreshold
+            || isNoisyPath(file.path) && changedLines(file, isStaged: isStaged) >= noisyChangedLineThreshold
+    }
+
+    private static func isDeleted(_ file: GitStatusFile) -> Bool {
+        file.xStatus == "D" || file.yStatus == "D"
+    }
+
+    private static func changedLines(_ file: GitStatusFile) -> Int {
+        (file.additions ?? 0) + (file.deletions ?? 0)
+    }
+
+    private static func changedLines(_ file: GitStatusFile, isStaged: Bool) -> Int {
+        (file.additions(isStaged: isStaged) ?? 0) + (file.deletions(isStaged: isStaged) ?? 0)
+    }
+
+    private static func isNoisyPath(_ path: String) -> Bool {
+        let fileName = URL(fileURLWithPath: path).lastPathComponent
+        if lockFileNames.contains(fileName) { return true }
+
+        let lowercased = path.lowercased()
+        return lowercased.contains("/__snapshots__/")
+            || lowercased.contains("/snapshots/")
+            || lowercased.contains("/fixtures/")
+            || lowercased.contains("/generated/")
+            || lowercased.contains(".generated.")
+            || lowercased.hasPrefix("dist/")
+            || lowercased.hasPrefix("build/")
+    }
+}

--- a/Muxy/Models/DiffHintPolicy.swift
+++ b/Muxy/Models/DiffHintPolicy.swift
@@ -1,9 +1,9 @@
 enum DiffHintPolicy {
     static func hints(file: GitStatusFile, isStaged: Bool) -> GitRepositoryService.DiffHints {
-        let isUntracked = file.xStatus == "?" && file.yStatus == "?"
+        let isUntrackedOrNew = (file.xStatus == "?" && file.yStatus == "?") || (!isStaged && file.xStatus == "A")
         if isStaged {
-            return GitRepositoryService.DiffHints(hasStaged: true, hasUnstaged: false, isUntrackedOrNew: isUntracked)
+            return GitRepositoryService.DiffHints(hasStaged: true, hasUnstaged: false, isUntrackedOrNew: isUntrackedOrNew)
         }
-        return GitRepositoryService.DiffHints(hasStaged: false, hasUnstaged: !isUntracked, isUntrackedOrNew: isUntracked)
+        return GitRepositoryService.DiffHints(hasStaged: false, hasUnstaged: !isUntrackedOrNew, isUntrackedOrNew: isUntrackedOrNew)
     }
 }

--- a/Muxy/Models/DiffHintPolicy.swift
+++ b/Muxy/Models/DiffHintPolicy.swift
@@ -1,0 +1,9 @@
+enum DiffHintPolicy {
+    static func hints(file: GitStatusFile, isStaged: Bool) -> GitRepositoryService.DiffHints {
+        let isUntracked = file.xStatus == "?" && file.yStatus == "?"
+        if isStaged {
+            return GitRepositoryService.DiffHints(hasStaged: true, hasUnstaged: false, isUntrackedOrNew: isUntracked)
+        }
+        return GitRepositoryService.DiffHints(hasStaged: false, hasUnstaged: !isUntracked, isUntrackedOrNew: isUntracked)
+    }
+}

--- a/Muxy/Models/DiffViewerTabState.swift
+++ b/Muxy/Models/DiffViewerTabState.swift
@@ -541,23 +541,40 @@ private struct WeakDiffViewerTabState {
 actor DiffLoadGate {
     static let shared = DiffLoadGate(limit: 4)
 
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
     private let limit: Int
     private var active = 0
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [Waiter] = []
 
     init(limit: Int) {
         self.limit = limit
     }
 
     func enter() async throws {
+        try Task.checkCancellation()
         if active < limit {
             active += 1
             return
         }
-        await withCheckedContinuation { continuation in
-            waiters.append(continuation)
+        let id = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                waiters.append(Waiter(id: id, continuation: continuation))
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: id) }
         }
         try Task.checkCancellation()
+    }
+
+    func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume()
     }
 
     func leave() {
@@ -565,7 +582,7 @@ actor DiffLoadGate {
             active -= 1
             return
         }
-        let continuation = waiters.removeFirst()
-        continuation.resume()
+        let waiter = waiters.removeFirst()
+        waiter.continuation.resume()
     }
 }

--- a/Muxy/Models/DiffViewerTabState.swift
+++ b/Muxy/Models/DiffViewerTabState.swift
@@ -16,8 +16,9 @@ final class DiffViewerTabState: Identifiable {
     struct PullRequestSource: Equatable {
         let number: Int
         let title: String
-        let baseRef: String
-        let headRef: String
+        let baseRef: String?
+        let headRef: String?
+        let baseBranch: String?
         let webURL: URL?
     }
 
@@ -61,7 +62,7 @@ final class DiffViewerTabState: Identifiable {
     var selectedFilePath: String?
     var selectedIsStaged = false
     var wordWrap = false
-    var fontSize: CGFloat = 13
+    var fontSize: CGFloat = DiffViewerTabState.loadPersistedFontSize()
     var scrollRequestVersion = 0
     var sidebarScrollRequestVersion = 0
     var collapsedCacheKeys: Set<String> = []
@@ -72,6 +73,13 @@ final class DiffViewerTabState: Identifiable {
     var filesError: String?
     let diffCache = DiffCache()
     private let git = GitRepositoryService()
+    private var sourceFilesTask: Task<Void, Never>?
+    private var pendingScrollCacheKey: String?
+    static let fontSizeDefaultsKey = "muxy.diffViewer.fontSize"
+    private static let defaultFontSize: CGFloat = 13
+    private static let minFontSize: CGFloat = 9
+    private static let maxFontSize: CGFloat = 28
+    private static var instances: [WeakDiffViewerTabState] = []
 
     var displayTitle: String {
         source.displayTitle
@@ -104,6 +112,7 @@ final class DiffViewerTabState: Identifiable {
         self.source = source
         projectPath = vcs.projectPath
         mode = vcs.mode
+        Self.register(self)
         selectInitialFile(filePath: filePath, isStaged: isStaged)
     }
 
@@ -116,10 +125,12 @@ final class DiffViewerTabState: Identifiable {
     }
 
     func setSource(_ source: Source, filePath: String? = nil, isStaged: Bool = false) {
+        cancelSourceLoads()
         self.source = source
         selectedFilePath = nil
         selectedIsStaged = isStaged
         activeCacheKey = nil
+        pendingScrollCacheKey = nil
         collapsedCacheKeys.removeAll()
         manuallyLoadedCacheKeys.removeAll()
         diffCache.clearAll()
@@ -131,6 +142,14 @@ final class DiffViewerTabState: Identifiable {
         }
     }
 
+    func prepareForClose() {
+        cancelSourceLoads()
+        diffCache.clearAll()
+        vcs.diffCache.evict { key in
+            key.hasPrefix("staged:") || key.hasPrefix("unstaged:")
+        }
+    }
+
     func loadFullDiff(filePath: String, isStaged: Bool) {
         let cacheKey = Self.cacheKey(filePath: filePath, isStaged: isStaged)
         manuallyLoadedCacheKeys.insert(cacheKey)
@@ -138,20 +157,32 @@ final class DiffViewerTabState: Identifiable {
         loadDiff(filePath: filePath, isStaged: isStaged, forceFull: true)
     }
 
+    func loadDiff(filePath: String, isStaged: Bool) {
+        loadDiff(filePath: filePath, isStaged: isStaged, forceFull: false)
+    }
+
     func select(filePath: String, isStaged: Bool) {
+        let cacheKey = Self.cacheKey(filePath: filePath, isStaged: isStaged)
         guard selectedFilePath != filePath || selectedIsStaged != isStaged else {
+            activeCacheKey = cacheKey
+            pendingScrollCacheKey = cacheKey
             scrollRequestVersion &+= 1
             loadSelectedDiff(forceFull: false)
             return
         }
         selectedFilePath = filePath
         selectedIsStaged = isStaged
-        activeCacheKey = Self.cacheKey(filePath: filePath, isStaged: isStaged)
+        activeCacheKey = cacheKey
+        pendingScrollCacheKey = cacheKey
         scrollRequestVersion &+= 1
         loadSelectedDiff(forceFull: false)
     }
 
     func activateFromDiffScroll(cacheKey: String?) {
+        if let pendingScrollCacheKey {
+            guard cacheKey == pendingScrollCacheKey else { return }
+            self.pendingScrollCacheKey = nil
+        }
         guard activeCacheKey != cacheKey else { return }
         activeCacheKey = cacheKey
         sidebarScrollRequestVersion &+= 1
@@ -171,11 +202,11 @@ final class DiffViewerTabState: Identifiable {
     }
 
     func adjustFontSize(by delta: CGFloat) {
-        fontSize = min(28, max(9, fontSize + delta))
+        Self.storeFontSize(fontSize + delta)
     }
 
     func resetFontSize() {
-        fontSize = 13
+        Self.storeFontSize(Self.defaultFontSize)
     }
 
     func isCollapsed(filePath: String, isStaged: Bool) -> Bool {
@@ -204,7 +235,9 @@ final class DiffViewerTabState: Identifiable {
     }
 
     func reconcileLargeDiffCollapse() {
-        collapsedCacheKeys.formUnion(allCacheKeys.filter(isLargeUnloadedDiff))
+        collapsedCacheKeys.formUnion(allCacheKeys.filter { cacheKey in
+            isLargeUnloadedDiff(cacheKey) || isEstimatedLargeDiff(cacheKey)
+        })
     }
 
     func reconcileSelection() {
@@ -287,33 +320,69 @@ final class DiffViewerTabState: Identifiable {
         guard let file = files.first(where: { $0.path == filePath }) else {
             return GitRepositoryService.DiffHints(hasStaged: isStaged, hasUnstaged: !isStaged, isUntrackedOrNew: false)
         }
-        let untrackedOrNew = (file.xStatus == "?" && file.yStatus == "?") || (!isStaged && file.xStatus == "A")
-        if isStaged {
-            return GitRepositoryService.DiffHints(hasStaged: true, hasUnstaged: false, isUntrackedOrNew: untrackedOrNew)
-        }
-        return GitRepositoryService.DiffHints(hasStaged: false, hasUnstaged: !untrackedOrNew, isUntrackedOrNew: untrackedOrNew)
+        return DiffHintPolicy.hints(file: file, isStaged: isStaged)
     }
 
     private func isLargeUnloadedDiff(_ cacheKey: String) -> Bool {
         activeDiffCache.diff(for: cacheKey)?.truncated == true && !manuallyLoadedCacheKeys.contains(cacheKey)
     }
 
+    private func isEstimatedLargeDiff(_ cacheKey: String) -> Bool {
+        guard !activeDiffCache.hasDiff(for: cacheKey) else { return false }
+        let isStaged = cacheKey.hasPrefix("staged:")
+        guard let file = files.first(where: { Self.cacheKey(filePath: $0.path, isStaged: isStaged) == cacheKey })
+        else {
+            return false
+        }
+        return DiffCollapsePolicy.shouldCollapseByDefault(file, isStaged: isStaged)
+    }
+
     private var activeDiffCache: DiffCache {
         source == .workingTree ? vcs.diffCache : diffCache
     }
 
+    private static func register(_ state: DiffViewerTabState) {
+        instances.removeAll { $0.value == nil }
+        instances.append(WeakDiffViewerTabState(value: state))
+    }
+
+    private static func loadPersistedFontSize() -> CGFloat {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: fontSizeDefaultsKey) != nil else { return defaultFontSize }
+        return clampedFontSize(CGFloat(defaults.double(forKey: fontSizeDefaultsKey)))
+    }
+
+    private static func storeFontSize(_ fontSize: CGFloat) {
+        let fontSize = clampedFontSize(fontSize)
+        UserDefaults.standard.set(Double(fontSize), forKey: fontSizeDefaultsKey)
+        instances.removeAll { $0.value == nil }
+        for instance in instances {
+            instance.value?.fontSize = fontSize
+        }
+    }
+
+    private static func clampedFontSize(_ fontSize: CGFloat) -> CGFloat {
+        min(maxFontSize, max(minFontSize, fontSize))
+    }
+
     private func loadSourceFiles(forceFull: Bool) {
         guard source != .workingTree else { return }
+        sourceFilesTask?.cancel()
+        diffCache.cancelAndClearLoading()
         isLoadingFiles = true
         filesError = nil
         let source = source
-        Task { [weak self] in
+        let task = Task { [weak self] in
             guard let self else { return }
             do {
-                let files = try await sourceFiles(for: source)
+                let resolvedSource = try await resolvedSource(source)
+                guard !Task.isCancelled else { return }
+                self.source = resolvedSource
+                let files = try await sourceFiles(for: resolvedSource)
                 guard !Task.isCancelled else { return }
                 sourceFiles = files
                 isLoadingFiles = false
+                reconcileLargeDiffCollapse()
                 reconcileSelection()
                 loadAllDiffs(forceFull: forceFull)
             } catch {
@@ -323,23 +392,47 @@ final class DiffViewerTabState: Identifiable {
                 filesError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
         }
+        sourceFilesTask = task
+    }
+
+    private func resolvedSource(_ source: Source) async throws -> Source {
+        guard case let .pullRequest(pullRequest) = source,
+              pullRequest.baseRef == nil || pullRequest.headRef == nil
+        else { return source }
+
+        let remote = await git.githubRemoteName(repoPath: projectPath) ?? "origin"
+        let baseRef = pullRequest.baseRef ?? "refs/remotes/\(remote)/\(pullRequest.baseBranch ?? "main")"
+        let headRef = try await git.fetchPullRequestDiffHead(
+            repoPath: projectPath,
+            number: pullRequest.number,
+            remote: remote
+        )
+        return .pullRequest(PullRequestSource(
+            number: pullRequest.number,
+            title: pullRequest.title,
+            baseRef: baseRef,
+            headRef: headRef,
+            baseBranch: pullRequest.baseBranch,
+            webURL: pullRequest.webURL
+        ))
     }
 
     private func sourceFiles(for source: Source) async throws -> [GitStatusFile] {
         switch source {
         case .workingTree:
-            vcs.files
+            return vcs.files
         case let .commit(commit):
-            try await git.changedFiles(repoPath: projectPath, commit: commit.hash)
+            return try await git.changedFiles(repoPath: projectPath, commit: commit.hash)
         case let .range(baseRef, headRef, _):
-            try await git.changedFiles(
+            return try await git.changedFiles(
                 repoPath: projectPath,
                 range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef)
             )
         case let .pullRequest(pullRequest):
-            try await git.changedFiles(
+            guard let baseRef = pullRequest.baseRef, let headRef = pullRequest.headRef else { return [] }
+            return try await git.changedFiles(
                 repoPath: projectPath,
-                range: GitRepositoryService.DiffRange(baseRef: pullRequest.baseRef, headRef: pullRequest.headRef)
+                range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef)
             )
         }
     }
@@ -378,34 +471,101 @@ final class DiffViewerTabState: Identifiable {
         diffCache.registerTask(task, for: cacheKey)
     }
 
+    private func cancelSourceLoads() {
+        sourceFilesTask?.cancel()
+        sourceFilesTask = nil
+        diffCache.cancelAndClearLoading()
+        isLoadingFiles = false
+    }
+
     private func sourceDiff(
         filePath: String,
         source: Source,
         lineLimit: Int?
     ) async throws -> GitRepositoryService.PatchAndCompareResult {
-        switch source {
-        case .workingTree:
-            try await git.patchAndCompare(repoPath: projectPath, filePath: filePath, lineLimit: lineLimit)
-        case let .commit(commit):
-            try await git.patchAndCompare(repoPath: projectPath, filePath: filePath, commit: commit.hash, lineLimit: lineLimit)
-        case let .range(baseRef, headRef, _):
-            try await git.patchAndCompare(
-                repoPath: projectPath,
-                filePath: filePath,
-                range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef),
-                lineLimit: lineLimit
-            )
-        case let .pullRequest(pullRequest):
-            try await git.patchAndCompare(
-                repoPath: projectPath,
-                filePath: filePath,
-                range: GitRepositoryService.DiffRange(baseRef: pullRequest.baseRef, headRef: pullRequest.headRef),
-                lineLimit: lineLimit
-            )
+        try await DiffLoadGate.shared.enter()
+        do {
+            try Task.checkCancellation()
+            switch source {
+            case .workingTree:
+                let result = try await git.patchAndCompare(repoPath: projectPath, filePath: filePath, lineLimit: lineLimit)
+                await DiffLoadGate.shared.leave()
+                return result
+            case let .commit(commit):
+                let result = try await git.patchAndCompare(
+                    repoPath: projectPath,
+                    filePath: filePath,
+                    commit: commit.hash,
+                    lineLimit: lineLimit
+                )
+                await DiffLoadGate.shared.leave()
+                return result
+            case let .range(baseRef, headRef, _):
+                let result = try await git.patchAndCompare(
+                    repoPath: projectPath,
+                    filePath: filePath,
+                    range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef),
+                    lineLimit: lineLimit
+                )
+                await DiffLoadGate.shared.leave()
+                return result
+            case let .pullRequest(pullRequest):
+                guard let baseRef = pullRequest.baseRef, let headRef = pullRequest.headRef else {
+                    await DiffLoadGate.shared.leave()
+                    return GitRepositoryService.PatchAndCompareResult(rows: [], truncated: false, additions: 0, deletions: 0)
+                }
+                let result = try await git.patchAndCompare(
+                    repoPath: projectPath,
+                    filePath: filePath,
+                    range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef),
+                    lineLimit: lineLimit
+                )
+                await DiffLoadGate.shared.leave()
+                return result
+            }
+        } catch {
+            await DiffLoadGate.shared.leave()
+            throw error
         }
     }
 
     static func cacheKey(filePath: String, isStaged: Bool) -> String {
         "\(isStaged ? "staged" : "unstaged"):\(filePath)"
+    }
+}
+
+private struct WeakDiffViewerTabState {
+    weak var value: DiffViewerTabState?
+}
+
+actor DiffLoadGate {
+    static let shared = DiffLoadGate(limit: 4)
+
+    private let limit: Int
+    private var active = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(limit: Int) {
+        self.limit = limit
+    }
+
+    func enter() async throws {
+        if active < limit {
+            active += 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+        try Task.checkCancellation()
+    }
+
+    func leave() {
+        guard !waiters.isEmpty else {
+            active -= 1
+            return
+        }
+        let continuation = waiters.removeFirst()
+        continuation.resume()
     }
 }

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -213,9 +213,6 @@ enum TabReducer {
     }
 
     private static func clearDiffViewerCache(for tab: TerminalTab?) {
-        guard let vcs = tab?.content.diffViewerState?.vcs else { return }
-        vcs.diffCache.evict { key in
-            key.hasPrefix("staged:") || key.hasPrefix("unstaged:")
-        }
+        tab?.content.diffViewerState?.prepareForClose()
     }
 }

--- a/Muxy/Services/Git/GitModels.swift
+++ b/Muxy/Services/Git/GitModels.swift
@@ -13,7 +13,37 @@ struct GitStatusFile: Identifiable, Hashable {
     let yStatus: Character
     let additions: Int?
     let deletions: Int?
+    let stagedAdditions: Int?
+    let stagedDeletions: Int?
+    let unstagedAdditions: Int?
+    let unstagedDeletions: Int?
     let isBinary: Bool
+
+    init(
+        path: String,
+        oldPath: String?,
+        xStatus: Character,
+        yStatus: Character,
+        additions: Int?,
+        deletions: Int?,
+        stagedAdditions: Int? = nil,
+        stagedDeletions: Int? = nil,
+        unstagedAdditions: Int? = nil,
+        unstagedDeletions: Int? = nil,
+        isBinary: Bool
+    ) {
+        self.path = path
+        self.oldPath = oldPath
+        self.xStatus = xStatus
+        self.yStatus = yStatus
+        self.additions = additions
+        self.deletions = deletions
+        self.stagedAdditions = stagedAdditions
+        self.stagedDeletions = stagedDeletions
+        self.unstagedAdditions = unstagedAdditions
+        self.unstagedDeletions = unstagedDeletions
+        self.isBinary = isBinary
+    }
 
     var id: String { path }
 
@@ -25,6 +55,20 @@ struct GitStatusFile: Identifiable, Hashable {
     var isUnstaged: Bool {
         let unstaged: Set<Character> = ["M", "D", "?"]
         return unstaged.contains(yStatus) || (xStatus == "?" && yStatus == "?")
+    }
+
+    func additions(isStaged: Bool) -> Int? {
+        if isStaged {
+            return stagedAdditions ?? additions
+        }
+        return unstagedAdditions ?? additions
+    }
+
+    func deletions(isStaged: Bool) -> Int? {
+        if isStaged {
+            return stagedDeletions ?? deletions
+        }
+        return unstagedDeletions ?? deletions
     }
 
     var statusText: String {

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -839,17 +839,46 @@ struct GitRepositoryService {
             repoPath: repoPath,
             arguments: ["-c", "core.quotepath=false", "diff", "HEAD", "--numstat", "--no-color", "--no-ext-diff"]
         )
+        async let stagedNumstatTask = GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["-c", "core.quotepath=false", "diff", "--cached", "--numstat", "--no-color", "--no-ext-diff"]
+        )
+        async let unstagedNumstatTask = GitProcessRunner.runGit(
+            repoPath: repoPath,
+            arguments: ["-c", "core.quotepath=false", "diff", "--numstat", "--no-color", "--no-ext-diff"]
+        )
 
         let statusResult = try await statusTask
         guard statusResult.status == 0 else {
             _ = try? await numstatTask
+            _ = try? await stagedNumstatTask
+            _ = try? await unstagedNumstatTask
             throw GitError.commandFailed(statusResult.stderr.isEmpty ? "Failed to load Git status." : statusResult.stderr)
         }
 
         let numstatResult = try await numstatTask
+        let stagedNumstatResult = try await stagedNumstatTask
+        let unstagedNumstatResult = try await unstagedNumstatTask
         let stats = numstatResult.status == 0 ? GitStatusParser.parseNumstat(numstatResult.stdout) : [:]
+        let stagedStats = stagedNumstatResult.status == 0 ? GitStatusParser.parseNumstat(stagedNumstatResult.stdout) : [:]
+        let unstagedStats = unstagedNumstatResult.status == 0 ? GitStatusParser.parseNumstat(unstagedNumstatResult.stdout) : [:]
 
         return GitStatusParser.parseStatusPorcelain(statusResult.stdoutData, stats: stats).map { file in
+            let staged = stagedStats[file.path]
+            let unstaged = unstagedStats[file.path]
+            let file = GitStatusFile(
+                path: file.path,
+                oldPath: file.oldPath,
+                xStatus: file.xStatus,
+                yStatus: file.yStatus,
+                additions: file.additions,
+                deletions: file.deletions,
+                stagedAdditions: staged?.additions,
+                stagedDeletions: staged?.deletions,
+                unstagedAdditions: unstaged?.additions,
+                unstagedDeletions: unstaged?.deletions,
+                isBinary: file.isBinary || staged?.isBinary == true || unstaged?.isBinary == true
+            )
             guard file.additions == nil, file.xStatus == "?" || file.xStatus == "A" else { return file }
             let lineCount = Self.countLines(repoPath: repoPath, relativePath: file.path)
             return GitStatusFile(
@@ -859,6 +888,10 @@ struct GitRepositoryService {
                 yStatus: file.yStatus,
                 additions: lineCount,
                 deletions: 0,
+                stagedAdditions: file.stagedAdditions,
+                stagedDeletions: file.stagedDeletions,
+                unstagedAdditions: file.unstagedAdditions,
+                unstagedDeletions: file.unstagedDeletions,
                 isBinary: file.isBinary
             )
         }

--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -11,6 +11,9 @@ private final class CodeEditorTextView: NSTextView {
     var canUndoRequest: (() -> Bool)?
     var canRedoRequest: (() -> Bool)?
     var usesNativeUndo = true
+    var diffLineKinds: [DiffDisplayRow.Kind]?
+    var diffViewportStartLine = 0
+    var diffLineStartOffsets: [Int] = []
 
     override var undoManager: UndoManager? {
         usesNativeUndo ? super.undoManager : nil
@@ -18,6 +21,11 @@ private final class CodeEditorTextView: NSTextView {
 
     override func paste(_ sender: Any?) {
         pasteAsPlainText(sender)
+    }
+
+    override func drawBackground(in rect: NSRect) {
+        super.drawBackground(in: rect)
+        drawDiffLineBackgrounds(in: rect)
     }
 
     @objc
@@ -44,6 +52,60 @@ private final class CodeEditorTextView: NSTextView {
             return canRedoRequest()
         }
         return super.validateUserInterfaceItem(item)
+    }
+
+    private func drawDiffLineBackgrounds(in dirtyRect: NSRect) {
+        guard let diffLineKinds,
+              !diffLineKinds.isEmpty,
+              let layoutManager,
+              let textContainer
+        else { return }
+
+        let glyphRange = layoutManager.glyphRange(forBoundingRect: dirtyRect, in: textContainer)
+        guard glyphRange.length > 0 else { return }
+        let origin = textContainerOrigin
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { _, usedRect, _, glyphRange, _ in
+            let characterIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
+            let localLine = self.localLine(containing: characterIndex)
+            let globalLine = self.diffViewportStartLine + localLine
+            guard globalLine < diffLineKinds.count else { return }
+            let color = self.diffBackgroundColor(for: diffLineKinds[globalLine])
+            guard color.alphaComponent > 0 else { return }
+            color.setFill()
+            let y = usedRect.minY + origin.y
+            let height = max(usedRect.height, 1)
+            NSRect(x: dirtyRect.minX, y: y, width: max(self.bounds.width, dirtyRect.maxX) - dirtyRect.minX, height: height).fill()
+        }
+    }
+
+    private func localLine(containing characterIndex: Int) -> Int {
+        guard !diffLineStartOffsets.isEmpty else { return 0 }
+        var low = 0
+        var high = diffLineStartOffsets.count - 1
+        while low <= high {
+            let mid = (low + high) / 2
+            if diffLineStartOffsets[mid] <= characterIndex {
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+        return max(0, high)
+    }
+
+    private func diffBackgroundColor(for kind: DiffDisplayRow.Kind) -> NSColor {
+        switch kind {
+        case .addition:
+            MuxyTheme.nsDiffAdd.withAlphaComponent(0.14)
+        case .deletion:
+            MuxyTheme.nsDiffRemove.withAlphaComponent(0.14)
+        case .hunk:
+            MuxyTheme.nsDiffHunk.withAlphaComponent(0.12)
+        case .collapsed:
+            EditorThemePalette.active.foreground.withAlphaComponent(0.08)
+        case .context:
+            .clear
+        }
     }
 
     override func scrollRangeToVisible(_ range: NSRange) {
@@ -307,6 +369,7 @@ struct CodeEditorView: NSViewRepresentable {
         layoutManager.addTextContainer(textContainer)
 
         let textView = CodeEditorTextView(frame: NSRect(origin: .zero, size: scrollView.contentSize), textContainer: textContainer)
+        textView.diffLineKinds = state.diffLineKinds
         textView.minSize = NSSize(width: 0, height: 0)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.isVerticallyResizable = true
@@ -1063,6 +1126,11 @@ struct CodeEditorView: NSViewRepresentable {
                 lastRenderedBackingStoreVersion = state.backingStoreVersion
                 needsViewportTextReload = false
                 rebuildLineStartOffsetsForViewport()
+            }
+            if let textView = textView as? CodeEditorTextView {
+                textView.diffLineKinds = state.diffLineKinds
+                textView.diffViewportStartLine = viewport.viewportStartLine
+                textView.diffLineStartOffsets = lineStartOffsets
             }
             let font = resolvedFont
             if let storage = textView.textStorage, storage.length > 0 {

--- a/Muxy/Views/Editor/Extensions/DiffLineStyleExtension.swift
+++ b/Muxy/Views/Editor/Extensions/DiffLineStyleExtension.swift
@@ -363,11 +363,6 @@ final class DiffLineStyleExtension: EditorExtension {
     ) {
         switch kind {
         case .addition:
-            layoutManager.addTemporaryAttribute(
-                .backgroundColor,
-                value: MuxyTheme.nsDiffAdd.withAlphaComponent(0.14),
-                forCharacterRange: range
-            )
             applyFallbackForeground(
                 MuxyTheme.nsDiffAdd,
                 range: range,
@@ -375,11 +370,6 @@ final class DiffLineStyleExtension: EditorExtension {
                 layoutManager: layoutManager
             )
         case .deletion:
-            layoutManager.addTemporaryAttribute(
-                .backgroundColor,
-                value: MuxyTheme.nsDiffRemove.withAlphaComponent(0.14),
-                forCharacterRange: range
-            )
             applyFallbackForeground(
                 MuxyTheme.nsDiffRemove,
                 range: range,
@@ -388,20 +378,10 @@ final class DiffLineStyleExtension: EditorExtension {
             )
         case .hunk:
             layoutManager.addTemporaryAttribute(.foregroundColor, value: MuxyTheme.nsDiffHunk, forCharacterRange: range)
-            layoutManager.addTemporaryAttribute(
-                .backgroundColor,
-                value: MuxyTheme.nsDiffHunk.withAlphaComponent(0.12),
-                forCharacterRange: range
-            )
         case .collapsed:
             layoutManager.addTemporaryAttribute(
                 .foregroundColor,
                 value: EditorThemePalette.active.foreground.withAlphaComponent(0.55),
-                forCharacterRange: range
-            )
-            layoutManager.addTemporaryAttribute(
-                .backgroundColor,
-                value: EditorThemePalette.active.foreground.withAlphaComponent(0.08),
                 forCharacterRange: range
             )
         case .context:

--- a/Muxy/Views/VCS/DiffEditorDocument.swift
+++ b/Muxy/Views/VCS/DiffEditorDocument.swift
@@ -296,6 +296,8 @@ struct DiffEditorFileSection {
     let rows: [DiffDisplayRow]
     let isCollapsed: Bool
     let isLargeUnloaded: Bool
+    let isLoading: Bool
+    let errorMessage: String?
     let additions: Int
     let deletions: Int
     let isStaged: Bool

--- a/Muxy/Views/VCS/DiffEditorView.swift
+++ b/Muxy/Views/VCS/DiffEditorView.swift
@@ -14,6 +14,7 @@ struct SingleDiffEditorView: View {
 
     @State private var editorSettings = EditorSettings.shared
     @State private var themeRevision = 0
+    @State private var documentRevision = 0
     @State private var splitScrollY: CGFloat = 0
     @State private var unifiedState: EditorTabState
     @State private var leftState: EditorTabState
@@ -100,6 +101,7 @@ struct SingleDiffEditorView: View {
             diffLineKinds: document.lineKinds,
             diffGutterLines: document.gutterLines
         )
+        documentRevision &+= 1
     }
 
     private func editor(state: EditorTabState, scrollY: Binding<CGFloat>?) -> some View {
@@ -110,7 +112,7 @@ struct SingleDiffEditorView: View {
             fontSizeOverride: fontSize,
             showLineNumbers: false,
             lineWrapping: wordWrap,
-            themeVersion: GhosttyService.shared.configVersion + themeRevision,
+            themeVersion: GhosttyService.shared.configVersion + themeRevision + documentRevision,
             showsVerticalScroller: false,
             focused: false,
             searchNeedle: "",

--- a/Muxy/Views/VCS/DiffViewerPane.swift
+++ b/Muxy/Views/VCS/DiffViewerPane.swift
@@ -536,8 +536,22 @@ private struct DiffFileCard: View {
             externalScrollY: externalScrollY,
             passesScrollWheelToParent: true
         )
-        .id("\(section.cacheKey):\(state.mode.rawValue):\(state.wordWrap):\(state.fontSize):\(usesVirtualBody):\(maxRenderedCharacters)")
+        .id(editorIdentity)
         .frame(maxWidth: .infinity)
+    }
+
+    private var editorIdentity: String {
+        [
+            section.cacheKey,
+            state.mode.rawValue,
+            String(state.wordWrap),
+            String(describing: state.fontSize),
+            String(usesVirtualBody),
+            String(maxRenderedCharacters),
+            String(section.rows.count),
+            section.rows.first?.id.uuidString ?? "empty",
+            section.rows.last?.id.uuidString ?? "empty",
+        ].joined(separator: ":")
     }
 
     private var maxRenderedCharacters: Int {

--- a/Muxy/Views/VCS/DiffViewerPane.swift
+++ b/Muxy/Views/VCS/DiffViewerPane.swift
@@ -27,11 +27,13 @@ struct DiffViewerPane: View {
                 state.vcs.refresh()
             }
             state.reconcileSelection()
+            state.reconcileLargeDiffCollapse()
             state.loadAllDiffs()
         }
         .onChange(of: state.vcs.files) { _, _ in
             guard state.source == .workingTree else { return }
             state.reconcileSelection()
+            state.reconcileLargeDiffCollapse()
             state.loadAllDiffs()
         }
         .onChange(of: state.vcs.diffCache.revision) { _, _ in
@@ -56,7 +58,7 @@ struct DiffViewerPane: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(fontShortcuts)
-        } else if isLoadingAnyDiff {
+        } else if state.isLoadingFiles || isLoadingAnyDiff {
             ProgressView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -82,8 +84,10 @@ struct DiffViewerPane: View {
                 rows: diff?.rows ?? [],
                 isCollapsed: state.collapsedCacheKeys.contains(cacheKey),
                 isLargeUnloaded: diff?.truncated == true && !state.manuallyLoadedCacheKeys.contains(cacheKey),
-                additions: diff?.additions ?? file.additions ?? 0,
-                deletions: diff?.deletions ?? file.deletions ?? 0,
+                isLoading: activeDiffCache.isLoading(cacheKey),
+                errorMessage: activeDiffCache.error(for: cacheKey),
+                additions: diff?.additions ?? file.additions(isStaged: isStaged) ?? 0,
+                deletions: diff?.deletions ?? file.deletions(isStaged: isStaged) ?? 0,
                 isStaged: isStaged
             )
         }
@@ -149,11 +153,17 @@ private struct DiffViewerBreadcrumb: View {
     @Bindable var state: DiffViewerTabState
 
     private var additions: Int {
-        state.files.compactMap(\.additions).reduce(0, +)
+        state.stagedFiles.compactMap { $0.additions(isStaged: true) }.reduce(0, +)
+            + state.unstagedFiles.compactMap { $0.additions(isStaged: false) }.reduce(0, +)
     }
 
     private var deletions: Int {
-        state.files.compactMap(\.deletions).reduce(0, +)
+        state.stagedFiles.compactMap { $0.deletions(isStaged: true) }.reduce(0, +)
+            + state.unstagedFiles.compactMap { $0.deletions(isStaged: false) }.reduce(0, +)
+    }
+
+    private var diffFileCount: Int {
+        state.stagedFiles.count + state.unstagedFiles.count
     }
 
     var body: some View {
@@ -187,7 +197,7 @@ private struct DiffViewerBreadcrumb: View {
                 .help("Open \(sourceLink.title)")
             }
 
-            Text("\(state.files.count) files")
+            Text("\(diffFileCount) files")
                 .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .padding(.horizontal, UIMetrics.scaled(5))
@@ -321,7 +331,7 @@ private struct DiffCardList: View {
         GeometryReader { geometry in
             ScrollViewReader { proxy in
                 ScrollView {
-                    VStack(spacing: cardSpacing) {
+                    LazyVStack(spacing: cardSpacing) {
                         ForEach(sections, id: \.cacheKey) { section in
                             DiffFileCard(
                                 state: state,
@@ -394,14 +404,27 @@ private struct DiffFileCard: View {
     }
 
     private var editorViewportHeight: CGFloat {
-        min(editorHeight, max(UIMetrics.scaled(160), viewportHeight + UIMetrics.scaled(80)))
+        DiffVirtualRenderWindow(
+            editorHeight: editorHeight,
+            viewportHeight: viewportHeight,
+            visibleBodyY: visibleBodyY,
+            minimumHeight: UIMetrics.scaled(160)
+        ).height
+    }
+
+    private var visibleBodyY: CGFloat {
+        guard usesVirtualBody else { return 0 }
+        let headerHeight = UIMetrics.scaled(37)
+        return max(0, -cardOffsetY - headerHeight)
     }
 
     private var bodyScrollY: CGFloat {
-        guard usesVirtualBody else { return 0 }
-        let headerHeight = UIMetrics.scaled(37)
-        let visibleBodyY = max(0, -cardOffsetY - headerHeight)
-        return min(max(0, editorHeight - editorViewportHeight), visibleBodyY)
+        DiffVirtualRenderWindow(
+            editorHeight: editorHeight,
+            viewportHeight: viewportHeight,
+            visibleBodyY: visibleBodyY,
+            minimumHeight: UIMetrics.scaled(160)
+        ).offsetY
     }
 
     var body: some View {
@@ -410,7 +433,11 @@ private struct DiffFileCard: View {
                 header
                 if !section.isCollapsed {
                     Rectangle().fill(MuxyTheme.border).frame(height: metrics.borderHeight)
-                    editorBody
+                    GeometryReader { proxy in
+                        let frame = proxy.frame(in: .named("diff-card-scroll"))
+                        editorBody(shouldRender: shouldRenderBody(frame: frame))
+                    }
+                    .frame(height: editorHeight)
                 }
             }
             Color.clear.frame(height: cardHeight)
@@ -425,8 +452,16 @@ private struct DiffFileCard: View {
     }
 
     @ViewBuilder
-    private var editorBody: some View {
-        if usesVirtualBody {
+    private func editorBody(shouldRender: Bool) -> some View {
+        if !shouldRender {
+            Color.clear
+        } else if section.isLoading, section.rows.isEmpty {
+            loadingBody
+        } else if let errorMessage = section.errorMessage, section.rows.isEmpty {
+            messageBody(errorMessage)
+        } else if section.rows.isEmpty {
+            emptyBody
+        } else if usesVirtualBody {
             ZStack(alignment: .top) {
                 Color.clear.frame(height: editorHeight)
                 editor(externalScrollY: bodyScrollY)
@@ -440,6 +475,52 @@ private struct DiffFileCard: View {
                 .frame(height: editorHeight)
                 .clipped()
         }
+    }
+
+    private func shouldRenderBody(frame: CGRect) -> Bool {
+        let overscan = viewportHeight
+        return frame.maxY >= -overscan && frame.minY <= viewportHeight + overscan
+    }
+
+    private var loadingBody: some View {
+        HStack(spacing: UIMetrics.spacing3) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Loading diff")
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                .foregroundStyle(MuxyTheme.fgMuted)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyBody: some View {
+        VStack(spacing: UIMetrics.spacing4) {
+            Text("Diff did not load")
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                .foregroundStyle(MuxyTheme.fgMuted)
+
+            Button("Load diff") {
+                state.loadDiff(filePath: section.filePath, isStaged: section.isStaged)
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            .foregroundStyle(MuxyTheme.accent)
+            .padding(.horizontal, UIMetrics.spacing4)
+            .frame(height: UIMetrics.controlSmall)
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .overlay(RoundedRectangle(cornerRadius: UIMetrics.radiusSM).stroke(MuxyTheme.border, lineWidth: 1))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func messageBody(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+            .foregroundStyle(MuxyTheme.diffRemoveFg)
+            .lineLimit(3)
+            .multilineTextAlignment(.center)
+            .padding(UIMetrics.spacing5)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func editor(externalScrollY: CGFloat?) -> some View {
@@ -532,8 +613,23 @@ private struct DiffFileCard: View {
         )
         .contentShape(Rectangle())
         .onTapGesture {
-            state.select(filePath: section.filePath, isStaged: section.isStaged)
+            state.toggleCollapsed(filePath: section.filePath, isStaged: section.isStaged)
         }
+    }
+}
+
+struct DiffVirtualRenderWindow {
+    let editorHeight: CGFloat
+    let viewportHeight: CGFloat
+    let visibleBodyY: CGFloat
+    let minimumHeight: CGFloat
+
+    var height: CGFloat {
+        min(editorHeight, max(minimumHeight, viewportHeight * 3))
+    }
+
+    var offsetY: CGFloat {
+        min(max(0, editorHeight - height), max(0, visibleBodyY - viewportHeight))
     }
 }
 
@@ -590,7 +686,7 @@ private struct DiffViewerSidebar: View {
                 }
             }
             Rectangle().fill(MuxyTheme.border).frame(height: 1)
-            DiffViewerStats(files: state.files)
+            DiffViewerStats(stagedFiles: state.stagedFiles, unstagedFiles: state.unstagedFiles)
         }
         .background(MuxyTheme.bg)
     }
@@ -605,7 +701,7 @@ private struct DiffViewerSidebar: View {
                 .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
 
-            Text("\(state.files.count)")
+            Text("\(state.stagedFiles.count + state.unstagedFiles.count)")
                 .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                 .foregroundStyle(MuxyTheme.bg)
                 .padding(.horizontal, UIMetrics.spacing3)
@@ -655,7 +751,7 @@ private struct DiffViewerSidebarSection: View {
                 .frame(height: UIMetrics.scaled(26))
 
                 if state.source != .workingTree || state.vcs.fileListMode == .flat {
-                    ForEach(files) { file in
+                    ForEach(files, id: \.path) { file in
                         DiffViewerSidebarFileRow(state: state, file: file, isStaged: isStaged, displayPath: file.path, depth: 0)
                     }
                 } else {
@@ -761,12 +857,12 @@ private struct DiffViewerSidebarFileRow: View {
 
             Spacer(minLength: 0)
 
-            if let additions = file.additions, additions > 0 {
+            if let additions = file.additions(isStaged: isStaged), additions > 0 {
                 Text("+\(additions)")
                     .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
                     .foregroundStyle(MuxyTheme.diffAddFg)
             }
-            if let deletions = file.deletions, deletions > 0 {
+            if let deletions = file.deletions(isStaged: isStaged), deletions > 0 {
                 Text("-\(deletions)")
                     .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
@@ -785,19 +881,26 @@ private struct DiffViewerSidebarFileRow: View {
 }
 
 private struct DiffViewerStats: View {
-    let files: [GitStatusFile]
+    let stagedFiles: [GitStatusFile]
+    let unstagedFiles: [GitStatusFile]
 
     private var additions: Int {
-        files.compactMap(\.additions).reduce(0, +)
+        stagedFiles.compactMap { $0.additions(isStaged: true) }.reduce(0, +)
+            + unstagedFiles.compactMap { $0.additions(isStaged: false) }.reduce(0, +)
     }
 
     private var deletions: Int {
-        files.compactMap(\.deletions).reduce(0, +)
+        stagedFiles.compactMap { $0.deletions(isStaged: true) }.reduce(0, +)
+            + unstagedFiles.compactMap { $0.deletions(isStaged: false) }.reduce(0, +)
+    }
+
+    private var fileCount: Int {
+        stagedFiles.count + unstagedFiles.count
     }
 
     var body: some View {
         VStack(spacing: UIMetrics.spacing3) {
-            statRow("Files", value: "\(files.count)", color: MuxyTheme.fg)
+            statRow("Files", value: "\(fileCount)", color: MuxyTheme.fg)
             statRow("Additions", value: "+\(additions)", color: MuxyTheme.diffAddFg)
             statRow("Deletions", value: "-\(deletions)", color: MuxyTheme.diffRemoveFg)
         }

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -862,33 +862,18 @@ struct VCSTabView: View {
 
     private func openPullRequestDiffInTab(_ pr: GitRepositoryService.PRListItem) {
         guard let projectID = appState.activeProjectID else { return }
-        Task { @MainActor in
-            let git = GitRepositoryService()
-            let remote = await git.githubRemoteName(repoPath: state.projectPath) ?? "origin"
-            let baseRef = "refs/remotes/\(remote)/\(pr.baseBranch)"
-            let headRef: String
-            do {
-                headRef = try await git.fetchPullRequestDiffHead(
-                    repoPath: state.projectPath,
-                    number: pr.number,
-                    remote: remote
-                )
-            } catch {
-                state.showStatus(error.localizedDescription, isError: true)
-                return
-            }
-            appState.openDiffViewer(
-                vcs: state,
-                source: .pullRequest(DiffViewerTabState.PullRequestSource(
-                    number: pr.number,
-                    title: pr.title,
-                    baseRef: baseRef,
-                    headRef: headRef,
-                    webURL: URL(string: pr.url)
-                )),
-                projectID: projectID
-            )
-        }
+        appState.openDiffViewer(
+            vcs: state,
+            source: .pullRequest(DiffViewerTabState.PullRequestSource(
+                number: pr.number,
+                title: pr.title,
+                baseRef: nil,
+                headRef: nil,
+                baseBranch: pr.baseBranch,
+                webURL: URL(string: pr.url)
+            )),
+            projectID: projectID
+        )
     }
 }
 

--- a/Tests/MuxyTests/Models/DiffCacheTests.swift
+++ b/Tests/MuxyTests/Models/DiffCacheTests.swift
@@ -47,8 +47,8 @@ struct DiffCacheTests {
         #expect(cache.error(for: "a.swift") == "oops")
     }
 
-    @Test("registerTask keeps existing load alive")
-    func registerTaskKeepsExistingLoadAlive() {
+    @Test("registerTask cancels existing load for path")
+    func registerTaskCancelsExistingLoadForPath() {
         let cache = DiffCache()
         let first = Task<Void, Never> {}
         let second = Task<Void, Never> {}
@@ -56,8 +56,7 @@ struct DiffCacheTests {
         cache.registerTask(first, for: "a.swift")
         cache.registerTask(second, for: "a.swift")
 
-        #expect(!first.isCancelled)
-        first.cancel()
+        #expect(first.isCancelled)
         second.cancel()
     }
 
@@ -136,6 +135,19 @@ struct DiffCacheTests {
         let cache = DiffCache()
         cache.markLoading("a.swift")
         cache.cancelLoad(for: "a.swift")
+        #expect(!cache.isLoading("a.swift"))
+    }
+
+    @Test("cancelAndClearLoading cancels registered tasks")
+    func cancelAndClearLoadingCancelsRegisteredTasks() {
+        let cache = DiffCache()
+        let task = Task<Void, Never> {}
+
+        cache.markLoading("a.swift")
+        cache.registerTask(task, for: "a.swift")
+        cache.cancelAndClearLoading()
+
+        #expect(task.isCancelled)
         #expect(!cache.isLoading("a.swift"))
     }
 }

--- a/Tests/MuxyTests/Models/DiffCollapsePolicyTests.swift
+++ b/Tests/MuxyTests/Models/DiffCollapsePolicyTests.swift
@@ -1,0 +1,73 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("DiffCollapsePolicy")
+struct DiffCollapsePolicyTests {
+    @Test("collapses binary and deleted files")
+    func collapsesBinaryAndDeletedFiles() {
+        #expect(DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "image.png", yStatus: "M", isBinary: true)))
+        #expect(DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "Old.swift", yStatus: "D")))
+    }
+
+    @Test("collapses large regular diffs")
+    func collapsesLargeRegularDiffs() {
+        #expect(DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "Feature.swift", yStatus: "M", additions: 900, deletions: 100)))
+    }
+
+    @Test("collapses noisy files at lower threshold")
+    func collapsesNoisyFilesAtLowerThreshold() {
+        #expect(DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "package-lock.json", yStatus: "M", additions: 200)))
+        #expect(DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "Sources/Generated/API.swift", yStatus: "M", additions: 200)))
+        #expect(DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "Tests/__snapshots__/View.snap", yStatus: "M", additions: 200)))
+    }
+
+    @Test("keeps small meaningful diffs expanded")
+    func keepsSmallMeaningfulDiffsExpanded() {
+        #expect(!DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "Feature.swift", yStatus: "M", additions: 50)))
+        #expect(!DiffCollapsePolicy.shouldCollapseByDefault(makeFile(path: "package-lock.json", yStatus: "M", additions: 199)))
+    }
+
+    @Test("uses staged and unstaged bucket stats independently")
+    func usesBucketStatsIndependently() {
+        let file = GitStatusFile(
+            path: "Feature.swift",
+            oldPath: nil,
+            xStatus: "M",
+            yStatus: "M",
+            additions: 1001,
+            deletions: 0,
+            stagedAdditions: 1,
+            stagedDeletions: 2,
+            unstagedAdditions: 900,
+            unstagedDeletions: 100,
+            isBinary: false
+        )
+
+        #expect(file.additions(isStaged: true) == 1)
+        #expect(file.deletions(isStaged: true) == 2)
+        #expect(file.additions(isStaged: false) == 900)
+        #expect(file.deletions(isStaged: false) == 100)
+        #expect(!DiffCollapsePolicy.shouldCollapseByDefault(file, isStaged: true))
+        #expect(DiffCollapsePolicy.shouldCollapseByDefault(file, isStaged: false))
+    }
+
+    private func makeFile(
+        path: String,
+        xStatus: Character = " ",
+        yStatus: Character,
+        additions: Int = 1,
+        deletions: Int = 0,
+        isBinary: Bool = false
+    ) -> GitStatusFile {
+        GitStatusFile(
+            path: path,
+            oldPath: nil,
+            xStatus: xStatus,
+            yStatus: yStatus,
+            additions: additions,
+            deletions: deletions,
+            isBinary: isBinary
+        )
+    }
+}

--- a/Tests/MuxyTests/Models/DiffHintPolicyTests.swift
+++ b/Tests/MuxyTests/Models/DiffHintPolicyTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("DiffHintPolicy")
+struct DiffHintPolicyTests {
+    @Test("unstaged edits to staged added file diff against index")
+    func unstagedEditsToStagedAddedFileDiffAgainstIndex() {
+        let hints = DiffHintPolicy.hints(
+            file: makeFile(xStatus: "A", yStatus: "M"),
+            isStaged: false
+        )
+
+        #expect(!hints.hasStaged)
+        #expect(hints.hasUnstaged)
+        #expect(!hints.isUntrackedOrNew)
+    }
+
+    @Test("untracked files use new file preview path")
+    func untrackedFilesUseNewFilePreviewPath() {
+        let hints = DiffHintPolicy.hints(
+            file: makeFile(xStatus: "?", yStatus: "?"),
+            isStaged: false
+        )
+
+        #expect(!hints.hasStaged)
+        #expect(!hints.hasUnstaged)
+        #expect(hints.isUntrackedOrNew)
+    }
+
+    @Test("staged side only loads cached diff")
+    func stagedSideOnlyLoadsCachedDiff() {
+        let hints = DiffHintPolicy.hints(
+            file: makeFile(xStatus: "M", yStatus: "M"),
+            isStaged: true
+        )
+
+        #expect(hints.hasStaged)
+        #expect(!hints.hasUnstaged)
+        #expect(!hints.isUntrackedOrNew)
+    }
+
+    private func makeFile(xStatus: Character, yStatus: Character) -> GitStatusFile {
+        GitStatusFile(
+            path: "File.swift",
+            oldPath: nil,
+            xStatus: xStatus,
+            yStatus: yStatus,
+            additions: 1,
+            deletions: 0,
+            isBinary: false
+        )
+    }
+}

--- a/Tests/MuxyTests/Models/DiffHintPolicyTests.swift
+++ b/Tests/MuxyTests/Models/DiffHintPolicyTests.swift
@@ -4,16 +4,16 @@ import Testing
 
 @Suite("DiffHintPolicy")
 struct DiffHintPolicyTests {
-    @Test("unstaged edits to staged added file diff against index")
-    func unstagedEditsToStagedAddedFileDiffAgainstIndex() {
+    @Test("unstaged side of staged added file uses new file preview path")
+    func unstagedSideOfStagedAddedFileUsesNewFilePreviewPath() {
         let hints = DiffHintPolicy.hints(
             file: makeFile(xStatus: "A", yStatus: "M"),
             isStaged: false
         )
 
         #expect(!hints.hasStaged)
-        #expect(hints.hasUnstaged)
-        #expect(!hints.isUntrackedOrNew)
+        #expect(!hints.hasUnstaged)
+        #expect(hints.isUntrackedOrNew)
     }
 
     @Test("untracked files use new file preview path")

--- a/Tests/MuxyTests/Models/DiffViewerTabStateTests.swift
+++ b/Tests/MuxyTests/Models/DiffViewerTabStateTests.swift
@@ -10,6 +10,10 @@ struct DiffViewerTabStateTests {
         GitStatusFile(path: path, oldPath: nil, xStatus: xStatus, yStatus: yStatus, additions: 1, deletions: 0, isBinary: false)
     }
 
+    private func makeFile(path: String, xStatus: Character, yStatus: Character, additions: Int, deletions: Int) -> GitStatusFile {
+        GitStatusFile(path: path, oldPath: nil, xStatus: xStatus, yStatus: yStatus, additions: additions, deletions: deletions, isBinary: false)
+    }
+
     private func makeDiff() -> DiffCache.LoadedDiff {
         DiffCache.LoadedDiff(rows: [], additions: 1, deletions: 0, truncated: false)
     }
@@ -46,6 +50,7 @@ struct DiffViewerTabStateTests {
             title: "New git diff viewer",
             baseRef: "refs/remotes/origin/main",
             headRef: "refs/muxy/pull/535/head",
+            baseBranch: "main",
             webURL: url
         ))
 
@@ -133,15 +138,27 @@ struct DiffViewerTabStateTests {
         vcs.diffCache.cancelAll()
     }
 
-    @Test("font size is diff specific and resettable")
-    func fontSizeIsDiffSpecificAndResettable() {
-        let state = DiffViewerTabState(vcs: VCSTabState(projectPath: NSTemporaryDirectory()))
+    @Test("font size is shared and persisted across diff viewers")
+    func fontSizeIsSharedAndPersistedAcrossDiffViewers() {
+        UserDefaults.standard.removeObject(forKey: DiffViewerTabState.fontSizeDefaultsKey)
+        let first = DiffViewerTabState(vcs: VCSTabState(projectPath: NSTemporaryDirectory()))
+        let second = DiffViewerTabState(vcs: VCSTabState(projectPath: NSTemporaryDirectory()))
 
-        #expect(state.fontSize == 13)
-        state.adjustFontSize(by: 4)
-        #expect(state.fontSize == 17)
-        state.resetFontSize()
-        #expect(state.fontSize == 13)
+        #expect(first.fontSize == 13)
+        #expect(second.fontSize == 13)
+
+        first.adjustFontSize(by: 4)
+
+        #expect(first.fontSize == 17)
+        #expect(second.fontSize == 17)
+        #expect(UserDefaults.standard.double(forKey: DiffViewerTabState.fontSizeDefaultsKey) == 17)
+        #expect(DiffViewerTabState(vcs: VCSTabState(projectPath: NSTemporaryDirectory())).fontSize == 17)
+
+        second.resetFontSize()
+
+        #expect(first.fontSize == 13)
+        #expect(second.fontSize == 13)
+        UserDefaults.standard.removeObject(forKey: DiffViewerTabState.fontSizeDefaultsKey)
     }
 
     @Test("selecting current file still emits scroll request")
@@ -184,6 +201,12 @@ struct DiffViewerTabStateTests {
 
         state.activateFromDiffScroll(cacheKey: DiffViewerTabState.cacheKey(filePath: firstPath, isStaged: false))
 
+        #expect(state.activeCacheKey == secondCacheKey)
+        #expect(state.sidebarScrollRequestVersion == 0)
+
+        state.activateFromDiffScroll(cacheKey: secondCacheKey)
+        state.activateFromDiffScroll(cacheKey: DiffViewerTabState.cacheKey(filePath: firstPath, isStaged: false))
+
         #expect(state.sidebarScrollRequestVersion == 1)
         vcs.diffCache.cancelAll()
     }
@@ -200,6 +223,28 @@ struct DiffViewerTabStateTests {
 
         #expect(state.selectedFilePath == "SourceDiff.swift")
         #expect(state.selectedIsStaged == false)
+        vcs.diffCache.cancelAll()
+        state.diffCache.cancelAll()
+    }
+
+    @Test("prepareForClose clears source and working tree diff loads")
+    func prepareForCloseClearsSourceAndWorkingTreeDiffLoads() {
+        let vcs = VCSTabState(projectPath: NSTemporaryDirectory())
+        let state = DiffViewerTabState(vcs: vcs)
+        let sourceKey = DiffViewerTabState.cacheKey(filePath: "SourceDiff.swift", isStaged: false)
+        let workingTreeKey = DiffViewerTabState.cacheKey(filePath: "WorkingTree.swift", isStaged: false)
+
+        state.diffCache.markLoading(sourceKey)
+        state.diffCache.store(makeDiff(), for: sourceKey, pinnedPaths: [])
+        vcs.diffCache.store(makeDiff(), for: workingTreeKey, pinnedPaths: [])
+        vcs.diffCache.store(makeDiff(), for: "WorkingTree.swift", pinnedPaths: [])
+
+        state.prepareForClose()
+
+        #expect(!state.diffCache.hasDiff(for: sourceKey))
+        #expect(!state.diffCache.isLoading(sourceKey))
+        #expect(!vcs.diffCache.hasDiff(for: workingTreeKey))
+        #expect(vcs.diffCache.hasDiff(for: "WorkingTree.swift"))
         vcs.diffCache.cancelAll()
         state.diffCache.cancelAll()
     }
@@ -248,6 +293,19 @@ struct DiffViewerTabStateTests {
         #expect(!state.isCollapsed(filePath: filePath, isStaged: false))
         #expect(state.manuallyLoadedCacheKeys.contains(cacheKey))
         #expect(vcs.diffCache.isLoading(cacheKey))
+        vcs.diffCache.cancelAll()
+    }
+
+    @Test("large diff stats collapse before preview loads")
+    func largeDiffStatsCollapseBeforePreviewLoads() {
+        let vcs = VCSTabState(projectPath: NSTemporaryDirectory())
+        let state = DiffViewerTabState(vcs: vcs)
+        let filePath = "Generated.swift"
+
+        vcs.files = [makeFile(path: filePath, xStatus: " ", yStatus: "M", additions: 900, deletions: 100)]
+        state.reconcileLargeDiffCollapse()
+
+        #expect(state.isCollapsed(filePath: filePath, isStaged: false))
         vcs.diffCache.cancelAll()
     }
 

--- a/Tests/MuxyTests/Views/DiffEditorDocumentTests.swift
+++ b/Tests/MuxyTests/Views/DiffEditorDocumentTests.swift
@@ -65,6 +65,8 @@ struct DiffEditorDocumentTests {
                 rows: firstRows,
                 isCollapsed: false,
                 isLargeUnloaded: false,
+                isLoading: false,
+                errorMessage: nil,
                 additions: 1,
                 deletions: 0,
                 isStaged: false
@@ -75,6 +77,8 @@ struct DiffEditorDocumentTests {
                 rows: secondRows,
                 isCollapsed: false,
                 isLargeUnloaded: false,
+                isLoading: false,
+                errorMessage: nil,
                 additions: 0,
                 deletions: 1,
                 isStaged: true
@@ -99,6 +103,8 @@ struct DiffEditorDocumentTests {
                 rows: [DiffDisplayRow(kind: .addition, oldLineNumber: nil, newLineNumber: 1, oldText: nil, newText: "hidden", text: "+hidden")],
                 isCollapsed: true,
                 isLargeUnloaded: false,
+                isLoading: false,
+                errorMessage: nil,
                 additions: 1,
                 deletions: 0,
                 isStaged: false

--- a/Tests/MuxyTests/Views/DiffVirtualRenderWindowTests.swift
+++ b/Tests/MuxyTests/Views/DiffVirtualRenderWindowTests.swift
@@ -1,0 +1,39 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("DiffVirtualRenderWindow")
+struct DiffVirtualRenderWindowTests {
+    @Test("window renders one viewport before and after visible content")
+    func windowRendersAroundVisibleContent() {
+        let window = DiffVirtualRenderWindow(
+            editorHeight: 5000,
+            viewportHeight: 600,
+            visibleBodyY: 1400,
+            minimumHeight: 160
+        )
+
+        #expect(window.height == 1800)
+        #expect(window.offsetY == 800)
+    }
+
+    @Test("window clamps to editor bounds near edges")
+    func windowClampsToEditorBounds() {
+        let topWindow = DiffVirtualRenderWindow(
+            editorHeight: 5000,
+            viewportHeight: 600,
+            visibleBodyY: 200,
+            minimumHeight: 160
+        )
+        let bottomWindow = DiffVirtualRenderWindow(
+            editorHeight: 2000,
+            viewportHeight: 600,
+            visibleBodyY: 1900,
+            minimumHeight: 160
+        )
+
+        #expect(topWindow.offsetY == 0)
+        #expect(bottomWindow.height == 1800)
+        #expect(bottomWindow.offsetY == 200)
+    }
+}


### PR DESCRIPTION
- Keep diff panels responsive by collapsing obviously large or noisy files sooner, and by capping concurrent diff loads.
- Preserve scroll position, loading, and error states more reliably when switching diff sources or closing a tab.
- Make font size apply across diff viewers and persist it between sessions.

Risk: PR diff sources now resolve base/head refs lazily, so PR loading depends on the repository remote being reachable.