### PR TITLE
feat: persist markdown default view mode in editor settings

### DIFF
--- a/Muxy/Models/EditorSettings.swift
+++ b/Muxy/Models/EditorSettings.swift
@@ -32,6 +32,7 @@ final class EditorSettings {
     static let markdownPreviewBaseFontSize: CGFloat = 14
     static let markdownPreviewZoomStep: CGFloat = 0.1
     static let defaultHTMLViewMode: EditorMarkdownViewMode = .code
+    static let defaultMarkdownViewMode: EditorMarkdownViewMode = .preview
 
     static let defaultLineHeightMultiplier: CGFloat = 1.2
     static let minLineHeightMultiplier: CGFloat = 1.1
@@ -48,6 +49,7 @@ final class EditorSettings {
     var markdownPreviewFontFamily: String = EditorSettings.defaultMarkdownPreviewFontFamily { didSet { save() } }
     var markdownPreviewFontScale: CGFloat = EditorSettings.defaultMarkdownPreviewFontScale { didSet { save() } }
     var htmlDefaultViewMode: EditorMarkdownViewMode = EditorSettings.defaultHTMLViewMode { didSet { save() } }
+    var markdownDefaultViewMode: EditorMarkdownViewMode = EditorSettings.defaultMarkdownViewMode { didSet { save() } }
     var highlightCurrentLine: Bool = true { didSet { save() } }
     var lineWrapping: Bool = false { didSet { save() } }
     var showLineNumbers: Bool = true { didSet { save() } }
@@ -147,6 +149,7 @@ final class EditorSettings {
         markdownPreviewFontFamily = Self.defaultMarkdownPreviewFontFamily
         markdownPreviewFontScale = Self.defaultMarkdownPreviewFontScale
         htmlDefaultViewMode = Self.defaultHTMLViewMode
+        markdownDefaultViewMode = Self.defaultMarkdownViewMode
         highlightCurrentLine = true
         lineWrapping = false
         showLineNumbers = true
@@ -168,6 +171,7 @@ final class EditorSettings {
             externalEditorCommand = snapshot.externalEditorCommand ?? "vim"
             markdownPreviewFontFamily = snapshot.markdownPreviewFontFamily ?? Self.defaultMarkdownPreviewFontFamily
             htmlDefaultViewMode = snapshot.htmlDefaultViewMode ?? Self.defaultHTMLViewMode
+            markdownDefaultViewMode = snapshot.markdownDefaultViewMode ?? Self.defaultMarkdownViewMode
             let loadedScale = snapshot.markdownPreviewFontScale ?? Self.defaultMarkdownPreviewFontScale
             markdownPreviewFontScale = min(
                 max(loadedScale, Self.minMarkdownPreviewFontScale),
@@ -207,6 +211,7 @@ final class EditorSettings {
                 markdownPreviewFontFamily: markdownPreviewFontFamily,
                 markdownPreviewFontScale: markdownPreviewFontScale,
                 htmlDefaultViewMode: htmlDefaultViewMode,
+                markdownDefaultViewMode: markdownDefaultViewMode,
                 highlightCurrentLine: highlightCurrentLine,
                 lineWrapping: lineWrapping,
                 showLineNumbers: showLineNumbers,
@@ -231,6 +236,7 @@ private struct Snapshot: Codable {
     let markdownPreviewFontFamily: String?
     let markdownPreviewFontScale: CGFloat?
     let htmlDefaultViewMode: EditorMarkdownViewMode?
+    let markdownDefaultViewMode: EditorMarkdownViewMode?
     let highlightCurrentLine: Bool?
     let lineWrapping: Bool?
     let showLineNumbers: Bool?

--- a/Muxy/Models/EditorTabState.swift
+++ b/Muxy/Models/EditorTabState.swift
@@ -183,7 +183,7 @@ final class EditorTabState: Identifiable {
         self.projectPath = projectPath
         self.filePath = filePath
         if isMarkdownFile {
-            markdownViewMode = .preview
+            markdownViewMode = EditorSettings.shared.markdownDefaultViewMode
         }
         if isHTMLFile {
             htmlViewMode = defaultHTMLViewMode

--- a/Muxy/Services/SettingsJSONStore.swift
+++ b/Muxy/Services/SettingsJSONStore.swift
@@ -256,6 +256,7 @@ enum SettingsJSONStore {
         case "editor.externalEditorCommand": settings.externalEditorCommand
         case "editor.markdownPreviewFontFamily": settings.markdownPreviewFontFamily
         case "editor.markdownPreviewFontScale": Double(settings.markdownPreviewFontScale)
+        case "editor.markdownDefaultViewMode": settings.markdownDefaultViewMode.rawValue
         case "editor.htmlDefaultViewMode": settings.htmlDefaultViewMode.rawValue
         case "editor.richInputImageStrategy": settings.richInputImageStrategy.rawValue
         case "editor.richInputFontFamily": settings.richInputFontFamily
@@ -374,6 +375,9 @@ enum SettingsJSONStore {
         case "editor.markdownPreviewFontScale":
             guard let value = doubleValue(value) else { return false }
             settings.markdownPreviewFontScale = CGFloat(value)
+        case "editor.markdownDefaultViewMode":
+            guard let rawValue = value as? String, let mode = EditorMarkdownViewMode(rawValue: rawValue) else { return false }
+            settings.markdownDefaultViewMode = mode
         case "editor.htmlDefaultViewMode":
             guard let rawValue = value as? String, let mode = EditorMarkdownViewMode(rawValue: rawValue) else { return false }
             settings.htmlDefaultViewMode = mode

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -107,6 +107,16 @@ struct EditorSettingsView: View {
                     .buttonStyle(.borderless)
                 }
             }
+
+            SettingsRow("Default View") {
+                Picker("", selection: $settings.markdownDefaultViewMode) {
+                    ForEach(EditorMarkdownViewMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
+            }
         }
 
         SettingsSection("HTML") {

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -280,6 +280,14 @@ enum SettingsCatalog {
             defaultValue: Double(EditorSettings.defaultMarkdownPreviewFontScale)
         ),
         SettingsCatalogItem(
+            key: "editor.markdownDefaultViewMode",
+            title: "Markdown Default View",
+            description: "Chooses the default view mode for Markdown files.",
+            category: .editor,
+            section: "Markdown Preview",
+            defaultValue: EditorSettings.defaultMarkdownViewMode.rawValue
+        ),
+        SettingsCatalogItem(
             key: "editor.htmlDefaultViewMode",
             title: "HTML Default View",
             description: "Chooses the default view mode for HTML files.",


### PR DESCRIPTION
Add persistent default view mode config for Markdown files, matching the existing HTML default view setting.

- Add `markdownDefaultViewMode` property to EditorSettings with full persistence
- Add Default View picker in Settings under Markdown Preview section
- EditorTabState now reads persisted config instead of hardcoding preview mode