### PR TITLE
feat: add 'Open with Default App' in sidebar and terminal context menus

### DIFF
--- a/Muxy/Views/FileTree/FileTreeCommands.swift
+++ b/Muxy/Views/FileTree/FileTreeCommands.swift
@@ -197,6 +197,11 @@ final class FileTreeCommands {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
+    func openWithDefaultApp(_ path: String) {
+        let url = URL(fileURLWithPath: path)
+        NSWorkspace.shared.open(url)
+    }
+
     func openInTerminal(path: String) {
         let dir = resolveDirectoryContext(for: path)
         openTerminal(dir)

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -575,6 +575,7 @@ private struct FileTreeContextMenuContents: View {
             Button("Copy Relative Path") { commands.copyRelativePath(path) }
         }
         Divider()
+        Button("Open with Default App") { commands.openWithDefaultApp(path) }
         Button("Reveal in Finder") { commands.revealInFinder(path) }
         Button("Open in Terminal") { commands.openInTerminal(path: path) }
     }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -25,6 +25,7 @@ final class GhosttyTerminalNSView: NSView {
     var onCmdClickFile: ((String) -> Void)?
     var resolveCmdHoverFile: ((String) -> Bool)?
     var onOpenURL: ((URL) -> Bool)?
+    var contextMenuResolveFile: ((String) -> String?)?
     private var isShowingHandCursor = false
     private var fileHoverUnderlineLayer: CAShapeLayer?
     private var lastMouseTopDownPoint: CGPoint?
@@ -203,6 +204,7 @@ final class GhosttyTerminalNSView: NSView {
         onOpenURL = nil
         onCmdClickFile = nil
         resolveCmdHoverFile = nil
+        contextMenuResolveFile = nil
         onTitleChange = nil
         onFocus = nil
         onExternalDragHoverChange = nil
@@ -822,6 +824,20 @@ final class GhosttyTerminalNSView: NSView {
     private func presentContextMenu(with event: NSEvent) {
         let menu = NSMenu(title: "Terminal")
 
+        if let word = readWordUnderMouse(),
+           let resolved = contextMenuResolveFile?(word)
+        {
+            let openItem = NSMenuItem(
+                title: "Open with Default App",
+                action: #selector(handleContextOpenFile(_:)),
+                keyEquivalent: ""
+            )
+            openItem.target = self
+            openItem.representedObject = resolved
+            menu.addItem(openItem)
+            menu.addItem(.separator())
+        }
+
         let paste = NSMenuItem(title: "Paste", action: #selector(handleContextPaste(_:)), keyEquivalent: "")
         paste.target = self
         paste.isEnabled = NSPasteboard.general.string(forType: .string).map { !$0.isEmpty } ?? false
@@ -842,6 +858,12 @@ final class GhosttyTerminalNSView: NSView {
         item.target = self
         item.representedObject = ContextSplit(direction: direction, position: position)
         return item
+    }
+
+    @objc
+    private func handleContextOpenFile(_ sender: NSMenuItem) {
+        guard let path = sender.representedObject as? String else { return }
+        NSWorkspace.shared.open(URL(fileURLWithPath: path))
     }
 
     @objc

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -253,6 +253,10 @@ struct TerminalBridge: NSViewRepresentable {
                 NotificationStore.shared.appState?.openFile(resolved, projectID: projectID, preserveFocus: true)
             }
         }
+        view.contextMenuResolveFile = { [projectPath] token in
+            let workDir = state.currentWorkingDirectory ?? projectPath
+            return Self.resolveFilePath(token, projectPath: workDir)
+        }
         view.resolveCmdHoverFile = { token in
             Self.resolveFilePath(token, projectPath: projectPath) != nil
         }


### PR DESCRIPTION
Adds the ability to open files with the system default application from two entry points:

1. **Sidebar file tree right-click menu** — new "Open with Default App" menu item
2. **Terminal right-click menu** — when right-clicking on a file path in the terminal, "Open with Default App" appears at the top of the context menu

Both use `NSWorkspace.shared.open` to launch the file with the macOS default handler (e.g. .dmg with DiskImageMounter, .pdf with Preview, etc.).

Relative paths in the terminal context menu are resolved against the pane's current working directory.