### PR TITLE
Send selected rich input text

### DIFF
--- a/Muxy/Services/RichInputSubmitter.swift
+++ b/Muxy/Services/RichInputSubmitter.swift
@@ -12,10 +12,16 @@ enum RichInputSubmitter {
         case image(URL)
     }
 
-    static func submit(richInput: RichInputState, paneIDs: [UUID], appendReturn: Bool) {
+    static func submit(
+        richInput: RichInputState,
+        paneIDs: [UUID],
+        appendReturn: Bool,
+        selectedText: String? = nil
+    ) {
         guard !paneIDs.isEmpty else { return }
-        let body = richInput.text
-        let fileAttachments = richInput.fileAttachments
+        let selectedBody = selectedSubmissionText(selectedText)
+        let body = selectedBody ?? richInput.text
+        let fileAttachments = selectedBody == nil ? richInput.fileAttachments : []
         let imageAttachments = richInput.imageAttachments
         let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedBody.isEmpty || !fileAttachments.isEmpty || !imageAttachments.isEmpty else { return }
@@ -94,6 +100,12 @@ enum RichInputSubmitter {
                 focusTarget.window?.makeFirstResponder(focusTarget)
             }
         }
+    }
+
+    nonisolated static func selectedSubmissionText(_ selectedText: String?) -> String? {
+        guard let selectedText else { return nil }
+        guard !selectedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return selectedText
     }
 
     private static func textOnlyPayload(segments: [Segment], appendReturn: Bool) -> Data {

--- a/Muxy/Views/Editor/Markdown/MarkdownTextEditor.swift
+++ b/Muxy/Views/Editor/Markdown/MarkdownTextEditor.swift
@@ -13,8 +13,8 @@ struct MarkdownTextEditor: NSViewRepresentable {
     }
 
     struct Callbacks {
-        var onSubmit: (() -> Void)?
-        var onSubmitWithoutReturn: (() -> Void)?
+        var onSubmit: ((String?) -> Void)?
+        var onSubmitWithoutReturn: ((String?) -> Void)?
         var onIncreaseFontSize: (() -> Void)?
         var onDecreaseFontSize: (() -> Void)?
         var onPasteImageData: ((Data) -> Void)?
@@ -88,10 +88,12 @@ struct MarkdownTextEditor: NSViewRepresentable {
         textView.insertionPointColor = MarkdownTextEditor.defaultForeground()
         textView.delegate = context.coordinator
         textView.onSubmit = { [weak coordinator = context.coordinator] in
-            coordinator?.parent.callbacks.onSubmit?()
+            guard let coordinator else { return }
+            coordinator.parent.callbacks.onSubmit?(coordinator.selectedText)
         }
         textView.onSubmitWithoutReturn = { [weak coordinator = context.coordinator] in
-            coordinator?.parent.callbacks.onSubmitWithoutReturn?()
+            guard let coordinator else { return }
+            coordinator.parent.callbacks.onSubmitWithoutReturn?(coordinator.selectedText)
         }
         textView.onIncreaseFontSize = { [weak coordinator = context.coordinator] in
             coordinator?.parent.callbacks.onIncreaseFontSize?()
@@ -187,6 +189,15 @@ struct MarkdownTextEditor: NSViewRepresentable {
             guard abs(height - lastReportedHeight) > 0.5 else { return }
             lastReportedHeight = height
             parent.callbacks.onContentHeightChange?(height)
+        }
+
+        var selectedText: String? {
+            guard let textView else { return nil }
+            let range = textView.selectedRange()
+            guard range.length > 0 else { return nil }
+            let text = textView.string as NSString
+            guard NSMaxRange(range) <= text.length else { return nil }
+            return text.substring(with: range)
         }
 
         func applyHighlighting() {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -961,7 +961,9 @@ struct MainWindow: View {
                 state: richInputState,
                 worktreeKey: worktreeKey,
                 onDismiss: { closeRichInputPanel() },
-                onSubmit: { appendReturn in submitRichInput(richInputState, appendReturn: appendReturn) }
+                onSubmit: { appendReturn, selectedText in
+                    submitRichInput(richInputState, appendReturn: appendReturn, selectedText: selectedText)
+                }
             )
             switch position {
             case .right:
@@ -1248,10 +1250,15 @@ struct MainWindow: View {
         }
     }
 
-    private func submitRichInput(_ richInput: RichInputState, appendReturn: Bool) {
+    private func submitRichInput(_ richInput: RichInputState, appendReturn: Bool, selectedText: String?) {
         let paneIDs = richInputBroadcast ? visibleTerminalPaneIDs() : [activeRichInputPaneID].compactMap(\.self)
         guard !paneIDs.isEmpty else { return }
-        RichInputSubmitter.submit(richInput: richInput, paneIDs: paneIDs, appendReturn: appendReturn)
+        RichInputSubmitter.submit(
+            richInput: richInput,
+            paneIDs: paneIDs,
+            appendReturn: appendReturn,
+            selectedText: selectedText
+        )
     }
 
     private func visibleTerminalPaneIDs() -> [UUID] {

--- a/Muxy/Views/Terminal/RichInputSidePanel.swift
+++ b/Muxy/Views/Terminal/RichInputSidePanel.swift
@@ -6,7 +6,7 @@ struct RichInputSidePanel: View {
     @Bindable var state: RichInputState
     let worktreeKey: WorktreeKey
     let onDismiss: () -> Void
-    let onSubmit: (_ appendReturn: Bool) -> Void
+    let onSubmit: (_ appendReturn: Bool, _ selectedText: String?) -> Void
 
     @State private var editorSettings = EditorSettings.shared
     @AppStorage(RichInputPreferences.fontSizeKey) private var fontSize: Double = RichInputPreferences.defaultFontSize
@@ -75,8 +75,8 @@ struct RichInputSidePanel: View {
 
     private var editorCallbacks: MarkdownTextEditor.Callbacks {
         MarkdownTextEditor.Callbacks(
-            onSubmit: { onSubmit(true) },
-            onSubmitWithoutReturn: { onSubmit(false) },
+            onSubmit: { selectedText in onSubmit(true, selectedText) },
+            onSubmitWithoutReturn: { selectedText in onSubmit(false, selectedText) },
             onIncreaseFontSize: increaseFontSize,
             onDecreaseFontSize: decreaseFontSize,
             onPasteImageData: { data in

--- a/Tests/MuxyTests/Services/RichInputSubmitterTests.swift
+++ b/Tests/MuxyTests/Services/RichInputSubmitterTests.swift
@@ -67,4 +67,16 @@ struct RichInputSubmitterTests {
         let segments = RichInputSubmitter.tokenize(text: "[Image 1]", images: [url])
         #expect(segments == [.image(url)])
     }
+
+    @Test("selected non-empty text is used as submission text")
+    func selectedTextOverridesFullText() {
+        let selected = RichInputSubmitter.selectedSubmissionText("selected part")
+        #expect(selected == "selected part")
+    }
+
+    @Test("empty selected text falls back to full text")
+    func emptySelectedTextFallsBack() {
+        let selected = RichInputSubmitter.selectedSubmissionText(" \n\t ")
+        #expect(selected == nil)
+    }
 }


### PR DESCRIPTION
Rich Input now sends the selected text for Cmd+Enter and Cmd+Shift+Enter. Falls back to full text when nothing is selected.