### PR TITLE
Block multiple Muxy main windows

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -228,6 +228,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if let window = Self.mainAppWindow() {
+            sender.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+        }
+        return false
+    }
+
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
         SentryService.shared.start()
@@ -266,6 +278,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
               isDirectory.boolValue
         else { return }
         handleOpenProjectPath(expanded)
+    }
+
+    static func mainAppWindow(excluding excludedWindow: NSWindow? = nil) -> NSWindow? {
+        NSApp.windows.first { window in
+            window !== excludedWindow && window.identifier == ShortcutContext.mainWindowIdentifier
+        }
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -512,6 +530,7 @@ struct WindowConfigurator: NSViewRepresentable {
         DispatchQueue.main.async {
             guard let w = v.window else { return }
             w.identifier = ShortcutContext.mainWindowIdentifier
+            if Self.closeDuplicateMainWindow(w) { return }
             w.titlebarAppearsTransparent = true
             w.titleVisibility = .hidden
             w.styleMask.insert(.fullSizeContentView)
@@ -543,6 +562,13 @@ struct WindowConfigurator: NSViewRepresentable {
 
     static func disableWindowTabbing(for window: NSWindow) {
         window.tabbingMode = .disallowed
+    }
+
+    static func closeDuplicateMainWindow(_ window: NSWindow) -> Bool {
+        guard let existingWindow = AppDelegate.mainAppWindow(excluding: window) else { return false }
+        existingWindow.makeKeyAndOrderFront(nil)
+        window.close()
+        return true
     }
 
     static func neutralizeSafeAreaInsets(in window: NSWindow) {

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -443,6 +443,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         settingsWindow = nil
     }
 
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard sender.identifier == ShortcutContext.mainWindowIdentifier else { return true }
+        NSApp.terminate(nil)
+        return false
+    }
+
     @MainActor
     private func observeSystemAppearanceChanges() {
         if let observer = systemAppearanceObserver {

--- a/Tests/MuxyTests/Views/WindowConfiguratorTests.swift
+++ b/Tests/MuxyTests/Views/WindowConfiguratorTests.swift
@@ -14,4 +14,11 @@ struct WindowConfiguratorTests {
 
         #expect(window.tabbingMode == .disallowed)
     }
+
+    @Test("rejects untitled window requests")
+    func rejectsUntitledWindowRequests() {
+        let delegate = AppDelegate()
+
+        #expect(!delegate.applicationShouldOpenUntitledFile(NSApp))
+    }
 }

--- a/Tests/MuxyTests/Views/WindowConfiguratorTests.swift
+++ b/Tests/MuxyTests/Views/WindowConfiguratorTests.swift
@@ -21,4 +21,12 @@ struct WindowConfiguratorTests {
 
         #expect(!delegate.applicationShouldOpenUntitledFile(NSApp))
     }
+
+    @Test("allows auxiliary windows to close")
+    func allowsAuxiliaryWindowsToClose() {
+        let delegate = AppDelegate()
+        let window = NSWindow()
+
+        #expect(delegate.windowShouldClose(window))
+    }
 }


### PR DESCRIPTION
Prevent duplicate main windows and route app reopens to the existing instance.
Keep CLI/project opens working through the current app window.