### PR TITLE
Speed up launch and local dev runs

### DIFF
--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -45,7 +45,7 @@ final class TerminalPaneState: Identifiable {
         self.closesOnStartupCommandExit = closesOnStartupCommandExit
         self.externalEditorFilePath = externalEditorFilePath
         self.restoredSession = restoredSession
-        branchObserver.update(repoPath: initialWorkingDirectory ?? projectPath)
+        branchObserver.update(repoPath: initialWorkingDirectory ?? projectPath, refresh: false)
         if let restoredSession {
             let decision = TerminalSessionRestorePolicy.decision(for: restoredSession)
             restoreDecision = decision

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -122,11 +122,15 @@ final class TerminalTab: Identifiable {
         isPinned = snapshot.isPinned
         switch snapshot.kind {
         case .terminal:
+            let restoredWorkingDirectory = Self.restoredWorkingDirectory(
+                restoredSession?.workingDirectory ?? snapshot.currentWorkingDirectory,
+                projectPath: snapshot.projectPath
+            )
             content = .terminal(TerminalPaneState(
                 id: snapshot.paneID ?? UUID(),
                 projectPath: snapshot.projectPath,
                 title: snapshot.paneTitle,
-                initialWorkingDirectory: restoredSession?.workingDirectory ?? snapshot.currentWorkingDirectory,
+                initialWorkingDirectory: restoredWorkingDirectory,
                 restoredSession: restoredSession
             ))
         case .vcs:
@@ -169,5 +173,15 @@ final class TerminalTab: Identifiable {
             filePath: content.editorState?.filePath ?? content.imageViewerState?.filePath,
             currentWorkingDirectory: content.pane?.currentWorkingDirectory
         )
+    }
+
+    private static func restoredWorkingDirectory(_ path: String?, projectPath: String) -> String? {
+        guard let path else { return nil }
+        let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        let standardizedProjectPath = URL(fileURLWithPath: projectPath).standardizedFileURL.path
+        guard standardizedPath == standardizedProjectPath || standardizedPath.hasPrefix(standardizedProjectPath + "/") else {
+            return nil
+        }
+        return path
     }
 }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -11,7 +11,7 @@ struct MuxyApp: App {
     @State private var worktreeStore: WorktreeStore
     @State private var projectGroupStore: ProjectGroupStore
     @State private var vcsWorktreeAutoRefresher: VCSWorktreeAutoRefresher
-    private let updateService = UpdateService.shared
+    @State private var didStartDeferredServices = false
 
     init() {
         _ = MuxyApp.launchDate
@@ -43,7 +43,6 @@ struct MuxyApp: App {
         _worktreeStore = State(initialValue: worktreeStore)
         _projectGroupStore = State(initialValue: projectGroupStore)
         _vcsWorktreeAutoRefresher = State(initialValue: vcsWorktreeAutoRefresher)
-        SettingsJSONStore.beginAutomaticUserSettingsSync()
     }
 
     var body: some Scene {
@@ -58,6 +57,7 @@ struct MuxyApp: App {
                 .environment(ThemeService.shared)
                 .preferredColorScheme(MuxyTheme.colorScheme)
                 .onAppear {
+                    startDeferredServicesIfNeeded()
                     NotificationStore.shared.appState = appState
                     NotificationStore.shared.worktreeStore = worktreeStore
                     NotificationStore.shared.markAllAsRead()
@@ -143,6 +143,18 @@ struct MuxyApp: App {
                 .preferredColorScheme(MuxyTheme.colorScheme)
         }
         .defaultSize(width: 820, height: 580)
+    }
+
+    private func startDeferredServicesIfNeeded() {
+        guard !didStartDeferredServices else { return }
+        didStartDeferredServices = true
+        Task { @MainActor in
+            await Task.yield()
+            SettingsJSONStore.beginAutomaticUserSettingsSync()
+            try? await Task.sleep(for: .seconds(2))
+            UpdateService.shared.start()
+            AIProviderRegistry.shared.installAll()
+        }
     }
 }
 
@@ -240,7 +252,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         ThemeService.shared.applyDefaultThemeIfNeeded()
         ThemeService.shared.migrateToPairedThemeIfNeeded()
         observeSystemAppearanceChanges()
-        UpdateService.shared.start()
         ModifierKeyMonitor.shared.start()
         NotificationSocketServer.shared.openProjectHandler = { [weak self] path in
             Task { @MainActor [weak self] in
@@ -248,7 +259,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
         }
         NotificationSocketServer.shared.start()
-        AIProviderRegistry.shared.installAll()
         _ = AIUsageSettingsStore.isUsageEnabled()
         DiagnosticsMenuController.shared.install()
         observeSettingsRequests()

--- a/Muxy/Services/PaneBranchObserver.swift
+++ b/Muxy/Services/PaneBranchObserver.swift
@@ -26,18 +26,21 @@ final class PaneBranchObserver {
         refreshTask?.cancel()
     }
 
-    func update(repoPath path: String?) {
+    func update(repoPath path: String?, refresh: Bool = true) {
         guard repoPath != path else { return }
         repoPath = path
         guard path != nil else {
             branch = nil
             return
         }
-        refresh()
+        if refresh {
+            self.refresh()
+        }
     }
 
     func start() {
         guard pollingTask == nil else { return }
+        refresh()
         let interval = refreshInterval
         pollingTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {

--- a/Muxy/Services/TerminalProgressStore.swift
+++ b/Muxy/Services/TerminalProgressStore.swift
@@ -11,7 +11,7 @@ final class TerminalProgressStore {
     private(set) var progresses: [UUID: TerminalProgress] = [:]
     private(set) var completionPending: Set<UUID> = []
     private var paneToProject: [UUID: UUID] = [:]
-    nonisolated(unsafe) private var didBecomeActiveObserver: NSObjectProtocol?
+    private var didBecomeActiveObserver: NSObjectProtocol?
 
     init() {
         didBecomeActiveObserver = NotificationCenter.default.addObserver(
@@ -26,8 +26,10 @@ final class TerminalProgressStore {
     }
 
     deinit {
-        if let didBecomeActiveObserver {
-            NotificationCenter.default.removeObserver(didBecomeActiveObserver)
+        MainActor.assumeIsolated {
+            if let didBecomeActiveObserver {
+                NotificationCenter.default.removeObserver(didBecomeActiveObserver)
+            }
         }
     }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -877,9 +877,10 @@ struct MainWindow: View {
     }
 
     private func mountedWorktreeKeys(for project: Project) -> [WorktreeKey] {
-        appState.workspaceRoots.keys
-            .filter { $0.projectID == project.id }
-            .sorted { $0.worktreeID.uuidString < $1.worktreeID.uuidString }
+        guard let activeKey = appState.activeWorktreeKey(for: project.id),
+              appState.workspaceRoots[activeKey] != nil
+        else { return [] }
+        return [activeKey]
     }
 
     private func handleShortcutAction(_ action: ShortcutAction) -> Bool {

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -24,6 +24,7 @@ struct ExpandedProjectRow: View {
     @State private var isRenaming = false
     @State private var renameText = ""
     @State private var isGitRepo = false
+    @State private var isCheckingGitRepo = true
     @State private var showCreateWorktreeSheet = false
     @State private var logoCropImage: IdentifiableExpandedImage?
     @State private var worktreesExpanded = false
@@ -47,6 +48,10 @@ struct ExpandedProjectRow: View {
         worktrees.first { $0.id == activeWorktreeID }
     }
 
+    private var hasWorktreeUI: Bool {
+        isGitRepo || worktrees.count > 1
+    }
+
     private var displayLetter: String {
         String(project.name.prefix(1)).uppercased()
     }
@@ -54,18 +59,22 @@ struct ExpandedProjectRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             projectHeader
-            if worktreesExpanded, isGitRepo {
+            if worktreesExpanded, hasWorktreeUI {
                 worktreeList
             }
         }
         .task(id: project.path) {
+            isCheckingGitRepo = true
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
             isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path)
-            if autoExpandWorktrees, isActive, isGitRepo {
+            isCheckingGitRepo = false
+            if autoExpandWorktrees, isActive, hasWorktreeUI {
                 worktreesExpanded = true
             }
         }
         .onChange(of: isActive) { _, active in
-            guard autoExpandWorktrees, active, isGitRepo else { return }
+            guard autoExpandWorktrees, active, hasWorktreeUI else { return }
             withAnimation(.easeInOut(duration: 0.15)) {
                 worktreesExpanded = true
             }
@@ -89,6 +98,10 @@ struct ExpandedProjectRow: View {
                 Divider()
                 Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
                 Button("New Worktree…") { showCreateWorktreeSheet = true }
+            } else if isCheckingGitRepo {
+                Divider()
+                Button("Loading Worktrees…") {}
+                    .disabled(true)
             }
             if !projectGroupStore.groups.isEmpty {
                 Divider()
@@ -149,7 +162,7 @@ struct ExpandedProjectRow: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
 
-                if isGitRepo, let worktree = activeWorktree {
+                if hasWorktreeUI, let worktree = activeWorktree {
                     Text(worktree.isPrimary ? "primary" : worktree.name)
                         .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fg)
@@ -160,9 +173,7 @@ struct ExpandedProjectRow: View {
 
             Spacer(minLength: UIMetrics.spacing2)
 
-            if isGitRepo {
-                worktreeChevron
-            }
+            worktreeAccessory
         }
         .padding(UIMetrics.spacing2)
         .background(headerBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
@@ -180,7 +191,7 @@ struct ExpandedProjectRow: View {
         }
         .onTapGesture {
             guard !isAnyDragging else { return }
-            if isActive, isGitRepo {
+            if isActive, hasWorktreeUI {
                 withAnimation(.easeInOut(duration: 0.15)) {
                     worktreesExpanded.toggle()
                 }
@@ -213,6 +224,20 @@ struct ExpandedProjectRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(worktreesExpanded ? "Collapse Worktrees" : "Expand Worktrees")
+    }
+
+    @ViewBuilder
+    private var worktreeAccessory: some View {
+        if hasWorktreeUI {
+            worktreeChevron
+        } else if isCheckingGitRepo {
+            ProgressView()
+                .controlSize(.mini)
+                .frame(width: UIMetrics.scaled(18), height: UIMetrics.scaled(18))
+        } else {
+            Color.clear
+                .frame(width: UIMetrics.scaled(18), height: UIMetrics.scaled(18))
+        }
     }
 
     private var projectIcon: some View {
@@ -287,7 +312,7 @@ struct ExpandedProjectRow: View {
 
     private var projectHeaderAccessibilityLabel: String {
         var label = project.name
-        if isGitRepo, let worktree = activeWorktree {
+        if hasWorktreeUI, let worktree = activeWorktree {
             label += ", worktree: \(worktree.isPrimary ? "primary" : worktree.name)"
         }
         return label

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -22,6 +22,7 @@ struct ProjectRow: View {
     @State private var renameText = ""
     @State private var showWorktreePopover = false
     @State private var isGitRepo = false
+    @State private var isCheckingGitRepo = true
     @State private var showCreateWorktreeSheet = false
     @State private var logoCropImage: IdentifiableImage?
     @State private var isRefreshingWorktrees = false
@@ -34,6 +35,10 @@ struct ProjectRow: View {
 
     private var worktrees: [Worktree] {
         worktreeStore.list(for: project.id)
+    }
+
+    private var hasWorktreeUI: Bool {
+        isGitRepo || worktrees.count > 1
     }
 
     private var displayLetter: String {
@@ -61,7 +66,11 @@ struct ProjectRow: View {
                 onSelect()
             }
             .task(id: project.path) {
+                isCheckingGitRepo = true
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
                 isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path)
+                isCheckingGitRepo = false
             }
             .contextMenu {
                 Button("Set Logo...") { pickLogoImage() }
@@ -82,6 +91,15 @@ struct ProjectRow: View {
                     Divider()
                     Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
                     Button("New Worktree…") { showCreateWorktreeSheet = true }
+                    if worktrees.count > 1 {
+                        Button("Switch Worktree…") { showWorktreePopover = true }
+                    }
+                } else if isCheckingGitRepo {
+                    Divider()
+                    Button("Loading Worktrees…") {}
+                        .disabled(true)
+                } else if hasWorktreeUI {
+                    Divider()
                     if worktrees.count > 1 {
                         Button("Switch Worktree…") { showWorktreePopover = true }
                     }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -237,7 +237,7 @@ final class GhosttyTerminalNSView: NSView {
         cleanupSurfaceConfigPointers()
     }
 
-    nonisolated(unsafe) private func cleanupSurfaceConfigPointers() {
+    nonisolated private func cleanupSurfaceConfigPointers() {
         surfaceEnvVarPointer?.deinitialize(count: surfaceEnvVarCount)
         surfaceEnvVarPointer?.deallocate()
         surfaceEnvVarPointer = nil

--- a/Package.swift
+++ b/Package.swift
@@ -43,12 +43,15 @@ let package = Package(
                 .product(name: "Sentry", package: "sentry-cocoa"),
             ],
             path: "Muxy",
-            exclude: ["Info.plist", "Muxy.entitlements", "Resources/ghostty", "Resources/terminfo", "Resources/rg"],
+            exclude: ["Info.plist", "Muxy.entitlements"],
             resources: [
-                .process("Resources"),
+                .process("Resources/Assets.xcassets"),
                 .copy("Resources/ghostty"),
-                .copy("Resources/terminfo"),
+                .copy("Resources/markdown-assets"),
+                .copy("Resources/ProviderIcons"),
                 .copy("Resources/rg"),
+                .copy("Resources/scripts"),
+                .copy("Resources/terminfo"),
             ],
             linkerSettings: [
                 .unsafeFlags([

--- a/Tests/MuxyTests/Models/TabAreaTests.swift
+++ b/Tests/MuxyTests/Models/TabAreaTests.swift
@@ -128,6 +128,41 @@ struct TabAreaTests {
         #expect(pane?.startupCommandInteractive == true)
     }
 
+    @Test("restoring terminal tab ignores stale working directory outside project")
+    func restoringTerminalTabIgnoresOutsideWorkingDirectory() {
+        let snapshot = TerminalTabSnapshot(
+            kind: .terminal,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: testPath,
+            paneTitle: "~",
+            currentWorkingDirectory: "/tmp"
+        )
+
+        let tab = TerminalTab(restoring: snapshot)
+
+        #expect(tab.content.pane?.projectPath == testPath)
+        #expect(tab.content.pane?.currentWorkingDirectory == nil)
+    }
+
+    @Test("restoring terminal tab keeps working directory inside project")
+    func restoringTerminalTabKeepsInsideWorkingDirectory() {
+        let snapshot = TerminalTabSnapshot(
+            kind: .terminal,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: testPath,
+            paneTitle: "Sources",
+            currentWorkingDirectory: "/tmp/test/Sources"
+        )
+
+        let tab = TerminalTab(restoring: snapshot)
+
+        #expect(tab.content.pane?.currentWorkingDirectory == "/tmp/test/Sources")
+    }
+
     @Test("createVCSTab adds tab with VCS content")
     func createVCSTab() {
         let area = TabArea(projectPath: testPath)

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env zsh
+
+set -euo pipefail
+
+root="${0:A:h:h}"
+binary="$root/.build/debug/Muxy"
+
+needs_build=false
+
+if [[ ! -x "$binary" ]]; then
+  needs_build=true
+else
+  for path in \
+    "$root/Package.swift" \
+    "$root/Package.resolved" \
+    "$root/Muxy"/**/*(.) \
+    "$root/MuxyShared"/**/*(.) \
+    "$root/MuxyServer"/**/*(.) \
+    "$root/GhosttyKit"/**/*(.); do
+    if [[ "$path" -nt "$binary" ]]; then
+      needs_build=true
+      break
+    fi
+  done
+fi
+
+if [[ "$needs_build" == true ]]; then
+  swift build --product Muxy --skip-update
+fi
+
+exec "$binary" "$@"


### PR DESCRIPTION
Defer non-critical startup work and stabilize worktree sidebar rendering.
Fix stale restored terminal paths and streamline SwiftPM resources.
Add scripts/run-dev.sh for faster repeat dev launches.