### PR TITLE
Fix diff status icons for PR and commit views

### DIFF
--- a/Muxy/Services/Git/GitModels.swift
+++ b/Muxy/Services/Git/GitModels.swift
@@ -106,6 +106,14 @@ struct GitStatusFile: Identifiable, Hashable {
         }
         return String(yStatus)
     }
+
+    func displayStatusText(isStaged: Bool) -> String {
+        let status = isStaged ? stagedStatusText : unstagedStatusText
+        if status.trimmingCharacters(in: .whitespaces).isEmpty {
+            return statusText
+        }
+        return status
+    }
 }
 
 struct GitCommit: Identifiable {

--- a/Muxy/Views/VCS/DiffViewerPane.swift
+++ b/Muxy/Views/VCS/DiffViewerPane.swift
@@ -838,7 +838,7 @@ private struct DiffViewerSidebarFileRow: View {
     }
 
     private var statusText: String {
-        isStaged ? file.stagedStatusText : file.unstagedStatusText
+        file.displayStatusText(isStaged: isStaged)
     }
 
     private var statusColor: Color {

--- a/Tests/MuxyTests/Git/GitModelsTests.swift
+++ b/Tests/MuxyTests/Git/GitModelsTests.swift
@@ -75,6 +75,12 @@ struct GitModelsTests {
         #expect(makeStatusFile(xStatus: "?", yStatus: "?").unstagedStatusText == "U")
     }
 
+    @Test("displayStatusText falls back to name status code")
+    func displayStatusTextFallsBackToNameStatusCode() {
+        #expect(makeStatusFile(xStatus: "M", yStatus: " ").displayStatusText(isStaged: false) == "M")
+        #expect(makeStatusFile(xStatus: "D", yStatus: " ").displayStatusText(isStaged: false) == "D")
+    }
+
     @Test("GitCommit.isMerge with single parent is false")
     func commitNotMerge() {
         let commit = GitCommit(


### PR DESCRIPTION
Show file status labels and colors for non-working-tree diffs.
Use name-status fallback when unstaged status is blank.
Add coverage for fallback display status.