### PR TITLE
Allow app shortcuts to be unassigned

### DIFF
--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -155,6 +155,8 @@ struct KeyCombo: Codable, Equatable, Hashable {
     }
 
     var displayString: String {
+        guard isAssigned else { return "Unassigned" }
+
         var parts = ""
         let flags = nsModifierFlags
         if flags.contains(.control) { parts += "⌃" }

--- a/Muxy/Services/SettingsJSONStore.swift
+++ b/Muxy/Services/SettingsJSONStore.swift
@@ -427,7 +427,9 @@ enum SettingsJSONStore {
         guard let dictionary = value as? [String: Any] else { return nil }
         var bindings: [KeyBinding] = []
         for (key, value) in dictionary {
-            guard let action = ShortcutAction(rawValue: key), let combo: KeyCombo = codableValue(from: value), isValidKeyCombo(combo) else {
+            guard let action = ShortcutAction(rawValue: key), let combo: KeyCombo = codableValue(from: value),
+                  isValidAppKeyCombo(combo)
+            else {
                 return nil
             }
             bindings.append(KeyBinding(action: action, combo: combo))
@@ -439,6 +441,10 @@ enum SettingsJSONStore {
         !combo.key.isEmpty
             && KeyCombo.normalized(key: combo.key) == combo.key
             && KeyCombo.normalized(modifiers: combo.modifiers) == combo.modifiers
+    }
+
+    private static func isValidAppKeyCombo(_ combo: KeyCombo) -> Bool {
+        !combo.isAssigned || isValidKeyCombo(combo)
     }
 
     private static func commandShortcutsJSONObject(_ configuration: CommandShortcutConfiguration) -> Any {

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -165,6 +165,11 @@ struct KeyboardShortcutsSettingsView: View {
                     },
                     onReset: { store.resetBinding(action: action)
                         conflictWarning = nil
+                    },
+                    onUnassign: {
+                        store.updateBinding(action: action, combo: KeyCombo(key: "", modifiers: 0))
+                        recordingAction = nil
+                        conflictWarning = nil
                     }
                 )
             }
@@ -386,6 +391,7 @@ private struct ShortcutRow: View {
     let onRecord: (KeyCombo) -> Void
     let onCancel: () -> Void
     let onReset: () -> Void
+    let onUnassign: () -> Void
     @State private var hovered = false
 
     var body: some View {
@@ -417,6 +423,15 @@ private struct ShortcutRow: View {
     private var comboDisplay: some View {
         HStack(spacing: 6) {
             if hovered {
+                Button(action: onUnassign) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                }
+                .buttonStyle(.plain)
+                .disabled(!combo.isAssigned)
+                .accessibilityLabel("Unassign Shortcut")
+
                 Button(action: onReset) {
                     Image(systemName: "arrow.counterclockwise")
                         .font(.system(size: 10))

--- a/Tests/MuxyTests/Models/KeyComboTests.swift
+++ b/Tests/MuxyTests/Models/KeyComboTests.swift
@@ -58,6 +58,12 @@ struct KeyComboTests {
         #expect(combo.displayString == "⌘T")
     }
 
+    @Test("displayString for unassigned shortcut")
+    func displayStringUnassigned() {
+        let combo = KeyCombo(key: "", modifiers: 0)
+        #expect(combo.displayString == "Unassigned")
+    }
+
     @Test("normalized key with bracket keyCodes")
     func normalizedBracketKeyCodes() {
         #expect(KeyCombo.normalized(key: "", keyCode: 33) == "[")

--- a/Tests/MuxyTests/Services/KeyBindingStoreTests.swift
+++ b/Tests/MuxyTests/Services/KeyBindingStoreTests.swift
@@ -56,6 +56,24 @@ struct KeyBindingStoreTests {
         #expect(store.combo(for: .openVCSTab) == KeyCombo(key: "y", command: true))
     }
 
+    @Test("action can be unassigned")
+    func actionCanBeUnassigned() throws {
+        let persistence = StubKeyBindingPersistence(bindings: KeyBinding.defaults)
+        let store = KeyBindingStore(persistence: persistence)
+        let combo = KeyCombo(key: "", modifiers: 0)
+        let event = try keyEvent(
+            characters: "y",
+            charactersIgnoringModifiers: "y",
+            keyCode: 16,
+            modifiers: [.command]
+        )
+
+        store.updateBinding(action: .openVCSTab, combo: combo)
+
+        #expect(store.combo(for: .openVCSTab) == combo)
+        #expect(store.action(for: event, scopes: [.mainWindow]) == nil)
+    }
+
     private func keyEvent(
         characters: String,
         charactersIgnoringModifiers: String,

--- a/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
@@ -92,6 +92,29 @@ struct SettingsJSONStoreTests {
     }
 
     @Test
+    func appShortcutsAllowUnassignedBindings() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [])
+        let originalBindings = KeyBindingStore.shared.bindings
+        defer {
+            KeyBindingStore.shared.replaceBindings(originalBindings)
+            snapshot.restore()
+        }
+
+        try SettingsJSONStore.saveUserSettingsText("""
+        {
+          "shortcuts.app": {
+            "openVCSTab": {
+              "key": "",
+              "modifiers": 0
+            }
+          }
+        }
+        """)
+
+        #expect(KeyBindingStore.shared.combo(for: .openVCSTab) == KeyCombo(key: "", modifiers: 0))
+    }
+
+    @Test
     func omittedKnownSettingsRemainUnchanged() throws {
         let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
         defer { snapshot.restore() }


### PR DESCRIPTION
Adds an unassign control for app shortcuts and persists inactive bindings. Includes coverage for unassigned shortcut display and behavior.