### PR TITLE
Fix muxy CLI socket requests

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -79,8 +79,13 @@ struct MuxyApp: App {
                         )
                     }
                     appDelegate.flushPendingOpens()
-                    NotificationSocketServer.shared.commandHandler = { [appState] message in
-                        await SocketCommandHandler.handleRequest(message, appState: appState)
+                    NotificationSocketServer.shared.commandHandler = { [appState, projectStore, worktreeStore] message in
+                        await SocketCommandHandler.handleRequest(
+                            message,
+                            appState: appState,
+                            projectStore: projectStore,
+                            worktreeStore: worktreeStore
+                        )
                     }
                     MobileServerService.shared.configure { server in
                         let delegate = RemoteServerDelegate(

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -20,7 +20,7 @@ send_message() {
         echo "Error: Muxy is not running" >&2
         exit 1
     fi
-    printf '%s' "$message" | nc -U "$SOCKET"
+    printf '%s\n' "$message" | nc -U "$SOCKET"
 }
 
 send_command() {
@@ -30,7 +30,7 @@ send_command() {
         exit 1
     fi
     local response
-    response=$(printf '%s' "$message" | nc -U "$SOCKET" 2>/dev/null)
+    response=$(printf '%s\n' "$message" | nc -U "$SOCKET" 2>/dev/null)
     if [ -z "$response" ]; then
         echo "Error: no response from Muxy" >&2
         exit 1
@@ -224,7 +224,7 @@ if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "spli
 
     ENCODED_PATH="$(percent_encode "$TARGET_DIR")"
 
-    if [ -e "$SOCKET" ] && printf '%s' "open-project|$TARGET_DIR" | nc -U "$SOCKET" 2>/dev/null; then
+    if [ -e "$SOCKET" ] && printf '%s\n' "open-project|$TARGET_DIR" | nc -U "$SOCKET" 2>/dev/null; then
         exit 0
     fi
 

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -209,7 +209,7 @@ case "$COMMAND" in
     switch-worktree)
         shift
         PROJECT=""
-        TARGET=""
+        TARGET_ARGS=()
         while [[ $# -gt 0 ]]; do
             case $1 in
                 --project)
@@ -217,12 +217,14 @@ case "$COMMAND" in
                         echo "Usage: muxy switch-worktree <name|id|path> [--project <name|id|path>]" >&2
                         exit 1
                     fi
-                    PROJECT="$2"
-                    shift 2
+                    shift
+                    PROJECT="$*"
+                    break
                     ;;
-                *) TARGET="$1"; shift ;;
+                *) TARGET_ARGS+=("$1"); shift ;;
             esac
         done
+        TARGET="${TARGET_ARGS[*]}"
         if [ -z "$TARGET" ]; then
             echo "Usage: muxy switch-worktree <name|id|path> [--project <name|id|path>]" >&2
             exit 1

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -10,6 +10,15 @@
 #   muxy close-pane --pane <id>              Close a pane
 #   muxy rename-pane --pane <id> <title>     Rename a pane tab
 #   muxy list-panes                          List all panes (tab-separated)
+#   muxy list-projects                       List projects
+#   muxy switch-project <name|id|path>        Switch active project
+#   muxy list-worktrees [project]             List worktrees
+#   muxy switch-worktree <name|id|path>       Switch active worktree
+#   muxy refresh-worktrees [project]          Refresh worktrees from Git
+#   muxy list-tabs                            List tabs
+#   muxy switch-tab <index|id|title>          Switch active tab
+#   muxy new-tab                              Create a terminal tab
+#   muxy next-tab|previous-tab                Switch tabs
 
 COMMAND="$1"
 SOCKET="$HOME/Library/Application Support/Muxy/muxy.sock"
@@ -178,6 +187,80 @@ case "$COMMAND" in
     list-panes)
         send_command "list-panes"
         ;;
+    list-projects)
+        send_command "list-projects"
+        ;;
+    switch-project)
+        shift
+        if [ $# -lt 1 ]; then
+            echo "Usage: muxy switch-project <name|id|path>" >&2
+            exit 1
+        fi
+        send_command "switch-project|$*"
+        ;;
+    list-worktrees)
+        shift
+        if [ $# -gt 0 ]; then
+            send_command "list-worktrees|$*"
+        else
+            send_command "list-worktrees"
+        fi
+        ;;
+    switch-worktree)
+        shift
+        PROJECT=""
+        TARGET=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --project)
+                    if [ $# -lt 2 ]; then
+                        echo "Usage: muxy switch-worktree <name|id|path> [--project <name|id|path>]" >&2
+                        exit 1
+                    fi
+                    PROJECT="$2"
+                    shift 2
+                    ;;
+                *) TARGET="$1"; shift ;;
+            esac
+        done
+        if [ -z "$TARGET" ]; then
+            echo "Usage: muxy switch-worktree <name|id|path> [--project <name|id|path>]" >&2
+            exit 1
+        fi
+        if [ -n "$PROJECT" ]; then
+            send_command "switch-worktree|$TARGET|$PROJECT"
+        else
+            send_command "switch-worktree|$TARGET"
+        fi
+        ;;
+    refresh-worktrees)
+        shift
+        if [ $# -gt 0 ]; then
+            send_command "refresh-worktrees|$*"
+        else
+            send_command "refresh-worktrees"
+        fi
+        ;;
+    list-tabs)
+        send_command "list-tabs"
+        ;;
+    switch-tab)
+        shift
+        if [ $# -lt 1 ]; then
+            echo "Usage: muxy switch-tab <index|id|title>" >&2
+            exit 1
+        fi
+        send_command "switch-tab|$*"
+        ;;
+    new-tab)
+        send_command "new-tab"
+        ;;
+    next-tab)
+        send_command "next-tab"
+        ;;
+    previous-tab)
+        send_command "previous-tab"
+        ;;
     ""|--help|-h)
         echo "Usage:"
         echo "  muxy <path>                              Open a folder in Muxy"
@@ -189,6 +272,16 @@ case "$COMMAND" in
         echo "  muxy close-pane --pane <id>              Close a pane"
         echo "  muxy rename-pane --pane <id> <title>     Rename a pane tab"
         echo "  muxy list-panes                          List all panes"
+        echo "  muxy list-projects                       List projects"
+        echo "  muxy switch-project <name|id|path>        Switch active project"
+        echo "  muxy list-worktrees [project]             List worktrees"
+        echo "  muxy switch-worktree <name|id|path>       Switch active worktree"
+        echo "  muxy refresh-worktrees [project]          Refresh worktrees from Git"
+        echo "  muxy list-tabs                            List tabs"
+        echo "  muxy switch-tab <index|id|title>          Switch active tab"
+        echo "  muxy new-tab                              Create a terminal tab"
+        echo "  muxy next-tab                             Switch to next tab"
+        echo "  muxy previous-tab                         Switch to previous tab"
         exit 1
         ;;
 esac
@@ -196,7 +289,12 @@ esac
 # If we reach here, it's a path to open
 if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "split-down" ] && \
    [ "$COMMAND" != "send" ] && [ "$COMMAND" != "send-keys" ] && [ "$COMMAND" != "read-screen" ] && \
-   [ "$COMMAND" != "close-pane" ] && [ "$COMMAND" != "rename-pane" ] && [ "$COMMAND" != "list-panes" ]; then
+   [ "$COMMAND" != "close-pane" ] && [ "$COMMAND" != "rename-pane" ] && [ "$COMMAND" != "list-panes" ] && \
+   [ "$COMMAND" != "list-projects" ] && [ "$COMMAND" != "switch-project" ] && \
+   [ "$COMMAND" != "list-worktrees" ] && [ "$COMMAND" != "switch-worktree" ] && \
+   [ "$COMMAND" != "refresh-worktrees" ] && [ "$COMMAND" != "list-tabs" ] && \
+   [ "$COMMAND" != "switch-tab" ] && [ "$COMMAND" != "new-tab" ] && \
+   [ "$COMMAND" != "next-tab" ] && [ "$COMMAND" != "previous-tab" ]; then
     TARGET_DIR="$COMMAND"
 
     case "$TARGET_DIR" in

--- a/Muxy/Services/CLIAccessor.swift
+++ b/Muxy/Services/CLIAccessor.swift
@@ -43,10 +43,7 @@ enum CLIAccessor {
     }
 
     static func installCLI() {
-        guard let resourceURL = Bundle.appResources.url(
-            forResource: "muxy-cli",
-            withExtension: ""
-        )
+        guard let resourceURL = cliResourceURL()
         else {
             alert(title: "CLI Not Found", body: "The CLI script was not found in the app bundle.")
             return
@@ -79,6 +76,20 @@ enum CLIAccessor {
                 )
             }
         }
+    }
+
+    private static func cliResourceURL() -> URL? {
+        if let url = Bundle.appResources.resourceURL?
+            .appendingPathComponent("scripts/muxy-cli"),
+            FileManager.default.fileExists(atPath: url.path)
+        {
+            return url
+        }
+
+        return Bundle.appResources.url(
+            forResource: "muxy-cli",
+            withExtension: ""
+        )
     }
 
     private static func copyScript(from resourceURL: URL, to binPath: String, label: String) -> Bool {

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -115,6 +115,9 @@ final class NotificationSocketServer: @unchecked Sendable {
                 logger.warning("Client exceeded max message size (\(Self.maxMessageSize) bytes), dropping")
                 return
             }
+            if data.contains(UInt8(ascii: "\n")) {
+                break
+            }
         }
 
         guard !data.isEmpty,

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -100,6 +100,8 @@ final class NotificationSocketServer: @unchecked Sendable {
     private static let commandNames = [
         "split-right", "split-down", "send", "send-keys",
         "read-screen", "close-pane", "rename-pane", "list-panes",
+        "list-projects", "switch-project", "list-worktrees", "switch-worktree", "refresh-worktrees",
+        "list-tabs", "switch-tab", "new-tab", "next-tab", "previous-tab",
     ]
 
     private func handleClient(_ fd: Int32) {

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -361,6 +361,7 @@ enum SocketCommandHandler {
               let root = appState.workspaceRoots[key]
         else { return "error:no active project" }
         if let index = Int(identifier) {
+            guard tab(at: index, in: root) != nil else { return "error:tab not found \(identifier)" }
             appState.selectTabByIndex(index, projectID: projectID)
             return "ok"
         }
@@ -425,6 +426,18 @@ enum SocketCommandHandler {
         tab.id.uuidString == identifier
             || tab.content.pane?.id.uuidString == identifier
             || tab.title.localizedCaseInsensitiveCompare(identifier) == .orderedSame
+    }
+
+    private static func tab(at index: Int, in root: SplitNode) -> TerminalTab? {
+        guard index >= 0 else { return nil }
+        var currentIndex = 0
+        for area in root.allAreas() {
+            for tab in area.tabs {
+                if currentIndex == index { return tab }
+                currentIndex += 1
+            }
+        }
+        return nil
     }
 
     private static func collectTabs(appState: AppState) -> Set<UUID> {

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -5,7 +5,12 @@ private let logger = Logger(subsystem: "app.muxy", category: "SocketCommandHandl
 
 @MainActor
 enum SocketCommandHandler {
-    static func handleRequest(_ message: String, appState: AppState) async -> String {
+    static func handleRequest(
+        _ message: String,
+        appState: AppState,
+        projectStore: ProjectStore? = nil,
+        worktreeStore: WorktreeStore? = nil
+    ) async -> String {
         let parts = message.components(separatedBy: "|")
         guard let cmd = parts.first else {
             return "error:empty command"
@@ -36,6 +41,58 @@ enum SocketCommandHandler {
             return handleRenamePane(paneIDStr: parts[1], title: parts.dropFirst(2).joined(separator: "|"), appState: appState)
         case "list-panes":
             return handleListPanes(appState: appState)
+        case "list-projects":
+            guard let projectStore else { return "error:project store unavailable" }
+            return handleListProjects(appState: appState, projectStore: projectStore)
+        case "switch-project":
+            guard parts.count >= 2 else { return "error:usage switch-project|name-or-id-or-path" }
+            guard let projectStore, let worktreeStore else { return "error:project store unavailable" }
+            return handleSwitchProject(
+                identifier: parts.dropFirst().joined(separator: "|"),
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+        case "list-worktrees":
+            guard let projectStore, let worktreeStore else { return "error:worktree store unavailable" }
+            let identifier = parts.count >= 2 ? parts.dropFirst().joined(separator: "|") : nil
+            return handleListWorktrees(
+                projectIdentifier: identifier,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+        case "switch-worktree":
+            guard parts.count >= 2 else { return "error:usage switch-worktree|name-or-id-or-path[|project]" }
+            guard let projectStore, let worktreeStore else { return "error:worktree store unavailable" }
+            let projectIdentifier = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
+            return handleSwitchWorktree(
+                identifier: parts[1],
+                projectIdentifier: projectIdentifier,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+        case "refresh-worktrees":
+            guard let projectStore, let worktreeStore else { return "error:worktree store unavailable" }
+            let identifier = parts.count >= 2 ? parts.dropFirst().joined(separator: "|") : nil
+            return await handleRefreshWorktrees(
+                projectIdentifier: identifier,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+        case "list-tabs":
+            return handleListTabs(appState: appState)
+        case "switch-tab":
+            guard parts.count >= 2 else { return "error:usage switch-tab|index-or-id-or-title" }
+            return handleSwitchTab(identifier: parts.dropFirst().joined(separator: "|"), appState: appState)
+        case "new-tab":
+            return handleNewTab(appState: appState)
+        case "next-tab":
+            return handleTabStep(next: true, appState: appState)
+        case "previous-tab":
+            return handleTabStep(next: false, appState: appState)
         default:
             return "error:unknown command \(cmd)"
         }
@@ -206,6 +263,180 @@ enum SocketCommandHandler {
             }
         }
         return lines.joined(separator: "\n")
+    }
+
+    private static func handleListProjects(appState: AppState, projectStore: ProjectStore) -> String {
+        projectStore.projects.map { project in
+            let active = project.id == appState.activeProjectID
+            return "\(project.id.uuidString)\t\(project.name)\t\(project.path)\t\(active)"
+        }.joined(separator: "\n")
+    }
+
+    private static func handleSwitchProject(
+        identifier: String,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) -> String {
+        guard let project = findProject(identifier, in: projectStore.projects) else {
+            return "error:project not found \(identifier)"
+        }
+        guard let worktree = worktreeStore.preferred(for: project.id, matching: appState.activeWorktreeID[project.id]) else {
+            return "error:no worktree for project \(project.name)"
+        }
+        appState.selectProject(project, worktree: worktree)
+        return "ok"
+    }
+
+    private static func handleListWorktrees(
+        projectIdentifier: String?,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) -> String {
+        guard let project = resolveProject(projectIdentifier, appState: appState, projectStore: projectStore) else {
+            return "error:project not found"
+        }
+        return worktreeStore.list(for: project.id).map { worktree in
+            let active = appState.activeProjectID == project.id && appState.activeWorktreeID[project.id] == worktree.id
+            return "\(worktree.id.uuidString)\t\(worktree.name)\t\(worktree.path)\t\(worktree.branch ?? "")\t\(active)"
+        }.joined(separator: "\n")
+    }
+
+    private static func handleSwitchWorktree(
+        identifier: String,
+        projectIdentifier: String?,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) -> String {
+        guard let project = resolveProject(projectIdentifier, appState: appState, projectStore: projectStore) else {
+            return "error:project not found"
+        }
+        guard let worktree = findWorktree(identifier, in: worktreeStore.list(for: project.id)) else {
+            return "error:worktree not found \(identifier)"
+        }
+        appState.selectWorktree(projectID: project.id, worktree: worktree)
+        return "ok"
+    }
+
+    private static func handleRefreshWorktrees(
+        projectIdentifier: String?,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) async -> String {
+        guard let project = resolveProject(projectIdentifier, appState: appState, projectStore: projectStore) else {
+            return "error:project not found"
+        }
+        do {
+            let worktrees = try await worktreeStore.refreshFromGit(project: project)
+            return "ok\t\(worktrees.count)"
+        } catch {
+            return "error:\(error.localizedDescription)"
+        }
+    }
+
+    private static func handleListTabs(appState: AppState) -> String {
+        guard let projectID = appState.activeProjectID,
+              let key = appState.activeWorktreeKey(for: projectID),
+              let root = appState.workspaceRoots[key]
+        else { return "error:no active project" }
+        let focusedAreaID = appState.focusedAreaID[key]
+        var index = 0
+        var lines: [String] = []
+        for area in root.allAreas() {
+            for tab in area.tabs {
+                let active = area.id == focusedAreaID && tab.id == area.activeTabID
+                lines.append("\(index)\t\(tab.id.uuidString)\t\(tab.kind.rawValue)\t\(tab.title)\t\(active)")
+                index += 1
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func handleSwitchTab(identifier: String, appState: AppState) -> String {
+        guard let projectID = appState.activeProjectID,
+              let key = appState.activeWorktreeKey(for: projectID),
+              let root = appState.workspaceRoots[key]
+        else { return "error:no active project" }
+        if let index = Int(identifier) {
+            appState.selectTabByIndex(index, projectID: projectID)
+            return "ok"
+        }
+        for area in root.allAreas() {
+            guard let tab = area.tabs.first(where: { tabMatches($0, identifier: identifier) }) else { continue }
+            appState.dispatch(.selectTab(projectID: projectID, areaID: area.id, tabID: tab.id))
+            return "ok"
+        }
+        return "error:tab not found \(identifier)"
+    }
+
+    private static func handleNewTab(appState: AppState) -> String {
+        guard let projectID = appState.activeProjectID else { return "error:no active project" }
+        let before = collectTabs(appState: appState)
+        appState.dispatch(.createTab(projectID: projectID, areaID: nil))
+        let added = collectTabs(appState: appState).subtracting(before)
+        return added.first?.uuidString ?? "ok"
+    }
+
+    private static func handleTabStep(next: Bool, appState: AppState) -> String {
+        guard let projectID = appState.activeProjectID else { return "error:no active project" }
+        if next {
+            appState.selectNextTab(projectID: projectID)
+        } else {
+            appState.selectPreviousTab(projectID: projectID)
+        }
+        return "ok"
+    }
+
+    private static func findProject(_ identifier: String, in projects: [Project]) -> Project? {
+        let standardizedPath = URL(fileURLWithPath: identifier).standardizedFileURL.path
+        return projects.first { project in
+            project.id.uuidString == identifier
+                || project.name.localizedCaseInsensitiveCompare(identifier) == .orderedSame
+                || URL(fileURLWithPath: project.path).standardizedFileURL.path == standardizedPath
+        }
+    }
+
+    private static func resolveProject(
+        _ identifier: String?,
+        appState: AppState,
+        projectStore: ProjectStore
+    ) -> Project? {
+        if let identifier, !identifier.isEmpty {
+            return findProject(identifier, in: projectStore.projects)
+        }
+        guard let activeProjectID = appState.activeProjectID else { return nil }
+        return projectStore.projects.first { $0.id == activeProjectID }
+    }
+
+    private static func findWorktree(_ identifier: String, in worktrees: [Worktree]) -> Worktree? {
+        let standardizedPath = URL(fileURLWithPath: identifier).standardizedFileURL.path
+        return worktrees.first { worktree in
+            worktree.id.uuidString == identifier
+                || worktree.name.localizedCaseInsensitiveCompare(identifier) == .orderedSame
+                || worktree.branch?.localizedCaseInsensitiveCompare(identifier) == .orderedSame
+                || URL(fileURLWithPath: worktree.path).standardizedFileURL.path == standardizedPath
+        }
+    }
+
+    private static func tabMatches(_ tab: TerminalTab, identifier: String) -> Bool {
+        tab.id.uuidString == identifier
+            || tab.content.pane?.id.uuidString == identifier
+            || tab.title.localizedCaseInsensitiveCompare(identifier) == .orderedSame
+    }
+
+    private static func collectTabs(appState: AppState) -> Set<UUID> {
+        var ids = Set<UUID>()
+        for root in appState.workspaceRoots.values {
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    ids.insert(tab.id)
+                }
+            }
+        }
+        return ids
     }
 
     private static func waitForView(

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -70,6 +70,16 @@ struct MuxyCLILaunchResourceTests {
         #expect(script.contains("printf '%s\\n' \"$message\" | nc -U \"$SOCKET\""))
     }
 
+    @Test("CLI installer prefers copied scripts resource directory")
+    func cliInstallerUsesScriptsResourceDirectory() throws {
+        let accessor = try String(
+            contentsOf: Self.repositoryRoot
+                .appendingPathComponent("Muxy/Services/CLIAccessor.swift"),
+            encoding: .utf8
+        )
+        #expect(accessor.contains("scripts/muxy-cli"))
+    }
+
     @Test("app bundle prohibits multiple running instances")
     func appProhibitsMultipleInstances() throws {
         let plistData = try Data(

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -66,6 +66,8 @@ struct MuxyCLILaunchResourceTests {
         let socketRange = try #require(script.range(of: "open-project|$TARGET_DIR"))
         let openRange = try #require(script.range(of: "open \"muxy://open?path="))
         #expect(socketRange.lowerBound < openRange.lowerBound)
+        #expect(script.contains("printf '%s\\n' \"open-project|$TARGET_DIR\""))
+        #expect(script.contains("printf '%s\\n' \"$message\" | nc -U \"$SOCKET\""))
     }
 
     @Test("app bundle prohibits multiple running instances")

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -222,6 +222,15 @@ struct SocketCommandHandlerTests {
         #expect(area.activeTabID == firstTabID)
     }
 
+    @Test("switch-tab reports invalid index")
+    func switchTabByInvalidIndex() async {
+        let appState = makeAppState()
+
+        let result = await SocketCommandHandler.handleRequest("switch-tab|99", appState: appState)
+
+        #expect(result.hasPrefix("error:tab not found"))
+    }
+
     @Test("new-tab creates terminal tab")
     func newTab() async {
         let appState = makeAppState()

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -138,6 +138,102 @@ struct SocketCommandHandlerTests {
         #expect(UUID(uuidString: result) != nil)
     }
 
+    @Test("list-projects returns projects with active marker")
+    func listProjects() async {
+        let project = Project(name: "Test Project", path: testPath)
+        let worktree = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let appState = makeAppState(projectID: project.id, worktreeID: worktree.id)
+        let stores = makeStores(project: project, worktree: worktree)
+
+        let result = await SocketCommandHandler.handleRequest(
+            "list-projects",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(result.contains(project.id.uuidString))
+        #expect(result.contains("Test Project"))
+        #expect(result.contains("\ttrue"))
+    }
+
+    @Test("switch-project selects matching project")
+    func switchProject() async {
+        let first = Project(name: "First", path: "/tmp/first")
+        let second = Project(name: "Second", path: "/tmp/second")
+        let firstWorktree = Worktree(name: first.name, path: first.path, isPrimary: true)
+        let secondWorktree = Worktree(name: second.name, path: second.path, isPrimary: true)
+        let appState = makeAppState(projectID: first.id, worktreeID: firstWorktree.id)
+        let stores = makeStores(projects: [first, second], worktrees: [first.id: [firstWorktree], second.id: [secondWorktree]])
+
+        let result = await SocketCommandHandler.handleRequest(
+            "switch-project|Second",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(result == "ok")
+        #expect(appState.activeProjectID == second.id)
+        #expect(appState.activeWorktreeID[second.id] == secondWorktree.id)
+    }
+
+    @Test("switch-worktree selects matching worktree")
+    func switchWorktree() async {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "Feature", path: "/tmp/test-feature", branch: "feature", isPrimary: false)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+
+        let result = await SocketCommandHandler.handleRequest(
+            "switch-worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(result == "ok")
+        #expect(appState.activeWorktreeID[project.id] == feature.id)
+    }
+
+    @Test("list-tabs includes active tab")
+    func listTabs() async {
+        let appState = makeAppState()
+        appState.dispatch(.createTab(projectID: appState.activeProjectID!, areaID: nil))
+
+        let result = await SocketCommandHandler.handleRequest("list-tabs", appState: appState)
+
+        #expect(result.contains("\tterminal\t"))
+        #expect(result.contains("\ttrue"))
+    }
+
+    @Test("switch-tab selects tab by index")
+    func switchTabByIndex() async {
+        let appState = makeAppState()
+        let projectID = appState.activeProjectID!
+        appState.dispatch(.createTab(projectID: projectID, areaID: nil))
+        let area = appState.focusedArea(for: projectID)!
+        let firstTabID = area.tabs[0].id
+
+        let result = await SocketCommandHandler.handleRequest("switch-tab|0", appState: appState)
+
+        #expect(result == "ok")
+        #expect(area.activeTabID == firstTabID)
+    }
+
+    @Test("new-tab creates terminal tab")
+    func newTab() async {
+        let appState = makeAppState()
+        let projectID = appState.activeProjectID!
+        let before = appState.focusedArea(for: projectID)!.tabs.count
+
+        let result = await SocketCommandHandler.handleRequest("new-tab", appState: appState)
+
+        #expect(UUID(uuidString: result) != nil)
+        #expect(appState.focusedArea(for: projectID)!.tabs.count == before + 1)
+    }
+
     private func pane(with paneID: UUID, appState: AppState) -> TerminalPaneState? {
         for root in appState.workspaceRoots.values {
             for area in root.allAreas() {
@@ -166,12 +262,54 @@ struct SocketCommandHandlerTests {
         appState.focusedAreaID[key] = area.id
         return appState
     }
+
+    private func makeStores(
+        project: Project,
+        worktree: Worktree
+    ) -> (projectStore: ProjectStore, worktreeStore: WorktreeStore) {
+        makeStores(projects: [project], worktrees: [project.id: [worktree]])
+    }
+
+    private func makeStores(
+        projects: [Project],
+        worktrees: [UUID: [Worktree]]
+    ) -> (projectStore: ProjectStore, worktreeStore: WorktreeStore) {
+        let projectStore = ProjectStore(persistence: ProjectPersistenceSocketStub(projects: projects))
+        let worktreeStore = WorktreeStore(
+            persistence: WorktreePersistenceSocketStub(worktrees: worktrees),
+            projects: projects
+        )
+        return (projectStore, worktreeStore)
+    }
 }
 
 private final class WorkspacePersistenceStub: WorkspacePersisting {
     private var snapshots: [WorkspaceSnapshot] = []
     func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
     func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+private final class ProjectPersistenceSocketStub: ProjectPersisting {
+    private var projects: [Project]
+
+    init(projects: [Project]) {
+        self.projects = projects
+    }
+
+    func loadProjects() throws -> [Project] { projects }
+    func saveProjects(_ projects: [Project]) throws { self.projects = projects }
+}
+
+private final class WorktreePersistenceSocketStub: WorktreePersisting {
+    private var worktrees: [UUID: [Worktree]]
+
+    init(worktrees: [UUID: [Worktree]]) {
+        self.worktrees = worktrees
+    }
+
+    func loadWorktrees(projectID: UUID) throws -> [Worktree] { worktrees[projectID] ?? [] }
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws { self.worktrees[projectID] = worktrees }
+    func removeWorktrees(projectID: UUID) throws { worktrees[projectID] = nil }
 }
 
 @MainActor

--- a/docs/features/muxy-cli.md
+++ b/docs/features/muxy-cli.md
@@ -1,8 +1,8 @@
 # Muxy CLI
 
-The `muxy` command lets you open projects and control Muxy panes from a terminal or automation script.
+The `muxy` command lets you open projects and control Muxy workspaces from a terminal or automation script.
 
-Use it for quick project launching, scripted split layouts, sending input to panes, reading visible terminal output, and closing or renaming panes without switching back to the UI.
+Use it for quick project launching, switching projects or worktrees, scripted split layouts, tab navigation, sending input to panes, reading visible terminal output, and closing or renaming panes without switching back to the UI.
 
 ## Install
 
@@ -31,6 +31,71 @@ muxy ~/Developer/my-app
 ```
 
 If the project is already open, Muxy selects the existing project instead of creating a duplicate.
+
+## Project and worktree control
+
+Project and worktree commands talk to the running Muxy app through a local Unix socket. Muxy must be open.
+
+### List and switch projects
+
+List projects:
+
+```bash
+muxy list-projects
+```
+
+Output is tab-separated:
+
+```text
+<project-id>  <name>  <path>  <active>
+```
+
+Switch to a project by name, ID, or path:
+
+```bash
+muxy switch-project "My App"
+muxy switch-project ~/Developer/my-app
+```
+
+### List and switch worktrees
+
+List worktrees for the active project:
+
+```bash
+muxy list-worktrees
+```
+
+List worktrees for a specific project:
+
+```bash
+muxy list-worktrees "My App"
+```
+
+Output is tab-separated:
+
+```text
+<worktree-id>  <name>  <path>  <branch>  <active>
+```
+
+Switch to a worktree by name, ID, path, or branch:
+
+```bash
+muxy switch-worktree feature/login
+muxy switch-worktree "Feature Login"
+```
+
+Switch to a worktree in a specific project:
+
+```bash
+muxy switch-worktree "Feature Login" --project "My App"
+```
+
+Refresh worktrees from Git:
+
+```bash
+muxy refresh-worktrees
+muxy refresh-worktrees "My App"
+```
 
 ## Pane control
 
@@ -142,6 +207,44 @@ Close a pane:
 muxy close-pane --pane "$PANE"
 ```
 
+## Tab control
+
+Tab commands talk to the running Muxy app through a local Unix socket. Muxy must be open.
+
+### List tabs
+
+```bash
+muxy list-tabs
+```
+
+Output is tab-separated:
+
+```text
+<index>  <tab-id>  <kind>  <title>  <active>
+```
+
+### Switch and create tabs
+
+Switch tabs by index, ID, or title:
+
+```bash
+muxy switch-tab 0
+muxy switch-tab "Server Logs"
+```
+
+Create a new terminal tab:
+
+```bash
+muxy new-tab
+```
+
+Move through tabs:
+
+```bash
+muxy next-tab
+muxy previous-tab
+```
+
 ## Example workflow
 
 Create a small development layout:
@@ -173,6 +276,9 @@ Muxy listens on:
 
 The socket is private to your user. It does not grant extra privileges, but any process already running as your user can use it while Muxy is open to:
 
+- list and switch projects
+- list, switch, or refresh worktrees
+- list, switch, or create tabs
 - list panes
 - read visible terminal text
 - send text or supported control keys


### PR DESCRIPTION
Fixes muxy CLI hangs by newline-terminating socket requests.
Processes CLI socket frames as soon as a newline arrives.
Adds coverage to keep the CLI socket protocol framed correctly.