### PR TITLE
Add create-worktree command to Muxy CLI

### DIFF
--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -13,6 +13,7 @@
 #   muxy list-projects                       List projects
 #   muxy switch-project <name|id|path>        Switch active project
 #   muxy list-worktrees [project]             List worktrees
+#   muxy create-worktree <name> [options]     Create and switch to a worktree
 #   muxy switch-worktree <name|id|path>       Switch active worktree
 #   muxy refresh-worktrees [project]          Refresh worktrees from Git
 #   muxy list-tabs                            List tabs
@@ -206,6 +207,72 @@ case "$COMMAND" in
             send_command "list-worktrees"
         fi
         ;;
+    create-worktree)
+        shift
+        NAME=""
+        BRANCH=""
+        PROJECT=""
+        PATH_ARG=""
+        CREATE_BRANCH="true"
+        BASE_BRANCH=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                --branch)
+                    if [ $# -lt 2 ]; then
+                        echo "Usage: muxy create-worktree <name> [--branch <branch>] [--base <branch>] [--project <project>] [--path <path>] [--existing]" >&2
+                        exit 1
+                    fi
+                    BRANCH="$2"
+                    shift 2
+                    ;;
+                --base)
+                    if [ $# -lt 2 ]; then
+                        echo "Usage: muxy create-worktree <name> [--branch <branch>] [--base <branch>] [--project <project>] [--path <path>] [--existing]" >&2
+                        exit 1
+                    fi
+                    BASE_BRANCH="$2"
+                    shift 2
+                    ;;
+                --project)
+                    if [ $# -lt 2 ]; then
+                        echo "Usage: muxy create-worktree <name> [--branch <branch>] [--base <branch>] [--project <project>] [--path <path>] [--existing]" >&2
+                        exit 1
+                    fi
+                    PROJECT="$2"
+                    shift 2
+                    ;;
+                --path)
+                    if [ $# -lt 2 ]; then
+                        echo "Usage: muxy create-worktree <name> [--branch <branch>] [--base <branch>] [--project <project>] [--path <path>] [--existing]" >&2
+                        exit 1
+                    fi
+                    PATH_ARG="$2"
+                    shift 2
+                    ;;
+                --existing)
+                    CREATE_BRANCH="false"
+                    shift
+                    ;;
+                *)
+                    if [ -z "$NAME" ]; then
+                        NAME="$1"
+                    else
+                        echo "Usage: muxy create-worktree <name> [--branch <branch>] [--base <branch>] [--project <project>] [--path <path>] [--existing]" >&2
+                        exit 1
+                    fi
+                    shift
+                    ;;
+            esac
+        done
+        if [ -z "$NAME" ]; then
+            echo "Usage: muxy create-worktree <name> [--branch <branch>] [--base <branch>] [--project <project>] [--path <path>] [--existing]" >&2
+            exit 1
+        fi
+        if [ -z "$BRANCH" ]; then
+            BRANCH="$NAME"
+        fi
+        send_command "create-worktree|$NAME|$BRANCH|$PROJECT|$PATH_ARG|$CREATE_BRANCH|$BASE_BRANCH"
+        ;;
     switch-worktree)
         shift
         PROJECT=""
@@ -277,6 +344,7 @@ case "$COMMAND" in
         echo "  muxy list-projects                       List projects"
         echo "  muxy switch-project <name|id|path>        Switch active project"
         echo "  muxy list-worktrees [project]             List worktrees"
+        echo "  muxy create-worktree <name> [options]     Create and switch to a worktree"
         echo "  muxy switch-worktree <name|id|path>       Switch active worktree"
         echo "  muxy refresh-worktrees [project]          Refresh worktrees from Git"
         echo "  muxy list-tabs                            List tabs"
@@ -293,7 +361,8 @@ if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "spli
    [ "$COMMAND" != "send" ] && [ "$COMMAND" != "send-keys" ] && [ "$COMMAND" != "read-screen" ] && \
    [ "$COMMAND" != "close-pane" ] && [ "$COMMAND" != "rename-pane" ] && [ "$COMMAND" != "list-panes" ] && \
    [ "$COMMAND" != "list-projects" ] && [ "$COMMAND" != "switch-project" ] && \
-   [ "$COMMAND" != "list-worktrees" ] && [ "$COMMAND" != "switch-worktree" ] && \
+    [ "$COMMAND" != "list-worktrees" ] && [ "$COMMAND" != "create-worktree" ] && \
+    [ "$COMMAND" != "switch-worktree" ] && \
    [ "$COMMAND" != "refresh-worktrees" ] && [ "$COMMAND" != "list-tabs" ] && \
    [ "$COMMAND" != "switch-tab" ] && [ "$COMMAND" != "new-tab" ] && \
    [ "$COMMAND" != "next-tab" ] && [ "$COMMAND" != "previous-tab" ]; then

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -100,7 +100,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private static let commandNames = [
         "split-right", "split-down", "send", "send-keys",
         "read-screen", "close-pane", "rename-pane", "list-panes",
-        "list-projects", "switch-project", "list-worktrees", "switch-worktree", "refresh-worktrees",
+        "list-projects", "switch-project", "list-worktrees", "create-worktree", "switch-worktree", "refresh-worktrees",
         "list-tabs", "switch-tab", "new-tab", "next-tab", "previous-tab",
     ]
 

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -62,6 +62,14 @@ enum SocketCommandHandler {
                 projectStore: projectStore,
                 worktreeStore: worktreeStore
             )
+        case "create-worktree":
+            guard let projectStore, let worktreeStore else { return "error:worktree store unavailable" }
+            return await handleCreateWorktree(
+                arguments: Array(parts.dropFirst()),
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
         case "switch-worktree":
             guard parts.count >= 2 else { return "error:usage switch-worktree|name-or-id-or-path[|project]" }
             guard let projectStore, let worktreeStore else { return "error:worktree store unavailable" }
@@ -320,6 +328,54 @@ enum SocketCommandHandler {
         return "ok"
     }
 
+    private static func handleCreateWorktree(
+        arguments: [String],
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) async -> String {
+        guard arguments.count >= 2 else {
+            return "error:usage create-worktree|name|branch[|project][|path][|createBranch][|baseBranch]"
+        }
+        let name = arguments[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = arguments[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        let projectIdentifier = arguments.count >= 3 ? arguments[2] : nil
+        let requestedPath = arguments.count >= 4 ? arguments[3].trimmingCharacters(in: .whitespacesAndNewlines) : ""
+        let createBranch = arguments.count >= 5 ? arguments[4] != "false" : true
+        let baseBranch = arguments.count >= 6 ? arguments[5].trimmingCharacters(in: .whitespacesAndNewlines) : ""
+
+        guard !name.isEmpty, !branch.isEmpty else {
+            return "error:name and branch are required"
+        }
+        guard let project = resolveProject(projectIdentifier, appState: appState, projectStore: projectStore) else {
+            return "error:project not found"
+        }
+
+        let path = requestedPath.isEmpty
+            ? WorktreeLocationResolver.worktreeDirectory(for: project, slug: slug(from: name))
+            : NSString(string: requestedPath).expandingTildeInPath
+        guard !FileManager.default.fileExists(atPath: path) else {
+            return "error:worktree path already exists"
+        }
+
+        do {
+            let worktree = try await worktreeStore.createWorktree(
+                project: project,
+                request: WorktreeCreationRequest(
+                    name: name,
+                    path: path,
+                    branch: branch,
+                    createBranch: createBranch,
+                    baseBranch: createBranch && !baseBranch.isEmpty ? baseBranch : nil
+                )
+            )
+            appState.selectWorktree(projectID: project.id, worktree: worktree)
+            return "ok\t\(worktree.id.uuidString)\t\(worktree.name)\t\(worktree.path)\t\(worktree.branch ?? "")"
+        } catch {
+            return "error:\(error.localizedDescription)"
+        }
+    }
+
     private static func handleRefreshWorktrees(
         projectIdentifier: String?,
         appState: AppState,
@@ -420,6 +476,15 @@ enum SocketCommandHandler {
                 || worktree.branch?.localizedCaseInsensitiveCompare(identifier) == .orderedSame
                 || URL(fileURLWithPath: worktree.path).standardizedFileURL.path == standardizedPath
         }
+    }
+
+    private static func slug(from name: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = name.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let collapsed = String(scalars)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+        return collapsed.isEmpty ? UUID().uuidString : collapsed
     }
 
     private static func tabMatches(_ tab: TerminalTab, identifier: String) -> Bool {

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -3,6 +3,14 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "WorktreeStore")
 
+struct WorktreeCreationRequest {
+    let name: String
+    let path: String
+    let branch: String
+    let createBranch: Bool
+    let baseBranch: String?
+}
+
 @MainActor
 @Observable
 final class WorktreeStore {
@@ -10,16 +18,27 @@ final class WorktreeStore {
     private var projectIDByPath: [String: UUID] = [:]
     private let persistence: any WorktreePersisting
     private let listGitWorktrees: @Sendable (String) async throws -> [GitWorktreeRecord]
+    private let addGitWorktree: @Sendable (String, String, String, Bool, String?) async throws -> Void
 
     init(
         persistence: any WorktreePersisting,
         listGitWorktrees: @escaping @Sendable (String) async throws -> [GitWorktreeRecord] = {
             try await GitWorktreeService.shared.listWorktrees(repoPath: $0)
         },
+        addGitWorktree: @escaping @Sendable (String, String, String, Bool, String?) async throws -> Void = {
+            try await GitWorktreeService.shared.addWorktree(
+                repoPath: $0,
+                path: $1,
+                branch: $2,
+                createBranch: $3,
+                baseBranch: $4
+            )
+        },
         projects: [Project] = []
     ) {
         self.persistence = persistence
         self.listGitWorktrees = listGitWorktrees
+        self.addGitWorktree = addGitWorktree
         guard !projects.isEmpty else { return }
         loadAll(projects: projects)
     }
@@ -77,6 +96,30 @@ final class WorktreeStore {
         list.append(worktree)
         setWorktrees(sortPrimaryFirst(list), for: projectID)
         save(projectID: projectID)
+    }
+
+    func createWorktree(
+        project: Project,
+        request: WorktreeCreationRequest
+    ) async throws -> Worktree {
+        try await GitProcessRunner.offMainThrowing {
+            try FileManager.default.createDirectory(
+                atPath: URL(fileURLWithPath: request.path).deletingLastPathComponent().path,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
+
+        try await addGitWorktree(project.path, request.path, request.branch, request.createBranch, request.baseBranch)
+        let worktree = Worktree(
+            name: request.name,
+            path: request.path,
+            branch: request.branch,
+            ownsBranch: request.createBranch,
+            isPrimary: false
+        )
+        add(worktree, to: project.id)
+        return worktree
     }
 
     func remove(worktreeID: UUID, from projectID: UUID) {

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -197,6 +197,38 @@ struct SocketCommandHandlerTests {
         #expect(appState.activeWorktreeID[project.id] == feature.id)
     }
 
+    @Test("create-worktree creates and selects worktree")
+    func createWorktree() async throws {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let createdPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-test-worktree-")
+            .appendingPathComponent(UUID().uuidString)
+            .path
+        let stores = makeStores(
+            projects: [project],
+            worktrees: [project.id: [primary]],
+            addGitWorktree: { _, _, _, _, _ in }
+        )
+
+        let result = await SocketCommandHandler.handleRequest(
+            "create-worktree|Feature|feature|\(project.name)|\(createdPath)|true|main",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        let fields = result.components(separatedBy: "\t")
+        #expect(fields.first == "ok")
+        #expect(fields.count == 5)
+        let worktree = try #require(stores.worktreeStore.list(for: project.id).first { $0.name == "Feature" })
+        #expect(worktree.branch == "feature")
+        #expect(worktree.path == createdPath)
+        #expect(worktree.ownsBranch)
+        #expect(appState.activeWorktreeID[project.id] == worktree.id)
+    }
+
     @Test("list-tabs includes active tab")
     func listTabs() async {
         let appState = makeAppState()
@@ -281,11 +313,13 @@ struct SocketCommandHandlerTests {
 
     private func makeStores(
         projects: [Project],
-        worktrees: [UUID: [Worktree]]
+        worktrees: [UUID: [Worktree]],
+        addGitWorktree: @escaping @Sendable (String, String, String, Bool, String?) async throws -> Void = { _, _, _, _, _ in }
     ) -> (projectStore: ProjectStore, worktreeStore: WorktreeStore) {
         let projectStore = ProjectStore(persistence: ProjectPersistenceSocketStub(projects: projects))
         let worktreeStore = WorktreeStore(
             persistence: WorktreePersistenceSocketStub(worktrees: worktrees),
+            addGitWorktree: addGitWorktree,
             projects: projects
         )
         return (projectStore, worktreeStore)


### PR DESCRIPTION
Adds `muxy create-worktree` with branch, base, project, path, and existing-branch options.
Routes creation through the socket handler and WorktreeStore so CLI-created worktrees are persisted and selected.
Includes unit coverage and passes `scripts/checks.sh --fix`.