### PR TITLE
feat: add Pi usage tracking from local session files

### DIFF
--- a/Muxy/Resources/ProviderIcons/pi.svg
+++ b/Muxy/Resources/ProviderIcons/pi.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="100" viewBox="0 0 800 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29V165.29ZM282.65 282.65V400H400V282.65H282.65Z" fill="currentColor"/>
+<path d="M517.36 400H634.72V634.72H517.36V400Z" fill="currentColor"/>
+</svg>

--- a/Muxy/Services/PiUsageParser.swift
+++ b/Muxy/Services/PiUsageParser.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+enum PiUsageParser {
+    struct DailyUsage: Equatable {
+        let cost: Double
+        let inputTokens: Double
+        let outputTokens: Double
+        let totalTokens: Double
+    }
+
+    static func parseDailyUsage(
+        from sessionDirectory: String,
+        calendar: Calendar = .current,
+        now: Date = Date()
+    ) -> DailyUsage {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: URL(fileURLWithPath: sessionDirectory, isDirectory: true),
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )
+        else {
+            return DailyUsage(cost: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0)
+        }
+
+        var totalCost: Double = 0
+        var totalInput: Double = 0
+        var totalOutput: Double = 0
+        var totalTokens: Double = 0
+
+        for case let fileURL as URL in enumerator {
+            guard fileURL.pathExtension == "jsonl" else { continue }
+
+            guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]),
+                  let modDate = values.contentModificationDate,
+                  calendar.isDate(modDate, inSameDayAs: now)
+            else {
+                continue
+            }
+
+            guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+
+            content.enumerateLines { line, _ in
+                guard let data = line.data(using: .utf8),
+                      let entry = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      entry["type"] as? String == "message",
+                      let message = entry["message"] as? [String: Any],
+                      message["role"] as? String == "assistant",
+                      let usage = message["usage"] as? [String: Any]
+                else {
+                    return
+                }
+
+                if let cost = usage["cost"] as? [String: Any] {
+                    totalCost += cost["total"] as? Double ?? 0
+                }
+
+                totalInput += usage["input"] as? Double ?? 0
+                totalOutput += usage["output"] as? Double ?? 0
+                totalTokens += usage["totalTokens"] as? Double ?? 0
+            }
+        }
+
+        return DailyUsage(
+            cost: totalCost,
+            inputTokens: totalInput,
+            outputTokens: totalOutput,
+            totalTokens: totalTokens
+        )
+    }
+
+    static func buildMetricRows(
+        from usage: DailyUsage,
+        now: Date = Date()
+    ) -> [AIUsageMetricRow] {
+        var rows: [AIUsageMetricRow] = []
+
+        let resetDate = Calendar.current.nextDate(
+            after: now,
+            matching: DateComponents(hour: 0, minute: 0, second: 0),
+            matchingPolicy: .nextTime
+        )
+
+        if usage.cost > 0 {
+            rows.append(
+                AIUsageMetricRow(
+                    label: "Daily cost",
+                    percent: nil,
+                    resetDate: resetDate,
+                    detail: AIUsageParserSupport.currencyDetail(amount: usage.cost)
+                )
+            )
+        }
+
+        if usage.totalTokens > 0 {
+            let formatted = AIUsageParserSupport.formatNumber(usage.totalTokens)
+            rows.append(
+                AIUsageMetricRow(
+                    label: "Daily tokens",
+                    percent: nil,
+                    resetDate: resetDate,
+                    detail: "\(formatted) tokens"
+                )
+            )
+        }
+
+        return rows
+    }
+}

--- a/Muxy/Services/Providers/PiProvider.swift
+++ b/Muxy/Services/Providers/PiProvider.swift
@@ -16,17 +16,27 @@ struct PiProvider: AIProviderIntegration, AIUsageProvider {
     private let homeDirectory: String
     private let pathEnvironment: String
     private let resourceURL: @Sendable (String, String) -> URL?
+    private let sessionDirectory: String
 
     init(
         homeDirectory: String = NSHomeDirectory(),
         pathEnvironment: String = ProcessInfo.processInfo.environment["PATH"] ?? "",
         resourceURL: @escaping @Sendable (String, String) -> URL? = { name, ext in
             Bundle.appResources.url(forResource: name, withExtension: ext)
-        }
+        },
+        sessionDirectory: String? = nil
     ) {
         self.homeDirectory = homeDirectory
         self.pathEnvironment = pathEnvironment
         self.resourceURL = resourceURL
+        self.sessionDirectory = sessionDirectory ?? {
+            let envDir = ProcessInfo.processInfo.environment["PI_CODING_AGENT_DIR"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if let envDir, !envDir.isEmpty {
+                return envDir + "/sessions"
+            }
+            return homeDirectory + "/.pi/agent/sessions"
+        }()
     }
 
     private var extensionsDir: String { homeDirectory + "/.pi/agent/extensions" }
@@ -133,6 +143,23 @@ struct PiProvider: AIProviderIntegration, AIUsageProvider {
             [.posixPermissions: FilePermissions.privateFile],
             ofItemAtPath: settingsPath
         )
+    }
+
+    func fetchUsageSnapshot() async -> AIProviderUsageSnapshot {
+        let fm = FileManager.default
+
+        guard fm.fileExists(atPath: sessionDirectory) else {
+            return snapshot(state: .unavailable(message: "Open Pi to see usage"))
+        }
+
+        let usage = PiUsageParser.parseDailyUsage(from: sessionDirectory)
+        let rows = PiUsageParser.buildMetricRows(from: usage)
+
+        guard !rows.isEmpty else {
+            return snapshot(state: .unavailable(message: "No usage today"))
+        }
+
+        return snapshot(state: .available, rows: rows)
     }
 }
 

--- a/Tests/MuxyTests/Services/PiProviderTests.swift
+++ b/Tests/MuxyTests/Services/PiProviderTests.swift
@@ -158,6 +158,62 @@ struct PiProviderTests {
         #expect(fixture.provider(pathEnvironment: binURL.path).isToolInstalled())
     }
 
+    @Test("fetchUsageSnapshot returns unavailable when session directory does not exist")
+    func fetchUsageSnapshotNoDirectory() async {
+        let provider = PiProvider(
+            homeDirectory: "/nonexistent-home-\(UUID().uuidString)",
+            pathEnvironment: "",
+            resourceURL: { _, _ in nil },
+            sessionDirectory: "/nonexistent-sessions-\(UUID().uuidString)"
+        )
+
+        let snapshot = await provider.fetchUsageSnapshot()
+        #expect(snapshot.state == .unavailable(message: "Open Pi to see usage"))
+    }
+
+    @Test("fetchUsageSnapshot returns unavailable when no usage today")
+    func fetchUsageSnapshotNoUsage() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        let sessionsDir = fixture.homeURL.appendingPathComponent(".pi/agent/sessions")
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+        let provider = fixture.provider()
+        let snapshot = await provider.fetchUsageSnapshot()
+        #expect(snapshot.state == .unavailable(message: "No usage today"))
+    }
+
+    @Test("fetchUsageSnapshot returns available with usage rows")
+    func fetchUsageSnapshotWithUsage() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        let sessionsDir = fixture.homeURL.appendingPathComponent(".pi/agent/sessions")
+        let projectDir = sessionsDir.appendingPathComponent("project", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let sessionJSONL = """
+        {"type":"session","version":3,"id":"abc","timestamp":"2026-01-01T00:00:00Z","cwd":"/project"}
+        {"type":"message","id":"m1","parentId":null,"timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input":100,"output":200,"cacheRead":0,"cacheWrite":0,"totalTokens":300,"cost":{"input":0.001,"output":0.003,"cacheRead":0,"cacheWrite":0,"total":0.004}},"stopReason":"stop"}}
+        """
+        try Data(sessionJSONL.utf8).write(
+            to: projectDir.appendingPathComponent("session.jsonl"),
+            options: .atomic
+        )
+
+        let provider = fixture.provider()
+        let snapshot = await provider.fetchUsageSnapshot()
+
+        guard case .available = snapshot.state else {
+            Issue.record("Expected available state, got \(snapshot.state)")
+            return
+        }
+        #expect(snapshot.rows.count == 2)
+        #expect(snapshot.rows[0].label == "Daily cost")
+        #expect(snapshot.rows[1].label == "Daily tokens")
+    }
+
     @Test("install throws when resource is missing")
     func installThrowsWhenResourceMissing() throws {
         let fixture = try Fixture()
@@ -166,7 +222,8 @@ struct PiProviderTests {
         let provider = PiProvider(
             homeDirectory: fixture.homeURL.path,
             pathEnvironment: "",
-            resourceURL: { _, _ in nil }
+            resourceURL: { _, _ in nil },
+            sessionDirectory: fixture.homeURL.appendingPathComponent(".pi/agent/sessions").path
         )
 
         #expect(throws: PiProviderError.bundleResourceNotFound) {
@@ -203,7 +260,8 @@ struct PiProviderTests {
             PiProvider(
                 homeDirectory: homeURL.path,
                 pathEnvironment: pathEnvironment,
-                resourceURL: { _, _ in sourceURL }
+                resourceURL: { _, _ in sourceURL },
+                sessionDirectory: homeURL.appendingPathComponent(".pi/agent/sessions").path
             )
         }
 

--- a/Tests/MuxyTests/Services/PiUsageParserTests.swift
+++ b/Tests/MuxyTests/Services/PiUsageParserTests.swift
@@ -1,0 +1,244 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("PiUsageParser")
+struct PiUsageParserTests {
+    @Test("parses daily usage from session files")
+    func parsesDailyUsage() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSession(lines: [
+            fixture.headerLine(cwd: "/project"),
+            fixture.assistantLine(cost: 0.01, input: 100, output: 200, totalTokens: 300),
+            fixture.assistantLine(cost: 0.02, input: 150, output: 250, totalTokens: 400),
+        ])
+
+        let usage = PiUsageParser.parseDailyUsage(
+            from: fixture.sessionsDirectoryPath,
+            calendar: fixture.calendar,
+            now: fixture.now
+        )
+
+        #expect(usage.cost == 0.03)
+        #expect(usage.inputTokens == 250)
+        #expect(usage.outputTokens == 450)
+        #expect(usage.totalTokens == 700)
+    }
+
+    @Test("ignores non-assistant messages")
+    func ignoresNonAssistantMessages() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSession(lines: [
+            fixture.headerLine(cwd: "/project"),
+            fixture.userLine(text: "Hello"),
+            fixture.toolResultLine(toolName: "bash"),
+        ])
+
+        let usage = PiUsageParser.parseDailyUsage(
+            from: fixture.sessionsDirectoryPath,
+            calendar: fixture.calendar,
+            now: fixture.now
+        )
+
+        #expect(usage.cost == 0)
+        #expect(usage.totalTokens == 0)
+    }
+
+    @Test("skips files not modified today")
+    func skipsOldFiles() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSession(lines: [
+            fixture.headerLine(cwd: "/project"),
+            fixture.assistantLine(cost: 0.05, input: 500, output: 500, totalTokens: 1000),
+        ])
+
+        let yesterday = fixture.calendar.date(byAdding: .day, value: -1, to: fixture.now)!
+        let usage = PiUsageParser.parseDailyUsage(
+            from: fixture.sessionsDirectoryPath,
+            calendar: fixture.calendar,
+            now: yesterday
+        )
+
+        #expect(usage.cost == 0)
+        #expect(usage.totalTokens == 0)
+    }
+
+    @Test("returns zero usage for empty directory")
+    func emptyDirectory() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        let usage = PiUsageParser.parseDailyUsage(
+            from: fixture.sessionsDirectoryPath,
+            calendar: fixture.calendar,
+            now: fixture.now
+        )
+
+        #expect(usage.cost == 0)
+        #expect(usage.totalTokens == 0)
+    }
+
+    @Test("returns zero usage for nonexistent directory")
+    func nonexistentDirectory() {
+        let usage = PiUsageParser.parseDailyUsage(
+            from: "/nonexistent/path/sessions"
+        )
+
+        #expect(usage.cost == 0)
+        #expect(usage.totalTokens == 0)
+    }
+
+    @Test("aggregates across multiple session files")
+    func aggregatesMultipleFiles() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeSession(
+            inSubdirectory: "project-a",
+            fileName: "session-a.jsonl",
+            lines: [
+                fixture.headerLine(cwd: "/project-a"),
+                fixture.assistantLine(cost: 0.01, input: 100, output: 100, totalTokens: 200),
+            ]
+        )
+
+        try fixture.writeSession(
+            inSubdirectory: "project-b",
+            fileName: "session-b.jsonl",
+            lines: [
+                fixture.headerLine(cwd: "/project-b"),
+                fixture.assistantLine(cost: 0.02, input: 200, output: 200, totalTokens: 400),
+            ]
+        )
+
+        let usage = PiUsageParser.parseDailyUsage(
+            from: fixture.sessionsDirectoryPath,
+            calendar: fixture.calendar,
+            now: fixture.now
+        )
+
+        #expect(usage.cost == 0.03)
+        #expect(usage.totalTokens == 600)
+    }
+
+    @Test("buildMetricRows creates daily cost row when cost > 0")
+    func costRow() {
+        let usage = PiUsageParser.DailyUsage(
+            cost: 1.23,
+            inputTokens: 1000,
+            outputTokens: 500,
+            totalTokens: 1500
+        )
+
+        let rows = PiUsageParser.buildMetricRows(from: usage)
+
+        #expect(rows.count == 2)
+        #expect(rows[0].label == "Daily cost")
+        #expect(rows[0].detail == "US$1.23")
+        #expect(rows[0].resetDate != nil)
+        #expect(rows[1].label == "Daily tokens")
+        #expect(rows[1].detail == "1500 tokens")
+    }
+
+    @Test("buildMetricRows returns empty when no usage")
+    func noUsageRows() {
+        let usage = PiUsageParser.DailyUsage(
+            cost: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0
+        )
+
+        let rows = PiUsageParser.buildMetricRows(from: usage)
+        #expect(rows.isEmpty)
+    }
+
+    @Test("buildMetricRows includes only cost row when tokens are zero")
+    func costOnlyRow() {
+        let usage = PiUsageParser.DailyUsage(
+            cost: 0.50,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0
+        )
+
+        let rows = PiUsageParser.buildMetricRows(from: usage)
+        #expect(rows.count == 1)
+        #expect(rows[0].label == "Daily cost")
+    }
+
+    private struct Fixture {
+        let rootURL: URL
+        let sessionsDirectoryURL: URL
+        let sessionsDirectoryPath: String
+        let calendar: Calendar
+        let now: Date
+
+        init() throws {
+            rootURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("PiUsageParserTests-\(UUID().uuidString)", isDirectory: true)
+            sessionsDirectoryURL = rootURL.appendingPathComponent("sessions", isDirectory: true)
+            sessionsDirectoryPath = sessionsDirectoryURL.path
+            calendar = Calendar(identifier: .gregorian)
+            now = Date()
+
+            try FileManager.default.createDirectory(
+                at: sessionsDirectoryURL,
+                withIntermediateDirectories: true
+            )
+        }
+
+        func writeSession(
+            inSubdirectory subdirectory: String? = nil,
+            fileName: String = "session.jsonl",
+            lines: [String]
+        ) throws {
+            let dirURL: URL
+            if let subdirectory {
+                dirURL = sessionsDirectoryURL.appendingPathComponent(subdirectory, isDirectory: true)
+                try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+            } else {
+                dirURL = sessionsDirectoryURL
+            }
+
+            let fileURL = dirURL.appendingPathComponent(fileName)
+            let content = lines.joined(separator: "\n")
+            try Data(content.utf8).write(to: fileURL, options: .atomic)
+        }
+
+        func headerLine(cwd: String) -> String {
+            """
+            {"type":"session","version":3,"id":"\(UUID().uuidString)","timestamp":"\(ISO8601DateFormatter().string(from: now))","cwd":"\(cwd)"}
+            """
+        }
+
+        func assistantLine(cost: Double, input: Int, output: Int, totalTokens: Int) -> String {
+            """
+            {"type":"message","id":"\(UUID().uuidString)","parentId":null,"timestamp":"\(ISO8601DateFormatter().string(from: now))","message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"usage":{"input":\(input),"output":\(output),"cacheRead":0,"cacheWrite":0,"totalTokens":\(totalTokens),"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":\(cost)}},"stopReason":"stop"}}
+            """
+        }
+
+        func userLine(text: String) -> String {
+            """
+            {"type":"message","id":"\(UUID().uuidString)","parentId":null,"timestamp":"\(ISO8601DateFormatter().string(from: now))","message":{"role":"user","content":"\(text)"}}
+            """
+        }
+
+        func toolResultLine(toolName: String) -> String {
+            """
+            {"type":"message","id":"\(UUID().uuidString)","parentId":null,"timestamp":"\(ISO8601DateFormatter().string(from: now))","message":{"role":"toolResult","toolCallId":"call_1","toolName":"\(toolName)","content":[{"type":"text","text":"output"}],"isError":false}}
+            """
+        }
+
+        func cleanUp() {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add usage tracking to PiProvider. Pi already had notification integration via a TypeScript extension; this adds the `fetchUsageSnapshot()` side so Pi appears in the usage dashboard.

## Changes

- Add `PiUsageParser` — scans `~/.pi/agent/sessions/` for `.jsonl` files modified today, extracts `usage.cost.total`, `usage.input`, `usage.output`, `usage.totalTokens` from assistant messages, aggregates into daily totals
- Implement `PiProvider.fetchUsageSnapshot()` — returns "Daily cost" (currency) and "Daily tokens" rows with midnight reset dates, or appropriate unavailable states
- Add `pi.svg` provider icon (official pi logo, `currentColor`-themed)
- Add `sessionDirectory` init parameter (reads `PI_CODING_AGENT_DIR` env var, defaults to `~/.pi/agent/sessions`)
- Add 12 new tests (9 for PiUsageParser, 3 for PiProvider.fetchUsageSnapshot)

### Existing Pi integration (not changed in this PR)

PiProvider already implements `AIProviderIntegration` for notifications. It installs a TypeScript extension (`muxy-pi-extension.ts`) into `~/.pi/agent/extensions/` and registers it in `~/.pi/agent/settings.json`. The extension listens for `agent_end` events and sends the last assistant message text to Muxy over a Unix socket.

## Testing

- [x] `swiftformat --lint .` passes
- [x] `swiftlint lint --strict` passes
- [x] `swift build` succeeds
- [x] `swift test` — all 27 Pi-related tests pass (1089 total, 1 pre-existing flaky failure in TextSearchServiceTests unrelated to this change)
- [ ] Tested manually on macOS