### PR TITLE
Improve scroll handling in code editor

### DIFF
--- a/Muxy/Views/Editor/CodeEditorRepresentable.swift
+++ b/Muxy/Views/Editor/CodeEditorRepresentable.swift
@@ -178,7 +178,7 @@ private final class CodeEditorScrollView: NSScrollView {
     }
 
     private func shouldForwardScrollWheel(_ event: NSEvent) -> Bool {
-        event.scrollingDeltaX == 0 && !event.modifierFlags.contains(.shift)
+        abs(event.scrollingDeltaY) >= abs(event.scrollingDeltaX) && !event.modifierFlags.contains(.shift)
     }
 }
 


### PR DESCRIPTION
- Treat horizontal-dominant trackpad gestures as editor navigation instead of forwarding them to the surrounding scroll view.
- Preserve vertical scrolling behavior while avoiding accidental parent scrolling during code editing.
- Risk: users with unusual input devices may see different scroll forwarding thresholds.