### PR TITLE
Run teardown commands before removing worktrees

### DIFF
--- a/Muxy/Models/WorktreeConfig.swift
+++ b/Muxy/Models/WorktreeConfig.swift
@@ -12,26 +12,35 @@ struct WorktreeConfig: Codable {
     }
 
     let setup: [SetupCommand]
+    let teardown: [SetupCommand]
 
     private enum CodingKeys: String, CodingKey {
         case setup
+        case teardown
     }
 
-    init(setup: [SetupCommand]) {
+    init(setup: [SetupCommand], teardown: [SetupCommand] = []) {
         self.setup = setup
+        self.teardown = teardown
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let objectEntries = try? container.decode([SetupCommand].self, forKey: .setup) {
-            setup = objectEntries
-            return
+        setup = Self.decodeCommands(from: container, forKey: .setup)
+        teardown = Self.decodeCommands(from: container, forKey: .teardown)
+    }
+
+    private static func decodeCommands(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> [SetupCommand] {
+        if let objectEntries = try? container.decode([SetupCommand].self, forKey: key) {
+            return objectEntries
         }
-        if let stringEntries = try? container.decode([String].self, forKey: .setup) {
-            setup = stringEntries.map { SetupCommand(command: $0) }
-            return
+        if let stringEntries = try? container.decode([String].self, forKey: key) {
+            return stringEntries.map { SetupCommand(command: $0) }
         }
-        setup = []
+        return []
     }
 
     static func load(fromProjectPath projectPath: String) -> WorktreeConfig? {

--- a/Muxy/Models/WorktreeConfig.swift
+++ b/Muxy/Models/WorktreeConfig.swift
@@ -34,14 +34,23 @@ struct WorktreeConfig: Codable {
         from container: KeyedDecodingContainer<CodingKeys>,
         forKey key: CodingKeys
     ) -> [SetupCommand] {
-        if let objectEntries = try? container.decode([SetupCommand].self, forKey: key) {
-            return objectEntries
+        guard var array = try? container.nestedUnkeyedContainer(forKey: key) else { return [] }
+        var commands: [SetupCommand] = []
+        while !array.isAtEnd {
+            if let command = try? array.decode(SetupCommand.self) {
+                commands.append(command)
+                continue
+            }
+            if let string = try? array.decode(String.self) {
+                commands.append(SetupCommand(command: string))
+                continue
+            }
+            _ = try? array.decode(EmptyEntry.self)
         }
-        if let stringEntries = try? container.decode([String].self, forKey: key) {
-            return stringEntries.map { SetupCommand(command: $0) }
-        }
-        return []
+        return commands
     }
+
+    private struct EmptyEntry: Decodable {}
 
     static func load(fromProjectPath projectPath: String) -> WorktreeConfig? {
         let url = URL(fileURLWithPath: projectPath)

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -98,17 +98,23 @@ struct MuxyApp: App {
                     }
                     appState.onProjectsEmptied = { [projectStore, worktreeStore] projectIDs in
                         for id in projectIDs {
-                            if let project = projectStore.projects.first(where: { $0.id == id }) {
-                                let knownWorktrees = worktreeStore.list(for: id)
-                                Task.detached {
-                                    await WorktreeStore.cleanupOnDisk(
+                            guard let project = projectStore.projects.first(where: { $0.id == id }) else {
+                                worktreeStore.removeProject(id)
+                                continue
+                            }
+                            let knownWorktrees = worktreeStore.list(for: id)
+                            Task {
+                                do {
+                                    try await WorktreeStore.cleanupOnDisk(
                                         for: project,
                                         knownWorktrees: knownWorktrees
                                     )
+                                    projectStore.remove(id: id)
+                                    worktreeStore.removeProject(id)
+                                } catch {
+                                    ToastState.shared.show("Could not remove \(project.name): \(error.localizedDescription)")
                                 }
                             }
-                            projectStore.remove(id: id)
-                            worktreeStore.removeProject(id)
                         }
                     }
                     projectStore.onProjectRemoved = { [projectGroupStore] projectID in

--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -48,6 +48,7 @@ enum GitProcessRunner {
         let executable: String
         let arguments: [String]
         let workingDirectory: String?
+        let environment: [String: String]?
         let lineLimit: Int?
         let signpostName: StaticString
     }
@@ -62,6 +63,7 @@ enum GitProcessRunner {
                 executable: "/usr/bin/env",
                 arguments: ["git"] + gitHubCredentialHelperArgs() + ["-C", repoPath] + arguments,
                 workingDirectory: nil,
+                environment: nil,
                 lineLimit: lineLimit,
                 signpostName: "git"
             )
@@ -79,13 +81,15 @@ enum GitProcessRunner {
     static func runCommand(
         executable: String,
         arguments: [String],
-        workingDirectory: String
+        workingDirectory: String,
+        environment: [String: String]? = nil
     ) async throws -> GitProcessResult {
         try await runProcess(
             ProcessSpec(
                 executable: executable,
                 arguments: arguments,
                 workingDirectory: workingDirectory,
+                environment: environment,
                 lineLimit: nil,
                 signpostName: "command"
             )
@@ -151,6 +155,9 @@ enum GitProcessRunner {
 
         var environment = ProcessInfo.processInfo.environment
         environment["GIT_OPTIONAL_LOCKS"] = "0"
+        if let specEnvironment = spec.environment {
+            environment.merge(specEnvironment) { _, new in new }
+        }
         process.environment = environment
 
         if let workingDirectory = spec.workingDirectory {

--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -48,7 +48,6 @@ enum GitProcessRunner {
         let executable: String
         let arguments: [String]
         let workingDirectory: String?
-        let environment: [String: String]?
         let lineLimit: Int?
         let signpostName: StaticString
     }
@@ -63,7 +62,6 @@ enum GitProcessRunner {
                 executable: "/usr/bin/env",
                 arguments: ["git"] + gitHubCredentialHelperArgs() + ["-C", repoPath] + arguments,
                 workingDirectory: nil,
-                environment: nil,
                 lineLimit: lineLimit,
                 signpostName: "git"
             )
@@ -81,15 +79,13 @@ enum GitProcessRunner {
     static func runCommand(
         executable: String,
         arguments: [String],
-        workingDirectory: String,
-        environment: [String: String]? = nil
+        workingDirectory: String
     ) async throws -> GitProcessResult {
         try await runProcess(
             ProcessSpec(
                 executable: executable,
                 arguments: arguments,
                 workingDirectory: workingDirectory,
-                environment: environment,
                 lineLimit: nil,
                 signpostName: "command"
             )
@@ -155,9 +151,6 @@ enum GitProcessRunner {
 
         var environment = ProcessInfo.processInfo.environment
         environment["GIT_OPTIONAL_LOCKS"] = "0"
-        if let specEnvironment = spec.environment {
-            environment.merge(specEnvironment) { _, new in new }
-        }
         process.environment = environment
 
         if let workingDirectory = spec.workingDirectory {

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -649,7 +649,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             throw RemoteVCSError.invalidInput("The primary worktree cannot be removed.")
         }
 
-        await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: project.path)
+        try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: project.path)
         worktreeStore.remove(worktreeID: worktreeID, from: projectID)
     }
 

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -649,7 +649,13 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
             throw RemoteVCSError.invalidInput("The primary worktree cannot be removed.")
         }
 
-        try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: project.path)
+        try await WorktreeStore.cleanupOnDisk(
+            worktree: worktree,
+            repoPath: project.path,
+            teardownEmit: { line in
+                logger.error("[teardown \(worktreeID)] \(line.text)")
+            }
+        )
         worktreeStore.remove(worktreeID: worktreeID, from: projectID)
     }
 

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -160,17 +160,14 @@ final class WorktreeStore {
     static func cleanupOnDisk(
         worktree: Worktree,
         repoPath: String
-    ) async {
+    ) async throws {
         guard worktree.canBeRemoved else { return }
-        do {
-            try await GitWorktreeService.shared.removeWorktree(
-                repoPath: repoPath,
-                path: worktree.path,
-                force: true
-            )
-        } catch {
-            logger.error("Failed to remove git worktree at \(worktree.path): \(error)")
-        }
+        try await WorktreeTeardownRunner.run(sourceProjectPath: repoPath, worktree: worktree)
+        try await GitWorktreeService.shared.removeWorktree(
+            repoPath: repoPath,
+            path: worktree.path,
+            force: true
+        )
 
         if worktree.ownsBranch,
            let branch = worktree.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -191,7 +188,11 @@ final class WorktreeStore {
     static func cleanupOnDisk(for project: Project, knownWorktrees: [Worktree]) async {
         let secondaryWorktrees = knownWorktrees.filter { $0.canBeRemoved && !$0.isExternallyManaged }
         for worktree in secondaryWorktrees {
-            await cleanupOnDisk(worktree: worktree, repoPath: project.path)
+            do {
+                try await cleanupOnDisk(worktree: worktree, repoPath: project.path)
+            } catch {
+                logger.error("Failed to clean up worktree at \(worktree.path): \(error)")
+            }
         }
 
         let root = MuxyFileStorage.worktreeRoot(forProjectID: project.id)

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -190,14 +190,10 @@ final class WorktreeStore {
         removeParentDirectoryIfEmpty(for: worktree.path)
     }
 
-    static func cleanupOnDisk(for project: Project, knownWorktrees: [Worktree]) async {
+    static func cleanupOnDisk(for project: Project, knownWorktrees: [Worktree]) async throws {
         let secondaryWorktrees = knownWorktrees.filter { $0.canBeRemoved && !$0.isExternallyManaged }
         for worktree in secondaryWorktrees {
-            do {
-                try await cleanupOnDisk(worktree: worktree, repoPath: project.path)
-            } catch {
-                logger.error("Failed to clean up worktree at \(worktree.path): \(error)")
-            }
+            try await cleanupOnDisk(worktree: worktree, repoPath: project.path)
         }
 
         let root = MuxyFileStorage.worktreeRoot(forProjectID: project.id)

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -159,10 +159,15 @@ final class WorktreeStore {
 
     static func cleanupOnDisk(
         worktree: Worktree,
-        repoPath: String
+        repoPath: String,
+        teardownEmit: @Sendable @escaping (WorktreeTeardownOutputLine) -> Void = { _ in }
     ) async throws {
         guard worktree.canBeRemoved else { return }
-        try await WorktreeTeardownRunner.run(sourceProjectPath: repoPath, worktree: worktree)
+        try await WorktreeTeardownRunner.run(
+            sourceProjectPath: repoPath,
+            worktree: worktree,
+            emit: teardownEmit
+        )
         try await GitWorktreeService.shared.removeWorktree(
             repoPath: repoPath,
             path: worktree.path,

--- a/Muxy/Services/WorktreeTeardownRunner.swift
+++ b/Muxy/Services/WorktreeTeardownRunner.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+enum WorktreeTeardownError: LocalizedError {
+    case commandFailed(command: String, output: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .commandFailed(command, output):
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                return "Teardown command failed: \(command)"
+            }
+            return "Teardown command failed: \(command)\n\n\(trimmed)"
+        }
+    }
+}
+
+enum WorktreeTeardownRunner {
+    typealias Executor = @Sendable (_ command: String, _ worktree: Worktree, _ environment: [String: String]) async throws -> GitProcessResult
+
+    static func run(
+        sourceProjectPath: String,
+        worktree: Worktree,
+        executor: Executor = execute
+    ) async throws {
+        guard !worktree.isExternallyManaged,
+              let config = WorktreeConfig.load(fromProjectPath: sourceProjectPath)
+        else { return }
+
+        for command in config.teardown.map(\.command) {
+            let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let result = try await executor(trimmed, worktree, environment(for: worktree))
+            guard result.status == 0 else {
+                throw WorktreeTeardownError.commandFailed(
+                    command: trimmed,
+                    output: result.stderr.isEmpty ? result.stdout : result.stderr
+                )
+            }
+        }
+    }
+
+    private static func execute(
+        command: String,
+        worktree: Worktree,
+        environment: [String: String]
+    ) async throws -> GitProcessResult {
+        try await GitProcessRunner.runCommand(
+            executable: "/bin/zsh",
+            arguments: ["-lc", command],
+            workingDirectory: worktree.path,
+            environment: environment
+        )
+    }
+
+    private static func environment(for worktree: Worktree) -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        environment["MUXY_WORKTREE_PATH"] = worktree.path
+        environment["MUXY_WORKTREE_NAME"] = worktree.name
+        environment["MUXY_WORKTREE_BRANCH"] = worktree.branch ?? ""
+        return environment
+    }
+}

--- a/Muxy/Services/WorktreeTeardownRunner.swift
+++ b/Muxy/Services/WorktreeTeardownRunner.swift
@@ -1,41 +1,63 @@
 import Foundation
 
+struct WorktreeTeardownOutputLine: Hashable, Identifiable {
+    enum Channel: Hashable {
+        case stdout
+        case stderr
+        case command
+        case status
+    }
+
+    let id = UUID()
+    let channel: Channel
+    let text: String
+}
+
 enum WorktreeTeardownError: LocalizedError {
-    case commandFailed(command: String, output: String)
+    case commandFailed(command: String)
 
     var errorDescription: String? {
         switch self {
-        case let .commandFailed(command, output):
-            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.isEmpty {
-                return "Teardown command failed: \(command)"
-            }
-            return "Teardown command failed: \(command)\n\n\(trimmed)"
+        case let .commandFailed(command):
+            "Teardown command failed: \(command)"
         }
     }
 }
 
 enum WorktreeTeardownRunner {
-    typealias Executor = @Sendable (_ command: String, _ worktree: Worktree, _ environment: [String: String]) async throws -> GitProcessResult
+    typealias Executor = @Sendable (
+        _ command: String,
+        _ worktree: Worktree,
+        _ environment: [String: String],
+        _ emit: @Sendable @escaping (WorktreeTeardownOutputLine) -> Void
+    ) async throws -> Int32
 
     static func run(
         sourceProjectPath: String,
         worktree: Worktree,
+        emit: @Sendable @escaping (WorktreeTeardownOutputLine) -> Void = { _ in },
         executor: Executor = execute
     ) async throws {
         guard !worktree.isExternallyManaged,
               let config = WorktreeConfig.load(fromProjectPath: sourceProjectPath)
         else { return }
 
-        for command in config.teardown.map(\.command) {
-            let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-            let result = try await executor(trimmed, worktree, environment(for: worktree))
-            guard result.status == 0 else {
-                throw WorktreeTeardownError.commandFailed(
-                    command: trimmed,
-                    output: result.stderr.isEmpty ? result.stdout : result.stderr
-                )
+        let commands = config.teardown
+            .map(\.command)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !commands.isEmpty else { return }
+
+        let environment = environment(for: worktree)
+        for command in commands {
+            emit(WorktreeTeardownOutputLine(channel: .command, text: "$ \(command)"))
+            let status = try await executor(command, worktree, environment, emit)
+            guard status == 0 else {
+                emit(WorktreeTeardownOutputLine(
+                    channel: .status,
+                    text: "Command exited with status \(status)."
+                ))
+                throw WorktreeTeardownError.commandFailed(command: command)
             }
         }
     }
@@ -43,13 +65,14 @@ enum WorktreeTeardownRunner {
     private static func execute(
         command: String,
         worktree: Worktree,
-        environment: [String: String]
-    ) async throws -> GitProcessResult {
-        try await GitProcessRunner.runCommand(
-            executable: "/bin/zsh",
-            arguments: ["-lc", command],
+        environment: [String: String],
+        emit: @Sendable @escaping (WorktreeTeardownOutputLine) -> Void
+    ) async throws -> Int32 {
+        try await WorktreeTeardownProcess.run(
+            command: command,
             workingDirectory: worktree.path,
-            environment: environment
+            environment: environment,
+            emit: emit
         )
     }
 
@@ -59,5 +82,123 @@ enum WorktreeTeardownRunner {
         environment["MUXY_WORKTREE_NAME"] = worktree.name
         environment["MUXY_WORKTREE_BRANCH"] = worktree.branch ?? ""
         return environment
+    }
+}
+
+enum WorktreeTeardownProcess {
+    static func run(
+        command: String,
+        workingDirectory: String,
+        environment: [String: String],
+        emit: @Sendable @escaping (WorktreeTeardownOutputLine) -> Void
+    ) async throws -> Int32 {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let status = try runProcess(
+                        command: command,
+                        workingDirectory: workingDirectory,
+                        environment: environment,
+                        emit: emit
+                    )
+                    continuation.resume(returning: status)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private static func runProcess(
+        command: String,
+        workingDirectory: String,
+        environment: [String: String],
+        emit: @Sendable @escaping (WorktreeTeardownOutputLine) -> Void
+    ) throws -> Int32 {
+        let process = Process()
+        let shell = environment["SHELL"].flatMap { FileManager.default.isExecutableFile(atPath: $0) ? $0 : nil }
+            ?? "/bin/zsh"
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-lc", command]
+        process.environment = environment
+        process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        let stdoutBuffer = LineBuffer { line in
+            emit(WorktreeTeardownOutputLine(channel: .stdout, text: line))
+        }
+        let stderrBuffer = LineBuffer { line in
+            emit(WorktreeTeardownOutputLine(channel: .stderr, text: line))
+        }
+
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                stdoutBuffer.flush()
+                return
+            }
+            stdoutBuffer.append(data)
+        }
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                stderrBuffer.flush()
+                return
+            }
+            stderrBuffer.append(data)
+        }
+
+        try process.run()
+        process.waitUntilExit()
+
+        stdout.fileHandleForReading.readabilityHandler = nil
+        stderr.fileHandleForReading.readabilityHandler = nil
+        stdoutBuffer.flush()
+        stderrBuffer.flush()
+
+        return process.terminationStatus
+    }
+}
+
+private final class LineBuffer: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "app.muxy.teardown-line-buffer")
+    private var pending = Data()
+    private let onLine: (String) -> Void
+
+    init(onLine: @escaping (String) -> Void) {
+        self.onLine = onLine
+    }
+
+    func append(_ data: Data) {
+        queue.sync {
+            pending.append(data)
+            while let newlineRange = pending.range(of: Data([0x0A])) {
+                let lineData = pending.subdata(in: 0 ..< newlineRange.lowerBound)
+                pending.removeSubrange(0 ..< newlineRange.upperBound)
+                emit(lineData)
+            }
+        }
+    }
+
+    func flush() {
+        queue.sync {
+            guard !pending.isEmpty else { return }
+            let lineData = pending
+            pending.removeAll(keepingCapacity: false)
+            emit(lineData)
+        }
+    }
+
+    private func emit(_ data: Data) {
+        let text = String(data: data, encoding: .utf8) ?? ""
+        let trimmed = text.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+        guard !trimmed.isEmpty else { return }
+        onLine(trimmed)
     }
 }

--- a/Muxy/Services/WorktreeTeardownRunner.swift
+++ b/Muxy/Services/WorktreeTeardownRunner.swift
@@ -159,6 +159,8 @@ enum WorktreeTeardownProcess {
 
         stdout.fileHandleForReading.readabilityHandler = nil
         stderr.fileHandleForReading.readabilityHandler = nil
+        stdoutBuffer.append(stdout.fileHandleForReading.readDataToEndOfFile())
+        stderrBuffer.append(stderr.fileHandleForReading.readDataToEndOfFile())
         stdoutBuffer.flush()
         stderrBuffer.flush()
 

--- a/Muxy/Services/WorktreeTeardownRunner.swift
+++ b/Muxy/Services/WorktreeTeardownRunner.swift
@@ -119,7 +119,7 @@ enum WorktreeTeardownProcess {
         let shell = environment["SHELL"].flatMap { FileManager.default.isExecutableFile(atPath: $0) ? $0 : nil }
             ?? "/bin/zsh"
         process.executableURL = URL(fileURLWithPath: shell)
-        process.arguments = ["-lc", command]
+        process.arguments = ["-c", command]
         process.environment = environment
         process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
 

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @MainActor
@@ -176,12 +177,26 @@ struct Sidebar: View {
     private func remove(_ project: Project) {
         let capturedProject = project
         let knownWorktrees = worktreeStore.list(for: project.id)
-        Task.detached {
-            await WorktreeStore.cleanupOnDisk(for: capturedProject, knownWorktrees: knownWorktrees)
+        Task {
+            do {
+                try await WorktreeStore.cleanupOnDisk(for: capturedProject, knownWorktrees: knownWorktrees)
+                appState.removeProject(project.id)
+                projectStore.remove(id: project.id)
+                worktreeStore.removeProject(project.id)
+            } catch {
+                presentProjectRemovalFailure(project: capturedProject, error: error)
+            }
         }
-        appState.removeProject(project.id)
-        projectStore.remove(id: project.id)
-        worktreeStore.removeProject(project.id)
+    }
+
+    private func presentProjectRemovalFailure(project: Project, error: Error) {
+        let alert = NSAlert()
+        alert.messageText = "Could not remove project \"\(project.name)\""
+        alert.informativeText = error.localizedDescription
+        alert.alertStyle = .warning
+        alert.icon = NSApp.applicationIconImage
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     private func reorderIfNeeded(at location: CGPoint) {

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -425,18 +425,30 @@ struct ExpandedProjectRow: View {
         let replacement = remaining.first(where: { $0.id == activeWorktreeID })
             ?? remaining.first(where: { $0.isPrimary })
             ?? remaining.first
-        appState.removeWorktree(
-            projectID: project.id,
-            worktree: worktree,
-            replacement: replacement
-        )
-        worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-        Task.detached {
-            await WorktreeStore.cleanupOnDisk(
-                worktree: worktree,
-                repoPath: repoPath
-            )
+        Task {
+            do {
+                try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: repoPath)
+                appState.removeWorktree(
+                    projectID: project.id,
+                    worktree: worktree,
+                    replacement: replacement
+                )
+                worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+            } catch {
+                presentRemoveFailure(worktree: worktree, error: error)
+            }
         }
+    }
+
+    private func presentRemoveFailure(worktree: Worktree, error: Error) {
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
+              window.attachedSheet == nil
+        else { return }
+
+        let alert = NSAlert(error: error)
+        alert.messageText = "Could not remove worktree \"\(worktree.name)\""
+        alert.icon = NSApp.applicationIconImage
+        alert.beginSheetModal(for: window)
     }
 
     private func startRename() {

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -31,6 +31,7 @@ struct ExpandedProjectRow: View {
     @State private var isRefreshingWorktrees = false
     @State private var showColorPicker = false
     @State private var showSymbolPicker = false
+    @State private var removalRequest: WorktreeRemovalRequest?
 
     private var isActive: Bool {
         appState.activeProjectID == project.id
@@ -137,6 +138,7 @@ struct ExpandedProjectRow: View {
                 onCancel: { cancelRename() }
             )
         }
+        .worktreeRemovalSheet($removalRequest)
         .popover(isPresented: $showColorPicker, arrowEdge: .trailing) {
             ProjectIconColorPicker(selectedID: project.iconColor) { id in
                 onSetIconColor(id)
@@ -420,35 +422,23 @@ struct ExpandedProjectRow: View {
     }
 
     private func performRemove(worktree: Worktree) {
-        let repoPath = project.path
         let remaining = worktrees.filter { $0.id != worktree.id }
         let replacement = remaining.first(where: { $0.id == activeWorktreeID })
             ?? remaining.first(where: { $0.isPrimary })
             ?? remaining.first
-        Task {
-            do {
-                try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: repoPath)
+        removalRequest = WorktreeRemovalRequest(
+            worktree: worktree,
+            repoPath: project.path,
+            onSuccess: {
                 appState.removeWorktree(
                     projectID: project.id,
                     worktree: worktree,
                     replacement: replacement
                 )
                 worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-            } catch {
-                presentRemoveFailure(worktree: worktree, error: error)
-            }
-        }
-    }
-
-    private func presentRemoveFailure(worktree: Worktree, error: Error) {
-        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
-              window.attachedSheet == nil
-        else { return }
-
-        let alert = NSAlert(error: error)
-        alert.messageText = "Could not remove worktree \"\(worktree.name)\""
-        alert.icon = NSApp.applicationIconImage
-        alert.beginSheetModal(for: window)
+            },
+            onFailure: {}
+        )
     }
 
     private func startRename() {

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -436,8 +436,7 @@ struct ExpandedProjectRow: View {
                     replacement: replacement
                 )
                 worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-            },
-            onFailure: {}
+            }
         )
     }
 

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -335,8 +335,7 @@ struct ProjectRow: View {
                     replacement: replacement
                 )
                 worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-            },
-            onFailure: {}
+            }
         )
     }
 }

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -28,6 +28,7 @@ struct ProjectRow: View {
     @State private var isRefreshingWorktrees = false
     @State private var showColorPicker = false
     @State private var showSymbolPicker = false
+    @State private var removalRequest: WorktreeRemovalRequest?
 
     private var isActive: Bool {
         appState.activeProjectID == project.id
@@ -119,11 +120,16 @@ struct ProjectRow: View {
                     onRequestCreate: {
                         showWorktreePopover = false
                         showCreateWorktreeSheet = true
+                    },
+                    onRequestRemove: { worktree in
+                        showWorktreePopover = false
+                        beginRemove(worktree: worktree)
                     }
                 )
                 .environment(appState)
                 .environment(worktreeStore)
             }
+            .worktreeRemovalSheet($removalRequest)
             .sheet(isPresented: $showCreateWorktreeSheet) {
                 CreateWorktreeSheet(project: project) { result in
                     showCreateWorktreeSheet = false
@@ -310,6 +316,27 @@ struct ProjectRow: View {
             appState: appState,
             worktreeStore: worktreeStore,
             isRefreshing: $isRefreshingWorktrees
+        )
+    }
+
+    private func beginRemove(worktree: Worktree) {
+        let activeWorktreeID = appState.activeWorktreeID[project.id]
+        let remaining = worktrees.filter { $0.id != worktree.id }
+        let replacement = remaining.first(where: { $0.id == activeWorktreeID })
+            ?? remaining.first(where: { $0.isPrimary })
+            ?? remaining.first
+        removalRequest = WorktreeRemovalRequest(
+            worktree: worktree,
+            repoPath: project.path,
+            onSuccess: {
+                appState.removeWorktree(
+                    projectID: project.id,
+                    worktree: worktree,
+                    replacement: replacement
+                )
+                worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+            },
+            onFailure: {}
         )
     }
 }

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -106,18 +106,30 @@ struct WorktreePopover: View {
         let replacement = remaining.first(where: { $0.id == activeWorktreeID })
             ?? remaining.first(where: { $0.isPrimary })
             ?? remaining.first
-        appState.removeWorktree(
-            projectID: project.id,
-            worktree: worktree,
-            replacement: replacement
-        )
-        worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-        Task.detached {
-            await WorktreeStore.cleanupOnDisk(
-                worktree: worktree,
-                repoPath: repoPath
-            )
+        Task {
+            do {
+                try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: repoPath)
+                appState.removeWorktree(
+                    projectID: project.id,
+                    worktree: worktree,
+                    replacement: replacement
+                )
+                worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+            } catch {
+                presentRemoveFailure(worktree: worktree, error: error)
+            }
         }
+    }
+
+    private func presentRemoveFailure(worktree: Worktree, error: Error) {
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
+              window.attachedSheet == nil
+        else { return }
+
+        let alert = NSAlert(error: error)
+        alert.messageText = "Could not remove worktree \"\(worktree.name)\""
+        alert.icon = NSApp.applicationIconImage
+        alert.beginSheetModal(for: window)
     }
 }
 

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -6,6 +6,7 @@ struct WorktreePopover: View {
     let isGitRepo: Bool
     let onDismiss: () -> Void
     let onRequestCreate: () -> Void
+    let onRequestRemove: (Worktree) -> Void
     var fixedSize: Bool = true
 
     @Environment(AppState.self) private var appState
@@ -73,7 +74,7 @@ struct WorktreePopover: View {
     private func requestRemove(worktree: Worktree) async {
         let hasChanges = await GitWorktreeService.shared.hasUncommittedChanges(worktreePath: worktree.path)
         if !hasChanges {
-            performRemove(worktree: worktree)
+            onRequestRemove(worktree)
             return
         }
         presentRemoveConfirmation(worktree: worktree)
@@ -96,40 +97,8 @@ struct WorktreePopover: View {
 
         alert.beginSheetModal(for: window) { response in
             guard response == .alertFirstButtonReturn else { return }
-            performRemove(worktree: worktree)
+            onRequestRemove(worktree)
         }
-    }
-
-    private func performRemove(worktree: Worktree) {
-        let repoPath = project.path
-        let remaining = worktrees.filter { $0.id != worktree.id }
-        let replacement = remaining.first(where: { $0.id == activeWorktreeID })
-            ?? remaining.first(where: { $0.isPrimary })
-            ?? remaining.first
-        Task {
-            do {
-                try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: repoPath)
-                appState.removeWorktree(
-                    projectID: project.id,
-                    worktree: worktree,
-                    replacement: replacement
-                )
-                worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-            } catch {
-                presentRemoveFailure(worktree: worktree, error: error)
-            }
-        }
-    }
-
-    private func presentRemoveFailure(worktree: Worktree, error: Error) {
-        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
-              window.attachedSheet == nil
-        else { return }
-
-        let alert = NSAlert(error: error)
-        alert.messageText = "Could not remove worktree \"\(worktree.name)\""
-        alert.icon = NSApp.applicationIconImage
-        alert.beginSheetModal(for: window)
     }
 }
 

--- a/Muxy/Views/Sidebar/WorktreeRemovalPresenter.swift
+++ b/Muxy/Views/Sidebar/WorktreeRemovalPresenter.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct WorktreeRemovalRequest: Identifiable {
+    let id = UUID()
+    let worktree: Worktree
+    let repoPath: String
+    let onSuccess: @MainActor () -> Void
+    let onFailure: @MainActor () -> Void
+}
+
+private struct WorktreeRemovalPresenterModifier: ViewModifier {
+    @Binding var request: WorktreeRemovalRequest?
+    @State private var controller: WorktreeRemovalController?
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: $request) { current in
+                let controller = controller(for: current)
+                WorktreeRemovalSheet(controller: controller) {
+                    request = nil
+                    self.controller = nil
+                    current.onFailure()
+                }
+                .task(id: current.id) { await run(current, controller: controller) }
+            }
+    }
+
+    private func controller(for current: WorktreeRemovalRequest) -> WorktreeRemovalController {
+        if let controller, controller.worktree.id == current.worktree.id { return controller }
+        let new = WorktreeRemovalController(worktree: current.worktree)
+        controller = new
+        return new
+    }
+
+    private func run(_ current: WorktreeRemovalRequest, controller: WorktreeRemovalController) async {
+        do {
+            try await WorktreeStore.cleanupOnDisk(
+                worktree: current.worktree,
+                repoPath: current.repoPath,
+                teardownEmit: { line in
+                    Task { @MainActor in controller.append(line) }
+                }
+            )
+            request = nil
+            self.controller = nil
+            current.onSuccess()
+        } catch {
+            controller.markFailed(error)
+        }
+    }
+}
+
+extension View {
+    func worktreeRemovalSheet(_ request: Binding<WorktreeRemovalRequest?>) -> some View {
+        modifier(WorktreeRemovalPresenterModifier(request: request))
+    }
+}

--- a/Muxy/Views/Sidebar/WorktreeRemovalPresenter.swift
+++ b/Muxy/Views/Sidebar/WorktreeRemovalPresenter.swift
@@ -5,7 +5,6 @@ struct WorktreeRemovalRequest: Identifiable {
     let worktree: Worktree
     let repoPath: String
     let onSuccess: @MainActor () -> Void
-    let onFailure: @MainActor () -> Void
 }
 
 private struct WorktreeRemovalPresenterModifier: ViewModifier {
@@ -16,12 +15,8 @@ private struct WorktreeRemovalPresenterModifier: ViewModifier {
         content
             .sheet(item: $request) { current in
                 let controller = controller(for: current)
-                WorktreeRemovalSheet(controller: controller) {
-                    request = nil
-                    self.controller = nil
-                    current.onFailure()
-                }
-                .task(id: current.id) { await run(current, controller: controller) }
+                WorktreeRemovalSheet(controller: controller, onDismiss: cleanup)
+                    .task(id: current.id) { await run(current, controller: controller) }
             }
     }
 
@@ -30,6 +25,11 @@ private struct WorktreeRemovalPresenterModifier: ViewModifier {
         let new = WorktreeRemovalController(worktree: current.worktree)
         controller = new
         return new
+    }
+
+    private func cleanup() {
+        request = nil
+        controller = nil
     }
 
     private func run(_ current: WorktreeRemovalRequest, controller: WorktreeRemovalController) async {
@@ -41,8 +41,7 @@ private struct WorktreeRemovalPresenterModifier: ViewModifier {
                     Task { @MainActor in controller.append(line) }
                 }
             )
-            request = nil
-            self.controller = nil
+            cleanup()
             current.onSuccess()
         } catch {
             controller.markFailed(error)

--- a/Muxy/Views/Sidebar/WorktreeRemovalSheet.swift
+++ b/Muxy/Views/Sidebar/WorktreeRemovalSheet.swift
@@ -1,0 +1,134 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+@Observable
+final class WorktreeRemovalController {
+    enum Phase: Equatable {
+        case running
+        case failed(message: String)
+    }
+
+    let worktree: Worktree
+    private(set) var lines: [WorktreeTeardownOutputLine] = []
+    private(set) var phase: Phase = .running
+
+    init(worktree: Worktree) {
+        self.worktree = worktree
+    }
+
+    func append(_ line: WorktreeTeardownOutputLine) {
+        lines.append(line)
+    }
+
+    func markFailed(_ error: Error) {
+        phase = .failed(message: error.localizedDescription)
+    }
+}
+
+struct WorktreeRemovalSheet: View {
+    @Bindable var controller: WorktreeRemovalController
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+            header
+            logView
+            footer
+        }
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(560), height: UIMetrics.scaled(380))
+    }
+
+    private var header: some View {
+        HStack(spacing: UIMetrics.spacing3) {
+            if case .running = controller.phase {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(MuxyTheme.diffRemoveFg)
+            }
+            VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
+                Text(headline)
+                    .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fg)
+                Text(subhead)
+                    .font(.system(size: UIMetrics.fontFootnote))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+            }
+            Spacer()
+        }
+    }
+
+    private var headline: String {
+        switch controller.phase {
+        case .running:
+            "Removing worktree \"\(controller.worktree.name)\""
+        case .failed:
+            "Could not remove worktree \"\(controller.worktree.name)\""
+        }
+    }
+
+    private var subhead: String {
+        switch controller.phase {
+        case .running:
+            "Running teardown commands."
+        case let .failed(message):
+            message
+        }
+    }
+
+    private var logView: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(controller.lines) { line in
+                        Text(line.text)
+                            .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
+                            .foregroundStyle(color(for: line.channel))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                            .id(line.id)
+                    }
+                }
+                .padding(UIMetrics.spacing4)
+            }
+            .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .onChange(of: controller.lines.count) { _, _ in
+                guard let last = controller.lines.last else { return }
+                withAnimation(.linear(duration: 0.1)) {
+                    proxy.scrollTo(last.id, anchor: .bottom)
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            switch controller.phase {
+            case .running:
+                Button("Cancel", action: onDismiss)
+                    .keyboardShortcut(.cancelAction)
+                    .disabled(true)
+            case .failed:
+                Button("Close", action: onDismiss)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    private func color(for channel: WorktreeTeardownOutputLine.Channel) -> Color {
+        switch channel {
+        case .command:
+            MuxyTheme.fg
+        case .stdout:
+            MuxyTheme.fg.opacity(0.85)
+        case .stderr:
+            MuxyTheme.diffRemoveFg
+        case .status:
+            MuxyTheme.fgMuted
+        }
+    }
+}

--- a/Muxy/Views/Sidebar/WorktreeRemovalSheet.swift
+++ b/Muxy/Views/Sidebar/WorktreeRemovalSheet.swift
@@ -104,15 +104,11 @@ struct WorktreeRemovalSheet: View {
         }
     }
 
+    @ViewBuilder
     private var footer: some View {
-        HStack {
-            Spacer()
-            switch controller.phase {
-            case .running:
-                Button("Cancel", action: onDismiss)
-                    .keyboardShortcut(.cancelAction)
-                    .disabled(true)
-            case .failed:
+        if case .failed = controller.phase {
+            HStack {
+                Spacer()
                 Button("Close", action: onDismiss)
                     .keyboardShortcut(.defaultAction)
             }

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -387,17 +387,19 @@ struct VCSTabView: View {
         let repoPath = project.path
         let remaining = worktreeStore.list(for: project.id).filter { $0.id != worktree.id }
         let replacement = remaining.first(where: { $0.isPrimary }) ?? remaining.first
-        appState.removeWorktree(
-            projectID: project.id,
-            worktree: worktree,
-            replacement: replacement
-        )
-        worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-        Task.detached {
-            await WorktreeStore.cleanupOnDisk(
-                worktree: worktree,
-                repoPath: repoPath
-            )
+        Task {
+            do {
+                try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: repoPath)
+                appState.removeWorktree(
+                    projectID: project.id,
+                    worktree: worktree,
+                    replacement: replacement
+                )
+                worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+            } catch {
+                presentWorktreeCleanupFailure(worktree: worktree, error: error)
+                return
+            }
             try? await GitRepositoryService().deleteRemoteBranch(
                 repoPath: repoPath,
                 branch: mergedBranch
@@ -408,6 +410,17 @@ struct VCSTabView: View {
                 baseBranch: baseBranch
             )
         }
+    }
+
+    private func presentWorktreeCleanupFailure(worktree: Worktree, error: Error) {
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
+              window.attachedSheet == nil
+        else { return }
+
+        let alert = NSAlert(error: error)
+        alert.messageText = "Could not clean up worktree \"\(worktree.name)\""
+        alert.icon = NSApp.applicationIconImage
+        alert.beginSheetModal(for: window)
     }
 
     @discardableResult

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -410,8 +410,7 @@ struct VCSTabView: View {
                         baseBranch: baseBranch
                     )
                 }
-            },
-            onFailure: {}
+            }
         )
     }
 

--- a/Muxy/Views/VCS/VCSTabView.swift
+++ b/Muxy/Views/VCS/VCSTabView.swift
@@ -14,6 +14,7 @@ struct VCSTabView: View {
     @State private var pendingClosePR: GitRepositoryService.PRInfo?
     @State private var pendingCheckoutPR: GitRepositoryService.PRListItem?
     @State private var pendingCheckoutPRInNewWorktree: GitRepositoryService.PRListItem?
+    @State private var removalRequest: WorktreeRemovalRequest?
     @AppStorage(GeneralSettingsKeys.defaultWorktreeParentPath)
     private var defaultWorktreeParentPath = ""
     private var commitEnabled: Bool {
@@ -160,6 +161,7 @@ struct VCSTabView: View {
                 onCancel: { showCreateBranchSheet = false }
             )
         }
+        .worktreeRemovalSheet($removalRequest)
     }
 
     private func requestOpenPR() {
@@ -387,40 +389,30 @@ struct VCSTabView: View {
         let repoPath = project.path
         let remaining = worktreeStore.list(for: project.id).filter { $0.id != worktree.id }
         let replacement = remaining.first(where: { $0.isPrimary }) ?? remaining.first
-        Task {
-            do {
-                try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: repoPath)
+        removalRequest = WorktreeRemovalRequest(
+            worktree: worktree,
+            repoPath: repoPath,
+            onSuccess: {
                 appState.removeWorktree(
                     projectID: project.id,
                     worktree: worktree,
                     replacement: replacement
                 )
                 worktreeStore.remove(worktreeID: worktree.id, from: project.id)
-            } catch {
-                presentWorktreeCleanupFailure(worktree: worktree, error: error)
-                return
-            }
-            try? await GitRepositoryService().deleteRemoteBranch(
-                repoPath: repoPath,
-                branch: mergedBranch
-            )
-            await Self.fastForwardAfterMerge(
-                repoPath: repoPath,
-                defaultBranch: defaultBranch,
-                baseBranch: baseBranch
-            )
-        }
-    }
-
-    private func presentWorktreeCleanupFailure(worktree: Worktree, error: Error) {
-        guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
-              window.attachedSheet == nil
-        else { return }
-
-        let alert = NSAlert(error: error)
-        alert.messageText = "Could not clean up worktree \"\(worktree.name)\""
-        alert.icon = NSApp.applicationIconImage
-        alert.beginSheetModal(for: window)
+                Task {
+                    try? await GitRepositoryService().deleteRemoteBranch(
+                        repoPath: repoPath,
+                        branch: mergedBranch
+                    )
+                    await Self.fastForwardAfterMerge(
+                        repoPath: repoPath,
+                        defaultBranch: defaultBranch,
+                        baseBranch: baseBranch
+                    )
+                }
+            },
+            onFailure: {}
+        )
     }
 
     @discardableResult

--- a/Tests/MuxyTests/Services/WorktreeTeardownRunnerTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeTeardownRunnerTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("WorktreeTeardownRunner")
+struct WorktreeTeardownRunnerTests {
+    @Test("WorktreeConfig decodes teardown strings and objects")
+    func configDecodesTeardownCommands() throws {
+        let json = """
+        {
+          "setup": ["pnpm install"],
+          "teardown": [
+            "docker compose down",
+            { "name": "cleanup", "command": "rm -rf tmp" }
+          ]
+        }
+        """
+
+        let config = try JSONDecoder().decode(WorktreeConfig.self, from: Data(json.utf8))
+
+        #expect(config.setup.map(\.command) == ["pnpm install"])
+        #expect(config.teardown.map(\.command) == ["docker compose down", "rm -rf tmp"])
+        #expect(config.teardown[1].name == "cleanup")
+    }
+
+    @Test("run executes teardown commands with worktree environment")
+    func runExecutesTeardownCommandsWithEnvironment() async throws {
+        let projectPath = try makeProjectConfig(teardown: [" first ", "", "second"])
+        let worktree = Worktree(
+            name: "Feature",
+            path: "/tmp/feature",
+            branch: "feature/test",
+            source: .muxy,
+            isPrimary: false
+        )
+        final class Capture: @unchecked Sendable {
+            var commands: [String] = []
+            var environments: [[String: String]] = []
+        }
+        let capture = Capture()
+
+        try await WorktreeTeardownRunner.run(sourceProjectPath: projectPath, worktree: worktree) { command, _, environment in
+            capture.commands.append(command)
+            capture.environments.append(environment)
+            return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
+        }
+
+        #expect(capture.commands == ["first", "second"])
+        #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_PATH"] == "/tmp/feature" })
+        #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_NAME"] == "Feature" })
+        #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_BRANCH"] == "feature/test" })
+    }
+
+    @Test("run skips externally managed worktrees")
+    func runSkipsExternalWorktrees() async throws {
+        let projectPath = try makeProjectConfig(teardown: ["cleanup"])
+        let worktree = Worktree(
+            name: "External",
+            path: "/tmp/external",
+            branch: "external",
+            source: .external,
+            isPrimary: false
+        )
+        final class Capture: @unchecked Sendable {
+            var count = 0
+        }
+        let capture = Capture()
+
+        try await WorktreeTeardownRunner.run(sourceProjectPath: projectPath, worktree: worktree) { _, _, _ in
+            capture.count += 1
+            return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
+        }
+
+        #expect(capture.count == 0)
+    }
+
+    @Test("run stops and throws on teardown failure")
+    func runStopsOnFailure() async throws {
+        let projectPath = try makeProjectConfig(teardown: ["fail", "after"])
+        let worktree = Worktree(name: "Feature", path: "/tmp/feature", branch: nil, source: .muxy, isPrimary: false)
+        final class Capture: @unchecked Sendable {
+            var commands: [String] = []
+        }
+        let capture = Capture()
+
+        await #expect(throws: WorktreeTeardownError.self) {
+            try await WorktreeTeardownRunner.run(sourceProjectPath: projectPath, worktree: worktree) { command, _, _ in
+                capture.commands.append(command)
+                return GitProcessResult(status: 1, stdout: "", stdoutData: Data(), stderr: "boom", truncated: false)
+            }
+        }
+        #expect(capture.commands == ["fail"])
+    }
+
+    private func makeProjectConfig(teardown: [String]) throws -> String {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("muxy-teardown-tests-\(UUID().uuidString)", isDirectory: true)
+        let configDirectory = root.appendingPathComponent(".muxy", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(WorktreeConfig(
+            setup: [],
+            teardown: teardown.map { WorktreeConfig.SetupCommand(command: $0) }
+        ))
+        try data.write(to: configDirectory.appendingPathComponent("worktree.json"))
+        return root.path
+    }
+}

--- a/Tests/MuxyTests/Services/WorktreeTeardownRunnerTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeTeardownRunnerTests.swift
@@ -106,6 +106,26 @@ struct WorktreeTeardownRunnerTests {
         #expect(lines.contains(where: { $0.channel == .stdout && $0.text == "hello" }))
     }
 
+    @Test("process captures final stdout and stderr without trailing newlines")
+    func processCapturesFinalOutputWithoutTrailingNewlines() async throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("muxy-teardown-process-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let collected = LineCollector()
+
+        let status = try await WorktreeTeardownProcess.run(
+            command: "printf out; printf err >&2",
+            workingDirectory: directory.path,
+            environment: ProcessInfo.processInfo.environment,
+            emit: { collected.append($0) }
+        )
+
+        let lines = collected.snapshot()
+        #expect(status == 0)
+        #expect(lines.contains(where: { $0.channel == .stdout && $0.text == "out" }))
+        #expect(lines.contains(where: { $0.channel == .stderr && $0.text == "err" }))
+    }
+
     private func makeProjectConfig(teardown: [String]) throws -> String {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("muxy-teardown-tests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MuxyTests/Services/WorktreeTeardownRunnerTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeTeardownRunnerTests.swift
@@ -34,17 +34,13 @@ struct WorktreeTeardownRunnerTests {
             source: .muxy,
             isPrimary: false
         )
-        final class Capture: @unchecked Sendable {
-            var commands: [String] = []
-            var environments: [[String: String]] = []
-        }
-        let capture = Capture()
+        let capture = ExecutionCapture()
 
-        try await WorktreeTeardownRunner.run(sourceProjectPath: projectPath, worktree: worktree) { command, _, environment in
-            capture.commands.append(command)
-            capture.environments.append(environment)
-            return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
-        }
+        try await WorktreeTeardownRunner.run(
+            sourceProjectPath: projectPath,
+            worktree: worktree,
+            executor: capture.executor(returning: 0)
+        )
 
         #expect(capture.commands == ["first", "second"])
         #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_PATH"] == "/tmp/feature" })
@@ -62,35 +58,52 @@ struct WorktreeTeardownRunnerTests {
             source: .external,
             isPrimary: false
         )
-        final class Capture: @unchecked Sendable {
-            var count = 0
-        }
-        let capture = Capture()
+        let capture = ExecutionCapture()
 
-        try await WorktreeTeardownRunner.run(sourceProjectPath: projectPath, worktree: worktree) { _, _, _ in
-            capture.count += 1
-            return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
-        }
+        try await WorktreeTeardownRunner.run(
+            sourceProjectPath: projectPath,
+            worktree: worktree,
+            executor: capture.executor(returning: 0)
+        )
 
-        #expect(capture.count == 0)
+        #expect(capture.commands.isEmpty)
     }
 
     @Test("run stops and throws on teardown failure")
     func runStopsOnFailure() async throws {
         let projectPath = try makeProjectConfig(teardown: ["fail", "after"])
         let worktree = Worktree(name: "Feature", path: "/tmp/feature", branch: nil, source: .muxy, isPrimary: false)
-        final class Capture: @unchecked Sendable {
-            var commands: [String] = []
-        }
-        let capture = Capture()
+        let capture = ExecutionCapture()
 
         await #expect(throws: WorktreeTeardownError.self) {
-            try await WorktreeTeardownRunner.run(sourceProjectPath: projectPath, worktree: worktree) { command, _, _ in
-                capture.commands.append(command)
-                return GitProcessResult(status: 1, stdout: "", stdoutData: Data(), stderr: "boom", truncated: false)
-            }
+            try await WorktreeTeardownRunner.run(
+                sourceProjectPath: projectPath,
+                worktree: worktree,
+                executor: capture.executor(returning: 1)
+            )
         }
         #expect(capture.commands == ["fail"])
+    }
+
+    @Test("run streams command and output lines to the emit closure")
+    func runStreamsOutputLines() async throws {
+        let projectPath = try makeProjectConfig(teardown: ["echo hello"])
+        let worktree = Worktree(name: "Feature", path: "/tmp/feature", branch: nil, source: .muxy, isPrimary: false)
+        let collected = LineCollector()
+
+        try await WorktreeTeardownRunner.run(
+            sourceProjectPath: projectPath,
+            worktree: worktree,
+            emit: { collected.append($0) },
+            executor: { _, _, _, emit in
+                emit(WorktreeTeardownOutputLine(channel: .stdout, text: "hello"))
+                return 0
+            }
+        )
+
+        let lines = collected.snapshot()
+        #expect(lines.contains(where: { $0.channel == .command && $0.text == "$ echo hello" }))
+        #expect(lines.contains(where: { $0.channel == .stdout && $0.text == "hello" }))
     }
 
     private func makeProjectConfig(teardown: [String]) throws -> String {
@@ -104,5 +117,37 @@ struct WorktreeTeardownRunnerTests {
         ))
         try data.write(to: configDirectory.appendingPathComponent("worktree.json"))
         return root.path
+    }
+}
+
+private final class ExecutionCapture: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "tests.execution-capture")
+    private var _commands: [String] = []
+    private var _environments: [[String: String]] = []
+
+    var commands: [String] { queue.sync { _commands } }
+    var environments: [[String: String]] { queue.sync { _environments } }
+
+    func executor(returning status: Int32) -> WorktreeTeardownRunner.Executor {
+        { command, _, environment, _ in
+            self.queue.sync {
+                self._commands.append(command)
+                self._environments.append(environment)
+            }
+            return status
+        }
+    }
+}
+
+private final class LineCollector: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "tests.line-collector")
+    private var lines: [WorktreeTeardownOutputLine] = []
+
+    func append(_ line: WorktreeTeardownOutputLine) {
+        queue.sync { lines.append(line) }
+    }
+
+    func snapshot() -> [WorktreeTeardownOutputLine] {
+        queue.sync { lines }
     }
 }

--- a/docs/features/worktrees.md
+++ b/docs/features/worktrees.md
@@ -32,9 +32,38 @@ The **New Worktree** sheet asks for:
 
 Muxy runs `git worktree add` and registers the new worktree with the project.
 
-## Setup commands
+## Setup & teardown commands
 
-If `.muxy/worktree.json` exists, its setup commands run automatically when a tab is created in a freshly added worktree. Use it to bootstrap dependencies (`npm install`, `bundle install`, …) for ephemeral worktrees.
+Drop a `.muxy/worktree.json` at the project root to script the lifecycle of ephemeral worktrees:
+
+```json
+{
+  "setup": [
+    "npm install",
+    { "name": "Migrate DB", "command": "bundle exec rake db:migrate" }
+  ],
+  "teardown": [
+    "docker compose down",
+    "rm -rf .cache"
+  ]
+}
+```
+
+Each entry is either a plain command string or `{ "name", "command" }`.
+
+**Setup** runs when the first tab is created in a freshly added worktree — use it to install dependencies, seed data, etc.
+
+**Teardown** runs when you remove a worktree from Muxy. A sheet streams stdout/stderr live; the worktree directory is only deleted after every command exits `0`. If any command fails, removal is aborted, the error is surfaced, and the worktree stays on disk so you can investigate.
+
+Commands run in the worktree directory under your login shell, with these extra environment variables:
+
+| Variable | Value |
+| --- | --- |
+| `MUXY_WORKTREE_PATH` | Absolute path to the worktree |
+| `MUXY_WORKTREE_NAME` | Worktree name as shown in Muxy |
+| `MUXY_WORKTREE_BRANCH` | Checked-out branch (empty if detached) |
+
+Externally managed worktrees (added with `git worktree add` outside Muxy) skip teardown — Muxy will not run scripts against directories it didn't create.
 
 ## Persistence
 

--- a/docs/features/worktrees.md
+++ b/docs/features/worktrees.md
@@ -34,7 +34,7 @@ Muxy runs `git worktree add` and registers the new worktree with the project.
 
 ## Setup & teardown commands
 
-Drop a `.muxy/worktree.json` at the project root to script the lifecycle of ephemeral worktrees:
+Drop a `.muxy/worktree.json` at the **source project root** (the primary worktree) to script the lifecycle of ephemeral worktrees. The file is only read from the project root — copies inside individual worktrees are ignored. One config governs every worktree spawned from that project.
 
 ```json
 {


### PR DESCRIPTION
- Adds a `teardown` hook to `.muxy/worktree.json` that runs in the worktree before it's deleted, mirroring `setup`.
- Surfaces teardown/removal failures as an alert and aborts the removal instead of silently logging, so users notice when cleanup didn't happen.

Closes #501