### PR TITLE
Fix diff viewer hang and main-thread blocking

### DIFF
--- a/Muxy/Models/DiffCache.swift
+++ b/Muxy/Models/DiffCache.swift
@@ -123,11 +123,21 @@ final class DiffCache {
     }
 
     private func enforceCap(pinnedPaths: Set<String>) {
-        while accessOrder.count > cap {
-            let oldest = accessOrder.removeFirst()
-            if pinnedPaths.contains(oldest) { continue }
-            diffsByPath.removeValue(forKey: oldest)
-            errorsByPath.removeValue(forKey: oldest)
+        var unpinnedCount = accessOrder.reduce(into: 0) { count, key in
+            if !pinnedPaths.contains(key) { count += 1 }
+        }
+        guard unpinnedCount > cap else { return }
+        var index = 0
+        while unpinnedCount > cap, index < accessOrder.count {
+            let candidate = accessOrder[index]
+            if pinnedPaths.contains(candidate) {
+                index += 1
+                continue
+            }
+            accessOrder.remove(at: index)
+            diffsByPath.removeValue(forKey: candidate)
+            errorsByPath.removeValue(forKey: candidate)
+            unpinnedCount -= 1
         }
     }
 }

--- a/Muxy/Models/DiffViewerTabState.swift
+++ b/Muxy/Models/DiffViewerTabState.swift
@@ -483,49 +483,36 @@ final class DiffViewerTabState: Identifiable {
         source: Source,
         lineLimit: Int?
     ) async throws -> GitRepositoryService.PatchAndCompareResult {
-        try await DiffLoadGate.shared.enter()
-        do {
-            try Task.checkCancellation()
-            switch source {
-            case .workingTree:
-                let result = try await git.patchAndCompare(repoPath: projectPath, filePath: filePath, lineLimit: lineLimit)
-                await DiffLoadGate.shared.leave()
-                return result
-            case let .commit(commit):
-                let result = try await git.patchAndCompare(
-                    repoPath: projectPath,
-                    filePath: filePath,
-                    commit: commit.hash,
-                    lineLimit: lineLimit
-                )
-                await DiffLoadGate.shared.leave()
-                return result
-            case let .range(baseRef, headRef, _):
-                let result = try await git.patchAndCompare(
-                    repoPath: projectPath,
-                    filePath: filePath,
-                    range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef),
-                    lineLimit: lineLimit
-                )
-                await DiffLoadGate.shared.leave()
-                return result
-            case let .pullRequest(pullRequest):
-                guard let baseRef = pullRequest.baseRef, let headRef = pullRequest.headRef else {
-                    await DiffLoadGate.shared.leave()
-                    return GitRepositoryService.PatchAndCompareResult(rows: [], truncated: false, additions: 0, deletions: 0)
-                }
-                let result = try await git.patchAndCompare(
-                    repoPath: projectPath,
-                    filePath: filePath,
-                    range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef),
-                    lineLimit: lineLimit
-                )
-                await DiffLoadGate.shared.leave()
-                return result
+        try await DiffLoadGate.shared.acquire()
+        defer { Task { await DiffLoadGate.shared.release() } }
+        try Task.checkCancellation()
+        switch source {
+        case .workingTree:
+            return try await git.patchAndCompare(repoPath: projectPath, filePath: filePath, lineLimit: lineLimit)
+        case let .commit(commit):
+            return try await git.patchAndCompare(
+                repoPath: projectPath,
+                filePath: filePath,
+                commit: commit.hash,
+                lineLimit: lineLimit
+            )
+        case let .range(baseRef, headRef, _):
+            return try await git.patchAndCompare(
+                repoPath: projectPath,
+                filePath: filePath,
+                range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef),
+                lineLimit: lineLimit
+            )
+        case let .pullRequest(pullRequest):
+            guard let baseRef = pullRequest.baseRef, let headRef = pullRequest.headRef else {
+                return GitRepositoryService.PatchAndCompareResult(rows: [], truncated: false, additions: 0, deletions: 0)
             }
-        } catch {
-            await DiffLoadGate.shared.leave()
-            throw error
+            return try await git.patchAndCompare(
+                repoPath: projectPath,
+                filePath: filePath,
+                range: GitRepositoryService.DiffRange(baseRef: baseRef, headRef: headRef),
+                lineLimit: lineLimit
+            )
         }
     }
 
@@ -541,9 +528,14 @@ private struct WeakDiffViewerTabState {
 actor DiffLoadGate {
     static let shared = DiffLoadGate(limit: 4)
 
-    private struct Waiter {
+    private final class Waiter {
         let id: UUID
-        let continuation: CheckedContinuation<Void, Never>
+        var continuation: CheckedContinuation<Bool, Never>?
+
+        init(id: UUID, continuation: CheckedContinuation<Bool, Never>) {
+            self.id = id
+            self.continuation = continuation
+        }
     }
 
     private let limit: Int
@@ -554,35 +546,41 @@ actor DiffLoadGate {
         self.limit = limit
     }
 
-    func enter() async throws {
+    func acquire() async throws {
         try Task.checkCancellation()
         if active < limit {
             active += 1
             return
         }
         let id = UUID()
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
+        let granted = await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 waiters.append(Waiter(id: id, continuation: continuation))
             }
         } onCancel: {
             Task { await self.cancelWaiter(id: id) }
         }
-        try Task.checkCancellation()
+        if !granted {
+            throw CancellationError()
+        }
     }
 
-    func cancelWaiter(id: UUID) {
-        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
-        let waiter = waiters.remove(at: index)
-        waiter.continuation.resume()
-    }
-
-    func leave() {
-        guard !waiters.isEmpty else {
-            active -= 1
+    func release() {
+        if let next = waiters.first, let continuation = next.continuation {
+            waiters.removeFirst()
+            next.continuation = nil
+            continuation.resume(returning: true)
             return
         }
-        let waiter = waiters.removeFirst()
-        waiter.continuation.resume()
+        active -= 1
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters[index]
+        guard let continuation = waiter.continuation else { return }
+        waiter.continuation = nil
+        waiters.remove(at: index)
+        continuation.resume(returning: false)
     }
 }

--- a/Muxy/Views/VCS/DiffEditorView.swift
+++ b/Muxy/Views/VCS/DiffEditorView.swift
@@ -19,6 +19,8 @@ struct SingleDiffEditorView: View {
     @State private var unifiedState: EditorTabState
     @State private var leftState: EditorTabState
     @State private var rightState: EditorTabState
+    @State private var syncTask: Task<Void, Never>?
+    @State private var appliedSignature: DiffEditorSignature?
 
     init(
         rows: [DiffDisplayRow],
@@ -81,17 +83,45 @@ struct SingleDiffEditorView: View {
     }
 
     private func syncDocument() {
-        switch mode {
-        case .unified:
-            apply(DiffEditorDocument.unified(rows: rows, options: renderOptions), to: unifiedState)
-        case .split:
-            apply(DiffEditorDocument.splitLeft(rows: rows, options: renderOptions), to: leftState)
-            apply(DiffEditorDocument.splitRight(rows: rows, options: renderOptions), to: rightState)
+        let targetSignature = signature
+        guard appliedSignature != targetSignature else { return }
+        syncTask?.cancel()
+        if rows.count <= Self.synchronousRowThreshold {
+            applyAll(DiffDocumentBuilder.build(rows: rows, mode: mode, options: renderOptions))
+            appliedSignature = targetSignature
+            syncTask = nil
+            return
+        }
+        let rows = rows
+        let mode = mode
+        let options = renderOptions
+        syncTask = Task {
+            let documents = await GitProcessRunner.offMain {
+                DiffDocumentBuilder.build(rows: rows, mode: mode, options: options)
+            }
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard signature == targetSignature else { return }
+                applyAll(documents)
+                appliedSignature = targetSignature
+            }
         }
     }
 
     private var renderOptions: DiffEditorDocument.RenderOptions {
         DiffEditorDocument.RenderOptions(maxLineCharacters: maxLineCharacters)
+    }
+
+    private func applyAll(_ documents: DocumentSet) {
+        if let unified = documents.unified {
+            apply(unified, to: unifiedState)
+        }
+        if let left = documents.left {
+            apply(left, to: leftState)
+        }
+        if let right = documents.right {
+            apply(right, to: rightState)
+        }
     }
 
     private func apply(_ document: DiffEditorDocument, to state: EditorTabState) {
@@ -103,6 +133,8 @@ struct SingleDiffEditorView: View {
         )
         documentRevision &+= 1
     }
+
+    private static let synchronousRowThreshold = 500
 
     private func editor(state: EditorTabState, scrollY: Binding<CGFloat>?) -> some View {
         CodeEditorView(
@@ -139,4 +171,29 @@ private struct DiffEditorSignature: Equatable {
     let cacheKey: String
     let mode: VCSTabState.ViewMode
     let rows: String
+}
+
+private struct DocumentSet {
+    let unified: DiffEditorDocument?
+    let left: DiffEditorDocument?
+    let right: DiffEditorDocument?
+}
+
+private enum DiffDocumentBuilder {
+    static func build(
+        rows: [DiffDisplayRow],
+        mode: VCSTabState.ViewMode,
+        options: DiffEditorDocument.RenderOptions
+    ) -> DocumentSet {
+        switch mode {
+        case .unified:
+            DocumentSet(unified: DiffEditorDocument.unified(rows: rows, options: options), left: nil, right: nil)
+        case .split:
+            DocumentSet(
+                unified: nil,
+                left: DiffEditorDocument.splitLeft(rows: rows, options: options),
+                right: DiffEditorDocument.splitRight(rows: rows, options: options)
+            )
+        }
+    }
 }

--- a/Tests/MuxyTests/Models/DiffLoadGateTests.swift
+++ b/Tests/MuxyTests/Models/DiffLoadGateTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("DiffLoadGate")
+struct DiffLoadGateTests {
+    @Test("acquire grants slots up to the limit immediately")
+    func acquireGrantsUntilLimit() async throws {
+        let gate = DiffLoadGate(limit: 2)
+        try await gate.acquire()
+        try await gate.acquire()
+        await gate.release()
+        await gate.release()
+    }
+
+    @Test("release hands slot to next waiter")
+    func releaseHandsToWaiter() async throws {
+        let gate = DiffLoadGate(limit: 1)
+        try await gate.acquire()
+
+        let waiter = Task {
+            try await gate.acquire()
+            await gate.release()
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        await gate.release()
+        try await waiter.value
+    }
+
+    @Test("cancelled waiter does not leak a slot")
+    func cancelledWaiterDoesNotLeakSlot() async throws {
+        let gate = DiffLoadGate(limit: 1)
+        try await gate.acquire()
+
+        let cancelled = Task {
+            do {
+                try await gate.acquire()
+                Issue.record("expected cancellation")
+            } catch {}
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        cancelled.cancel()
+        await cancelled.value
+
+        await gate.release()
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await gate.acquire()
+                await gate.release()
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    @Test("many cancelled waiters do not exhaust the gate")
+    func manyCancelledWaitersDoNotExhaustGate() async throws {
+        let gate = DiffLoadGate(limit: 1)
+        try await gate.acquire()
+
+        for _ in 0 ..< 16 {
+            let waiter = Task {
+                do {
+                    try await gate.acquire()
+                    await gate.release()
+                } catch {}
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+            waiter.cancel()
+            await waiter.value
+        }
+
+        await gate.release()
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 4 {
+                group.addTask {
+                    try await gate.acquire()
+                    await gate.release()
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix DiffLoadGate slot leak that starved PR/commit diff loads after cancelled waiters.
- Build diff documents off main for large diffs to stop the rainbow spinner.
- Fix DiffCache.enforceCap dropping pinned entries from access order.

## Test plan
- [ ] Open a PR with many large files in the diff viewer
- [ ] Switch between files rapidly while loads are in flight
- [ ] Confirm no permanent loading state and no UI freeze