### PR TITLE
fix: add --no-session flag to Pi assistant invocation

### DIFF
--- a/Muxy/Services/AIAssistant/AIAssistantProvider.swift
+++ b/Muxy/Services/AIAssistant/AIAssistantProvider.swift
@@ -56,7 +56,7 @@ enum AIAssistantProvider: String, CaseIterable, Identifiable, Codable {
             }
             return args
         case .pi:
-            var args = ["-p"]
+            var args = ["--no-session", "-p"]
             if let model, !model.isEmpty {
                 args.append(contentsOf: ["--model", model])
             }


### PR DESCRIPTION
Related to #558

Add `--no-session` flag to prevent Pi from saving a session when Muxy calls it for commit message generation via stdin pipe.