### PR TITLE
Install Pi notifications via app-local pi wrapper

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 swiftformat 0.60.1
-swiftlint 0.57.1
+swiftlint 0.63.2
 xcode 16.4

--- a/Muxy/Resources/scripts/muxy-pi-wrapper.sh
+++ b/Muxy/Resources/scripts/muxy-pi-wrapper.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+find_real_pi() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/pi" ]] && printf '%s' "$d/pi" && return 0
+    done
+    return 1
+}
+
+REAL_PI="$(find_real_pi)" || { echo "Error: pi not found in PATH" >&2; exit 127; }
+
+if [ -z "${MUXY_SOCKET_PATH:-}" ] || [ -z "${MUXY_PANE_ID:-}" ]; then
+    exec "$REAL_PI" "$@"
+fi
+
+case "${1:-}" in
+    install|remove|uninstall|update|list|config) exec "$REAL_PI" "$@" ;;
+esac
+
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h|--version|-v) exec "$REAL_PI" "$@" ;;
+    esac
+done
+
+EXTENSION_PATH="$(cd "$(dirname "$0")" && pwd)/muxy-pi-extension.ts"
+exec "$REAL_PI" --extension "$EXTENSION_PATH" "$@"

--- a/Muxy/Services/AIProviderIntegration.swift
+++ b/Muxy/Services/AIProviderIntegration.swift
@@ -137,11 +137,28 @@ final class AIProviderRegistry {
         }
     }
 
+    func provider(forSocketType socketType: String) -> AIProviderIntegration? {
+        providers.first { $0.socketTypeKey == socketType }
+    }
+
     func notificationSource(for socketType: String) -> MuxyNotification.Source {
-        for provider in providers where provider.socketTypeKey == socketType {
+        if let provider = provider(forSocketType: socketType) {
             return .aiProvider(provider.id)
         }
         return .socket
+    }
+
+    func displayName(forSocketType socketType: String) -> String? {
+        provider(forSocketType: socketType)?.displayName
+    }
+
+    func displayName(for source: MuxyNotification.Source) -> String? {
+        switch source {
+        case .osc,
+             .socket: nil
+        case let .aiProvider(id):
+            providers.first { $0.id == id }?.displayName
+        }
     }
 
     func iconName(for source: MuxyNotification.Source) -> String {

--- a/Muxy/Services/MuxyAgentBin.swift
+++ b/Muxy/Services/MuxyAgentBin.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum MuxyAgentBin {
+    static let wrapperName = "pi"
+    static let extensionFileName = "muxy-pi-extension.ts"
+
+    static func directory(appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory()) -> URL {
+        appSupportDirectory.appendingPathComponent("bin", isDirectory: true)
+    }
+
+    static func wrapperURL(appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory()) -> URL {
+        directory(appSupportDirectory: appSupportDirectory).appendingPathComponent(wrapperName)
+    }
+
+    static func extensionURL(appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory()) -> URL {
+        directory(appSupportDirectory: appSupportDirectory).appendingPathComponent(extensionFileName)
+    }
+
+    static func pathPrefixForTerminal(
+        appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory(),
+        fileManager: FileManager = .default
+    ) -> String? {
+        let wrapperPath = wrapperURL(appSupportDirectory: appSupportDirectory).path
+        guard fileManager.isExecutableFile(atPath: wrapperPath) else { return nil }
+        return directory(appSupportDirectory: appSupportDirectory).path
+    }
+}

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -214,19 +214,31 @@ final class NotificationSocketServer: @unchecked Sendable {
         let type = parts[0]
         let paneIDString = parts[1]
         let rawTitle = parts[2]
-        let title = rawTitle.isEmpty ? "Task completed!" : rawTitle
+        let fallbackTitle = rawTitle.isEmpty ? "Task completed!" : rawTitle
         let body = parts.count > 3 ? parts[3] : ""
 
         DispatchQueue.main.async { [weak self] in
-            self?.dispatchNotification(type: type, title: title, body: body, paneIDString: paneIDString)
+            self?.dispatchNotification(
+                type: type,
+                fallbackTitle: fallbackTitle,
+                body: body,
+                paneIDString: paneIDString
+            )
         }
     }
 
     @MainActor
-    private func dispatchNotification(type: String, title: String, body: String, paneIDString: String?) {
+    private func dispatchNotification(
+        type: String,
+        fallbackTitle: String,
+        body: String,
+        paneIDString: String?
+    ) {
         guard let appState = NotificationStore.shared.appState else { return }
 
-        let source = AIProviderRegistry.shared.notificationSource(for: type)
+        let registry = AIProviderRegistry.shared
+        let source = registry.notificationSource(for: type)
+        let title = registry.displayName(forSocketType: type) ?? fallbackTitle
 
         if let paneIDString, let paneID = UUID(uuidString: paneIDString) {
             NotificationStore.shared.add(

--- a/Muxy/Services/NotificationStore.swift
+++ b/Muxy/Services/NotificationStore.swift
@@ -139,7 +139,8 @@ final class NotificationStore {
 
     private func deliverNotification(_ notification: MuxyNotification) {
         if Self.defaults.bool(forKey: "muxy.notifications.toastEnabled", fallback: true) {
-            ToastState.shared.show(notification.title)
+            let label = AIProviderRegistry.shared.displayName(for: notification.source) ?? notification.title
+            ToastState.shared.show(label)
         }
         playSound()
     }

--- a/Muxy/Services/Providers/PiProvider.swift
+++ b/Muxy/Services/Providers/PiProvider.swift
@@ -9,31 +9,44 @@ struct PiProvider: AIProviderIntegration, AIUsageProvider {
     let hookScriptName = "muxy-pi-extension"
     let hookScriptExtension = "ts"
 
-    private static let destinationFileName = "muxy-notify.ts"
-    private static let bundleResourceName = "muxy-pi-extension"
-    private static let bundleResourceExtension = "ts"
+    private static let legacyDestinationFileName = "muxy-notify.ts"
+    private static let bundleExtensionName = "muxy-pi-extension"
+    private static let bundleExtensionExtension = "ts"
+    private static let bundleWrapperName = "muxy-pi-wrapper"
+    private static let bundleWrapperExtension = "sh"
 
     private let homeDirectory: String
     private let pathEnvironment: String
+    private let appSupportDirectory: URL
     private let resourceURL: @Sendable (String, String) -> URL?
 
     init(
         homeDirectory: String = NSHomeDirectory(),
         pathEnvironment: String = ProcessInfo.processInfo.environment["PATH"] ?? "",
+        appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory(),
         resourceURL: @escaping @Sendable (String, String) -> URL? = { name, ext in
             Bundle.appResources.url(forResource: name, withExtension: ext)
         }
     ) {
         self.homeDirectory = homeDirectory
         self.pathEnvironment = pathEnvironment
+        self.appSupportDirectory = appSupportDirectory
         self.resourceURL = resourceURL
     }
 
-    private var extensionsDir: String { homeDirectory + "/.pi/agent/extensions" }
-    private var destinationPath: String { extensionsDir + "/" + Self.destinationFileName }
-    private var settingsPath: String { homeDirectory + "/.pi/agent/settings.json" }
+    private var legacyExtensionsDir: String { homeDirectory + "/.pi/agent/extensions" }
+    private var legacyDestinationPath: String {
+        legacyExtensionsDir + "/" + Self.legacyDestinationFileName
+    }
+
+    private var legacySettingsPath: String { homeDirectory + "/.pi/agent/settings.json" }
+
+    private var binDirectory: URL { MuxyAgentBin.directory(appSupportDirectory: appSupportDirectory) }
+    private var wrapperURL: URL { MuxyAgentBin.wrapperURL(appSupportDirectory: appSupportDirectory) }
+    private var extensionURL: URL { MuxyAgentBin.extensionURL(appSupportDirectory: appSupportDirectory) }
 
     func isToolInstalled() -> Bool {
+        let muxyBin = binDirectory.path
         let paths = [
             "\(homeDirectory)/.local/bin/pi",
             "/usr/local/bin/pi",
@@ -41,80 +54,84 @@ struct PiProvider: AIProviderIntegration, AIUsageProvider {
         ] + pathEnvironment
             .split(separator: ":", omittingEmptySubsequences: true)
             .map { "\($0)/pi" }
+            .filter { !$0.hasPrefix(muxyBin + "/") }
 
         return paths.contains { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
     func install(hookScriptPath: String) throws {
-        guard let sourceURL = resourceURL(Self.bundleResourceName, Self.bundleResourceExtension) else {
+        guard let sourceExtensionURL = resourceURL(Self.bundleExtensionName, Self.bundleExtensionExtension) else {
             throw PiProviderError.bundleResourceNotFound
         }
+        guard let sourceWrapperURL = resourceURL(Self.bundleWrapperName, Self.bundleWrapperExtension) else {
+            throw PiProviderError.bundleWrapperNotFound
+        }
 
-        let sourceData = try Data(contentsOf: sourceURL)
+        let extensionData = try Data(contentsOf: sourceExtensionURL)
+        let wrapperData = try Data(contentsOf: sourceWrapperURL)
 
-        if FileManager.default.fileExists(atPath: destinationPath),
-           let existingData = try? Data(contentsOf: URL(fileURLWithPath: destinationPath)),
-           existingData == sourceData
-        {
+        if isCurrentInstall(extensionData: extensionData, wrapperData: wrapperData) {
+            try removeLegacyInstall()
             return
         }
 
         try FileManager.default.createDirectory(
-            atPath: extensionsDir,
+            at: binDirectory,
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: FilePermissions.privateDirectory]
         )
 
-        let destURL = URL(fileURLWithPath: destinationPath)
-        if FileManager.default.fileExists(atPath: destinationPath) {
-            try FileManager.default.removeItem(at: destURL)
-        }
+        try writeExecutableFile(extensionData, to: extensionURL)
+        try writeExecutableFile(wrapperData, to: wrapperURL)
 
-        try sourceData.write(to: destURL, options: .atomic)
-
-        try registerExtensionInSettings()
+        try removeLegacyInstall()
     }
 
     func uninstall() throws {
-        guard FileManager.default.fileExists(atPath: destinationPath) else { return }
-        try FileManager.default.removeItem(atPath: destinationPath)
-        try unregisterExtensionFromSettings()
+        try? FileManager.default.removeItem(at: wrapperURL)
+        try? FileManager.default.removeItem(at: extensionURL)
+        try removeLegacyInstall()
     }
 
-    private func registerExtensionInSettings() throws {
-        guard FileManager.default.fileExists(atPath: settingsPath) else { return }
-        let url = URL(fileURLWithPath: settingsPath)
-        let data = try Data(contentsOf: url)
-        guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-
-        var extensions = json["extensions"] as? [String] ?? []
-        let extensionPath = destinationPath
-
-        if !extensions.contains(extensionPath) {
-            extensions.append(extensionPath)
-            json["extensions"] = extensions
-            let updatedData = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-
-            let backupPath = settingsPath + ".muxy-backup"
-            try? FileManager.default.removeItem(atPath: backupPath)
-            try FileManager.default.copyItem(atPath: settingsPath, toPath: backupPath)
-
-            try updatedData.write(to: url, options: .atomic)
-            try FileManager.default.setAttributes(
-                [.posixPermissions: FilePermissions.privateFile],
-                ofItemAtPath: settingsPath
-            )
+    private func isCurrentInstall(extensionData: Data, wrapperData: Data) -> Bool {
+        guard FileManager.default.fileExists(atPath: wrapperURL.path),
+              FileManager.default.fileExists(atPath: extensionURL.path),
+              let installedExtension = try? Data(contentsOf: extensionURL),
+              let installedWrapper = try? Data(contentsOf: wrapperURL)
+        else {
+            return false
         }
+        return installedExtension == extensionData && installedWrapper == wrapperData
     }
 
-    private func unregisterExtensionFromSettings() throws {
-        guard FileManager.default.fileExists(atPath: settingsPath) else { return }
-        let url = URL(fileURLWithPath: settingsPath)
+    private func writeExecutableFile(_ data: Data, to url: URL) throws {
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.executable],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func removeLegacyInstall() throws {
+        if FileManager.default.fileExists(atPath: legacyDestinationPath) {
+            try FileManager.default.removeItem(atPath: legacyDestinationPath)
+        }
+        try unregisterExtensionFromLegacySettings()
+    }
+
+    private func unregisterExtensionFromLegacySettings() throws {
+        guard FileManager.default.fileExists(atPath: legacySettingsPath) else { return }
+        let url = URL(fileURLWithPath: legacySettingsPath)
         let data = try Data(contentsOf: url)
         guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
 
         guard var extensions = json["extensions"] as? [String] else { return }
-        extensions.removeAll { $0 == destinationPath }
+        let hadLegacyRegistration = extensions.contains(legacyDestinationPath)
+        extensions.removeAll { $0 == legacyDestinationPath }
+        guard hadLegacyRegistration else { return }
 
         if extensions.isEmpty {
             json.removeValue(forKey: "extensions")
@@ -123,26 +140,24 @@ struct PiProvider: AIProviderIntegration, AIUsageProvider {
         }
 
         let updatedData = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-
-        let backupPath = settingsPath + ".muxy-backup"
-        try? FileManager.default.removeItem(atPath: backupPath)
-        try FileManager.default.copyItem(atPath: settingsPath, toPath: backupPath)
-
         try updatedData.write(to: url, options: .atomic)
         try FileManager.default.setAttributes(
             [.posixPermissions: FilePermissions.privateFile],
-            ofItemAtPath: settingsPath
+            ofItemAtPath: legacySettingsPath
         )
     }
 }
 
 enum PiProviderError: LocalizedError {
     case bundleResourceNotFound
+    case bundleWrapperNotFound
 
     var errorDescription: String? {
         switch self {
         case .bundleResourceNotFound:
             "Pi extension file (muxy-pi-extension.ts) not found in app bundle"
+        case .bundleWrapperNotFound:
+            "Pi wrapper script (muxy-pi-wrapper.sh) not found in app bundle"
         }
     }
 }

--- a/Muxy/Views/NotificationPanel.swift
+++ b/Muxy/Views/NotificationPanel.swift
@@ -31,7 +31,7 @@ struct NotificationPanel: View {
             NotificationPanelItem(
                 id: n.id,
                 sourceIcon: registry.iconName(for: n.source),
-                title: n.title,
+                title: registry.displayName(for: n.source) ?? n.title,
                 body: n.body,
                 timestamp: n.timestamp,
                 isRead: n.isRead

--- a/Muxy/Views/Settings/SettingsComponents.swift
+++ b/Muxy/Views/Settings/SettingsComponents.swift
@@ -4,7 +4,7 @@ import SwiftUI
 extension EnvironmentValues {
     @Entry var settingsSearchQuery: String = ""
 
-    @Entry var settingsCategory: SettingsCategory?
+    @Entry var settingsCategory: SettingsCategory? = nil
 }
 
 enum SettingsMetrics {

--- a/Muxy/Views/Terminal/TerminalEnvVarBuilder.swift
+++ b/Muxy/Views/Terminal/TerminalEnvVarBuilder.swift
@@ -2,7 +2,12 @@ import Foundation
 
 @MainActor
 enum TerminalEnvVarBuilder {
-    static func build(paneID: UUID, worktreeKey key: WorktreeKey) -> [(key: String, value: String)] {
+    static func build(
+        paneID: UUID,
+        worktreeKey key: WorktreeKey,
+        appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory(),
+        inheritedPath: String? = ProcessInfo.processInfo.environment["PATH"]
+    ) -> [(key: String, value: String)] {
         var vars: [(key: String, value: String)] = [
             (key: "MUXY_PANE_ID", value: paneID.uuidString),
             (key: "MUXY_PROJECT_ID", value: key.projectID.uuidString),
@@ -12,6 +17,23 @@ enum TerminalEnvVarBuilder {
         if let hookPath = MuxyNotificationHooks.hookScriptPath {
             vars.append((key: "MUXY_HOOK_SCRIPT", value: hookPath))
         }
+        if let path = terminalPATH(
+            appSupportDirectory: appSupportDirectory,
+            inheritedPath: inheritedPath
+        ) {
+            vars.append((key: "PATH", value: path))
+        }
         return vars
+    }
+
+    static func terminalPATH(
+        appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory(),
+        inheritedPath: String? = ProcessInfo.processInfo.environment["PATH"]
+    ) -> String? {
+        guard let prefix = MuxyAgentBin.pathPrefixForTerminal(appSupportDirectory: appSupportDirectory) else {
+            return nil
+        }
+        let base = inheritedPath ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+        return "\(prefix):\(base)"
     }
 }

--- a/Tests/MuxyTests/Services/AIProviderRegistryTests.swift
+++ b/Tests/MuxyTests/Services/AIProviderRegistryTests.swift
@@ -1,0 +1,41 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("AIProviderRegistry notifications")
+@MainActor
+struct AIProviderRegistryTests {
+    private let registry = AIProviderRegistry.shared
+
+    @Test("displayName for pi socket type returns Pi")
+    func displayNameForPiSocketType() {
+        #expect(registry.displayName(forSocketType: "pi") == "Pi")
+    }
+
+    @Test("displayName for claude_hook socket type returns Claude Code")
+    func displayNameForClaudeSocketType() {
+        #expect(registry.displayName(forSocketType: "claude_hook") == "Claude Code")
+    }
+
+    @Test("displayName for unknown socket type returns nil")
+    func displayNameForUnknownSocketType() {
+        #expect(registry.displayName(forSocketType: "custom") == nil)
+    }
+
+    @Test("notificationSource for pi maps to aiProvider pi")
+    func notificationSourceForPi() {
+        #expect(registry.notificationSource(for: "pi") == .aiProvider("pi"))
+    }
+
+    @Test("displayName for aiProvider source returns provider display name")
+    func displayNameForAIProviderSource() {
+        #expect(registry.displayName(for: .aiProvider("pi")) == "Pi")
+        #expect(registry.displayName(for: .aiProvider("claude")) == "Claude Code")
+    }
+
+    @Test("displayName for osc and socket sources returns nil")
+    func displayNameForNonAIProviderSources() {
+        #expect(registry.displayName(for: .osc) == nil)
+        #expect(registry.displayName(for: .socket) == nil)
+    }
+}

--- a/Tests/MuxyTests/Services/PiProviderTests.swift
+++ b/Tests/MuxyTests/Services/PiProviderTests.swift
@@ -59,28 +59,25 @@ struct PiProviderTests {
         defaults.removeObject(forKey: key)
     }
 
-    @Test("install creates extension file and registers settings")
-    func installCreatesFileAndRegistersSettings() throws {
+    @Test("install creates wrapper and extension in Muxy bin without mutating Pi settings")
+    func installCreatesWrapperAndExtension() throws {
         let fixture = try Fixture()
         defer { fixture.cleanUp() }
 
-        let provider = fixture.provider()
+        try fixture.provider().install(hookScriptPath: "")
 
-        try provider.install(hookScriptPath: "")
-
-        let destinationURL = fixture.homeURL
-            .appendingPathComponent(".pi/agent/extensions/muxy-notify.ts")
-        let installedData = try Data(contentsOf: destinationURL)
-        let sourceData = try Data(contentsOf: fixture.sourceURL)
-        #expect(installedData == sourceData)
+        let wrapperData = try Data(contentsOf: fixture.wrapperURL)
+        let extensionData = try Data(contentsOf: fixture.extensionURL)
+        #expect(wrapperData == fixture.wrapperSourceData)
+        #expect(extensionData == fixture.extensionSourceData)
+        #expect(FileManager.default.isExecutableFile(atPath: fixture.wrapperURL.path))
 
         let settings = try fixture.readSettings()
-        let extensions = try #require(settings["extensions"] as? [String])
-        #expect(extensions == [destinationURL.path])
-        #expect(FileManager.default.fileExists(atPath: fixture.settingsURL.path + ".muxy-backup"))
+        #expect(settings["extensions"] as? [String] == [])
+        #expect(!FileManager.default.fileExists(atPath: fixture.legacyExtensionURL.path))
     }
 
-    @Test("install is idempotent when extension is already current")
+    @Test("install is idempotent when wrapper and extension are already current")
     func installIsIdempotent() throws {
         let fixture = try Fixture()
         defer { fixture.cleanUp() }
@@ -88,15 +85,15 @@ struct PiProviderTests {
         let provider = fixture.provider()
 
         try provider.install(hookScriptPath: "")
+        let firstWrapperMod = try fixture.wrapperURL.resourceValues(forKeys: [.contentModificationDateKey])
         try provider.install(hookScriptPath: "")
 
-        let settings = try fixture.readSettings()
-        let extensions = try #require(settings["extensions"] as? [String])
-        #expect(extensions.count == 1)
+        let secondWrapperMod = try fixture.wrapperURL.resourceValues(forKeys: [.contentModificationDateKey])
+        #expect(firstWrapperMod.contentModificationDate == secondWrapperMod.contentModificationDate)
     }
 
-    @Test("uninstall removes extension file and unregisters settings")
-    func uninstallRemovesFileAndUnregistersSettings() throws {
+    @Test("uninstall removes wrapper and extension from Muxy bin")
+    func uninstallRemovesWrapperAndExtension() throws {
         let fixture = try Fixture()
         defer { fixture.cleanUp() }
 
@@ -105,21 +102,38 @@ struct PiProviderTests {
         try provider.install(hookScriptPath: "")
         try provider.uninstall()
 
-        let destinationPath = fixture.homeURL
-            .appendingPathComponent(".pi/agent/extensions/muxy-notify.ts")
-            .path
-        #expect(!FileManager.default.fileExists(atPath: destinationPath))
-
-        let settings = try fixture.readSettings()
-        #expect(settings["extensions"] == nil)
+        #expect(!FileManager.default.fileExists(atPath: fixture.wrapperURL.path))
+        #expect(!FileManager.default.fileExists(atPath: fixture.extensionURL.path))
     }
 
-    @Test("uninstall does nothing when file does not exist")
-    func uninstallNoFile() throws {
+    @Test("uninstall does nothing when wrapper does not exist")
+    func uninstallNoWrapper() throws {
         let fixture = try Fixture()
         defer { fixture.cleanUp() }
 
         try fixture.provider().uninstall()
+    }
+
+    @Test("install removes legacy global extension and settings registration")
+    func installRemovesLegacyGlobalInstall() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try FileManager.default.createDirectory(
+            at: fixture.legacyExtensionURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fixture.extensionSourceData.write(to: fixture.legacyExtensionURL)
+        var settings = try fixture.readSettings()
+        settings["extensions"] = [fixture.legacyExtensionURL.path]
+        try fixture.writeSettings(settings)
+
+        try fixture.provider().install(hookScriptPath: "")
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.legacyExtensionURL.path))
+        let updatedSettings = try fixture.readSettings()
+        let extensions = updatedSettings["extensions"] as? [String] ?? []
+        #expect(!extensions.contains(fixture.legacyExtensionURL.path))
     }
 
     @Test("isToolInstalled checks common paths")
@@ -141,32 +155,36 @@ struct PiProviderTests {
         #expect(fixture.provider().isToolInstalled())
     }
 
-    @Test("isToolInstalled checks PATH entries")
-    func isToolInstalledFromPath() throws {
+    @Test("isToolInstalled checks PATH entries but ignores Muxy wrapper")
+    func isToolInstalledFromPathIgnoresMuxyWrapper() throws {
         let fixture = try Fixture()
         defer { fixture.cleanUp() }
 
-        let binURL = fixture.rootURL.appendingPathComponent("npm/bin")
-        let executableURL = binURL.appendingPathComponent("pi")
-        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
-        try Data().write(to: executableURL)
+        try fixture.provider().install(hookScriptPath: "")
+
+        let realPiURL = fixture.rootURL.appendingPathComponent("npm/bin/pi")
+        try FileManager.default.createDirectory(at: realPiURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data().write(to: realPiURL)
         try FileManager.default.setAttributes(
             [.posixPermissions: FilePermissions.executable],
-            ofItemAtPath: executableURL.path
+            ofItemAtPath: realPiURL.path
         )
 
-        #expect(fixture.provider(pathEnvironment: binURL.path).isToolInstalled())
+        let path = "\(fixture.binDirectory.path):\(realPiURL.deletingLastPathComponent().path)"
+        #expect(fixture.provider(pathEnvironment: path).isToolInstalled())
     }
 
-    @Test("install throws when resource is missing")
-    func installThrowsWhenResourceMissing() throws {
+    @Test("install throws when extension resource is missing")
+    func installThrowsWhenExtensionResourceMissing() throws {
         let fixture = try Fixture()
         defer { fixture.cleanUp() }
 
         let provider = PiProvider(
             homeDirectory: fixture.homeURL.path,
-            pathEnvironment: "",
-            resourceURL: { _, _ in nil }
+            appSupportDirectory: fixture.appSupportURL,
+            resourceURL: { _, ext in
+                ext == "sh" ? fixture.wrapperSourceURL : nil
+            }
         )
 
         #expect(throws: PiProviderError.bundleResourceNotFound) {
@@ -174,42 +192,82 @@ struct PiProviderTests {
         }
     }
 
+    @Test("install throws when wrapper resource is missing")
+    func installThrowsWhenWrapperResourceMissing() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        let provider = PiProvider(
+            homeDirectory: fixture.homeURL.path,
+            appSupportDirectory: fixture.appSupportURL,
+            resourceURL: { _, ext in
+                ext == "ts" ? fixture.extensionSourceURL : nil
+            }
+        )
+
+        #expect(throws: PiProviderError.bundleWrapperNotFound) {
+            try provider.install(hookScriptPath: "")
+        }
+    }
+
     private struct Fixture {
         let rootURL: URL
         let homeURL: URL
-        let sourceURL: URL
+        let appSupportURL: URL
+        let extensionSourceURL: URL
+        let wrapperSourceURL: URL
         let settingsURL: URL
+        let legacyExtensionURL: URL
+
+        var binDirectory: URL { MuxyAgentBin.directory(appSupportDirectory: appSupportURL) }
+        var wrapperURL: URL { MuxyAgentBin.wrapperURL(appSupportDirectory: appSupportURL) }
+        var extensionURL: URL { MuxyAgentBin.extensionURL(appSupportDirectory: appSupportURL) }
+        var extensionSourceData: Data { try! Data(contentsOf: extensionSourceURL) }
+        var wrapperSourceData: Data { try! Data(contentsOf: wrapperSourceURL) }
 
         init() throws {
             rootURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("PiProviderTests-\(UUID().uuidString)", isDirectory: true)
             homeURL = rootURL.appendingPathComponent("home", isDirectory: true)
-            sourceURL = rootURL.appendingPathComponent("muxy-pi-extension.ts")
+            appSupportURL = rootURL.appendingPathComponent("Muxy", isDirectory: true)
+            extensionSourceURL = rootURL.appendingPathComponent("muxy-pi-extension.ts")
+            wrapperSourceURL = rootURL.appendingPathComponent("muxy-pi-wrapper.sh")
             settingsURL = homeURL.appendingPathComponent(".pi/agent/settings.json")
+            legacyExtensionURL = homeURL.appendingPathComponent(".pi/agent/extensions/muxy-notify.ts")
 
+            try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+            try Data("extension source".utf8).write(to: extensionSourceURL)
+            try Data("#!/usr/bin/env bash\nexec pi \"$@\"\n".utf8).write(to: wrapperSourceURL)
             try FileManager.default.createDirectory(
                 at: settingsURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
-            try Data("extension source".utf8).write(to: sourceURL)
-            let settingsData = try JSONSerialization.data(
-                withJSONObject: ["extensions": []],
-                options: [.prettyPrinted, .sortedKeys]
-            )
-            try settingsData.write(to: settingsURL)
+            try writeSettings(["extensions": []])
         }
 
         func provider(pathEnvironment: String = "") -> PiProvider {
             PiProvider(
                 homeDirectory: homeURL.path,
                 pathEnvironment: pathEnvironment,
-                resourceURL: { _, _ in sourceURL }
+                appSupportDirectory: appSupportURL,
+                resourceURL: { name, ext in
+                    switch (name, ext) {
+                    case ("muxy-pi-extension", "ts"): extensionSourceURL
+                    case ("muxy-pi-wrapper", "sh"): wrapperSourceURL
+                    default: nil
+                    }
+                }
             )
         }
 
         func readSettings() throws -> [String: Any] {
             let data = try Data(contentsOf: settingsURL)
             return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+
+        func writeSettings(_ settings: [String: Any]) throws {
+            let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: settingsURL)
         }
 
         func cleanUp() {

--- a/Tests/MuxyTests/Views/TerminalEnvVarBuilderTests.swift
+++ b/Tests/MuxyTests/Views/TerminalEnvVarBuilderTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("TerminalEnvVarBuilder")
+struct TerminalEnvVarBuilderTests {
+    @Test("prepends Muxy bin to PATH when Pi wrapper is installed")
+    func prependsMuxyBinToPATH() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalEnvVarBuilderTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appSupport = root.appendingPathComponent("Muxy", isDirectory: true)
+        let bin = MuxyAgentBin.directory(appSupportDirectory: appSupport)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+
+        let wrapper = MuxyAgentBin.wrapperURL(appSupportDirectory: appSupport)
+        try Data("#!/usr/bin/env bash\n".utf8).write(to: wrapper)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.executable],
+            ofItemAtPath: wrapper.path
+        )
+
+        let path = TerminalEnvVarBuilder.terminalPATH(
+            appSupportDirectory: appSupport,
+            inheritedPath: "/usr/bin:/bin"
+        )
+
+        #expect(path == "\(bin.path):/usr/bin:/bin")
+    }
+
+    @Test("does not override PATH when Pi wrapper is absent")
+    func leavesPATHUnsetWithoutWrapper() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalEnvVarBuilderTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appSupport = root.appendingPathComponent("Muxy", isDirectory: true)
+
+        let path = TerminalEnvVarBuilder.terminalPATH(
+            appSupportDirectory: appSupport,
+            inheritedPath: "/usr/bin:/bin"
+        )
+
+        #expect(path == nil)
+    }
+
+    @Test("build includes PATH when Pi wrapper is installed")
+    func buildIncludesPATH() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalEnvVarBuilderTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appSupport = root.appendingPathComponent("Muxy", isDirectory: true)
+        let bin = MuxyAgentBin.directory(appSupportDirectory: appSupport)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+
+        let wrapper = MuxyAgentBin.wrapperURL(appSupportDirectory: appSupport)
+        try Data("#!/usr/bin/env bash\n".utf8).write(to: wrapper)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.executable],
+            ofItemAtPath: wrapper.path
+        )
+
+        let vars = TerminalEnvVarBuilder.build(
+            paneID: UUID(),
+            worktreeKey: WorktreeKey(projectID: UUID(), worktreeID: UUID()),
+            appSupportDirectory: appSupport,
+            inheritedPath: "/usr/bin"
+        )
+
+        let pathPair = vars.first { $0.key == "PATH" }
+        #expect(pathPair?.value == "\(bin.path):/usr/bin")
+    }
+}

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -7,7 +7,7 @@ Notifications alert users when terminal events occur (command completion, AI age
 ```mermaid
 flowchart TB
   OSC[OSC 9/777<br/>terminal escape] --> Adapter[GhosttyRuntimeEventAdapter]
-  Claude[Agent CLI hooks<br/>Claude / Codex / Cursor / Droid / OpenCode] --> Sock[Unix socket<br/>muxy.sock]
+  Claude[Agent CLI hooks<br/>Claude / Codex / Cursor / Droid / OpenCode / Pi] --> Sock[Unix socket<br/>muxy.sock]
   External[External tools] --> Sock
   Sock --> Server[NotificationSocketServer]
   Adapter --> Lookup[TerminalViewRegistry<br/>paneID lookup]
@@ -23,7 +23,7 @@ flowchart TB
 | Source | Mechanism |
 | --- | --- |
 | OSC 9 / 777 | `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` in `GhosttyRuntimeEventAdapter`. |
-| Agent CLIs (Claude Code, Codex, Cursor, Droid, OpenCode) | `AIProviderRegistry` installs per-tool hook scripts that route lifecycle events through the socket. |
+| Agent CLIs (Claude Code, Codex, Cursor, Droid, OpenCode, Pi) | `AIProviderRegistry` installs per-tool hook scripts that route lifecycle events through the socket. |
 | Unix socket | `~/Library/Application Support/Muxy/muxy.sock`, pipe-delimited messages with paneID. |
 
 ## Click-to-navigate

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -23,7 +23,7 @@ flowchart TB
 | Source | Mechanism |
 | --- | --- |
 | OSC 9 / 777 | `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` in `GhosttyRuntimeEventAdapter`. |
-| Agent CLIs (Claude Code, Codex, Cursor, Droid, OpenCode) | `AIProviderRegistry` installs per-tool hook scripts that route lifecycle events through the socket. |
+| Agent CLIs (Claude Code, Codex, Cursor, Droid, OpenCode, Pi) | `AIProviderRegistry` installs per-tool hook scripts or PATH wrappers that route lifecycle events through the socket. Pi uses a Muxy-owned `pi` wrapper with `--extension` instead of mutating `~/.pi`. |
 | Unix socket | `~/Library/Application Support/Muxy/muxy.sock`, pipe-delimited messages with paneID. |
 
 ## Click-to-navigate

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -1,6 +1,6 @@
 # Notification Setup
 
-Muxy ships built-in integrations for **Claude Code**, **Codex**, **Cursor**, **Droid**, and **OpenCode** — toggle them under **Settings → Notifications**. This page is for everything else: sending notifications into Muxy from any other tool (a custom CLI, a build script, a different AI agent, …).
+Muxy ships built-in integrations for **Claude Code**, **Codex**, **Cursor**, **Droid**, **OpenCode**, and **Pi** — toggle them under **Settings → Notifications**. This page is for everything else: sending notifications into Muxy from any other tool (a custom CLI, a build script, a different AI agent, …).
 
 ```mermaid
 flowchart TB
@@ -31,7 +31,7 @@ One message per connection: a single UTF-8 line with four pipe-separated fields:
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `type` | yes | Source identifier. Unknown values are accepted and shown generically. Built-in: `claude_hook`, `codex_hook`, `cursor_hook`, `droid_hook`, `opencode`. |
+| `type` | yes | Source identifier. Unknown values are accepted and shown generically. Built-in: `claude_hook`, `codex_hook`, `cursor_hook`, `droid_hook`, `opencode`, `pi`. |
 | `paneID` | yes | Pane the event belongs to. Use `$MUXY_PANE_ID` from inside a Muxy terminal. Leave empty to attach to the active pane. |
 | `title` | yes | Notification title. Empty falls back to `Task completed!`. |
 | `body` | no | Body. Must not contain `\|` or newlines — replace them first. |

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -143,11 +143,18 @@ if [ "$failed" -eq 0 ] && [ "$HAS_SWIFTLINT" -eq 1 ]; then
 fi
 
 if [ "$failed" -eq 0 ]; then
-  run_step "Build" swift build || failed=1
+  SWIFT_BUILD=(swift build)
+  SWIFT_TEST=(swift test)
+  if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+    export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+    SWIFT_BUILD=(xcrun swift build)
+    SWIFT_TEST=(xcrun swift test)
+  fi
+  run_step "Build" "${SWIFT_BUILD[@]}" || failed=1
 fi
 
 if [ "$failed" -eq 0 ]; then
-  run_step "Test" swift test || failed=1
+  run_step "Test" "${SWIFT_TEST[@]}" || failed=1
 fi
 
 printf "\n"


### PR DESCRIPTION
Continues #529 with an app-local install path that avoids mutating `~/.pi`.

## Summary
- Install Pi notification extension and a Muxy-owned `pi` wrapper under Application Support instead of mutating `~/.pi`
- Prepend the Muxy `bin` directory to terminal `PATH` so Pi sessions use the wrapper automatically
- Migrate away the legacy global extension install and bump SwiftLint to 0.63.2

## Test plan
- [ ] Run `scripts/checks.sh`
- [ ] Install Pi provider from Muxy settings and confirm files land in `~/Library/Application Support/Muxy/bin`
- [ ] Open a Pi terminal pane and verify `which pi` resolves to the Muxy wrapper
- [ ] Trigger a Pi notification and confirm it appears in Muxy with click-to-navigate