### PR TITLE
Fix Pi notification pill showing wrong provider name

### DIFF
--- a/Muxy/Services/AIProviderIntegration.swift
+++ b/Muxy/Services/AIProviderIntegration.swift
@@ -137,11 +137,28 @@ final class AIProviderRegistry {
         }
     }
 
+    func provider(forSocketType socketType: String) -> AIProviderIntegration? {
+        providers.first { $0.socketTypeKey == socketType }
+    }
+
     func notificationSource(for socketType: String) -> MuxyNotification.Source {
-        for provider in providers where provider.socketTypeKey == socketType {
+        if let provider = provider(forSocketType: socketType) {
             return .aiProvider(provider.id)
         }
         return .socket
+    }
+
+    func displayName(forSocketType socketType: String) -> String? {
+        provider(forSocketType: socketType)?.displayName
+    }
+
+    func displayName(for source: MuxyNotification.Source) -> String? {
+        switch source {
+        case .osc,
+             .socket: nil
+        case let .aiProvider(id):
+            providers.first { $0.id == id }?.displayName
+        }
     }
 
     func iconName(for source: MuxyNotification.Source) -> String {

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -214,19 +214,31 @@ final class NotificationSocketServer: @unchecked Sendable {
         let type = parts[0]
         let paneIDString = parts[1]
         let rawTitle = parts[2]
-        let title = rawTitle.isEmpty ? "Task completed!" : rawTitle
+        let fallbackTitle = rawTitle.isEmpty ? "Task completed!" : rawTitle
         let body = parts.count > 3 ? parts[3] : ""
 
         DispatchQueue.main.async { [weak self] in
-            self?.dispatchNotification(type: type, title: title, body: body, paneIDString: paneIDString)
+            self?.dispatchNotification(
+                type: type,
+                fallbackTitle: fallbackTitle,
+                body: body,
+                paneIDString: paneIDString
+            )
         }
     }
 
     @MainActor
-    private func dispatchNotification(type: String, title: String, body: String, paneIDString: String?) {
+    private func dispatchNotification(
+        type: String,
+        fallbackTitle: String,
+        body: String,
+        paneIDString: String?
+    ) {
         guard let appState = NotificationStore.shared.appState else { return }
 
-        let source = AIProviderRegistry.shared.notificationSource(for: type)
+        let registry = AIProviderRegistry.shared
+        let source = registry.notificationSource(for: type)
+        let title = registry.displayName(forSocketType: type) ?? fallbackTitle
 
         if let paneIDString, let paneID = UUID(uuidString: paneIDString) {
             NotificationStore.shared.add(

--- a/Muxy/Services/NotificationStore.swift
+++ b/Muxy/Services/NotificationStore.swift
@@ -139,7 +139,8 @@ final class NotificationStore {
 
     private func deliverNotification(_ notification: MuxyNotification) {
         if Self.defaults.bool(forKey: "muxy.notifications.toastEnabled", fallback: true) {
-            ToastState.shared.show(notification.title)
+            let label = AIProviderRegistry.shared.displayName(for: notification.source) ?? notification.title
+            ToastState.shared.show(label)
         }
         playSound()
     }

--- a/Muxy/Views/NotificationPanel.swift
+++ b/Muxy/Views/NotificationPanel.swift
@@ -31,7 +31,7 @@ struct NotificationPanel: View {
             NotificationPanelItem(
                 id: n.id,
                 sourceIcon: registry.iconName(for: n.source),
-                title: n.title,
+                title: registry.displayName(for: n.source) ?? n.title,
                 body: n.body,
                 timestamp: n.timestamp,
                 isRead: n.isRead

--- a/Muxy/Views/Settings/SettingsComponents.swift
+++ b/Muxy/Views/Settings/SettingsComponents.swift
@@ -4,7 +4,7 @@ import SwiftUI
 extension EnvironmentValues {
     @Entry var settingsSearchQuery: String = ""
 
-    @Entry var settingsCategory: SettingsCategory?
+    @Entry var settingsCategory: SettingsCategory? = nil
 }
 
 enum SettingsMetrics {

--- a/Tests/MuxyTests/Services/AIProviderRegistryTests.swift
+++ b/Tests/MuxyTests/Services/AIProviderRegistryTests.swift
@@ -1,0 +1,41 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("AIProviderRegistry notifications")
+@MainActor
+struct AIProviderRegistryTests {
+    private let registry = AIProviderRegistry.shared
+
+    @Test("displayName for pi socket type returns Pi")
+    func displayNameForPiSocketType() {
+        #expect(registry.displayName(forSocketType: "pi") == "Pi")
+    }
+
+    @Test("displayName for claude_hook socket type returns Claude Code")
+    func displayNameForClaudeSocketType() {
+        #expect(registry.displayName(forSocketType: "claude_hook") == "Claude Code")
+    }
+
+    @Test("displayName for unknown socket type returns nil")
+    func displayNameForUnknownSocketType() {
+        #expect(registry.displayName(forSocketType: "custom") == nil)
+    }
+
+    @Test("notificationSource for pi maps to aiProvider pi")
+    func notificationSourceForPi() {
+        #expect(registry.notificationSource(for: "pi") == .aiProvider("pi"))
+    }
+
+    @Test("displayName for aiProvider source returns provider display name")
+    func displayNameForAIProviderSource() {
+        #expect(registry.displayName(for: .aiProvider("pi")) == "Pi")
+        #expect(registry.displayName(for: .aiProvider("claude")) == "Claude Code")
+    }
+
+    @Test("displayName for osc and socket sources returns nil")
+    func displayNameForNonAIProviderSources() {
+        #expect(registry.displayName(for: .osc) == nil)
+        #expect(registry.displayName(for: .socket) == nil)
+    }
+}

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -7,7 +7,7 @@ Notifications alert users when terminal events occur (command completion, AI age
 ```mermaid
 flowchart TB
   OSC[OSC 9/777<br/>terminal escape] --> Adapter[GhosttyRuntimeEventAdapter]
-  Claude[Agent CLI hooks<br/>Claude / Codex / Cursor / Droid / OpenCode] --> Sock[Unix socket<br/>muxy.sock]
+  Claude[Agent CLI hooks<br/>Claude / Codex / Cursor / Droid / OpenCode / Pi] --> Sock[Unix socket<br/>muxy.sock]
   External[External tools] --> Sock
   Sock --> Server[NotificationSocketServer]
   Adapter --> Lookup[TerminalViewRegistry<br/>paneID lookup]
@@ -23,7 +23,7 @@ flowchart TB
 | Source | Mechanism |
 | --- | --- |
 | OSC 9 / 777 | `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` in `GhosttyRuntimeEventAdapter`. |
-| Agent CLIs (Claude Code, Codex, Cursor, Droid, OpenCode) | `AIProviderRegistry` installs per-tool hook scripts that route lifecycle events through the socket. |
+| Agent CLIs (Claude Code, Codex, Cursor, Droid, OpenCode, Pi) | `AIProviderRegistry` installs per-tool hook scripts that route lifecycle events through the socket. |
 | Unix socket | `~/Library/Application Support/Muxy/muxy.sock`, pipe-delimited messages with paneID. |
 
 ## Click-to-navigate

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -1,6 +1,6 @@
 # Notification Setup
 
-Muxy ships built-in integrations for **Claude Code**, **Codex**, **Cursor**, **Droid**, and **OpenCode** — toggle them under **Settings → Notifications**. This page is for everything else: sending notifications into Muxy from any other tool (a custom CLI, a build script, a different AI agent, …).
+Muxy ships built-in integrations for **Claude Code**, **Codex**, **Cursor**, **Droid**, **OpenCode**, and **Pi** — toggle them under **Settings → Notifications**. This page is for everything else: sending notifications into Muxy from any other tool (a custom CLI, a build script, a different AI agent, …).
 
 ```mermaid
 flowchart TB
@@ -31,7 +31,7 @@ One message per connection: a single UTF-8 line with four pipe-separated fields:
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `type` | yes | Source identifier. Unknown values are accepted and shown generically. Built-in: `claude_hook`, `codex_hook`, `cursor_hook`, `droid_hook`, `opencode`. |
+| `type` | yes | Source identifier. Unknown values are accepted and shown generically. Built-in: `claude_hook`, `codex_hook`, `cursor_hook`, `droid_hook`, `opencode`, `pi`. |
 | `paneID` | yes | Pane the event belongs to. Use `$MUXY_PANE_ID` from inside a Muxy terminal. Leave empty to attach to the active pane. |
 | `title` | yes | Notification title. Empty falls back to `Task completed!`. |
 | `body` | no | Body. Must not contain `\|` or newlines — replace them first. |


### PR DESCRIPTION
Fixes muxy-app/muxy#484

## Summary
- Resolve notification toast and panel titles from `AIProviderRegistry` for known socket types (e.g. `pi` → "Pi") instead of the raw hook title field.
- Map socket payloads to provider display names at ingest time in `NotificationSocketServer`.
- Add `AIProviderRegistryTests` and document Pi in notification docs.

## Test plan
- [x] `swift test --filter AIProviderRegistryTests`
- [x] Manual socket test: toast pill and notification panel show **Pi** for `pi|…|Claude Code|…`
- [ ] CI on upstream

Related: https://github.com/muxy-app/muxy/issues/484

Made with [Cursor](https://cursor.com)