### PR TITLE
Fix pane lookup across worktrees and eagerly create terminal surface for CLI commands

### DIFF
--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -137,7 +137,7 @@ enum WorkspaceReducer {
             )
 
         case let .closeTab(projectID, areaID, tabID):
-            guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { break }
+            guard let key = WorkspaceReducerShared.keyForArea(projectID: projectID, areaID: areaID, state: state) else { break }
             TabReducer.closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)
 
         case let .selectTab(projectID, areaID, tabID):
@@ -156,7 +156,7 @@ enum WorkspaceReducer {
             SplitReducer.splitArea(request, state: &state)
 
         case let .closeArea(projectID, areaID):
-            guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { break }
+            guard let key = WorkspaceReducerShared.keyForArea(projectID: projectID, areaID: areaID, state: state) else { break }
             SplitReducer.closeArea(areaID, key: key, state: &state, effects: &effects)
 
         case let .moveTab(projectID, request):

--- a/Muxy/Models/WorkspaceReducer/SplitReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/SplitReducer.swift
@@ -3,7 +3,7 @@ import Foundation
 @MainActor
 enum SplitReducer {
     static func splitArea(_ request: AppState.SplitAreaRequest, state: inout WorkspaceState) {
-        guard let key = WorkspaceReducerShared.activeKey(projectID: request.projectID, state: state),
+        guard let key = WorkspaceReducerShared.keyForArea(projectID: request.projectID, areaID: request.areaID, state: state),
               let root = state.workspaceRoots[key]
         else { return }
         let (newRoot, newAreaID) = root.splitting(

--- a/Muxy/Models/WorkspaceReducer/WorkspaceReducerShared.swift
+++ b/Muxy/Models/WorkspaceReducer/WorkspaceReducerShared.swift
@@ -7,6 +7,12 @@ enum WorkspaceReducerShared {
         return WorktreeKey(projectID: projectID, worktreeID: worktreeID)
     }
 
+    static func keyForArea(projectID: UUID, areaID: UUID, state: WorkspaceState) -> WorktreeKey? {
+        state.workspaceRoots.first(where: { key, root in
+            key.projectID == projectID && root.containsArea(id: areaID)
+        })?.key
+    }
+
     static func resolveArea(key: WorktreeKey, areaID: UUID?, state: WorkspaceState) -> TabArea? {
         guard let root = state.workspaceRoots[key] else { return nil }
         if let areaID {

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -522,20 +522,38 @@ enum SocketCommandHandler {
         appState: AppState? = nil,
         timeout: Duration = .seconds(3)
     ) async -> GhosttyTerminalNSView? {
-        if let view = TerminalViewRegistry.shared.existingView(for: paneID) {
+        if let view = TerminalViewRegistry.shared.existingView(for: paneID),
+           view.surface != nil
+        {
             return view
         }
-        if let appState, locateTab(paneID: paneID, appState: appState) == nil {
-            return nil
+        guard let appState,
+              let loc = locateTab(paneID: paneID, appState: appState),
+              let area = appState.workspaceRoots[loc.key]?.findArea(id: loc.areaID),
+              let tab = area.tabs.first(where: { $0.id == loc.tabID }),
+              let pane = tab.content.pane
+        else { return nil }
+        let view = TerminalViewRegistry.shared.view(
+            for: paneID,
+            workingDirectory: pane.currentWorkingDirectory ?? pane.projectPath,
+            command: pane.startupCommand,
+            commandInteractive: pane.startupCommandInteractive
+        )
+        if view.envVars.isEmpty {
+            view.envVars = TerminalEnvVarBuilder.build(paneID: paneID, worktreeKey: loc.key)
+        }
+        view.createSurfaceEagerly()
+        if view.surface != nil {
+            return view
         }
         let deadline = ContinuousClock.now + timeout
         while ContinuousClock.now < deadline {
-            if let view = TerminalViewRegistry.shared.existingView(for: paneID) {
+            if view.surface != nil {
                 return view
             }
             try? await Task.sleep(for: .milliseconds(50))
         }
-        return nil
+        return view.surface != nil ? view : nil
     }
 
     private static func collectAllPaneIDs(appState: AppState) -> Set<UUID> {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -109,8 +109,20 @@ final class GhosttyTerminalNSView: NSView {
             pendingSurfaceCreation = true
             return
         }
-        pendingSurfaceCreation = false
+        createSurface(with: backingSize, app: app)
+    }
 
+    func createSurfaceEagerly() {
+        guard surface == nil, let app = GhosttyService.shared.app else { return }
+        if bounds.width <= 0 || bounds.height <= 0 {
+            frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        }
+        let backingSize = backingPixelSize() ?? (width: 800, height: 600)
+        pendingSurfaceCreation = false
+        createSurface(with: backingSize, app: app)
+    }
+
+    private func createSurface(with backingSize: (width: UInt32, height: UInt32), app: ghostty_app_t) {
         var config = ghostty_surface_config_new()
         config.platform_tag = GHOSTTY_PLATFORM_MACOS
         config.platform = ghostty_platform_u(

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -1039,4 +1039,184 @@ struct WorkspaceReducerTests {
         let newSecondArea = area(in: state, key: key, areaID: secondAreaID)!
         #expect(newSecondArea.activeTabID == newSecondArea.tabs[1].id)
     }
+
+    @Test("splitArea finds area in non-active worktree")
+    func splitAreaInNonActiveWorktree() {
+        let projectID = UUID()
+        let worktreeAID = UUID()
+        let worktreeBID = UUID()
+        let keyA = WorktreeKey(projectID: projectID, worktreeID: worktreeAID)
+        let keyB = WorktreeKey(projectID: projectID, worktreeID: worktreeBID)
+
+        var state = makeState(projectID: projectID, worktreeID: worktreeAID, worktreePath: "/tmp/a")
+
+        let areaB = TabArea(projectPath: "/tmp/b")
+        state.workspaceRoots[keyB] = .tabArea(areaB)
+        state.focusedAreaID[keyB] = areaB.id
+
+        state.activeWorktreeID[projectID] = worktreeBID
+
+        let areaAID = state.workspaceRoots[keyA]!.allAreas()[0].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: areaAID,
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[keyA]!.allAreas().count == 2)
+        #expect(state.workspaceRoots[keyB]!.allAreas().count == 1)
+        #expect(state.focusedAreaID[keyA] != areaAID)
+        #expect(state.activeWorktreeID[projectID] == worktreeBID)
+    }
+
+    @Test("closeTab finds area in non-active worktree")
+    func closeTabInNonActiveWorktree() {
+        let projectID = UUID()
+        let worktreeAID = UUID()
+        let worktreeBID = UUID()
+        let keyA = WorktreeKey(projectID: projectID, worktreeID: worktreeAID)
+        let keyB = WorktreeKey(projectID: projectID, worktreeID: worktreeBID)
+
+        var state = makeState(projectID: projectID, worktreeID: worktreeAID, worktreePath: "/tmp/a")
+
+        let areaB = TabArea(projectPath: "/tmp/b")
+        state.workspaceRoots[keyB] = .tabArea(areaB)
+        state.focusedAreaID[keyB] = areaB.id
+
+        state.activeWorktreeID[projectID] = worktreeBID
+
+        let areaAID = state.workspaceRoots[keyA]!.allAreas()[0].id
+        let tabInA = state.workspaceRoots[keyA]!.findArea(id: areaAID)!.tabs[0].id
+
+        let areaA = state.workspaceRoots[keyA]!.findArea(id: areaAID)!
+        areaA.createTab()
+        let secondTabInA = areaA.tabs[1].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .closeTab(projectID: projectID, areaID: areaAID, tabID: tabInA),
+            state: &state
+        )
+
+        let areaAfterClose = state.workspaceRoots[keyA]!.findArea(id: areaAID)
+        #expect(areaAfterClose?.tabs.count == 1)
+        #expect(areaAfterClose?.tabs[0].id == secondTabInA)
+        #expect(state.workspaceRoots[keyB]!.allAreas().count == 1)
+        #expect(state.activeWorktreeID[projectID] == worktreeBID)
+    }
+
+    @Test("closeArea finds area in non-active worktree")
+    func closeAreaInNonActiveWorktree() {
+        let projectID = UUID()
+        let worktreeAID = UUID()
+        let worktreeBID = UUID()
+        let keyA = WorktreeKey(projectID: projectID, worktreeID: worktreeAID)
+        let keyB = WorktreeKey(projectID: projectID, worktreeID: worktreeBID)
+
+        var state = makeState(projectID: projectID, worktreeID: worktreeAID, worktreePath: "/tmp/a")
+
+        let areaB = TabArea(projectPath: "/tmp/b")
+        state.workspaceRoots[keyB] = .tabArea(areaB)
+        state.focusedAreaID[keyB] = areaB.id
+
+        state.activeWorktreeID[projectID] = worktreeBID
+
+        let areaAID = state.workspaceRoots[keyA]!.allAreas()[0].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .closeArea(projectID: projectID, areaID: areaAID),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[keyA] == nil)
+        #expect(state.workspaceRoots[keyB]!.allAreas().count == 1)
+        #expect(state.activeWorktreeID[projectID] == worktreeBID)
+    }
+
+    @Test("keyForArea finds area across all worktrees")
+    func keyForAreaFindsAcrossWorktrees() {
+        let projectID = UUID()
+        let worktreeAID = UUID()
+        let worktreeBID = UUID()
+        let keyA = WorktreeKey(projectID: projectID, worktreeID: worktreeAID)
+        let keyB = WorktreeKey(projectID: projectID, worktreeID: worktreeBID)
+
+        var state = makeState(projectID: projectID, worktreeID: worktreeAID)
+        let areaB = TabArea(projectPath: "/tmp/b")
+        state.workspaceRoots[keyB] = .tabArea(areaB)
+        state.activeWorktreeID[projectID] = worktreeBID
+
+        let areaAID = state.workspaceRoots[keyA]!.allAreas()[0].id
+        let foundKey = WorkspaceReducerShared.keyForArea(projectID: projectID, areaID: areaAID, state: state)
+
+        #expect(foundKey == keyA)
+    }
+
+    @Test("keyForArea returns nil for unknown area")
+    func keyForAreaReturnsNilForUnknownArea() {
+        let state = makeState(projectID: UUID(), worktreeID: UUID())
+        let result = WorkspaceReducerShared.keyForArea(
+            projectID: UUID(),
+            areaID: UUID(),
+            state: state
+        )
+        #expect(result == nil)
+    }
+
+    @Test("splitArea with unknown areaID does nothing")
+    func splitAreaUnknownArea() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let originalRootID = state.workspaceRoots[key]!.id
+
+        _ = WorkspaceReducer.reduce(
+            action: .splitArea(AppState.SplitAreaRequest(
+                projectID: projectID,
+                areaID: UUID(),
+                direction: .horizontal,
+                position: .second
+            )),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[key]!.id == originalRootID)
+    }
+
+    @Test("closeTab with unknown areaID does nothing")
+    func closeTabUnknownArea() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let originalRootID = state.workspaceRoots[key]!.id
+
+        _ = WorkspaceReducer.reduce(
+            action: .closeTab(projectID: projectID, areaID: UUID(), tabID: UUID()),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[key]!.id == originalRootID)
+    }
+
+    @Test("closeArea with unknown areaID does nothing")
+    func closeAreaUnknownArea() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let originalRootID = state.workspaceRoots[key]!.id
+
+        _ = WorkspaceReducer.reduce(
+            action: .closeArea(projectID: projectID, areaID: UUID()),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[key]!.id == originalRootID)
+    }
 }


### PR DESCRIPTION
## Problem

Two related bugs when switching between projects/worktrees:

1. **`split-right/down --from <paneID>` fails with 'pane not found'** when the target pane is in a non-active worktree. The reducer used `activeKey()` which only looks at the currently active worktree root.

2. **`send --pane <id>` / `send-keys` / `read-screen` fail** after creating a split because the GhosttyTerminalNSView (and its surface) are only created by SwiftUI asynchronously, but CLI commands need the view immediately.

3. **Background pane process exits not cleaning up** — `forceCloseTab` dispatched by the process exit callback also uses `activeKey()` and silently fails for non-active worktrees.

## Changes

### Reducer fixes (root cause #1 and #3)

- Added `WorkspaceReducerShared.keyForArea(projectID:areaID:state:)` — searches all workspace roots for the given project to find the worktree key containing a specific area ID.
- Updated `SplitReducer.splitArea()` to use `keyForArea` instead of `activeKey`.
- Updated `closeTab` and `closeArea` in `WorkspaceReducer.reduce` to use `keyForArea`.

### CLI fixes (root cause #2)

- Added `GhosttyTerminalNSView.createSurfaceEagerly()` — creates a Ghostty surface even when the NSView is not in a window hierarchy, using fallback dimensions.
- Updated `SocketCommandHandler.waitForView()` to eagerly create the NSView and its surface when the pane exists in state but has no view yet, instead of passively waiting for SwiftUI.

## Tests

- `splitAreaInNonActiveWorktree` — split targets an area in a non-active worktree
- `closeTabInNonActiveWorktree` — close tab in a non-active worktree
- `closeAreaInNonActiveWorktree` — close area in a non-active worktree
- `keyForAreaFindsAcrossWorktrees` — keyForArea finds the correct key
- `keyForAreaReturnsNilForUnknownArea` — keyForArea returns nil for nonexistent areas
- `splitAreaUnknownArea` / `closeTabUnknownArea` / `closeAreaUnknownArea` — no-op for unknown areas