### PR TITLE
Add a shortcut to refresh worktrees

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -56,17 +56,6 @@ struct MuxyCommands: Commands {
         )
     }
 
-    private func refreshActiveProjectWorktrees() {
-        guard let project = activeProject else { return }
-        Task { @MainActor in
-            await WorktreeRefreshHelper.refresh(
-                project: project,
-                appState: appState,
-                worktreeStore: worktreeStore
-            )
-        }
-    }
-
     private func performShortcutAction(_ action: ShortcutAction) {
         _ = shortcutDispatcher.perform(action, activeProject: activeProject) { project in
             VCSDisplayMode.current.route(
@@ -124,10 +113,11 @@ struct MuxyCommands: Commands {
             .shortcut(for: .reloadConfig, store: keyBindings)
 
             Button {
-                refreshActiveProjectWorktrees()
+                performShortcutAction(.refreshWorktrees)
             } label: {
                 Label("Refresh Worktrees", systemImage: "arrow.triangle.2.circlepath")
             }
+            .shortcut(for: .refreshWorktrees, store: keyBindings)
             .disabled(activeProject == nil)
 
             Divider()

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -113,6 +113,7 @@ struct MuxyCommands: Commands {
             .shortcut(for: .reloadConfig, store: keyBindings)
 
             Button {
+                guard isMainWindowFocused else { return }
                 performShortcutAction(.refreshWorktrees)
             } label: {
                 Label("Refresh Worktrees", systemImage: "arrow.triangle.2.circlepath")

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -28,6 +28,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case newProject
     case openProject
     case reloadConfig
+    case refreshWorktrees
     case selectTab1
     case selectTab2
     case selectTab3
@@ -90,6 +91,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .toggleThemePicker,
         .openProject,
         .reloadConfig,
+        .refreshWorktrees,
         .selectTab1,
         .selectTab2,
         .selectTab3,
@@ -233,6 +235,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .newProject: ShortcutMetadata(displayName: "New Project", category: "App", scope: .mainWindow)
         case .openProject: ShortcutMetadata(displayName: "Open Project", category: "App", scope: .mainWindow)
         case .reloadConfig: ShortcutMetadata(displayName: "Reload Configuration", category: "App", scope: .global)
+        case .refreshWorktrees: ShortcutMetadata(displayName: "Refresh Worktrees", category: "App", scope: .mainWindow)
         case .toggleMaximizePane: ShortcutMetadata(displayName: "Toggle Maximize Pane", category: "Panes", scope: .mainWindow)
         }
     }
@@ -320,6 +323,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .openDiffViewerTab, combo: KeyCombo(key: "y", command: true, shift: true)),
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),
         Self(action: .reloadConfig, combo: KeyCombo(key: "r", command: true, shift: true)),
+        Self(action: .refreshWorktrees, combo: KeyCombo(key: "r", command: true, option: true)),
         Self(action: .nextTab, combo: KeyCombo(key: "]", command: true)),
         Self(action: .previousTab, combo: KeyCombo(key: "[", command: true)),
         Self(action: .selectTab1, combo: KeyCombo(key: "1", command: true)),

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -129,6 +129,16 @@ struct ShortcutActionDispatcher {
         case .reloadConfig:
             ghostty.reloadConfig()
             return true
+        case .refreshWorktrees:
+            guard let activeProject else { return false }
+            Task { @MainActor in
+                await WorktreeRefreshHelper.refresh(
+                    project: activeProject,
+                    appState: appState,
+                    worktreeStore: worktreeStore
+                )
+            }
+            return true
         case .nextProject:
             appState.selectNextProject(projects: navigableProjects, worktrees: worktreeStore.worktrees)
             return true

--- a/Tests/MuxyTests/Models/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/KeyBindingTests.swift
@@ -120,6 +120,12 @@ struct KeyBindingTests {
         #expect(combos[.terminalOmniboxHistory] == KeyCombo(key: "h", command: true, option: true))
     }
 
+    @Test("Refresh Worktrees uses Cmd+Opt+R by default")
+    func refreshWorktreesUsesCommandOptionRByDefault() {
+        let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
+        #expect(combos[.refreshWorktrees] == KeyCombo(key: "r", command: true, option: true))
+    }
+
     @Test("KeyBinding Codable round-trip")
     func codableRoundTrip() throws {
         let binding = KeyBinding(

--- a/Tests/MuxyTests/Services/KeyBindingStoreTests.swift
+++ b/Tests/MuxyTests/Services/KeyBindingStoreTests.swift
@@ -74,6 +74,16 @@ struct KeyBindingStoreTests {
         #expect(store.action(for: event, scopes: [.mainWindow]) == nil)
     }
 
+    @Test("saved custom bindings gain new default actions")
+    func savedCustomBindingsGainNewDefaultActions() {
+        let customOpenProject = KeyBinding(action: .openProject, combo: KeyCombo(key: "j", command: true, option: true))
+        let persistence = StubKeyBindingPersistence(bindings: [customOpenProject])
+        let store = KeyBindingStore(persistence: persistence)
+
+        #expect(store.combo(for: .openProject) == customOpenProject.combo)
+        #expect(store.combo(for: .refreshWorktrees) == KeyCombo(key: "r", command: true, option: true))
+    }
+
     private func keyEvent(
         characters: String,
         charactersIgnoringModifiers: String,


### PR DESCRIPTION
- Let users refresh the active project’s worktrees from the keyboard or the app menu without changing focus.
- Preserve custom keybindings while adding a default shortcut for the new action.
- Risk: the shortcut only works when a project is active, so inactive states still do nothing.

Closes #455