### PR TITLE
Prevent CLI hangs by adding timeouts and startup guard

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -14,7 +14,7 @@ struct MuxyApp: App {
     @State private var didStartDeferredServices = false
 
     init() {
-        _ = LaunchArgumentGuard.terminateIfNeeded()
+        LaunchArgumentGuard.terminateIfNeeded()
         _ = MuxyApp.launchDate
         let environment = AppEnvironment.live
         let projectStore = ProjectStore(persistence: environment.projectPersistence)

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -14,6 +14,7 @@ struct MuxyApp: App {
     @State private var didStartDeferredServices = false
 
     init() {
+        _ = LaunchArgumentGuard.terminateIfNeeded()
         _ = MuxyApp.launchDate
         let environment = AppEnvironment.live
         let projectStore = ProjectStore(persistence: environment.projectPersistence)

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -22,7 +22,7 @@
 
 COMMAND="$1"
 SOCKET="${MUXY_SOCKET_PATH:-$HOME/Library/Application Support/Muxy/muxy.sock}"
-NC_TIMEOUT=2
+NC_TIMEOUT=6
 
 send_message() {
     local message="$1"

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -21,7 +21,8 @@
 #   muxy next-tab|previous-tab                Switch tabs
 
 COMMAND="$1"
-SOCKET="$HOME/Library/Application Support/Muxy/muxy.sock"
+SOCKET="${MUXY_SOCKET_PATH:-$HOME/Library/Application Support/Muxy/muxy.sock}"
+NC_TIMEOUT=2
 
 send_message() {
     local message="$1"
@@ -29,7 +30,10 @@ send_message() {
         echo "Error: Muxy is not running" >&2
         exit 1
     fi
-    printf '%s\n' "$message" | nc -U "$SOCKET"
+    if ! printf '%s\n' "$message" | nc -w "$NC_TIMEOUT" -U "$SOCKET"; then
+        echo "Error: no response from Muxy" >&2
+        exit 1
+    fi
 }
 
 send_command() {
@@ -39,7 +43,7 @@ send_command() {
         exit 1
     fi
     local response
-    response=$(printf '%s\n' "$message" | nc -U "$SOCKET" 2>/dev/null)
+    response=$(printf '%s\n' "$message" | nc -w "$NC_TIMEOUT" -U "$SOCKET" 2>/dev/null)
     if [ -z "$response" ]; then
         echo "Error: no response from Muxy" >&2
         exit 1
@@ -324,7 +328,7 @@ if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "spli
 
     ENCODED_PATH="$(percent_encode "$TARGET_DIR")"
 
-    if [ -e "$SOCKET" ] && printf '%s\n' "open-project|$TARGET_DIR" | nc -U "$SOCKET" 2>/dev/null; then
+    if [ -e "$SOCKET" ] && printf '%s\n' "open-project|$TARGET_DIR" | nc -w "$NC_TIMEOUT" -U "$SOCKET" 2>/dev/null; then
         exit 0
     fi
 

--- a/Muxy/Services/LaunchArgumentGuard.swift
+++ b/Muxy/Services/LaunchArgumentGuard.swift
@@ -1,0 +1,23 @@
+import Darwin
+import Foundation
+
+enum LaunchArgumentGuard {
+    private static let cliSubcommands: Set<String> = [
+        "split-right", "split-down", "send", "send-keys", "read-screen",
+        "close-pane", "rename-pane", "list-panes", "list-projects",
+        "switch-project", "list-worktrees", "switch-worktree", "refresh-worktrees",
+        "list-tabs", "switch-tab", "new-tab", "next-tab", "previous-tab",
+    ]
+
+    static func isCLISubcommandLaunch(_ arguments: [String]) -> Bool {
+        guard arguments.count > 1 else { return false }
+        return cliSubcommands.contains(arguments[1])
+    }
+
+    static func terminateIfNeeded(arguments: [String] = CommandLine.arguments) -> Never? {
+        guard isCLISubcommandLaunch(arguments) else { return nil }
+        let message = "Error: Muxy app cannot run CLI subcommands directly. Install and use the muxy CLI wrapper.\n"
+        FileHandle.standardError.write(Data(message.utf8))
+        exit(EX_USAGE)
+    }
+}

--- a/Muxy/Services/LaunchArgumentGuard.swift
+++ b/Muxy/Services/LaunchArgumentGuard.swift
@@ -2,20 +2,16 @@ import Darwin
 import Foundation
 
 enum LaunchArgumentGuard {
-    private static let cliSubcommands: Set<String> = [
-        "split-right", "split-down", "send", "send-keys", "read-screen",
-        "close-pane", "rename-pane", "list-panes", "list-projects",
-        "switch-project", "list-worktrees", "switch-worktree", "refresh-worktrees",
-        "list-tabs", "switch-tab", "new-tab", "next-tab", "previous-tab",
-    ]
-
     static func isCLISubcommandLaunch(_ arguments: [String]) -> Bool {
         guard arguments.count > 1 else { return false }
-        return cliSubcommands.contains(arguments[1])
+        let first = arguments[1]
+        if first.hasPrefix("-") { return false }
+        if first.hasPrefix("/") || first.hasPrefix("~") { return false }
+        return true
     }
 
-    static func terminateIfNeeded(arguments: [String] = CommandLine.arguments) -> Never? {
-        guard isCLISubcommandLaunch(arguments) else { return nil }
+    static func terminateIfNeeded(arguments: [String] = CommandLine.arguments) {
+        guard isCLISubcommandLaunch(arguments) else { return }
         let message = "Error: Muxy app cannot run CLI subcommands directly. Install and use the muxy CLI wrapper.\n"
         FileHandle.standardError.write(Data(message.utf8))
         exit(EX_USAGE)

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -67,7 +67,8 @@ struct MuxyCLILaunchResourceTests {
         let openRange = try #require(script.range(of: "open \"muxy://open?path="))
         #expect(socketRange.lowerBound < openRange.lowerBound)
         #expect(script.contains("printf '%s\\n' \"open-project|$TARGET_DIR\""))
-        #expect(script.contains("printf '%s\\n' \"$message\" | nc -U \"$SOCKET\""))
+        #expect(script.contains("SOCKET=\"${MUXY_SOCKET_PATH:-$HOME/Library/Application Support/Muxy/muxy.sock}\""))
+        #expect(script.contains("nc -w \"$NC_TIMEOUT\" -U \"$SOCKET\""))
     }
 
     @Test("CLI installer prefers copied scripts resource directory")
@@ -88,6 +89,14 @@ struct MuxyCLILaunchResourceTests {
         )
         let plist = try #require(PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any])
         #expect(plist["LSMultipleInstancesProhibited"] as? Bool == true)
+    }
+
+    @Test("app binary rejects CLI subcommands before GUI startup")
+    func appRejectsCLISubcommands() {
+        #expect(LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "list-panes"]))
+        #expect(LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "split-right", "pwd"]))
+        #expect(!LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "/tmp"]))
+        #expect(!LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy"]))
     }
 
     private static var repositoryRoot: URL {

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -95,7 +95,10 @@ struct MuxyCLILaunchResourceTests {
     func appRejectsCLISubcommands() {
         #expect(LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "list-panes"]))
         #expect(LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "split-right", "pwd"]))
+        #expect(LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "future-unknown-command"]))
         #expect(!LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "/tmp"]))
+        #expect(!LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "~/Projects"]))
+        #expect(!LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy", "-NSDocumentRevisionsDebugMode", "YES"]))
         #expect(!LaunchArgumentGuard.isCLISubcommandLaunch(["Muxy"]))
     }
 


### PR DESCRIPTION
Add 2s timeout to CLI socket calls to avoid indefinite hangs. Reject CLI subcommands at app startup with error message, forcing users to use the wrapper script. Supports custom socket path via `MUXY_SOCKET_PATH` env var for testing.

Closes #504