### PR TITLE
Add newly opened projects to active group

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -70,12 +70,13 @@ struct MuxyApp: App {
                     appDelegate.hasUnsavedEditorTabs = { [appState] in
                         appState.unsavedEditorTabs()
                     }
-                    appDelegate.openProjectFromPath = { [appState, projectStore, worktreeStore] path in
+                    appDelegate.openProjectFromPath = { [appState, projectStore, worktreeStore, projectGroupStore] path in
                         CLIAccessor.openProjectFromPath(
                             path,
                             appState: appState,
                             projectStore: projectStore,
-                            worktreeStore: worktreeStore
+                            worktreeStore: worktreeStore,
+                            projectGroupStore: projectGroupStore
                         )
                     }
                     appDelegate.flushPendingOpens()

--- a/Muxy/Services/CLIAccessor.swift
+++ b/Muxy/Services/CLIAccessor.swift
@@ -8,7 +8,7 @@ enum CLIAccessor {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
-        projectGroupStore: ProjectGroupStore? = nil
+        projectGroupStore: ProjectGroupStore
     ) {
         let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
         var isDirectory: ObjCBool = false
@@ -31,7 +31,7 @@ enum CLIAccessor {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
-        projectGroupStore?.addProjectToActiveGroup(projectID: project.id)
+        projectGroupStore.addProjectToActiveGroup(projectID: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return }
         appState.selectProject(project, worktree: primary)

--- a/Muxy/Services/CLIAccessor.swift
+++ b/Muxy/Services/CLIAccessor.swift
@@ -19,6 +19,7 @@ enum CLIAccessor {
         if let existing = projectStore.projects.first(where: { $0.path == standardizedPath }),
            let primary = worktreeStore.primary(for: existing.id)
         {
+            projectGroupStore.addProjectToActiveGroup(projectID: existing.id)
             appState.selectProject(existing, worktree: primary)
             activateApp()
             return

--- a/Muxy/Services/CLIAccessor.swift
+++ b/Muxy/Services/CLIAccessor.swift
@@ -7,7 +7,8 @@ enum CLIAccessor {
         _ path: String,
         appState: AppState,
         projectStore: ProjectStore,
-        worktreeStore: WorktreeStore
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore? = nil
     ) {
         let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
         var isDirectory: ObjCBool = false
@@ -30,6 +31,7 @@ enum CLIAccessor {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
+        projectGroupStore?.addProjectToActiveGroup(projectID: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return }
         appState.selectProject(project, worktree: primary)

--- a/Muxy/Services/ProjectGroupStore.swift
+++ b/Muxy/Services/ProjectGroupStore.swift
@@ -64,6 +64,11 @@ final class ProjectGroupStore {
         save()
     }
 
+    func addProjectToActiveGroup(projectID: UUID) {
+        guard let activeGroupID else { return }
+        addProject(projectID: projectID, toGroup: activeGroupID)
+    }
+
     func removeProject(projectID: UUID, fromGroup groupID: UUID) {
         guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
         groups[index].projectIDs.removeAll { $0 == projectID }

--- a/Muxy/Services/ProjectOpenService.swift
+++ b/Muxy/Services/ProjectOpenService.swift
@@ -5,7 +5,8 @@ enum ProjectOpenService {
     static func openProject(
         appState: AppState,
         projectStore: ProjectStore,
-        worktreeStore: WorktreeStore
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore? = nil
     ) {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
@@ -19,6 +20,7 @@ enum ProjectOpenService {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
+        projectGroupStore?.addProjectToActiveGroup(projectID: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return }
         appState.selectProject(project, worktree: primary)
@@ -28,6 +30,7 @@ enum ProjectOpenService {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore? = nil,
         preferences: ProjectPickerPreferences = ProjectPickerPreferences(),
         notificationCenter: NotificationCenter = .default,
         openWithFinder: (() -> Void)? = nil
@@ -36,7 +39,12 @@ enum ProjectOpenService {
             if let openWithFinder {
                 openWithFinder()
             } else {
-                openProject(appState: appState, projectStore: projectStore, worktreeStore: worktreeStore)
+                openProject(
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore,
+                    projectGroupStore: projectGroupStore
+                )
             }
         }
         presentOpenProject(
@@ -77,6 +85,7 @@ enum ProjectOpenService {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore? = nil,
         createIfMissing: Bool = false
     ) -> Bool {
         confirmProjectPathResult(
@@ -84,6 +93,7 @@ enum ProjectOpenService {
             appState: appState,
             projectStore: projectStore,
             worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
             createIfMissing: createIfMissing
         ).didConfirm
     }
@@ -94,12 +104,14 @@ enum ProjectOpenService {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore? = nil,
         createIfMissing: Bool = false
     ) -> ProjectOpenConfirmationResult {
         ProjectPathConfirmationService(
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
         .confirm(path: path, createIfMissing: createIfMissing)
     }

--- a/Muxy/Services/ProjectOpenService.swift
+++ b/Muxy/Services/ProjectOpenService.swift
@@ -6,7 +6,7 @@ enum ProjectOpenService {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
-        projectGroupStore: ProjectGroupStore? = nil
+        projectGroupStore: ProjectGroupStore
     ) {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
@@ -20,7 +20,7 @@ enum ProjectOpenService {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
-        projectGroupStore?.addProjectToActiveGroup(projectID: project.id)
+        projectGroupStore.addProjectToActiveGroup(projectID: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return }
         appState.selectProject(project, worktree: primary)
@@ -30,7 +30,7 @@ enum ProjectOpenService {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
-        projectGroupStore: ProjectGroupStore? = nil,
+        projectGroupStore: ProjectGroupStore,
         preferences: ProjectPickerPreferences = ProjectPickerPreferences(),
         notificationCenter: NotificationCenter = .default,
         openWithFinder: (() -> Void)? = nil
@@ -85,7 +85,7 @@ enum ProjectOpenService {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
-        projectGroupStore: ProjectGroupStore? = nil,
+        projectGroupStore: ProjectGroupStore,
         createIfMissing: Bool = false
     ) -> Bool {
         confirmProjectPathResult(
@@ -104,7 +104,7 @@ enum ProjectOpenService {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
-        projectGroupStore: ProjectGroupStore? = nil,
+        projectGroupStore: ProjectGroupStore,
         createIfMissing: Bool = false
     ) -> ProjectOpenConfirmationResult {
         ProjectPathConfirmationService(

--- a/Muxy/Services/ProjectPathConfirmationService.swift
+++ b/Muxy/Services/ProjectPathConfirmationService.swift
@@ -75,6 +75,7 @@ struct ProjectPathConfirmationService {
         }
 
         let project = project(at: standardizedPath)
+        projectGroupStore.addProjectToActiveGroup(projectID: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return .failed }
         appState.selectProject(project, worktree: primary)
@@ -115,7 +116,6 @@ struct ProjectPathConfirmationService {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
-        projectGroupStore.addProjectToActiveGroup(projectID: project.id)
         return project
     }
 }

--- a/Muxy/Services/ProjectPathConfirmationService.swift
+++ b/Muxy/Services/ProjectPathConfirmationService.swift
@@ -47,14 +47,14 @@ struct ProjectPathConfirmationService {
     let appState: AppState
     let projectStore: ProjectStore
     let worktreeStore: WorktreeStore
-    let projectGroupStore: ProjectGroupStore?
+    let projectGroupStore: ProjectGroupStore
     let fileSystem: any ProjectPathConfirmationFileSystem
 
     init(
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
-        projectGroupStore: ProjectGroupStore? = nil,
+        projectGroupStore: ProjectGroupStore,
         fileSystem: any ProjectPathConfirmationFileSystem = FileManagerProjectPathConfirmationFileSystem()
     ) {
         self.appState = appState
@@ -115,7 +115,7 @@ struct ProjectPathConfirmationService {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
-        projectGroupStore?.addProjectToActiveGroup(projectID: project.id)
+        projectGroupStore.addProjectToActiveGroup(projectID: project.id)
         return project
     }
 }

--- a/Muxy/Services/ProjectPathConfirmationService.swift
+++ b/Muxy/Services/ProjectPathConfirmationService.swift
@@ -47,17 +47,20 @@ struct ProjectPathConfirmationService {
     let appState: AppState
     let projectStore: ProjectStore
     let worktreeStore: WorktreeStore
+    let projectGroupStore: ProjectGroupStore?
     let fileSystem: any ProjectPathConfirmationFileSystem
 
     init(
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore? = nil,
         fileSystem: any ProjectPathConfirmationFileSystem = FileManagerProjectPathConfirmationFileSystem()
     ) {
         self.appState = appState
         self.projectStore = projectStore
         self.worktreeStore = worktreeStore
+        self.projectGroupStore = projectGroupStore
         self.fileSystem = fileSystem
     }
 
@@ -112,6 +115,7 @@ struct ProjectPathConfirmationService {
             sortOrder: projectStore.projects.count
         )
         projectStore.add(project)
+        projectGroupStore?.addProjectToActiveGroup(projectID: project.id)
         return project
     }
 }

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -5,7 +5,7 @@ struct ShortcutActionDispatcher {
     let appState: AppState
     let projectStore: ProjectStore
     let worktreeStore: WorktreeStore
-    let projectGroupStore: ProjectGroupStore?
+    let projectGroupStore: ProjectGroupStore
     let ghostty: GhosttyService
     let notificationCenter: NotificationCenter
 
@@ -13,7 +13,7 @@ struct ShortcutActionDispatcher {
         appState: AppState,
         projectStore: ProjectStore,
         worktreeStore: WorktreeStore,
-        projectGroupStore: ProjectGroupStore? = nil,
+        projectGroupStore: ProjectGroupStore,
         ghostty: GhosttyService,
         notificationCenter: NotificationCenter = .default
     ) {
@@ -26,8 +26,7 @@ struct ShortcutActionDispatcher {
     }
 
     private var navigableProjects: [Project] {
-        guard let projectGroupStore else { return projectStore.projects }
-        return projectGroupStore.filteredProjects(from: projectStore.projects)
+        projectGroupStore.filteredProjects(from: projectStore.projects)
     }
 
     func perform(_ action: ShortcutAction, activeProject: Project?, openVCS: (Project) -> Void) -> Bool {
@@ -123,7 +122,8 @@ struct ShortcutActionDispatcher {
             ProjectOpenService.openProjectViaPicker(
                 appState: appState,
                 projectStore: projectStore,
-                worktreeStore: worktreeStore
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
             )
             return true
         case .reloadConfig:

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -649,6 +649,7 @@ struct MainWindow: View {
                         appState: appState,
                         projectStore: projectStore,
                         worktreeStore: worktreeStore,
+                        projectGroupStore: projectGroupStore,
                         createIfMissing: createIfMissing
                     )
                 },
@@ -656,7 +657,8 @@ struct MainWindow: View {
                     ProjectOpenService.openProject(
                         appState: appState,
                         projectStore: projectStore,
-                        worktreeStore: worktreeStore
+                        worktreeStore: worktreeStore,
+                        projectGroupStore: projectGroupStore
                     )
                 },
                 onDismiss: { showProjectPicker = false }

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -73,7 +73,8 @@ struct Sidebar: View {
             ProjectOpenService.openProjectViaPicker(
                 appState: appState,
                 projectStore: projectStore,
-                worktreeStore: worktreeStore
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
             )
         }
         .help(shortcutTooltip("Add Project", for: .openProject))

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -103,7 +103,7 @@ struct MuxyCLILaunchResourceTests {
 @Suite("CLIAccessor.openProjectFromPath")
 @MainActor
 struct CLIAccessorOpenProjectFromPathTests {
-    private func makeStores() -> (AppState, ProjectStore, WorktreeStore) {
+    private func makeStores() -> (AppState, ProjectStore, WorktreeStore, ProjectGroupStore) {
         let projectStore = ProjectStore(persistence: ProjectPersistenceStub())
         let worktreeStore = WorktreeStore(
             persistence: WorktreePersistenceStub(),
@@ -114,24 +114,26 @@ struct CLIAccessorOpenProjectFromPathTests {
             terminalViews: TerminalViewRemovingStub(),
             workspacePersistence: WorkspacePersistenceStub()
         )
-        return (appState, projectStore, worktreeStore)
+        let projectGroupStore = ProjectGroupStore(persistence: ProjectGroupPersistenceStub())
+        return (appState, projectStore, worktreeStore, projectGroupStore)
     }
 
     @Test("missing directory is ignored")
     func missingDirectory() {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         CLIAccessor.openProjectFromPath(
             "/tmp/muxy-tests/does-not-exist-\(UUID().uuidString)",
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
         #expect(projectStore.projects.isEmpty)
     }
 
     @Test("regular file is ignored")
     func regularFile() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let file = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-test-\(UUID().uuidString).txt")
         try Data().write(to: file)
@@ -141,14 +143,15 @@ struct CLIAccessorOpenProjectFromPathTests {
             file.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
         #expect(projectStore.projects.isEmpty)
     }
 
     @Test("new directory is added as project")
     func newProjectAdded() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -158,7 +161,8 @@ struct CLIAccessorOpenProjectFromPathTests {
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
         #expect(projectStore.projects.count == 1)
         let standardized = URL(fileURLWithPath: dir.path).standardizedFileURL.path
@@ -167,7 +171,7 @@ struct CLIAccessorOpenProjectFromPathTests {
 
     @Test("opening the same path twice does not duplicate the project")
     func dedupeOnSecondOpen() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -177,13 +181,15 @@ struct CLIAccessorOpenProjectFromPathTests {
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
         CLIAccessor.openProjectFromPath(
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
         #expect(projectStore.projects.count == 1)
     }

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -193,6 +193,33 @@ struct CLIAccessorOpenProjectFromPathTests {
         )
         #expect(projectStore.projects.count == 1)
     }
+
+    @Test("existing project is added to selected group")
+    func existingProjectAddedToSelectedGroup() throws {
+        let (appState, projectStore, worktreeStore, _) = makeStores()
+        let group = ProjectGroup(name: "Work")
+        let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
+        let projectGroupStore = ProjectGroupStore(persistence: groupPersistence)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let project = Project(name: dir.lastPathComponent, path: dir.standardizedFileURL.path)
+        projectStore.add(project)
+        worktreeStore.ensurePrimary(for: project)
+
+        projectGroupStore.selectGroup(id: group.id)
+        CLIAccessor.openProjectFromPath(
+            dir.path,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+
+        #expect(projectStore.projects.count == 1)
+        #expect(groupPersistence.savedGroups?.first?.projectIDs == [project.id])
+    }
 }
 
 private final class ProjectPersistenceStub: ProjectPersisting {

--- a/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
@@ -91,6 +91,32 @@ struct ProjectGroupStoreTests {
         #expect(store.groups.first?.projectIDs.count == 1)
     }
 
+    @Test("addProjectToActiveGroup adds project to selected group and persists")
+    func addProjectToActiveGroup() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+        let projectID = UUID()
+
+        store.selectGroup(id: group.id)
+        store.addProjectToActiveGroup(projectID: projectID)
+
+        #expect(store.groups.first?.projectIDs == [projectID])
+        #expect(persistence.savedGroups?.first?.projectIDs == [projectID])
+    }
+
+    @Test("addProjectToActiveGroup preserves All Projects behavior")
+    func addProjectToActiveGroupNoSelection() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addProjectToActiveGroup(projectID: UUID())
+
+        #expect(store.groups.first?.projectIDs.isEmpty == true)
+        #expect(persistence.savedGroups == nil)
+    }
+
     @Test("removeProject removes projectID from the group and persists")
     func removeProject() {
         let projectID = UUID()

--- a/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
+++ b/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
@@ -26,6 +26,56 @@ struct ProjectOpenServiceTests {
         #expect(appState.activeProjectID == projectStore.projects.first?.id)
     }
 
+    @Test("new project is added to selected group")
+    func newProjectAddedToSelectedGroup() throws {
+        let (appState, projectStore, worktreeStore) = makeStores()
+        let group = ProjectGroup(name: "Work")
+        let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
+        let projectGroupStore = ProjectGroupStore(persistence: groupPersistence)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        projectGroupStore.selectGroup(id: group.id)
+        let didConfirm = ProjectOpenService.confirmProjectPath(
+            dir.path,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+
+        #expect(didConfirm)
+        #expect(projectStore.projects.count == 1)
+        #expect(projectGroupStore.filteredProjects(from: projectStore.projects).first?.id == projectStore.projects.first?.id)
+        #expect(groupPersistence.savedGroups?.first?.projectIDs == [projectStore.projects.first?.id])
+    }
+
+    @Test("new project remains visible in All Projects without group assignment")
+    func newProjectPreservesAllProjectsBehavior() throws {
+        let (appState, projectStore, worktreeStore) = makeStores()
+        let group = ProjectGroup(name: "Work")
+        let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
+        let projectGroupStore = ProjectGroupStore(persistence: groupPersistence)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let didConfirm = ProjectOpenService.confirmProjectPath(
+            dir.path,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+
+        #expect(didConfirm)
+        #expect(projectGroupStore.filteredProjects(from: projectStore.projects).count == 1)
+        #expect(groupPersistence.savedGroups == nil)
+    }
+
     @Test("already-added path is selected without creating a duplicate project")
     func existingProjectSelectedWithoutDuplicate() throws {
         let (appState, projectStore, worktreeStore) = makeStores()

--- a/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
+++ b/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
@@ -8,7 +8,7 @@ import Testing
 struct ProjectOpenServiceTests {
     @Test("existing directory is added and selected")
     func existingDirectoryAddedAndSelected() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -18,7 +18,8 @@ struct ProjectOpenServiceTests {
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
 
         #expect(didConfirm)
@@ -28,7 +29,7 @@ struct ProjectOpenServiceTests {
 
     @Test("new project is added to selected group")
     func newProjectAddedToSelectedGroup() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, _) = makeStores()
         let group = ProjectGroup(name: "Work")
         let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
         let projectGroupStore = ProjectGroupStore(persistence: groupPersistence)
@@ -46,15 +47,16 @@ struct ProjectOpenServiceTests {
             projectGroupStore: projectGroupStore
         )
 
+        let addedProject = try #require(projectStore.projects.first)
         #expect(didConfirm)
         #expect(projectStore.projects.count == 1)
-        #expect(projectGroupStore.filteredProjects(from: projectStore.projects).first?.id == projectStore.projects.first?.id)
-        #expect(groupPersistence.savedGroups?.first?.projectIDs == [projectStore.projects.first?.id])
+        #expect(projectGroupStore.filteredProjects(from: projectStore.projects).first?.id == addedProject.id)
+        #expect(groupPersistence.savedGroups?.first?.projectIDs == [addedProject.id])
     }
 
     @Test("new project remains visible in All Projects without group assignment")
     func newProjectPreservesAllProjectsBehavior() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, _) = makeStores()
         let group = ProjectGroup(name: "Work")
         let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
         let projectGroupStore = ProjectGroupStore(persistence: groupPersistence)
@@ -78,7 +80,7 @@ struct ProjectOpenServiceTests {
 
     @Test("already-added path is selected without creating a duplicate project")
     func existingProjectSelectedWithoutDuplicate() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -88,7 +90,8 @@ struct ProjectOpenServiceTests {
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         ))
         appState.activeProjectID = nil
 
@@ -96,7 +99,8 @@ struct ProjectOpenServiceTests {
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         ))
         #expect(projectStore.projects.count == 1)
         #expect(appState.activeProjectID == projectStore.projects.first?.id)
@@ -104,7 +108,7 @@ struct ProjectOpenServiceTests {
 
     @Test("already-added path recovers a missing primary worktree without creating a duplicate project")
     func existingProjectWithMissingPrimaryRecoversWithoutDuplicate() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -116,7 +120,8 @@ struct ProjectOpenServiceTests {
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
 
         #expect(didConfirm)
@@ -127,7 +132,7 @@ struct ProjectOpenServiceTests {
 
     @Test("standardized equivalent path selects an existing project without creating a duplicate")
     func standardizedEquivalentPathDedupesExistingProject() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -139,7 +144,8 @@ struct ProjectOpenServiceTests {
             dir.standardizedFileURL.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
 
         #expect(result == .success)
@@ -149,7 +155,7 @@ struct ProjectOpenServiceTests {
 
     @Test("regular file path is rejected")
     func regularFilePathRejected() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let file = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
         try Data().write(to: file)
@@ -160,6 +166,7 @@ struct ProjectOpenServiceTests {
             appState: appState,
             projectStore: projectStore,
             worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
             createIfMissing: true
         )
 
@@ -169,6 +176,7 @@ struct ProjectOpenServiceTests {
             appState: appState,
             projectStore: projectStore,
             worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
             createIfMissing: true
         ))
         #expect(projectStore.projects.isEmpty)
@@ -177,7 +185,7 @@ struct ProjectOpenServiceTests {
 
     @Test("missing directory is rejected when creation is not requested")
     func missingDirectoryRejectedWithoutCreation() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -186,7 +194,8 @@ struct ProjectOpenServiceTests {
             dir.path,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
 
         #expect(!didConfirm)
@@ -197,7 +206,7 @@ struct ProjectOpenServiceTests {
 
     @Test("missing directory is created before adding when creation is confirmed")
     func missingDirectoryCreatedThenAdded() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -207,6 +216,7 @@ struct ProjectOpenServiceTests {
             appState: appState,
             projectStore: projectStore,
             worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
             createIfMissing: true
         )
 
@@ -217,11 +227,12 @@ struct ProjectOpenServiceTests {
 
     @Test("create failure returns create failed without adding a project")
     func createFailureReturnsCreateFailedWithoutAddingProject() {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let service = ProjectPathConfirmationService(
             appState: appState,
             projectStore: projectStore,
             worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
             fileSystem: ProjectPathConfirmationFileSystemStub(
                 state: .missing,
                 createError: ProjectPathConfirmationFileSystemStub.Error()
@@ -237,7 +248,7 @@ struct ProjectOpenServiceTests {
 
     @Test("custom picker preference posts picker notification without opening Finder")
     func customPreferencePresentsProjectPickerWithoutOpeningFinder() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let suiteName = "ProjectOpenServiceTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             Issue.record("Unable to create isolated UserDefaults suite")
@@ -261,6 +272,7 @@ struct ProjectOpenServiceTests {
             appState: appState,
             projectStore: projectStore,
             worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
             preferences: preferences,
             notificationCenter: notificationCenter,
             openWithFinder: { didOpenFinder = true }
@@ -272,7 +284,7 @@ struct ProjectOpenServiceTests {
 
     @Test("finder picker preference opens Finder without posting picker notification")
     func finderPreferencePresentsFinderWithoutProjectPickerNotification() throws {
-        let (appState, projectStore, worktreeStore) = makeStores()
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
         let suiteName = "ProjectOpenServiceTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             Issue.record("Unable to create isolated UserDefaults suite")
@@ -297,6 +309,7 @@ struct ProjectOpenServiceTests {
             appState: appState,
             projectStore: projectStore,
             worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
             preferences: preferences,
             notificationCenter: notificationCenter,
             openWithFinder: { didOpenFinder = true }
@@ -306,7 +319,7 @@ struct ProjectOpenServiceTests {
         #expect(didOpenFinder)
     }
 
-    private func makeStores() -> (AppState, ProjectStore, WorktreeStore) {
+    private func makeStores() -> (AppState, ProjectStore, WorktreeStore, ProjectGroupStore) {
         let projectStore = ProjectStore(persistence: ProjectPersistenceStub())
         let worktreeStore = WorktreeStore(persistence: WorktreePersistenceStub(), projects: [])
         let appState = AppState(
@@ -314,7 +327,8 @@ struct ProjectOpenServiceTests {
             terminalViews: TerminalViewRemovingStub(),
             workspacePersistence: WorkspacePersistenceStub()
         )
-        return (appState, projectStore, worktreeStore)
+        let projectGroupStore = ProjectGroupStore(persistence: ProjectGroupPersistenceStub())
+        return (appState, projectStore, worktreeStore, projectGroupStore)
     }
 }
 

--- a/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
+++ b/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
@@ -106,6 +106,33 @@ struct ProjectOpenServiceTests {
         #expect(appState.activeProjectID == projectStore.projects.first?.id)
     }
 
+    @Test("already-added path is added to selected group")
+    func existingProjectAddedToSelectedGroup() throws {
+        let (appState, projectStore, worktreeStore, _) = makeStores()
+        let group = ProjectGroup(name: "Work")
+        let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
+        let projectGroupStore = ProjectGroupStore(persistence: groupPersistence)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-project-picker-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let project = Project(name: dir.lastPathComponent, path: dir.standardizedFileURL.path)
+        projectStore.add(project)
+
+        projectGroupStore.selectGroup(id: group.id)
+        let didConfirm = ProjectOpenService.confirmProjectPath(
+            dir.path,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+
+        #expect(didConfirm)
+        #expect(projectStore.projects.count == 1)
+        #expect(groupPersistence.savedGroups?.first?.projectIDs == [project.id])
+    }
+
     @Test("already-added path recovers a missing primary worktree without creating a duplicate project")
     func existingProjectWithMissingPrimaryRecoversWithoutDuplicate() throws {
         let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()


### PR DESCRIPTION
When a project is opened via dialog, CLI, or path confirmation, automatically add it to the user's currently selected group. Preserves "All Projects" behavior when no group is active. Includes tests covering group assignment and fallback scenarios.

Closes #549