### PR TITLE
Increase remote snapshot rows to 100 for mobile takeover

### DIFF
--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -277,6 +277,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
 
     func takeOverPane(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32) {
         ensureTerminalView(paneID: paneID)
+        applyPTYSize(paneID: paneID, cols: cols, rows: RemoteTerminalSnapshotBuilder.snapshotRows)
         let snapshotBytes = buildTerminalSnapshot(paneID: paneID)
         PaneOwnershipStore.shared.assign(paneID: paneID, to: clientID)
         if let bytes = snapshotBytes, !bytes.isEmpty {

--- a/Muxy/Services/RemoteTerminalSnapshotBuilder.swift
+++ b/Muxy/Services/RemoteTerminalSnapshotBuilder.swift
@@ -2,6 +2,8 @@ import Foundation
 import MuxyShared
 
 enum RemoteTerminalSnapshotBuilder {
+    static let snapshotRows: UInt32 = 100
+
     static func buildBytes(from snapshot: TerminalCellsDTO) -> Data {
         let cols = Int(snapshot.cols)
         let rows = Int(snapshot.rows)


### PR DESCRIPTION
Resizes the headless pane to 100 rows before building the takeover snapshot, then back to the mobile's viewport.
  Gives mobile clients far more context on initial connection.