### PR TITLE
Add Gherkin syntax highlighting

### DIFF
--- a/Muxy/Syntax/Grammars/GherkinGrammar.swift
+++ b/Muxy/Syntax/Grammars/GherkinGrammar.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension SyntaxGrammar {
+    static let gherkin = SyntaxGrammar(
+        name: "Gherkin",
+        extensions: ["feature"],
+        caseSensitiveKeywords: true,
+        lineComments: ["#"],
+        lineCommentScope: .comment,
+        blockComments: [],
+        strings: [
+            StringRule(id: 1, open: "\"\"\"", close: "\"\"\"", escape: nil, multiline: true, scope: .docComment),
+            StringRule(id: 2, open: "\"", close: "\"", escape: "\\", multiline: false, scope: .string),
+            StringRule(id: 3, open: "'", close: "'", escape: "\\", multiline: false, scope: .string),
+        ],
+        keywordGroups: [
+            KeywordGroup(words: ["Feature"], scope: .heading),
+            KeywordGroup(words: [
+                "Background", "Rule",
+                "Scenario", "Example", "Examples", "Scenarios",
+                "Outline", "Template",
+            ], scope: .keyword),
+            KeywordGroup(words: [
+                "Given", "When", "Then", "And", "But",
+            ], scope: .builtin),
+        ],
+        supportsNumbers: true,
+        supportsHashDirectives: false,
+        hashDirectiveScope: .preprocessor,
+        supportsAtAttributes: true,
+        atAttributeScope: .attribute,
+        highlightFunctionCalls: false,
+        highlightAllCapsAsConstant: false,
+        identifierStart: SyntaxGrammar.defaultIdentifierStart,
+        identifierBody: {
+            var set = SyntaxGrammar.defaultIdentifierBody
+            set.insert("-")
+            return set
+        }()
+    )
+}

--- a/Muxy/Syntax/SyntaxLanguageRegistry.swift
+++ b/Muxy/Syntax/SyntaxLanguageRegistry.swift
@@ -46,6 +46,7 @@ enum SyntaxLanguageRegistry {
         .sql,
         .dockerfile,
         .makefile,
+        .gherkin,
     ]
 
     private static let extensionMap: [String: SyntaxGrammar] = {
@@ -153,6 +154,7 @@ enum SyntaxLanguageRegistry {
         "php": "php",
         "xml": "xml",
         "css": "css",
+        "gherkin": "feature",
     ]
 
     static func grammar(forLanguageHint hint: String) -> SyntaxGrammar? {

--- a/Tests/MuxyTests/Models/SyntaxLanguageRegistryTests.swift
+++ b/Tests/MuxyTests/Models/SyntaxLanguageRegistryTests.swift
@@ -69,6 +69,15 @@ struct SyntaxLanguageRegistryTests {
         #expect(SyntaxLanguageRegistry.grammar(forFile: "data.tsv")?.name == "CSV")
     }
 
+    @Test("recognizes Gherkin")
+    func gherkin() {
+        #expect(SyntaxLanguageRegistry.grammar(forFile: "login.feature")?.name == "Gherkin")
+        #expect(SyntaxLanguageRegistry.grammar(forFile: "/specs/checkout.feature")?.name == "Gherkin")
+        #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "gherkin")?.name == "Gherkin")
+        #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "feature")?.name == "Gherkin")
+        #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "Gherkin")?.name == "Gherkin")
+    }
+
     @Test("language hint resolves common fence labels")
     func hintCommonFences() {
         #expect(SyntaxLanguageRegistry.grammar(forLanguageHint: "swift")?.name == "Swift")

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -20,7 +20,7 @@ Muxy includes a lightweight built-in code editor that opens files as tabs. Desig
 
 ## Syntax highlighting
 
-The editor highlights 30+ languages including Swift, C / C++ / Objective-C, JavaScript / TypeScript, Python, Ruby, Go, Rust, HTML / CSS, JSON / YAML / TOML, Markdown, and shell scripts. The active syntax theme follows the app theme — change it in **Settings → Appearance**.
+The editor highlights 40+ languages including Swift, C / C++ / Objective-C, JavaScript / TypeScript, Python, Ruby, Go, Rust, HTML / CSS, JSON / YAML / TOML, Markdown, shell scripts, and Gherkin. The active syntax theme follows the app theme — change it in **Settings → Appearance**.
 
 ## Find / Replace
 


### PR DESCRIPTION
## Summary

Adds syntax highlighting for Cucumber/Gherkin `.feature` files. The editor previously rendered them as plain text. Registers a new `SyntaxGrammar` in the existing data-driven pipeline — no tokenizer changes.

## Changes

- New `Muxy/Syntax/Grammars/GherkinGrammar.swift` with three keyword tiers (`Feature` → heading, section keywords → keyword, step keywords `Given` / `When` / `Then` / `And` / `But` → builtin), `@`-prefixed tag support, `"""` doc strings, and inline `"..."` / `'...'` strings.
- Registered `.gherkin` in `SyntaxLanguageRegistry.allGrammars` and added `gherkin` hint alias for code fences.
- New `recognizes Gherkin` test in `SyntaxLanguageRegistryTests`.
- `docs/features/editor.md` — bumped language count and listed Gherkin.

Known engine limitations not addressed: `*` bullet step keyword, `<param>` placeholders, and table cell `|` delimiters render as plain text — these would require pattern-matching features no other grammar uses.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS
- `swift test --filter SyntaxLanguageRegistryTests` — 16/16 pass including new `recognizes Gherkin` test
- Visually verified on a real `.feature` file via a side-by-side install build

## Screenshots

<img width="1084" height="258" alt="1" src="https://github.com/user-attachments/assets/9e17ff5a-d75d-4e9d-8930-c31046aae7f9" />