### PR TITLE
Add topbar, status bar, and settings APIs for extensions

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -74,6 +74,84 @@ struct ExtensionTabType: Codable, Equatable, Identifiable {
     let defaultData: ExtensionJSON?
 }
 
+enum ExtensionIcon: Codable, Equatable {
+    case symbol(String)
+    case svg(String)
+
+    private enum CodingKeys: String, CodingKey {
+        case symbol
+        case svg
+    }
+
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer(),
+           let raw = try? container.decode(String.self)
+        {
+            self = .symbol(raw)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let symbol = try container.decodeIfPresent(String.self, forKey: .symbol) {
+            self = .symbol(symbol)
+            return
+        }
+        if let svg = try container.decodeIfPresent(String.self, forKey: .svg) {
+            self = .svg(svg)
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            forKey: CodingKeys.symbol,
+            in: container,
+            debugDescription: "Icon requires either a 'symbol' or 'svg' field"
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .symbol(value): try container.encode(value, forKey: .symbol)
+        case let .svg(value): try container.encode(value, forKey: .svg)
+        }
+    }
+}
+
+struct ExtensionTopbarItem: Codable, Equatable, Identifiable {
+    let id: String
+    let icon: ExtensionIcon
+    let tooltip: String?
+    let command: String
+}
+
+struct ExtensionStatusBarItem: Codable, Equatable, Identifiable {
+    enum Side: String, Codable {
+        case left
+        case right
+    }
+
+    let id: String
+    let icon: ExtensionIcon
+    let text: String?
+    let tooltip: String?
+    let side: Side
+    let command: String
+}
+
+enum ExtensionSettingType: String, Codable {
+    case string
+    case bool
+    case number
+}
+
+struct ExtensionSettingEntry: Codable, Equatable, Identifiable {
+    let key: String
+    let title: String
+    let description: String?
+    let type: ExtensionSettingType
+    let defaultValue: ExtensionJSON?
+
+    var id: String { key }
+}
+
 enum ExtensionCommandAction: Codable, Equatable {
     case event
     case openTab(tabType: String, data: ExtensionJSON?)
@@ -171,6 +249,9 @@ struct ExtensionManifest: Codable, Equatable {
     let tabTypes: [ExtensionTabType]
     let permissions: [ExtensionPermission]
     let aiProvider: ExtensionAIProvider?
+    let topbarItems: [ExtensionTopbarItem]
+    let statusBarItems: [ExtensionStatusBarItem]
+    let settings: [ExtensionSettingEntry]
     let enabled: Bool
 
     private enum CodingKeys: String, CodingKey {
@@ -183,6 +264,9 @@ struct ExtensionManifest: Codable, Equatable {
         case tabTypes
         case permissions
         case aiProvider
+        case topbarItems
+        case statusBarItems
+        case settings
         case enabled
     }
 
@@ -196,6 +280,9 @@ struct ExtensionManifest: Codable, Equatable {
         tabTypes: [ExtensionTabType] = [],
         permissions: [ExtensionPermission] = [],
         aiProvider: ExtensionAIProvider? = nil,
+        topbarItems: [ExtensionTopbarItem] = [],
+        statusBarItems: [ExtensionStatusBarItem] = [],
+        settings: [ExtensionSettingEntry] = [],
         enabled: Bool = true
     ) {
         self.name = name
@@ -207,6 +294,9 @@ struct ExtensionManifest: Codable, Equatable {
         self.tabTypes = tabTypes
         self.permissions = permissions
         self.aiProvider = aiProvider
+        self.topbarItems = topbarItems
+        self.statusBarItems = statusBarItems
+        self.settings = settings
         self.enabled = enabled
     }
 
@@ -221,11 +311,22 @@ struct ExtensionManifest: Codable, Equatable {
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
         permissions = try container.decodeIfPresent([ExtensionPermission].self, forKey: .permissions) ?? []
         aiProvider = try container.decodeIfPresent(ExtensionAIProvider.self, forKey: .aiProvider)
+        topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
+        statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
+        settings = try container.decodeIfPresent([ExtensionSettingEntry].self, forKey: .settings) ?? []
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
     }
 
     func tabType(id: String) -> ExtensionTabType? {
         tabTypes.first { $0.id == id }
+    }
+
+    func setting(key: String) -> ExtensionSettingEntry? {
+        settings.first { $0.key == key }
+    }
+
+    func statusBarItem(id: String) -> ExtensionStatusBarItem? {
+        statusBarItems.first { $0.id == id }
     }
 
     func withEnabled(_ enabled: Bool) -> ExtensionManifest {
@@ -239,6 +340,9 @@ struct ExtensionManifest: Codable, Equatable {
             tabTypes: tabTypes,
             permissions: permissions,
             aiProvider: aiProvider,
+            topbarItems: topbarItems,
+            statusBarItems: statusBarItems,
+            settings: settings,
             enabled: enabled
         )
     }
@@ -257,6 +361,18 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case commandReferencesUnknownTabType(commandID: String, tabType: String)
     case scriptMissing(commandID: String, url: URL)
     case scriptOutsideDirectory(commandID: String, url: URL)
+    case topbarItemEmptyID
+    case duplicateTopbarItem(String)
+    case topbarItemReferencesUnknownCommand(itemID: String, command: String)
+    case topbarItemSVGMissing(itemID: String, url: URL)
+    case topbarItemSVGOutsideDirectory(itemID: String, url: URL)
+    case statusBarItemEmptyID
+    case duplicateStatusBarItem(String)
+    case statusBarItemReferencesUnknownCommand(itemID: String, command: String)
+    case statusBarItemSVGMissing(itemID: String, url: URL)
+    case statusBarItemSVGOutsideDirectory(itemID: String, url: URL)
+    case settingEmptyKey
+    case duplicateSettingKey(String)
 
     var errorDescription: String? {
         switch self {
@@ -284,6 +400,30 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Command '\(commandID)' script not found at \(url.path)"
         case let .scriptOutsideDirectory(commandID, url):
             "Command '\(commandID)' script at \(url.path) escapes the extension directory"
+        case .topbarItemEmptyID:
+            "Topbar item id must not be empty"
+        case let .duplicateTopbarItem(id):
+            "Duplicate topbar item '\(id)'"
+        case let .topbarItemReferencesUnknownCommand(itemID, command):
+            "Topbar item '\(itemID)' references unknown command '\(command)'"
+        case let .topbarItemSVGMissing(itemID, url):
+            "Topbar item '\(itemID)' icon SVG not found at \(url.path)"
+        case let .topbarItemSVGOutsideDirectory(itemID, url):
+            "Topbar item '\(itemID)' icon SVG at \(url.path) escapes the extension directory"
+        case .statusBarItemEmptyID:
+            "Status bar item id must not be empty"
+        case let .duplicateStatusBarItem(id):
+            "Duplicate status bar item '\(id)'"
+        case let .statusBarItemReferencesUnknownCommand(itemID, command):
+            "Status bar item '\(itemID)' references unknown command '\(command)'"
+        case let .statusBarItemSVGMissing(itemID, url):
+            "Status bar item '\(itemID)' icon SVG not found at \(url.path)"
+        case let .statusBarItemSVGOutsideDirectory(itemID, url):
+            "Status bar item '\(itemID)' icon SVG at \(url.path) escapes the extension directory"
+        case .settingEmptyKey:
+            "Setting key must not be empty"
+        case let .duplicateSettingKey(key):
+            "Duplicate setting key '\(key)'"
         }
     }
 }
@@ -352,6 +492,9 @@ enum ExtensionManifestLoader {
         let muxyExtension = MuxyExtension(id: manifest.name, directory: directory, manifest: manifest)
         try validateTabTypes(manifest: manifest, in: muxyExtension)
         try validateCommands(manifest: manifest, in: muxyExtension)
+        try validateTopbarItems(manifest: manifest, in: muxyExtension)
+        try validateStatusBarItems(manifest: manifest, in: muxyExtension)
+        try validateSettings(manifest: manifest)
 
         return muxyExtension
     }
@@ -404,6 +547,72 @@ enum ExtensionManifestLoader {
                 guard FileManager.default.fileExists(atPath: url.path) else {
                     throw ExtensionLoadError.scriptMissing(commandID: command.id, url: url)
                 }
+            }
+        }
+    }
+
+    private static func validateTopbarItems(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
+        let commandIDs = Set(manifest.commands.map(\.id))
+        var seen = Set<String>()
+        for item in manifest.topbarItems {
+            guard !item.id.isEmpty else { throw ExtensionLoadError.topbarItemEmptyID }
+            guard seen.insert(item.id).inserted else {
+                throw ExtensionLoadError.duplicateTopbarItem(item.id)
+            }
+            guard commandIDs.contains(item.command) else {
+                throw ExtensionLoadError.topbarItemReferencesUnknownCommand(
+                    itemID: item.id,
+                    command: item.command
+                )
+            }
+            if case let .svg(path) = item.icon {
+                guard let url = muxyExtension.resolveResource(path) else {
+                    throw ExtensionLoadError.topbarItemSVGOutsideDirectory(
+                        itemID: item.id,
+                        url: muxyExtension.directory.appendingPathComponent(path)
+                    )
+                }
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    throw ExtensionLoadError.topbarItemSVGMissing(itemID: item.id, url: url)
+                }
+            }
+        }
+    }
+
+    private static func validateStatusBarItems(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
+        let commandIDs = Set(manifest.commands.map(\.id))
+        var seen = Set<String>()
+        for item in manifest.statusBarItems {
+            guard !item.id.isEmpty else { throw ExtensionLoadError.statusBarItemEmptyID }
+            guard seen.insert(item.id).inserted else {
+                throw ExtensionLoadError.duplicateStatusBarItem(item.id)
+            }
+            guard commandIDs.contains(item.command) else {
+                throw ExtensionLoadError.statusBarItemReferencesUnknownCommand(
+                    itemID: item.id,
+                    command: item.command
+                )
+            }
+            if case let .svg(path) = item.icon {
+                guard let url = muxyExtension.resolveResource(path) else {
+                    throw ExtensionLoadError.statusBarItemSVGOutsideDirectory(
+                        itemID: item.id,
+                        url: muxyExtension.directory.appendingPathComponent(path)
+                    )
+                }
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    throw ExtensionLoadError.statusBarItemSVGMissing(itemID: item.id, url: url)
+                }
+            }
+        }
+    }
+
+    private static func validateSettings(manifest: ExtensionManifest) throws {
+        var seen = Set<String>()
+        for entry in manifest.settings {
+            guard !entry.key.isEmpty else { throw ExtensionLoadError.settingEmptyKey }
+            guard seen.insert(entry.key).inserted else {
+                throw ExtensionLoadError.duplicateSettingKey(entry.key)
             }
         }
     }

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -551,6 +551,8 @@ enum ExtensionManifestLoader {
         }
     }
 
+    static let maxIconSVGBytes = 256 * 1024
+
     private static func validateTopbarItems(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
         let commandIDs = Set(manifest.commands.map(\.id))
         var seen = Set<String>()
@@ -565,17 +567,12 @@ enum ExtensionManifestLoader {
                     command: item.command
                 )
             }
-            if case let .svg(path) = item.icon {
-                guard let url = muxyExtension.resolveResource(path) else {
-                    throw ExtensionLoadError.topbarItemSVGOutsideDirectory(
-                        itemID: item.id,
-                        url: muxyExtension.directory.appendingPathComponent(path)
-                    )
-                }
-                guard FileManager.default.fileExists(atPath: url.path) else {
-                    throw ExtensionLoadError.topbarItemSVGMissing(itemID: item.id, url: url)
-                }
-            }
+            try validateIcon(
+                item.icon,
+                in: muxyExtension,
+                missing: { ExtensionLoadError.topbarItemSVGMissing(itemID: item.id, url: $0) },
+                outside: { ExtensionLoadError.topbarItemSVGOutsideDirectory(itemID: item.id, url: $0) }
+            )
         }
     }
 
@@ -593,17 +590,34 @@ enum ExtensionManifestLoader {
                     command: item.command
                 )
             }
-            if case let .svg(path) = item.icon {
-                guard let url = muxyExtension.resolveResource(path) else {
-                    throw ExtensionLoadError.statusBarItemSVGOutsideDirectory(
-                        itemID: item.id,
-                        url: muxyExtension.directory.appendingPathComponent(path)
-                    )
-                }
-                guard FileManager.default.fileExists(atPath: url.path) else {
-                    throw ExtensionLoadError.statusBarItemSVGMissing(itemID: item.id, url: url)
-                }
-            }
+            try validateIcon(
+                item.icon,
+                in: muxyExtension,
+                missing: { ExtensionLoadError.statusBarItemSVGMissing(itemID: item.id, url: $0) },
+                outside: { ExtensionLoadError.statusBarItemSVGOutsideDirectory(itemID: item.id, url: $0) }
+            )
+        }
+    }
+
+    private static func validateIcon(
+        _ icon: ExtensionIcon,
+        in muxyExtension: MuxyExtension,
+        missing: (URL) -> ExtensionLoadError,
+        outside: (URL) -> ExtensionLoadError
+    ) throws {
+        guard case let .svg(path) = icon else { return }
+        guard path.lowercased().hasSuffix(".svg") else {
+            throw outside(muxyExtension.directory.appendingPathComponent(path))
+        }
+        guard let url = muxyExtension.resolveResource(path) else {
+            throw outside(muxyExtension.directory.appendingPathComponent(path))
+        }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw missing(url)
+        }
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        if let size = attributes[.size] as? Int, size > maxIconSVGBytes {
+            throw missing(url)
         }
     }
 

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -55,6 +55,8 @@ struct MuxyApp: App {
                 .environment(GhosttyService.shared)
                 .environment(MuxyConfig.shared)
                 .environment(ThemeService.shared)
+                .environment(ExtensionStore.shared)
+                .environment(ExtensionSettingsStore.shared)
                 .preferredColorScheme(MuxyTheme.colorScheme)
                 .onAppear {
                     startDeferredServicesIfNeeded()
@@ -442,6 +444,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             rootView: SettingsView()
                 .frame(width: 980, height: 680)
                 .preferredColorScheme(MuxyTheme.colorScheme)
+                .environment(ExtensionStore.shared)
+                .environment(ExtensionSettingsStore.shared)
         )
         let window = SettingsModalWindow(contentViewController: host)
         window.title = "Settings"

--- a/Muxy/Services/ExtensionIconAssetCache.swift
+++ b/Muxy/Services/ExtensionIconAssetCache.swift
@@ -1,0 +1,35 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class ExtensionIconAssetCache {
+    static let shared = ExtensionIconAssetCache()
+
+    private var images: [String: NSImage] = [:]
+
+    private init() {}
+
+    func image(extensionID: String, url: URL) -> NSImage? {
+        let key = cacheKey(extensionID: extensionID, url: url)
+        if let cached = images[key] {
+            return cached
+        }
+        guard let image = NSImage(contentsOf: url) else { return nil }
+        image.isTemplate = true
+        images[key] = image
+        return image
+    }
+
+    func invalidate(extensionID: String) {
+        let prefix = "\(extensionID)\t"
+        images = images.filter { !$0.key.hasPrefix(prefix) }
+    }
+
+    func invalidateAll() {
+        images.removeAll()
+    }
+
+    private func cacheKey(extensionID: String, url: URL) -> String {
+        "\(extensionID)\t\(url.path)"
+    }
+}

--- a/Muxy/Services/ExtensionSettingsStore.swift
+++ b/Muxy/Services/ExtensionSettingsStore.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+@MainActor
+@Observable
+final class ExtensionSettingsStore {
+    static let shared = ExtensionSettingsStore()
+
+    private let defaults: UserDefaults
+    private var changeTick: Int = 0
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    static let keyPrefix = "muxy.ext."
+
+    static func storageKey(extensionID: String, key: String) -> String {
+        "\(keyPrefix)\(extensionID).\(key)"
+    }
+
+    func value(extensionID: String, key: String) -> ExtensionJSON? {
+        _ = changeTick
+        return readValue(extensionID: extensionID, key: key)
+    }
+
+    func setValue(_ value: ExtensionJSON?, extensionID: String, key: String) {
+        let storageKey = Self.storageKey(extensionID: extensionID, key: key)
+        guard let value else {
+            defaults.removeObject(forKey: storageKey)
+            changeTick &+= 1
+            return
+        }
+        defaults.set(encodeForStorage(value), forKey: storageKey)
+        changeTick &+= 1
+    }
+
+    func effectiveValue(extensionID: String, entry: ExtensionSettingEntry) -> ExtensionJSON? {
+        if let override = value(extensionID: extensionID, key: entry.key) {
+            return override
+        }
+        return entry.defaultValue
+    }
+
+    func clearAll(extensionID: String) {
+        let prefix = "\(Self.keyPrefix)\(extensionID)."
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(prefix) {
+            defaults.removeObject(forKey: key)
+        }
+        changeTick &+= 1
+    }
+
+    private func readValue(extensionID: String, key: String) -> ExtensionJSON? {
+        let storageKey = Self.storageKey(extensionID: extensionID, key: key)
+        guard let raw = defaults.object(forKey: storageKey) else { return nil }
+        return decodeFromStorage(raw)
+    }
+
+    private func encodeForStorage(_ value: ExtensionJSON) -> Any {
+        switch value {
+        case .null: NSNull()
+        case let .bool(value): value
+        case let .number(value): value
+        case let .string(value): value
+        case let .array(value): value.map(encodeForStorage)
+        case let .object(value): value.mapValues(encodeForStorage)
+        }
+    }
+
+    private func decodeFromStorage(_ raw: Any) -> ExtensionJSON {
+        if raw is NSNull { return .null }
+        if let value = raw as? Bool { return .bool(value) }
+        if let value = raw as? Double { return .number(value) }
+        if let value = raw as? Int { return .number(Double(value)) }
+        if let value = raw as? NSNumber {
+            if CFGetTypeID(value) == CFBooleanGetTypeID() { return .bool(value.boolValue) }
+            return .number(value.doubleValue)
+        }
+        if let value = raw as? String { return .string(value) }
+        if let value = raw as? [Any] { return .array(value.map(decodeFromStorage)) }
+        if let value = raw as? [String: Any] { return .object(value.mapValues(decodeFromStorage)) }
+        return .null
+    }
+}

--- a/Muxy/Services/ExtensionSettingsStore.swift
+++ b/Muxy/Services/ExtensionSettingsStore.swift
@@ -5,8 +5,8 @@ import Foundation
 final class ExtensionSettingsStore {
     static let shared = ExtensionSettingsStore()
 
-    private let defaults: UserDefaults
-    private var changeTick: Int = 0
+    @ObservationIgnored private let defaults: UserDefaults
+    private var cache: [String: ExtensionJSON] = [:]
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -19,19 +19,25 @@ final class ExtensionSettingsStore {
     }
 
     func value(extensionID: String, key: String) -> ExtensionJSON? {
-        _ = changeTick
-        return readValue(extensionID: extensionID, key: key)
+        let storageKey = Self.storageKey(extensionID: extensionID, key: key)
+        if let cached = cache[storageKey] {
+            return cached
+        }
+        guard let raw = defaults.object(forKey: storageKey) else { return nil }
+        let decoded = decodeFromStorage(raw)
+        cache[storageKey] = decoded
+        return decoded
     }
 
     func setValue(_ value: ExtensionJSON?, extensionID: String, key: String) {
         let storageKey = Self.storageKey(extensionID: extensionID, key: key)
         guard let value else {
+            cache.removeValue(forKey: storageKey)
             defaults.removeObject(forKey: storageKey)
-            changeTick &+= 1
             return
         }
+        cache[storageKey] = value
         defaults.set(encodeForStorage(value), forKey: storageKey)
-        changeTick &+= 1
     }
 
     func effectiveValue(extensionID: String, entry: ExtensionSettingEntry) -> ExtensionJSON? {
@@ -43,16 +49,12 @@ final class ExtensionSettingsStore {
 
     func clearAll(extensionID: String) {
         let prefix = "\(Self.keyPrefix)\(extensionID)."
+        for key in cache.keys where key.hasPrefix(prefix) {
+            cache.removeValue(forKey: key)
+        }
         for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(prefix) {
             defaults.removeObject(forKey: key)
         }
-        changeTick &+= 1
-    }
-
-    private func readValue(extensionID: String, key: String) -> ExtensionJSON? {
-        let storageKey = Self.storageKey(extensionID: extensionID, key: key)
-        guard let raw = defaults.object(forKey: storageKey) else { return nil }
-        return decodeFromStorage(raw)
     }
 
     private func encodeForStorage(_ value: ExtensionJSON) -> Any {

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import Security
 
 private let logger = Logger(subsystem: "app.muxy", category: "ExtensionStore")
 
@@ -32,6 +33,7 @@ final class ExtensionStore {
     private(set) var loadFailures: [LoadFailure] = []
 
     private var processes: [String: Process] = [:]
+    private var tokens: [String: String] = [:]
     private let rootDirectoryURL: URL
 
     private init(rootDirectory: URL = ExtensionStore.defaultRootDirectory) {
@@ -50,6 +52,7 @@ final class ExtensionStore {
         for index in statuses.indices where statuses[index].muxyExtension.manifest.enabled {
             startExtension(at: index)
         }
+        rebuildExtensionUICache()
         publishSnapshot()
     }
 
@@ -58,6 +61,8 @@ final class ExtensionStore {
             stopProcess(extensionID: status.id)
         }
         statusBarTextOverrides.removeAll()
+        ExtensionIconAssetCache.shared.invalidateAll()
+        rebuildExtensionUICache()
         publishSnapshot()
     }
 
@@ -88,7 +93,9 @@ final class ExtensionStore {
         }
         if !enabled {
             statusBarTextOverrides.removeValue(forKey: extensionID)
+            ExtensionIconAssetCache.shared.invalidate(extensionID: extensionID)
         }
+        rebuildExtensionUICache()
         publishSnapshot()
     }
 
@@ -105,10 +112,12 @@ final class ExtensionStore {
         var entries: [String: NotificationSocketServer.ExtensionSnapshotEntry] = [:]
         for status in statuses where status.muxyExtension.manifest.enabled {
             let manifest = status.muxyExtension.manifest
+            guard let token = tokens[status.id] else { continue }
             entries[status.id] = NotificationSocketServer.ExtensionSnapshotEntry(
                 allowedEvents: Set(manifest.events),
                 commandEvents: Set(manifest.commands.map(\.eventName)),
-                permissions: Set(manifest.permissions)
+                permissions: Set(manifest.permissions),
+                token: token
             )
         }
         return NotificationSocketServer.ExtensionSnapshot(entries: entries)
@@ -118,14 +127,17 @@ final class ExtensionStore {
         NotificationSocketServer.shared.applyExtensionSnapshot(snapshotForSocketServer())
     }
 
-    static func buildSnapshotForTesting(from extensions: [MuxyExtension]) -> NotificationSocketServer.ExtensionSnapshot {
+    static func buildSnapshotForTesting(from extensions: [MuxyExtension], token: String = "test-token") -> NotificationSocketServer
+        .ExtensionSnapshot
+    {
         var entries: [String: NotificationSocketServer.ExtensionSnapshotEntry] = [:]
         for ext in extensions where ext.manifest.enabled {
             let manifest = ext.manifest
             entries[ext.id] = NotificationSocketServer.ExtensionSnapshotEntry(
                 allowedEvents: Set(manifest.events),
                 commandEvents: Set(manifest.commands.map(\.eventName)),
-                permissions: Set(manifest.permissions)
+                permissions: Set(manifest.permissions),
+                token: token
             )
         }
         return NotificationSocketServer.ExtensionSnapshot(entries: entries)
@@ -153,6 +165,9 @@ final class ExtensionStore {
     }
 
     private var statusBarTextOverrides: [String: [String: String]] = [:]
+    private(set) var topbarItems: [TopbarItemBinding] = []
+    private(set) var leftStatusBarItems: [StatusBarItemBinding] = []
+    private(set) var rightStatusBarItems: [StatusBarItemBinding] = []
 
     func paletteCommands() -> [PaletteCommandBinding] {
         statuses
@@ -162,30 +177,35 @@ final class ExtensionStore {
             }
     }
 
-    func topbarItems() -> [TopbarItemBinding] {
-        statuses
-            .filter(\.muxyExtension.manifest.enabled)
-            .flatMap { status in
-                status.muxyExtension.manifest.topbarItems.map { item in
-                    TopbarItemBinding(muxyExtension: status.muxyExtension, item: item)
-                }
-            }
+    func statusBarItems(side: ExtensionStatusBarItem.Side) -> [StatusBarItemBinding] {
+        side == .left ? leftStatusBarItems : rightStatusBarItems
     }
 
-    func statusBarItems(side: ExtensionStatusBarItem.Side) -> [StatusBarItemBinding] {
-        statuses
-            .filter(\.muxyExtension.manifest.enabled)
-            .flatMap { status in
-                status.muxyExtension.manifest.statusBarItems
-                    .filter { $0.side == side }
-                    .map { item in
-                        StatusBarItemBinding(
-                            muxyExtension: status.muxyExtension,
-                            item: item,
-                            liveText: statusBarTextOverrides[status.id]?[item.id]
-                        )
-                    }
+    private func rebuildExtensionUICache() {
+        var topbar: [TopbarItemBinding] = []
+        var left: [StatusBarItemBinding] = []
+        var right: [StatusBarItemBinding] = []
+        for status in statuses where status.muxyExtension.manifest.enabled {
+            let ext = status.muxyExtension
+            let overrides = statusBarTextOverrides[status.id]
+            for item in ext.manifest.topbarItems {
+                topbar.append(TopbarItemBinding(muxyExtension: ext, item: item))
             }
+            for item in ext.manifest.statusBarItems {
+                let binding = StatusBarItemBinding(
+                    muxyExtension: ext,
+                    item: item,
+                    liveText: overrides?[item.id]
+                )
+                switch item.side {
+                case .left: left.append(binding)
+                case .right: right.append(binding)
+                }
+            }
+        }
+        topbarItems = topbar
+        leftStatusBarItems = left
+        rightStatusBarItems = right
     }
 
     func setStatusBarText(extensionID: String, itemID: String, text: String?) -> Bool {
@@ -200,6 +220,7 @@ final class ExtensionStore {
             overrides.removeValue(forKey: itemID)
         }
         statusBarTextOverrides[extensionID] = overrides.isEmpty ? nil : overrides
+        rebuildExtensionUICache()
         return true
     }
 
@@ -388,9 +409,13 @@ final class ExtensionStore {
         process.executableURL = ext.entrypointURL
         process.currentDirectoryURL = ext.directory
 
+        let token = Self.generateToken()
+        tokens[ext.id] = token
+
         var environment = ProcessInfo.processInfo.environment
         environment["MUXY_SOCKET_PATH"] = NotificationSocketServer.socketPath
         environment["MUXY_EXTENSION_ID"] = ext.id
+        environment["MUXY_EXTENSION_TOKEN"] = token
         let logURL = ExtensionLogStore.shared.logURL(extensionID: ext.id, directory: ext.directory)
         environment["MUXY_EXTENSION_LOG"] = logURL.path
         process.environment = environment
@@ -440,6 +465,7 @@ final class ExtensionStore {
 
     private func stopProcess(extensionID: String) {
         ExtensionScriptRunner.shared.evict(extensionID: extensionID)
+        tokens.removeValue(forKey: extensionID)
         guard let process = processes.removeValue(forKey: extensionID) else { return }
         if process.isRunning {
             process.terminate()
@@ -447,6 +473,15 @@ final class ExtensionStore {
         if let index = statuses.firstIndex(where: { $0.id == extensionID }) {
             statuses[index].isRunning = false
         }
+    }
+
+    private static func generateToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let result = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard result == errSecSuccess else {
+            return UUID().uuidString + UUID().uuidString
+        }
+        return Data(bytes).base64EncodedString()
     }
 
     private func handleTermination(extensionID: String, process: Process) {

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -57,6 +57,7 @@ final class ExtensionStore {
         for status in statuses where status.isRunning {
             stopProcess(extensionID: status.id)
         }
+        statusBarTextOverrides.removeAll()
         publishSnapshot()
     }
 
@@ -84,6 +85,9 @@ final class ExtensionStore {
             startExtension(at: index)
         } else if !enabled, statuses[index].isRunning {
             stopProcess(extensionID: extensionID)
+        }
+        if !enabled {
+            statusBarTextOverrides.removeValue(forKey: extensionID)
         }
         publishSnapshot()
     }
@@ -132,12 +136,71 @@ final class ExtensionStore {
         let command: ExtensionPaletteCommand
     }
 
+    struct TopbarItemBinding: Equatable, Identifiable {
+        let muxyExtension: MuxyExtension
+        let item: ExtensionTopbarItem
+
+        var id: String { "\(muxyExtension.id):\(item.id)" }
+    }
+
+    struct StatusBarItemBinding: Equatable, Identifiable {
+        let muxyExtension: MuxyExtension
+        let item: ExtensionStatusBarItem
+        let liveText: String?
+
+        var id: String { "\(muxyExtension.id):\(item.id)" }
+        var displayText: String? { liveText ?? item.text }
+    }
+
+    private var statusBarTextOverrides: [String: [String: String]] = [:]
+
     func paletteCommands() -> [PaletteCommandBinding] {
         statuses
             .filter(\.muxyExtension.manifest.enabled)
             .flatMap { status in
                 status.muxyExtension.manifest.commands.map { PaletteCommandBinding(muxyExtension: status.muxyExtension, command: $0) }
             }
+    }
+
+    func topbarItems() -> [TopbarItemBinding] {
+        statuses
+            .filter(\.muxyExtension.manifest.enabled)
+            .flatMap { status in
+                status.muxyExtension.manifest.topbarItems.map { item in
+                    TopbarItemBinding(muxyExtension: status.muxyExtension, item: item)
+                }
+            }
+    }
+
+    func statusBarItems(side: ExtensionStatusBarItem.Side) -> [StatusBarItemBinding] {
+        statuses
+            .filter(\.muxyExtension.manifest.enabled)
+            .flatMap { status in
+                status.muxyExtension.manifest.statusBarItems
+                    .filter { $0.side == side }
+                    .map { item in
+                        StatusBarItemBinding(
+                            muxyExtension: status.muxyExtension,
+                            item: item,
+                            liveText: statusBarTextOverrides[status.id]?[item.id]
+                        )
+                    }
+            }
+    }
+
+    func setStatusBarText(extensionID: String, itemID: String, text: String?) -> Bool {
+        guard let muxyExtension = loadedExtension(id: extensionID),
+              muxyExtension.manifest.statusBarItem(id: itemID) != nil
+        else { return false }
+
+        var overrides = statusBarTextOverrides[extensionID] ?? [:]
+        if let text {
+            overrides[itemID] = text
+        } else {
+            overrides.removeValue(forKey: itemID)
+        }
+        statusBarTextOverrides[extensionID] = overrides.isEmpty ? nil : overrides
+        return true
     }
 
     struct CommandInvocation {

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -131,6 +131,14 @@ enum MuxyAPI {
             cliAliases[verb] ?? verb
         }
 
+        static let verbNames: Set<String> = Set(cliAliases.keys).union(extensionVerbs)
+
+        private static let extensionVerbs: Set<String> = [
+            "extension.settings.get",
+            "extension.settings.set",
+            "extension.statusbar.set",
+        ]
+
         private static let cliAliases: [String: String] = [
             "split-right": "panes.split",
             "split-down": "panes.split",
@@ -152,9 +160,6 @@ enum MuxyAPI {
             "next-tab": "tabs.next",
             "previous-tab": "tabs.previous",
             "open-tab": "tabs.open",
-            "extension.settings.get": "extension.settings.get",
-            "extension.settings.set": "extension.settings.set",
-            "extension.statusbar.set": "extension.statusbar.set",
         ]
 
         private static let verbPermissions: [String: ExtensionPermission] = [

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -152,6 +152,9 @@ enum MuxyAPI {
             "next-tab": "tabs.next",
             "previous-tab": "tabs.previous",
             "open-tab": "tabs.open",
+            "extension.settings.get": "extension.settings.get",
+            "extension.settings.set": "extension.settings.set",
+            "extension.statusbar.set": "extension.statusbar.set",
         ]
 
         private static let verbPermissions: [String: ExtensionPermission] = [

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -10,6 +10,7 @@ final class NotificationSocketServer: @unchecked Sendable {
         let allowedEvents: Set<String>
         let commandEvents: Set<String>
         let permissions: Set<ExtensionPermission>
+        let token: String
     }
 
     struct ExtensionSnapshot: Equatable {
@@ -194,12 +195,7 @@ final class NotificationSocketServer: @unchecked Sendable {
         "subscribe", "identify",
     ]
 
-    private static let commandNames: Set<String> = [
-        "split-right", "split-down", "send", "send-keys",
-        "read-screen", "close-pane", "rename-pane", "list-panes",
-        "list-projects", "switch-project", "list-worktrees", "create-worktree", "switch-worktree", "refresh-worktrees",
-        "list-tabs", "switch-tab", "new-tab", "next-tab", "previous-tab", "open-tab",
-    ]
+    private static let commandNames: Set<String> = MuxyAPI.Permissions.verbNames
 
     private func openSession(_ session: ClientSession) {
         let readSource = DispatchSource.makeReadSource(fileDescriptor: session.fd, queue: queue)
@@ -269,11 +265,15 @@ final class NotificationSocketServer: @unchecked Sendable {
     private func evaluateSticky(head: String, message: String, session: ClientSession) -> String {
         switch head {
         case "identify":
-            let parts = message.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false).map(String.init)
-            guard parts.count == 2, !parts[1].isEmpty else { return "error:usage identify|<extension-id>" }
+            let parts = message.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
+            guard parts.count >= 2, !parts[1].isEmpty else { return "error:usage identify|<extension-id>|<token>" }
             let claimedID = parts[1]
-            guard extensionSnapshot.entries[claimedID] != nil else {
+            guard let entry = extensionSnapshot.entries[claimedID] else {
                 return "error:unknown extension \(claimedID)"
+            }
+            let providedToken = parts.count >= 3 ? parts[2] : ""
+            guard !entry.token.isEmpty, providedToken == entry.token else {
+                return "error:invalid extension token"
             }
             session.extensionID = claimedID
             return "ok"

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -190,9 +190,74 @@ enum SocketCommandHandler {
             } catch {
                 return "error:invalid open-tab payload: \(error.localizedDescription)"
             }
+        case "extension.settings.get":
+            guard parts.count >= 2 else { return "error:usage extension.settings.get|key" }
+            return handleSettingsGet(key: parts[1], extensionID: clientContext.extensionID)
+        case "extension.settings.set":
+            guard parts.count >= 3 else { return "error:usage extension.settings.set|key|<json-value>" }
+            let value = parts.dropFirst(2).joined(separator: "|")
+            return handleSettingsSet(key: parts[1], rawValue: value, extensionID: clientContext.extensionID)
+        case "extension.statusbar.set":
+            guard parts.count >= 2 else { return "error:usage extension.statusbar.set|itemID[|text]" }
+            let text = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
+            return handleStatusBarSet(itemID: parts[1], text: text, extensionID: clientContext.extensionID)
         default:
             return "error:unknown command \(cmd)"
         }
+    }
+
+    private static func handleSettingsGet(key: String, extensionID: String?) -> String {
+        guard let extensionID else { return "error:identify required" }
+        guard let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID) else {
+            return "error:unknown extension"
+        }
+        guard muxyExtension.manifest.setting(key: key) != nil else {
+            return "error:setting '\(key)' not declared in manifest"
+        }
+        let store = ExtensionSettingsStore.shared
+        let entry = muxyExtension.manifest.setting(key: key)
+        guard let entry,
+              let value = store.effectiveValue(extensionID: extensionID, entry: entry)
+        else { return "ok\tnull" }
+
+        do {
+            let data = try JSONEncoder().encode(value)
+            let json = String(data: data, encoding: .utf8) ?? "null"
+            return "ok\t\(json)"
+        } catch {
+            return "error:encode failed"
+        }
+    }
+
+    private static func handleSettingsSet(key: String, rawValue: String, extensionID: String?) -> String {
+        guard let extensionID else { return "error:identify required" }
+        guard let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID) else {
+            return "error:unknown extension"
+        }
+        guard muxyExtension.manifest.setting(key: key) != nil else {
+            return "error:setting '\(key)' not declared in manifest"
+        }
+        guard let data = rawValue.data(using: .utf8) else {
+            return "error:invalid value encoding"
+        }
+        do {
+            let value = try JSONDecoder().decode(ExtensionJSON.self, from: data)
+            ExtensionSettingsStore.shared.setValue(value, extensionID: extensionID, key: key)
+            return "ok"
+        } catch {
+            return "error:invalid json value: \(error.localizedDescription)"
+        }
+    }
+
+    private static func handleStatusBarSet(itemID: String, text: String?, extensionID: String?) -> String {
+        guard let extensionID else { return "error:identify required" }
+        let updated = ExtensionStore.shared.setStatusBarText(
+            extensionID: extensionID,
+            itemID: itemID,
+            text: text
+        )
+        guard updated else { return "error:unknown status bar item '\(itemID)'" }
+        return "ok"
     }
 
     private static func handleCreateWorktree(

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -199,7 +199,8 @@ enum SocketCommandHandler {
             return handleSettingsSet(key: parts[1], rawValue: value, extensionID: clientContext.extensionID)
         case "extension.statusbar.set":
             guard parts.count >= 2 else { return "error:usage extension.statusbar.set|itemID[|text]" }
-            let text = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
+            let rawText = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
+            let text = (rawText?.isEmpty == true) ? nil : rawText
             return handleStatusBarSet(itemID: parts[1], text: text, extensionID: clientContext.extensionID)
         default:
             return "error:unknown command \(cmd)"
@@ -211,15 +212,12 @@ enum SocketCommandHandler {
         guard let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID) else {
             return "error:unknown extension"
         }
-        guard muxyExtension.manifest.setting(key: key) != nil else {
+        guard let entry = muxyExtension.manifest.setting(key: key) else {
             return "error:setting '\(key)' not declared in manifest"
         }
-        let store = ExtensionSettingsStore.shared
-        let entry = muxyExtension.manifest.setting(key: key)
-        guard let entry,
-              let value = store.effectiveValue(extensionID: extensionID, entry: entry)
-        else { return "ok\tnull" }
-
+        guard let value = ExtensionSettingsStore.shared.effectiveValue(extensionID: extensionID, entry: entry) else {
+            return "ok"
+        }
         do {
             let data = try JSONEncoder().encode(value)
             let json = String(data: data, encoding: .utf8) ?? "null"
@@ -229,16 +227,21 @@ enum SocketCommandHandler {
         }
     }
 
+    private static let maxSettingValueBytes = 64 * 1024
+
     private static func handleSettingsSet(key: String, rawValue: String, extensionID: String?) -> String {
         guard let extensionID else { return "error:identify required" }
+        guard let data = rawValue.data(using: .utf8) else {
+            return "error:invalid value encoding"
+        }
+        guard data.count <= maxSettingValueBytes else {
+            return "error:value exceeds \(maxSettingValueBytes)-byte limit"
+        }
         guard let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID) else {
             return "error:unknown extension"
         }
         guard muxyExtension.manifest.setting(key: key) != nil else {
             return "error:setting '\(key)' not declared in manifest"
-        }
-        guard let data = rawValue.data(using: .utf8) else {
-            return "error:invalid value encoding"
         }
         do {
             let value = try JSONDecoder().decode(ExtensionJSON.self, from: data)

--- a/Muxy/Views/Components/ExtensionIconButton.swift
+++ b/Muxy/Views/Components/ExtensionIconButton.swift
@@ -8,17 +8,15 @@ struct ExtensionIconButton: View {
     var hoverColor: Color = MuxyTheme.fg
     let accessibilityLabel: String
     let action: () -> Void
-    @State private var hovered = false
 
     var body: some View {
-        Button(action: action) {
+        IconButtonChrome(
+            color: color,
+            hoverColor: hoverColor,
+            accessibilityLabel: accessibilityLabel,
+            action: action
+        ) {
             ExtensionIconView(icon: icon, muxyExtension: muxyExtension, size: size)
-                .foregroundStyle(hovered ? hoverColor : color)
-                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
-                .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .onHover { hovered = $0 }
-        .accessibilityLabel(accessibilityLabel)
     }
 }

--- a/Muxy/Views/Components/ExtensionIconButton.swift
+++ b/Muxy/Views/Components/ExtensionIconButton.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct ExtensionIconButton: View {
+    let icon: ExtensionIcon
+    let muxyExtension: MuxyExtension
+    var size: CGFloat = 13
+    var color: Color = MuxyTheme.fgMuted
+    var hoverColor: Color = MuxyTheme.fg
+    let accessibilityLabel: String
+    let action: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            ExtensionIconView(icon: icon, muxyExtension: muxyExtension, size: size)
+                .foregroundStyle(hovered ? hoverColor : color)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .accessibilityLabel(accessibilityLabel)
+    }
+}

--- a/Muxy/Views/Components/ExtensionIconView.swift
+++ b/Muxy/Views/Components/ExtensionIconView.swift
@@ -1,0 +1,35 @@
+import AppKit
+import SwiftUI
+
+struct ExtensionIconView: View {
+    let icon: ExtensionIcon
+    let muxyExtension: MuxyExtension
+    var size: CGFloat = 12
+    var weight: Font.Weight = .semibold
+
+    var body: some View {
+        switch icon {
+        case let .symbol(name):
+            Image(systemName: name)
+                .font(.system(size: UIMetrics.scaled(size), weight: weight))
+        case let .svg(path):
+            svgImage(path: path)
+        }
+    }
+
+    @ViewBuilder
+    private func svgImage(path: String) -> some View {
+        if let url = muxyExtension.resolveResource(path),
+           let nsImage = NSImage(contentsOf: url)
+        {
+            Image(nsImage: nsImage)
+                .resizable()
+                .renderingMode(.template)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: UIMetrics.scaled(size), height: UIMetrics.scaled(size))
+        } else {
+            Image(systemName: "puzzlepiece.extension")
+                .font(.system(size: UIMetrics.scaled(size), weight: weight))
+        }
+    }
+}

--- a/Muxy/Views/Components/ExtensionIconView.swift
+++ b/Muxy/Views/Components/ExtensionIconView.swift
@@ -20,7 +20,7 @@ struct ExtensionIconView: View {
     @ViewBuilder
     private func svgImage(path: String) -> some View {
         if let url = muxyExtension.resolveResource(path),
-           let nsImage = NSImage(contentsOf: url)
+           let nsImage = ExtensionIconAssetCache.shared.image(extensionID: muxyExtension.id, url: url)
         {
             Image(nsImage: nsImage)
                 .resizable()

--- a/Muxy/Views/Components/IconButton.swift
+++ b/Muxy/Views/Components/IconButton.swift
@@ -7,12 +7,31 @@ struct IconButton: View {
     var hoverColor: Color = MuxyTheme.fg
     let accessibilityLabel: String
     let action: () -> Void
+
+    var body: some View {
+        IconButtonChrome(
+            color: color,
+            hoverColor: hoverColor,
+            accessibilityLabel: accessibilityLabel,
+            action: action
+        ) {
+            Image(systemName: symbol)
+                .font(.system(size: UIMetrics.scaled(size), weight: .semibold))
+        }
+    }
+}
+
+struct IconButtonChrome<Label: View>: View {
+    var color: Color = MuxyTheme.fgMuted
+    var hoverColor: Color = MuxyTheme.fg
+    let accessibilityLabel: String
+    let action: () -> Void
+    @ViewBuilder var label: Label
     @State private var hovered = false
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: symbol)
-                .font(.system(size: UIMetrics.scaled(size), weight: .semibold))
+            label
                 .foregroundStyle(hovered ? hoverColor : color)
                 .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -408,7 +408,18 @@ struct MainWindow: View {
                     isInteractive: activeTerminalPane != nil && !overlayAnimatingOut,
                     richInputVisible: richInputPanelVisible,
                     richInputFontSize: $richInputFontSize,
-                    extensionOutputVisible: $showExtensionOutput
+                    extensionOutputVisible: $showExtensionOutput,
+                    onTriggerExtensionCommand: { binding in
+                        ExtensionStore.shared.triggerCommand(
+                            ExtensionStore.CommandInvocation(
+                                extensionID: binding.muxyExtension.id,
+                                commandID: binding.item.command,
+                                appState: appState,
+                                projectStore: projectStore,
+                                worktreeStore: worktreeStore
+                            )
+                        )
+                    }
                 )
             }
         }

--- a/Muxy/Views/Settings/ExtensionCustomSettingsView.swift
+++ b/Muxy/Views/Settings/ExtensionCustomSettingsView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct ExtensionCustomSettingsView: View {
     let extensionID: String
-    @State private var store = ExtensionStore.shared
-    @State private var settingsStore = ExtensionSettingsStore.shared
+    @Environment(ExtensionStore.self) private var store
+    @Environment(ExtensionSettingsStore.self) private var settingsStore
 
     private var muxyExtension: MuxyExtension? {
         store.statuses.first(where: { $0.id == extensionID })?.muxyExtension

--- a/Muxy/Views/Settings/ExtensionCustomSettingsView.swift
+++ b/Muxy/Views/Settings/ExtensionCustomSettingsView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+struct ExtensionCustomSettingsView: View {
+    let extensionID: String
+    @State private var store = ExtensionStore.shared
+    @State private var settingsStore = ExtensionSettingsStore.shared
+
+    private var muxyExtension: MuxyExtension? {
+        store.statuses.first(where: { $0.id == extensionID })?.muxyExtension
+    }
+
+    var body: some View {
+        SettingsContainer {
+            if let muxyExtension {
+                if muxyExtension.manifest.settings.isEmpty {
+                    SettingsSection("Settings") {
+                        Text("This extension does not declare any settings.")
+                            .font(.system(size: SettingsMetrics.footnoteFontSize))
+                            .foregroundStyle(SettingsStyle.mutedForeground)
+                            .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                            .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+                    }
+                } else {
+                    SettingsSection(muxyExtension.displayName) {
+                        ForEach(muxyExtension.manifest.settings) { entry in
+                            ExtensionSettingRow(
+                                extensionID: extensionID,
+                                entry: entry,
+                                settingsStore: settingsStore
+                            )
+                        }
+                    }
+                }
+            } else {
+                Text("Extension is not loaded.")
+                    .font(.system(size: SettingsMetrics.footnoteFontSize))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                    .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                    .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+            }
+        }
+    }
+}
+
+private struct ExtensionSettingRow: View {
+    let extensionID: String
+    let entry: ExtensionSettingEntry
+    let settingsStore: ExtensionSettingsStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            SettingsRow(entry.title) {
+                control
+            }
+            if let description = entry.description, !description.isEmpty {
+                Text(description)
+                    .font(.system(size: SettingsMetrics.footnoteFontSize))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                    .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                    .padding(.bottom, SettingsMetrics.rowVerticalPadding)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var control: some View {
+        switch entry.type {
+        case .bool:
+            Toggle("", isOn: boolBinding)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+        case .string:
+            TextField("", text: stringBinding)
+                .settingsTextInput(width: SettingsMetrics.controlWidth)
+        case .number:
+            TextField("", text: numberBinding)
+                .settingsTextInput(width: SettingsMetrics.controlWidth)
+        }
+    }
+
+    private var boolBinding: Binding<Bool> {
+        Binding(
+            get: {
+                guard let value = settingsStore.effectiveValue(extensionID: extensionID, entry: entry) else { return false }
+                if case let .bool(value) = value { return value }
+                return false
+            },
+            set: { newValue in
+                settingsStore.setValue(.bool(newValue), extensionID: extensionID, key: entry.key)
+            }
+        )
+    }
+
+    private var stringBinding: Binding<String> {
+        Binding(
+            get: {
+                guard let value = settingsStore.effectiveValue(extensionID: extensionID, entry: entry) else { return "" }
+                if case let .string(value) = value { return value }
+                return ""
+            },
+            set: { newValue in
+                settingsStore.setValue(.string(newValue), extensionID: extensionID, key: entry.key)
+            }
+        )
+    }
+
+    private var numberBinding: Binding<String> {
+        Binding(
+            get: {
+                guard let value = settingsStore.effectiveValue(extensionID: extensionID, entry: entry) else { return "" }
+                if case let .number(value) = value {
+                    return value.truncatingRemainder(dividingBy: 1) == 0
+                        ? String(Int(value))
+                        : String(value)
+                }
+                return ""
+            },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty, let parsed = Double(trimmed) else {
+                    settingsStore.setValue(nil, extensionID: extensionID, key: entry.key)
+                    return
+                }
+                settingsStore.setValue(.number(parsed), extensionID: extensionID, key: entry.key)
+            }
+        )
+    }
+}

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -59,6 +59,18 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     }
 }
 
+enum SettingsRoute: Hashable, Identifiable {
+    case builtin(SettingsCategory)
+    case ext(String)
+
+    var id: String {
+        switch self {
+        case let .builtin(category): "builtin.\(category.rawValue)"
+        case let .ext(extensionID): "ext.\(extensionID)"
+        }
+    }
+}
+
 struct SettingsCatalogItem: Identifiable, Equatable {
     let key: String
     let title: String

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -2,12 +2,30 @@ import AppKit
 import SwiftUI
 
 struct SettingsView: View {
-    @State private var selectedCategory: SettingsCategory = .general
+    @State private var selectedRoute: SettingsRoute = .builtin(.general)
     @State private var searchText = ""
     @State private var themeRefreshID = 0
+    @State private var extensionStore = ExtensionStore.shared
 
     private var visibleCategories: [SettingsCategory] {
         SettingsCatalog.categories.filter { SettingsCatalog.categoryMatches($0, query: searchText) }
+    }
+
+    private var visibleExtensionRoutes: [(extensionID: String, displayName: String)] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return extensionStore.statuses
+            .filter { $0.muxyExtension.manifest.enabled && !$0.muxyExtension.manifest.settings.isEmpty }
+            .filter { status in
+                guard !query.isEmpty else { return true }
+                let displayName = status.muxyExtension.displayName.lowercased()
+                if displayName.contains(query) { return true }
+                return status.muxyExtension.manifest.settings.contains { entry in
+                    entry.key.lowercased().contains(query)
+                        || entry.title.lowercased().contains(query)
+                        || (entry.description?.lowercased().contains(query) ?? false)
+                }
+            }
+            .map { ($0.id, $0.muxyExtension.displayName) }
     }
 
     var body: some View {
@@ -17,7 +35,8 @@ struct SettingsView: View {
             HStack(spacing: 0) {
                 SettingsSidebar(
                     categories: visibleCategories,
-                    selectedCategory: $selectedCategory,
+                    extensionRoutes: visibleExtensionRoutes,
+                    selectedRoute: $selectedRoute,
                     searchText: searchText
                 )
                 Rectangle()
@@ -26,7 +45,7 @@ struct SettingsView: View {
                 settingsContent
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .environment(\.settingsSearchQuery, searchText)
-                    .environment(\.settingsCategory, selectedCategory)
+                    .environment(\.settingsCategory, selectedBuiltinCategory ?? .general)
             }
         }
         .frame(minWidth: 860, minHeight: 620)
@@ -36,21 +55,47 @@ struct SettingsView: View {
         .preferredColorScheme(MuxyTheme.colorScheme)
         .resetsSettingsFocusOnOutsideClick()
         .onChange(of: searchText) { _, _ in
-            guard !visibleCategories.contains(selectedCategory), let first = visibleCategories.first else { return }
-            selectedCategory = first
+            guard !isRouteVisible(selectedRoute) else { return }
+            if let first = visibleCategories.first {
+                selectedRoute = .builtin(first)
+            } else if let ext = visibleExtensionRoutes.first {
+                selectedRoute = .ext(ext.extensionID)
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .focusProjectPickerDefaultLocation)) { _ in
             searchText = ""
-            selectedCategory = .projects
+            selectedRoute = .builtin(.projects)
         }
         .onReceive(NotificationCenter.default.publisher(for: .themeDidChange)) { _ in
             themeRefreshID += 1
         }
     }
 
+    private var selectedBuiltinCategory: SettingsCategory? {
+        if case let .builtin(category) = selectedRoute { return category }
+        return nil
+    }
+
+    private func isRouteVisible(_ route: SettingsRoute) -> Bool {
+        switch route {
+        case let .builtin(category): visibleCategories.contains(category)
+        case let .ext(extensionID): visibleExtensionRoutes.contains { $0.extensionID == extensionID }
+        }
+    }
+
     @ViewBuilder
     private var settingsContent: some View {
-        switch selectedCategory {
+        switch selectedRoute {
+        case let .builtin(category):
+            builtinContent(for: category)
+        case let .ext(extensionID):
+            ExtensionCustomSettingsView(extensionID: extensionID)
+        }
+    }
+
+    @ViewBuilder
+    private func builtinContent(for category: SettingsCategory) -> some View {
+        switch category {
         case .general:
             GeneralSettingsView()
         case .projects:
@@ -151,51 +196,35 @@ private struct SettingsHeader: View {
 
 private struct SettingsSidebar: View {
     let categories: [SettingsCategory]
-    @Binding var selectedCategory: SettingsCategory
+    let extensionRoutes: [(extensionID: String, displayName: String)]
+    @Binding var selectedRoute: SettingsRoute
     let searchText: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            if categories.isEmpty {
+            if categories.isEmpty, extensionRoutes.isEmpty {
                 Text("No settings found")
                     .font(.system(size: SettingsMetrics.labelFontSize))
                     .foregroundStyle(SettingsStyle.mutedForeground)
                     .padding(SettingsMetrics.horizontalPadding)
             } else {
                 ForEach(categories) { category in
-                    Button {
-                        selectedCategory = category
-                    } label: {
-                        HStack(spacing: 8) {
-                            Image(systemName: category.symbolName)
-                                .font(.system(size: 12, weight: .medium))
-                                .frame(width: 16)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(category.title)
-                                    .font(.system(size: 12, weight: selectedCategory == category ? .semibold : .regular))
-                                    .foregroundStyle(SettingsStyle.foreground)
-                                if !searchText.isEmpty {
-                                    Text(matchCountText(for: category))
-                                        .font(.system(size: 10))
-                                        .foregroundStyle(SettingsStyle.mutedForeground)
-                                }
-                            }
-                            Spacer(minLength: 0)
-                            if let badge = category.developmentBadge {
-                                SettingsDevelopmentBadge(text: badge)
-                            }
-                        }
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 7)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                        .background(
-                            selectedCategory == category ? SettingsStyle.accentSoft : .clear,
-                            in: RoundedRectangle(cornerRadius: 8)
-                        )
-                        .foregroundStyle(selectedCategory == category ? SettingsStyle.accent : SettingsStyle.mutedForeground)
-                    }
-                    .buttonStyle(.plain)
+                    sidebarRow(
+                        route: .builtin(category),
+                        symbol: category.symbolName,
+                        title: category.title,
+                        badge: category.developmentBadge,
+                        matchCountText: searchText.isEmpty ? nil : matchCountText(for: category)
+                    )
+                }
+                ForEach(extensionRoutes, id: \.extensionID) { route in
+                    sidebarRow(
+                        route: .ext(route.extensionID),
+                        symbol: "puzzlepiece.extension",
+                        title: route.displayName,
+                        badge: nil,
+                        matchCountText: nil
+                    )
                 }
             }
             Spacer()
@@ -203,6 +232,52 @@ private struct SettingsSidebar: View {
         .padding(10)
         .frame(width: 210)
         .background(SettingsStyle.sidebarBackground)
+    }
+
+    @ViewBuilder
+    private func sidebarRow(
+        route: SettingsRoute,
+        symbol: String,
+        title: String,
+        badge: String?,
+        matchCountText: String?
+    ) -> some View {
+        let isSelected = selectedRoute == route
+        Button {
+            selectedRoute = route
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: symbol)
+                    .font(.system(size: 12, weight: .medium))
+                    .frame(width: 16)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
+                        .foregroundStyle(SettingsStyle.foreground)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    if let matchCountText {
+                        Text(matchCountText)
+                            .font(.system(size: 10))
+                            .foregroundStyle(SettingsStyle.mutedForeground)
+                    }
+                }
+                Spacer(minLength: 0)
+                if let badge {
+                    SettingsDevelopmentBadge(text: badge)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .background(
+                isSelected ? SettingsStyle.accentSoft : .clear,
+                in: RoundedRectangle(cornerRadius: 8)
+            )
+            .foregroundStyle(isSelected ? SettingsStyle.accent : SettingsStyle.mutedForeground)
+        }
+        .buttonStyle(.plain)
     }
 
     private func matchCountText(for category: SettingsCategory) -> String {

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -5,7 +5,7 @@ struct SettingsView: View {
     @State private var selectedRoute: SettingsRoute = .builtin(.general)
     @State private var searchText = ""
     @State private var themeRefreshID = 0
-    @State private var extensionStore = ExtensionStore.shared
+    @Environment(ExtensionStore.self) private var extensionStore
 
     private var visibleCategories: [SettingsCategory] {
         SettingsCatalog.categories.filter { SettingsCatalog.categoryMatches($0, query: searchText) }
@@ -45,7 +45,7 @@ struct SettingsView: View {
                 settingsContent
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .environment(\.settingsSearchQuery, searchText)
-                    .environment(\.settingsCategory, selectedBuiltinCategory ?? .general)
+                    .environment(\.settingsCategory, selectedBuiltinCategory)
             }
         }
         .frame(minWidth: 860, minHeight: 620)

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -15,6 +15,8 @@ struct ProjectStatusBar: View {
     let richInputVisible: Bool
     @Binding var richInputFontSize: Double
     @Binding var extensionOutputVisible: Bool
+    var onTriggerExtensionCommand: ((ExtensionStore.StatusBarItemBinding) -> Void)?
+    @State private var extensionStore = ExtensionStore.shared
 
     private var richInputShortcutLabel: String {
         KeyBindingStore.shared.combo(for: .toggleRichInput).displayString
@@ -26,31 +28,9 @@ struct ProjectStatusBar: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            if let statusContext {
-                pathButton(statusContext.path)
-                if let worktreeName = statusContext.worktreeName {
-                    separator
-                    worktreeLabel(worktreeName)
-                }
-                if let branch = statusContext.branch {
-                    separator
-                    branchLabel(branch)
-                }
-            }
+            leftSide
             Spacer(minLength: 8)
-            extensionOutputChip
-            separator
-            if richInputVisible {
-                zoomControls
-                separator
-                shortcutHints
-                separator
-            }
-            if activePane != nil {
-                richInputToggleButton
-                separator
-                voiceRecordingButton
-            }
+            rightSide
         }
         .padding(.horizontal, 10)
         .frame(height: 28)
@@ -61,6 +41,69 @@ struct ProjectStatusBar: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Status bar")
+    }
+
+    private var leftItems: [AnyView] {
+        var items: [AnyView] = []
+        if let statusContext {
+            items.append(AnyView(pathButton(statusContext.path)))
+            if let worktreeName = statusContext.worktreeName {
+                items.append(AnyView(worktreeLabel(worktreeName)))
+            }
+            if let branch = statusContext.branch {
+                items.append(AnyView(branchLabel(branch)))
+            }
+        }
+        for binding in extensionStore.statusBarItems(side: .left) {
+            items.append(AnyView(extensionItem(binding: binding)))
+        }
+        return items
+    }
+
+    private var rightItems: [AnyView] {
+        var items: [AnyView] = [AnyView(extensionOutputChip)]
+        for binding in extensionStore.statusBarItems(side: .right) {
+            items.append(AnyView(extensionItem(binding: binding)))
+        }
+        if richInputVisible {
+            items.append(AnyView(zoomControls))
+            items.append(AnyView(shortcutHints))
+        }
+        if activePane != nil {
+            items.append(AnyView(richInputToggleButton))
+            items.append(AnyView(voiceRecordingButton))
+        }
+        return items
+    }
+
+    @ViewBuilder
+    private var leftSide: some View {
+        let items = leftItems
+        if items.isEmpty {
+            EmptyView()
+        } else {
+            HStack(spacing: 8) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    item
+                    separator
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var rightSide: some View {
+        let items = rightItems
+        if items.isEmpty {
+            EmptyView()
+        } else {
+            HStack(spacing: 8) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    separator
+                    item
+                }
+            }
+        }
     }
 
     private var statusContext: StatusContext? {
@@ -151,6 +194,29 @@ struct ProjectStatusBar: View {
             .frame(width: 1)
             .frame(maxHeight: .infinity)
             .accessibilityHidden(true)
+    }
+
+    private func extensionItem(binding: ExtensionStore.StatusBarItemBinding) -> some View {
+        Button {
+            onTriggerExtensionCommand?(binding)
+        } label: {
+            HStack(spacing: 4) {
+                ExtensionIconView(
+                    icon: binding.item.icon,
+                    muxyExtension: binding.muxyExtension,
+                    size: 10
+                )
+                if let text = binding.displayText, !text.isEmpty {
+                    Text(text)
+                        .font(.system(size: 11, weight: .medium))
+                        .lineLimit(1)
+                }
+            }
+            .foregroundStyle(MuxyTheme.fgMuted)
+        }
+        .buttonStyle(.plain)
+        .help(binding.item.tooltip ?? binding.item.id)
+        .accessibilityLabel(binding.item.tooltip ?? binding.item.id)
     }
 
     private var extensionOutputChip: some View {

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -16,7 +16,7 @@ struct ProjectStatusBar: View {
     @Binding var richInputFontSize: Double
     @Binding var extensionOutputVisible: Bool
     var onTriggerExtensionCommand: ((ExtensionStore.StatusBarItemBinding) -> Void)?
-    @State private var extensionStore = ExtensionStore.shared
+    @Environment(ExtensionStore.self) private var extensionStore
 
     private var richInputShortcutLabel: String {
         KeyBindingStore.shared.combo(for: .toggleRichInput).displayString
@@ -43,65 +43,46 @@ struct ProjectStatusBar: View {
         .accessibilityLabel("Status bar")
     }
 
-    private var leftItems: [AnyView] {
-        var items: [AnyView] = []
-        if let statusContext {
-            items.append(AnyView(pathButton(statusContext.path)))
-            if let worktreeName = statusContext.worktreeName {
-                items.append(AnyView(worktreeLabel(worktreeName)))
-            }
-            if let branch = statusContext.branch {
-                items.append(AnyView(branchLabel(branch)))
-            }
-        }
-        for binding in extensionStore.statusBarItems(side: .left) {
-            items.append(AnyView(extensionItem(binding: binding)))
-        }
-        return items
-    }
-
-    private var rightItems: [AnyView] {
-        var items: [AnyView] = [AnyView(extensionOutputChip)]
-        for binding in extensionStore.statusBarItems(side: .right) {
-            items.append(AnyView(extensionItem(binding: binding)))
-        }
-        if richInputVisible {
-            items.append(AnyView(zoomControls))
-            items.append(AnyView(shortcutHints))
-        }
-        if activePane != nil {
-            items.append(AnyView(richInputToggleButton))
-            items.append(AnyView(voiceRecordingButton))
-        }
-        return items
-    }
-
-    @ViewBuilder
     private var leftSide: some View {
-        let items = leftItems
-        if items.isEmpty {
-            EmptyView()
-        } else {
-            HStack(spacing: 8) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                    item
+        HStack(spacing: 8) {
+            if let statusContext {
+                pathButton(statusContext.path)
+                separator
+                if let worktreeName = statusContext.worktreeName {
+                    worktreeLabel(worktreeName)
                     separator
                 }
+                if let branch = statusContext.branch {
+                    branchLabel(branch)
+                    separator
+                }
+            }
+            ForEach(extensionStore.statusBarItems(side: .left)) { binding in
+                extensionItem(binding: binding)
+                separator
             }
         }
     }
 
-    @ViewBuilder
     private var rightSide: some View {
-        let items = rightItems
-        if items.isEmpty {
-            EmptyView()
-        } else {
-            HStack(spacing: 8) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                    separator
-                    item
-                }
+        HStack(spacing: 8) {
+            separator
+            extensionOutputChip
+            ForEach(extensionStore.statusBarItems(side: .right)) { binding in
+                separator
+                extensionItem(binding: binding)
+            }
+            if richInputVisible {
+                separator
+                zoomControls
+                separator
+                shortcutHints
+            }
+            if activePane != nil {
+                separator
+                richInputToggleButton
+                separator
+                voiceRecordingButton
             }
         }
     }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -44,7 +44,11 @@ struct PaneTabStrip: View {
     let onSetColorID: (UUID, String?) -> Void
     let onReorderTab: (IndexSet, Int) -> Void
     @Environment(TabDragCoordinator.self) private var dragCoordinator
+    @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
     @State private var dragState = TabDragState()
+    @State private var extensionStore = ExtensionStore.shared
 
     static func snapshots(from tabs: [TerminalTab]) -> [TabSnapshot] {
         tabs.map { tab in
@@ -98,6 +102,15 @@ struct PaneTabStrip: View {
                     let label = isMaximized ? "Restore Pane" : "Maximize Pane"
                     IconButton(symbol: symbol, accessibilityLabel: label, action: onToggleMaximize)
                         .help(shortcutTooltip("Toggle Maximize Pane", for: .toggleMaximizePane))
+                }
+                ForEach(extensionStore.topbarItems()) { binding in
+                    ExtensionIconButton(
+                        icon: binding.item.icon,
+                        muxyExtension: binding.muxyExtension,
+                        accessibilityLabel: binding.item.tooltip ?? binding.item.id,
+                        action: { triggerExtensionCommand(binding: binding) }
+                    )
+                    .help(binding.item.tooltip ?? binding.item.id)
                 }
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
                     .help(shortcutTooltip("Split Right", for: .splitRight))
@@ -211,6 +224,18 @@ struct PaneTabStrip: View {
 
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {
         "\(name) (\(KeyBindingStore.shared.combo(for: action).displayString))"
+    }
+
+    private func triggerExtensionCommand(binding: ExtensionStore.TopbarItemBinding) {
+        extensionStore.triggerCommand(
+            ExtensionStore.CommandInvocation(
+                extensionID: binding.muxyExtension.id,
+                commandID: binding.item.command,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+        )
     }
 
     private var developmentBadge: some View {

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -47,8 +47,8 @@ struct PaneTabStrip: View {
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
+    @Environment(ExtensionStore.self) private var extensionStore
     @State private var dragState = TabDragState()
-    @State private var extensionStore = ExtensionStore.shared
 
     static func snapshots(from tabs: [TerminalTab]) -> [TabSnapshot] {
         tabs.map { tab in
@@ -103,7 +103,7 @@ struct PaneTabStrip: View {
                     IconButton(symbol: symbol, accessibilityLabel: label, action: onToggleMaximize)
                         .help(shortcutTooltip("Toggle Maximize Pane", for: .toggleMaximizePane))
                 }
-                ForEach(extensionStore.topbarItems()) { binding in
+                ForEach(extensionStore.topbarItems) { binding in
                     ExtensionIconButton(
                         icon: binding.item.icon,
                         muxyExtension: binding.muxyExtension,

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -288,6 +288,77 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("rejects empty topbar item id")
+    func rejectsEmptyTopbarID() throws {
+        let directory = try makeTemporaryExtension(
+            name: "topbar-empty",
+            manifest: """
+            {
+                "name": "topbar-empty",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "commands": [ { "id": "noop", "title": "noop" } ],
+                "topbarItems": [
+                    { "id": "", "icon": "x.circle", "command": "noop" }
+                ]
+            }
+            """,
+            files: ["run.sh": "#!/bin/sh\n"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects empty setting key")
+    func rejectsEmptySettingKey() throws {
+        let directory = try makeTemporaryExtension(
+            name: "settings-empty",
+            manifest: """
+            {
+                "name": "settings-empty",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "settings": [
+                    { "key": "", "title": "X", "type": "bool" }
+                ]
+            }
+            """,
+            files: ["run.sh": "#!/bin/sh\n"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects non-svg icon path")
+    func rejectsNonSVGIconPath() throws {
+        let directory = try makeTemporaryExtension(
+            name: "bad-icon",
+            manifest: """
+            {
+                "name": "bad-icon",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "commands": [ { "id": "noop", "title": "noop" } ],
+                "topbarItems": [
+                    { "id": "x", "icon": { "svg": "assets/foo.png" }, "command": "noop" }
+                ]
+            }
+            """,
+            files: [
+                "run.sh": "#!/bin/sh\n",
+                "assets/foo.png": "PNG-not-SVG",
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     @Test("withEnabled preserves tabTypes")
     func withEnabledPreservesTabTypes() {
         let tabType = ExtensionTabType(id: "details", title: "Details", entry: "ui/index.html", defaultData: nil)

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -177,6 +177,117 @@ struct ExtensionManifestTests {
         #expect(invalidName.errorDescription?.contains("bad name") == true)
     }
 
+    @Test("decodes topbar items, statusbar items, and settings")
+    func decodesNewSurfaces() throws {
+        let json = #"""
+        {
+            "name": "demo",
+            "version": "1.0.0",
+            "entrypoint": "run.sh",
+            "commands": [
+                { "id": "open-pr", "title": "Open PR" }
+            ],
+            "topbarItems": [
+                { "id": "pr", "icon": { "symbol": "arrow.triangle.pull" }, "command": "open-pr" }
+            ],
+            "statusBarItems": [
+                { "id": "build", "icon": "hammer", "side": "right", "command": "open-pr" }
+            ],
+            "settings": [
+                { "key": "endpoint", "title": "Endpoint", "type": "string", "defaultValue": "https://x" }
+            ]
+        }
+        """#
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+
+        #expect(manifest.topbarItems.count == 1)
+        #expect(manifest.topbarItems[0].command == "open-pr")
+        if case let .symbol(name) = manifest.topbarItems[0].icon {
+            #expect(name == "arrow.triangle.pull")
+        } else {
+            Issue.record("expected symbol icon")
+        }
+        #expect(manifest.statusBarItems[0].side == .right)
+        if case let .symbol(name) = manifest.statusBarItems[0].icon {
+            #expect(name == "hammer")
+        } else {
+            Issue.record("expected bare string to decode as symbol icon")
+        }
+        #expect(manifest.settings[0].key == "endpoint")
+        #expect(manifest.settings[0].type == .string)
+    }
+
+    @Test("rejects topbar item referencing unknown command")
+    func rejectsTopbarUnknownCommand() throws {
+        let directory = try makeTemporaryExtension(
+            name: "topbar-bad",
+            manifest: """
+            {
+                "name": "topbar-bad",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "topbarItems": [
+                    { "id": "x", "icon": "puzzlepiece.extension", "command": "missing" }
+                ]
+            }
+            """,
+            files: ["run.sh": "#!/bin/sh\n"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects topbar item with missing SVG")
+    func rejectsTopbarMissingSVG() throws {
+        let directory = try makeTemporaryExtension(
+            name: "topbar-svg",
+            manifest: """
+            {
+                "name": "topbar-svg",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "commands": [ { "id": "noop", "title": "noop" } ],
+                "topbarItems": [
+                    { "id": "x", "icon": { "svg": "assets/missing.svg" }, "command": "noop" }
+                ]
+            }
+            """,
+            files: ["run.sh": "#!/bin/sh\n"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects duplicate setting keys")
+    func rejectsDuplicateSettingKeys() throws {
+        let directory = try makeTemporaryExtension(
+            name: "settings-dup",
+            manifest: """
+            {
+                "name": "settings-dup",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "settings": [
+                    { "key": "x", "title": "X", "type": "bool" },
+                    { "key": "x", "title": "X again", "type": "bool" }
+                ]
+            }
+            """,
+            files: ["run.sh": "#!/bin/sh\n"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     @Test("withEnabled preserves tabTypes")
     func withEnabledPreservesTabTypes() {
         let tabType = ExtensionTabType(id: "details", title: "Details", entry: "ui/index.html", defaultData: nil)

--- a/Tests/MuxyTests/Services/ExtensionSettingsStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionSettingsStoreTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("ExtensionSettingsStore")
+struct ExtensionSettingsStoreTests {
+    @Test("round-trips primitive values per extension and key")
+    func roundTripsPrimitives() {
+        let defaults = makeIsolatedDefaults()
+        let store = ExtensionSettingsStore(defaults: defaults)
+
+        store.setValue(.bool(true), extensionID: "ext-a", key: "enabled")
+        store.setValue(.string("https://x"), extensionID: "ext-a", key: "endpoint")
+        store.setValue(.number(42), extensionID: "ext-b", key: "count")
+
+        #expect(store.value(extensionID: "ext-a", key: "enabled") == .bool(true))
+        #expect(store.value(extensionID: "ext-a", key: "endpoint") == .string("https://x"))
+        #expect(store.value(extensionID: "ext-b", key: "count") == .number(42))
+        #expect(store.value(extensionID: "ext-a", key: "count") == nil)
+    }
+
+    @Test("nil clears the stored value")
+    func nilClears() {
+        let defaults = makeIsolatedDefaults()
+        let store = ExtensionSettingsStore(defaults: defaults)
+
+        store.setValue(.bool(true), extensionID: "ext", key: "k")
+        #expect(store.value(extensionID: "ext", key: "k") == .bool(true))
+
+        store.setValue(nil, extensionID: "ext", key: "k")
+        #expect(store.value(extensionID: "ext", key: "k") == nil)
+    }
+
+    @Test("effectiveValue falls back to manifest default")
+    func effectiveValueFallback() {
+        let defaults = makeIsolatedDefaults()
+        let store = ExtensionSettingsStore(defaults: defaults)
+        let entry = ExtensionSettingEntry(
+            key: "endpoint",
+            title: "Endpoint",
+            description: nil,
+            type: .string,
+            defaultValue: .string("default")
+        )
+
+        #expect(store.effectiveValue(extensionID: "ext", entry: entry) == .string("default"))
+
+        store.setValue(.string("override"), extensionID: "ext", key: "endpoint")
+        #expect(store.effectiveValue(extensionID: "ext", entry: entry) == .string("override"))
+    }
+
+    @Test("clearAll removes only this extension's keys")
+    func clearAllIsolated() {
+        let defaults = makeIsolatedDefaults()
+        let store = ExtensionSettingsStore(defaults: defaults)
+
+        store.setValue(.bool(true), extensionID: "ext-a", key: "k1")
+        store.setValue(.bool(true), extensionID: "ext-a", key: "k2")
+        store.setValue(.bool(true), extensionID: "ext-b", key: "k1")
+
+        store.clearAll(extensionID: "ext-a")
+        #expect(store.value(extensionID: "ext-a", key: "k1") == nil)
+        #expect(store.value(extensionID: "ext-a", key: "k2") == nil)
+        #expect(store.value(extensionID: "ext-b", key: "k1") == .bool(true))
+    }
+
+    @Test("storageKey is prefixed and includes extensionID")
+    func storageKeyFormat() {
+        #expect(ExtensionSettingsStore.storageKey(extensionID: "ext", key: "k") == "muxy.ext.ext.k")
+    }
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suiteName = "ExtensionSettingsStoreTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create isolated UserDefaults")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/Tests/MuxyTests/Services/ExtensionSettingsStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionSettingsStoreTests.swift
@@ -71,6 +71,28 @@ struct ExtensionSettingsStoreTests {
         #expect(ExtensionSettingsStore.storageKey(extensionID: "ext", key: "k") == "muxy.ext.ext.k")
     }
 
+    @Test("round-trips arrays and objects")
+    func roundTripsArraysAndObjects() {
+        let defaults = makeIsolatedDefaults()
+        let store = ExtensionSettingsStore(defaults: defaults)
+
+        store.setValue(.array([.bool(true), .string("x"), .number(1)]), extensionID: "ext", key: "list")
+        store.setValue(.object(["enabled": .bool(true), "name": .string("demo")]), extensionID: "ext", key: "obj")
+
+        #expect(store.value(extensionID: "ext", key: "list") == .array([.bool(true), .string("x"), .number(1)]))
+        #expect(store.value(extensionID: "ext", key: "obj") == .object(["enabled": .bool(true), "name": .string("demo")]))
+    }
+
+    @Test("survives a second store instance pointing at the same defaults")
+    func survivesAcrossInstances() {
+        let defaults = makeIsolatedDefaults()
+        let writer = ExtensionSettingsStore(defaults: defaults)
+        writer.setValue(.string("v"), extensionID: "ext", key: "k")
+
+        let reader = ExtensionSettingsStore(defaults: defaults)
+        #expect(reader.value(extensionID: "ext", key: "k") == .string("v"))
+    }
+
     private func makeIsolatedDefaults() -> UserDefaults {
         let suiteName = "ExtensionSettingsStoreTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {

--- a/Tests/MuxyTests/Services/ExtensionStoreSnapshotTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreSnapshotTests.swift
@@ -10,7 +10,8 @@ struct ExtensionSnapshotTests {
         let entry = NotificationSocketServer.ExtensionSnapshotEntry(
             allowedEvents: ["pane.created", "tab.focused"],
             commandEvents: [],
-            permissions: []
+            permissions: [],
+            token: "test-token"
         )
         #expect(NotificationSocketServer.canSubscribeForTesting(entry: entry, to: "pane.created"))
         #expect(NotificationSocketServer.canSubscribeForTesting(entry: entry, to: "tab.focused"))
@@ -22,7 +23,8 @@ struct ExtensionSnapshotTests {
         let entry = NotificationSocketServer.ExtensionSnapshotEntry(
             allowedEvents: [],
             commandEvents: ["command.ping", "command.run"],
-            permissions: []
+            permissions: [],
+            token: "test-token"
         )
         #expect(NotificationSocketServer.canSubscribeForTesting(entry: entry, to: "command.ping"))
         #expect(NotificationSocketServer.canSubscribeForTesting(entry: entry, to: "command.run"))

--- a/Tests/MuxyTests/Services/ExtensionVerbRoutingTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionVerbRoutingTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Extension verb routing")
+@MainActor
+struct ExtensionVerbRoutingTests {
+    @Test("MuxyAPI verbNames includes the three extension verbs")
+    func verbNamesIncludesExtensionVerbs() {
+        let verbs = MuxyAPI.Permissions.verbNames
+        #expect(verbs.contains("extension.settings.get"))
+        #expect(verbs.contains("extension.settings.set"))
+        #expect(verbs.contains("extension.statusbar.set"))
+    }
+
+    @Test("MuxyAPI verbNames includes the legacy CLI verbs")
+    func verbNamesIncludesLegacyVerbs() {
+        let verbs = MuxyAPI.Permissions.verbNames
+        for verb in ["split-right", "split-down", "send", "send-keys", "read-screen", "open-tab", "list-tabs"] {
+            #expect(verbs.contains(verb), "verbNames missing legacy verb \(verb)")
+        }
+    }
+
+    @Test("extension.settings.get without identify returns error")
+    func settingsGetRequiresIdentify() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest(
+            "extension.settings.get|missing",
+            appState: appState
+        )
+        #expect(result == "error:identify required")
+    }
+
+    @Test("extension.settings.set without identify returns error")
+    func settingsSetRequiresIdentify() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest(
+            "extension.settings.set|key|true",
+            appState: appState
+        )
+        #expect(result == "error:identify required")
+    }
+
+    @Test("extension.statusbar.set without identify returns error")
+    func statusBarSetRequiresIdentify() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest(
+            "extension.statusbar.set|item|text",
+            appState: appState
+        )
+        #expect(result == "error:identify required")
+    }
+
+    @Test("extension.settings.set rejects oversize payload")
+    func settingsSetRejectsOversize() async {
+        let appState = makeAppState()
+        let big = String(repeating: "a", count: 65 * 1024)
+        let payload = "\"\(big)\""
+        let result = await SocketCommandHandler.handleRequest(
+            "extension.settings.set|k|\(payload)",
+            appState: appState,
+            clientContext: .init(extensionID: "ghost")
+        )
+        #expect(result.hasPrefix("error:value exceeds"))
+    }
+
+    @Test("extension.settings.set rejects unknown extension")
+    func settingsSetUnknownExtension() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest(
+            "extension.settings.set|key|true",
+            appState: appState,
+            clientContext: .init(extensionID: "ghost-extension-xyz")
+        )
+        #expect(result == "error:unknown extension")
+    }
+
+    @Test("extension.statusbar.set rejects unknown item")
+    func statusBarSetUnknownItem() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest(
+            "extension.statusbar.set|nope|hello",
+            appState: appState,
+            clientContext: .init(extensionID: "ghost-extension-xyz")
+        )
+        #expect(result.hasPrefix("error:"))
+    }
+
+    @Test("extension.statusbar.set with empty text is treated as clear")
+    func statusBarSetEmptyClears() async {
+        let appState = makeAppState()
+        let resultExplicit = await SocketCommandHandler.handleRequest(
+            "extension.statusbar.set|item|",
+            appState: appState,
+            clientContext: .init(extensionID: "ghost-extension-xyz")
+        )
+        let resultImplicit = await SocketCommandHandler.handleRequest(
+            "extension.statusbar.set|item",
+            appState: appState,
+            clientContext: .init(extensionID: "ghost-extension-xyz")
+        )
+        #expect(resultExplicit == resultImplicit)
+    }
+
+    private func makeAppState() -> AppState {
+        AppState(
+            selectionStore: SelectionStoreNoop(),
+            terminalViews: TerminalViewNoop(),
+            workspacePersistence: WorkspacePersistenceNoop()
+        )
+    }
+}
+
+private final class WorkspacePersistenceNoop: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class SelectionStoreNoop: ActiveProjectSelectionStoring {
+    func loadActiveProjectID() -> UUID? { nil }
+    func saveActiveProjectID(_: UUID?) {}
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { [:] }
+    func saveActiveWorktreeIDs(_: [UUID: UUID]) {}
+}
+
+@MainActor
+private final class TerminalViewNoop: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -14,6 +14,9 @@ User-installed subprocesses that Muxy launches and talks to over the existing no
 | [Events](events.md) | Identify/subscribe handshake, event list, wire format |
 | [Palette Commands](palette-commands.md) | Register commands and react to triggers |
 | [Tabs](tabs.md) | Register webview tab types and the injected `window.muxy` JS API |
+| [Topbar](topbar.md) | Attach icons to the tab strip that trigger a command |
+| [Status Bar](statusbar.md) | Attach icons to the footer status bar; update text live |
+| [Settings](settings.md) | Declare typed settings and read/write them at runtime |
 | [Scripts](scripts.md) | Run JS files as palette commands in a per-extension JSContext |
 | [Logs](logs.md) | Where logs live on disk, console.* bridge, size cap and trim policy |
 | [AI Provider Hooks](ai-provider.md) | Route third-party agent notifications to a custom source |

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -25,8 +25,8 @@ User-installed subprocesses that Muxy launches and talks to over the existing no
 
 - Install path: `~/.config/muxy/extensions/<name>/`
 - Transport: `~/Library/Application Support/Muxy/muxy.sock` (same socket as `muxy` CLI)
-- Subprocess environment: `MUXY_SOCKET_PATH`, `MUXY_EXTENSION_ID`
-- Sticky verbs: `identify|<id>`, `subscribe|<event>`
+- Subprocess environment: `MUXY_SOCKET_PATH`, `MUXY_EXTENSION_ID`, `MUXY_EXTENSION_TOKEN`
+- Sticky verbs: `identify|<id>|<token>`, `subscribe|<event>`
 - See [the muxy CLI feature page](../features/muxy-cli.md) for the verb vocabulary
 
 ## Minimal example
@@ -53,7 +53,7 @@ User-installed subprocesses that Muxy launches and talks to over the existing no
 ```bash
 #!/bin/bash
 {
-  printf 'identify|%s\n' "$MUXY_EXTENSION_ID"
+  printf 'identify|%s|%s\n' "$MUXY_EXTENSION_ID" "$MUXY_EXTENSION_TOKEN"
   printf 'subscribe|pane.created\n'
   printf 'subscribe|command.ping\n'
   while sleep 60; do :; done

--- a/docs/extensions/events.md
+++ b/docs/extensions/events.md
@@ -9,7 +9,7 @@ sequenceDiagram
   participant E as Extension
   participant M as Muxy
 
-  E->>M: identify|hello
+  E->>M: identify|hello|<token>
   M-->>E: ok
   E->>M: subscribe|pane.created
   M-->>E: ok
@@ -25,9 +25,10 @@ The connection stays open for the lifetime of the extension subprocess. Muxy fan
 
 ## Identify rules
 
-- `identify|<id>` is checked against the set of extensions currently loaded by `ExtensionStore`. Unknown IDs are rejected with `error:unknown extension <id>`.
-- An extension may identify only once per connection. Subsequent `identify` lines overwrite the session's claimed ID.
-- Sessions that never call `identify` (e.g. the `muxy` CLI) are treated as unidentified. They can still call verbs, but cannot subscribe to or be limited by manifest declarations.
+- `identify|<id>|<token>` is checked against the set of extensions currently loaded by `ExtensionStore`. Unknown IDs are rejected with `error:unknown extension <id>`.
+- `<token>` must match the value Muxy passed to the subprocess as `MUXY_EXTENSION_TOKEN`. Mismatches return `error:invalid extension token`. The token is regenerated on every extension start.
+- An extension may identify only once per connection. Subsequent `identify` lines overwrite the session's claimed ID — but must still present the correct token.
+- Sessions that never call `identify` (e.g. the `muxy` CLI) are treated as unidentified. They can still call verbs that don't require an extension identity.
 
 ## Subscribe rules
 

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -30,8 +30,25 @@ Every extension declares itself in a `manifest.json` next to its entrypoint.
 | `events` | string[] | no | Events the extension is allowed to subscribe to. See [Events](events.md). Defaults to empty. |
 | `commands` | object[] | no | Palette commands to register. See [Palette Commands](palette-commands.md). |
 | `tabTypes` | object[] | no | Webview tab types the extension exposes. See [Tabs](tabs.md). |
+| `topbarItems` | object[] | no | Icons to attach to the tab strip. See [Topbar](topbar.md). |
+| `statusBarItems` | object[] | no | Icons to attach to the footer status bar. See [Status Bar](statusbar.md). |
+| `settings` | object[] | no | Typed settings shown in the Settings sidebar. See [Settings](settings.md). |
 | `aiProvider` | object | no | Optional notification source mapping. See [AI Provider Hooks](ai-provider.md). |
 | `enabled` | bool | no | Defaults to `true`. Toggling in Settings persists across launches at runtime. |
+
+## Icons
+
+Topbar and status bar items accept an `icon` field in one of two forms:
+
+```json
+{ "icon": { "symbol": "puzzlepiece.extension" } }
+{ "icon": { "svg": "assets/badge.svg" } }
+```
+
+A bare string (`"icon": "puzzlepiece.extension"`) is accepted as shorthand for `{ "symbol": ... }`.
+
+- **`symbol`** — any SF Symbol name. Tinted with the chrome's muted/hover colors automatically.
+- **`svg`** — a path **relative to the extension directory** to an `.svg` file. The file must exist at load time and must not escape the extension directory. Rendered as a *template* image, so SVG fills/strokes that use `currentColor` (or a single solid color) pick up the chrome tint.
 
 ## Loader behaviour
 

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -47,8 +47,8 @@ Topbar and status bar items accept an `icon` field in one of two forms:
 
 A bare string (`"icon": "puzzlepiece.extension"`) is accepted as shorthand for `{ "symbol": ... }`.
 
-- **`symbol`** — any SF Symbol name. Tinted with the chrome's muted/hover colors automatically.
-- **`svg`** — a path **relative to the extension directory** to an `.svg` file. The file must exist at load time and must not escape the extension directory. Rendered as a *template* image, so SVG fills/strokes that use `currentColor` (or a single solid color) pick up the chrome tint.
+- **`symbol`** — any SF Symbol name. Tinted with the chrome's foreground color (topbar items also pick up a hover color).
+- **`svg`** — a path **relative to the extension directory** to a file with a `.svg` extension. The file must exist at load time, must not escape the extension directory, and must be at most 256 KiB. Rendered as a *template* image, so SVG fills/strokes that use `currentColor` (or a single solid color) pick up the chrome tint.
 
 ## Loader behaviour
 
@@ -69,5 +69,6 @@ Each enabled extension is spawned with these environment variables:
 | --- | --- |
 | `MUXY_SOCKET_PATH` | Absolute path to `muxy.sock` |
 | `MUXY_EXTENSION_ID` | The extension's `name` from the manifest |
+| `MUXY_EXTENSION_TOKEN` | Random per-launch token. Required as the third argument of `identify`. |
 
-Both must be passed back when the extension connects — see [Events](events.md) for the handshake.
+All three must be passed back when the extension connects — see [Events](events.md) for the handshake.

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -45,7 +45,7 @@ flowchart TB
 Extensions use the same Unix socket as the `muxy` CLI, with a small protocol on top: two sticky commands (`identify`, `subscribe`) followed by any of the existing verbs.
 
 ```
-identify|<extension-id>          # claim identity (must match manifest name)
+identify|<extension-id>|<token>  # claim identity; token comes from MUXY_EXTENSION_TOKEN env
 subscribe|<event-name>           # receive `event|<name>|key=value...` lines
 <verb>|<args>                    # any CLI verb (permission-gated)
 ```

--- a/docs/extensions/palette-commands.md
+++ b/docs/extensions/palette-commands.md
@@ -56,7 +56,7 @@ sequenceDiagram
 The extension must subscribe to its own command event. The command id auto-allowlists the corresponding `command.<id>` event — you do **not** need to add it to the manifest `events` array.
 
 ```bash
-identify|hello
+identify|hello|"$MUXY_EXTENSION_TOKEN"
 subscribe|command.ping
 ```
 

--- a/docs/extensions/settings.md
+++ b/docs/extensions/settings.md
@@ -42,10 +42,10 @@ The sidebar adds one row per enabled extension that declares at least one settin
 
 ## Runtime API
 
-The extension reads and writes its own settings over the existing notification socket. The verbs are scoped to the calling extension — there is no permission to declare. They use JSON-encoded values for round-trippable types.
+The extension reads and writes its own settings over the existing notification socket. The verbs are scoped to the calling extension via the per-launch `MUXY_EXTENSION_TOKEN`: a process that doesn't echo the token back during `identify` cannot read or write any extension's settings. Treat the token as a secret on a par with the socket path itself.
 
 ```
-identify|<extension-id>
+identify|<extension-id>|<token>
 extension.settings.get|<key>
 extension.settings.set|<key>|<json-value>
 ```
@@ -54,20 +54,22 @@ extension.settings.set|<key>|<json-value>
 
 | Response | Meaning |
 | --- | --- |
-| `ok\t<json>` | Current effective value. JSON `null` is returned when no override exists and there is no `defaultValue`. |
+| `ok` (no payload) | No override and no `defaultValue` — the setting is unset. |
+| `ok\t<json>` | Current effective value, JSON-encoded. A literal `null` here means the stored value is the JSON null (distinct from "unset"). |
 | `error:setting '<key>' not declared in manifest` | Add the key under `settings` in the manifest. |
 | `error:identify required` | Connection has not called `identify` yet. |
 
 ### Set
 
-The third pipe-separated argument is a single JSON value — `true`, `42`, `"hello"`, etc. Pipes inside JSON strings are passed through verbatim (the verb concatenates the remainder of the message).
+The third pipe-separated argument is a single JSON value — `true`, `42`, `"hello"`, etc. Pipes inside JSON strings are passed through verbatim (the verb concatenates the remainder of the message). Total payload must be at most 64 KiB.
 
 | Response | Meaning |
 | --- | --- |
 | `ok` | Value stored. |
 | `error:invalid json value: …` | The payload could not be JSON-decoded. |
 | `error:setting '<key>' not declared in manifest` | Add the key under `settings` in the manifest. |
+| `error:value exceeds 65536-byte limit` | Payload too large. |
 
 ## Storage
 
-Values live under `UserDefaults.standard` with keys of the form `muxy.ext.<extension-id>.<key>`. They survive app restarts but are not synced across machines. Disabling an extension does not clear its settings; uninstalling does not either (settings persist by design so a re-installed extension keeps its configuration).
+Storage layout is an implementation detail and may change without notice. At time of writing values live under `UserDefaults.standard` with keys of the form `muxy.ext.<extension-id>.<key>`. They survive app restarts but are not synced across machines. Disabling an extension does not clear its settings; uninstalling does not either (settings persist by design so a re-installed extension keeps its configuration).

--- a/docs/extensions/settings.md
+++ b/docs/extensions/settings.md
@@ -1,0 +1,73 @@
+# Settings
+
+Extensions can declare typed settings that appear in their own row in the Settings sidebar. The values are stored per-extension and can be read or written from the extension subprocess.
+
+```json
+{
+  "settings": [
+    {
+      "key": "endpoint",
+      "title": "API Endpoint",
+      "description": "Base URL for the build server.",
+      "type": "string",
+      "defaultValue": "https://builds.example.com"
+    },
+    {
+      "key": "notify",
+      "title": "Notify on Failure",
+      "type": "bool",
+      "defaultValue": true
+    }
+  ]
+}
+```
+
+## Entry fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `key` | string | yes | Unique within the extension. Persisted as `muxy.ext.<extension-id>.<key>` in app defaults. |
+| `title` | string | yes | Row label in the Settings UI. |
+| `description` | string | no | Sub-text shown below the row. |
+| `type` | string | yes | `string`, `bool`, or `number`. Controls the renderer and JSON type. |
+| `defaultValue` | any | no | JSON value used when the user has not set the key. Type should match `type`. |
+
+## UI
+
+The sidebar adds one row per enabled extension that declares at least one setting, immediately below the built-in **Extensions** row. The row icon is the standard puzzle-piece glyph and the title is the extension's display name. The detail pane lists each setting as a labeled control:
+
+- `bool` → toggle switch
+- `string` → text input
+- `number` → text input (parses as `Double`; an empty field resets to default)
+
+## Runtime API
+
+The extension reads and writes its own settings over the existing notification socket. The verbs are scoped to the calling extension — there is no permission to declare. They use JSON-encoded values for round-trippable types.
+
+```
+identify|<extension-id>
+extension.settings.get|<key>
+extension.settings.set|<key>|<json-value>
+```
+
+### Get
+
+| Response | Meaning |
+| --- | --- |
+| `ok\t<json>` | Current effective value. JSON `null` is returned when no override exists and there is no `defaultValue`. |
+| `error:setting '<key>' not declared in manifest` | Add the key under `settings` in the manifest. |
+| `error:identify required` | Connection has not called `identify` yet. |
+
+### Set
+
+The third pipe-separated argument is a single JSON value — `true`, `42`, `"hello"`, etc. Pipes inside JSON strings are passed through verbatim (the verb concatenates the remainder of the message).
+
+| Response | Meaning |
+| --- | --- |
+| `ok` | Value stored. |
+| `error:invalid json value: …` | The payload could not be JSON-decoded. |
+| `error:setting '<key>' not declared in manifest` | Add the key under `settings` in the manifest. |
+
+## Storage
+
+Values live under `UserDefaults.standard` with keys of the form `muxy.ext.<extension-id>.<key>`. They survive app restarts but are not synced across machines. Disabling an extension does not clear its settings; uninstalling does not either (settings persist by design so a re-installed extension keeps its configuration).

--- a/docs/extensions/statusbar.md
+++ b/docs/extensions/statusbar.md
@@ -34,13 +34,15 @@ Extensions can place items in either side of the footer status bar — the row t
 ## Updating text at runtime
 
 ```
-identify|<extension-id>
+identify|<extension-id>|<token>
 extension.statusbar.set|<itemID>|<text>
 ```
 
+`<token>` comes from the `MUXY_EXTENSION_TOKEN` environment variable Muxy injects when it spawns the extension. The connecting process must echo it back; identify is rejected otherwise.
+
 | Response | Meaning |
 | --- | --- |
-| `ok` | Text updated. Pass an empty body to clear back to the manifest value. |
+| `ok` | Text updated. To clear back to the manifest value, send `extension.statusbar.set\|<itemID>` (no third argument) or pass an empty text \(`extension.statusbar.set\|<itemID>\|`\). |
 | `error:identify required` | Connection has not called `identify` yet. |
 | `error:unknown status bar item '<id>'` | The id is not declared in the extension's `statusBarItems`. |
 

--- a/docs/extensions/statusbar.md
+++ b/docs/extensions/statusbar.md
@@ -1,0 +1,51 @@
+# Status Bar Items
+
+Extensions can place items in either side of the footer status bar — the row that shows the project path, branch, and rich-input controls. Each item has an icon, optional text, and triggers one of the extension's declared palette commands.
+
+```json
+{
+  "commands": [
+    { "id": "show-builds", "title": "Builds", "action": { "kind": "openTab", "tabType": "builds" } }
+  ],
+  "statusBarItems": [
+    {
+      "id": "build",
+      "icon": { "symbol": "hammer.fill" },
+      "text": "0",
+      "tooltip": "Show recent builds",
+      "side": "right",
+      "command": "show-builds"
+    }
+  ]
+}
+```
+
+## Fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Unique within the extension. |
+| `icon` | object | yes | `{ "symbol": "<sf-symbol>" }` or `{ "svg": "<path>" }`. See [Icons](manifest.md#icons). |
+| `text` | string | no | Static text shown next to the icon. Can be replaced at runtime — see below. |
+| `tooltip` | string | no | Hover tooltip / accessibility label. Defaults to the id. |
+| `side` | string | yes | `left` or `right`. Items group with the built-in status bar entries on that side. |
+| `command` | string | yes | Must reference a declared `commands[].id`. |
+
+## Updating text at runtime
+
+```
+identify|<extension-id>
+extension.statusbar.set|<itemID>|<text>
+```
+
+| Response | Meaning |
+| --- | --- |
+| `ok` | Text updated. Pass an empty body to clear back to the manifest value. |
+| `error:identify required` | Connection has not called `identify` yet. |
+| `error:unknown status bar item '<id>'` | The id is not declared in the extension's `statusBarItems`. |
+
+The override lives in-memory for the lifetime of the session. Disabling or reloading the extension clears it.
+
+## Separators
+
+The footer status bar draws a 1-pixel separator between every item on each side, including extension items. A separator is appended after the last left item and prepended before the first right item, so the two groups always have a visible edge against the central spacer.

--- a/docs/extensions/topbar.md
+++ b/docs/extensions/topbar.md
@@ -1,0 +1,40 @@
+# Topbar Items
+
+Extensions can attach icons to the right-hand side of the tab strip — the same row that holds the VCS, file-diff, and file-tree buttons. Clicking an icon triggers one of the extension's declared palette commands.
+
+```json
+{
+  "commands": [
+    { "id": "open-pr", "title": "Open PR…", "action": { "kind": "openTab", "tabType": "pr-viewer" } }
+  ],
+  "topbarItems": [
+    {
+      "id": "pr",
+      "icon": { "symbol": "arrow.triangle.pull" },
+      "tooltip": "Open Pull Request",
+      "command": "open-pr"
+    }
+  ]
+}
+```
+
+## Fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Unique within the extension. |
+| `icon` | object | yes | `{ "symbol": "<sf-symbol>" }` or `{ "svg": "<path>" }`. See [Icons](manifest.md#icons). A bare string is treated as a symbol. |
+| `tooltip` | string | no | Hover tooltip and accessibility label. Defaults to the id. |
+| `command` | string | yes | Must reference a declared `commands[].id`. |
+
+## Behavior
+
+Clicking a topbar icon dispatches the referenced command through the same path as the command palette — including the command's `action` (`event`, `openTab`, or `runScript`). Permissions required by the resulting action still apply (e.g. `commands:run-script` for a `runScript` action).
+
+Disabled extensions contribute no topbar items. Items disappear immediately when the extension is toggled off.
+
+## Limits
+
+- Topbar icons render in the order extensions are loaded.
+- An item whose `command` references an unknown id fails the manifest load — fix the reference before reloading.
+- SVG icons must live inside the extension directory and exist at load time.

--- a/docs/extensions/topbar.md
+++ b/docs/extensions/topbar.md
@@ -33,8 +33,11 @@ Clicking a topbar icon dispatches the referenced command through the same path a
 
 Disabled extensions contribute no topbar items. Items disappear immediately when the extension is toggled off.
 
+## Placement and order
+
+Icons appear in the right-hand cluster of the tab strip, inserted just before the built-in **Split Right / Split Down / New Tab** group. Among themselves they're ordered first by extension directory name, then by the order they appear in the extension's `topbarItems` array.
+
 ## Limits
 
-- Topbar icons render in the order extensions are loaded.
 - An item whose `command` references an unknown id fails the manifest load — fix the reference before reloading.
-- SVG icons must live inside the extension directory and exist at load time.
+- SVG icons must live inside the extension directory, have a `.svg` extension, and be at most 256 KiB.


### PR DESCRIPTION
Extensions can now register topbar icons, status bar items (with live text), and typed settings via the manifest.
  Adds extension.settings.get/set and extension.statusbar.set socket verbs, and normalizes status bar separators.