### PR TITLE
Fix extension disable: clean exit + persist across restarts

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -277,7 +277,6 @@ struct ExtensionManifest: Codable, Equatable {
     let topbarItems: [ExtensionTopbarItem]
     let statusBarItems: [ExtensionStatusBarItem]
     let settings: [ExtensionSettingEntry]
-    let enabled: Bool
 
     private enum CodingKeys: String, CodingKey {
         case name
@@ -306,8 +305,7 @@ struct ExtensionManifest: Codable, Equatable {
         aiProvider: ExtensionAIProvider? = nil,
         topbarItems: [ExtensionTopbarItem] = [],
         statusBarItems: [ExtensionStatusBarItem] = [],
-        settings: [ExtensionSettingEntry] = [],
-        enabled: Bool = true
+        settings: [ExtensionSettingEntry] = []
     ) {
         self.name = name
         self.version = version
@@ -321,7 +319,6 @@ struct ExtensionManifest: Codable, Equatable {
         self.topbarItems = topbarItems
         self.statusBarItems = statusBarItems
         self.settings = settings
-        self.enabled = enabled
     }
 
     init(from decoder: Decoder) throws {
@@ -338,7 +335,6 @@ struct ExtensionManifest: Codable, Equatable {
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
         settings = try container.decodeIfPresent([ExtensionSettingEntry].self, forKey: .settings) ?? []
-        enabled = true
     }
 
     func tabType(id: String) -> ExtensionTabType? {
@@ -351,24 +347,6 @@ struct ExtensionManifest: Codable, Equatable {
 
     func statusBarItem(id: String) -> ExtensionStatusBarItem? {
         statusBarItems.first { $0.id == id }
-    }
-
-    func withEnabled(_ enabled: Bool) -> ExtensionManifest {
-        ExtensionManifest(
-            name: name,
-            version: version,
-            description: description,
-            entrypoint: entrypoint,
-            events: events,
-            commands: commands,
-            tabTypes: tabTypes,
-            permissions: permissions,
-            aiProvider: aiProvider,
-            topbarItems: topbarItems,
-            statusBarItems: statusBarItems,
-            settings: settings,
-            enabled: enabled
-        )
     }
 }
 

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -498,7 +498,17 @@ enum ExtensionManifestLoader {
         try validateStatusBarItems(manifest: manifest, in: muxyExtension)
         try validateSettings(manifest: manifest)
 
+        migrateLegacyEnabledFlag(rawManifest: data, extensionID: manifest.name)
+
         return muxyExtension
+    }
+
+    private static func migrateLegacyEnabledFlag(rawManifest: Data, extensionID: String) {
+        guard !ExtensionEnabledStore.hasOverride(extensionID: extensionID) else { return }
+        guard let object = try? JSONSerialization.jsonObject(with: rawManifest) as? [String: Any],
+              let legacyValue = object["enabled"] as? Bool
+        else { return }
+        ExtensionEnabledStore.setEnabled(legacyValue, extensionID: extensionID)
     }
 
     static func validate(name: String) throws {

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -292,7 +292,6 @@ struct ExtensionManifest: Codable, Equatable {
         case topbarItems
         case statusBarItems
         case settings
-        case enabled
     }
 
     init(
@@ -339,7 +338,7 @@ struct ExtensionManifest: Codable, Equatable {
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
         settings = try container.decodeIfPresent([ExtensionSettingEntry].self, forKey: .settings) ?? []
-        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        enabled = true
     }
 
     func tabType(id: String) -> ExtensionTabType? {

--- a/Muxy/Services/ExtensionEnabledStore.swift
+++ b/Muxy/Services/ExtensionEnabledStore.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@MainActor
+final class ExtensionEnabledStore {
+    static let shared = ExtensionEnabledStore()
+
+    private let defaults: UserDefaults
+    private static let keyPrefix = "muxy.ext.enabled."
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func override(extensionID: String) -> Bool? {
+        let key = Self.storageKey(extensionID: extensionID)
+        guard defaults.object(forKey: key) != nil else { return nil }
+        return defaults.bool(forKey: key)
+    }
+
+    func setOverride(_ enabled: Bool, extensionID: String) {
+        defaults.set(enabled, forKey: Self.storageKey(extensionID: extensionID))
+    }
+
+    func clearOverride(extensionID: String) {
+        defaults.removeObject(forKey: Self.storageKey(extensionID: extensionID))
+    }
+
+    private static func storageKey(extensionID: String) -> String {
+        "\(keyPrefix)\(extensionID)"
+    }
+}

--- a/Muxy/Services/ExtensionEnabledStore.swift
+++ b/Muxy/Services/ExtensionEnabledStore.swift
@@ -1,28 +1,20 @@
 import Foundation
 
-@MainActor
-final class ExtensionEnabledStore {
-    static let shared = ExtensionEnabledStore()
-
-    private let defaults: UserDefaults
+enum ExtensionEnabledStore {
     private static let keyPrefix = "muxy.ext.enabled."
 
-    init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
-    }
-
-    func override(extensionID: String) -> Bool? {
-        let key = Self.storageKey(extensionID: extensionID)
-        guard defaults.object(forKey: key) != nil else { return nil }
+    static func isEnabled(extensionID: String, defaults: UserDefaults = .standard) -> Bool {
+        let key = storageKey(extensionID: extensionID)
+        guard defaults.object(forKey: key) != nil else { return true }
         return defaults.bool(forKey: key)
     }
 
-    func setOverride(_ enabled: Bool, extensionID: String) {
-        defaults.set(enabled, forKey: Self.storageKey(extensionID: extensionID))
+    static func setEnabled(_ enabled: Bool, extensionID: String, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: storageKey(extensionID: extensionID))
     }
 
-    func clearOverride(extensionID: String) {
-        defaults.removeObject(forKey: Self.storageKey(extensionID: extensionID))
+    static func clear(extensionID: String, defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: storageKey(extensionID: extensionID))
     }
 
     private static func storageKey(extensionID: String) -> String {

--- a/Muxy/Services/ExtensionEnabledStore.swift
+++ b/Muxy/Services/ExtensionEnabledStore.swift
@@ -9,6 +9,10 @@ enum ExtensionEnabledStore {
         return defaults.bool(forKey: key)
     }
 
+    static func hasOverride(extensionID: String, defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: storageKey(extensionID: extensionID)) != nil
+    }
+
     static func setEnabled(_ enabled: Bool, extensionID: String, defaults: UserDefaults = .standard) {
         defaults.set(enabled, forKey: storageKey(extensionID: extensionID))
     }

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -346,7 +346,6 @@ final class ExtensionStore {
     private func loadFromDisk() {
         statuses = []
         loadFailures = []
-        intentionalStops.removeAll()
 
         try? FileManager.default.createDirectory(
             at: rootDirectoryURL,

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -34,6 +34,7 @@ final class ExtensionStore {
 
     private var processes: [String: Process] = [:]
     private var tokens: [String: String] = [:]
+    private var intentionalStops: Set<String> = []
     private let rootDirectoryURL: URL
 
     private init(rootDirectory: URL = ExtensionStore.defaultRootDirectory) {
@@ -73,6 +74,7 @@ final class ExtensionStore {
 
     func setEnabled(_ enabled: Bool, for extensionID: String) {
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }
+        ExtensionEnabledStore.shared.setOverride(enabled, extensionID: extensionID)
         let updatedExtension = MuxyExtension(
             id: statuses[index].muxyExtension.id,
             directory: statuses[index].muxyExtension.directory,
@@ -375,15 +377,16 @@ final class ExtensionStore {
             else { continue }
 
             do {
-                let ext = try ExtensionManifestLoader.load(from: url)
-                guard !seenIDs.contains(ext.id) else {
+                let loaded = try ExtensionManifestLoader.load(from: url)
+                guard !seenIDs.contains(loaded.id) else {
                     loadFailures.append(LoadFailure(
                         directory: url,
-                        message: ExtensionLoadError.duplicateName(ext.id).localizedDescription
+                        message: ExtensionLoadError.duplicateName(loaded.id).localizedDescription
                     ))
                     continue
                 }
-                seenIDs.insert(ext.id)
+                seenIDs.insert(loaded.id)
+                let ext = applyEnabledOverride(to: loaded)
                 ExtensionLogStore.shared.register(extensionID: ext.id, directory: ext.directory)
                 statuses.append(ExtensionStatus(
                     id: ext.id,
@@ -399,6 +402,18 @@ final class ExtensionStore {
                 logger.error("Failed to load extension at \(url.path): \(error.localizedDescription)")
             }
         }
+    }
+
+    private func applyEnabledOverride(to ext: MuxyExtension) -> MuxyExtension {
+        guard let override = ExtensionEnabledStore.shared.override(extensionID: ext.id) else {
+            return ext
+        }
+        if override == ext.manifest.enabled { return ext }
+        return MuxyExtension(
+            id: ext.id,
+            directory: ext.directory,
+            manifest: ext.manifest.withEnabled(override)
+        )
     }
 
     private func startExtension(at index: Int) {
@@ -468,6 +483,7 @@ final class ExtensionStore {
         tokens.removeValue(forKey: extensionID)
         guard let process = processes.removeValue(forKey: extensionID) else { return }
         if process.isRunning {
+            intentionalStops.insert(extensionID)
             process.terminate()
         }
         if let index = statuses.firstIndex(where: { $0.id == extensionID }) {
@@ -486,8 +502,13 @@ final class ExtensionStore {
 
     private func handleTermination(extensionID: String, process: Process) {
         processes.removeValue(forKey: extensionID)
+        let wasIntentional = intentionalStops.remove(extensionID) != nil
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }
         statuses[index].isRunning = false
+        if wasIntentional {
+            ExtensionLogStore.shared.append(extensionID: extensionID, line: "[muxy] stopped")
+            return
+        }
         let status = process.terminationStatus
         if status != 0 {
             let message = "Process exited with status \(status)"

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -12,6 +12,7 @@ final class ExtensionStore {
     struct ExtensionStatus: Identifiable, Equatable {
         let id: String
         let muxyExtension: MuxyExtension
+        var isEnabled: Bool
         var isRunning: Bool
         var lastError: String?
 
@@ -50,7 +51,7 @@ final class ExtensionStore {
 
     func startAll() {
         loadFromDisk()
-        for index in statuses.indices where statuses[index].muxyExtension.manifest.enabled {
+        for index in statuses.indices where statuses[index].isEnabled {
             startExtension(at: index)
         }
         rebuildExtensionUICache()
@@ -74,19 +75,8 @@ final class ExtensionStore {
 
     func setEnabled(_ enabled: Bool, for extensionID: String) {
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }
-        ExtensionEnabledStore.shared.setOverride(enabled, extensionID: extensionID)
-        let updatedExtension = MuxyExtension(
-            id: statuses[index].muxyExtension.id,
-            directory: statuses[index].muxyExtension.directory,
-            manifest: statuses[index].muxyExtension.manifest.withEnabled(enabled)
-        )
-
-        statuses[index] = ExtensionStatus(
-            id: updatedExtension.id,
-            muxyExtension: updatedExtension,
-            isRunning: statuses[index].isRunning,
-            lastError: statuses[index].lastError
-        )
+        ExtensionEnabledStore.setEnabled(enabled, extensionID: extensionID)
+        statuses[index].isEnabled = enabled
 
         if enabled, !statuses[index].isRunning {
             startExtension(at: index)
@@ -107,12 +97,12 @@ final class ExtensionStore {
     }
 
     func loadedExtension(id: String) -> MuxyExtension? {
-        statuses.first(where: { $0.id == id && $0.muxyExtension.manifest.enabled })?.muxyExtension
+        statuses.first(where: { $0.id == id && $0.isEnabled })?.muxyExtension
     }
 
     func snapshotForSocketServer() -> NotificationSocketServer.ExtensionSnapshot {
         var entries: [String: NotificationSocketServer.ExtensionSnapshotEntry] = [:]
-        for status in statuses where status.muxyExtension.manifest.enabled {
+        for status in statuses where status.isEnabled {
             let manifest = status.muxyExtension.manifest
             guard let token = tokens[status.id] else { continue }
             entries[status.id] = NotificationSocketServer.ExtensionSnapshotEntry(
@@ -129,20 +119,21 @@ final class ExtensionStore {
         NotificationSocketServer.shared.applyExtensionSnapshot(snapshotForSocketServer())
     }
 
-    static func buildSnapshotForTesting(from extensions: [MuxyExtension], token: String = "test-token") -> NotificationSocketServer
-        .ExtensionSnapshot
-    {
-        var entries: [String: NotificationSocketServer.ExtensionSnapshotEntry] = [:]
-        for ext in extensions where ext.manifest.enabled {
+    static func buildSnapshotForTesting(
+        from entries: [(MuxyExtension, isEnabled: Bool)],
+        token: String = "test-token"
+    ) -> NotificationSocketServer.ExtensionSnapshot {
+        var result: [String: NotificationSocketServer.ExtensionSnapshotEntry] = [:]
+        for (ext, isEnabled) in entries where isEnabled {
             let manifest = ext.manifest
-            entries[ext.id] = NotificationSocketServer.ExtensionSnapshotEntry(
+            result[ext.id] = NotificationSocketServer.ExtensionSnapshotEntry(
                 allowedEvents: Set(manifest.events),
                 commandEvents: Set(manifest.commands.map(\.eventName)),
                 permissions: Set(manifest.permissions),
                 token: token
             )
         }
-        return NotificationSocketServer.ExtensionSnapshot(entries: entries)
+        return NotificationSocketServer.ExtensionSnapshot(entries: result)
     }
 
     struct PaletteCommandBinding: Equatable {
@@ -173,7 +164,7 @@ final class ExtensionStore {
 
     func paletteCommands() -> [PaletteCommandBinding] {
         statuses
-            .filter(\.muxyExtension.manifest.enabled)
+            .filter(\.isEnabled)
             .flatMap { status in
                 status.muxyExtension.manifest.commands.map { PaletteCommandBinding(muxyExtension: status.muxyExtension, command: $0) }
             }
@@ -187,7 +178,7 @@ final class ExtensionStore {
         var topbar: [TopbarItemBinding] = []
         var left: [StatusBarItemBinding] = []
         var right: [StatusBarItemBinding] = []
-        for status in statuses where status.muxyExtension.manifest.enabled {
+        for status in statuses where status.isEnabled {
             let ext = status.muxyExtension
             let overrides = statusBarTextOverrides[status.id]
             for item in ext.manifest.topbarItems {
@@ -342,7 +333,7 @@ final class ExtensionStore {
     }
 
     func declaredAIProvider(for socketTypeKey: String) -> (extensionID: String, provider: ExtensionAIProvider)? {
-        for status in statuses where status.muxyExtension.manifest.enabled {
+        for status in statuses where status.isEnabled {
             if let provider = status.muxyExtension.manifest.aiProvider,
                provider.socketTypeKey == socketTypeKey
             {
@@ -355,6 +346,7 @@ final class ExtensionStore {
     private func loadFromDisk() {
         statuses = []
         loadFailures = []
+        intentionalStops.removeAll()
 
         try? FileManager.default.createDirectory(
             at: rootDirectoryURL,
@@ -377,20 +369,20 @@ final class ExtensionStore {
             else { continue }
 
             do {
-                let loaded = try ExtensionManifestLoader.load(from: url)
-                guard !seenIDs.contains(loaded.id) else {
+                let ext = try ExtensionManifestLoader.load(from: url)
+                guard !seenIDs.contains(ext.id) else {
                     loadFailures.append(LoadFailure(
                         directory: url,
-                        message: ExtensionLoadError.duplicateName(loaded.id).localizedDescription
+                        message: ExtensionLoadError.duplicateName(ext.id).localizedDescription
                     ))
                     continue
                 }
-                seenIDs.insert(loaded.id)
-                let ext = applyEnabledOverride(to: loaded)
+                seenIDs.insert(ext.id)
                 ExtensionLogStore.shared.register(extensionID: ext.id, directory: ext.directory)
                 statuses.append(ExtensionStatus(
                     id: ext.id,
                     muxyExtension: ext,
+                    isEnabled: ExtensionEnabledStore.isEnabled(extensionID: ext.id),
                     isRunning: false,
                     lastError: nil
                 ))
@@ -402,18 +394,6 @@ final class ExtensionStore {
                 logger.error("Failed to load extension at \(url.path): \(error.localizedDescription)")
             }
         }
-    }
-
-    private func applyEnabledOverride(to ext: MuxyExtension) -> MuxyExtension {
-        guard let override = ExtensionEnabledStore.shared.override(extensionID: ext.id) else {
-            return ext
-        }
-        if override == ext.manifest.enabled { return ext }
-        return MuxyExtension(
-            id: ext.id,
-            directory: ext.directory,
-            manifest: ext.manifest.withEnabled(override)
-        )
     }
 
     private func startExtension(at index: Int) {
@@ -505,17 +485,31 @@ final class ExtensionStore {
         let wasIntentional = intentionalStops.remove(extensionID) != nil
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }
         statuses[index].isRunning = false
-        if wasIntentional {
+        let outcome = Self.classifyTermination(
+            wasIntentional: wasIntentional,
+            terminationStatus: process.terminationStatus
+        )
+        switch outcome {
+        case .stopped:
             ExtensionLogStore.shared.append(extensionID: extensionID, line: "[muxy] stopped")
-            return
-        }
-        let status = process.terminationStatus
-        if status != 0 {
+        case .exitedCleanly:
+            ExtensionLogStore.shared.append(extensionID: extensionID, line: "[muxy] exited cleanly")
+        case let .exitedWithStatus(status):
             let message = "Process exited with status \(status)"
             statuses[index].lastError = message
             ExtensionLogStore.shared.append(extensionID: extensionID, line: "[muxy] \(message)")
-        } else {
-            ExtensionLogStore.shared.append(extensionID: extensionID, line: "[muxy] exited cleanly")
         }
+    }
+
+    enum TerminationOutcome: Equatable {
+        case stopped
+        case exitedCleanly
+        case exitedWithStatus(Int32)
+    }
+
+    nonisolated static func classifyTermination(wasIntentional: Bool, terminationStatus: Int32) -> TerminationOutcome {
+        if wasIntentional { return .stopped }
+        if terminationStatus == 0 { return .exitedCleanly }
+        return .exitedWithStatus(terminationStatus)
     }
 }

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -328,7 +328,7 @@ private struct ExtensionStatusBadge: View {
     @MainActor
     private var info: (String, Color) {
         if status.isRunning { return ("running", MuxyTheme.diffAddFg) }
-        if status.muxyExtension.manifest.enabled { return ("stopped", MuxyTheme.fgMuted) }
+        if status.isEnabled { return ("stopped", MuxyTheme.fgMuted) }
         return ("disabled", MuxyTheme.fgDim)
     }
 }
@@ -715,7 +715,7 @@ private struct ExtensionDetailPage: View {
 
     private var enabledBinding: Binding<Bool> {
         Binding(
-            get: { ext.manifest.enabled },
+            get: { status.isEnabled },
             set: { store.setEnabled($0, for: status.id) }
         )
     }

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
     private var visibleExtensionRoutes: [(extensionID: String, displayName: String)] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return extensionStore.statuses
-            .filter { $0.muxyExtension.manifest.enabled && !$0.muxyExtension.manifest.settings.isEmpty }
+            .filter { $0.isEnabled && !$0.muxyExtension.manifest.settings.isEmpty }
             .filter { status in
                 guard !query.isEmpty else { return true }
                 let displayName = status.muxyExtension.displayName.lowercased()

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -72,6 +72,56 @@ struct ExtensionManifestTests {
         #expect(FileManager.default.isExecutableFile(atPath: ext.entrypointURL.path))
     }
 
+    @Test("migrates legacy manifest enabled=false into ExtensionEnabledStore")
+    func migratesLegacyEnabledFalse() throws {
+        let extensionID = "legacy-disabled-\(UUID().uuidString)"
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "\(extensionID)",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "enabled": false
+            }
+            """,
+            files: ["run.sh": "#!/bin/sh\n"]
+        )
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            ExtensionEnabledStore.clear(extensionID: extensionID)
+        }
+
+        _ = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ExtensionEnabledStore.hasOverride(extensionID: extensionID))
+        #expect(!ExtensionEnabledStore.isEnabled(extensionID: extensionID))
+    }
+
+    @Test("legacy migration does not overwrite an existing user override")
+    func legacyMigrationRespectsExistingOverride() throws {
+        let extensionID = "legacy-respect-\(UUID().uuidString)"
+        ExtensionEnabledStore.setEnabled(true, extensionID: extensionID)
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "\(extensionID)",
+                "version": "1.0.0",
+                "entrypoint": "run.sh",
+                "enabled": false
+            }
+            """,
+            files: ["run.sh": "#!/bin/sh\n"]
+        )
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            ExtensionEnabledStore.clear(extensionID: extensionID)
+        }
+
+        _ = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ExtensionEnabledStore.isEnabled(extensionID: extensionID))
+    }
+
     @Test("fails when manifest missing")
     func failsWhenManifestMissing() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("ext-\(UUID().uuidString)")

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -23,7 +23,6 @@ struct ExtensionManifestTests {
         #expect(manifest.commands.isEmpty)
         #expect(manifest.permissions.isEmpty)
         #expect(manifest.aiProvider == nil)
-        #expect(manifest.enabled == true)
     }
 
     @Test("decodes full manifest with permissions, events, commands and aiProvider")
@@ -49,13 +48,11 @@ struct ExtensionManifestTests {
         #expect(manifest.commands == [ExtensionPaletteCommand(id: "greet", title: "Say hello", subtitle: "demo")])
         #expect(manifest.permissions == [.panesRead, .tabsWrite])
         #expect(manifest.aiProvider == ExtensionAIProvider(socketTypeKey: "demo", displayName: "Demo", iconName: "sparkles"))
-        #expect(manifest.enabled == true)
     }
 
     @Test("loads from directory and resolves entrypoint")
     func loadsFromDirectory() throws {
         let directory = try makeTemporaryExtension(
-            name: "tmp-ext",
             manifest: """
             {
                 "name": "tmp-ext",
@@ -89,7 +86,6 @@ struct ExtensionManifestTests {
     @Test("fails when entrypoint not executable")
     func failsWhenEntrypointNotExecutable() throws {
         let directory = try makeTemporaryExtension(
-            name: "no-exec",
             manifest: """
             {
                 "name": "no-exec",
@@ -219,7 +215,6 @@ struct ExtensionManifestTests {
     @Test("rejects topbar item referencing unknown command")
     func rejectsTopbarUnknownCommand() throws {
         let directory = try makeTemporaryExtension(
-            name: "topbar-bad",
             manifest: """
             {
                 "name": "topbar-bad",
@@ -242,7 +237,6 @@ struct ExtensionManifestTests {
     @Test("rejects topbar item with missing SVG")
     func rejectsTopbarMissingSVG() throws {
         let directory = try makeTemporaryExtension(
-            name: "topbar-svg",
             manifest: """
             {
                 "name": "topbar-svg",
@@ -266,7 +260,6 @@ struct ExtensionManifestTests {
     @Test("rejects duplicate setting keys")
     func rejectsDuplicateSettingKeys() throws {
         let directory = try makeTemporaryExtension(
-            name: "settings-dup",
             manifest: """
             {
                 "name": "settings-dup",
@@ -290,7 +283,6 @@ struct ExtensionManifestTests {
     @Test("rejects empty topbar item id")
     func rejectsEmptyTopbarID() throws {
         let directory = try makeTemporaryExtension(
-            name: "topbar-empty",
             manifest: """
             {
                 "name": "topbar-empty",
@@ -313,7 +305,6 @@ struct ExtensionManifestTests {
     @Test("rejects empty setting key")
     func rejectsEmptySettingKey() throws {
         let directory = try makeTemporaryExtension(
-            name: "settings-empty",
             manifest: """
             {
                 "name": "settings-empty",
@@ -335,7 +326,6 @@ struct ExtensionManifestTests {
     @Test("rejects non-svg icon path")
     func rejectsNonSVGIconPath() throws {
         let directory = try makeTemporaryExtension(
-            name: "bad-icon",
             manifest: """
             {
                 "name": "bad-icon",
@@ -358,30 +348,7 @@ struct ExtensionManifestTests {
         }
     }
 
-    @Test("withEnabled preserves tabTypes")
-    func withEnabledPreservesTabTypes() {
-        let tabType = ExtensionTabType(id: "details", title: "Details", entry: "ui/index.html", defaultData: nil)
-        let original = ExtensionManifest(
-            name: "demo",
-            version: "1.0.0",
-            entrypoint: "run.sh",
-            tabTypes: [tabType],
-            permissions: [.tabsRead],
-            enabled: true
-        )
-
-        let disabled = original.withEnabled(false)
-        #expect(disabled.enabled == false)
-        #expect(disabled.tabTypes == [tabType])
-        #expect(disabled.permissions == [.tabsRead])
-
-        let reEnabled = disabled.withEnabled(true)
-        #expect(reEnabled.enabled == true)
-        #expect(reEnabled.tabTypes == [tabType])
-    }
-
     private func makeTemporaryExtension(
-        name: String,
         manifest: String,
         files: [String: String],
         makeEntrypointExecutable: Bool = true
@@ -403,7 +370,6 @@ struct ExtensionManifestTests {
                 )
             }
         }
-        _ = name
         return directory
     }
 }

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -39,8 +39,7 @@ struct ExtensionManifestTests {
                 { "id": "greet", "title": "Say hello", "subtitle": "demo" }
             ],
             "permissions": ["panes:read", "tabs:write"],
-            "aiProvider": { "socketTypeKey": "demo", "displayName": "Demo", "iconName": "sparkles" },
-            "enabled": false
+            "aiProvider": { "socketTypeKey": "demo", "displayName": "Demo", "iconName": "sparkles" }
         }
         """#
         let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
@@ -50,7 +49,7 @@ struct ExtensionManifestTests {
         #expect(manifest.commands == [ExtensionPaletteCommand(id: "greet", title: "Say hello", subtitle: "demo")])
         #expect(manifest.permissions == [.panesRead, .tabsWrite])
         #expect(manifest.aiProvider == ExtensionAIProvider(socketTypeKey: "demo", displayName: "Demo", iconName: "sparkles"))
-        #expect(manifest.enabled == false)
+        #expect(manifest.enabled == true)
     }
 
     @Test("loads from directory and resolves entrypoint")

--- a/Tests/MuxyTests/Services/ExtensionEnabledStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionEnabledStoreTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionEnabledStore")
+struct ExtensionEnabledStoreTests {
+    @Test("defaults to enabled when no value is stored")
+    func defaultsToEnabledWhenUnset() {
+        let defaults = makeIsolatedDefaults()
+        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+    }
+
+    @Test("persists disabled state and reads it back")
+    func persistsDisabledState() {
+        let defaults = makeIsolatedDefaults()
+        ExtensionEnabledStore.setEnabled(false, extensionID: "ext-a", defaults: defaults)
+        #expect(!ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+    }
+
+    @Test("persists enabled state explicitly and reads it back")
+    func persistsEnabledStateExplicitly() {
+        let defaults = makeIsolatedDefaults()
+        ExtensionEnabledStore.setEnabled(false, extensionID: "ext-a", defaults: defaults)
+        ExtensionEnabledStore.setEnabled(true, extensionID: "ext-a", defaults: defaults)
+        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+    }
+
+    @Test("clear removes the stored override")
+    func clearResetsToDefault() {
+        let defaults = makeIsolatedDefaults()
+        ExtensionEnabledStore.setEnabled(false, extensionID: "ext-a", defaults: defaults)
+        ExtensionEnabledStore.clear(extensionID: "ext-a", defaults: defaults)
+        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+    }
+
+    @Test("isolates state per extension id")
+    func isolatesPerExtension() {
+        let defaults = makeIsolatedDefaults()
+        ExtensionEnabledStore.setEnabled(false, extensionID: "ext-a", defaults: defaults)
+        #expect(!ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-b", defaults: defaults))
+    }
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suiteName = "ExtensionEnabledStoreTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create isolated UserDefaults")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/Tests/MuxyTests/Services/ExtensionEnabledStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionEnabledStoreTests.swift
@@ -42,6 +42,16 @@ struct ExtensionEnabledStoreTests {
         #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-b", defaults: defaults))
     }
 
+    @Test("hasOverride reflects whether a value has been stored")
+    func hasOverrideReflectsStorage() {
+        let defaults = makeIsolatedDefaults()
+        #expect(!ExtensionEnabledStore.hasOverride(extensionID: "ext-a", defaults: defaults))
+        ExtensionEnabledStore.setEnabled(false, extensionID: "ext-a", defaults: defaults)
+        #expect(ExtensionEnabledStore.hasOverride(extensionID: "ext-a", defaults: defaults))
+        ExtensionEnabledStore.clear(extensionID: "ext-a", defaults: defaults)
+        #expect(!ExtensionEnabledStore.hasOverride(extensionID: "ext-a", defaults: defaults))
+    }
+
     private func makeIsolatedDefaults() -> UserDefaults {
         let suiteName = "ExtensionEnabledStoreTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {

--- a/Tests/MuxyTests/Services/ExtensionStoreSnapshotTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreSnapshotTests.swift
@@ -38,7 +38,6 @@ struct ExtensionStoreSnapshotBuildingTests {
     @Test("snapshotForSocketServer includes enabled extensions only")
     func snapshotIncludesEnabledOnly() throws {
         let enabledDir = try makeTemporaryExtension(
-            name: "enabled-ext",
             manifest: """
             {
                 "name": "enabled-ext",
@@ -51,7 +50,6 @@ struct ExtensionStoreSnapshotBuildingTests {
             """
         )
         let disabledDir = try makeTemporaryExtension(
-            name: "disabled-ext",
             manifest: """
             {
                 "name": "disabled-ext",
@@ -67,13 +65,10 @@ struct ExtensionStoreSnapshotBuildingTests {
         }
 
         let enabled = try ExtensionManifestLoader.load(from: enabledDir)
-        let loadedDisabled = try ExtensionManifestLoader.load(from: disabledDir)
-        let disabled = MuxyExtension(
-            id: loadedDisabled.id,
-            directory: loadedDisabled.directory,
-            manifest: loadedDisabled.manifest.withEnabled(false)
+        let disabled = try ExtensionManifestLoader.load(from: disabledDir)
+        let snapshot = ExtensionStore.buildSnapshotForTesting(
+            from: [(enabled, isEnabled: true), (disabled, isEnabled: false)]
         )
-        let snapshot = ExtensionStore.buildSnapshotForTesting(from: [enabled, disabled])
 
         let entry = try #require(snapshot.entries["enabled-ext"])
         #expect(entry.allowedEvents == ["pane.created"])
@@ -82,7 +77,7 @@ struct ExtensionStoreSnapshotBuildingTests {
         #expect(snapshot.entries["disabled-ext"] == nil)
     }
 
-    private func makeTemporaryExtension(name: String, manifest: String) throws -> URL {
+    private func makeTemporaryExtension(manifest: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("ext-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let manifestURL = directory.appendingPathComponent("manifest.json")
@@ -93,7 +88,27 @@ struct ExtensionStoreSnapshotBuildingTests {
             [.posixPermissions: FilePermissions.executable],
             ofItemAtPath: entrypoint.path
         )
-        _ = name
         return directory
+    }
+}
+
+@Suite("ExtensionStore termination classification")
+struct ExtensionStoreTerminationClassificationTests {
+    @Test("intentional stop is reported as stopped regardless of exit status")
+    func intentionalStopMapsToStopped() {
+        #expect(ExtensionStore.classifyTermination(wasIntentional: true, terminationStatus: 0) == .stopped)
+        #expect(ExtensionStore.classifyTermination(wasIntentional: true, terminationStatus: 15) == .stopped)
+        #expect(ExtensionStore.classifyTermination(wasIntentional: true, terminationStatus: 1) == .stopped)
+    }
+
+    @Test("unintended zero exit is reported as exitedCleanly")
+    func zeroExitMapsToCleanly() {
+        #expect(ExtensionStore.classifyTermination(wasIntentional: false, terminationStatus: 0) == .exitedCleanly)
+    }
+
+    @Test("unintended non-zero exit reports the underlying status")
+    func nonZeroExitMapsToStatus() {
+        #expect(ExtensionStore.classifyTermination(wasIntentional: false, terminationStatus: 15) == .exitedWithStatus(15))
+        #expect(ExtensionStore.classifyTermination(wasIntentional: false, terminationStatus: 1) == .exitedWithStatus(1))
     }
 }

--- a/Tests/MuxyTests/Services/ExtensionStoreSnapshotTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreSnapshotTests.swift
@@ -57,7 +57,6 @@ struct ExtensionStoreSnapshotBuildingTests {
                 "name": "disabled-ext",
                 "version": "1.0.0",
                 "entrypoint": "run.sh",
-                "enabled": false,
                 "events": ["pane.closed"]
             }
             """
@@ -68,7 +67,12 @@ struct ExtensionStoreSnapshotBuildingTests {
         }
 
         let enabled = try ExtensionManifestLoader.load(from: enabledDir)
-        let disabled = try ExtensionManifestLoader.load(from: disabledDir)
+        let loadedDisabled = try ExtensionManifestLoader.load(from: disabledDir)
+        let disabled = MuxyExtension(
+            id: loadedDisabled.id,
+            directory: loadedDisabled.directory,
+            manifest: loadedDisabled.manifest.withEnabled(false)
+        )
         let snapshot = ExtensionStore.buildSnapshotForTesting(from: [enabled, disabled])
 
         let entry = try #require(snapshot.entries["enabled-ext"])

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -34,7 +34,7 @@ Every extension declares itself in a `manifest.json` next to its entrypoint.
 | `settings` | object[] | no | Typed settings shown in the Settings sidebar. See [Settings](settings.md). |
 | `aiProvider` | object | no | Optional notification source mapping. See [AI Provider Hooks](ai-provider.md). |
 
-Extensions are enabled by default after loading. Users toggle them in **Settings → Extensions**; that toggle is stored per-extension and persists across launches separately from the manifest.
+Extensions are enabled by default after loading. Users toggle them in **Settings → Extensions**; that toggle is persisted in `UserDefaults` under `muxy.ext.enabled.<extension-id>` and survives across launches.
 
 ## Icons
 

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -13,8 +13,7 @@ Every extension declares itself in a `manifest.json` next to its entrypoint.
   "commands": [
     { "id": "ping", "title": "Hello: Ping", "subtitle": "Demo command" }
   ],
-  "aiProvider": null,
-  "enabled": true
+  "aiProvider": null
 }
 ```
 
@@ -34,7 +33,8 @@ Every extension declares itself in a `manifest.json` next to its entrypoint.
 | `statusBarItems` | object[] | no | Icons to attach to the footer status bar. See [Status Bar](statusbar.md). |
 | `settings` | object[] | no | Typed settings shown in the Settings sidebar. See [Settings](settings.md). |
 | `aiProvider` | object | no | Optional notification source mapping. See [AI Provider Hooks](ai-provider.md). |
-| `enabled` | bool | no | Defaults to `true`. Toggling in Settings persists across launches at runtime. |
+
+Extensions are enabled by default after loading. Users toggle them in **Settings → Extensions**; that toggle is stored per-extension and persists across launches separately from the manifest.
 
 ## Icons
 

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -36,6 +36,8 @@ Every extension declares itself in a `manifest.json` next to its entrypoint.
 
 Extensions are enabled by default after loading. Users toggle them in **Settings → Extensions**; that toggle is persisted in `UserDefaults` under `muxy.ext.enabled.<extension-id>` and survives across launches.
 
+A legacy `enabled` field on the manifest is no longer part of the schema. If present and no user override exists yet, it is migrated into the UserDefaults entry above on first load and otherwise ignored.
+
 ## Icons
 
 Topbar and status bar items accept an `icon` field in one of two forms:


### PR DESCRIPTION
Treat extension disable as a clean stop (no spurious "exit code 15") and persist user toggles in UserDefaults
  instead of the author's manifest. The manifest's enabled field is dropped; docs and tests updated accordingly.