### PR TITLE
Add Create Extension flow with scaffolder and fix reload race

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
     static let openProjectPicker = Notification.Name("MuxyOpenProjectPicker")
     static let openSettingsModal = Notification.Name("MuxyOpenSettingsModal")
     static let openExtensionsModal = Notification.Name("MuxyOpenExtensionsModal")
+    static let openExtensionDirectoryAsProject = Notification.Name("MuxyOpenExtensionDirectoryAsProject")
     static let focusProjectPickerDefaultLocation = Notification.Name("MuxyFocusProjectPickerDefaultLocation")
     static let saveActiveEditor = Notification.Name("MuxySaveActiveEditor")
     static let windowFullScreenDidChange = Notification.Name("MuxyWindowFullScreenDidChange")
@@ -32,4 +33,8 @@ extension Notification.Name {
 enum ExternalDragHoverUserInfoKey {
     static let isHovering = "isHovering"
     static let areaID = "areaID"
+}
+
+enum OpenExtensionDirectoryUserInfoKey {
+    static let path = "path"
 }

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -513,6 +513,7 @@ enum ExtensionManifestLoader {
 
     static func validate(name: String) throws {
         guard !name.isEmpty else { throw ExtensionLoadError.invalidName(name) }
+        guard !name.hasPrefix(".") else { throw ExtensionLoadError.invalidName(name) }
         for scalar in name.unicodeScalars where !allowedNameCharacters.contains(scalar) {
             throw ExtensionLoadError.invalidName(name)
         }

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -1,0 +1,540 @@
+---
+name: muxy-extension
+description: Use when authoring or modifying a Muxy extension. Covers manifest fields, the runtime socket protocol, the in-tab `window.muxy` bridge, theme adaptation, and end-to-end examples drawn from the reference extension.
+---
+
+# Muxy Extension Author Guide
+
+Muxy extensions live in `~/.config/muxy/extensions/<name>/` and load when Muxy starts. Each extension is a directory containing a `manifest.json` and a single executable entrypoint. Optional resources (HTML tabs, scripts, icons, assets) live alongside.
+
+## When to use this skill
+
+Use this skill when:
+
+- Writing a new Muxy extension (manifest, entrypoint, tab UI).
+- Adding a command, topbar item, status-bar item, settings entry, or tab type.
+- Styling an extension tab so it adapts to the user's current Muxy theme.
+- Reading Muxy state (panes, tabs, projects, worktrees) or executing shell from a tab.
+- Subscribing to Muxy events or pushing live updates to the status bar.
+
+## Project layout
+
+A typical extension looks like this:
+
+```
+my-extension/
+├── manifest.json           # required
+├── run.sh                  # required (executable entrypoint)
+├── CLAUDE.md               # author guide for this extension
+├── AGENTS.md → CLAUDE.md   # symlink for non-Claude agents
+├── .gitignore
+├── tabs/
+│   ├── playground.html
+│   ├── playground.css
+│   └── playground.js
+├── scripts/
+│   └── do-something.js     # invoked via { "kind": "runScript" }
+└── assets/
+    └── icon.svg            # used by topbar/status-bar items
+```
+
+Every relative path in `manifest.json` is resolved against the extension directory and rejected if it escapes the directory.
+
+## Manifest
+
+The full reference manifest, taken from the bundled demo extension:
+
+```json
+{
+  "name": "demo",
+  "version": "0.2.0",
+  "description": "Reference extension: playground tab, runScript command, topbar icon, status bar items, and settings.",
+  "entrypoint": "run.sh",
+  "permissions": [
+    "tabs:read", "tabs:write",
+    "panes:read", "panes:write",
+    "projects:read", "projects:write",
+    "worktrees:read", "worktrees:write",
+    "notifications:write",
+    "commands:run-script",
+    "commands:exec"
+  ],
+  "tabTypes": [
+    { "id": "playground", "title": "Muxy API Playground", "entry": "tabs/playground.html" },
+    { "id": "dashboard",  "title": "Git Dashboard",       "entry": "tabs/dashboard.html"  }
+  ],
+  "commands": [
+    {
+      "id": "open-playground",
+      "title": "Demo: Open Playground",
+      "action": { "kind": "openTab", "tabType": "playground" }
+    },
+    {
+      "id": "run-script",
+      "title": "Demo: Open Git Dashboard",
+      "action": { "kind": "runScript", "script": "scripts/git-status.js" }
+    }
+  ],
+  "topbarItems": [
+    {
+      "id": "playground",
+      "icon": { "svg": "assets/playground.svg" },
+      "tooltip": "Open Demo Playground",
+      "command": "open-playground"
+    }
+  ],
+  "statusBarItems": [
+    {
+      "id": "ticker",
+      "icon": { "symbol": "leaf.fill" },
+      "text": "ready",
+      "tooltip": "Demo ticker (left)",
+      "side": "left",
+      "command": "open-playground"
+    },
+    {
+      "id": "dashboard",
+      "icon": { "symbol": "chart.bar.fill" },
+      "tooltip": "Open Git Dashboard",
+      "side": "right",
+      "command": "run-script"
+    }
+  ],
+  "settings": [
+    {
+      "key": "refreshSeconds",
+      "title": "Refresh Interval (s)",
+      "description": "How often to update the left status bar ticker.",
+      "type": "number",
+      "defaultValue": 5
+    }
+  ]
+}
+```
+
+Field-by-field:
+
+- `name` — required. Alphanumerics, dash, underscore, dot only. Must match the directory name.
+- `version` — required semver string.
+- `description` — optional one-line summary shown in the Extensions modal.
+- `entrypoint` — required relative path. Must exist and be executable.
+- `permissions` — array of permission strings. Declare only what the entrypoint or tabs actually use.
+- `events` — array of event names this extension subscribes to (for example `pane.created`, `tab.focused`, `pane.closed`). Command events (`command.<id>`) are auto-allowed.
+- `tabTypes` — declares HTML pages renderable as tabs.
+- `commands` — palette commands. Each command's `action.kind` is `event` (default — fires `command.<id>`), `openTab`, or `runScript`.
+- `topbarItems` / `statusBarItems` — UI hooks bound to a command. `icon` is either `{ "symbol": "<sf-symbol>" }` or `{ "svg": "<relative/path.svg>" }`.
+- `settings` — user-visible settings (`string` | `bool` | `number`) reachable from `extension.settings.get` over the socket and editable in the Extensions modal.
+
+Common load failures: missing entrypoint, entrypoint not executable, tab entry escapes the extension directory, a command references an unknown `tabType`, a topbar or status-bar item references an unknown command. Failures appear in the Extensions modal under "Load Errors".
+
+## Permissions reference
+
+Permissions are gated server-side. Requests without the matching permission fail.
+
+| Permission | Enables |
+| --- | --- |
+| `panes:read` | `panes.list`, `panes.readScreen` |
+| `panes:write` | `panes.send`, `panes.sendKeys`, `panes.close`, `panes.rename` |
+| `tabs:read` | `tabs.list` |
+| `tabs:write` | `tabs.open`, `tabs.switch`, `tabs.new`, `tabs.next`, `tabs.previous` |
+| `projects:read` | `projects.list` |
+| `projects:write` | `projects.switch` |
+| `worktrees:read` | `worktrees.list` |
+| `worktrees:write` | `worktrees.switch`, `worktrees.refresh` |
+| `notifications:write` | `toast` |
+| `commands:run-script` | `runScript` commands |
+| `commands:exec` | `muxy.exec` (always prompts the user the first time) |
+
+Principle: least privilege. Add a permission only when adding the call that requires it.
+
+## Entrypoint
+
+The entrypoint runs for the lifetime of the extension. Muxy launches it with these environment variables:
+
+- `MUXY_SOCKET_PATH` — Unix-domain socket path for IPC.
+- `MUXY_EXTENSION_ID` — the extension's `name`.
+- `MUXY_EXTENSION_TOKEN` — auth token. Every request must include it.
+- `MUXY_EXTENSION_LOG` — log file path. stdout/stderr also land here.
+
+### Minimum entrypoint (sleep forever)
+
+```sh
+#!/bin/sh
+echo "[muxy] $MUXY_EXTENSION_ID started"
+while true; do sleep 3600; done
+```
+
+This is enough to make the extension's manifest UI (palette commands, topbar items, tab types) usable. Most extensions need more — the socket protocol below.
+
+### Full entrypoint (reads a setting, pushes status-bar text)
+
+This is the exact `run.sh` from the demo extension. It identifies, reads its `refreshSeconds` setting, and updates the left status-bar item every tick using `nc -U`:
+
+```sh
+#!/bin/bash
+set -eu
+
+SOCKET="${MUXY_SOCKET_PATH:?MUXY_SOCKET_PATH is required}"
+EXT_ID="${MUXY_EXTENSION_ID:?MUXY_EXTENSION_ID is required}"
+TOKEN="${MUXY_EXTENSION_TOKEN:?MUXY_EXTENSION_TOKEN is required}"
+
+send() {
+    local request="$1"
+    printf '%s\n' "$request" | nc -U -w 2 "$SOCKET" | head -n 1
+}
+
+get_setting() {
+    local key="$1"
+    local response
+    response=$(send "identify|${EXT_ID}|${TOKEN}
+extension.settings.get|${key}" | tail -n 1)
+    case "$response" in
+        "ok\t"*) printf '%s' "${response#ok	}" ;;
+        *)       printf '' ;;
+    esac
+}
+
+set_ticker() {
+    send "identify|${EXT_ID}|${TOKEN}
+extension.statusbar.set|ticker|$1" >/dev/null
+}
+
+set_ticker "starting"
+while true; do
+    set_ticker "$(date -u +%H:%M:%SZ)"
+    sleep "$(get_setting refreshSeconds || echo 5)"
+done
+```
+
+Socket frames are pipe-delimited and newline-terminated. The first frame on every connection must be `identify|<extensionID>|<token>`.
+
+## In-tab bridge (`window.muxy`)
+
+When a tab type renders an HTML page, Muxy injects a `window.muxy` object before the page scripts run. Use it to read Muxy state, open tabs, mutate panes, subscribe to events, and read the current theme.
+
+### Bootstrap (read context and theme)
+
+```js
+console.log('running as', muxy.extensionID, 'in tab', muxy.tabInstanceID);
+console.log('initial data payload:', muxy.data);
+console.log('current theme:', muxy.theme);
+
+muxy.onThemeChange((theme) => {
+  // Theme changed (user toggled light/dark or accent). CSS variables
+  // (--muxy-background, --muxy-accent, ...) are already updated on
+  // document.documentElement — this hook is for JS-driven re-renders.
+  console.log('theme changed to', theme.colorScheme, theme.accent);
+});
+```
+
+### Read Muxy state
+
+```js
+const tabs       = await muxy.tabs.list();
+const panes      = await muxy.panes.list();
+const projects   = await muxy.projects.list();
+const worktrees  = await muxy.worktrees.list();
+
+const activeProject = projects.find((p) => p.isActive);
+```
+
+### Open / switch / mutate tabs
+
+```js
+await muxy.tabs.new();                                  // new terminal tab
+await muxy.tabs.next();                                 // cycle forward
+await muxy.tabs.switchTo(0);                            // by index
+
+await muxy.tabs.open({ kind: 'terminal' });
+await muxy.tabs.open({ kind: 'vcs' });
+await muxy.tabs.open({ kind: 'editor', filePath: '/abs/path/README.md' });
+
+// Open another instance of this extension's tab, with a custom data payload.
+await muxy.tabs.open({
+  kind: 'extensionWebView',
+  extension: {
+    id: muxy.extensionID,
+    tabType: 'dashboard',
+    data: { source: 'self', when: new Date().toISOString() },
+  },
+});
+```
+
+### Drive terminal panes
+
+```js
+const [pane] = await muxy.panes.list();
+await muxy.panes.send(pane.id, 'echo hi\n');           // write text
+await muxy.panes.sendKeys(pane.id, 'Enter');           // press a key
+await muxy.panes.rename(pane.id, 'Renamed');
+const buffer = await muxy.panes.readScreen(pane.id, 5); // last 5 lines
+```
+
+### Run shell
+
+```js
+// Simple argv (no shell parsing):
+const result = await muxy.exec(['git', 'status', '--short']);
+// { exitCode, stdout, stderr, timedOut }
+
+// Shell string (uses /bin/sh -c):
+await muxy.exec({ shell: 'git diff | wc -l' });
+
+// With working dir and a hard timeout:
+await muxy.exec(['ls', '-1'], { cwd: '~' });
+await muxy.exec(['sleep', '5'], { timeoutMs: 500 }); // timedOut: true
+```
+
+`muxy.exec` requires `commands:exec` and prompts the user the first time. Users can save allow/deny rules per command.
+
+### Subscribe to live events
+
+```js
+const off = muxy.events.subscribe('pane.created', (payload) => {
+  console.log('new pane:', payload);
+});
+
+// Stop listening:
+off();
+```
+
+Only events declared in `manifest.events` (or auto-allowed command events) reach the callback.
+
+### Notifications
+
+```js
+await muxy.toast({ title: 'Done', body: 'Build finished in 3.2s' });
+```
+
+## Run-script commands (Node-style sandbox)
+
+A command with `{ "kind": "runScript", "script": "scripts/x.js" }` runs in a tiny JS sandbox that exposes the same `muxy.*` surface as tabs, plus `console.log`. Use this for one-shot tasks that compute data and then open a tab to display it.
+
+Example — `scripts/git-status.js` from the demo extension:
+
+```js
+function run(argv) {
+  const result = muxy.exec(argv); // synchronous in scripts
+  return result.exitCode === 0 ? result.stdout.trim() : '';
+}
+
+const branch       = run(['git', 'rev-parse', '--abbrev-ref', 'HEAD']);
+const totalCommits = Number(run(['git', 'rev-list', '--count', 'HEAD'])) || 0;
+
+muxy.tabs.open({
+  kind: 'extensionWebView',
+  extension: {
+    id: muxy.extensionID,
+    tabType: 'dashboard',
+    data: { branch, totalCommits, generatedAt: new Date().toISOString() },
+  },
+});
+```
+
+Receive the payload in the tab as `muxy.data`.
+
+## Theming — adapt to the user's current Muxy theme
+
+**Do not hardcode colors.** Muxy supports paired light/dark themes and a user-selected accent color. Every extension tab inherits CSS custom properties on `document.documentElement` that match the live theme. They update automatically when the user changes theme.
+
+### Available CSS variables
+
+| Variable | Use for |
+| --- | --- |
+| `--muxy-background` | Page background |
+| `--muxy-foreground` | Primary text |
+| `--muxy-foreground-muted` | Secondary text, labels, captions |
+| `--muxy-surface` | Cards, buttons, code blocks, input backgrounds |
+| `--muxy-border` | 1px borders, dividers |
+| `--muxy-hover` | Hover state for buttons / rows |
+| `--muxy-accent` | Primary action color, links, focus rings |
+| `--muxy-accent-soft` | Translucent accent for highlights, badges |
+| `--muxy-diff-add` | Added lines, success states |
+| `--muxy-diff-remove` | Removed lines, error states |
+| `--muxy-diff-hunk` | Hunk headers in diffs |
+| `--muxy-color-scheme` | Mirrors `document.documentElement.style.colorScheme` (`light` / `dark`) |
+
+### Best-practice CSS — copy as a starting point
+
+```css
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 16px;
+  font: 13px -apple-system, "SF Pro", system-ui, sans-serif;
+  background: var(--muxy-background);
+  color: var(--muxy-foreground);
+}
+
+h2 {
+  font-size: 11px;
+  margin: 16px 0 6px;
+  color: var(--muxy-foreground-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+button {
+  background: var(--muxy-surface);
+  color: var(--muxy-foreground);
+  border: 1px solid var(--muxy-border);
+  border-radius: 5px;
+  padding: 6px 10px;
+  font: inherit;
+  cursor: pointer;
+}
+button:hover  { background: var(--muxy-hover); border-color: var(--muxy-accent); }
+button:active { transform: translateY(1px); }
+
+.card {
+  background: var(--muxy-surface);
+  border: 1px solid var(--muxy-border);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+
+.badge {
+  font-family: "SF Mono", Menlo, monospace;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--muxy-surface);
+  color: var(--muxy-accent);
+  border: 1px solid var(--muxy-border);
+}
+
+pre, code {
+  font-family: "SF Mono", Menlo, monospace;
+  background: var(--muxy-surface);
+  color: var(--muxy-foreground);
+}
+
+.diff-add    { color: var(--muxy-diff-add); }
+.diff-remove { color: var(--muxy-diff-remove); }
+.diff-hunk   { color: var(--muxy-diff-hunk); }
+```
+
+### Theming rules
+
+1. **No hex literals for UI chrome.** Use `var(--muxy-…)` everywhere. The only exception is decorative art that is meant to be theme-independent.
+2. **Treat `--muxy-accent` as the only saturated color.** Use it sparingly — for the primary action, focus rings, key numbers — so it stays distinctive.
+3. **Use `--muxy-surface` for elevation.** Cards, code blocks, inputs, and buttons share one surface color; depth comes from `--muxy-border` and `--muxy-hover`, not from new colors.
+4. **Make hover states obvious.** `background: var(--muxy-hover); border-color: var(--muxy-accent);` is the standard pattern.
+5. **Light-on-accent text** — when filling a chip or pill with `var(--muxy-accent)`, set its text color to `var(--muxy-background)` so it stays legible in both light and dark.
+6. **Respect `prefers-reduced-motion`.** Muxy users opt into Reduce Motion at the OS level; avoid long transitions, large translations, or autoplay animations.
+7. **Don't sniff `colorScheme` to pick colors.** Variables already invert. Only branch on `muxy.theme.colorScheme` for things variables can't express (for example, swapping a logo image).
+8. **JS-driven re-renders must re-read the theme.** Use `muxy.onThemeChange(theme => …)` to redraw canvas/SVG that doesn't pick up CSS variables automatically.
+
+### Theming example (JS-side)
+
+This is the pattern from the demo playground tab:
+
+```js
+const badge = document.createElement('span');
+badge.style.cssText =
+  'padding:1px 6px;border-radius:3px;' +
+  'background:var(--muxy-accent);color:var(--muxy-background);';
+badge.textContent = `${muxy.theme.colorScheme} · ${muxy.theme.accent}`;
+document.body.appendChild(badge);
+
+muxy.onThemeChange((theme) => {
+  badge.textContent = `${theme.colorScheme} · ${theme.accent}`;
+});
+```
+
+## End-to-end example (minimal extension)
+
+A complete "hello-world" extension that adds a palette command, a tab, and a theme-aware UI:
+
+```
+hello-world/
+├── manifest.json
+├── run.sh
+└── tabs/
+    ├── index.html
+    └── styles.css
+```
+
+```json
+// manifest.json
+{
+  "name": "hello-world",
+  "version": "0.1.0",
+  "description": "Minimal Muxy extension",
+  "entrypoint": "run.sh",
+  "permissions": ["tabs:write"],
+  "tabTypes": [
+    { "id": "main", "title": "Hello", "entry": "tabs/index.html" }
+  ],
+  "commands": [
+    {
+      "id": "open",
+      "title": "Hello World: Open",
+      "action": { "kind": "openTab", "tabType": "main" }
+    }
+  ]
+}
+```
+
+```sh
+# run.sh — keeps the extension alive so its UI stays registered
+#!/bin/sh
+while true; do sleep 3600; done
+```
+
+```html
+<!-- tabs/index.html -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Hello, <span id="who">world</span>!</h1>
+  <button id="say">Toast</button>
+  <script>
+    document.getElementById('who').textContent = muxy.extensionID;
+    document.getElementById('say').addEventListener('click', () =>
+      muxy.toast({ title: 'Hello', body: `theme: ${muxy.theme.colorScheme}` })
+    );
+  </script>
+</body>
+</html>
+```
+
+```css
+/* tabs/styles.css */
+body {
+  margin: 0; padding: 24px;
+  font: 13px -apple-system, system-ui, sans-serif;
+  background: var(--muxy-background);
+  color: var(--muxy-foreground);
+}
+h1 { font-size: 18px; color: var(--muxy-accent); }
+button {
+  background: var(--muxy-surface);
+  color: var(--muxy-foreground);
+  border: 1px solid var(--muxy-border);
+  border-radius: 5px;
+  padding: 6px 10px;
+}
+button:hover { background: var(--muxy-hover); border-color: var(--muxy-accent); }
+```
+
+> Note: `muxy.toast` requires `notifications:write`. Add it to `permissions` if you use it.
+
+## Reload workflow
+
+After editing `manifest.json`, scripts, tab HTML/CSS/JS, or the entrypoint, click **Reload** in the Muxy Extensions modal. Muxy terminates the running process and re-validates the manifest. Tabs are not auto-refreshed — close and reopen them, or use `tabs.open` to get a fresh instance.
+
+## Quick checklist before shipping
+
+- [ ] `manifest.json` parses; `entrypoint` exists and is executable.
+- [ ] `permissions` declares only what is actually used.
+- [ ] Every CSS rule for UI chrome uses `var(--muxy-…)`.
+- [ ] `muxy.onThemeChange` is wired for any canvas/SVG/JS-rendered color.
+- [ ] Hover and active states are visible in both light and dark themes.
+- [ ] No hardcoded paths to `~/.config/muxy` from inside the extension — use `muxy.exec({ cwd: … })` or rely on the working directory Muxy sets.
+- [ ] Long-running work happens in `run.sh`, not in tab JS, so closing a tab does not lose state.

--- a/Muxy/Services/ExtensionScaffoldService.swift
+++ b/Muxy/Services/ExtensionScaffoldService.swift
@@ -11,7 +11,6 @@ struct ExtensionScaffoldRequest: Equatable {
 }
 
 enum ExtensionScaffoldError: LocalizedError, Equatable {
-    case invalidName(String)
     case invalidVersion(String)
     case directoryAlreadyExists(URL)
     case skillResourceMissing
@@ -19,8 +18,6 @@ enum ExtensionScaffoldError: LocalizedError, Equatable {
 
     var errorDescription: String? {
         switch self {
-        case let .invalidName(name):
-            "Extension name '\(name)' is invalid (use letters, digits, dash, underscore, dot)"
         case let .invalidVersion(version):
             "Extension version '\(version)' is empty"
         case let .directoryAlreadyExists(url):

--- a/Muxy/Services/ExtensionScaffoldService.swift
+++ b/Muxy/Services/ExtensionScaffoldService.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+struct ExtensionScaffoldRequest: Equatable {
+    let name: String
+    let version: String
+    let description: String
+
+    var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
+    var trimmedVersion: String { version.trimmingCharacters(in: .whitespacesAndNewlines) }
+    var trimmedDescription: String { description.trimmingCharacters(in: .whitespacesAndNewlines) }
+}
+
+enum ExtensionScaffoldError: LocalizedError, Equatable {
+    case invalidName(String)
+    case invalidVersion(String)
+    case directoryAlreadyExists(URL)
+    case skillResourceMissing
+    case fileSystem(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidName(name):
+            "Extension name '\(name)' is invalid (use letters, digits, dash, underscore, dot)"
+        case let .invalidVersion(version):
+            "Extension version '\(version)' is empty"
+        case let .directoryAlreadyExists(url):
+            "An extension already exists at \(url.path)"
+        case .skillResourceMissing:
+            "Could not locate the bundled muxy-extension skill resource"
+        case let .fileSystem(message):
+            message
+        }
+    }
+}
+
+enum ExtensionScaffoldService {
+    static func create(
+        _ request: ExtensionScaffoldRequest,
+        in rootDirectory: URL,
+        skillSourceURL: URL? = bundledSkillSourceURL()
+    ) throws -> URL {
+        let name = request.trimmedName
+        let version = request.trimmedVersion
+        let description = request.trimmedDescription
+
+        try ExtensionManifestLoader.validate(name: name)
+        guard !version.isEmpty else { throw ExtensionScaffoldError.invalidVersion(version) }
+
+        try FileManager.default.createDirectory(
+            at: rootDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
+        )
+
+        let extensionDirectory = rootDirectory.appendingPathComponent(name, isDirectory: true)
+        guard !FileManager.default.fileExists(atPath: extensionDirectory.path) else {
+            throw ExtensionScaffoldError.directoryAlreadyExists(extensionDirectory)
+        }
+
+        guard let skillSourceURL else { throw ExtensionScaffoldError.skillResourceMissing }
+        guard FileManager.default.fileExists(atPath: skillSourceURL.path) else {
+            throw ExtensionScaffoldError.skillResourceMissing
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: extensionDirectory, withIntermediateDirectories: false)
+            try writeManifest(name: name, version: version, description: description, in: extensionDirectory)
+            try writeEntrypoint(in: extensionDirectory)
+            try writeClaudeMarkdown(name: name, description: description, in: extensionDirectory)
+            try writeAgentsSymlink(in: extensionDirectory)
+            try writeGitignore(in: extensionDirectory)
+            try copySkill(from: skillSourceURL, into: extensionDirectory)
+        } catch let error as ExtensionScaffoldError {
+            try? FileManager.default.removeItem(at: extensionDirectory)
+            throw error
+        } catch {
+            try? FileManager.default.removeItem(at: extensionDirectory)
+            throw ExtensionScaffoldError.fileSystem(error.localizedDescription)
+        }
+
+        return extensionDirectory
+    }
+
+    static func bundledSkillSourceURL() -> URL? {
+        if let url = Bundle.appResources.url(forResource: "SKILL", withExtension: "md", subdirectory: "skills/muxy-extension") {
+            return url
+        }
+        return Bundle.appResources.resourceURL?
+            .appendingPathComponent("skills/muxy-extension/SKILL.md")
+    }
+
+    private static func writeManifest(
+        name: String,
+        version: String,
+        description: String,
+        in directory: URL
+    ) throws {
+        var manifest: [String: Any] = [
+            "name": name,
+            "version": version,
+            "entrypoint": "run.sh",
+            "events": [],
+            "commands": [],
+            "permissions": [],
+        ]
+        if !description.isEmpty {
+            manifest["description"] = description
+        }
+        let data = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: directory.appendingPathComponent("manifest.json"))
+    }
+
+    private static func writeEntrypoint(in directory: URL) throws {
+        let entrypointURL = directory.appendingPathComponent("run.sh")
+        let script = """
+        #!/bin/sh
+        # Muxy keeps this process running for the lifetime of the extension.
+        # Replace this stub with logic that connects to "$MUXY_SOCKET_PATH" and
+        # authenticates with "$MUXY_EXTENSION_TOKEN" before subscribing to events.
+        echo "[muxy] $MUXY_EXTENSION_ID started"
+        while true; do sleep 3600; done
+        """
+        try Data(script.utf8).write(to: entrypointURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.executable],
+            ofItemAtPath: entrypointURL.path
+        )
+    }
+
+    private static func writeClaudeMarkdown(
+        name: String,
+        description: String,
+        in directory: URL
+    ) throws {
+        let header = description.isEmpty ? "" : "\n\n\(description)"
+        let contents = """
+        # \(name)\(header)
+
+        Muxy extension scaffolded by Muxy.
+
+        ## Layout
+
+        - `manifest.json` — declares the extension to Muxy.
+        - `run.sh` — the long-running entrypoint Muxy launches on startup.
+
+        ## Editing
+
+        After changing `manifest.json` or `run.sh`, click "Reload" in the
+        Muxy Extensions modal to pick up the changes.
+
+        ## Skill
+
+        Coding agents in this directory should consult the `muxy-extension`
+        skill in `.claude/skills/` or `.agents/skills/` before generating
+        manifest or runtime changes.
+        """
+        try Data(contents.utf8).write(to: directory.appendingPathComponent("CLAUDE.md"))
+    }
+
+    private static func writeAgentsSymlink(in directory: URL) throws {
+        let symlinkURL = directory.appendingPathComponent("AGENTS.md")
+        try FileManager.default.createSymbolicLink(
+            atPath: symlinkURL.path,
+            withDestinationPath: "CLAUDE.md"
+        )
+    }
+
+    private static func writeGitignore(in directory: URL) throws {
+        let contents = """
+        .DS_Store
+        node_modules/
+        dist/
+        build/
+        *.log
+        """
+        try Data(contents.utf8).write(to: directory.appendingPathComponent(".gitignore"))
+    }
+
+    private static func copySkill(from source: URL, into directory: URL) throws {
+        for parent in [".claude", ".agents"] {
+            let skillDirectory = directory
+                .appendingPathComponent(parent, isDirectory: true)
+                .appendingPathComponent("skills", isDirectory: true)
+                .appendingPathComponent("muxy-extension", isDirectory: true)
+            try FileManager.default.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
+            try FileManager.default.copyItem(
+                at: source,
+                to: skillDirectory.appendingPathComponent("SKILL.md")
+            )
+        }
+    }
+}

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -461,10 +461,12 @@ final class ExtensionStore {
         ExtensionScriptRunner.shared.evict(extensionID: extensionID)
         tokens.removeValue(forKey: extensionID)
         guard let process = processes.removeValue(forKey: extensionID) else { return }
+        process.terminationHandler = nil
         if process.isRunning {
             intentionalStops.insert(extensionID)
             process.terminate()
         }
+        intentionalStops.remove(extensionID)
         if let index = statuses.firstIndex(where: { $0.id == extensionID }) {
             statuses[index].isRunning = false
         }
@@ -480,6 +482,7 @@ final class ExtensionStore {
     }
 
     private func handleTermination(extensionID: String, process: Process) {
+        guard processes[extensionID] === process else { return }
         processes.removeValue(forKey: extensionID)
         let wasIntentional = intentionalStops.remove(extensionID) != nil
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -461,12 +461,10 @@ final class ExtensionStore {
         ExtensionScriptRunner.shared.evict(extensionID: extensionID)
         tokens.removeValue(forKey: extensionID)
         guard let process = processes.removeValue(forKey: extensionID) else { return }
-        process.terminationHandler = nil
         if process.isRunning {
             intentionalStops.insert(extensionID)
             process.terminate()
         }
-        intentionalStops.remove(extensionID)
         if let index = statuses.firstIndex(where: { $0.id == extensionID }) {
             statuses[index].isRunning = false
         }

--- a/Muxy/Views/Extensions/CreateExtensionSheet.swift
+++ b/Muxy/Views/Extensions/CreateExtensionSheet.swift
@@ -9,13 +9,12 @@ struct CreateExtensionSheet: View {
     @State private var version = "0.1.0"
     @State private var description = ""
     @State private var errorMessage: String?
-    @State private var inProgress = false
 
     private var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
     private var trimmedVersion: String { version.trimmingCharacters(in: .whitespacesAndNewlines) }
 
     private var canCreate: Bool {
-        !trimmedName.isEmpty && !trimmedVersion.isEmpty && !inProgress
+        !trimmedName.isEmpty && !trimmedVersion.isEmpty
     }
 
     var body: some View {
@@ -23,6 +22,8 @@ struct CreateExtensionSheet: View {
             Text("New Extension")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
+
+            guideBlock
 
             field(
                 label: "Name",
@@ -70,6 +71,47 @@ struct CreateExtensionSheet: View {
         .background(MuxyTheme.bg)
     }
 
+    private var guideBlock: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            guideRow(
+                symbol: "folder",
+                text: "Creates the extension in \(store.rootDirectory.path)/<name>"
+            )
+            guideRow(
+                symbol: "doc.text",
+                text: "Adds CLAUDE.md and AGENTS.md and bundles the muxy-extension skill"
+            )
+            guideRow(
+                symbol: "sidebar.left",
+                text: "Adds the directory to the Muxy sidebar as a project"
+            )
+            guideRow(
+                symbol: "wand.and.stars",
+                text: "Open your agentic coding tool there and ask it to write the extension"
+            )
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(MuxyTheme.border, lineWidth: 1)
+        )
+    }
+
+    private func guideRow(symbol: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 11))
+                .foregroundStyle(MuxyTheme.accent)
+                .frame(width: 14, alignment: .center)
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     private func field(
         label: String,
         hint: String?,
@@ -97,20 +139,18 @@ struct CreateExtensionSheet: View {
 
     private func create() {
         errorMessage = nil
-        inProgress = true
         let request = ExtensionScaffoldRequest(name: name, version: version, description: description)
         do {
             let directory = try ExtensionScaffoldService.create(request, in: store.rootDirectory)
             store.reload()
+            onFinish()
+            NSApp.keyWindow?.close()
             NotificationCenter.default.post(
                 name: .openExtensionDirectoryAsProject,
                 object: nil,
                 userInfo: [OpenExtensionDirectoryUserInfoKey.path: directory.path]
             )
-            onFinish()
-            NSApp.keyWindow?.close()
         } catch {
-            inProgress = false
             errorMessage = error.localizedDescription
         }
     }

--- a/Muxy/Views/Extensions/CreateExtensionSheet.swift
+++ b/Muxy/Views/Extensions/CreateExtensionSheet.swift
@@ -1,0 +1,117 @@
+import AppKit
+import SwiftUI
+
+struct CreateExtensionSheet: View {
+    let store: ExtensionStore
+    let onFinish: () -> Void
+
+    @State private var name = ""
+    @State private var version = "0.1.0"
+    @State private var description = ""
+    @State private var errorMessage: String?
+    @State private var inProgress = false
+
+    private var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedVersion: String { version.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+    private var canCreate: Bool {
+        !trimmedName.isEmpty && !trimmedVersion.isEmpty && !inProgress
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("New Extension")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+
+            field(
+                label: "Name",
+                hint: "letters, digits, dash, underscore, dot",
+                placeholder: "my-extension",
+                value: $name,
+                monospaced: true
+            )
+
+            field(
+                label: "Version",
+                hint: nil,
+                placeholder: "0.1.0",
+                value: $version,
+                monospaced: true
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Description")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                TextField("Optional summary", text: $description, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(2 ... 4)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.diffRemoveFg)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { onFinish() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Create") { create() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canCreate)
+            }
+        }
+        .padding(20)
+        .frame(width: 440)
+        .background(MuxyTheme.bg)
+    }
+
+    private func field(
+        label: String,
+        hint: String?,
+        placeholder: String,
+        value: Binding<String>,
+        monospaced: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(label)
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                if let hint {
+                    Text(hint)
+                        .font(.system(size: 10))
+                        .foregroundStyle(MuxyTheme.fgDim)
+                }
+            }
+            TextField(placeholder, text: value)
+                .font(.system(size: 12, design: monospaced ? .monospaced : .default))
+                .textFieldStyle(.roundedBorder)
+                .disableAutocorrection(true)
+        }
+    }
+
+    private func create() {
+        errorMessage = nil
+        inProgress = true
+        let request = ExtensionScaffoldRequest(name: name, version: version, description: description)
+        do {
+            let directory = try ExtensionScaffoldService.create(request, in: store.rootDirectory)
+            store.reload()
+            NotificationCenter.default.post(
+                name: .openExtensionDirectoryAsProject,
+                object: nil,
+                userInfo: [OpenExtensionDirectoryUserInfoKey.path: directory.path]
+            )
+            onFinish()
+            NSApp.keyWindow?.close()
+        } catch {
+            inProgress = false
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -5,6 +5,7 @@ struct ExtensionsView: View {
     @State private var store = ExtensionStore.shared
     @State private var grantStore = ExtensionGrantStore.shared
     @State private var selectedExtensionID: String?
+    @State private var showCreateSheet = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -17,6 +18,12 @@ struct ExtensionsView: View {
         .foregroundStyle(MuxyTheme.fg)
         .tint(MuxyTheme.accent)
         .preferredColorScheme(MuxyTheme.colorScheme)
+        .sheet(isPresented: $showCreateSheet) {
+            CreateExtensionSheet(
+                store: store,
+                onFinish: { showCreateSheet = false }
+            )
+        }
     }
 
     @ViewBuilder
@@ -67,6 +74,15 @@ struct ExtensionsView: View {
             }
             Spacer()
             if selectedExtensionID == nil {
+                Button {
+                    showCreateSheet = true
+                } label: {
+                    Text("Create")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuxyTheme.accent)
+                }
+                .buttonStyle(.plain)
+                .help("Create a new extension")
                 Button {
                     store.reload()
                 } label: {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -196,6 +196,16 @@ struct MainWindow: View {
         .onReceive(NotificationCenter.default.publisher(for: .openProjectPicker)) { _ in
             showProjectPicker = true
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openExtensionDirectoryAsProject)) { notification in
+            guard let path = notification.userInfo?[OpenExtensionDirectoryUserInfoKey.path] as? String else { return }
+            CLIAccessor.openProjectFromPath(
+                path,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
+            )
+        }
         .onReceive(NotificationCenter.default.publisher(for: .terminalOmnibox)) { notification in
             let launchScope = terminalOmniboxScope(from: notification)
             if showTerminalOmnibox, launchScope != terminalOmniboxLaunchScope {

--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,7 @@ let package = Package(
                 .copy("Resources/ProviderIcons"),
                 .copy("Resources/rg"),
                 .copy("Resources/scripts"),
+                .copy("Resources/skills"),
                 .copy("Resources/terminfo"),
             ],
             linkerSettings: [

--- a/Tests/MuxyTests/Services/ExtensionScaffoldServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionScaffoldServiceTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionScaffoldService")
+struct ExtensionScaffoldServiceTests {
+    @Test("scaffolds a complete extension directory")
+    func scaffoldsCompleteDirectory() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+
+        let extensionURL = try ExtensionScaffoldService.create(
+            ExtensionScaffoldRequest(name: "demo", version: "0.1.0", description: "A demo extension"),
+            in: fixture.rootURL,
+            skillSourceURL: fixture.skillSourceURL
+        )
+
+        #expect(extensionURL.lastPathComponent == "demo")
+        try assertManifest(at: extensionURL, name: "demo", version: "0.1.0", description: "A demo extension")
+        try assertEntrypointExecutable(at: extensionURL)
+        try assertClaudeMarkdown(at: extensionURL, includes: "# demo")
+        try assertAgentsSymlinkPointsToClaude(at: extensionURL)
+        try assertGitignore(at: extensionURL)
+        try assertSkillCopied(at: extensionURL)
+    }
+
+    @Test("omits description from manifest when blank")
+    func omitsDescriptionWhenBlank() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+
+        let extensionURL = try ExtensionScaffoldService.create(
+            ExtensionScaffoldRequest(name: "tidy", version: "1.0.0", description: "  "),
+            in: fixture.rootURL,
+            skillSourceURL: fixture.skillSourceURL
+        )
+
+        let manifest = try loadManifest(at: extensionURL)
+        #expect(manifest["description"] == nil)
+    }
+
+    @Test("rejects invalid names")
+    func rejectsInvalidNames() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionScaffoldService.create(
+                ExtensionScaffoldRequest(name: "bad name!", version: "0.1.0", description: ""),
+                in: fixture.rootURL,
+                skillSourceURL: fixture.skillSourceURL
+            )
+        }
+    }
+
+    @Test("rejects empty version")
+    func rejectsEmptyVersion() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+
+        #expect(throws: ExtensionScaffoldError.self) {
+            try ExtensionScaffoldService.create(
+                ExtensionScaffoldRequest(name: "no-version", version: "  ", description: ""),
+                in: fixture.rootURL,
+                skillSourceURL: fixture.skillSourceURL
+            )
+        }
+    }
+
+    @Test("refuses to overwrite an existing extension directory")
+    func refusesExistingDirectory() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+
+        _ = try ExtensionScaffoldService.create(
+            ExtensionScaffoldRequest(name: "dup", version: "0.1.0", description: ""),
+            in: fixture.rootURL,
+            skillSourceURL: fixture.skillSourceURL
+        )
+
+        #expect(throws: ExtensionScaffoldError.self) {
+            try ExtensionScaffoldService.create(
+                ExtensionScaffoldRequest(name: "dup", version: "0.1.0", description: ""),
+                in: fixture.rootURL,
+                skillSourceURL: fixture.skillSourceURL
+            )
+        }
+    }
+
+    @Test("loads the scaffolded extension via ExtensionManifestLoader")
+    func scaffoldedExtensionLoadsCleanly() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+
+        let extensionURL = try ExtensionScaffoldService.create(
+            ExtensionScaffoldRequest(name: "loadable", version: "0.2.0", description: "Round-trip"),
+            in: fixture.rootURL,
+            skillSourceURL: fixture.skillSourceURL
+        )
+
+        let loaded = try ExtensionManifestLoader.load(from: extensionURL)
+        #expect(loaded.id == "loadable")
+        #expect(loaded.manifest.version == "0.2.0")
+        #expect(loaded.manifest.description == "Round-trip")
+        #expect(loaded.manifest.entrypoint == "run.sh")
+    }
+
+    private struct Fixture {
+        let rootURL: URL
+        let skillSourceURL: URL
+
+        init() throws {
+            let base = FileManager.default.temporaryDirectory
+                .appendingPathComponent("muxy-scaffold-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+            rootURL = base.appendingPathComponent("extensions")
+            try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+
+            skillSourceURL = base.appendingPathComponent("SKILL.md")
+            try Data("# Test Skill\n".utf8).write(to: skillSourceURL)
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: rootURL.deletingLastPathComponent())
+        }
+    }
+
+    private func loadManifest(at extensionURL: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: extensionURL.appendingPathComponent("manifest.json"))
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Issue.record("manifest.json was not a JSON object")
+            return [:]
+        }
+        return object
+    }
+
+    private func assertManifest(
+        at extensionURL: URL,
+        name: String,
+        version: String,
+        description: String
+    ) throws {
+        let manifest = try loadManifest(at: extensionURL)
+        #expect(manifest["name"] as? String == name)
+        #expect(manifest["version"] as? String == version)
+        #expect(manifest["entrypoint"] as? String == "run.sh")
+        #expect(manifest["description"] as? String == description)
+    }
+
+    private func assertEntrypointExecutable(at extensionURL: URL) throws {
+        let entrypoint = extensionURL.appendingPathComponent("run.sh")
+        #expect(FileManager.default.fileExists(atPath: entrypoint.path))
+        #expect(FileManager.default.isExecutableFile(atPath: entrypoint.path))
+    }
+
+    private func assertClaudeMarkdown(at extensionURL: URL, includes substring: String) throws {
+        let url = extensionURL.appendingPathComponent("CLAUDE.md")
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains(substring))
+    }
+
+    private func assertAgentsSymlinkPointsToClaude(at extensionURL: URL) throws {
+        let agentsURL = extensionURL.appendingPathComponent("AGENTS.md")
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: agentsURL.path)
+        #expect(destination == "CLAUDE.md")
+        #expect(FileManager.default.fileExists(atPath: agentsURL.path))
+    }
+
+    private func assertGitignore(at extensionURL: URL) throws {
+        let url = extensionURL.appendingPathComponent(".gitignore")
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains(".DS_Store"))
+        #expect(contents.contains("node_modules/"))
+    }
+
+    private func assertSkillCopied(at extensionURL: URL) throws {
+        let claudeSkill = extensionURL.appendingPathComponent(".claude/skills/muxy-extension/SKILL.md")
+        let agentsSkill = extensionURL.appendingPathComponent(".agents/skills/muxy-extension/SKILL.md")
+        #expect(FileManager.default.fileExists(atPath: claudeSkill.path))
+        #expect(FileManager.default.fileExists(atPath: agentsSkill.path))
+        let claudeContents = try String(contentsOf: claudeSkill, encoding: .utf8)
+        #expect(claudeContents.contains("Test Skill"))
+    }
+}

--- a/Tests/MuxyTests/Services/ExtensionScaffoldServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionScaffoldServiceTests.swift
@@ -54,6 +54,22 @@ struct ExtensionScaffoldServiceTests {
         }
     }
 
+    @Test("rejects names that escape the extensions directory")
+    func rejectsPathTraversalNames() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+
+        for name in ["..", ".", ".hidden"] {
+            #expect(throws: ExtensionLoadError.self) {
+                try ExtensionScaffoldService.create(
+                    ExtensionScaffoldRequest(name: name, version: "0.1.0", description: ""),
+                    in: fixture.rootURL,
+                    skillSourceURL: fixture.skillSourceURL
+                )
+            }
+        }
+    }
+
     @Test("rejects empty version")
     func rejectsEmptyVersion() throws {
         let fixture = try Fixture()


### PR DESCRIPTION
 Adds a Create button in the Extensions modal that scaffolds an extension under ~/.config/muxy/extensions/<name>
  (manifest, run.sh, CLAUDE.md, AGENTS.md symlink, .gitignore, bundled muxy-extension skill copied into
  .claude/skills and .agents/skills) and opens the new directory as a project. Also fixes a reload race where a
  stale terminationHandler from the old process clobbered the new lifecycle, making running extensions appear
  stopped after reload or after creating a new extension.