### PR TITLE
fix: socket commands lose response when client disconnects before line processing

### DIFF
--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -212,6 +212,7 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private func readFromSession(_ session: ClientSession) {
         var buffer = [UInt8](repeating: 0, count: 4096)
+        var reachedEOF = false
         while true {
             let bytesRead = read(session.fd, &buffer, buffer.count)
             if bytesRead > 0 {
@@ -221,11 +222,12 @@ final class NotificationSocketServer: @unchecked Sendable {
                     disposeSession(session)
                     return
                 }
+                processBufferedLines(session: session)
                 continue
             }
             if bytesRead == 0 {
-                disposeSession(session)
-                return
+                reachedEOF = true
+                break
             }
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 break
@@ -234,6 +236,14 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
 
+        processBufferedLines(session: session)
+
+        if reachedEOF {
+            disposeSession(session)
+        }
+    }
+
+    private func processBufferedLines(session: ClientSession) {
         while let newlineRange = session.inputBuffer.range(of: Data([UInt8(ascii: "\n")])) {
             let lineData = session.inputBuffer.subdata(in: 0 ..< newlineRange.lowerBound)
             session.inputBuffer.removeSubrange(0 ..< newlineRange.upperBound)


### PR DESCRIPTION
## Problem

All CLI socket commands (`muxy split-right`, `muxy split-down`, `muxy list-panes`, etc.) return `Error: no response from Muxy`.

## Root Cause

After the Extension API refactor (#575/#577) switched NotificationSocketServer from blocking I/O to non-blocking DispatchSource mode, a race condition was introduced in `readFromSession`:

When CLI sends a command via `echo "split-right" | nc -U ...`, nc closes the connection (EOF) immediately after sending data. The server's read loop calls `disposeSession()` and returns on the second `read()` returning 0 — before ever reaching the line processing logic below the loop. The command is swallowed with no response.

## Fix

Extract line processing into `processBufferedLines()`. Process lines immediately after each read within the loop, and on EOF, process any remaining buffered data before disposing the session.