### PR TITLE
fix: socket commands lose response when client disconnects before line processing

### DIFF
--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -413,7 +413,7 @@ final class ExtensionStore {
         tokens[ext.id] = token
 
         var environment = ProcessInfo.processInfo.environment
-        environment["MUXY_SOCKET_PATH"] = NotificationSocketServer.socketPath
+        environment["MUXY_SOCKET_PATH"] = NotificationSocketServer.shared.socketPath
         environment["MUXY_EXTENSION_ID"] = ext.id
         environment["MUXY_EXTENSION_TOKEN"] = token
         let logURL = ExtensionLogStore.shared.logURL(extensionID: ext.id, directory: ext.directory)

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -27,6 +27,8 @@ final class NotificationSocketServer: @unchecked Sendable {
         var inputBuffer = Data()
         var writeSource: DispatchSourceWrite?
         var droppedNotificationCount = 0
+        var pendingCommandCount = 0
+        var pendingDispose = false
 
         init(fd: Int32) {
             self.fd = fd
@@ -48,13 +50,11 @@ final class NotificationSocketServer: @unchecked Sendable {
         let extensionID: String?
     }
 
-    static var socketPath: String {
-        MuxyFileStorage.appSupportDirectory()
-            .appendingPathComponent("muxy.sock")
-            .path
-    }
+    var socketPath: String = MuxyFileStorage.appSupportDirectory()
+        .appendingPathComponent("muxy.sock")
+        .path
 
-    private init() {}
+    init() {}
 
     func start() {
         queue.async { [weak self] in
@@ -123,7 +123,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     }
 
     private func startListening() {
-        let path = Self.socketPath
+        let path = socketPath
         unlink(path)
 
         serverFD = socket(AF_UNIX, SOCK_STREAM, 0)
@@ -239,7 +239,15 @@ final class NotificationSocketServer: @unchecked Sendable {
         processBufferedLines(session: session)
 
         if reachedEOF {
+<<<<<<< Updated upstream
             disposeSession(session)
+=======
+            if session.pendingCommandCount > 0 {
+                session.pendingDispose = true
+            } else {
+                disposeSession(session)
+            }
+>>>>>>> Stashed changes
         }
     }
 
@@ -312,11 +320,17 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
         let context = ClientContext(extensionID: session.extensionID)
-        Task { @Sendable [weak self] in
+        session.pendingCommandCount += 1
+        Task { @Sendable [weak self, weak session] in
             let response = await handler(message, context)
-            guard let self else { return }
+            guard let self, let session else { return }
             self.queue.async { [weak self] in
-                self?.enqueueWrite(session: session, text: response + "\n")
+                guard let self else { return }
+                self.enqueueWrite(session: session, text: response + "\n")
+                session.pendingCommandCount -= 1
+                if session.pendingCommandCount == 0, session.pendingDispose {
+                    self.disposeSession(session)
+                }
             }
         }
     }

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -212,6 +212,7 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private func readFromSession(_ session: ClientSession) {
         var buffer = [UInt8](repeating: 0, count: 4096)
+        var reachedEOF = false
         while true {
             let bytesRead = read(session.fd, &buffer, buffer.count)
             if bytesRead > 0 {
@@ -221,11 +222,12 @@ final class NotificationSocketServer: @unchecked Sendable {
                     disposeSession(session)
                     return
                 }
+                processBufferedLines(session: session)
                 continue
             }
             if bytesRead == 0 {
-                disposeSession(session)
-                return
+                reachedEOF = true
+                break
             }
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 break
@@ -234,6 +236,14 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
 
+        processBufferedLines(session: session)
+
+        if reachedEOF {
+            disposeSession(session)
+        }
+    }
+
+    private func processBufferedLines(session: ClientSession) {
         while let newlineRange = session.inputBuffer.range(of: Data([UInt8(ascii: "\n")])) {
             let lineData = session.inputBuffer.subdata(in: 0 ..< newlineRange.lowerBound)
             session.inputBuffer.removeSubrange(0 ..< newlineRange.upperBound)

--- a/Muxy/Views/Terminal/TerminalEnvVarBuilder.swift
+++ b/Muxy/Views/Terminal/TerminalEnvVarBuilder.swift
@@ -7,7 +7,7 @@ enum TerminalEnvVarBuilder {
             (key: "MUXY_PANE_ID", value: paneID.uuidString),
             (key: "MUXY_PROJECT_ID", value: key.projectID.uuidString),
             (key: "MUXY_WORKTREE_ID", value: key.worktreeID.uuidString),
-            (key: "MUXY_SOCKET_PATH", value: NotificationSocketServer.socketPath),
+            (key: "MUXY_SOCKET_PATH", value: NotificationSocketServer.shared.socketPath),
         ]
         if let hookPath = MuxyNotificationHooks.hookScriptPath {
             vars.append((key: "MUXY_HOOK_SCRIPT", value: hookPath))

--- a/Tests/MuxyTests/Services/NotificationSocketServerTests.swift
+++ b/Tests/MuxyTests/Services/NotificationSocketServerTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+private final class SendableArray: @unchecked Sendable {
+    private var values: [String] = []
+    private let lock = NSLock()
+
+    func append(_ value: String) {
+        lock.withLock { values.append(value) }
+    }
+
+    var count: Int {
+        lock.withLock { values.count }
+    }
+}
+
+@Suite("NotificationSocketServer")
+struct NotificationSocketServerTests {
+    @Test("processes command when client closes write side immediately")
+    func processesCommandAfterClientEOF() async throws {
+        let tempPath = "/tmp/muxy-test-\(UUID().uuidString).sock"
+        let server = NotificationSocketServer()
+        server.socketPath = tempPath
+
+        server.commandHandler = { message, _ in
+            if message.hasPrefix("split-right") {
+                return UUID().uuidString
+            }
+            return "error:unknown"
+        }
+
+        server.start()
+
+        try await waitForSocket(at: tempPath)
+
+        let clientFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(clientFD >= 0)
+        defer { close(clientFD) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        _ = tempPath.withCString { strncpy(&addr.sun_path, $0, MemoryLayout.size(ofValue: addr.sun_path) - 1) }
+
+        let connected = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                connect(clientFD, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        #expect(connected == 0, "Failed to connect to test socket: \(String(cString: strerror(errno)))")
+
+        let message = "split-right\n"
+        let written = message.withCString { ptr in
+            Darwin.write(clientFD, ptr, message.utf8.count)
+        }
+        #expect(written == message.utf8.count)
+
+        shutdown(clientFD, SHUT_WR)
+
+        var responseBuffer = [UInt8](repeating: 0, count: 1024)
+        let bytesRead = read(clientFD, &responseBuffer, responseBuffer.count)
+        #expect(bytesRead > 0, "Expected response but got EOF or error: \(String(cString: strerror(errno)))")
+
+        let response = String(bytes: responseBuffer[0 ..< bytesRead], encoding: .utf8) ?? ""
+        #expect(!response.isEmpty)
+        #expect(response.hasSuffix("\n"))
+
+        let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(UUID(uuidString: trimmed) != nil, "Expected valid UUID, got: \(trimmed)")
+
+        server.stop()
+        unlink(tempPath)
+    }
+
+    @Test("processes multiple commands before client disconnects")
+    func processesMultipleCommandsBeforeEOF() async throws {
+        let tempPath = "/tmp/muxy-test-\(UUID().uuidString).sock"
+        let server = NotificationSocketServer()
+        server.socketPath = tempPath
+
+        let handledCommands = SendableArray()
+        server.commandHandler = { message, _ in
+            handledCommands.append(message)
+            if message.hasPrefix("split-right") {
+                return UUID().uuidString
+            }
+            return "ok"
+        }
+
+        server.start()
+
+        try await waitForSocket(at: tempPath)
+
+        let clientFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(clientFD >= 0)
+        defer { close(clientFD) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        _ = tempPath.withCString { strncpy(&addr.sun_path, $0, MemoryLayout.size(ofValue: addr.sun_path) - 1) }
+
+        let connected = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                connect(clientFD, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        #expect(connected == 0)
+
+        let messages = "split-right\nlist-panes\nlist-tabs\n"
+        let written = messages.withCString { ptr in
+            Darwin.write(clientFD, ptr, messages.utf8.count)
+        }
+        #expect(written == messages.utf8.count)
+
+        shutdown(clientFD, SHUT_WR)
+
+        var allResponses = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let bytesRead = read(clientFD, &buffer, buffer.count)
+            if bytesRead <= 0 { break }
+            allResponses.append(contentsOf: buffer[0 ..< bytesRead])
+        }
+
+        let responseString = String(data: allResponses, encoding: .utf8) ?? ""
+        let lines = responseString.components(separatedBy: "\n").filter { !$0.isEmpty }
+        #expect(lines.count == 3, "Expected 3 responses, got \(lines.count): \(lines)")
+
+        let count = handledCommands.count
+        #expect(count == 3, "Expected 3 commands handled, got \(count)")
+
+        server.stop()
+        unlink(tempPath)
+    }
+
+    @Test("sends error when no handler registered")
+    func sendsErrorWhenNoHandler() async throws {
+        let tempPath = "/tmp/muxy-test-\(UUID().uuidString).sock"
+        let server = NotificationSocketServer()
+        server.socketPath = tempPath
+
+        server.start()
+
+        try await waitForSocket(at: tempPath)
+
+        let clientFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(clientFD >= 0)
+        defer { close(clientFD) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        _ = tempPath.withCString { strncpy(&addr.sun_path, $0, MemoryLayout.size(ofValue: addr.sun_path) - 1) }
+
+        let connected = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                connect(clientFD, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        #expect(connected == 0)
+
+        let message = "list-panes\n"
+        _ = message.withCString { ptr in
+            Darwin.write(clientFD, ptr, message.utf8.count)
+        }
+        shutdown(clientFD, SHUT_WR)
+
+        var responseBuffer = [UInt8](repeating: 0, count: 1024)
+        let bytesRead = read(clientFD, &responseBuffer, responseBuffer.count)
+        #expect(bytesRead > 0)
+
+        let response = String(bytes: responseBuffer[0 ..< bytesRead], encoding: .utf8) ?? ""
+        #expect(response.contains("error:no handler"))
+
+        server.stop()
+        unlink(tempPath)
+    }
+
+    private func waitForSocket(at path: String) async throws {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if access(path, F_OK) == 0 {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Socket did not appear at \(path)"])
+    }
+}


### PR DESCRIPTION
## Problem

All CLI socket commands (`muxy split-right`, `muxy split-down`, `muxy list-panes`, etc.) return `Error: no response from Muxy`.

## Root Cause

After the Extension API refactor (#575/#577) switched NotificationSocketServer from blocking I/O to non-blocking DispatchSource mode, two race conditions were introduced in `readFromSession`:

1. **Line processing deferred past EOF**: The read loop collects data and defers line processing to after the loop. When a client sends a command and immediately closes the connection (EOF via `nc`), `read()` returns 0 and `disposeSession()` is called — before the line processing logic is ever reached.

2. **Async command handler vs session dispose**: `processCommand` creates an async `Task` that writes the response back. If the session is disposed before the Task completes, the response is lost.

## Fix

1. Extract `processBufferedLines()` and call it immediately after each read within the loop, and on EOF before checking whether to dispose.

2. Track `pendingCommandCount` per session — defer disposal until all in-flight command handlers have completed and written their responses.

## Tests

Added `NotificationSocketServerTests` with 3 integration tests using real Unix sockets:
- Command processed when client closes write side immediately
- Multiple commands processed before client disconnects
- Error sent when no handler registered