### PR TITLE
Make extension manifest entrypoint optional

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -268,7 +268,7 @@ struct ExtensionManifest: Codable, Equatable {
     let name: String
     let version: String
     let description: String?
-    let entrypoint: String
+    let entrypoint: String?
     let events: [String]
     let commands: [ExtensionPaletteCommand]
     let tabTypes: [ExtensionTabType]
@@ -297,7 +297,7 @@ struct ExtensionManifest: Codable, Equatable {
         name: String,
         version: String,
         description: String? = nil,
-        entrypoint: String,
+        entrypoint: String? = nil,
         events: [String] = [],
         commands: [ExtensionPaletteCommand] = [],
         tabTypes: [ExtensionTabType] = [],
@@ -326,7 +326,7 @@ struct ExtensionManifest: Codable, Equatable {
         name = try container.decode(String.self, forKey: .name)
         version = try container.decode(String.self, forKey: .version)
         description = try container.decodeIfPresent(String.self, forKey: .description)
-        entrypoint = try container.decode(String.self, forKey: .entrypoint)
+        entrypoint = try container.decodeIfPresent(String.self, forKey: .entrypoint)
         events = try container.decodeIfPresent([String].self, forKey: .events) ?? []
         commands = try container.decodeIfPresent([ExtensionPaletteCommand].self, forKey: .commands) ?? []
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
@@ -435,8 +435,9 @@ struct MuxyExtension: Identifiable, Equatable {
     let directory: URL
     let manifest: ExtensionManifest
 
-    var entrypointURL: URL {
-        directory.appendingPathComponent(manifest.entrypoint)
+    var entrypointURL: URL? {
+        guard let entrypoint = manifest.entrypoint else { return nil }
+        return directory.appendingPathComponent(entrypoint)
     }
 
     var displayName: String { manifest.name }
@@ -483,12 +484,13 @@ enum ExtensionManifestLoader {
 
         try validate(name: manifest.name)
 
-        let entrypoint = directory.appendingPathComponent(manifest.entrypoint)
-        guard FileManager.default.fileExists(atPath: entrypoint.path) else {
-            throw ExtensionLoadError.entrypointMissing(entrypoint)
-        }
-        guard FileManager.default.isExecutableFile(atPath: entrypoint.path) else {
-            throw ExtensionLoadError.entrypointNotExecutable(entrypoint)
+        if let entrypoint = manifest.entrypoint.map(directory.appendingPathComponent) {
+            guard FileManager.default.fileExists(atPath: entrypoint.path) else {
+                throw ExtensionLoadError.entrypointMissing(entrypoint)
+            }
+            guard FileManager.default.isExecutableFile(atPath: entrypoint.path) else {
+                throw ExtensionLoadError.entrypointNotExecutable(entrypoint)
+            }
         }
 
         let muxyExtension = MuxyExtension(id: manifest.name, directory: directory, manifest: manifest)

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -5,7 +5,7 @@ description: Use when authoring or modifying a Muxy extension. Covers manifest f
 
 # Muxy Extension Author Guide
 
-Muxy extensions live in `~/.config/muxy/extensions/<name>/` and load when Muxy starts. Each extension is a directory containing a `manifest.json` and a single executable entrypoint. Optional resources (HTML tabs, scripts, icons, assets) live alongside.
+Muxy extensions live in `~/.config/muxy/extensions/<name>/` and load when Muxy starts. Each extension is a directory containing a `manifest.json`. An executable entrypoint is optional — declare one only when the extension needs to receive pushed events. Optional resources (HTML tabs, scripts, icons, assets) live alongside.
 
 ## When to use this skill
 
@@ -24,7 +24,7 @@ A typical extension looks like this:
 ```
 my-extension/
 ├── manifest.json           # required
-├── run.sh                  # required (executable entrypoint)
+├── run.sh                  # optional executable entrypoint (only for pushed events)
 ├── CLAUDE.md               # author guide for this extension
 ├── AGENTS.md → CLAUDE.md   # symlink for non-Claude agents
 ├── .gitignore
@@ -117,7 +117,7 @@ Field-by-field:
 - `name` — required. Alphanumerics, dash, underscore, dot only. Must match the directory name.
 - `version` — required semver string.
 - `description` — optional one-line summary shown in the Extensions modal.
-- `entrypoint` — required relative path. Must exist and be executable.
+- `entrypoint` — optional relative path. When present, must exist and be executable; Muxy launches it as a long-lived subprocess. Provide it only to receive pushed events — command, topbar, status bar, tab, and `runScript` extensions need none.
 - `permissions` — array of permission strings. Declare only what the entrypoint or tabs actually use.
 - `events` — array of event names this extension subscribes to (for example `pane.created`, `tab.focused`, `pane.closed`). Command events (`command.<id>`) are auto-allowed.
 - `tabTypes` — declares HTML pages renderable as tabs.
@@ -125,7 +125,7 @@ Field-by-field:
 - `topbarItems` / `statusBarItems` — UI hooks bound to a command. `icon` is either `{ "symbol": "<sf-symbol>" }` or `{ "svg": "<relative/path.svg>" }`.
 - `settings` — user-visible settings (`string` | `bool` | `number`) reachable from `extension.settings.get` over the socket and editable in the Extensions modal.
 
-Common load failures: missing entrypoint, entrypoint not executable, tab entry escapes the extension directory, a command references an unknown `tabType`, a topbar or status-bar item references an unknown command. Failures appear in the Extensions modal under "Load Errors".
+Common load failures: a declared entrypoint that is missing or not executable, tab entry escapes the extension directory, a command references an unknown `tabType`, a topbar or status-bar item references an unknown command. Failures appear in the Extensions modal under "Load Errors".
 
 ## Permissions reference
 
@@ -149,7 +149,9 @@ Principle: least privilege. Add a permission only when adding the call that requ
 
 ## Entrypoint
 
-The entrypoint runs for the lifetime of the extension. Muxy launches it with these environment variables:
+The entrypoint is optional. Manifest UI (palette commands, topbar items, status-bar items, tab types) and `runScript` commands all work without one. Add an entrypoint only when the extension must **receive pushed events** — Muxy launches it as a long-lived subprocess that holds the socket connection open to get `event|...` lines. Without an entrypoint there is no resident process and no idle socket session.
+
+When present, the entrypoint runs for the lifetime of the extension. Muxy launches it with these environment variables:
 
 - `MUXY_SOCKET_PATH` — Unix-domain socket path for IPC.
 - `MUXY_EXTENSION_ID` — the extension's `name`.
@@ -164,7 +166,7 @@ echo "[muxy] $MUXY_EXTENSION_ID started"
 while true; do sleep 3600; done
 ```
 
-This is enough to make the extension's manifest UI (palette commands, topbar items, tab types) usable. Most extensions need more — the socket protocol below.
+A bare sleep loop holds a process and socket session open but does nothing — drop the entrypoint entirely rather than ship this. Add an entrypoint only when it subscribes to events and reacts, as in the socket protocol below.
 
 ### Full entrypoint (reads a setting, pushes status-bar text)
 
@@ -450,11 +452,12 @@ A complete "hello-world" extension that adds a palette command, a tab, and a the
 ```
 hello-world/
 ├── manifest.json
-├── run.sh
 └── tabs/
     ├── index.html
     └── styles.css
 ```
+
+This extension only opens a tab from a palette command, so it declares no entrypoint and runs no subprocess.
 
 ```json
 // manifest.json
@@ -462,7 +465,6 @@ hello-world/
   "name": "hello-world",
   "version": "0.1.0",
   "description": "Minimal Muxy extension",
-  "entrypoint": "run.sh",
   "permissions": ["tabs:write"],
   "tabTypes": [
     { "id": "main", "title": "Hello", "entry": "tabs/index.html" }
@@ -475,12 +477,6 @@ hello-world/
     }
   ]
 }
-```
-
-```sh
-# run.sh — keeps the extension alive so its UI stays registered
-#!/bin/sh
-while true; do sleep 3600; done
 ```
 
 ```html
@@ -531,10 +527,10 @@ After editing `manifest.json`, scripts, tab HTML/CSS/JS, or the entrypoint, clic
 
 ## Quick checklist before shipping
 
-- [ ] `manifest.json` parses; `entrypoint` exists and is executable.
+- [ ] `manifest.json` parses; any declared `entrypoint` exists and is executable.
 - [ ] `permissions` declares only what is actually used.
 - [ ] Every CSS rule for UI chrome uses `var(--muxy-…)`.
 - [ ] `muxy.onThemeChange` is wired for any canvas/SVG/JS-rendered color.
 - [ ] Hover and active states are visible in both light and dark themes.
 - [ ] No hardcoded paths to `~/.config/muxy` from inside the extension — use `muxy.exec({ cwd: … })` or rely on the working directory Muxy sets.
-- [ ] Long-running work happens in `run.sh`, not in tab JS, so closing a tab does not lose state.
+- [ ] Event-driven work happens in the entrypoint, not in tab JS, so closing a tab does not lose state. No entrypoint unless events are needed.

--- a/Muxy/Services/ExtensionScaffoldService.swift
+++ b/Muxy/Services/ExtensionScaffoldService.swift
@@ -62,7 +62,6 @@ enum ExtensionScaffoldService {
         do {
             try FileManager.default.createDirectory(at: extensionDirectory, withIntermediateDirectories: false)
             try writeManifest(name: name, version: version, description: description, in: extensionDirectory)
-            try writeEntrypoint(in: extensionDirectory)
             try writeClaudeMarkdown(name: name, description: description, in: extensionDirectory)
             try writeAgentsSymlink(in: extensionDirectory)
             try writeGitignore(in: extensionDirectory)
@@ -95,7 +94,6 @@ enum ExtensionScaffoldService {
         var manifest: [String: Any] = [
             "name": name,
             "version": version,
-            "entrypoint": "run.sh",
             "events": [],
             "commands": [],
             "permissions": [],
@@ -108,23 +106,6 @@ enum ExtensionScaffoldService {
             options: [.prettyPrinted, .sortedKeys]
         )
         try data.write(to: directory.appendingPathComponent("manifest.json"))
-    }
-
-    private static func writeEntrypoint(in directory: URL) throws {
-        let entrypointURL = directory.appendingPathComponent("run.sh")
-        let script = """
-        #!/bin/sh
-        # Muxy keeps this process running for the lifetime of the extension.
-        # Replace this stub with logic that connects to "$MUXY_SOCKET_PATH" and
-        # authenticates with "$MUXY_EXTENSION_TOKEN" before subscribing to events.
-        echo "[muxy] $MUXY_EXTENSION_ID started"
-        while true; do sleep 3600; done
-        """
-        try Data(script.utf8).write(to: entrypointURL)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: FilePermissions.executable],
-            ofItemAtPath: entrypointURL.path
-        )
     }
 
     private static func writeClaudeMarkdown(
@@ -141,12 +122,17 @@ enum ExtensionScaffoldService {
         ## Layout
 
         - `manifest.json` — declares the extension to Muxy.
-        - `run.sh` — the long-running entrypoint Muxy launches on startup.
+
+        Add an `"entrypoint"` to the manifest only if the extension needs to
+        receive pushed workspace events. Muxy launches that executable as a
+        long-running process that connects to "$MUXY_SOCKET_PATH" and
+        authenticates with "$MUXY_EXTENSION_TOKEN" before subscribing. Command,
+        topbar, status bar, tab, and runScript extensions need no entrypoint.
 
         ## Editing
 
-        After changing `manifest.json` or `run.sh`, click "Reload" in the
-        Muxy Extensions modal to pick up the changes.
+        After changing `manifest.json`, click "Reload" in the Muxy Extensions
+        modal to pick up the changes.
 
         ## Skill
 

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -399,8 +399,10 @@ final class ExtensionStore {
         let status = statuses[index]
         let ext = status.muxyExtension
 
+        guard let entrypointURL = ext.entrypointURL else { return }
+
         let process = Process()
-        process.executableURL = ext.entrypointURL
+        process.executableURL = entrypointURL
         process.currentDirectoryURL = ext.directory
 
         let token = Self.generateToken()

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -344,6 +344,7 @@ private struct ExtensionStatusBadge: View {
     @MainActor
     private var info: (String, Color) {
         if status.isRunning { return ("running", MuxyTheme.diffAddFg) }
+        if status.isEnabled, status.muxyExtension.entrypointURL == nil { return ("active", MuxyTheme.diffAddFg) }
         if status.isEnabled { return ("stopped", MuxyTheme.fgMuted) }
         return ("disabled", MuxyTheme.fgDim)
     }

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -69,7 +69,26 @@ struct ExtensionManifestTests {
 
         #expect(ext.id == "tmp-ext")
         #expect(ext.manifest.permissions == [.panesRead])
-        #expect(FileManager.default.isExecutableFile(atPath: ext.entrypointURL.path))
+        #expect(ext.entrypointURL.map { FileManager.default.isExecutableFile(atPath: $0.path) } == true)
+    }
+
+    @Test("loads without an entrypoint")
+    func loadsWithoutEntrypoint() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "no-entry",
+                "version": "1.0.0",
+                "commands": [{ "id": "ping", "title": "Ping" }]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ext.manifest.entrypoint == nil)
+        #expect(ext.entrypointURL == nil)
     }
 
     @Test("migrates legacy manifest enabled=false into ExtensionEnabledStore")
@@ -178,7 +197,7 @@ struct ExtensionManifestTests {
         let manifest = ExtensionManifest(name: "demo", version: "0.1.0", entrypoint: "bin/run")
         let ext = MuxyExtension(id: "demo", directory: directory, manifest: manifest)
 
-        #expect(ext.entrypointURL.path == "/tmp/example/bin/run")
+        #expect(ext.entrypointURL?.path == "/tmp/example/bin/run")
         #expect(ext.displayName == "demo")
     }
 
@@ -400,7 +419,7 @@ struct ExtensionManifestTests {
 
     private func makeTemporaryExtension(
         manifest: String,
-        files: [String: String],
+        files: [String: String] = [:],
         makeEntrypointExecutable: Bool = true
     ) throws -> URL {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("ext-\(UUID().uuidString)")

--- a/Tests/MuxyTests/Services/ExtensionScaffoldServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionScaffoldServiceTests.swift
@@ -18,7 +18,7 @@ struct ExtensionScaffoldServiceTests {
 
         #expect(extensionURL.lastPathComponent == "demo")
         try assertManifest(at: extensionURL, name: "demo", version: "0.1.0", description: "A demo extension")
-        try assertEntrypointExecutable(at: extensionURL)
+        try assertNoEntrypoint(at: extensionURL)
         try assertClaudeMarkdown(at: extensionURL, includes: "# demo")
         try assertAgentsSymlinkPointsToClaude(at: extensionURL)
         try assertGitignore(at: extensionURL)
@@ -119,7 +119,7 @@ struct ExtensionScaffoldServiceTests {
         #expect(loaded.id == "loadable")
         #expect(loaded.manifest.version == "0.2.0")
         #expect(loaded.manifest.description == "Round-trip")
-        #expect(loaded.manifest.entrypoint == "run.sh")
+        #expect(loaded.manifest.entrypoint == nil)
     }
 
     private struct Fixture {
@@ -160,14 +160,13 @@ struct ExtensionScaffoldServiceTests {
         let manifest = try loadManifest(at: extensionURL)
         #expect(manifest["name"] as? String == name)
         #expect(manifest["version"] as? String == version)
-        #expect(manifest["entrypoint"] as? String == "run.sh")
+        #expect(manifest["entrypoint"] == nil)
         #expect(manifest["description"] as? String == description)
     }
 
-    private func assertEntrypointExecutable(at extensionURL: URL) throws {
+    private func assertNoEntrypoint(at extensionURL: URL) throws {
         let entrypoint = extensionURL.appendingPathComponent("run.sh")
-        #expect(FileManager.default.fileExists(atPath: entrypoint.path))
-        #expect(FileManager.default.isExecutableFile(atPath: entrypoint.path))
+        #expect(!FileManager.default.fileExists(atPath: entrypoint.path))
     }
 
     private func assertClaudeMarkdown(at extensionURL: URL, includes substring: String) throws {

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -1,6 +1,6 @@
 # Manifest
 
-Every extension declares itself in a `manifest.json` next to its entrypoint.
+Every extension declares itself in a `manifest.json` at the root of its directory.
 
 ```json
 {
@@ -24,7 +24,7 @@ Every extension declares itself in a `manifest.json` next to its entrypoint.
 | `name` | string | yes | Letters, digits, `-`, `_`, `.` only. Must match the directory name in practice. Used as the extension ID. |
 | `version` | string | yes | Free-form. Shown in Settings → Extensions. |
 | `description` | string | no | One-line description shown in Settings. |
-| `entrypoint` | string | yes | Path (relative to manifest) to an executable file. Permission bit must be set. |
+| `entrypoint` | string | no | Path (relative to manifest) to an executable file. Permission bit must be set. Provide it only when the extension needs to receive pushed [events](events.md); Muxy launches it as a long-lived subprocess. Command, topbar, status bar, tab, and `runScript` extensions need none. |
 | `permissions` | string[] | no | See [Permissions](permissions.md). Verbs not in the list are rejected. Defaults to empty. |
 | `events` | string[] | no | Events the extension is allowed to subscribe to. See [Events](events.md). Defaults to empty. |
 | `commands` | object[] | no | Palette commands to register. See [Palette Commands](palette-commands.md). |
@@ -58,14 +58,14 @@ A bare string (`"icon": "puzzlepiece.extension"`) is accepted as shorthand for `
 
 1. Decodes the manifest with JSON.
 2. Validates `name` against the allowed character set.
-3. Verifies `entrypoint` exists and is executable.
+3. If `entrypoint` is present, verifies it exists and is executable.
 4. Refuses duplicates (same `name`); surfaces the second one as a load error in Settings.
 
 Any failure is reported in **Settings → Extensions → Load Errors** with the directory name and reason. The app does not retry until you click **Reload Extensions** or restart Muxy.
 
 ## Subprocess environment
 
-Each enabled extension is spawned with these environment variables:
+Each enabled extension that declares an `entrypoint` is spawned with these environment variables:
 
 | Variable | Value |
 | --- | --- |

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -35,10 +35,10 @@ flowchart TB
 ~/.config/muxy/extensions/
   <name>/
     manifest.json
-    <entrypoint>      # any executable
+    <entrypoint>      # optional executable; only for pushed events
 ```
 
-`ExtensionStore` scans the directory on app start, validates each manifest, and spawns one subprocess per enabled extension. Settings → Extensions lists every loaded extension with toggle, permissions, and recent stdout/stderr.
+`ExtensionStore` scans the directory on app start, validates each manifest, and spawns one subprocess per enabled extension **that declares an entrypoint**. Extensions without one register their UI (commands, topbar, status bar, tabs) and run `runScript` commands with no resident process. Settings → Extensions lists every loaded extension with toggle, permissions, and recent stdout/stderr.
 
 ## How extensions talk to Muxy
 
@@ -54,7 +54,7 @@ See [Events](events.md) for the handshake walkthrough and the line format.
 
 ## Process & failure model
 
-- One long-lived subprocess per extension. Crashes are surfaced in Settings → Extensions; the extension is marked `stopped` until toggled or the app restarts.
+- One long-lived subprocess per extension that declares an entrypoint. Crashes are surfaced in Settings → Extensions; the extension is marked `stopped` until toggled or the app restarts.
 - Stdout and stderr are captured to an in-app rolling log (last 200 lines per extension).
 - Stopping Muxy terminates all extension subprocesses.
 

--- a/docs/extensions/tabs.md
+++ b/docs/extensions/tabs.md
@@ -8,7 +8,6 @@ Extensions can register custom tab types that render HTML/CSS/JS inside Muxy. Ea
 {
   "name": "pr-tools",
   "version": "0.1.0",
-  "entrypoint": "run.sh",
   "permissions": ["tabs:write", "notifications:write"],
   "tabTypes": [
     {


### PR DESCRIPTION
Entrypoint is a long-lived subprocess only needed for pushed events; command/topbar/statusbar/tab/runScript
  extensions ran an idle sleep loop for nothing.
  Now optional: no entrypoint means no subprocess. Scaffolder stops generating run.sh; badge shows "active" for
  process-less extensions.