### PR TITLE
Fix held-key repeat in terminal by disabling press-and-hold popup

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -274,6 +274,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
+        UserDefaults.standard.register(defaults: ["ApplePressAndHoldEnabled": false])
         SentryService.shared.start()
         NSWindow.allowsAutomaticWindowTabbing = false
         NSApp.setActivationPolicy(.regular)


### PR DESCRIPTION
Held keys (hjkl in Vim) triggered the macOS accent popup instead of repeating.
  Register ApplePressAndHoldEnabled=false as an app-scoped default at launch.
  Scoped to Muxy only; doesn't touch system-wide settings.