### PR TITLE
Make sidebar resizable

### DIFF
--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -112,6 +112,7 @@ struct MainWindow: View {
     @State private var overlayAnimatingOut = false
     @State private var isFullScreen = false
     @AppStorage("muxy.sidebarExpanded") private var sidebarExpanded = false
+    @AppStorage("muxy.sidebarWideWidth") private var sidebarWideWidth = 220.0
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
     @AppStorage("muxy.showExtensionOutput") private var showExtensionOutput = false
     @AppStorage("muxy.extensionOutputSelected") private var extensionOutputSelectedStored = ""
@@ -278,31 +279,43 @@ struct MainWindow: View {
     }
 
     private var leftNavigationColumn: some View {
-        VStack(spacing: 0) {
-            if !isFullScreen {
-                Color.clear
-                    .frame(height: UIMetrics.titleBarHeight)
-                    .background(WindowDragRepresentable())
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                if !isFullScreen {
+                    Color.clear
+                        .frame(height: UIMetrics.titleBarHeight)
+                        .background(WindowDragRepresentable())
 
-                Rectangle().fill(MuxyTheme.border).frame(height: 1)
-                    .accessibilityHidden(true)
+                    Rectangle().fill(MuxyTheme.border).frame(height: 1)
+                        .accessibilityHidden(true)
+                }
+
+                Sidebar(
+                    expanded: sidebarExpanded,
+                    width: leftNavigationWidth
+                )
+            }
+            .frame(width: leftNavigationWidth, alignment: .leading)
+            .clipped()
+            .background(MuxyTheme.bg)
+            .overlay(alignment: .trailing) {
+                if leftNavigationShowsBorder {
+                    Rectangle().fill(MuxyTheme.border)
+                        .frame(width: 1)
+                        .padding(.top, leftNavigationBorderTopPadding)
+                        .accessibilityHidden(true)
+                }
             }
 
-            Sidebar(expanded: sidebarExpanded)
-        }
-        .frame(width: leftNavigationWidth, alignment: .leading)
-        .clipped()
-        .background(MuxyTheme.bg)
-        .overlay(alignment: .trailing) {
-            if leftNavigationWidth > 0 {
-                Rectangle().fill(MuxyTheme.border)
-                    .frame(width: 1)
-                    .padding(.top, leftNavigationBorderTopPadding)
-                    .accessibilityHidden(true)
+            if leftNavigationShowsResizeHandle {
+                sidePanelResizeHandle { delta in
+                    let next = CGFloat(sidebarWideWidth) + delta
+                    sidebarWideWidth = Double(SidebarLayout.clampedWideWidth(next))
+                }
             }
         }
         .fixedSize(horizontal: true, vertical: false)
-        .animation(.easeInOut(duration: 0.2), value: leftNavigationWidth)
+        .animation(.easeInOut(duration: 0.2), value: sidebarLayoutAnimationToken)
     }
 
     private var mainWorkspaceColumn: some View {
@@ -330,7 +343,7 @@ struct MainWindow: View {
 
             topBarContent
         }
-        .animation(.easeInOut(duration: 0.2), value: mainTitleBarLeadingInset)
+        .animation(.easeInOut(duration: 0.2), value: sidebarLayoutAnimationToken)
     }
 
     @ViewBuilder
@@ -350,7 +363,7 @@ struct MainWindow: View {
                         }
                     }
                 }
-                .animation(.easeInOut(duration: 0.2), value: titleBarNavigationOverlayWidth)
+                .animation(.easeInOut(duration: 0.2), value: sidebarLayoutAnimationToken)
         }
     }
 
@@ -854,8 +867,21 @@ struct MainWindow: View {
         SidebarLayout.resolvedWidth(
             expanded: sidebarExpanded,
             collapsedStyle: sidebarCollapsedStyle,
-            expandedStyle: sidebarExpandedStyle
+            expandedStyle: sidebarExpandedStyle,
+            wideWidth: CGFloat(sidebarWideWidth)
         )
+    }
+
+    private var leftNavigationShowsResizeHandle: Bool {
+        SidebarLayout.isWide(expanded: sidebarExpanded, expandedStyle: sidebarExpandedStyle)
+    }
+
+    private var leftNavigationShowsBorder: Bool {
+        leftNavigationWidth > 0 && !leftNavigationShowsResizeHandle
+    }
+
+    private var sidebarLayoutAnimationToken: String {
+        "\(sidebarExpanded)-\(sidebarCollapsedStyle.rawValue)-\(sidebarExpandedStyle.rawValue)"
     }
 
     private var leftNavigationWidth: CGFloat {

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -5,17 +5,24 @@ import SwiftUI
 enum SidebarLayout {
     static var collapsedWidth: CGFloat { UIMetrics.sidebarCollapsedWidth }
     static var expandedWidth: CGFloat { UIMetrics.sidebarExpandedWidth }
-    static var width: CGFloat { UIMetrics.sidebarCollapsedWidth }
+    static var defaultWideWidth: CGFloat { expandedWidth }
+    static var minWideWidth: CGFloat { UIMetrics.scaled(180) }
+    static var maxWideWidth: CGFloat { UIMetrics.scaled(600) }
 
     static func resolvedWidth(
         expanded: Bool,
         collapsedStyle: SidebarCollapsedStyle,
-        expandedStyle: SidebarExpandedStyle
+        expandedStyle: SidebarExpandedStyle,
+        wideWidth: CGFloat? = nil
     ) -> CGFloat {
         if expanded {
-            return expandedStyle == .wide ? expandedWidth : collapsedWidth
+            return expandedStyle == .wide ? clampedWideWidth(wideWidth ?? defaultWideWidth) : collapsedWidth
         }
         return collapsedStyle == .hidden ? 0 : collapsedWidth
+    }
+
+    static func clampedWideWidth(_ width: CGFloat) -> CGFloat {
+        max(minWideWidth, min(maxWideWidth, width))
     }
 
     static func isWide(expanded: Bool, expandedStyle: SidebarExpandedStyle) -> Bool {
@@ -35,6 +42,7 @@ struct Sidebar: View {
     @State private var dragState = ProjectDragState()
     @State private var projectPendingRemoval: Project?
     let expanded: Bool
+    let width: CGFloat
     @AppStorage(SidebarCollapsedStyle.storageKey) private var collapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var expandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
 
@@ -64,7 +72,7 @@ struct Sidebar: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxHeight: .infinity, alignment: .bottom)
-        .frame(width: isHidden ? 0 : (isWide ? SidebarLayout.expandedWidth : SidebarLayout.collapsedWidth))
+        .frame(width: width)
         .opacity(isHidden ? 0 : 1)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Sidebar")

--- a/Tests/MuxyTests/Views/SidebarLayoutTests.swift
+++ b/Tests/MuxyTests/Views/SidebarLayoutTests.swift
@@ -49,6 +49,39 @@ struct SidebarLayoutTests {
         #expect(!SidebarLayout.isHidden(expanded: true, collapsedStyle: .hidden))
         #expect(SidebarLayout.isWide(expanded: true, expandedStyle: .wide))
     }
+
+    @Test("expanded wide sidebar uses the persisted custom width")
+    func expandedWideSidebarUsesPersistedWidth() {
+        #expect(SidebarLayout.resolvedWidth(
+            expanded: true,
+            collapsedStyle: .hidden,
+            expandedStyle: .wide,
+            wideWidth: 312
+        ) == 312)
+    }
+
+    @Test("wide sidebar width is clamped to the supported range")
+    func wideSidebarWidthIsClamped() {
+        #expect(SidebarLayout.clampedWideWidth(120) == SidebarLayout.minWideWidth)
+        #expect(SidebarLayout.clampedWideWidth(312) == 312)
+        #expect(SidebarLayout.clampedWideWidth(720) == SidebarLayout.maxWideWidth)
+    }
+
+    @Test("non-wide sidebar modes ignore the persisted wide width")
+    func nonWideSidebarModesIgnorePersistedWidth() {
+        #expect(SidebarLayout.resolvedWidth(
+            expanded: true,
+            collapsedStyle: .hidden,
+            expandedStyle: .icons,
+            wideWidth: 312
+        ) == SidebarLayout.collapsedWidth)
+        #expect(SidebarLayout.resolvedWidth(
+            expanded: false,
+            collapsedStyle: .hidden,
+            expandedStyle: .wide,
+            wideWidth: 312
+        ) == 0)
+    }
 }
 
 @Suite("MainWindowLayout")


### PR DESCRIPTION
## Summary

The wide sidebar was always a fixed width with no way to adjust it. This adds a drag handle on the trailing edge so users can resize it to whatever width feels right — and it remembers that preference across restarts.

## Changes

- Added a resize handle on the trailing edge of the wide sidebar
- Sidebar width is persisted via `AppStorage` and clamped between 180–600pt
- Added unit tests for width clamping and mode-specific width resolution

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS
- [x] Unit tests are passing

```
muxy on  feature/left-sidebar-resizable [✘!+] via 🐦 v6.2.3
❯ scripts/checks.sh

  ✓ Formatting 0s
  ✓ Linting 0s
  ✓ Build 7s
  ✓ Test 14s

  All checks passed in 21s
```

## Screenshots

https://github.com/user-attachments/assets/cf6acaa0-01cf-4b5f-b96a-11d823983abb