### PR TITLE
fix: race condition causing CLI socket commands to return no response after EOF

### DIFF
--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -20,7 +20,9 @@ final class NotificationSocketServer: @unchecked Sendable {
     final class ClientSession: @unchecked Sendable {
         static let droppedNotificationDisconnectThreshold = 100
 
-        let fd: Int32
+        var fd: Int32
+        var pendingClose = false
+        var commandInFlight = false
         var extensionID: String?
         var subscriptions: Set<String> = []
         var writeBuffer = Data()
@@ -239,7 +241,17 @@ final class NotificationSocketServer: @unchecked Sendable {
         processBufferedLines(session: session)
 
         if reachedEOF {
-            disposeSession(session)
+            session.pendingClose = true
+            let id = ObjectIdentifier(session)
+            if let source = readSources.removeValue(forKey: id) {
+                source.cancel()
+            }
+            subscribers.removeValue(forKey: id)
+            if session.writeBuffer.isEmpty, !session.commandInFlight, session.fd >= 0 {
+                close(session.fd)
+                session.fd = -1
+                session.pendingClose = false
+            }
         }
     }
 
@@ -312,11 +324,13 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
         let context = ClientContext(extensionID: session.extensionID)
+        session.commandInFlight = true
         Task { @Sendable [weak self] in
             let response = await handler(message, context)
             guard let self else { return }
             self.queue.async { [weak self] in
                 self?.enqueueWrite(session: session, text: response + "\n")
+                session.commandInFlight = false
             }
         }
     }
@@ -340,8 +354,16 @@ final class NotificationSocketServer: @unchecked Sendable {
                 scheduleWriteSource(session: session)
                 return
             }
+            session.pendingClose = false
             disposeSession(session)
             return
+        }
+        if session.pendingClose {
+            if session.fd >= 0 {
+                close(session.fd)
+                session.fd = -1
+            }
+            session.pendingClose = false
         }
     }
 
@@ -485,7 +507,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private func closeSession(_ session: ClientSession) {
         session.writeSource?.cancel()
         session.writeSource = nil
-        if session.fd >= 0 {
+        if session.fd >= 0, !session.pendingClose {
             close(session.fd)
         }
     }

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -212,6 +212,7 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private func readFromSession(_ session: ClientSession) {
         var buffer = [UInt8](repeating: 0, count: 4096)
+        var reachedEOF = false
         while true {
             let bytesRead = read(session.fd, &buffer, buffer.count)
             if bytesRead > 0 {
@@ -221,11 +222,12 @@ final class NotificationSocketServer: @unchecked Sendable {
                     disposeSession(session)
                     return
                 }
+                processBufferedLines(session: session)
                 continue
             }
             if bytesRead == 0 {
-                disposeSession(session)
-                return
+                reachedEOF = true
+                break
             }
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 break
@@ -234,6 +236,14 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
 
+        processBufferedLines(session: session)
+
+        if reachedEOF {
+            disposeSession(session)
+        }
+    }
+
+    private func processBufferedLines(session: ClientSession) {
         while let newlineRange = session.inputBuffer.range(of: Data([UInt8(ascii: "\n")])) {
             let lineData = session.inputBuffer.subdata(in: 0 ..< newlineRange.lowerBound)
             session.inputBuffer.removeSubrange(0 ..< newlineRange.upperBound)


### PR DESCRIPTION
## Problem
CLI commands like `muxy split-down` return "Error: no response from Muxy". The split succeeds, but the CLI never receives the response.

## Root Cause
Two issues in `NotificationSocketServer`:

1. **Premature dispose on EOF**: When `nc` sends a command and closes its write end, `readFromSession` detected EOF and called `disposeSession` before processing the buffered command line — the response was never even prepared.

2. **Async write race**: `processCommand` spawns a `Task` to invoke `SocketCommandHandler.handleRequest` on `@MainActor` and returns synchronously. After the command was processed, `readFromSession` would reach EOF (client already half-closed) and dispose the session — closing the fd before the async Task could enqueue and flush its response write.

## Fix
- Extracted `processBufferedLines` from `readFromSession` and call it before checking EOF, ensuring the command is always parsed before dispose
- Added `pendingClose` flag — on EOF, cancel only the read source while keeping the fd alive for pending writes
- Added `commandInFlight` flag — defer close when the async Task hasn't enqueued its write yet (buffer may be empty at EOF time)
- `flushWrites` closes the fd after draining when `pendingClose` is set; `closeSession` skips the fd when `pendingClose` is active

This fixes all CLI socket commands (`split-right`, `split-down`, `send`, `list-panes`, etc.) in one change.

## Files Changed
- `Muxy/Services/NotificationSocketServer.swift` — 25 insertions, 3 deletions

## Testing
- All 1265 existing tests pass
- Manually verified via local integration: built a signed release, ran `muxy split-down` / `muxy split-right` / `muxy list-panes` etc., all return correct responses
- Unit tests for this specific race condition are difficult to write without exposing internal socket/session management — the race involves socket half-close timing and async Task scheduling across the socket queue and MainActor