### PR TITLE
fix: CLI falsely reports "no response" for commands with empty output

### DIFF
--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -45,7 +45,7 @@ send_command() {
     fi
     local response
     response=$(printf '%s\n' "$message" | nc -w "$NC_TIMEOUT" -U "$SOCKET" 2>/dev/null)
-    if [ -z "$response" ]; then
+    if [ $? -ne 0 ]; then
         echo "Error: no response from Muxy" >&2
         exit 1
     fi


### PR DESCRIPTION
## Problem
`muxy list-panes` reports "Error: no response from Muxy" even when the server responds correctly.

## Root Cause
`send_command` uses `[ -z "$response" ]` to detect connection failures, treating an empty response as an error. However, some commands (e.g. `list-panes` with no open panes) legitimately return empty output. The correct signal for connection health is `nc`'s exit code, not the response content.

## Fix
Changed the failure check from `[ -z "$response" ]` to `[ $? -ne 0 ]`. `nc` exits 0 on a clean read/shutdown and non-zero on timeout or connection failure — independent of response content.

## Files Changed
- `Muxy/Resources/scripts/muxy-cli` — 1 line