### PR TITLE
Persist last selected Settings tab

### DIFF
--- a/Muxy/Services/ExtensionLogStore.swift
+++ b/Muxy/Services/ExtensionLogStore.swift
@@ -64,6 +64,10 @@ final class ExtensionLogStore: @unchecked Sendable {
         }
     }
 
+    func flush() {
+        queue.sync {}
+    }
+
     private func startTrimTimer() {
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now() + Self.trimInterval, repeating: Self.trimInterval)

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -59,6 +59,40 @@ enum SettingsRoute: Hashable, Identifiable {
         case let .ext(extensionID): "ext.\(extensionID)"
         }
     }
+
+    init?(storedID: String) {
+        if storedID.hasPrefix("builtin.") {
+            let rawCategory = String(storedID.dropFirst("builtin.".count))
+            guard let category = SettingsCategory(rawValue: rawCategory) else { return nil }
+            self = .builtin(category)
+            return
+        }
+
+        if storedID.hasPrefix("ext.") {
+            let extensionID = String(storedID.dropFirst("ext.".count))
+            guard !extensionID.isEmpty else { return nil }
+            self = .ext(extensionID)
+            return
+        }
+
+        return nil
+    }
+}
+
+enum SettingsRouteSelectionStore {
+    static let storageKey = "muxy.settings.selectedRoute"
+    static let fallbackRoute = SettingsRoute.builtin(.general)
+
+    static func load(defaults: UserDefaults = .standard) -> SettingsRoute {
+        guard let storedID = defaults.string(forKey: storageKey),
+              let route = SettingsRoute(storedID: storedID)
+        else { return fallbackRoute }
+        return route
+    }
+
+    static func save(_ route: SettingsRoute, defaults: UserDefaults = .standard) {
+        defaults.set(route.id, forKey: storageKey)
+    }
 }
 
 struct SettingsCatalogItem: Identifiable, Equatable {

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 struct SettingsView: View {
-    @State private var selectedRoute: SettingsRoute = .builtin(.general)
+    @State private var selectedRoute = SettingsRouteSelectionStore.load()
     @State private var searchText = ""
     @Environment(ExtensionStore.self) private var extensionStore
 
@@ -53,13 +53,15 @@ struct SettingsView: View {
         .tint(SettingsStyle.accent)
         .preferredColorScheme(MuxyTheme.colorScheme)
         .resetsSettingsFocusOnOutsideClick()
+        .onAppear {
+            selectedRoute = validatedRoute(selectedRoute)
+        }
         .onChange(of: searchText) { _, _ in
             guard !isRouteVisible(selectedRoute) else { return }
-            if let first = visibleCategories.first {
-                selectedRoute = .builtin(first)
-            } else if let ext = visibleExtensionRoutes.first {
-                selectedRoute = .ext(ext.extensionID)
-            }
+            selectedRoute = fallbackVisibleRoute()
+        }
+        .onChange(of: selectedRoute) { _, route in
+            SettingsRouteSelectionStore.save(route)
         }
         .onReceive(NotificationCenter.default.publisher(for: .focusProjectPickerDefaultLocation)) { _ in
             searchText = ""
@@ -77,6 +79,23 @@ struct SettingsView: View {
         case let .builtin(category): visibleCategories.contains(category)
         case let .ext(extensionID): visibleExtensionRoutes.contains { $0.extensionID == extensionID }
         }
+    }
+
+    private func validatedRoute(_ route: SettingsRoute) -> SettingsRoute {
+        guard isRouteVisible(route) else { return fallbackVisibleRoute() }
+        return route
+    }
+
+    private func fallbackVisibleRoute() -> SettingsRoute {
+        if let first = visibleCategories.first {
+            return .builtin(first)
+        }
+
+        if let ext = visibleExtensionRoutes.first {
+            return .ext(ext.extensionID)
+        }
+
+        return SettingsRouteSelectionStore.fallbackRoute
     }
 
     @ViewBuilder

--- a/Tests/MuxyTests/Services/ExtensionLogStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionLogStoreTests.swift
@@ -3,10 +3,10 @@ import Testing
 
 @testable import Muxy
 
-@Suite("ExtensionLogStore")
+@Suite("ExtensionLogStore", .serialized)
 struct ExtensionLogStoreTests {
     @Test("append writes the line to the extension log file")
-    func appendWritesLine() async throws {
+    func appendWritesLine() throws {
         let store = ExtensionLogStore.shared
         let directory = try makeExtensionDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -14,10 +14,9 @@ struct ExtensionLogStoreTests {
 
         store.register(extensionID: extensionID, directory: directory)
         store.append(extensionID: extensionID, line: "hello world")
-        try await waitForCondition(timeout: 1.0) {
-            FileManager.default.fileExists(atPath: store.logURL(extensionID: extensionID, directory: directory).path)
-        }
+        store.flush()
         store.unregister(extensionID: extensionID)
+        store.flush()
 
         let logURL = store.logURL(extensionID: extensionID, directory: directory)
         let text = try String(contentsOf: logURL, encoding: .utf8)
@@ -25,7 +24,7 @@ struct ExtensionLogStoreTests {
     }
 
     @Test("clear empties the log file")
-    func clearEmptiesLog() async throws {
+    func clearEmptiesLog() throws {
         let store = ExtensionLogStore.shared
         let directory = try makeExtensionDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -34,16 +33,14 @@ struct ExtensionLogStoreTests {
         store.register(extensionID: extensionID, directory: directory)
         store.append(extensionID: extensionID, line: "first")
         store.append(extensionID: extensionID, line: "second")
-        let logURL = store.logURL(extensionID: extensionID, directory: directory)
-        try await waitForCondition(timeout: 1.0) {
-            (try? String(contentsOf: logURL, encoding: .utf8))?.contains("second") == true
-        }
+        store.flush()
 
         store.clear(extensionID: extensionID)
-        try await waitForCondition(timeout: 1.0) {
-            (try? Data(contentsOf: logURL).isEmpty) == true
-        }
+        store.flush()
         store.unregister(extensionID: extensionID)
+        store.flush()
+
+        let logURL = store.logURL(extensionID: extensionID, directory: directory)
         let data = try Data(contentsOf: logURL)
         #expect(data.isEmpty)
     }
@@ -53,17 +50,5 @@ struct ExtensionLogStoreTests {
             .appendingPathComponent("ext-log-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
-    }
-
-    private func waitForCondition(
-        timeout: TimeInterval,
-        check: @escaping () -> Bool
-    ) async throws {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if check() { return }
-            try await Task.sleep(nanoseconds: 30_000_000)
-        }
-        Issue.record("condition not satisfied within \(timeout)s")
     }
 }

--- a/Tests/MuxyTests/Views/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/SettingsCatalogTests.swift
@@ -5,6 +5,15 @@ import Testing
 @Suite("SettingsCatalog")
 @MainActor
 struct SettingsCatalogTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "SettingsRouteSelectionStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Unable to create isolated UserDefaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
     @Test
     func searchFindsSettingsByAliasAndDescription() {
         let results = SettingsCatalog.matchingItems(query: "hotkeys")
@@ -58,12 +67,7 @@ struct SettingsCatalogTests {
 
     @Test
     func selectedSettingsRoutePersists() throws {
-        let suiteName = "SettingsRouteSelectionStoreTests-\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            Issue.record("Unable to create isolated UserDefaults suite")
-            return
-        }
-        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        let defaults = makeDefaults()
 
         #expect(SettingsRouteSelectionStore.load(defaults: defaults) == .builtin(.general))
 

--- a/Tests/MuxyTests/Views/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/SettingsCatalogTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Muxy
 
@@ -45,5 +46,32 @@ struct SettingsCatalogTests {
         #expect(SettingsCatalog.items.contains { $0.key.hasPrefix("editor.") })
         #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == "editor.defaultEditor" })
         #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == "editor.richInputLineHeightMultiplier" })
+    }
+
+    @Test
+    func settingsRoutesRoundTripStoredIDs() throws {
+        #expect(SettingsRoute(storedID: "builtin.terminal") == .builtin(.terminal))
+        #expect(SettingsRoute(storedID: "ext.com.example.tool") == .ext("com.example.tool"))
+        #expect(SettingsRoute(storedID: "builtin.missing") == nil)
+        #expect(SettingsRoute(storedID: "ext.") == nil)
+    }
+
+    @Test
+    func selectedSettingsRoutePersists() throws {
+        let suiteName = "SettingsRouteSelectionStoreTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            Issue.record("Unable to create isolated UserDefaults suite")
+            return
+        }
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        #expect(SettingsRouteSelectionStore.load(defaults: defaults) == .builtin(.general))
+
+        SettingsRouteSelectionStore.save(.builtin(.editor), defaults: defaults)
+        #expect(defaults.string(forKey: SettingsRouteSelectionStore.storageKey) == "builtin.editor")
+        #expect(SettingsRouteSelectionStore.load(defaults: defaults) == .builtin(.editor))
+
+        defaults.set("invalid", forKey: SettingsRouteSelectionStore.storageKey)
+        #expect(SettingsRouteSelectionStore.load(defaults: defaults) == .builtin(.general))
     }
 }


### PR DESCRIPTION
Persist Settings route selection across launches.
  Validate restored routes and fall back safely.
  Add focused tests for route storage.