### PR TITLE
fix: resource lookup fails on clean build for subdirectory-bundled assets (markdown JS, provider icons)

### DIFF
--- a/Muxy/Extensions/BundleExtension.swift
+++ b/Muxy/Extensions/BundleExtension.swift
@@ -22,11 +22,6 @@ extension Bundle {
     static var providerIconsURL: URL? {
         var candidates: [URL] = []
 
-        if let resourceURL = Bundle.main.resourceURL {
-            candidates.append(resourceURL.appendingPathComponent("ProviderIcons"))
-        }
-        candidates.append(Bundle.main.bundleURL.appendingPathComponent("ProviderIcons"))
-        candidates.append(Bundle.main.bundleURL.appendingPathComponent("Contents/Resources/ProviderIcons"))
         if let resourceURL = appResources.resourceURL {
             candidates.append(resourceURL.appendingPathComponent("ProviderIcons"))
         }

--- a/Muxy/Extensions/BundleExtension.swift
+++ b/Muxy/Extensions/BundleExtension.swift
@@ -25,10 +25,11 @@ extension Bundle {
         if let resourceURL = Bundle.main.resourceURL {
             candidates.append(resourceURL.appendingPathComponent("ProviderIcons"))
         }
-        candidates.append(contentsOf: [
-            Bundle.main.bundleURL.appendingPathComponent("ProviderIcons"),
-            Bundle.main.bundleURL.appendingPathComponent("Contents/Resources/ProviderIcons"),
-        ])
+        candidates.append(Bundle.main.bundleURL.appendingPathComponent("ProviderIcons"))
+        candidates.append(Bundle.main.bundleURL.appendingPathComponent("Contents/Resources/ProviderIcons"))
+        if let resourceURL = appResources.resourceURL {
+            candidates.append(resourceURL.appendingPathComponent("ProviderIcons"))
+        }
 
         for candidate in candidates {
             var isDirectory: ObjCBool = false

--- a/Muxy/Views/Markdown/MarkdownAssetSchemeHandler.swift
+++ b/Muxy/Views/Markdown/MarkdownAssetSchemeHandler.swift
@@ -26,7 +26,8 @@ final class MarkdownAssetSchemeHandler: NSObject, WKURLSchemeHandler {
 
         let filename = url.lastPathComponent
         guard Self.allowedFiles.contains(filename),
-              let resourceURL = Bundle.appResources.url(forResource: filename, withExtension: nil),
+              let resourceURL = Bundle.appResources.url(forResource: filename, withExtension: nil, subdirectory: "markdown-assets") ??
+              Bundle.appResources.url(forResource: filename, withExtension: nil),
               let data = try? Data(contentsOf: resourceURL)
         else {
             urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))

--- a/Muxy/Views/ProviderIconView.swift
+++ b/Muxy/Views/ProviderIconView.swift
@@ -62,7 +62,8 @@ struct ProviderIconView: View {
             }
         }
 
-        if let url = Bundle.appResources.url(forResource: name, withExtension: "svg") ??
+        if let url = Bundle.appResources.url(forResource: name, withExtension: "svg", subdirectory: "ProviderIcons") ??
+            Bundle.appResources.url(forResource: name, withExtension: "svg") ??
             Bundle.main.url(forResource: name, withExtension: "svg")
         {
             return NSImage(contentsOf: url)


### PR DESCRIPTION
## Root Cause

The build script (`build-release.sh`) copies the entire `Muxy_Muxy.bundle` from SPM's build output into the `.app` without cleaning it first. SPM does not remove stale files from the bundle when `Package.swift` resource rules change.

The resource configuration was changed in commit `aa49de9` (Speed up launch and local dev runs #552):

```diff
- .process("Resources"),
+ .process("Resources/Assets.xcassets"),
+ .copy("Resources/markdown-assets"),
+ .copy("Resources/ProviderIcons"),
+ .copy("Resources/scripts"),
```

Before this commit, `.process("Resources")` recursively processed all files in `Resources/` and placed each file directly at the **bundle root**. So `markdown-renderer.js`, `marked.min.js`, `mermaid.min.js`, and provider icon SVGs were at the root, and lookups like `Bundle.appResources.url(forResource:withExtension:)` found them.

After this commit, `.copy("Resources/markdown-assets")` and `.copy("Resources/ProviderIcons")` place entire directories as **subdirectories** (`markdown-assets/`, `ProviderIcons/`). However, the old root-level copies persist in the bundle across rebuilds because SPM never cleans them.

So the lookup finds the stale root-level file — it works, but only by accident:

| State | Root level | Subdirectory | Resources |
|-------|-----------|-------------|-----------|
| Before aa49de9 | ✅ Files at root | — | ✅ Works |
| After aa49de9, dirty `.build` | ✅ Stale copies remain | ✅ New copies | ✅ Works (by accident) |
| After aa49de9, clean `.build` | ❌ Gone | ✅ New copies | ❌ **Fails** |

### Affected resources

| Resource | File(s) | Fix |
|----------|---------|-----|
| Markdown JS (`markdown-renderer.js`, etc.) | `MarkdownAssetSchemeHandler.swift` | ✅ Search `markdown-assets/` subdirectory first |
| Provider icons (`claude.svg`, `copilot.svg`, etc.) | `ProviderIconView.swift`, `BundleExtension.swift` | ✅ Search `ProviderIcons/` subdirectory first; add `appResources` bundle path |

## Fix

For each affected lookup, search the subdirectory first, falling back to the bundle root for compatibility:

```swift
// markdown-assets
Bundle.appResources.url(forResource: filename, withExtension: nil, subdirectory: "markdown-assets")
?? Bundle.appResources.url(forResource: filename, withExtension: nil)

// ProviderIcons
Bundle.appResources.url(forResource: name, withExtension: "svg", subdirectory: "ProviderIcons")
?? Bundle.appResources.url(forResource: name, withExtension: "svg")
```

Also added `Bundle.appResources.resourceURL` as a candidate for `providerIconsURL`, since `ProviderIcons/` lives inside `Muxy_Muxy.bundle`.

## Reproduction

1. Clean build caches:
   ```bash
   rm -rf .build
   rm -rf build/*.dmg
   ```
2. Build: `scripts/build-release.sh --arch arm64 --version 0.31.0`
3. Install the `.dmg` and open any `.md` file
4. The markdown preview shows a blank page; source/code mode works normally

> Installing a previously-built `.dmg` (from a dirty build) will NOT reproduce the bug — stale root-level files are still present in that bundle.
