### PR TITLE
Add extension panel API with a unified panel system

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -63,6 +63,7 @@ enum ExtensionPermission: String, Codable, CaseIterable {
     case worktreesRead = "worktrees:read"
     case worktreesWrite = "worktrees:write"
     case notificationsWrite = "notifications:write"
+    case panelsWrite = "panels:write"
     case commandsRunScript = "commands:run-script"
     case commandsExec = "commands:exec"
 
@@ -83,7 +84,8 @@ enum ExtensionPermission: String, Codable, CaseIterable {
              .tabsWrite,
              .projectsWrite,
              .worktreesWrite,
-             .notificationsWrite:
+             .notificationsWrite,
+             .panelsWrite:
             .write
         case .commandsRunScript,
              .commandsExec:
@@ -97,6 +99,60 @@ struct ExtensionTabType: Codable, Equatable, Identifiable {
     let title: String
     let entry: String
     let defaultData: ExtensionJSON?
+}
+
+struct ExtensionPanel: Codable, Equatable, Identifiable {
+    let id: String
+    let title: String?
+    let icon: ExtensionIcon?
+    let entry: String
+    let position: PanelPosition
+    let mode: PanelMode
+    let hiddenControls: [PanelHeaderControl]
+    let defaultData: ExtensionJSON?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case icon
+        case entry
+        case position
+        case mode
+        case hiddenControls
+        case defaultData
+    }
+
+    init(
+        id: String,
+        title: String? = nil,
+        icon: ExtensionIcon? = nil,
+        entry: String,
+        position: PanelPosition = .right,
+        mode: PanelMode = .floating,
+        hiddenControls: [PanelHeaderControl] = [],
+        defaultData: ExtensionJSON? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.icon = icon
+        self.entry = entry
+        self.position = position
+        self.mode = mode
+        self.hiddenControls = hiddenControls
+        self.defaultData = defaultData
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        icon = try container.decodeIfPresent(ExtensionIcon.self, forKey: .icon)
+        entry = try container.decode(String.self, forKey: .entry)
+        position = try container.decodeIfPresent(PanelPosition.self, forKey: .position) ?? .right
+        mode = try container.decodeIfPresent(PanelMode.self, forKey: .mode) ?? .floating
+        hiddenControls = try container.decodeIfPresent([PanelHeaderControl].self, forKey: .hiddenControls) ?? []
+        defaultData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .defaultData)
+    }
 }
 
 enum ExtensionIcon: Codable, Equatable {
@@ -180,11 +236,13 @@ struct ExtensionSettingEntry: Codable, Equatable, Identifiable {
 enum ExtensionCommandAction: Codable, Equatable {
     case event
     case openTab(tabType: String, data: ExtensionJSON?)
+    case togglePanel(panel: String)
     case runScript(script: String)
 
     private enum CodingKeys: String, CodingKey {
         case kind
         case tabType
+        case panel
         case data
         case script
     }
@@ -192,6 +250,7 @@ enum ExtensionCommandAction: Codable, Equatable {
     private enum Kind: String, Codable {
         case event
         case openTab
+        case togglePanel
         case runScript
     }
 
@@ -205,6 +264,9 @@ enum ExtensionCommandAction: Codable, Equatable {
             let tabType = try container.decode(String.self, forKey: .tabType)
             let data = try container.decodeIfPresent(ExtensionJSON.self, forKey: .data)
             self = .openTab(tabType: tabType, data: data)
+        case .togglePanel:
+            let panel = try container.decode(String.self, forKey: .panel)
+            self = .togglePanel(panel: panel)
         case .runScript:
             let script = try container.decode(String.self, forKey: .script)
             self = .runScript(script: script)
@@ -220,6 +282,9 @@ enum ExtensionCommandAction: Codable, Equatable {
             try container.encode(Kind.openTab, forKey: .kind)
             try container.encode(tabType, forKey: .tabType)
             try container.encodeIfPresent(data, forKey: .data)
+        case let .togglePanel(panel):
+            try container.encode(Kind.togglePanel, forKey: .kind)
+            try container.encode(panel, forKey: .panel)
         case let .runScript(script):
             try container.encode(Kind.runScript, forKey: .kind)
             try container.encode(script, forKey: .script)
@@ -272,6 +337,7 @@ struct ExtensionManifest: Codable, Equatable {
     let events: [String]
     let commands: [ExtensionPaletteCommand]
     let tabTypes: [ExtensionTabType]
+    let panels: [ExtensionPanel]
     let permissions: [ExtensionPermission]
     let aiProvider: ExtensionAIProvider?
     let topbarItems: [ExtensionTopbarItem]
@@ -286,6 +352,7 @@ struct ExtensionManifest: Codable, Equatable {
         case events
         case commands
         case tabTypes
+        case panels
         case permissions
         case aiProvider
         case topbarItems
@@ -301,6 +368,7 @@ struct ExtensionManifest: Codable, Equatable {
         events: [String] = [],
         commands: [ExtensionPaletteCommand] = [],
         tabTypes: [ExtensionTabType] = [],
+        panels: [ExtensionPanel] = [],
         permissions: [ExtensionPermission] = [],
         aiProvider: ExtensionAIProvider? = nil,
         topbarItems: [ExtensionTopbarItem] = [],
@@ -314,6 +382,7 @@ struct ExtensionManifest: Codable, Equatable {
         self.events = events
         self.commands = commands
         self.tabTypes = tabTypes
+        self.panels = panels
         self.permissions = permissions
         self.aiProvider = aiProvider
         self.topbarItems = topbarItems
@@ -330,6 +399,7 @@ struct ExtensionManifest: Codable, Equatable {
         events = try container.decodeIfPresent([String].self, forKey: .events) ?? []
         commands = try container.decodeIfPresent([ExtensionPaletteCommand].self, forKey: .commands) ?? []
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
+        panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
         permissions = try container.decodeIfPresent([ExtensionPermission].self, forKey: .permissions) ?? []
         aiProvider = try container.decodeIfPresent(ExtensionAIProvider.self, forKey: .aiProvider)
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
@@ -339,6 +409,10 @@ struct ExtensionManifest: Codable, Equatable {
 
     func tabType(id: String) -> ExtensionTabType? {
         tabTypes.first { $0.id == id }
+    }
+
+    func panel(id: String) -> ExtensionPanel? {
+        panels.first { $0.id == id }
     }
 
     func setting(key: String) -> ExtensionSettingEntry? {
@@ -360,7 +434,13 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case tabTypeEntryMissing(tabTypeID: String, url: URL)
     case tabTypeEntryOutsideDirectory(tabTypeID: String, url: URL)
     case duplicateTabType(String)
+    case panelEntryMissing(panelID: String, url: URL)
+    case panelEntryOutsideDirectory(panelID: String, url: URL)
+    case duplicatePanel(String)
+    case panelSVGMissing(panelID: String, url: URL)
+    case panelSVGOutsideDirectory(panelID: String, url: URL)
     case commandReferencesUnknownTabType(commandID: String, tabType: String)
+    case commandReferencesUnknownPanel(commandID: String, panel: String)
     case scriptMissing(commandID: String, url: URL)
     case scriptOutsideDirectory(commandID: String, url: URL)
     case topbarItemEmptyID
@@ -396,8 +476,20 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Tab type '\(tabTypeID)' entry at \(url.path) escapes the extension directory"
         case let .duplicateTabType(id):
             "Duplicate tab type '\(id)'"
+        case let .panelEntryMissing(panelID, url):
+            "Panel '\(panelID)' entry not found at \(url.path)"
+        case let .panelEntryOutsideDirectory(panelID, url):
+            "Panel '\(panelID)' entry at \(url.path) escapes the extension directory"
+        case let .duplicatePanel(id):
+            "Duplicate panel '\(id)'"
+        case let .panelSVGMissing(panelID, url):
+            "Panel '\(panelID)' icon SVG not found at \(url.path)"
+        case let .panelSVGOutsideDirectory(panelID, url):
+            "Panel '\(panelID)' icon SVG at \(url.path) escapes the extension directory"
         case let .commandReferencesUnknownTabType(commandID, tabType):
             "Command '\(commandID)' references unknown tab type '\(tabType)'"
+        case let .commandReferencesUnknownPanel(commandID, panel):
+            "Command '\(commandID)' references unknown panel '\(panel)'"
         case let .scriptMissing(commandID, url):
             "Command '\(commandID)' script not found at \(url.path)"
         case let .scriptOutsideDirectory(commandID, url):
@@ -495,6 +587,7 @@ enum ExtensionManifestLoader {
 
         let muxyExtension = MuxyExtension(id: manifest.name, directory: directory, manifest: manifest)
         try validateTabTypes(manifest: manifest, in: muxyExtension)
+        try validatePanels(manifest: manifest, in: muxyExtension)
         try validateCommands(manifest: manifest, in: muxyExtension)
         try validateTopbarItems(manifest: manifest, in: muxyExtension)
         try validateStatusBarItems(manifest: manifest, in: muxyExtension)
@@ -539,8 +632,35 @@ enum ExtensionManifestLoader {
         }
     }
 
+    private static func validatePanels(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
+        var seen = Set<String>()
+        for panel in manifest.panels {
+            guard seen.insert(panel.id).inserted else {
+                throw ExtensionLoadError.duplicatePanel(panel.id)
+            }
+            guard let url = muxyExtension.resolveResource(panel.entry) else {
+                throw ExtensionLoadError.panelEntryOutsideDirectory(
+                    panelID: panel.id,
+                    url: muxyExtension.directory.appendingPathComponent(panel.entry)
+                )
+            }
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ExtensionLoadError.panelEntryMissing(panelID: panel.id, url: url)
+            }
+            if let icon = panel.icon {
+                try validateIcon(
+                    icon,
+                    in: muxyExtension,
+                    missing: { ExtensionLoadError.panelSVGMissing(panelID: panel.id, url: $0) },
+                    outside: { ExtensionLoadError.panelSVGOutsideDirectory(panelID: panel.id, url: $0) }
+                )
+            }
+        }
+    }
+
     private static func validateCommands(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
         let tabTypeIDs = Set(manifest.tabTypes.map(\.id))
+        let panelIDs = Set(manifest.panels.map(\.id))
         for command in manifest.commands {
             switch command.action {
             case .event:
@@ -550,6 +670,13 @@ enum ExtensionManifestLoader {
                     throw ExtensionLoadError.commandReferencesUnknownTabType(
                         commandID: command.id,
                         tabType: tabType
+                    )
+                }
+            case let .togglePanel(panel):
+                guard panelIDs.contains(panel) else {
+                    throw ExtensionLoadError.commandReferencesUnknownPanel(
+                        commandID: command.id,
+                        panel: panel
                     )
                 }
             case let .runScript(script):

--- a/Muxy/Models/ExtensionPanelState.swift
+++ b/Muxy/Models/ExtensionPanelState.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+@Observable
+final class ExtensionPanelState: Identifiable {
+    let id = UUID()
+    let extensionID: String
+    let panelID: String
+    let initialData: ExtensionJSON?
+
+    init(extensionID: String, panelID: String, initialData: ExtensionJSON? = nil) {
+        self.extensionID = extensionID
+        self.panelID = panelID
+        self.initialData = initialData
+    }
+
+    var hostPanelID: String { ExtensionPanelState.hostPanelID(extensionID: extensionID, panelID: panelID) }
+
+    static func hostPanelID(extensionID: String, panelID: String) -> String {
+        "ext:\(extensionID):\(panelID)"
+    }
+}

--- a/Muxy/Models/Panel.swift
+++ b/Muxy/Models/Panel.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+enum PanelPosition: String, CaseIterable, Identifiable, Codable {
+    case right
+    case bottom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .right: "Right"
+        case .bottom: "Bottom"
+        }
+    }
+
+    var opposite: PanelPosition {
+        switch self {
+        case .right: .bottom
+        case .bottom: .right
+        }
+    }
+}
+
+enum PanelMode: String, CaseIterable, Identifiable, Codable {
+    case pinned
+    case floating
+
+    var id: String { rawValue }
+}
+
+enum PanelHeaderControl: String, CaseIterable, Codable {
+    case close
+    case pin
+    case position
+}
+
+struct PanelHeaderButton: Identifiable, Equatable {
+    let id: String
+    let symbol: String
+    let label: String
+    let isActive: Bool
+    let action: () -> Void
+
+    init(
+        id: String,
+        symbol: String,
+        label: String,
+        isActive: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.id = id
+        self.symbol = symbol
+        self.label = label
+        self.isActive = isActive
+        self.action = action
+    }
+
+    static func == (lhs: PanelHeaderButton, rhs: PanelHeaderButton) -> Bool {
+        lhs.id == rhs.id
+            && lhs.symbol == rhs.symbol
+            && lhs.label == rhs.label
+            && lhs.isActive == rhs.isActive
+    }
+}
+
+struct PanelChrome {
+    let iconSymbol: String?
+    let title: String?
+    let hiddenControls: Set<PanelHeaderControl>
+    let leadingButtons: [PanelHeaderButton]
+    let trailingButtons: [PanelHeaderButton]
+
+    init(
+        iconSymbol: String? = nil,
+        title: String? = nil,
+        hiddenControls: Set<PanelHeaderControl> = [],
+        leadingButtons: [PanelHeaderButton] = [],
+        trailingButtons: [PanelHeaderButton] = []
+    ) {
+        self.iconSymbol = iconSymbol
+        self.title = title
+        self.hiddenControls = hiddenControls
+        self.leadingButtons = leadingButtons
+        self.trailingButtons = trailingButtons
+    }
+
+    func shows(_ control: PanelHeaderControl) -> Bool {
+        !hiddenControls.contains(control)
+    }
+
+    var hasHeaderContent: Bool {
+        iconSymbol != nil
+            || title != nil
+            || !leadingButtons.isEmpty
+            || !trailingButtons.isEmpty
+            || !hiddenControls.isSuperset(of: PanelHeaderControl.allCases)
+    }
+}

--- a/Muxy/Models/Panel.swift
+++ b/Muxy/Models/Panel.swift
@@ -67,20 +67,17 @@ struct PanelChrome {
     let iconSymbol: String?
     let title: String?
     let hiddenControls: Set<PanelHeaderControl>
-    let leadingButtons: [PanelHeaderButton]
     let trailingButtons: [PanelHeaderButton]
 
     init(
         iconSymbol: String? = nil,
         title: String? = nil,
         hiddenControls: Set<PanelHeaderControl> = [],
-        leadingButtons: [PanelHeaderButton] = [],
         trailingButtons: [PanelHeaderButton] = []
     ) {
         self.iconSymbol = iconSymbol
         self.title = title
         self.hiddenControls = hiddenControls
-        self.leadingButtons = leadingButtons
         self.trailingButtons = trailingButtons
     }
 
@@ -91,7 +88,6 @@ struct PanelChrome {
     var hasHeaderContent: Bool {
         iconSymbol != nil
             || title != nil
-            || !leadingButtons.isEmpty
             || !trailingButtons.isEmpty
             || !hiddenControls.isSuperset(of: PanelHeaderControl.allCases)
     }

--- a/Muxy/Models/RichInputPreferences.swift
+++ b/Muxy/Models/RichInputPreferences.swift
@@ -29,4 +29,11 @@ enum RichInputPanelPosition: String, CaseIterable, Identifiable {
         case .bottom: "Bottom"
         }
     }
+
+    var panelPosition: PanelPosition {
+        switch self {
+        case .right: .right
+        case .bottom: .bottom
+        }
+    }
 }

--- a/Muxy/Models/RichInputPreferences.swift
+++ b/Muxy/Models/RichInputPreferences.swift
@@ -11,29 +11,8 @@ enum RichInputPreferences {
     static let defaultFloating = true
 
     static let positionKey = "muxy.richInput.position"
-    static let defaultPosition: RichInputPanelPosition = .right
+    static let defaultPosition: PanelPosition = .right
 
     static let broadcastKey = "muxy.richInput.broadcast"
     static let defaultBroadcast = false
-}
-
-enum RichInputPanelPosition: String, CaseIterable, Identifiable {
-    case right
-    case bottom
-
-    var id: String { rawValue }
-
-    var displayName: String {
-        switch self {
-        case .right: "Right"
-        case .bottom: "Bottom"
-        }
-    }
-
-    var panelPosition: PanelPosition {
-        switch self {
-        case .right: .right
-        case .bottom: .bottom
-        }
-    }
 }

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -121,11 +121,12 @@ Field-by-field:
 - `permissions` — array of permission strings. Declare only what the entrypoint or tabs actually use.
 - `events` — array of event names this extension subscribes to (for example `pane.created`, `tab.focused`, `pane.closed`). Command events (`command.<id>`) are auto-allowed.
 - `tabTypes` — declares HTML pages renderable as tabs.
-- `commands` — palette commands. Each command's `action.kind` is `event` (default — fires `command.<id>`), `openTab`, or `runScript`.
+- `panels` — declares HTML pages renderable as dockable/floating panels (`position`: `right`|`bottom`, `mode`: `floating`|`pinned`, optional `icon`/`title`/`hiddenControls`). Requires `panels:write` to open/close at runtime. One pinned and one floating panel per position; opening another in that slot replaces it.
+- `commands` — palette commands. Each command's `action.kind` is `event` (default — fires `command.<id>`), `openTab`, `togglePanel`, or `runScript`.
 - `topbarItems` / `statusBarItems` — UI hooks bound to a command. `icon` is either `{ "symbol": "<sf-symbol>" }` or `{ "svg": "<relative/path.svg>" }`.
 - `settings` — user-visible settings (`string` | `bool` | `number`) reachable from `extension.settings.get` over the socket and editable in the Extensions modal.
 
-Common load failures: a declared entrypoint that is missing or not executable, tab entry escapes the extension directory, a command references an unknown `tabType`, a topbar or status-bar item references an unknown command. Failures appear in the Extensions modal under "Load Errors".
+Common load failures: a declared entrypoint that is missing or not executable, tab/panel entry escapes the extension directory, a command references an unknown `tabType` or `panel`, a topbar or status-bar item references an unknown command. Failures appear in the Extensions modal under "Load Errors".
 
 ## Permissions reference
 
@@ -260,6 +261,17 @@ await muxy.tabs.open({
     data: { source: 'self', when: new Date().toISOString() },
   },
 });
+```
+
+### Open / close panels
+
+Requires `panels:write`. The panel id must be declared under `panels` in the manifest.
+
+```js
+await muxy.panels.open('dashboard');                 // open (or move) the panel
+await muxy.panels.toggle('dashboard');               // open if closed, close if open
+await muxy.panels.open('dashboard', { tab: 'logs' }); // override defaultData for this instance
+await muxy.panels.close('dashboard');
 ```
 
 ### Drive terminal panes

--- a/Muxy/Services/ExtensionPanelRegistry.swift
+++ b/Muxy/Services/ExtensionPanelRegistry.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+@MainActor
+@Observable
+final class ExtensionPanelRegistry {
+    static let shared = ExtensionPanelRegistry()
+
+    private(set) var openStates: [ExtensionPanelState] = []
+
+    func state(forHostPanelID hostPanelID: String) -> ExtensionPanelState? {
+        openStates.first { $0.hostPanelID == hostPanelID }
+    }
+
+    @discardableResult
+    func open(
+        extensionID: String,
+        panel: ExtensionPanel,
+        data: ExtensionJSON?
+    ) -> ExtensionPanelState {
+        let hostPanelID = ExtensionPanelState.hostPanelID(extensionID: extensionID, panelID: panel.id)
+        openStates.removeAll { $0.hostPanelID == hostPanelID }
+        let state = ExtensionPanelState(
+            extensionID: extensionID,
+            panelID: panel.id,
+            initialData: data ?? panel.defaultData
+        )
+        openStates.append(state)
+        PanelHost.shared.open(hostPanelID, at: panel.position, mode: panel.mode)
+        pruneClosed()
+        return state
+    }
+
+    func toggle(extensionID: String, panel: ExtensionPanel, data: ExtensionJSON?) {
+        let hostPanelID = ExtensionPanelState.hostPanelID(extensionID: extensionID, panelID: panel.id)
+        if PanelHost.shared.isOpen(hostPanelID) {
+            close(hostPanelID: hostPanelID)
+            return
+        }
+        open(extensionID: extensionID, panel: panel, data: data)
+    }
+
+    func setMode(_ mode: PanelMode, forHostPanelID hostPanelID: String) {
+        PanelHost.shared.setMode(mode, for: hostPanelID)
+        pruneClosed()
+    }
+
+    func move(_ position: PanelPosition, forHostPanelID hostPanelID: String) {
+        PanelHost.shared.move(hostPanelID, to: position)
+        pruneClosed()
+    }
+
+    func close(hostPanelID: String) {
+        PanelHost.shared.close(hostPanelID)
+        openStates.removeAll { $0.hostPanelID == hostPanelID }
+    }
+
+    func closeAll(extensionID: String) {
+        for state in openStates where state.extensionID == extensionID {
+            PanelHost.shared.close(state.hostPanelID)
+        }
+        openStates.removeAll { $0.extensionID == extensionID }
+    }
+
+    func pruneClosed() {
+        openStates.removeAll { !PanelHost.shared.isOpen($0.hostPanelID) }
+    }
+}

--- a/Muxy/Services/ExtensionPanelRegistry.swift
+++ b/Muxy/Services/ExtensionPanelRegistry.swift
@@ -7,6 +7,10 @@ final class ExtensionPanelRegistry {
 
     private(set) var openStates: [ExtensionPanelState] = []
 
+    init() {
+        PanelHost.shared.onDisplace = { [weak self] _ in self?.pruneClosed() }
+    }
+
     func state(forHostPanelID hostPanelID: String) -> ExtensionPanelState? {
         openStates.first { $0.hostPanelID == hostPanelID }
     }
@@ -26,7 +30,6 @@ final class ExtensionPanelRegistry {
         )
         openStates.append(state)
         PanelHost.shared.open(hostPanelID, at: panel.position, mode: panel.mode)
-        pruneClosed()
         return state
     }
 
@@ -41,12 +44,10 @@ final class ExtensionPanelRegistry {
 
     func setMode(_ mode: PanelMode, forHostPanelID hostPanelID: String) {
         PanelHost.shared.setMode(mode, for: hostPanelID)
-        pruneClosed()
     }
 
     func move(_ position: PanelPosition, forHostPanelID hostPanelID: String) {
         PanelHost.shared.move(hostPanelID, to: position)
-        pruneClosed()
     }
 
     func close(hostPanelID: String) {
@@ -61,7 +62,7 @@ final class ExtensionPanelRegistry {
         openStates.removeAll { $0.extensionID == extensionID }
     }
 
-    func pruneClosed() {
+    private func pruneClosed() {
         openStates.removeAll { !PanelHost.shared.isOpen($0.hostPanelID) }
     }
 }

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -64,6 +64,9 @@ final class ExtensionStore {
         }
         statusBarTextOverrides.removeAll()
         ExtensionIconAssetCache.shared.invalidateAll()
+        for status in statuses {
+            ExtensionPanelRegistry.shared.closeAll(extensionID: status.id)
+        }
         rebuildExtensionUICache()
         publishSnapshot()
     }
@@ -86,6 +89,7 @@ final class ExtensionStore {
         if !enabled {
             statusBarTextOverrides.removeValue(forKey: extensionID)
             ExtensionIconAssetCache.shared.invalidate(extensionID: extensionID)
+            ExtensionPanelRegistry.shared.closeAll(extensionID: extensionID)
         }
         rebuildExtensionUICache()
         publishSnapshot()
@@ -258,6 +262,13 @@ final class ExtensionStore {
                 data: data,
                 in: muxyExtension,
                 appState: invocation.appState
+            )
+        case let .togglePanel(panelID):
+            guard let panel = muxyExtension.manifest.panel(id: panelID) else { return }
+            ExtensionPanelRegistry.shared.toggle(
+                extensionID: invocation.extensionID,
+                panel: panel,
+                data: nil
             )
         case let .runScript(script):
             runExtensionScript(script: script, in: muxyExtension, invocation: invocation)

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -137,6 +137,9 @@ enum MuxyAPI {
             "extension.settings.get",
             "extension.settings.set",
             "extension.statusbar.set",
+            "panel.open",
+            "panel.close",
+            "panel.toggle",
         ]
 
         private static let cliAliases: [String: String] = [
@@ -183,8 +186,39 @@ enum MuxyAPI {
             "worktrees.switch": .worktreesWrite,
             "worktrees.refresh": .worktreesWrite,
             "toast": .notificationsWrite,
+            "panel.open": .panelsWrite,
+            "panel.close": .panelsWrite,
+            "panel.toggle": .panelsWrite,
             "exec": .commandsExec,
         ]
+    }
+
+    @MainActor
+    enum Panels {
+        static func open(
+            extensionID: String,
+            panelID: String,
+            data: ExtensionJSON?,
+            toggle: Bool
+        ) -> Result<Void, APIError> {
+            guard let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID),
+                  let panel = muxyExtension.manifest.panel(id: panelID)
+            else {
+                return .failure(.invalidArguments("unknown panel '\(panelID)'"))
+            }
+            if toggle {
+                ExtensionPanelRegistry.shared.toggle(extensionID: extensionID, panel: panel, data: data)
+            } else {
+                ExtensionPanelRegistry.shared.open(extensionID: extensionID, panel: panel, data: data)
+            }
+            return .success(())
+        }
+
+        static func close(extensionID: String, panelID: String) -> Result<Void, APIError> {
+            let hostPanelID = ExtensionPanelState.hostPanelID(extensionID: extensionID, panelID: panelID)
+            ExtensionPanelRegistry.shared.close(hostPanelID: hostPanelID)
+            return .success(())
+        }
     }
 
     @MainActor

--- a/Muxy/Services/MuxyAPIDispatcher.swift
+++ b/Muxy/Services/MuxyAPIDispatcher.swift
@@ -18,6 +18,28 @@ enum MuxyAPIDispatcher {
         switch verb {
         case "toast":
             return try await handleToast(args: args, context: context)
+        case "panel.open":
+            try unwrap(MuxyAPI.Panels.open(
+                extensionID: context.extensionID,
+                panelID: stringArg(args, "panel"),
+                data: panelData(args),
+                toggle: false
+            ))
+            return NSNull()
+        case "panel.toggle":
+            try unwrap(MuxyAPI.Panels.open(
+                extensionID: context.extensionID,
+                panelID: stringArg(args, "panel"),
+                data: panelData(args),
+                toggle: true
+            ))
+            return NSNull()
+        case "panel.close":
+            try unwrap(MuxyAPI.Panels.close(
+                extensionID: context.extensionID,
+                panelID: stringArg(args, "panel")
+            ))
+            return NSNull()
         case "exec":
             return try await handleExec(args: args, context: context)
         case "tabs.list":
@@ -201,6 +223,12 @@ enum MuxyAPIDispatcher {
         case let .success(value): return value
         case let .failure(error): throw error
         }
+    }
+
+    private static func panelData(_ args: [String: Any]) -> ExtensionJSON? {
+        guard let raw = args["data"] else { return nil }
+        guard let data = try? JSONSerialization.data(withJSONObject: raw) else { return nil }
+        return try? JSONDecoder().decode(ExtensionJSON.self, from: data)
     }
 
     private static func decodeOpenTabRequest(_ args: [String: Any]) throws -> OpenTabRequest {

--- a/Muxy/Services/PanelHost.swift
+++ b/Muxy/Services/PanelHost.swift
@@ -13,6 +13,8 @@ final class PanelHost {
 
     private(set) var placements: [PanelPlacement] = []
 
+    var onDisplace: ((String) -> Void)?
+
     func placement(for panelID: String) -> PanelPlacement? {
         placements.first { $0.panelID == panelID }
     }
@@ -31,8 +33,10 @@ final class PanelHost {
 
     func open(_ panelID: String, at position: PanelPosition, mode: PanelMode) {
         placements.removeAll { $0.panelID == panelID }
+        let displaced = placements.filter { $0.position == position && $0.mode == mode }
         placements.removeAll { $0.position == position && $0.mode == mode }
         placements.append(PanelPlacement(panelID: panelID, position: position, mode: mode))
+        displaced.forEach { onDisplace?($0.panelID) }
     }
 
     func toggle(_ panelID: String, at position: PanelPosition, mode: PanelMode) {

--- a/Muxy/Services/PanelHost.swift
+++ b/Muxy/Services/PanelHost.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+struct PanelPlacement: Equatable {
+    let panelID: String
+    let position: PanelPosition
+    let mode: PanelMode
+}
+
+@MainActor
+@Observable
+final class PanelHost {
+    static let shared = PanelHost()
+
+    private(set) var placements: [PanelPlacement] = []
+
+    func placement(for panelID: String) -> PanelPlacement? {
+        placements.first { $0.panelID == panelID }
+    }
+
+    func isOpen(_ panelID: String) -> Bool {
+        placement(for: panelID) != nil
+    }
+
+    func pinnedPanel(at position: PanelPosition) -> String? {
+        placements.first { $0.position == position && $0.mode == .pinned }?.panelID
+    }
+
+    func floatingPanel(at position: PanelPosition) -> String? {
+        placements.first { $0.position == position && $0.mode == .floating }?.panelID
+    }
+
+    func open(_ panelID: String, at position: PanelPosition, mode: PanelMode) {
+        placements.removeAll { $0.panelID == panelID }
+        placements.removeAll { $0.position == position && $0.mode == mode }
+        placements.append(PanelPlacement(panelID: panelID, position: position, mode: mode))
+    }
+
+    func toggle(_ panelID: String, at position: PanelPosition, mode: PanelMode) {
+        if placement(for: panelID) != nil {
+            close(panelID)
+            return
+        }
+        open(panelID, at: position, mode: mode)
+    }
+
+    func move(_ panelID: String, to position: PanelPosition) {
+        guard let current = placement(for: panelID) else { return }
+        open(panelID, at: position, mode: current.mode)
+    }
+
+    func setMode(_ mode: PanelMode, for panelID: String) {
+        guard let current = placement(for: panelID) else { return }
+        open(panelID, at: current.position, mode: mode)
+    }
+
+    func close(_ panelID: String) {
+        placements.removeAll { $0.panelID == panelID }
+    }
+
+    func closeAll() {
+        placements.removeAll()
+    }
+}

--- a/Muxy/Services/SettingsJSONStore.swift
+++ b/Muxy/Services/SettingsJSONStore.swift
@@ -201,7 +201,7 @@ enum SettingsJSONStore {
             SidebarCollapsedStyle.storageKey: Set(SidebarCollapsedStyle.allCases.map(\.rawValue)),
             SidebarExpandedStyle.storageKey: Set(SidebarExpandedStyle.allCases.map(\.rawValue)),
             "muxy.vcsDisplayMode": Set(VCSDisplayMode.allCases.map(\.rawValue)),
-            RichInputPreferences.positionKey: Set(RichInputPanelPosition.allCases.map(\.rawValue)),
+            RichInputPreferences.positionKey: Set(PanelPosition.allCases.map(\.rawValue)),
             "editor.defaultEditor": Set(EditorSettings.DefaultEditor.allCases.map(\.rawValue)),
             "editor.htmlDefaultViewMode": Set(EditorMarkdownViewMode.allCases.map(\.rawValue)),
             "editor.richInputImageStrategy": Set(RichInputImageStrategy.allCases.map(\.rawValue)),

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -202,9 +202,45 @@ enum SocketCommandHandler {
             let rawText = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
             let text = (rawText?.isEmpty == true) ? nil : rawText
             return handleStatusBarSet(itemID: parts[1], text: text, extensionID: clientContext.extensionID)
+        case "panel.open",
+             "panel.toggle":
+            guard parts.count >= 2 else { return "error:usage \(cmd)|panelID[|<json-data>]" }
+            return handlePanelOpen(
+                panelID: parts[1],
+                rawData: parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil,
+                toggle: cmd == "panel.toggle",
+                extensionID: clientContext.extensionID
+            )
+        case "panel.close":
+            guard parts.count >= 2 else { return "error:usage panel.close|panelID" }
+            return handlePanelClose(panelID: parts[1], extensionID: clientContext.extensionID)
         default:
             return "error:unknown command \(cmd)"
         }
+    }
+
+    private static func handlePanelOpen(
+        panelID: String,
+        rawData: String?,
+        toggle: Bool,
+        extensionID: String?
+    ) -> String {
+        guard let extensionID else { return "error:identify required" }
+        let data = rawData
+            .flatMap { $0.data(using: .utf8) }
+            .flatMap { try? JSONDecoder().decode(ExtensionJSON.self, from: $0) }
+        return serialize(
+            MuxyAPI.Panels.open(extensionID: extensionID, panelID: panelID, data: data, toggle: toggle),
+            ok: "ok"
+        )
+    }
+
+    private static func handlePanelClose(panelID: String, extensionID: String?) -> String {
+        guard let extensionID else { return "error:identify required" }
+        return serialize(
+            MuxyAPI.Panels.close(extensionID: extensionID, panelID: panelID),
+            ok: "ok"
+        )
     }
 
     private static func handleSettingsGet(key: String, extensionID: String?) -> String {

--- a/Muxy/Views/Extensions/ExtensionOutputPanel.swift
+++ b/Muxy/Views/Extensions/ExtensionOutputPanel.swift
@@ -2,7 +2,6 @@ import AppKit
 import SwiftUI
 
 struct ExtensionOutputPanel: View {
-    @Binding var isPresented: Bool
     @Binding var selectedExtensionID: String?
 
     @State private var store = ExtensionStore.shared
@@ -17,10 +16,6 @@ struct ExtensionOutputPanel: View {
         }
         .frame(maxWidth: .infinity)
         .background(MuxyTheme.bg)
-        .overlay(
-            Rectangle().fill(MuxyTheme.border).frame(height: 1),
-            alignment: .top
-        )
         .onAppear { restartTailer() }
         .onDisappear { tailer?.stop() }
         .onChange(of: effectiveExtensionID) { _, _ in
@@ -30,9 +25,6 @@ struct ExtensionOutputPanel: View {
 
     private var header: some View {
         HStack(spacing: 8) {
-            Text("Extension Output")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
-                .foregroundStyle(MuxyTheme.fg)
             Menu {
                 ForEach(store.statuses) { status in
                     Button(status.muxyExtension.displayName) {
@@ -70,13 +62,6 @@ struct ExtensionOutputPanel: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(MuxyTheme.accent)
-            Button {
-                isPresented = false
-            } label: {
-                Image(systemName: "xmark")
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(MuxyTheme.fgMuted)
         }
         .font(.system(size: UIMetrics.fontFootnote))
         .padding(.horizontal, 10)
@@ -110,7 +95,7 @@ struct ExtensionOutputPanel: View {
                 proxy.scrollTo(newCount - 1, anchor: .bottom)
             }
         }
-        .frame(maxHeight: 220)
+        .frame(maxHeight: .infinity)
     }
 
     private var effectiveExtensionID: String? {

--- a/Muxy/Views/Extensions/ExtensionWebBridge.swift
+++ b/Muxy/Views/Extensions/ExtensionWebBridge.swift
@@ -96,6 +96,11 @@ enum ExtensionWebBridge {
                     list() { return send('projects.list', {}); },
                     switchTo(identifier) { return send('projects.switch', { identifier: String(identifier) }); },
                 },
+                panels: {
+                    open(panel, data) { return send('panel.open', { panel: String(panel), data: data ?? null }); },
+                    toggle(panel, data) { return send('panel.toggle', { panel: String(panel), data: data ?? null }); },
+                    close(panel) { return send('panel.close', { panel: String(panel) }); },
+                },
                 exec(argvOrOptions, maybeOptions) {
                     let payload;
                     if (Array.isArray(argvOrOptions)) {
@@ -158,6 +163,7 @@ enum ExtensionWebBridge {
             Object.freeze(muxy.tabs);
             Object.freeze(muxy.panes);
             Object.freeze(muxy.projects);
+            Object.freeze(muxy.panels);
             Object.freeze(muxy.worktrees);
             Object.freeze(muxy.events);
             Object.freeze(muxy);

--- a/Muxy/Views/Extensions/ExtensionWebView.swift
+++ b/Muxy/Views/Extensions/ExtensionWebView.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+import WebKit
+
+struct ExtensionWebView: NSViewRepresentable {
+    let extensionID: String
+    let instanceID: String
+    let entryURL: URL
+    let initialData: ExtensionJSON?
+    let appState: AppState
+    let projectStore: ProjectStore?
+    let worktreeStore: WorktreeStore?
+    let onFocus: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onFocus: onFocus)
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        guard let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID) else {
+            return WKWebView(frame: .zero)
+        }
+
+        let config = WKWebViewConfiguration()
+        config.setURLSchemeHandler(
+            ExtensionAssetSchemeHandler(extensionID: muxyExtension.id, directory: muxyExtension.directory),
+            forURLScheme: ExtensionAssetSchemeHandler.scheme
+        )
+
+        let bridge = ExtensionBridgeHandler(
+            extensionID: muxyExtension.id,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        )
+        context.coordinator.bridge = bridge
+
+        let userContent = config.userContentController
+        userContent.addScriptMessageHandler(
+            bridge,
+            contentWorld: .page,
+            name: ExtensionWebBridge.messageHandlerName
+        )
+        let console = ExtensionConsoleHandler(extensionID: muxyExtension.id)
+        userContent.add(console, name: ExtensionConsoleHandler.messageHandlerName)
+        context.coordinator.consoleHandler = console
+
+        context.coordinator.configureScriptInjection(
+            extensionID: muxyExtension.id,
+            tabInstanceID: instanceID,
+            initialData: initialData
+        )
+        context.coordinator.installBridgeScript(into: userContent)
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+        webView.setValue(false, forKey: "drawsBackground")
+        webView.load(URLRequest(url: entryURL))
+        bridge.attach(to: webView)
+        context.coordinator.observeThemeChanges(for: webView)
+        return webView
+    }
+
+    func updateNSView(_: WKWebView, context _: Context) {}
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.stopObservingThemeChanges()
+        coordinator.bridge?.dropAllEventSubscriptions()
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        webView.configuration.userContentController.removeAllScriptMessageHandlers()
+        webView.configuration.userContentController.removeAllUserScripts()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+        var bridge: ExtensionBridgeHandler?
+        var consoleHandler: ExtensionConsoleHandler?
+        let onFocus: () -> Void
+        private weak var webView: WKWebView?
+        private weak var userContent: WKUserContentController?
+        private var themeObserver: NSObjectProtocol?
+        private var extensionID: String = ""
+        private var tabInstanceID: String = ""
+        private var initialData: ExtensionJSON?
+
+        init(onFocus: @escaping () -> Void) {
+            self.onFocus = onFocus
+        }
+
+        func configureScriptInjection(
+            extensionID: String,
+            tabInstanceID: String,
+            initialData: ExtensionJSON?
+        ) {
+            self.extensionID = extensionID
+            self.tabInstanceID = tabInstanceID
+            self.initialData = initialData
+        }
+
+        func installBridgeScript(into userContent: WKUserContentController) {
+            self.userContent = userContent
+            reinstallBridgeScript()
+        }
+
+        private func reinstallBridgeScript() {
+            guard let userContent else { return }
+            userContent.removeAllUserScripts()
+            userContent.addUserScript(WKUserScript(
+                source: ExtensionWebBridge.script(
+                    extensionID: extensionID,
+                    tabInstanceID: tabInstanceID,
+                    data: initialData,
+                    theme: ExtensionThemeSnapshot.current()
+                ),
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            ))
+        }
+
+        func observeThemeChanges(for webView: WKWebView) {
+            self.webView = webView
+            themeObserver = NotificationCenter.default.addObserver(
+                forName: .themeDidChange,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.pushThemeUpdate()
+                }
+            }
+        }
+
+        func stopObservingThemeChanges() {
+            if let observer = themeObserver {
+                NotificationCenter.default.removeObserver(observer)
+                themeObserver = nil
+            }
+        }
+
+        private func pushThemeUpdate() {
+            guard let webView else { return }
+            let theme = ExtensionThemeSnapshot.current()
+            let script = ExtensionWebBridge.themeUpdateScript(theme: theme)
+            webView.evaluateJavaScript(script, completionHandler: nil)
+        }
+
+        func webView(
+            _: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard let url = navigationAction.request.url else {
+                decisionHandler(.allow)
+                return
+            }
+            if url.scheme == ExtensionAssetSchemeHandler.scheme {
+                decisionHandler(.allow)
+                return
+            }
+            if url.scheme == "about" {
+                decisionHandler(.allow)
+                return
+            }
+            decisionHandler(.cancel)
+        }
+
+        func webView(
+            _: WKWebView,
+            createWebViewWith _: WKWebViewConfiguration,
+            for _: WKNavigationAction,
+            windowFeatures _: WKWindowFeatures
+        ) -> WKWebView? {
+            nil
+        }
+
+        func webView(_: WKWebView, didCommit _: WKNavigation!) {
+            bridge?.dropAllEventSubscriptions()
+        }
+    }
+}
+
+extension ExtensionWebView {
+    static func entryURL(for muxyExtension: MuxyExtension, entry: String) -> URL? {
+        guard muxyExtension.resolveResource(entry) != nil else { return nil }
+        let normalized = entry.hasPrefix("/") ? String(entry.dropFirst()) : entry
+        return URL(string: "\(ExtensionAssetSchemeHandler.scheme)://\(muxyExtension.id)/\(normalized)")
+    }
+}

--- a/Muxy/Views/Extensions/ExtensionWebViewPane.swift
+++ b/Muxy/Views/Extensions/ExtensionWebViewPane.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import WebKit
 
 struct ExtensionWebViewPane: View {
     let state: ExtensionTabState
@@ -14,12 +13,13 @@ struct ExtensionWebViewPane: View {
         Group {
             if let muxyExtension = ExtensionStore.shared.loadedExtension(id: state.extensionID),
                let tabType = muxyExtension.manifest.tabType(id: state.tabTypeID),
-               let entryURL = entryURL(for: muxyExtension, tabType: tabType)
+               let entryURL = ExtensionWebView.entryURL(for: muxyExtension, entry: tabType.entry)
             {
-                ExtensionWebViewRepresentable(
-                    state: state,
-                    extension: muxyExtension,
+                ExtensionWebView(
+                    extensionID: muxyExtension.id,
+                    instanceID: state.id.uuidString,
                     entryURL: entryURL,
+                    initialData: state.initialData,
                     appState: appState,
                     projectStore: projectStore,
                     worktreeStore: worktreeStore,
@@ -47,185 +47,5 @@ struct ExtensionWebViewPane: View {
                 .foregroundStyle(.secondary)
         }
         .padding()
-    }
-
-    private func entryURL(for muxyExtension: MuxyExtension, tabType: ExtensionTabType) -> URL? {
-        guard muxyExtension.resolveResource(tabType.entry) != nil else { return nil }
-        let normalizedEntry = tabType.entry.hasPrefix("/") ? String(tabType.entry.dropFirst()) : tabType.entry
-        return URL(string: "\(ExtensionAssetSchemeHandler.scheme)://\(muxyExtension.id)/\(normalizedEntry)")
-    }
-}
-
-private struct ExtensionWebViewRepresentable: NSViewRepresentable {
-    let state: ExtensionTabState
-    let `extension`: MuxyExtension
-    let entryURL: URL
-    let appState: AppState
-    let projectStore: ProjectStore?
-    let worktreeStore: WorktreeStore?
-    let onFocus: () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(onFocus: onFocus)
-    }
-
-    func makeNSView(context: Context) -> WKWebView {
-        let config = WKWebViewConfiguration()
-        config.setURLSchemeHandler(
-            ExtensionAssetSchemeHandler(extensionID: `extension`.id, directory: `extension`.directory),
-            forURLScheme: ExtensionAssetSchemeHandler.scheme
-        )
-
-        let bridge = ExtensionBridgeHandler(
-            extensionID: `extension`.id,
-            appState: appState,
-            projectStore: projectStore,
-            worktreeStore: worktreeStore
-        )
-        context.coordinator.bridge = bridge
-
-        let userContent = config.userContentController
-        userContent.addScriptMessageHandler(
-            bridge,
-            contentWorld: .page,
-            name: ExtensionWebBridge.messageHandlerName
-        )
-        let console = ExtensionConsoleHandler(extensionID: `extension`.id)
-        userContent.add(console, name: ExtensionConsoleHandler.messageHandlerName)
-        context.coordinator.consoleHandler = console
-
-        context.coordinator.configureScriptInjection(
-            extensionID: `extension`.id,
-            tabInstanceID: state.id.uuidString,
-            initialData: state.initialData
-        )
-        context.coordinator.installBridgeScript(into: userContent)
-
-        let webView = WKWebView(frame: .zero, configuration: config)
-        webView.navigationDelegate = context.coordinator
-        webView.uiDelegate = context.coordinator
-        webView.setValue(false, forKey: "drawsBackground")
-        webView.load(URLRequest(url: entryURL))
-        bridge.attach(to: webView)
-        context.coordinator.observeThemeChanges(for: webView)
-        return webView
-    }
-
-    func updateNSView(_: WKWebView, context _: Context) {}
-
-    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
-        coordinator.stopObservingThemeChanges()
-        coordinator.bridge?.dropAllEventSubscriptions()
-        webView.navigationDelegate = nil
-        webView.uiDelegate = nil
-        webView.configuration.userContentController.removeAllScriptMessageHandlers()
-        webView.configuration.userContentController.removeAllUserScripts()
-    }
-
-    @MainActor
-    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
-        var bridge: ExtensionBridgeHandler?
-        var consoleHandler: ExtensionConsoleHandler?
-        let onFocus: () -> Void
-        private weak var webView: WKWebView?
-        private weak var userContent: WKUserContentController?
-        private var themeObserver: NSObjectProtocol?
-        private var extensionID: String = ""
-        private var tabInstanceID: String = ""
-        private var initialData: ExtensionJSON?
-
-        init(onFocus: @escaping () -> Void) {
-            self.onFocus = onFocus
-        }
-
-        func configureScriptInjection(
-            extensionID: String,
-            tabInstanceID: String,
-            initialData: ExtensionJSON?
-        ) {
-            self.extensionID = extensionID
-            self.tabInstanceID = tabInstanceID
-            self.initialData = initialData
-        }
-
-        func installBridgeScript(into userContent: WKUserContentController) {
-            self.userContent = userContent
-            reinstallBridgeScript()
-        }
-
-        private func reinstallBridgeScript() {
-            guard let userContent else { return }
-            userContent.removeAllUserScripts()
-            userContent.addUserScript(WKUserScript(
-                source: ExtensionWebBridge.script(
-                    extensionID: extensionID,
-                    tabInstanceID: tabInstanceID,
-                    data: initialData,
-                    theme: ExtensionThemeSnapshot.current()
-                ),
-                injectionTime: .atDocumentStart,
-                forMainFrameOnly: true
-            ))
-        }
-
-        func observeThemeChanges(for webView: WKWebView) {
-            self.webView = webView
-            themeObserver = NotificationCenter.default.addObserver(
-                forName: .themeDidChange,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.pushThemeUpdate()
-                }
-            }
-        }
-
-        func stopObservingThemeChanges() {
-            if let observer = themeObserver {
-                NotificationCenter.default.removeObserver(observer)
-                themeObserver = nil
-            }
-        }
-
-        private func pushThemeUpdate() {
-            guard let webView else { return }
-            let theme = ExtensionThemeSnapshot.current()
-            let script = ExtensionWebBridge.themeUpdateScript(theme: theme)
-            webView.evaluateJavaScript(script, completionHandler: nil)
-        }
-
-        func webView(
-            _: WKWebView,
-            decidePolicyFor navigationAction: WKNavigationAction,
-            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
-        ) {
-            guard let url = navigationAction.request.url else {
-                decisionHandler(.allow)
-                return
-            }
-            if url.scheme == ExtensionAssetSchemeHandler.scheme {
-                decisionHandler(.allow)
-                return
-            }
-            if url.scheme == "about" {
-                decisionHandler(.allow)
-                return
-            }
-            decisionHandler(.cancel)
-        }
-
-        func webView(
-            _: WKWebView,
-            createWebViewWith _: WKWebViewConfiguration,
-            for _: WKNavigationAction,
-            windowFeatures _: WKWindowFeatures
-        ) -> WKWebView? {
-            nil
-        }
-
-        func webView(_: WKWebView, didCommit _: WKNavigation!) {
-            bridge?.dropAllEventSubscriptions()
-        }
     }
 }

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -494,6 +494,7 @@ private struct ExtensionDetailPage: View {
                 permissionsBlock
                 if !ext.manifest.commands.isEmpty { commandsBlock }
                 if !ext.manifest.tabTypes.isEmpty { tabTypesBlock }
+                if !ext.manifest.panels.isEmpty { panelsBlock }
                 grantsBlock
                 logsBlock
             }
@@ -618,6 +619,7 @@ private struct ExtensionDetailPage: View {
         switch action {
         case .event: "event"
         case let .openTab(tabType, _): "opens \(tabType)"
+        case let .togglePanel(panel): "toggles \(panel)"
         case let .runScript(script): "runs \(script)"
         }
     }
@@ -632,6 +634,25 @@ private struct ExtensionDetailPage: View {
                             .foregroundStyle(MuxyTheme.fg)
                             .frame(minWidth: 140, alignment: .leading)
                         Text(tabType.title)
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuxyTheme.fgMuted)
+                    }
+                    .padding(.vertical, 3)
+                }
+            }
+        }
+    }
+
+    private var panelsBlock: some View {
+        DetailSection(title: "Panels") {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(ext.manifest.panels) { panel in
+                    HStack(spacing: 8) {
+                        Text(panel.id)
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundStyle(MuxyTheme.fg)
+                            .frame(minWidth: 140, alignment: .leading)
+                        Text("\(panel.position.displayName) · \(panel.mode.rawValue)")
                             .font(.system(size: 11))
                             .foregroundStyle(MuxyTheme.fgMuted)
                     }

--- a/Muxy/Views/MainWindow+Panels.swift
+++ b/Muxy/Views/MainWindow+Panels.swift
@@ -8,46 +8,53 @@ enum BuiltinPanel {
 }
 
 enum PanelLayoutMetrics {
+    static let vcsWidthRange: ClosedRange<CGFloat> = 200 ... 800
+    static let vcsDefaultWidth: Double = 400
+
+    static let fileTreeWidthRange: ClosedRange<CGFloat> = 180 ... 600
+    static let fileTreeDefaultWidth: Double = 260
+
+    static let richInputWidthRange: ClosedRange<CGFloat> = 280 ... 800
+    static let richInputDefaultWidth: Double = 380
+    static let richInputHeightRange: ClosedRange<CGFloat> = 120 ... 600
+    static let richInputDefaultHeight: Double = 220
+
+    static let consoleHeightRange: ClosedRange<CGFloat> = 120 ... 600
+    static let consoleDefaultHeight: Double = 220
+
     static let extensionWidthRange: ClosedRange<CGFloat> = 240 ... 800
-    static let extensionHeightRange: ClosedRange<CGFloat> = 160 ... 600
     static let extensionDefaultWidth: Double = 360
+    static let extensionHeightRange: ClosedRange<CGFloat> = 160 ... 600
     static let extensionDefaultHeight: Double = 240
 }
 
 struct PanelFrame: ViewModifier {
     let position: PanelPosition
-    let width: Binding<Double>
-    let height: Binding<Double>
-    let widthRange: ClosedRange<CGFloat>
-    let heightRange: ClosedRange<CGFloat>
+    let size: Binding<Double>
+    let range: ClosedRange<CGFloat>
 
     func body(content: Content) -> some View {
         switch position {
         case .right:
             HStack(spacing: 0) {
-                handle(axis: .horizontal, edge: .leading, value: width, range: widthRange)
-                content.frame(width: CGFloat(width.wrappedValue))
+                handle(axis: .horizontal, edge: .leading)
+                content.frame(width: CGFloat(size.wrappedValue))
             }
         case .bottom:
             VStack(spacing: 0) {
-                handle(axis: .vertical, edge: .top, value: height, range: heightRange)
-                content.frame(height: CGFloat(height.wrappedValue))
+                handle(axis: .vertical, edge: .top)
+                content.frame(height: CGFloat(size.wrappedValue))
             }
         }
     }
 
-    private func handle(
-        axis: ResizeHandle.Axis,
-        edge: PanelResizeHandle.Edge,
-        value: Binding<Double>,
-        range: ClosedRange<CGFloat>
-    ) -> some View {
+    private func handle(axis: ResizeHandle.Axis, edge: PanelResizeHandle.Edge) -> some View {
         PanelResizeHandle(
             axis: axis,
             edge: edge,
-            current: { CGFloat(value.wrappedValue) },
+            current: { CGFloat(size.wrappedValue) },
             apply: { next in
-                value.wrappedValue = Double(min(range.upperBound, max(range.lowerBound, next)))
+                size.wrappedValue = Double(min(range.upperBound, max(range.lowerBound, next)))
             }
         )
     }

--- a/Muxy/Views/MainWindow+Panels.swift
+++ b/Muxy/Views/MainWindow+Panels.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+enum BuiltinPanel {
+    static let vcs = "builtin:vcs"
+    static let fileTree = "builtin:fileTree"
+    static let richInput = "builtin:richInput"
+    static let extensionConsole = "builtin:extensionConsole"
+}
+
+enum PanelLayoutMetrics {
+    static let extensionWidthRange: ClosedRange<CGFloat> = 240 ... 800
+    static let extensionHeightRange: ClosedRange<CGFloat> = 160 ... 600
+    static let extensionDefaultWidth: Double = 360
+    static let extensionDefaultHeight: Double = 240
+}
+
+struct PanelFrame: ViewModifier {
+    let position: PanelPosition
+    let width: Binding<Double>
+    let height: Binding<Double>
+    let widthRange: ClosedRange<CGFloat>
+    let heightRange: ClosedRange<CGFloat>
+
+    func body(content: Content) -> some View {
+        switch position {
+        case .right:
+            HStack(spacing: 0) {
+                handle(axis: .horizontal, edge: .leading, value: width, range: widthRange)
+                content.frame(width: CGFloat(width.wrappedValue))
+            }
+        case .bottom:
+            VStack(spacing: 0) {
+                handle(axis: .vertical, edge: .top, value: height, range: heightRange)
+                content.frame(height: CGFloat(height.wrappedValue))
+            }
+        }
+    }
+
+    private func handle(
+        axis: ResizeHandle.Axis,
+        edge: PanelResizeHandle.Edge,
+        value: Binding<Double>,
+        range: ClosedRange<CGFloat>
+    ) -> some View {
+        PanelResizeHandle(
+            axis: axis,
+            edge: edge,
+            current: { CGFloat(value.wrappedValue) },
+            apply: { next in
+                value.wrappedValue = Double(min(range.upperBound, max(range.lowerBound, next)))
+            }
+        )
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -54,11 +54,6 @@ struct MainWindow: View {
         static let maxHeight: CGFloat = 600
     }
 
-    private enum SidePanelKind {
-        case vcs
-        case fileTree
-    }
-
     private enum CloseConfirmationKind {
         case lastTab
         case unsavedEditor
@@ -92,15 +87,14 @@ struct MainWindow: View {
         }
     }
 
-    @State private var vcsPanelVisible = false
-    @State private var vcsPanelWidth: CGFloat = AttachedVCSLayout.defaultWidth
-    @State private var fileTreePanelVisible = false
+    @State var panelHost = PanelHost.shared
+    @State private var vcsPanelWidth: Double = .init(AttachedVCSLayout.defaultWidth)
     @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
     @State private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
     @State private var fileTreeLastTerminalPaths: [WorktreeKey: String] = [:]
     @AppStorage(GeneralSettingsKeys.fileTreeSource) private var fileTreeSourceRaw = FileTreeSourcePreference.defaultValue.rawValue
-    @State private var richInputPanelVisible = false
-    @State private var panelToRestoreAfterRichInput: SidePanelKind?
+    @AppStorage("muxy.extensionPanelWidth") private var extensionPanelWidth: Double = PanelLayoutMetrics.extensionDefaultWidth
+    @AppStorage("muxy.extensionPanelHeight") private var extensionPanelHeight: Double = PanelLayoutMetrics.extensionDefaultHeight
     @AppStorage("muxy.richInputPanelWidth") private var richInputPanelWidth: Double = .init(RichInputPanelLayout.defaultWidth)
     @AppStorage("muxy.richInputPanelHeight") private var richInputPanelHeight: Double = .init(RichInputPanelLayout.defaultHeight)
     @AppStorage(RichInputPreferences.fontSizeKey) private var richInputFontSize: Double = RichInputPreferences.defaultFontSize
@@ -118,8 +112,8 @@ struct MainWindow: View {
     @State private var isFullScreen = false
     @AppStorage("muxy.sidebarExpanded") private var sidebarExpanded = false
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
-    @AppStorage("muxy.showExtensionOutput") private var showExtensionOutput = false
     @AppStorage("muxy.extensionOutputSelected") private var extensionOutputSelectedStored = ""
+    @AppStorage("muxy.extensionConsoleHeight") private var extensionConsoleHeight: Double = .init(RichInputPanelLayout.defaultHeight)
     @State private var extensionOutputSelected: String?
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
@@ -409,31 +403,16 @@ struct MainWindow: View {
                     }
                 }
 
-                rightSidePanel
+                pinnedPanelSlot(at: .right)
             }
             .overlay(alignment: .trailing) {
-                floatingRichInputOverlay
+                floatingPanelOverlay(at: .right)
             }
             .overlay(alignment: .bottom) {
-                floatingBottomRichInputOverlay
+                floatingPanelOverlay(at: .bottom)
             }
-            .animation(.easeInOut(duration: 0.2), value: richInputPanelVisible)
 
-            bottomDockedRichInputPanel
-
-            if showExtensionOutput {
-                ExtensionOutputPanel(
-                    isPresented: $showExtensionOutput,
-                    selectedExtensionID: Binding(
-                        get: { extensionOutputSelected ?? (extensionOutputSelectedStored.isEmpty ? nil : extensionOutputSelectedStored) },
-                        set: { newValue in
-                            extensionOutputSelected = newValue
-                            extensionOutputSelectedStored = newValue ?? ""
-                        }
-                    )
-                )
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
+            pinnedPanelSlot(at: .bottom)
 
             if showStatusBar {
                 ProjectStatusBar(
@@ -443,7 +422,7 @@ struct MainWindow: View {
                     isInteractive: activeTerminalPane != nil && !overlayAnimatingOut,
                     richInputVisible: richInputPanelVisible,
                     richInputFontSize: $richInputFontSize,
-                    extensionOutputVisible: $showExtensionOutput,
+                    extensionOutputVisible: extensionConsoleBinding,
                     onTriggerExtensionCommand: { binding in
                         ExtensionStore.shared.triggerCommand(
                             ExtensionStore.CommandInvocation(
@@ -1013,120 +992,235 @@ struct MainWindow: View {
         projectStore.projects.filter { appState.workspaceRoot(for: $0.id) != nil }
     }
 
+    var vcsPanelVisible: Bool { panelHost.isOpen(BuiltinPanel.vcs) }
+    var fileTreePanelVisible: Bool { panelHost.isOpen(BuiltinPanel.fileTree) }
+    var richInputPanelVisible: Bool { panelHost.isOpen(BuiltinPanel.richInput) }
+    var showExtensionOutput: Bool { panelHost.isOpen(BuiltinPanel.extensionConsole) }
+
+    private var extensionConsoleBinding: Binding<Bool> {
+        Binding(
+            get: { panelHost.isOpen(BuiltinPanel.extensionConsole) },
+            set: { _ in panelHost.toggle(BuiltinPanel.extensionConsole, at: .bottom, mode: .floating) }
+        )
+    }
+
     @ViewBuilder
-    private var floatingRichInputOverlay: some View {
-        if isRichInputVisible(floating: true, at: .right) {
-            richInputPanelContent(at: .right)
+    func pinnedPanelSlot(at position: PanelPosition) -> some View {
+        if let panelID = panelHost.pinnedPanel(at: position) {
+            panelContent(for: panelID, position: position, mode: .pinned)
+        }
+    }
+
+    @ViewBuilder
+    func floatingPanelOverlay(at position: PanelPosition) -> some View {
+        if let panelID = panelHost.floatingPanel(at: position) {
+            panelContent(for: panelID, position: position, mode: .floating)
                 .background(MuxyTheme.bg)
-                .transition(.move(edge: .trailing))
         }
     }
 
     @ViewBuilder
-    private var bottomDockedRichInputPanel: some View {
-        if isRichInputVisible(floating: false, at: .bottom) {
-            richInputPanelContent(at: .bottom)
+    private func panelContent(for panelID: String, position: PanelPosition, mode: PanelMode) -> some View {
+        switch panelID {
+        case BuiltinPanel.vcs:
+            vcsPanelBody(position: position)
+        case BuiltinPanel.fileTree:
+            fileTreePanelBody(position: position)
+        case BuiltinPanel.richInput:
+            richInputPanelBody(position: position, mode: mode)
+        case BuiltinPanel.extensionConsole:
+            extensionConsolePanelBody(position: position, mode: mode)
+        default:
+            extensionPanelBody(panelID: panelID, position: position, mode: mode)
         }
     }
 
     @ViewBuilder
-    private var floatingBottomRichInputOverlay: some View {
-        if isRichInputVisible(floating: true, at: .bottom) {
-            richInputPanelContent(at: .bottom)
-                .background(MuxyTheme.bg)
-                .transition(.move(edge: .bottom))
-        }
-    }
-
-    private func isRichInputVisible(floating: Bool, at position: RichInputPanelPosition) -> Bool {
-        richInputPanelVisible
-            && richInputFloating == floating
-            && richInputPosition == position
-            && activeRichInputState != nil
-            && activeWorktreeKey != nil
-    }
-
-    @ViewBuilder
-    private func richInputPanelContent(at position: RichInputPanelPosition) -> some View {
-        if let richInputState = activeRichInputState, let worktreeKey = activeWorktreeKey {
-            let panel = RichInputSidePanel(
-                state: richInputState,
-                worktreeKey: worktreeKey,
-                onDismiss: { closeRichInputPanel() },
-                onSubmit: { appendReturn, selectedText in
-                    submitRichInput(richInputState, appendReturn: appendReturn, selectedText: selectedText)
+    private func vcsPanelBody(position: PanelPosition) -> some View {
+        if VCSDisplayMode.current == .attached, let state = activeVCSState {
+            PanelContainer(
+                chrome: PanelChrome(
+                    iconSymbol: "arrow.triangle.branch",
+                    title: "Source Control",
+                    hiddenControls: [.pin, .position]
+                ),
+                mode: .pinned,
+                position: position,
+                onClose: { panelHost.close(BuiltinPanel.vcs) },
+                onTogglePin: nil,
+                onTogglePosition: nil,
+                content: {
+                    VCSTabView(state: state, focused: false, onFocus: {})
                 }
             )
-            switch position {
-            case .right:
-                HStack(spacing: 0) {
-                    panelResize(
-                        axis: .horizontal,
-                        edge: .leading,
-                        value: $richInputPanelWidth,
-                        range: RichInputPanelLayout.minWidth ... RichInputPanelLayout.maxWidth
-                    )
-                    panel.frame(width: CGFloat(richInputPanelWidth))
-                }
-            case .bottom:
-                VStack(spacing: 0) {
-                    panelResize(
-                        axis: .vertical,
-                        edge: .top,
-                        value: $richInputPanelHeight,
-                        range: RichInputPanelLayout.minHeight ... RichInputPanelLayout.maxHeight
-                    )
-                    panel.frame(height: CGFloat(richInputPanelHeight))
-                }
-            }
+            .modifier(builtinPanelFrame(
+                position: position,
+                width: $vcsPanelWidth,
+                height: $vcsPanelWidth,
+                widthRange: AttachedVCSLayout.minWidth ... AttachedVCSLayout.maxWidth,
+                heightRange: AttachedVCSLayout.minWidth ... AttachedVCSLayout.maxWidth
+            ))
         }
     }
 
     @ViewBuilder
-    private var rightSidePanel: some View {
-        if isRichInputVisible(floating: false, at: .right) {
-            richInputPanelContent(at: .right)
-        } else if vcsPanelVisible, VCSDisplayMode.current == .attached, let state = activeVCSState {
-            HStack(spacing: 0) {
-                panelResize(
-                    axis: .horizontal,
-                    edge: .leading,
-                    value: $vcsPanelWidth,
-                    range: AttachedVCSLayout.minWidth ... AttachedVCSLayout.maxWidth
-                )
-                VCSTabView(state: state, focused: false, onFocus: {})
-                    .frame(width: vcsPanelWidth)
-            }
-        } else if fileTreePanelVisible, let treeState = activeFileTreeState {
-            HStack(spacing: 0) {
-                panelResize(
-                    axis: .horizontal,
-                    edge: .leading,
-                    value: $fileTreePanelWidth,
-                    range: FileTreeLayout.minWidth ... FileTreeLayout.maxWidth
-                )
-                FileTreeView(
-                    state: treeState,
-                    onOpenFile: { filePath in
-                        guard let projectID = appState.activeProjectID else { return }
-                        appState.openFile(filePath, projectID: projectID, preserveFocus: true)
-                    },
-                    onOpenTerminal: { directory in
-                        guard let projectID = appState.activeProjectID else { return }
-                        appState.dispatch(.createTabInDirectory(
-                            projectID: projectID,
-                            areaID: nil,
-                            directory: directory
-                        ))
-                    },
-                    onFileMoved: { oldPath, newPath in
-                        appState.handleFileMoved(from: oldPath, to: newPath)
-                    }
-                )
-                .id(activeFileTreeIdentity)
-                .frame(width: CGFloat(fileTreePanelWidth))
-            }
+    private func fileTreePanelBody(position: PanelPosition) -> some View {
+        if let treeState = activeFileTreeState {
+            PanelContainer(
+                chrome: PanelChrome(
+                    iconSymbol: "folder",
+                    title: "Files",
+                    hiddenControls: [.pin, .position]
+                ),
+                mode: .pinned,
+                position: position,
+                onClose: { toggleFileTreePanel() },
+                onTogglePin: nil,
+                onTogglePosition: nil,
+                content: {
+                    FileTreeView(
+                        state: treeState,
+                        onOpenFile: { filePath in
+                            guard let projectID = appState.activeProjectID else { return }
+                            appState.openFile(filePath, projectID: projectID, preserveFocus: true)
+                        },
+                        onOpenTerminal: { directory in
+                            guard let projectID = appState.activeProjectID else { return }
+                            appState.dispatch(.createTabInDirectory(
+                                projectID: projectID,
+                                areaID: nil,
+                                directory: directory
+                            ))
+                        },
+                        onFileMoved: { oldPath, newPath in
+                            appState.handleFileMoved(from: oldPath, to: newPath)
+                        }
+                    )
+                    .id(activeFileTreeIdentity)
+                }
+            )
+            .modifier(builtinPanelFrame(
+                position: position,
+                width: $fileTreePanelWidth,
+                height: $fileTreePanelWidth,
+                widthRange: FileTreeLayout.minWidth ... FileTreeLayout.maxWidth,
+                heightRange: FileTreeLayout.minWidth ... FileTreeLayout.maxWidth
+            ))
         }
+    }
+
+    @ViewBuilder
+    private func richInputPanelBody(position: PanelPosition, mode: PanelMode) -> some View {
+        if let richInputState = activeRichInputState, let worktreeKey = activeWorktreeKey {
+            PanelContainer(
+                chrome: PanelChrome(
+                    iconSymbol: "keyboard",
+                    title: "Rich Input",
+                    trailingButtons: [richInputBroadcastButton]
+                ),
+                mode: mode,
+                position: position,
+                onClose: { closeRichInputPanel() },
+                onTogglePin: { toggleRichInputFloating() },
+                onTogglePosition: { toggleRichInputPosition() },
+                content: {
+                    RichInputSidePanel(
+                        state: richInputState,
+                        worktreeKey: worktreeKey,
+                        onSubmit: { appendReturn, selectedText in
+                            submitRichInput(richInputState, appendReturn: appendReturn, selectedText: selectedText)
+                        }
+                    )
+                }
+            )
+            .modifier(builtinPanelFrame(
+                position: position,
+                width: $richInputPanelWidth,
+                height: $richInputPanelHeight,
+                widthRange: RichInputPanelLayout.minWidth ... RichInputPanelLayout.maxWidth,
+                heightRange: RichInputPanelLayout.minHeight ... RichInputPanelLayout.maxHeight
+            ))
+        }
+    }
+
+    private func extensionConsolePanelBody(position: PanelPosition, mode: PanelMode) -> some View {
+        PanelContainer(
+            chrome: PanelChrome(
+                iconSymbol: "terminal",
+                title: "Extension Output",
+                hiddenControls: [.pin, .position]
+            ),
+            mode: mode,
+            position: position,
+            onClose: { panelHost.close(BuiltinPanel.extensionConsole) },
+            onTogglePin: nil,
+            onTogglePosition: nil,
+            content: {
+                ExtensionOutputPanel(
+                    selectedExtensionID: Binding(
+                        get: { extensionOutputSelected ?? (extensionOutputSelectedStored.isEmpty ? nil : extensionOutputSelectedStored) },
+                        set: { newValue in
+                            extensionOutputSelected = newValue
+                            extensionOutputSelectedStored = newValue ?? ""
+                        }
+                    )
+                )
+            }
+        )
+        .modifier(builtinPanelFrame(
+            position: position,
+            width: $extensionConsoleHeight,
+            height: $extensionConsoleHeight,
+            widthRange: RichInputPanelLayout.minHeight ... RichInputPanelLayout.maxHeight,
+            heightRange: RichInputPanelLayout.minHeight ... RichInputPanelLayout.maxHeight
+        ))
+    }
+
+    @ViewBuilder
+    private func extensionPanelBody(panelID: String, position: PanelPosition, mode: PanelMode) -> some View {
+        if let state = ExtensionPanelRegistry.shared.state(forHostPanelID: panelID) {
+            ExtensionPanelView(
+                state: state,
+                placement: PanelPlacement(panelID: panelID, position: position, mode: mode)
+            )
+            .modifier(builtinPanelFrame(
+                position: position,
+                width: $extensionPanelWidth,
+                height: $extensionPanelHeight,
+                widthRange: PanelLayoutMetrics.extensionWidthRange,
+                heightRange: PanelLayoutMetrics.extensionHeightRange
+            ))
+        }
+    }
+
+    private func builtinPanelFrame(
+        position: PanelPosition,
+        width: Binding<Double>,
+        height: Binding<Double>,
+        widthRange: ClosedRange<CGFloat>,
+        heightRange: ClosedRange<CGFloat>
+    ) -> PanelFrame {
+        PanelFrame(
+            position: position,
+            width: width,
+            height: height,
+            widthRange: widthRange,
+            heightRange: heightRange
+        )
+    }
+
+    private var richInputBroadcastButton: PanelHeaderButton {
+        PanelHeaderButton(
+            id: "richInput.broadcast",
+            symbol: richInputBroadcast
+                ? "dot.radiowaves.left.and.right"
+                : "antenna.radiowaves.left.and.right.slash",
+            label: richInputBroadcast
+                ? "Broadcast On — Send to All Split Panes"
+                : "Broadcast Off — Send to Active Pane",
+            isActive: richInputBroadcast,
+            action: { richInputBroadcast.toggle() }
+        )
     }
 
     private var sidebarResizeHandle: some View {
@@ -1237,38 +1331,30 @@ struct MainWindow: View {
         guard VCSDisplayMode.current == .attached,
               activeProject != nil
         else {
-            vcsPanelVisible = false
+            panelHost.close(BuiltinPanel.vcs)
             return
         }
-
-        let isShowing = !vcsPanelVisible
-        vcsPanelVisible = isShowing
-        if isShowing {
-            fileTreePanelVisible = false
-            panelToRestoreAfterRichInput = nil
-            closeRichInputPanel()
-        }
+        panelHost.toggle(BuiltinPanel.vcs, at: .right, mode: .pinned)
+        ExtensionPanelRegistry.shared.pruneClosed()
     }
 
     private func toggleFileTreePanel() {
         guard let project = activeProject else {
             if fileTreePanelVisible {
-                fileTreePanelVisible = false
+                panelHost.close(BuiltinPanel.fileTree)
                 NotificationCenter.default.post(name: .refocusActiveTerminal, object: nil)
             }
             return
         }
 
-        ensureFileTreeState(for: project)
-        let isShowing = !fileTreePanelVisible
-        fileTreePanelVisible = isShowing
-        if isShowing {
-            vcsPanelVisible = false
-            panelToRestoreAfterRichInput = nil
-            closeRichInputPanel()
-        } else {
+        if fileTreePanelVisible {
+            panelHost.close(BuiltinPanel.fileTree)
             NotificationCenter.default.post(name: .refocusActiveTerminal, object: nil)
+            return
         }
+        ensureFileTreeState(for: project)
+        panelHost.open(BuiltinPanel.fileTree, at: .right, mode: .pinned)
+        ExtensionPanelRegistry.shared.pruneClosed()
     }
 
     private var activeRichInputState: RichInputState? {
@@ -1296,20 +1382,8 @@ struct MainWindow: View {
     private func toggleRichInputPanel() {
         guard let richInputState = activeRichInputState else { return }
         guard richInputPanelVisible else {
-            if richInputReplacesRightSidePanel {
-                if vcsPanelVisible {
-                    panelToRestoreAfterRichInput = .vcs
-                } else if fileTreePanelVisible {
-                    panelToRestoreAfterRichInput = .fileTree
-                } else {
-                    panelToRestoreAfterRichInput = nil
-                }
-                vcsPanelVisible = false
-                fileTreePanelVisible = false
-            } else {
-                panelToRestoreAfterRichInput = nil
-            }
-            richInputPanelVisible = true
+            panelHost.open(BuiltinPanel.richInput, at: richInputPosition.panelPosition, mode: richInputMode)
+            ExtensionPanelRegistry.shared.pruneClosed()
             richInputState.focusVersion += 1
             return
         }
@@ -1320,29 +1394,26 @@ struct MainWindow: View {
         }
     }
 
-    private var richInputReplacesRightSidePanel: Bool {
-        !richInputFloating && richInputPosition == .right
+    private var richInputMode: PanelMode {
+        richInputFloating ? .floating : .pinned
+    }
+
+    private func toggleRichInputFloating() {
+        richInputFloating.toggle()
+        guard richInputPanelVisible else { return }
+        panelHost.setMode(richInputMode, for: BuiltinPanel.richInput)
+        ExtensionPanelRegistry.shared.pruneClosed()
+    }
+
+    private func toggleRichInputPosition() {
+        richInputPosition = richInputPosition == .right ? .bottom : .right
+        guard richInputPanelVisible else { return }
+        panelHost.move(BuiltinPanel.richInput, to: richInputPosition.panelPosition)
+        ExtensionPanelRegistry.shared.pruneClosed()
     }
 
     private func closeRichInputPanel() {
-        richInputPanelVisible = false
-        let panelToRestore = panelToRestoreAfterRichInput
-        panelToRestoreAfterRichInput = nil
-        switch panelToRestore {
-        case .vcs:
-            if VCSDisplayMode.current == .attached, activeProject != nil {
-                vcsPanelVisible = true
-                return
-            }
-        case .fileTree:
-            if let project = activeProject {
-                ensureFileTreeState(for: project)
-                fileTreePanelVisible = true
-                return
-            }
-        case .none:
-            break
-        }
+        panelHost.close(BuiltinPanel.richInput)
         guard let paneID = activeRichInputPaneID,
               let view = TerminalViewRegistry.shared.existingView(for: paneID)
         else { return }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -33,27 +33,6 @@ struct MainWindow: View {
     @Environment(GhosttyService.self) private var ghostty
     @Environment(\.openWindow) private var openWindow
     @State private var dragCoordinator = TabDragCoordinator()
-    private enum AttachedVCSLayout {
-        static let minWidth: CGFloat = 200
-        static let defaultWidth: CGFloat = 400
-        static let maxWidth: CGFloat = 800
-    }
-
-    private enum FileTreeLayout {
-        static let minWidth: CGFloat = 180
-        static let defaultWidth: CGFloat = 260
-        static let maxWidth: CGFloat = 600
-    }
-
-    private enum RichInputPanelLayout {
-        static let minWidth: CGFloat = 280
-        static let defaultWidth: CGFloat = 380
-        static let maxWidth: CGFloat = 800
-        static let minHeight: CGFloat = 120
-        static let defaultHeight: CGFloat = 220
-        static let maxHeight: CGFloat = 600
-    }
-
     private enum CloseConfirmationKind {
         case lastTab
         case unsavedEditor
@@ -88,18 +67,18 @@ struct MainWindow: View {
     }
 
     @State var panelHost = PanelHost.shared
-    @State private var vcsPanelWidth: Double = .init(AttachedVCSLayout.defaultWidth)
-    @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = .init(FileTreeLayout.defaultWidth)
+    @State private var vcsPanelWidth: Double = PanelLayoutMetrics.vcsDefaultWidth
+    @AppStorage("muxy.fileTreeWidth") private var fileTreePanelWidth: Double = PanelLayoutMetrics.fileTreeDefaultWidth
     @State private var fileTreeStates: [WorktreeKey: FileTreeState] = [:]
     @State private var fileTreeLastTerminalPaths: [WorktreeKey: String] = [:]
     @AppStorage(GeneralSettingsKeys.fileTreeSource) private var fileTreeSourceRaw = FileTreeSourcePreference.defaultValue.rawValue
     @AppStorage("muxy.extensionPanelWidth") private var extensionPanelWidth: Double = PanelLayoutMetrics.extensionDefaultWidth
     @AppStorage("muxy.extensionPanelHeight") private var extensionPanelHeight: Double = PanelLayoutMetrics.extensionDefaultHeight
-    @AppStorage("muxy.richInputPanelWidth") private var richInputPanelWidth: Double = .init(RichInputPanelLayout.defaultWidth)
-    @AppStorage("muxy.richInputPanelHeight") private var richInputPanelHeight: Double = .init(RichInputPanelLayout.defaultHeight)
+    @AppStorage("muxy.richInputPanelWidth") private var richInputPanelWidth: Double = PanelLayoutMetrics.richInputDefaultWidth
+    @AppStorage("muxy.richInputPanelHeight") private var richInputPanelHeight: Double = PanelLayoutMetrics.richInputDefaultHeight
     @AppStorage(RichInputPreferences.fontSizeKey) private var richInputFontSize: Double = RichInputPreferences.defaultFontSize
     @AppStorage(RichInputPreferences.floatingKey) private var richInputFloating = RichInputPreferences.defaultFloating
-    @AppStorage(RichInputPreferences.positionKey) private var richInputPosition: RichInputPanelPosition = RichInputPreferences
+    @AppStorage(RichInputPreferences.positionKey) private var richInputPosition: PanelPosition = RichInputPreferences
         .defaultPosition
     @AppStorage(RichInputPreferences.broadcastKey) private var richInputBroadcast = RichInputPreferences.defaultBroadcast
     @State private var richInputStates: [WorktreeKey: RichInputState] = [:]
@@ -113,7 +92,7 @@ struct MainWindow: View {
     @AppStorage("muxy.sidebarExpanded") private var sidebarExpanded = false
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
     @AppStorage("muxy.extensionOutputSelected") private var extensionOutputSelectedStored = ""
-    @AppStorage("muxy.extensionConsoleHeight") private var extensionConsoleHeight: Double = .init(RichInputPanelLayout.defaultHeight)
+    @AppStorage("muxy.extensionConsoleHeight") private var extensionConsoleHeight: Double = PanelLayoutMetrics.consoleDefaultHeight
     @State private var extensionOutputSelected: String?
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
@@ -1039,26 +1018,20 @@ struct MainWindow: View {
     private func vcsPanelBody(position: PanelPosition) -> some View {
         if VCSDisplayMode.current == .attached, let state = activeVCSState {
             PanelContainer(
-                chrome: PanelChrome(
-                    iconSymbol: "arrow.triangle.branch",
-                    title: "Source Control",
-                    hiddenControls: [.pin, .position]
-                ),
+                chrome: PanelChrome(hiddenControls: [.close, .pin, .position]),
                 mode: .pinned,
                 position: position,
-                onClose: { panelHost.close(BuiltinPanel.vcs) },
+                onClose: nil,
                 onTogglePin: nil,
                 onTogglePosition: nil,
                 content: {
                     VCSTabView(state: state, focused: false, onFocus: {})
                 }
             )
-            .modifier(builtinPanelFrame(
+            .modifier(PanelFrame(
                 position: position,
-                width: $vcsPanelWidth,
-                height: $vcsPanelWidth,
-                widthRange: AttachedVCSLayout.minWidth ... AttachedVCSLayout.maxWidth,
-                heightRange: AttachedVCSLayout.minWidth ... AttachedVCSLayout.maxWidth
+                size: $vcsPanelWidth,
+                range: PanelLayoutMetrics.vcsWidthRange
             ))
         }
     }
@@ -1067,14 +1040,10 @@ struct MainWindow: View {
     private func fileTreePanelBody(position: PanelPosition) -> some View {
         if let treeState = activeFileTreeState {
             PanelContainer(
-                chrome: PanelChrome(
-                    iconSymbol: "folder",
-                    title: "Files",
-                    hiddenControls: [.pin, .position]
-                ),
+                chrome: PanelChrome(hiddenControls: [.close, .pin, .position]),
                 mode: .pinned,
                 position: position,
-                onClose: { toggleFileTreePanel() },
+                onClose: nil,
                 onTogglePin: nil,
                 onTogglePosition: nil,
                 content: {
@@ -1099,12 +1068,10 @@ struct MainWindow: View {
                     .id(activeFileTreeIdentity)
                 }
             )
-            .modifier(builtinPanelFrame(
+            .modifier(PanelFrame(
                 position: position,
-                width: $fileTreePanelWidth,
-                height: $fileTreePanelWidth,
-                widthRange: FileTreeLayout.minWidth ... FileTreeLayout.maxWidth,
-                heightRange: FileTreeLayout.minWidth ... FileTreeLayout.maxWidth
+                size: $fileTreePanelWidth,
+                range: PanelLayoutMetrics.fileTreeWidthRange
             ))
         }
     }
@@ -1133,12 +1100,12 @@ struct MainWindow: View {
                     )
                 }
             )
-            .modifier(builtinPanelFrame(
+            .modifier(PanelFrame(
                 position: position,
-                width: $richInputPanelWidth,
-                height: $richInputPanelHeight,
-                widthRange: RichInputPanelLayout.minWidth ... RichInputPanelLayout.maxWidth,
-                heightRange: RichInputPanelLayout.minHeight ... RichInputPanelLayout.maxHeight
+                size: position == .bottom ? $richInputPanelHeight : $richInputPanelWidth,
+                range: position == .bottom
+                    ? PanelLayoutMetrics.richInputHeightRange
+                    : PanelLayoutMetrics.richInputWidthRange
             ))
         }
     }
@@ -1167,12 +1134,10 @@ struct MainWindow: View {
                 )
             }
         )
-        .modifier(builtinPanelFrame(
+        .modifier(PanelFrame(
             position: position,
-            width: $extensionConsoleHeight,
-            height: $extensionConsoleHeight,
-            widthRange: RichInputPanelLayout.minHeight ... RichInputPanelLayout.maxHeight,
-            heightRange: RichInputPanelLayout.minHeight ... RichInputPanelLayout.maxHeight
+            size: $extensionConsoleHeight,
+            range: PanelLayoutMetrics.consoleHeightRange
         ))
     }
 
@@ -1183,30 +1148,14 @@ struct MainWindow: View {
                 state: state,
                 placement: PanelPlacement(panelID: panelID, position: position, mode: mode)
             )
-            .modifier(builtinPanelFrame(
+            .modifier(PanelFrame(
                 position: position,
-                width: $extensionPanelWidth,
-                height: $extensionPanelHeight,
-                widthRange: PanelLayoutMetrics.extensionWidthRange,
-                heightRange: PanelLayoutMetrics.extensionHeightRange
+                size: position == .bottom ? $extensionPanelHeight : $extensionPanelWidth,
+                range: position == .bottom
+                    ? PanelLayoutMetrics.extensionHeightRange
+                    : PanelLayoutMetrics.extensionWidthRange
             ))
         }
-    }
-
-    private func builtinPanelFrame(
-        position: PanelPosition,
-        width: Binding<Double>,
-        height: Binding<Double>,
-        widthRange: ClosedRange<CGFloat>,
-        heightRange: ClosedRange<CGFloat>
-    ) -> PanelFrame {
-        PanelFrame(
-            position: position,
-            width: width,
-            height: height,
-            widthRange: widthRange,
-            heightRange: heightRange
-        )
     }
 
     private var richInputBroadcastButton: PanelHeaderButton {
@@ -1382,7 +1331,7 @@ struct MainWindow: View {
     private func toggleRichInputPanel() {
         guard let richInputState = activeRichInputState else { return }
         guard richInputPanelVisible else {
-            panelHost.open(BuiltinPanel.richInput, at: richInputPosition.panelPosition, mode: richInputMode)
+            panelHost.open(BuiltinPanel.richInput, at: richInputPosition, mode: richInputMode)
             ExtensionPanelRegistry.shared.pruneClosed()
             richInputState.focusVersion += 1
             return
@@ -1406,9 +1355,9 @@ struct MainWindow: View {
     }
 
     private func toggleRichInputPosition() {
-        richInputPosition = richInputPosition == .right ? .bottom : .right
+        richInputPosition = richInputPosition.opposite
         guard richInputPanelVisible else { return }
-        panelHost.move(BuiltinPanel.richInput, to: richInputPosition.panelPosition)
+        panelHost.move(BuiltinPanel.richInput, to: richInputPosition)
         ExtensionPanelRegistry.shared.pruneClosed()
     }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1284,7 +1284,6 @@ struct MainWindow: View {
             return
         }
         panelHost.toggle(BuiltinPanel.vcs, at: .right, mode: .pinned)
-        ExtensionPanelRegistry.shared.pruneClosed()
     }
 
     private func toggleFileTreePanel() {
@@ -1303,7 +1302,6 @@ struct MainWindow: View {
         }
         ensureFileTreeState(for: project)
         panelHost.open(BuiltinPanel.fileTree, at: .right, mode: .pinned)
-        ExtensionPanelRegistry.shared.pruneClosed()
     }
 
     private var activeRichInputState: RichInputState? {
@@ -1332,7 +1330,6 @@ struct MainWindow: View {
         guard let richInputState = activeRichInputState else { return }
         guard richInputPanelVisible else {
             panelHost.open(BuiltinPanel.richInput, at: richInputPosition, mode: richInputMode)
-            ExtensionPanelRegistry.shared.pruneClosed()
             richInputState.focusVersion += 1
             return
         }
@@ -1351,14 +1348,12 @@ struct MainWindow: View {
         richInputFloating.toggle()
         guard richInputPanelVisible else { return }
         panelHost.setMode(richInputMode, for: BuiltinPanel.richInput)
-        ExtensionPanelRegistry.shared.pruneClosed()
     }
 
     private func toggleRichInputPosition() {
         richInputPosition = richInputPosition.opposite
         guard richInputPanelVisible else { return }
         panelHost.move(BuiltinPanel.richInput, to: richInputPosition)
-        ExtensionPanelRegistry.shared.pruneClosed()
     }
 
     private func closeRichInputPanel() {

--- a/Muxy/Views/Panels/ExtensionPanelView.swift
+++ b/Muxy/Views/Panels/ExtensionPanelView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct ExtensionPanelView: View {
+    let state: ExtensionPanelState
+    let placement: PanelPlacement
+
+    @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
+
+    var body: some View {
+        if let muxyExtension = ExtensionStore.shared.loadedExtension(id: state.extensionID),
+           let panel = muxyExtension.manifest.panel(id: state.panelID),
+           let entryURL = ExtensionWebView.entryURL(for: muxyExtension, entry: panel.entry)
+        {
+            PanelContainer(
+                chrome: chrome(for: panel),
+                mode: placement.mode,
+                position: placement.position,
+                onClose: { ExtensionPanelRegistry.shared.close(hostPanelID: state.hostPanelID) },
+                onTogglePin: { togglePin() },
+                onTogglePosition: { togglePosition() },
+                content: {
+                    ExtensionWebView(
+                        extensionID: muxyExtension.id,
+                        instanceID: state.id.uuidString,
+                        entryURL: entryURL,
+                        initialData: state.initialData,
+                        appState: appState,
+                        projectStore: projectStore,
+                        worktreeStore: worktreeStore,
+                        onFocus: {}
+                    )
+                }
+            )
+        }
+    }
+
+    private func chrome(for panel: ExtensionPanel) -> PanelChrome {
+        PanelChrome(
+            iconSymbol: panel.icon.flatMap(symbol(from:)),
+            title: panel.title,
+            hiddenControls: Set(panel.hiddenControls)
+        )
+    }
+
+    private func symbol(from icon: ExtensionIcon) -> String? {
+        guard case let .symbol(name) = icon else { return nil }
+        return name
+    }
+
+    private func togglePin() {
+        let nextMode: PanelMode = placement.mode == .pinned ? .floating : .pinned
+        ExtensionPanelRegistry.shared.setMode(nextMode, forHostPanelID: state.hostPanelID)
+    }
+
+    private func togglePosition() {
+        ExtensionPanelRegistry.shared.move(placement.position.opposite, forHostPanelID: state.hostPanelID)
+    }
+}

--- a/Muxy/Views/Panels/PanelContainer.swift
+++ b/Muxy/Views/Panels/PanelContainer.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct PanelContainer<Content: View>: View {
+    let chrome: PanelChrome
+    let mode: PanelMode
+    let position: PanelPosition
+    let onClose: (() -> Void)?
+    let onTogglePin: (() -> Void)?
+    let onTogglePosition: (() -> Void)?
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if chrome.hasHeaderContent {
+                header
+                Rectangle().fill(MuxyTheme.border).frame(height: 1)
+            }
+            content()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(MuxyTheme.bg)
+    }
+
+    private var header: some View {
+        HStack(spacing: UIMetrics.spacing2) {
+            if let symbol = chrome.iconSymbol {
+                Image(systemName: symbol)
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+            }
+            if let title = chrome.title {
+                Text(title)
+                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .lineLimit(1)
+            }
+            ForEach(chrome.leadingButtons) { button in
+                customButton(button)
+            }
+            Spacer(minLength: UIMetrics.spacing2)
+            HStack(spacing: 0) {
+                ForEach(chrome.trailingButtons) { button in
+                    customButton(button)
+                }
+                if chrome.shows(.position), let onTogglePosition {
+                    control(
+                        symbol: positionSymbol,
+                        label: positionLabel,
+                        action: onTogglePosition
+                    )
+                }
+                if chrome.shows(.pin), let onTogglePin {
+                    control(
+                        symbol: mode == .floating ? "pin" : "pin.slash",
+                        label: mode == .floating ? "Dock Panel" : "Float Panel",
+                        action: onTogglePin
+                    )
+                }
+                if chrome.shows(.close), let onClose {
+                    control(symbol: "xmark", label: "Close", action: onClose)
+                }
+            }
+        }
+        .padding(.leading, UIMetrics.spacing4)
+        .padding(.trailing, UIMetrics.spacing2)
+        .frame(height: UIMetrics.scaled(32))
+        .background(MuxyTheme.bg)
+    }
+
+    private func customButton(_ button: PanelHeaderButton) -> some View {
+        IconButton(
+            symbol: button.symbol,
+            color: button.isActive ? MuxyTheme.accent : MuxyTheme.fgMuted,
+            hoverColor: button.isActive ? MuxyTheme.accent : MuxyTheme.fg,
+            accessibilityLabel: button.label,
+            action: button.action
+        )
+        .help(button.label)
+    }
+
+    private func control(symbol: String, label: String, action: @escaping () -> Void) -> some View {
+        IconButton(symbol: symbol, accessibilityLabel: label, action: action)
+            .help(label)
+    }
+
+    private var positionSymbol: String {
+        switch position {
+        case .right: "rectangle.bottomhalf.inset.filled"
+        case .bottom: "rectangle.righthalf.inset.filled"
+        }
+    }
+
+    private var positionLabel: String {
+        "Move to \(position.opposite.displayName)"
+    }
+}

--- a/Muxy/Views/Panels/PanelContainer.swift
+++ b/Muxy/Views/Panels/PanelContainer.swift
@@ -34,9 +34,6 @@ struct PanelContainer<Content: View>: View {
                     .foregroundStyle(MuxyTheme.fg)
                     .lineLimit(1)
             }
-            ForEach(chrome.leadingButtons) { button in
-                customButton(button)
-            }
             Spacer(minLength: UIMetrics.spacing2)
             HStack(spacing: 0) {
                 ForEach(chrome.trailingButtons) { button in

--- a/Muxy/Views/Settings/EditorSettingsView.swift
+++ b/Muxy/Views/Settings/EditorSettingsView.swift
@@ -6,7 +6,7 @@ struct EditorSettingsView: View {
     @State private var markdownFonts: [String] = []
     @State private var allowMarkdownRemoteImages = MarkdownPreviewPreferences.allowRemoteImages
     @AppStorage(RichInputPreferences.floatingKey) private var richInputFloating = RichInputPreferences.defaultFloating
-    @AppStorage(RichInputPreferences.positionKey) private var richInputPosition: RichInputPanelPosition = RichInputPreferences
+    @AppStorage(RichInputPreferences.positionKey) private var richInputPosition: PanelPosition = RichInputPreferences
         .defaultPosition
 
     private var showsAppearanceSection: Bool { settings.defaultEditor == .builtIn }
@@ -139,7 +139,7 @@ struct EditorSettingsView: View {
 
             SettingsRow("Position") {
                 Picker("", selection: $richInputPosition) {
-                    ForEach(RichInputPanelPosition.allCases) { position in
+                    ForEach(PanelPosition.allCases) { position in
                         Text(position.displayName).tag(position)
                     }
                 }

--- a/Muxy/Views/Terminal/RichInputSidePanel.swift
+++ b/Muxy/Views/Terminal/RichInputSidePanel.swift
@@ -5,20 +5,13 @@ import UniformTypeIdentifiers
 struct RichInputSidePanel: View {
     @Bindable var state: RichInputState
     let worktreeKey: WorktreeKey
-    let onDismiss: () -> Void
     let onSubmit: (_ appendReturn: Bool, _ selectedText: String?) -> Void
 
     @State private var editorSettings = EditorSettings.shared
     @AppStorage(RichInputPreferences.fontSizeKey) private var fontSize: Double = RichInputPreferences.defaultFontSize
-    @AppStorage(RichInputPreferences.positionKey) private var position: RichInputPanelPosition = RichInputPreferences
-        .defaultPosition
-    @AppStorage(RichInputPreferences.floatingKey) private var floating: Bool = RichInputPreferences.defaultFloating
-    @AppStorage(RichInputPreferences.broadcastKey) private var broadcast: Bool = RichInputPreferences.defaultBroadcast
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-            Rectangle().fill(MuxyTheme.border).frame(height: 1)
             MarkdownTextEditor(
                 text: $state.text,
                 focusVersion: state.focusVersion,
@@ -102,92 +95,6 @@ struct RichInputSidePanel: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
             .allowsHitTesting(false)
-    }
-
-    private var header: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "keyboard")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(MuxyTheme.fgMuted)
-            Text("Rich Input")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(MuxyTheme.fg)
-            Spacer(minLength: 8)
-            Button(action: toggleBroadcast) {
-                Image(systemName: broadcastToggleIcon)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(broadcast ? MuxyTheme.accent : MuxyTheme.fgMuted)
-            }
-            .buttonStyle(RichInputToolbarButtonStyle())
-            .accessibilityLabel(broadcastToggleLabel)
-            .help(broadcastToggleLabel)
-            Button(action: toggleFloating) {
-                Image(systemName: pinToggleIcon)
-                    .font(.system(size: 11, weight: .semibold))
-            }
-            .buttonStyle(RichInputToolbarButtonStyle())
-            .accessibilityLabel(pinToggleLabel)
-            .help(pinToggleLabel)
-            Button(action: togglePosition) {
-                Image(systemName: positionToggleIcon)
-                    .font(.system(size: 11, weight: .semibold))
-            }
-            .buttonStyle(RichInputToolbarButtonStyle())
-            .accessibilityLabel(positionToggleLabel)
-            .help(positionToggleLabel)
-            Button(action: onDismiss) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
-            }
-            .buttonStyle(RichInputToolbarButtonStyle())
-            .accessibilityLabel("Close Rich Input")
-            .help("Close Rich Input")
-        }
-        .padding(.horizontal, 10)
-        .frame(height: 32)
-        .background(MuxyTheme.bg)
-    }
-
-    private var positionToggleIcon: String {
-        switch position {
-        case .right: "rectangle.bottomhalf.inset.filled"
-        case .bottom: "rectangle.righthalf.inset.filled"
-        }
-    }
-
-    private var positionToggleLabel: String {
-        switch position {
-        case .right: "Move to Bottom"
-        case .bottom: "Move to Right"
-        }
-    }
-
-    private func togglePosition() {
-        position = position == .right ? .bottom : .right
-    }
-
-    private var pinToggleIcon: String {
-        floating ? "pin" : "pin.slash"
-    }
-
-    private var pinToggleLabel: String {
-        floating ? "Dock Panel" : "Float Panel"
-    }
-
-    private func toggleFloating() {
-        floating.toggle()
-    }
-
-    private var broadcastToggleIcon: String {
-        broadcast ? "dot.radiowaves.left.and.right" : "antenna.radiowaves.left.and.right.slash"
-    }
-
-    private var broadcastToggleLabel: String {
-        broadcast ? "Broadcast On — Send to All Split Panes" : "Broadcast Off — Send to Active Pane"
-    }
-
-    private func toggleBroadcast() {
-        broadcast.toggle()
     }
 
     private func increaseFontSize() {

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -349,6 +349,116 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("decodes panels with defaults and explicit values")
+    func decodesPanels() throws {
+        let json = #"""
+        {
+            "name": "panel-ext",
+            "version": "1.0.0",
+            "panels": [
+                { "id": "minimal", "entry": "panels/a.html" },
+                {
+                    "id": "full",
+                    "title": "Sidebar",
+                    "icon": "sidebar.left",
+                    "entry": "panels/b.html",
+                    "position": "bottom",
+                    "mode": "pinned",
+                    "hiddenControls": ["pin", "position"]
+                }
+            ]
+        }
+        """#
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+        #expect(manifest.panels.count == 2)
+        let minimal = try #require(manifest.panel(id: "minimal"))
+        #expect(minimal.position == .right)
+        #expect(minimal.mode == .floating)
+        #expect(minimal.hiddenControls.isEmpty)
+        let full = try #require(manifest.panel(id: "full"))
+        #expect(full.title == "Sidebar")
+        #expect(full.position == .bottom)
+        #expect(full.mode == .pinned)
+        #expect(full.hiddenControls == [.pin, .position])
+    }
+
+    @Test("loads an extension declaring a valid panel")
+    func loadsPanel() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-ok",
+                "version": "1.0.0",
+                "panels": [ { "id": "side", "entry": "panels/side.html" } ]
+            }
+            """,
+            files: ["panels/side.html": "<html></html>"],
+            makeEntrypointExecutable: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let ext = try ExtensionManifestLoader.load(from: directory)
+        #expect(ext.manifest.panel(id: "side") != nil)
+    }
+
+    @Test("rejects a panel whose entry is missing")
+    func rejectsPanelMissingEntry() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-missing",
+                "version": "1.0.0",
+                "panels": [ { "id": "side", "entry": "panels/side.html" } ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects duplicate panel ids")
+    func rejectsDuplicatePanels() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-dup",
+                "version": "1.0.0",
+                "panels": [
+                    { "id": "side", "entry": "panels/side.html" },
+                    { "id": "side", "entry": "panels/side.html" }
+                ]
+            }
+            """,
+            files: ["panels/side.html": "<html></html>"],
+            makeEntrypointExecutable: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects command referencing an unknown panel")
+    func rejectsCommandUnknownPanel() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-cmd-bad",
+                "version": "1.0.0",
+                "commands": [
+                    { "id": "show", "title": "Show", "action": { "kind": "togglePanel", "panel": "ghost" } }
+                ]
+            }
+            """,
+            makeEntrypointExecutable: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     @Test("rejects empty topbar item id")
     func rejectsEmptyTopbarID() throws {
         let directory = try makeTemporaryExtension(

--- a/Tests/MuxyTests/Services/PanelHostTests.swift
+++ b/Tests/MuxyTests/Services/PanelHostTests.swift
@@ -84,4 +84,20 @@ struct PanelHostTests {
         #expect(host.placement(for: "b")?.position == .right)
         #expect(!host.isOpen("a"))
     }
+
+    @Test("opening over an occupied slot reports the displaced panel")
+    func displaceNotifiesEvictedPanel() {
+        let host = makeHost()
+        let previous = host.onDisplace
+        defer { host.onDisplace = previous }
+        var displaced: [String] = []
+        host.onDisplace = { displaced.append($0) }
+
+        host.open("a", at: .right, mode: .floating)
+        host.open("b", at: .right, mode: .floating)
+        #expect(displaced == ["a"])
+
+        host.move("b", to: .right)
+        #expect(displaced == ["a"])
+    }
 }

--- a/Tests/MuxyTests/Services/PanelHostTests.swift
+++ b/Tests/MuxyTests/Services/PanelHostTests.swift
@@ -1,0 +1,87 @@
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("PanelHost")
+struct PanelHostTests {
+    private func makeHost() -> PanelHost {
+        let host = PanelHost.shared
+        host.closeAll()
+        return host
+    }
+
+    @Test("opening a panel records its placement")
+    func opensPanel() {
+        let host = makeHost()
+        host.open("a", at: .right, mode: .pinned)
+        #expect(host.isOpen("a"))
+        #expect(host.pinnedPanel(at: .right) == "a")
+    }
+
+    @Test("only one pinned panel per position")
+    func onePinnedPerPosition() {
+        let host = makeHost()
+        host.open("a", at: .right, mode: .pinned)
+        host.open("b", at: .right, mode: .pinned)
+        #expect(host.pinnedPanel(at: .right) == "b")
+        #expect(!host.isOpen("a"))
+    }
+
+    @Test("only one floating panel per position")
+    func oneFloatingPerPosition() {
+        let host = makeHost()
+        host.open("a", at: .bottom, mode: .floating)
+        host.open("b", at: .bottom, mode: .floating)
+        #expect(host.floatingPanel(at: .bottom) == "b")
+        #expect(!host.isOpen("a"))
+    }
+
+    @Test("pinned and floating coexist at the same position")
+    func pinnedAndFloatingCoexist() {
+        let host = makeHost()
+        host.open("pinned", at: .right, mode: .pinned)
+        host.open("floating", at: .right, mode: .floating)
+        #expect(host.pinnedPanel(at: .right) == "pinned")
+        #expect(host.floatingPanel(at: .right) == "floating")
+    }
+
+    @Test("a panel opened twice keeps a single placement")
+    func reopenMovesPanel() {
+        let host = makeHost()
+        host.open("a", at: .right, mode: .pinned)
+        host.open("a", at: .bottom, mode: .floating)
+        #expect(host.pinnedPanel(at: .right) == nil)
+        #expect(host.floatingPanel(at: .bottom) == "a")
+        #expect(host.placements.count == 1)
+    }
+
+    @Test("toggle opens then closes the same panel")
+    func toggle() {
+        let host = makeHost()
+        host.toggle("a", at: .right, mode: .pinned)
+        #expect(host.isOpen("a"))
+        host.toggle("a", at: .right, mode: .pinned)
+        #expect(!host.isOpen("a"))
+    }
+
+    @Test("move preserves mode")
+    func movePreservesMode() {
+        let host = makeHost()
+        host.open("a", at: .right, mode: .floating)
+        host.move("a", to: .bottom)
+        #expect(host.placement(for: "a")?.position == .bottom)
+        #expect(host.placement(for: "a")?.mode == .floating)
+    }
+
+    @Test("setMode preserves position and displaces same-mode panel")
+    func setMode() {
+        let host = makeHost()
+        host.open("a", at: .right, mode: .pinned)
+        host.open("b", at: .right, mode: .floating)
+        host.setMode(.pinned, for: "b")
+        #expect(host.placement(for: "b")?.mode == .pinned)
+        #expect(host.placement(for: "b")?.position == .right)
+        #expect(!host.isOpen("a"))
+    }
+}

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -14,6 +14,7 @@ User-installed subprocesses that Muxy launches and talks to over the existing no
 | [Events](events.md) | Identify/subscribe handshake, event list, wire format |
 | [Palette Commands](palette-commands.md) | Register commands and react to triggers |
 | [Tabs](tabs.md) | Register webview tab types and the injected `window.muxy` JS API |
+| [Panels](panels.md) | Register dockable/floating webview panels and the placement rules |
 | [Topbar](topbar.md) | Attach icons to the tab strip that trigger a command |
 | [Status Bar](statusbar.md) | Attach icons to the footer status bar; update text live |
 | [Settings](settings.md) | Declare typed settings and read/write them at runtime |

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -29,6 +29,7 @@ Every extension declares itself in a `manifest.json` at the root of its director
 | `events` | string[] | no | Events the extension is allowed to subscribe to. See [Events](events.md). Defaults to empty. |
 | `commands` | object[] | no | Palette commands to register. See [Palette Commands](palette-commands.md). |
 | `tabTypes` | object[] | no | Webview tab types the extension exposes. See [Tabs](tabs.md). |
+| `panels` | object[] | no | Dockable/floating webview panels the extension exposes. See [Panels](panels.md). |
 | `topbarItems` | object[] | no | Icons to attach to the tab strip. See [Topbar](topbar.md). |
 | `statusBarItems` | object[] | no | Icons to attach to the footer status bar. See [Status Bar](statusbar.md). |
 | `settings` | object[] | no | Typed settings shown in the Settings sidebar. See [Settings](settings.md). |

--- a/docs/extensions/palette-commands.md
+++ b/docs/extensions/palette-commands.md
@@ -30,6 +30,7 @@ Extensions can declare commands that appear in Muxy's command palette. Selecting
 | --- | --- | --- |
 | `event` | Broadcasts `command.<id>` over the socket. Default if `action` is omitted. | — |
 | `openTab` | Opens an extension webview tab of the named type. | `tabType` (required, must reference a declared [tab type](tabs.md)); `data` (optional JSON merged into `window.muxy.data`). |
+| `togglePanel` | Toggles an extension [panel](panels.md) open/closed. | `panel` (required, must reference a declared panel id). |
 | `runScript` | Runs the script in a JavaScriptCore context with the same `muxy.*` API as webview tabs (no DOM). Read the [Scripts](scripts.md) page. Requires `commands:run-script`. | `script` (required, relative path within the extension directory). |
 
 ## How it surfaces

--- a/docs/extensions/panels.md
+++ b/docs/extensions/panels.md
@@ -1,0 +1,79 @@
+# Extension Panels
+
+Panels are dockable or floating webviews that live alongside Muxy's built-in panels (Source Control, Files, Rich Input). They render the same way as [tabs](tabs.md) — each panel is its own `WKWebView` with the injected `window.muxy` API — but instead of a tab they occupy a docked slot or float over the workspace.
+
+All panels in Muxy, built-in and extension, obey the same placement rules:
+
+- At most **one pinned panel per position** (right or bottom). Pinning another panel to a position unpins the current one.
+- At most **one floating panel per position**. Opening a floating panel where one is already floating closes the existing one.
+
+## Declaring a panel
+
+```json
+{
+  "name": "review-tools",
+  "version": "0.1.0",
+  "permissions": ["panels:write"],
+  "panels": [
+    {
+      "id": "review",
+      "title": "Review",
+      "icon": "checklist",
+      "entry": "panels/review.html",
+      "position": "right",
+      "mode": "floating",
+      "hiddenControls": ["position"]
+    }
+  ],
+  "commands": [
+    {
+      "id": "open-review",
+      "title": "Open Review Panel",
+      "action": { "kind": "togglePanel", "panel": "review" }
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Stable per extension. Referenced from commands and from `muxy.panels.*`. |
+| `entry` | string | yes | Path relative to the extension directory. Must resolve inside the directory (no `..` traversal). |
+| `title` | string | no | Shown in the panel header. Omit to hide the title. |
+| `icon` | string \| object | no | SF Symbol name or `{ "svg": "assets/icon.svg" }`. Shown in the panel header. |
+| `position` | string | no | `right` or `bottom`. Defaults to `right`. |
+| `mode` | string | no | `floating` or `pinned`. Defaults to `floating`. |
+| `hiddenControls` | string[] | no | Header controls to hide: any of `close`, `pin`, `position`. Defaults to none hidden. |
+| `defaultData` | object | no | JSON payload merged into `window.muxy.data` when no explicit data is passed. |
+
+The loader validates that `entry` exists inside the extension directory, that panel ids are unique, and that `togglePanel` commands reference a declared panel id.
+
+## Opening and closing
+
+A `togglePanel` command toggles the panel from the palette, a topbar button, or a status bar item.
+
+From a webview (a tab or another panel), the `panels:write` permission unlocks:
+
+```ts
+window.muxy.panels.open(panelID, data?): Promise<void>;
+window.muxy.panels.toggle(panelID, data?): Promise<void>;
+window.muxy.panels.close(panelID): Promise<void>;
+```
+
+From an entrypoint subprocess over the socket:
+
+```
+panel.open|<panelID>[|<json-data>]
+panel.toggle|<panelID>[|<json-data>]
+panel.close|<panelID>
+```
+
+`data` overrides the panel's `defaultData` for that instance and is exposed to the page as `window.muxy.data`.
+
+## Header controls
+
+The panel header is owned by the host. It shows the optional icon and title on the left, and on the right — unless hidden via `hiddenControls` — a position toggle (right ⇄ bottom), a pin toggle (float ⇄ dock), and a close button. The webview content fills the rest of the panel.
+
+Panels close automatically when the extension is disabled or stopped.

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -30,6 +30,7 @@ flowchart LR
 | `worktrees:read` | `list-worktrees` |
 | `worktrees:write` | `create-worktree`, `switch-worktree`, `refresh-worktrees` |
 | `notifications:write` | Post notifications via `type\|paneID\|title\|body` |
+| `panels:write` | `panel.open`, `panel.toggle`, `panel.close` — open and close the extension's declared [panels](panels.md). |
 | `commands:run-script` | Execute `runScript` palette command actions in the per-extension JavaScriptCore context. |
 | `commands:exec` | Run shell commands via `muxy.exec` (subprocess execution with stdout/stderr capture). |
 


### PR DESCRIPTION
Introduces PanelHost as the single source of truth for all panels (VCS, file tree, rich input, extension console)
  with one-pinned/one-floating-per-position rules and a shared PanelContainer chrome. Extensions can now register
  their own dockable/floating webview panels via the manifest (panels:write, panel.open/close/toggle). Migrates the
  built-in panels onto it.