### PR TITLE
feat: add 'Open with default app' in sidebar and terminal context menus

### DIFF
--- a/Muxy/Views/FileTree/FileTreeCommands.swift
+++ b/Muxy/Views/FileTree/FileTreeCommands.swift
@@ -197,6 +197,11 @@ final class FileTreeCommands {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
+    func openWithDefaultApp(_ path: String) {
+        let url = URL(fileURLWithPath: path)
+        NSWorkspace.shared.open(url)
+    }
+
     func openInTerminal(path: String) {
         let dir = resolveDirectoryContext(for: path)
         openTerminal(dir)

--- a/Muxy/Views/FileTree/FileTreeView.swift
+++ b/Muxy/Views/FileTree/FileTreeView.swift
@@ -575,6 +575,7 @@ private struct FileTreeContextMenuContents: View {
             Button("Copy Relative Path") { commands.copyRelativePath(path) }
         }
         Divider()
+        Button("Open with default app") { commands.openWithDefaultApp(path) }
         Button("Reveal in Finder") { commands.revealInFinder(path) }
         Button("Open in Terminal") { commands.openInTerminal(path: path) }
     }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -25,6 +25,7 @@ final class GhosttyTerminalNSView: NSView {
     var onCmdClickFile: ((String) -> Void)?
     var resolveCmdHoverFile: ((String) -> Bool)?
     var onOpenURL: ((URL) -> Bool)?
+    var contextMenuResolveFile: ((String) -> String?)?
     private var isShowingHandCursor = false
     private var fileHoverUnderlineLayer: CAShapeLayer?
     private var lastMouseTopDownPoint: CGPoint?
@@ -203,6 +204,7 @@ final class GhosttyTerminalNSView: NSView {
         onOpenURL = nil
         onCmdClickFile = nil
         resolveCmdHoverFile = nil
+        contextMenuResolveFile = nil
         onTitleChange = nil
         onFocus = nil
         onExternalDragHoverChange = nil
@@ -822,6 +824,20 @@ final class GhosttyTerminalNSView: NSView {
     private func presentContextMenu(with event: NSEvent) {
         let menu = NSMenu(title: "Terminal")
 
+        if let word = readWordUnderMouse(),
+           let resolved = contextMenuResolveFile?(word)
+        {
+            let openItem = NSMenuItem(
+                title: "Open with default app",
+                action: #selector(handleContextOpenFile(_:)),
+                keyEquivalent: ""
+            )
+            openItem.target = self
+            openItem.representedObject = resolved
+            menu.addItem(openItem)
+            menu.addItem(.separator())
+        }
+
         let paste = ClosureMenuItem(title: "Paste") { [weak self] in
             self?.performContextPaste()
         }
@@ -842,6 +858,12 @@ final class GhosttyTerminalNSView: NSView {
         ClosureMenuItem(title: title) { [weak self] in
             self?.onSplitRequest?(direction, position)
         }
+    }
+
+    @objc
+    private func handleContextOpenFile(_ sender: NSMenuItem) {
+        guard let path = sender.representedObject as? String else { return }
+        NSWorkspace.shared.open(URL(fileURLWithPath: path))
     }
 
     private func performContextPaste() {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -253,6 +253,10 @@ struct TerminalBridge: NSViewRepresentable {
                 NotificationStore.shared.appState?.openFile(resolved, projectID: projectID, preserveFocus: true)
             }
         }
+        view.contextMenuResolveFile = { [projectPath] token in
+            let workDir = state.currentWorkingDirectory ?? projectPath
+            return Self.resolveFilePath(token, projectPath: workDir)
+        }
         view.resolveCmdHoverFile = { token in
             Self.resolveFilePath(token, projectPath: projectPath) != nil
         }


### PR DESCRIPTION
Add 'Open with Default App' option in:
- Sidebar file tree context menu
- Terminal right-click context menu (when hovering over a file path)