### PR TITLE
Fix orphaned extension entry points and child processes on stop/reload

### DIFF
--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -38,6 +38,8 @@ final class ExtensionStore {
     private var intentionalStops: Set<String> = []
     private let rootDirectoryURL: URL
 
+    nonisolated private static let processTerminationGracePeriod: TimeInterval = 2
+
     private init(rootDirectory: URL = ExtensionStore.defaultRootDirectory) {
         rootDirectoryURL = rootDirectory
     }
@@ -59,8 +61,8 @@ final class ExtensionStore {
     }
 
     func stopAll() {
-        for status in statuses where status.isRunning {
-            stopProcess(extensionID: status.id)
+        for extensionID in Array(processes.keys) {
+            stopProcess(extensionID: extensionID)
         }
         statusBarTextOverrides.removeAll()
         ExtensionIconAssetCache.shared.invalidateAll()
@@ -476,11 +478,24 @@ final class ExtensionStore {
         guard let process = processes.removeValue(forKey: extensionID) else { return }
         if process.isRunning {
             intentionalStops.insert(extensionID)
-            process.terminate()
+            Self.terminateProcessTree(pid: process.processIdentifier)
         }
         if let index = statuses.firstIndex(where: { $0.id == extensionID }) {
             statuses[index].isRunning = false
         }
+    }
+
+    nonisolated private static func terminateProcessTree(pid: pid_t) {
+        let group = getpgid(pid)
+        let target = group > 0 ? group : pid
+        killpg(target, SIGTERM)
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + processTerminationGracePeriod) {
+            killpg(target, SIGKILL)
+        }
+    }
+
+    nonisolated static func terminateProcessTreeForTesting(pid: pid_t) {
+        terminateProcessTree(pid: pid)
     }
 
     private static func generateToken() -> String {
@@ -493,9 +508,9 @@ final class ExtensionStore {
     }
 
     private func handleTermination(extensionID: String, process: Process) {
+        let wasIntentional = intentionalStops.remove(extensionID) != nil
         guard processes[extensionID] === process else { return }
         processes.removeValue(forKey: extensionID)
-        let wasIntentional = intentionalStops.remove(extensionID) != nil
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }
         statuses[index].isRunning = false
         let outcome = Self.classifyTermination(

--- a/Tests/MuxyTests/Services/ExtensionProcessTreeTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionProcessTreeTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionProcessTree")
+struct ExtensionProcessTreeTests {
+    @Test("terminating an entry point kills its child processes")
+    func terminatingEntryPointKillsChildren() async throws {
+        let marker = UUID().uuidString
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "sh -c 'sleep 90; echo \(marker)' & wait"]
+        try process.run()
+
+        try await Task.sleep(for: .milliseconds(400))
+        #expect(childCount(marker: marker) >= 1)
+
+        ExtensionStore.terminateProcessTreeForTesting(pid: process.processIdentifier)
+
+        try await Task.sleep(for: .milliseconds(600))
+        #expect(childCount(marker: marker) == 0)
+    }
+
+    private func childCount(marker: String) -> Int {
+        let probe = Process()
+        probe.executableURL = URL(fileURLWithPath: "/bin/sh")
+        probe.arguments = ["-c", "pgrep -f 'sleep 90; echo \(marker)' | wc -l"]
+        let pipe = Pipe()
+        probe.standardOutput = pipe
+        try? probe.run()
+        probe.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let text = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "0"
+        return Int(text) ?? 0
+    }
+}


### PR DESCRIPTION
Stop cleanup now iterates live processes (not statuses), so extensions whose
  folder was deleted are still terminated. Entry points are killed by process
  group, so child processes die with them.