### PR TITLE
Add extension popover API

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -155,6 +155,53 @@ struct ExtensionPanel: Codable, Equatable, Identifiable {
     }
 }
 
+struct ExtensionPopover: Codable, Equatable, Identifiable {
+    static let defaultWidth: Double = 320
+    static let defaultHeight: Double = 360
+
+    let id: String
+    let title: String?
+    let entry: String
+    let width: Double
+    let height: Double
+    let defaultData: ExtensionJSON?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case entry
+        case width
+        case height
+        case defaultData
+    }
+
+    init(
+        id: String,
+        title: String? = nil,
+        entry: String,
+        width: Double = ExtensionPopover.defaultWidth,
+        height: Double = ExtensionPopover.defaultHeight,
+        defaultData: ExtensionJSON? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.entry = entry
+        self.width = width
+        self.height = height
+        self.defaultData = defaultData
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        entry = try container.decode(String.self, forKey: .entry)
+        width = try container.decodeIfPresent(Double.self, forKey: .width) ?? ExtensionPopover.defaultWidth
+        height = try container.decodeIfPresent(Double.self, forKey: .height) ?? ExtensionPopover.defaultHeight
+        defaultData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .defaultData)
+    }
+}
+
 enum ExtensionIcon: Codable, Equatable {
     case symbol(String)
     case svg(String)
@@ -237,12 +284,14 @@ enum ExtensionCommandAction: Codable, Equatable {
     case event
     case openTab(tabType: String, data: ExtensionJSON?)
     case togglePanel(panel: String)
+    case openPopover(popover: String)
     case runScript(script: String)
 
     private enum CodingKeys: String, CodingKey {
         case kind
         case tabType
         case panel
+        case popover
         case data
         case script
     }
@@ -251,6 +300,7 @@ enum ExtensionCommandAction: Codable, Equatable {
         case event
         case openTab
         case togglePanel
+        case openPopover
         case runScript
     }
 
@@ -267,6 +317,9 @@ enum ExtensionCommandAction: Codable, Equatable {
         case .togglePanel:
             let panel = try container.decode(String.self, forKey: .panel)
             self = .togglePanel(panel: panel)
+        case .openPopover:
+            let popover = try container.decode(String.self, forKey: .popover)
+            self = .openPopover(popover: popover)
         case .runScript:
             let script = try container.decode(String.self, forKey: .script)
             self = .runScript(script: script)
@@ -285,6 +338,9 @@ enum ExtensionCommandAction: Codable, Equatable {
         case let .togglePanel(panel):
             try container.encode(Kind.togglePanel, forKey: .kind)
             try container.encode(panel, forKey: .panel)
+        case let .openPopover(popover):
+            try container.encode(Kind.openPopover, forKey: .kind)
+            try container.encode(popover, forKey: .popover)
         case let .runScript(script):
             try container.encode(Kind.runScript, forKey: .kind)
             try container.encode(script, forKey: .script)
@@ -338,6 +394,7 @@ struct ExtensionManifest: Codable, Equatable {
     let commands: [ExtensionPaletteCommand]
     let tabTypes: [ExtensionTabType]
     let panels: [ExtensionPanel]
+    let popovers: [ExtensionPopover]
     let permissions: [ExtensionPermission]
     let aiProvider: ExtensionAIProvider?
     let topbarItems: [ExtensionTopbarItem]
@@ -353,6 +410,7 @@ struct ExtensionManifest: Codable, Equatable {
         case commands
         case tabTypes
         case panels
+        case popovers
         case permissions
         case aiProvider
         case topbarItems
@@ -369,6 +427,7 @@ struct ExtensionManifest: Codable, Equatable {
         commands: [ExtensionPaletteCommand] = [],
         tabTypes: [ExtensionTabType] = [],
         panels: [ExtensionPanel] = [],
+        popovers: [ExtensionPopover] = [],
         permissions: [ExtensionPermission] = [],
         aiProvider: ExtensionAIProvider? = nil,
         topbarItems: [ExtensionTopbarItem] = [],
@@ -383,6 +442,7 @@ struct ExtensionManifest: Codable, Equatable {
         self.commands = commands
         self.tabTypes = tabTypes
         self.panels = panels
+        self.popovers = popovers
         self.permissions = permissions
         self.aiProvider = aiProvider
         self.topbarItems = topbarItems
@@ -400,6 +460,7 @@ struct ExtensionManifest: Codable, Equatable {
         commands = try container.decodeIfPresent([ExtensionPaletteCommand].self, forKey: .commands) ?? []
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
         panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
+        popovers = try container.decodeIfPresent([ExtensionPopover].self, forKey: .popovers) ?? []
         permissions = try container.decodeIfPresent([ExtensionPermission].self, forKey: .permissions) ?? []
         aiProvider = try container.decodeIfPresent(ExtensionAIProvider.self, forKey: .aiProvider)
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
@@ -413,6 +474,10 @@ struct ExtensionManifest: Codable, Equatable {
 
     func panel(id: String) -> ExtensionPanel? {
         panels.first { $0.id == id }
+    }
+
+    func popover(id: String) -> ExtensionPopover? {
+        popovers.first { $0.id == id }
     }
 
     func setting(key: String) -> ExtensionSettingEntry? {
@@ -439,8 +504,12 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case duplicatePanel(String)
     case panelSVGMissing(panelID: String, url: URL)
     case panelSVGOutsideDirectory(panelID: String, url: URL)
+    case popoverEntryMissing(popoverID: String, url: URL)
+    case popoverEntryOutsideDirectory(popoverID: String, url: URL)
+    case duplicatePopover(String)
     case commandReferencesUnknownTabType(commandID: String, tabType: String)
     case commandReferencesUnknownPanel(commandID: String, panel: String)
+    case commandReferencesUnknownPopover(commandID: String, popover: String)
     case scriptMissing(commandID: String, url: URL)
     case scriptOutsideDirectory(commandID: String, url: URL)
     case topbarItemEmptyID
@@ -486,10 +555,18 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Panel '\(panelID)' icon SVG not found at \(url.path)"
         case let .panelSVGOutsideDirectory(panelID, url):
             "Panel '\(panelID)' icon SVG at \(url.path) escapes the extension directory"
+        case let .popoverEntryMissing(popoverID, url):
+            "Popover '\(popoverID)' entry not found at \(url.path)"
+        case let .popoverEntryOutsideDirectory(popoverID, url):
+            "Popover '\(popoverID)' entry at \(url.path) escapes the extension directory"
+        case let .duplicatePopover(id):
+            "Duplicate popover '\(id)'"
         case let .commandReferencesUnknownTabType(commandID, tabType):
             "Command '\(commandID)' references unknown tab type '\(tabType)'"
         case let .commandReferencesUnknownPanel(commandID, panel):
             "Command '\(commandID)' references unknown panel '\(panel)'"
+        case let .commandReferencesUnknownPopover(commandID, popover):
+            "Command '\(commandID)' references unknown popover '\(popover)'"
         case let .scriptMissing(commandID, url):
             "Command '\(commandID)' script not found at \(url.path)"
         case let .scriptOutsideDirectory(commandID, url):
@@ -588,6 +665,7 @@ enum ExtensionManifestLoader {
         let muxyExtension = MuxyExtension(id: manifest.name, directory: directory, manifest: manifest)
         try validateTabTypes(manifest: manifest, in: muxyExtension)
         try validatePanels(manifest: manifest, in: muxyExtension)
+        try validatePopovers(manifest: manifest, in: muxyExtension)
         try validateCommands(manifest: manifest, in: muxyExtension)
         try validateTopbarItems(manifest: manifest, in: muxyExtension)
         try validateStatusBarItems(manifest: manifest, in: muxyExtension)
@@ -658,9 +736,28 @@ enum ExtensionManifestLoader {
         }
     }
 
+    private static func validatePopovers(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
+        var seen = Set<String>()
+        for popover in manifest.popovers {
+            guard seen.insert(popover.id).inserted else {
+                throw ExtensionLoadError.duplicatePopover(popover.id)
+            }
+            guard let url = muxyExtension.resolveResource(popover.entry) else {
+                throw ExtensionLoadError.popoverEntryOutsideDirectory(
+                    popoverID: popover.id,
+                    url: muxyExtension.directory.appendingPathComponent(popover.entry)
+                )
+            }
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ExtensionLoadError.popoverEntryMissing(popoverID: popover.id, url: url)
+            }
+        }
+    }
+
     private static func validateCommands(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
         let tabTypeIDs = Set(manifest.tabTypes.map(\.id))
         let panelIDs = Set(manifest.panels.map(\.id))
+        let popoverIDs = Set(manifest.popovers.map(\.id))
         for command in manifest.commands {
             switch command.action {
             case .event:
@@ -677,6 +774,13 @@ enum ExtensionManifestLoader {
                     throw ExtensionLoadError.commandReferencesUnknownPanel(
                         commandID: command.id,
                         panel: panel
+                    )
+                }
+            case let .openPopover(popover):
+                guard popoverIDs.contains(popover) else {
+                    throw ExtensionLoadError.commandReferencesUnknownPopover(
+                        commandID: command.id,
+                        popover: popover
                     )
                 }
             case let .runScript(script):

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -287,6 +287,11 @@ enum ExtensionCommandAction: Codable, Equatable {
     case openPopover(popover: String)
     case runScript(script: String)
 
+    var isAnchored: Bool {
+        if case .openPopover = self { return true }
+        return false
+    }
+
     private enum CodingKeys: String, CodingKey {
         case kind
         case tabType

--- a/Muxy/Models/ExtensionPopoverState.swift
+++ b/Muxy/Models/ExtensionPopoverState.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@MainActor
+@Observable
+final class ExtensionPopoverState: Identifiable {
+    let id = UUID()
+    let extensionID: String
+    let popoverID: String
+    let initialData: ExtensionJSON?
+    var width: Double
+    var height: Double
+
+    init(extensionID: String, popoverID: String, width: Double, height: Double, initialData: ExtensionJSON? = nil) {
+        self.extensionID = extensionID
+        self.popoverID = popoverID
+        self.width = width
+        self.height = height
+        self.initialData = initialData
+    }
+}

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -12,7 +12,7 @@ Muxy extensions live in `~/.config/muxy/extensions/<name>/` and load when Muxy s
 Use this skill when:
 
 - Writing a new Muxy extension (manifest, entrypoint, tab UI).
-- Adding a command, topbar item, status-bar item, settings entry, or tab type.
+- Adding a command, topbar item, status-bar item, settings entry, tab type, panel, or popover.
 - Styling an extension tab so it adapts to the user's current Muxy theme.
 - Reading Muxy state (panes, tabs, projects, worktrees) or executing shell from a tab.
 - Subscribing to Muxy events or pushing live updates to the status bar.
@@ -122,11 +122,12 @@ Field-by-field:
 - `events` — array of event names this extension subscribes to (for example `pane.created`, `tab.focused`, `pane.closed`). Command events (`command.<id>`) are auto-allowed.
 - `tabTypes` — declares HTML pages renderable as tabs.
 - `panels` — declares HTML pages renderable as dockable/floating panels (`position`: `right`|`bottom`, `mode`: `floating`|`pinned`, optional `icon`/`title`/`hiddenControls`). Requires `panels:write` to open/close at runtime. One pinned and one floating panel per position; opening another in that slot replaces it.
-- `commands` — palette commands. Each command's `action.kind` is `event` (default — fires `command.<id>`), `openTab`, `togglePanel`, or `runScript`.
+- `popovers` — declares HTML pages renderable as transient popovers anchored to a topbar/status-bar item (`entry` required; optional `title`, `width`, `height` defaulting to 320×360). Frameless, auto-dismiss on outside click, at most one open at a time. Opened via an `openPopover` command bound to a topbar/status-bar item; the page sizes itself with `muxy.popover.resize()` (needs `panels:write`).
+- `commands` — palette commands. Each command's `action.kind` is `event` (default — fires `command.<id>`), `openTab`, `togglePanel`, `openPopover`, or `runScript`.
 - `topbarItems` / `statusBarItems` — UI hooks bound to a command. `icon` is either `{ "symbol": "<sf-symbol>" }` or `{ "svg": "<relative/path.svg>" }`.
 - `settings` — user-visible settings (`string` | `bool` | `number`) reachable from `extension.settings.get` over the socket and editable in the Extensions modal.
 
-Common load failures: a declared entrypoint that is missing or not executable, tab/panel entry escapes the extension directory, a command references an unknown `tabType` or `panel`, a topbar or status-bar item references an unknown command. Failures appear in the Extensions modal under "Load Errors".
+Common load failures: a declared entrypoint that is missing or not executable, tab/panel/popover entry escapes the extension directory, a command references an unknown `tabType`, `panel`, or `popover`, a topbar or status-bar item references an unknown command. Failures appear in the Extensions modal under "Load Errors".
 
 ## Permissions reference
 
@@ -143,6 +144,7 @@ Permissions are gated server-side. Requests without the matching permission fail
 | `worktrees:read` | `worktrees.list` |
 | `worktrees:write` | `worktrees.switch`, `worktrees.refresh` |
 | `notifications:write` | `toast` |
+| `panels:write` | `panel.open`, `panel.toggle`, `panel.close`, `popover.resize`, `popover.close` |
 | `commands:run-script` | `runScript` commands |
 | `commands:exec` | `muxy.exec` (always prompts the user the first time) |
 
@@ -274,6 +276,22 @@ await muxy.panels.open('dashboard', { tab: 'logs' }); // override defaultData fo
 await muxy.panels.close('dashboard');
 ```
 
+### Size / close a popover
+
+Available inside a popover page. Requires `panels:write`. A popover is opened by the user from its anchoring topbar/status-bar item (there is no `open` from JS) — the page only sizes itself to its content and can dismiss itself.
+
+```js
+// Fit the popover to its content once laid out:
+window.addEventListener('load', () =>
+  muxy.popover.resize(
+    document.documentElement.scrollWidth,
+    document.documentElement.scrollHeight
+  )
+);
+
+await muxy.popover.close(); // dismiss self
+```
+
 ### Drive terminal panes
 
 ```js
@@ -349,7 +367,9 @@ Receive the payload in the tab as `muxy.data`.
 
 ## Theming — adapt to the user's current Muxy theme
 
-**Do not hardcode colors.** Muxy supports paired light/dark themes and a user-selected accent color. Every extension tab inherits CSS custom properties on `document.documentElement` that match the live theme. They update automatically when the user changes theme.
+**Do not hardcode colors. Adopting the app theme is the best practice — and it is required for popovers,** which sit directly against the app chrome and look broken if they don't match. Muxy supports paired light/dark themes and a user-selected accent color. Every extension webview — tab, panel, **and popover** — inherits the same CSS custom properties on `document.documentElement` that match the live theme. They update automatically when the user changes theme, and the rules below apply identically to all three surfaces.
+
+**Popovers: leave the page background transparent.** The webview is presented over the native macOS popover material (translucent vibrancy that is already light/dark-aware), and its backing is non-opaque. Set `body { background: transparent; }` — do **not** paint `--muxy-background` on the popover body — so the system material shows through and the popover matches macOS automatically. Foreground text, accents, and translucent `--muxy-surface` chips/buttons still use the theme variables as usual. (Tabs and panels fill their whole region, so they *do* paint `--muxy-background` on the body.)
 
 ### Available CSS variables
 
@@ -532,6 +552,67 @@ button:hover { background: var(--muxy-hover); border-color: var(--muxy-accent); 
 ```
 
 > Note: `muxy.toast` requires `notifications:write`. Add it to `permissions` if you use it.
+
+## End-to-end example (popover)
+
+A status-bar item that opens a self-sizing popover. The popover replaces what used to be a built-in popover (e.g. an AI-usage meter): a small, read-mostly surface anchored to its item.
+
+```json
+// manifest.json
+{
+  "name": "status-popover",
+  "version": "0.1.0",
+  "permissions": ["panels:write"],
+  "popovers": [
+    { "id": "summary", "title": "Summary", "entry": "popovers/summary.html", "width": 280, "height": 200 }
+  ],
+  "commands": [
+    { "id": "open-summary", "title": "Status: Summary", "action": { "kind": "openPopover", "popover": "summary" } }
+  ],
+  "statusBarItems": [
+    { "id": "summary", "icon": { "symbol": "gauge" }, "text": "Status", "side": "right", "command": "open-summary" }
+  ]
+}
+```
+
+```html
+<!-- popovers/summary.html -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    /* Popover: transparent body so the native macOS popover material shows through. */
+    body { margin: 0; font: 13px -apple-system, system-ui, sans-serif;
+           background: transparent; color: var(--muxy-foreground); }
+    .box { padding: 16px; display: flex; flex-direction: column; gap: 10px; }
+    .line { color: var(--muxy-foreground-muted); }
+    button { font: inherit; padding: 6px 10px; border-radius: 6px;
+             background: var(--muxy-surface); color: inherit;
+             border: 1px solid var(--muxy-border); cursor: pointer; }
+    button:hover { background: var(--muxy-hover); border-color: var(--muxy-accent); }
+  </style>
+</head>
+<body>
+  <div class="box">
+    <strong>Summary</strong>
+    <span class="line" id="line">loading…</span>
+    <button onclick="muxy.popover.close()">Close</button>
+  </div>
+  <script>
+    document.getElementById('line').textContent = `running as ${muxy.extensionID}`;
+    window.addEventListener('load', () =>
+      muxy.popover.resize(
+        document.documentElement.scrollWidth,
+        document.documentElement.scrollHeight
+      )
+    );
+  </script>
+</body>
+</html>
+```
+
+The popover anchors to the status-bar item, opens/toggles when it is clicked, and dismisses on outside click. No entrypoint is needed.
 
 ## Reload workflow
 

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -66,6 +66,7 @@ final class ExtensionStore {
         ExtensionIconAssetCache.shared.invalidateAll()
         for status in statuses {
             ExtensionPanelRegistry.shared.closeAll(extensionID: status.id)
+            PopoverHost.shared.close(extensionID: status.id)
         }
         rebuildExtensionUICache()
         publishSnapshot()
@@ -90,6 +91,7 @@ final class ExtensionStore {
             statusBarTextOverrides.removeValue(forKey: extensionID)
             ExtensionIconAssetCache.shared.invalidate(extensionID: extensionID)
             ExtensionPanelRegistry.shared.closeAll(extensionID: extensionID)
+            PopoverHost.shared.close(extensionID: extensionID)
         }
         rebuildExtensionUICache()
         publishSnapshot()
@@ -170,7 +172,9 @@ final class ExtensionStore {
         statuses
             .filter(\.isEnabled)
             .flatMap { status in
-                status.muxyExtension.manifest.commands.map { PaletteCommandBinding(muxyExtension: status.muxyExtension, command: $0) }
+                status.muxyExtension.manifest.commands
+                    .filter { !$0.action.isAnchored }
+                    .map { PaletteCommandBinding(muxyExtension: status.muxyExtension, command: $0) }
             }
     }
 
@@ -277,14 +281,8 @@ final class ExtensionStore {
                 panel: panel,
                 data: nil
             )
-        case let .openPopover(popoverID):
-            guard let popover = muxyExtension.manifest.popover(id: popoverID) else { return }
-            PopoverHost.shared.toggle(
-                anchorID: "command:\(invocation.extensionID):\(invocation.commandID)",
-                extensionID: invocation.extensionID,
-                popover: popover,
-                data: nil
-            )
+        case .openPopover:
+            break
         case let .runScript(script):
             runExtensionScript(script: script, in: muxyExtension, invocation: invocation)
         }
@@ -513,6 +511,7 @@ final class ExtensionStore {
         let wasIntentional = intentionalStops.remove(extensionID) != nil
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }
         statuses[index].isRunning = false
+        PopoverHost.shared.close(extensionID: extensionID)
         let outcome = Self.classifyTermination(
             wasIntentional: wasIntentional,
             terminationStatus: process.terminationStatus

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -178,6 +178,13 @@ final class ExtensionStore {
         side == .left ? leftStatusBarItems : rightStatusBarItems
     }
 
+    func popover(for muxyExtension: MuxyExtension, command commandID: String) -> ExtensionPopover? {
+        guard let command = muxyExtension.manifest.commands.first(where: { $0.id == commandID }),
+              case let .openPopover(popoverID) = command.action
+        else { return nil }
+        return muxyExtension.manifest.popover(id: popoverID)
+    }
+
     private func rebuildExtensionUICache() {
         var topbar: [TopbarItemBinding] = []
         var left: [StatusBarItemBinding] = []
@@ -268,6 +275,14 @@ final class ExtensionStore {
             ExtensionPanelRegistry.shared.toggle(
                 extensionID: invocation.extensionID,
                 panel: panel,
+                data: nil
+            )
+        case let .openPopover(popoverID):
+            guard let popover = muxyExtension.manifest.popover(id: popoverID) else { return }
+            PopoverHost.shared.toggle(
+                anchorID: "command:\(invocation.extensionID):\(invocation.commandID)",
+                extensionID: invocation.extensionID,
+                popover: popover,
                 data: nil
             )
         case let .runScript(script):

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -140,6 +140,8 @@ enum MuxyAPI {
             "panel.open",
             "panel.close",
             "panel.toggle",
+            "popover.close",
+            "popover.resize",
         ]
 
         private static let cliAliases: [String: String] = [
@@ -189,6 +191,8 @@ enum MuxyAPI {
             "panel.open": .panelsWrite,
             "panel.close": .panelsWrite,
             "panel.toggle": .panelsWrite,
+            "popover.close": .panelsWrite,
+            "popover.resize": .panelsWrite,
             "exec": .commandsExec,
         ]
     }
@@ -217,6 +221,22 @@ enum MuxyAPI {
         static func close(extensionID: String, panelID: String) -> Result<Void, APIError> {
             let hostPanelID = ExtensionPanelState.hostPanelID(extensionID: extensionID, panelID: panelID)
             ExtensionPanelRegistry.shared.close(hostPanelID: hostPanelID)
+            return .success(())
+        }
+    }
+
+    @MainActor
+    enum Popovers {
+        static func close(extensionID: String) -> Result<Void, APIError> {
+            PopoverHost.shared.close(extensionID: extensionID)
+            return .success(())
+        }
+
+        static func resize(extensionID: String, width: Double, height: Double) -> Result<Void, APIError> {
+            guard width > 0, height > 0 else {
+                return .failure(.invalidArguments("popover.resize requires positive width and height"))
+            }
+            PopoverHost.shared.resize(extensionID: extensionID, width: width, height: height)
             return .success(())
         }
     }

--- a/Muxy/Services/MuxyAPIDispatcher.swift
+++ b/Muxy/Services/MuxyAPIDispatcher.swift
@@ -40,6 +40,16 @@ enum MuxyAPIDispatcher {
                 panelID: stringArg(args, "panel")
             ))
             return NSNull()
+        case "popover.close":
+            try unwrap(MuxyAPI.Popovers.close(extensionID: context.extensionID))
+            return NSNull()
+        case "popover.resize":
+            try unwrap(MuxyAPI.Popovers.resize(
+                extensionID: context.extensionID,
+                width: doubleArg(args, "width"),
+                height: doubleArg(args, "height")
+            ))
+            return NSNull()
         case "exec":
             return try await handleExec(args: args, context: context)
         case "tabs.list":
@@ -215,6 +225,13 @@ enum MuxyAPIDispatcher {
 
     private static func stringArg(_ args: [String: Any], _ key: String) throws -> String {
         if let value = args[key] as? String { return value }
+        throw APIError.invalidArguments("missing argument '\(key)'")
+    }
+
+    private static func doubleArg(_ args: [String: Any], _ key: String) throws -> Double {
+        if let value = args[key] as? Double { return value }
+        if let value = args[key] as? Int { return Double(value) }
+        if let value = args[key] as? NSNumber { return value.doubleValue }
         throw APIError.invalidArguments("missing argument '\(key)'")
     }
 

--- a/Muxy/Services/PopoverHost.swift
+++ b/Muxy/Services/PopoverHost.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+@MainActor
+@Observable
+final class PopoverHost {
+    static let shared = PopoverHost()
+
+    static let minSize: Double = 80
+    static let maxWidth: Double = 600
+    static let maxHeight: Double = 720
+
+    struct Open: Identifiable {
+        let anchorID: String
+        let state: ExtensionPopoverState
+        var id: String { anchorID }
+    }
+
+    private(set) var open: Open?
+
+    func isOpen(anchorID: String) -> Bool {
+        open?.anchorID == anchorID
+    }
+
+    func state(for extensionID: String) -> ExtensionPopoverState? {
+        guard let open, open.state.extensionID == extensionID else { return nil }
+        return open.state
+    }
+
+    func toggle(anchorID: String, extensionID: String, popover: ExtensionPopover, data: ExtensionJSON?) {
+        if isOpen(anchorID: anchorID) {
+            close()
+            return
+        }
+        present(anchorID: anchorID, extensionID: extensionID, popover: popover, data: data)
+    }
+
+    func present(anchorID: String, extensionID: String, popover: ExtensionPopover, data: ExtensionJSON?) {
+        let state = ExtensionPopoverState(
+            extensionID: extensionID,
+            popoverID: popover.id,
+            width: popover.width,
+            height: popover.height,
+            initialData: data ?? popover.defaultData
+        )
+        open = Open(anchorID: anchorID, state: state)
+    }
+
+    func close() {
+        open = nil
+    }
+
+    func close(anchorID: String) {
+        guard isOpen(anchorID: anchorID) else { return }
+        close()
+    }
+
+    func close(extensionID: String) {
+        guard open?.state.extensionID == extensionID else { return }
+        close()
+    }
+
+    func resize(extensionID: String, width: Double, height: Double) {
+        guard let state = state(for: extensionID) else { return }
+        state.width = min(max(width, PopoverHost.minSize), PopoverHost.maxWidth)
+        state.height = min(max(height, PopoverHost.minSize), PopoverHost.maxHeight)
+    }
+}

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -214,6 +214,15 @@ enum SocketCommandHandler {
         case "panel.close":
             guard parts.count >= 2 else { return "error:usage panel.close|panelID" }
             return handlePanelClose(panelID: parts[1], extensionID: clientContext.extensionID)
+        case "popover.close":
+            return handlePopoverClose(extensionID: clientContext.extensionID)
+        case "popover.resize":
+            guard parts.count >= 3 else { return "error:usage popover.resize|width|height" }
+            return handlePopoverResize(
+                width: parts[1],
+                height: parts[2],
+                extensionID: clientContext.extensionID
+            )
         default:
             return "error:unknown command \(cmd)"
         }
@@ -239,6 +248,22 @@ enum SocketCommandHandler {
         guard let extensionID else { return "error:identify required" }
         return serialize(
             MuxyAPI.Panels.close(extensionID: extensionID, panelID: panelID),
+            ok: "ok"
+        )
+    }
+
+    private static func handlePopoverClose(extensionID: String?) -> String {
+        guard let extensionID else { return "error:identify required" }
+        return serialize(MuxyAPI.Popovers.close(extensionID: extensionID), ok: "ok")
+    }
+
+    private static func handlePopoverResize(width: String, height: String, extensionID: String?) -> String {
+        guard let extensionID else { return "error:identify required" }
+        guard let widthValue = Double(width), let heightValue = Double(height) else {
+            return "error:usage popover.resize|width|height"
+        }
+        return serialize(
+            MuxyAPI.Popovers.resize(extensionID: extensionID, width: widthValue, height: heightValue),
             ok: "ok"
         )
     }

--- a/Muxy/Views/Extensions/ExtensionWebBridge.swift
+++ b/Muxy/Views/Extensions/ExtensionWebBridge.swift
@@ -101,6 +101,10 @@ enum ExtensionWebBridge {
                     toggle(panel, data) { return send('panel.toggle', { panel: String(panel), data: data ?? null }); },
                     close(panel) { return send('panel.close', { panel: String(panel) }); },
                 },
+                popover: {
+                    close() { return send('popover.close', {}); },
+                    resize(width, height) { return send('popover.resize', { width: Number(width), height: Number(height) }); },
+                },
                 exec(argvOrOptions, maybeOptions) {
                     let payload;
                     if (Array.isArray(argvOrOptions)) {
@@ -164,6 +168,7 @@ enum ExtensionWebBridge {
             Object.freeze(muxy.panes);
             Object.freeze(muxy.projects);
             Object.freeze(muxy.panels);
+            Object.freeze(muxy.popover);
             Object.freeze(muxy.worktrees);
             Object.freeze(muxy.events);
             Object.freeze(muxy);

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -620,6 +620,7 @@ private struct ExtensionDetailPage: View {
         case .event: "event"
         case let .openTab(tabType, _): "opens \(tabType)"
         case let .togglePanel(panel): "toggles \(panel)"
+        case let .openPopover(popover): "opens \(popover)"
         case let .runScript(script): "runs \(script)"
         }
     }

--- a/Muxy/Views/Popovers/ExtensionPopoverView.swift
+++ b/Muxy/Views/Popovers/ExtensionPopoverView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct ExtensionPopoverView: View {
+    let state: ExtensionPopoverState
+
+    @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
+
+    var body: some View {
+        Group {
+            if let muxyExtension = ExtensionStore.shared.loadedExtension(id: state.extensionID),
+               let popover = muxyExtension.manifest.popover(id: state.popoverID),
+               let entryURL = ExtensionWebView.entryURL(for: muxyExtension, entry: popover.entry)
+            {
+                ExtensionWebView(
+                    extensionID: muxyExtension.id,
+                    instanceID: state.id.uuidString,
+                    entryURL: entryURL,
+                    initialData: state.initialData,
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore,
+                    onFocus: {}
+                )
+            } else {
+                Color.clear
+            }
+        }
+        .frame(width: state.width, height: state.height)
+    }
+}
+
+extension View {
+    func extensionPopover(anchorID: String, host: PopoverHost) -> some View {
+        let item = Binding<ExtensionPopoverState?>(
+            get: { host.isOpen(anchorID: anchorID) ? host.open?.state : nil },
+            set: { newValue in if newValue == nil { host.close(anchorID: anchorID) } }
+        )
+        return popover(item: item, arrowEdge: .bottom) { state in
+            ExtensionPopoverView(state: state)
+        }
+    }
+}

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -17,6 +17,7 @@ struct ProjectStatusBar: View {
     @Binding var extensionOutputVisible: Bool
     var onTriggerExtensionCommand: ((ExtensionStore.StatusBarItemBinding) -> Void)?
     @Environment(ExtensionStore.self) private var extensionStore
+    @State private var popoverHost = PopoverHost.shared
     @AppStorage(AIUsageSettingsStore.usageEnabledKey) private var usageEnabled = false
     @AppStorage(AIUsageSettingsStore.usageDisplayModeKey) private var usageDisplayModeRaw = AIUsageSettingsStore
         .defaultUsageDisplayMode.rawValue
@@ -206,8 +207,18 @@ struct ProjectStatusBar: View {
     }
 
     private func extensionItem(binding: ExtensionStore.StatusBarItemBinding) -> some View {
-        Button {
-            onTriggerExtensionCommand?(binding)
+        let popover = extensionStore.popover(for: binding.muxyExtension, command: binding.item.command)
+        return Button {
+            if let popover {
+                popoverHost.toggle(
+                    anchorID: binding.id,
+                    extensionID: binding.muxyExtension.id,
+                    popover: popover,
+                    data: nil
+                )
+            } else {
+                onTriggerExtensionCommand?(binding)
+            }
         } label: {
             HStack(spacing: 4) {
                 ExtensionIconView(
@@ -226,6 +237,7 @@ struct ProjectStatusBar: View {
         .buttonStyle(.plain)
         .help(binding.item.tooltip ?? binding.item.id)
         .accessibilityLabel(binding.item.tooltip ?? binding.item.id)
+        .extensionPopover(anchorID: binding.id, host: popoverHost)
     }
 
     private var previewProviderDisplay: (percent: Int, iconName: String)? {

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -48,6 +48,7 @@ struct PaneTabStrip: View {
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ExtensionStore.self) private var extensionStore
+    @State private var popoverHost = PopoverHost.shared
     @State private var dragState = TabDragState()
 
     static func snapshots(from tabs: [TerminalTab]) -> [TabSnapshot] {
@@ -111,6 +112,7 @@ struct PaneTabStrip: View {
                         action: { triggerExtensionCommand(binding: binding) }
                     )
                     .help(binding.item.tooltip ?? binding.item.id)
+                    .extensionPopover(anchorID: binding.id, host: popoverHost)
                 }
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
                     .help(shortcutTooltip("Split Right", for: .splitRight))
@@ -227,6 +229,15 @@ struct PaneTabStrip: View {
     }
 
     private func triggerExtensionCommand(binding: ExtensionStore.TopbarItemBinding) {
+        if let popover = extensionStore.popover(for: binding.muxyExtension, command: binding.item.command) {
+            popoverHost.toggle(
+                anchorID: binding.id,
+                extensionID: binding.muxyExtension.id,
+                popover: popover,
+                data: nil
+            )
+            return
+        }
         extensionStore.triggerCommand(
             ExtensionStore.CommandInvocation(
                 extensionID: binding.muxyExtension.id,

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -527,6 +527,121 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("decodes popovers with defaults and explicit values")
+    func decodesPopovers() throws {
+        let json = #"""
+        {
+            "name": "popover-ext",
+            "version": "1.0.0",
+            "popovers": [
+                { "id": "minimal", "entry": "popovers/a.html" },
+                {
+                    "id": "full",
+                    "title": "Usage",
+                    "entry": "popovers/b.html",
+                    "width": 280,
+                    "height": 200
+                }
+            ]
+        }
+        """#
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+        #expect(manifest.popovers.count == 2)
+        let minimal = try #require(manifest.popover(id: "minimal"))
+        #expect(minimal.width == ExtensionPopover.defaultWidth)
+        #expect(minimal.height == ExtensionPopover.defaultHeight)
+        #expect(minimal.title == nil)
+        let full = try #require(manifest.popover(id: "full"))
+        #expect(full.title == "Usage")
+        #expect(full.width == 280)
+        #expect(full.height == 200)
+    }
+
+    @Test("loads an extension declaring a valid popover")
+    func loadsPopover() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "popover-ok",
+                "version": "1.0.0",
+                "popovers": [ { "id": "info", "entry": "popovers/info.html" } ]
+            }
+            """,
+            files: ["popovers/info.html": "<html></html>"],
+            makeEntrypointExecutable: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let ext = try ExtensionManifestLoader.load(from: directory)
+        #expect(ext.manifest.popover(id: "info") != nil)
+    }
+
+    @Test("rejects a popover whose entry is missing")
+    func rejectsPopoverMissingEntry() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "popover-missing",
+                "version": "1.0.0",
+                "popovers": [ { "id": "info", "entry": "popovers/info.html" } ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects duplicate popover ids")
+    func rejectsDuplicatePopovers() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "popover-dup",
+                "version": "1.0.0",
+                "popovers": [
+                    { "id": "info", "entry": "popovers/info.html" },
+                    { "id": "info", "entry": "popovers/info.html" }
+                ]
+            }
+            """,
+            files: ["popovers/info.html": "<html></html>"],
+            makeEntrypointExecutable: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects command referencing an unknown popover")
+    func rejectsCommandUnknownPopover() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "popover-cmd-bad",
+                "version": "1.0.0",
+                "commands": [
+                    { "id": "show", "title": "Show", "action": { "kind": "openPopover", "popover": "ghost" } }
+                ]
+            }
+            """,
+            makeEntrypointExecutable: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("openPopover command action round-trips through Codable")
+    func openPopoverActionRoundTrips() throws {
+        let action = ExtensionCommandAction.openPopover(popover: "usage")
+        let encoded = try JSONEncoder().encode(action)
+        let decoded = try JSONDecoder().decode(ExtensionCommandAction.self, from: encoded)
+        #expect(decoded == action)
+    }
+
     private func makeTemporaryExtension(
         manifest: String,
         files: [String: String] = [:],

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -642,6 +642,15 @@ struct ExtensionManifestTests {
         #expect(decoded == action)
     }
 
+    @Test("only openPopover actions are anchored to a UI item")
+    func anchoredActionsAreOpenPopover() {
+        #expect(ExtensionCommandAction.openPopover(popover: "usage").isAnchored)
+        #expect(!ExtensionCommandAction.event.isAnchored)
+        #expect(!ExtensionCommandAction.togglePanel(panel: "dashboard").isAnchored)
+        #expect(!ExtensionCommandAction.openTab(tabType: "logs", data: nil).isAnchored)
+        #expect(!ExtensionCommandAction.runScript(script: "s.js").isAnchored)
+    }
+
     private func makeTemporaryExtension(
         manifest: String,
         files: [String: String] = [:],

--- a/Tests/MuxyTests/Services/PopoverHostTests.swift
+++ b/Tests/MuxyTests/Services/PopoverHostTests.swift
@@ -43,6 +43,16 @@ struct PopoverHostTests {
         #expect(!host.isOpen(anchorID: "a"))
     }
 
+    @Test("close by extension only closes a matching extension")
+    func closeByExtensionMatches() {
+        let host = makeHost()
+        host.toggle(anchorID: "a", extensionID: "ext", popover: popover(), data: nil)
+        host.close(extensionID: "other")
+        #expect(host.isOpen(anchorID: "a"))
+        host.close(extensionID: "ext")
+        #expect(!host.isOpen(anchorID: "a"))
+    }
+
     @Test("resize clamps the reported size and is scoped to the extension")
     func resizeClampsAndScopes() {
         let host = makeHost()

--- a/Tests/MuxyTests/Services/PopoverHostTests.swift
+++ b/Tests/MuxyTests/Services/PopoverHostTests.swift
@@ -1,0 +1,62 @@
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("PopoverHost")
+struct PopoverHostTests {
+    private func makeHost() -> PopoverHost {
+        let host = PopoverHost.shared
+        host.close()
+        return host
+    }
+
+    private func popover(id: String = "p", width: Double = 320, height: Double = 360) -> ExtensionPopover {
+        ExtensionPopover(id: id, entry: "popovers/\(id).html", width: width, height: height)
+    }
+
+    @Test("toggle opens then closes the same anchor")
+    func toggleOpensAndCloses() {
+        let host = makeHost()
+        host.toggle(anchorID: "a", extensionID: "ext", popover: popover(), data: nil)
+        #expect(host.isOpen(anchorID: "a"))
+        host.toggle(anchorID: "a", extensionID: "ext", popover: popover(), data: nil)
+        #expect(!host.isOpen(anchorID: "a"))
+    }
+
+    @Test("opening a second anchor closes the first")
+    func singleOpenAtATime() {
+        let host = makeHost()
+        host.toggle(anchorID: "a", extensionID: "ext", popover: popover(), data: nil)
+        host.toggle(anchorID: "b", extensionID: "ext", popover: popover(), data: nil)
+        #expect(!host.isOpen(anchorID: "a"))
+        #expect(host.isOpen(anchorID: "b"))
+    }
+
+    @Test("close by anchor only closes a matching anchor")
+    func closeByAnchorMatches() {
+        let host = makeHost()
+        host.toggle(anchorID: "a", extensionID: "ext", popover: popover(), data: nil)
+        host.close(anchorID: "other")
+        #expect(host.isOpen(anchorID: "a"))
+        host.close(anchorID: "a")
+        #expect(!host.isOpen(anchorID: "a"))
+    }
+
+    @Test("resize clamps the reported size and is scoped to the extension")
+    func resizeClampsAndScopes() {
+        let host = makeHost()
+        host.toggle(anchorID: "a", extensionID: "ext", popover: popover(), data: nil)
+
+        host.resize(extensionID: "other", width: 100, height: 100)
+        #expect(host.state(for: "ext")?.width == 320)
+
+        host.resize(extensionID: "ext", width: 9999, height: 9999)
+        #expect(host.state(for: "ext")?.width == PopoverHost.maxWidth)
+        #expect(host.state(for: "ext")?.height == PopoverHost.maxHeight)
+
+        host.resize(extensionID: "ext", width: 1, height: 1)
+        #expect(host.state(for: "ext")?.width == PopoverHost.minSize)
+        #expect(host.state(for: "ext")?.height == PopoverHost.minSize)
+    }
+}

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -15,6 +15,7 @@ User-installed directories that Muxy loads and talks to over the existing notifi
 | [Palette Commands](palette-commands.md) | Register commands and react to triggers |
 | [Tabs](tabs.md) | Register webview tab types and the injected `window.muxy` JS API |
 | [Panels](panels.md) | Register dockable/floating webview panels and the placement rules |
+| [Popovers](popovers.md) | Anchor a transient webview popover to a topbar/status bar item |
 | [Topbar](topbar.md) | Attach icons to the tab strip that trigger a command |
 | [Status Bar](statusbar.md) | Attach icons to the footer status bar; update text live |
 | [Settings](settings.md) | Declare typed settings and read/write them at runtime |

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -30,6 +30,7 @@ Every extension declares itself in a `manifest.json` at the root of its director
 | `commands` | object[] | no | Palette commands to register. See [Palette Commands](palette-commands.md). |
 | `tabTypes` | object[] | no | Webview tab types the extension exposes. See [Tabs](tabs.md). |
 | `panels` | object[] | no | Dockable/floating webview panels the extension exposes. See [Panels](panels.md). |
+| `popovers` | object[] | no | Transient webview popovers anchored to a topbar/status bar item. See [Popovers](popovers.md). |
 | `topbarItems` | object[] | no | Icons to attach to the tab strip. See [Topbar](topbar.md). |
 | `statusBarItems` | object[] | no | Icons to attach to the footer status bar. See [Status Bar](statusbar.md). |
 | `settings` | object[] | no | Typed settings shown in the Settings sidebar. See [Settings](settings.md). |

--- a/docs/extensions/palette-commands.md
+++ b/docs/extensions/palette-commands.md
@@ -31,6 +31,7 @@ Extensions can declare commands that appear in Muxy's command palette. Selecting
 | `event` | Broadcasts `command.<id>` over the socket. Default if `action` is omitted. | — |
 | `openTab` | Opens an extension webview tab of the named type. | `tabType` (required, must reference a declared [tab type](tabs.md)); `data` (optional JSON merged into `window.muxy.data`). |
 | `togglePanel` | Toggles an extension [panel](panels.md) open/closed. | `panel` (required, must reference a declared panel id). |
+| `openPopover` | Toggles an extension [popover](popovers.md) anchored to its topbar/status bar item. | `popover` (required, must reference a declared popover id). |
 | `runScript` | Runs the script in a JavaScriptCore context with the same `muxy.*` API as webview tabs (no DOM). Read the [Scripts](scripts.md) page. Requires `commands:run-script`. | `script` (required, relative path within the extension directory). |
 
 ## How it surfaces

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -30,7 +30,7 @@ flowchart LR
 | `worktrees:read` | `list-worktrees` |
 | `worktrees:write` | `create-worktree`, `switch-worktree`, `refresh-worktrees` |
 | `notifications:write` | Post notifications via `type\|paneID\|title\|body` |
-| `panels:write` | `panel.open`, `panel.toggle`, `panel.close` — open and close the extension's declared [panels](panels.md). |
+| `panels:write` | `panel.open`, `panel.toggle`, `panel.close` — open and close the extension's declared [panels](panels.md); `popover.resize`, `popover.close` — size and dismiss the extension's open [popover](popovers.md). |
 | `commands:run-script` | Execute `runScript` palette command actions in the per-extension JavaScriptCore context. |
 | `commands:exec` | Run shell commands via `muxy.exec` (subprocess execution with stdout/stderr capture). |
 

--- a/docs/extensions/popovers.md
+++ b/docs/extensions/popovers.md
@@ -1,0 +1,90 @@
+# Extension Popovers
+
+Popovers are transient webviews anchored to a [topbar](topbar.md) or [status bar](statusbar.md) item. Clicking the item opens the popover; clicking outside dismisses it. Unlike [panels](panels.md), a popover does not dock and is not persisted — it is the right surface for a quick, read-mostly view (usage meters, a status summary, a small action list).
+
+At most **one extension popover is open at a time**. Opening another anchor's popover closes the current one.
+
+## Declaring a popover
+
+```json
+{
+  "name": "ai-usage",
+  "version": "0.1.0",
+  "permissions": ["panels:write"],
+  "popovers": [
+    {
+      "id": "usage",
+      "title": "AI Usage",
+      "entry": "popovers/usage.html",
+      "width": 320,
+      "height": 360
+    }
+  ],
+  "commands": [
+    {
+      "id": "open-usage",
+      "title": "Open AI Usage",
+      "action": { "kind": "openPopover", "popover": "usage" }
+    }
+  ],
+  "statusBarItems": [
+    { "id": "usage", "icon": "sparkles", "side": "right", "command": "open-usage" }
+  ]
+}
+```
+
+A popover is always reached through a topbar/status bar item whose `command` resolves to an `openPopover` action. The popover anchors to that exact item.
+
+### Fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Stable per extension. Referenced from an `openPopover` command. |
+| `entry` | string | yes | Path relative to the extension directory. Must resolve inside the directory (no `..` traversal). |
+| `title` | string | no | Available to the page; the popover itself is frameless (no host chrome). |
+| `width` | number | no | Initial width in points. Defaults to `320`. |
+| `height` | number | no | Initial height in points. Defaults to `360`. |
+| `defaultData` | object | no | JSON payload exposed to the page as `window.muxy.data`. |
+
+The loader validates that `entry` exists inside the extension directory, that popover ids are unique, and that `openPopover` commands reference a declared popover id.
+
+## Sizing
+
+The popover opens at its declared `width`/`height` and the page resizes it to fit its content via the `panels:write` API:
+
+```ts
+window.muxy.popover.resize(width, height): Promise<void>;
+```
+
+A common pattern is to report the document size once the content has laid out:
+
+```js
+const fit = () => muxy.popover.resize(
+  document.documentElement.scrollWidth,
+  document.documentElement.scrollHeight
+);
+window.addEventListener('load', fit);
+```
+
+The host clamps the reported size to a sane range.
+
+## Theming
+
+The popover is presented over the native macOS popover material, and the webview's backing is transparent. Leave the page background transparent (`body { background: transparent; }`) so the system material — already light/dark aware — shows through and the popover matches macOS. Use the injected `--muxy-*` theme variables for foreground text, accents, and translucent `--muxy-surface` chips/buttons, exactly as in [tabs](tabs.md) and [panels](panels.md).
+
+## Closing
+
+The popover dismisses on outside click, or when the page asks the host to close it:
+
+```ts
+window.muxy.popover.close(): Promise<void>;
+```
+
+From an entrypoint subprocess over the socket:
+
+```
+popover.resize|<width>|<height>
+popover.close
+```
+
+`popover.resize` and `popover.close` act on the popover currently open for the calling extension; there is no `open` verb because popovers are user-triggered from their anchor. Both require the `panels:write` permission. Popovers close automatically when the extension is disabled or stopped.


### PR DESCRIPTION
Extensions can now anchor a transient webview popover to a topbar/status bar item via an `openPopover` command.
  Popovers self-size through `muxy.popover.resize()` and render over the native macOS popover material.
  
  Docs, author skill, and a demo extension included. Lays the groundwork to replace the built-in AI Usage popover
  with an extension.