### PR TITLE
Add support for Athas IDE

### DIFF
--- a/Muxy/Services/IDEIntegrationService.swift
+++ b/Muxy/Services/IDEIntegrationService.swift
@@ -555,6 +555,7 @@ final class IDEIntegrationService: ObservableObject {
         "com.microsoft.VSCodeInsiders": .init(symbolName: "chevron.left.forwardslash.chevron.right", rank: 11, group: .editor),
         "com.vscodium": .init(symbolName: "chevron.left.forwardslash.chevron.right", rank: 12, group: .editor),
         "com.todesktop.230313mzl4w4u92": .init(symbolName: "cursorarrow.click.2", rank: 13, group: .editor),
+        "com.code.athas": .init(symbolName: "chevron.left.forwardslash.chevron.right", rank: 34, group: .editor),
         "dev.zed.Zed": .init(symbolName: "bolt.horizontal", rank: 14, group: .editor),
         "com.exafunction.windsurf": .init(symbolName: "wind", rank: 15, group: .editor),
         "com.qoder.ide": .init(symbolName: "chevron.left.forwardslash.chevron.right", rank: 16, group: .editor),

--- a/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
+++ b/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
@@ -342,6 +342,53 @@ struct IDEIntegrationServiceTests {
         #expect(app?.group == .editor)
     }
 
+    @Test("classifies Athas by curated bundle identifier")
+    func classifiesAthasByCuratedBundleIdentifier() {
+        let metadata = IDEIntegrationService.AppMetadata(
+            bundleIdentifier: "com.code.athas",
+            displayName: "Athas",
+            executableName: "athas",
+            category: "public.app-category.developer-tools",
+            appURL: URL(fileURLWithPath: "/Applications/Athas.app")
+        )
+
+        let app = IDEIntegrationService.ideApplication(from: metadata)
+
+        #expect(app?.displayName == "Athas")
+        #expect(app?.group == .editor)
+    }
+
+    @Test("launchCommands opens Athas generically with project and file")
+    func launchCommandsOpensAthasGenericallyWithProjectAndFile() {
+        let ide = IDEIntegrationService.IDEApplication(
+            bundleIdentifier: "com.code.athas",
+            displayName: "Athas",
+            appURL: URL(fileURLWithPath: "/Applications/Athas.app"),
+            symbolName: "chevron.left.forwardslash.chevron.right",
+            rank: 34,
+            group: .editor
+        )
+        let location = IDEIntegrationService.EditorLocation(
+            filePath: "/tmp/repo/Sources/App.swift",
+            line: 12,
+            column: 7
+        )
+
+        let commands = IDEIntegrationService.launchCommands(
+            for: ide,
+            projectPath: "/tmp/repo",
+            editorLocation: location,
+            availableCLICommands: [:]
+        )
+
+        #expect(commands == [
+            .init(
+                executablePath: "/usr/bin/open",
+                arguments: ["-a", "/Applications/Athas.app", "/tmp/repo", "/tmp/repo/Sources/App.swift"]
+            ),
+        ])
+    }
+
     @Test("classifies Antigravity IDE by curated bundle identifier")
     func classifiesAntigravityIDEByCuratedBundleIdentifier() {
         let metadata = IDEIntegrationService.AppMetadata(


### PR DESCRIPTION
Registers Athas (com.code.athas) as a recognized editor with generic launch support for projects and files. Includes classification test and launch command verification.