### PR TITLE
OpenCode: notify on permission.asked and question.asked events

### DIFF
--- a/Muxy/Resources/scripts/opencode-muxy-plugin.js
+++ b/Muxy/Resources/scripts/opencode-muxy-plugin.js
@@ -1,5 +1,83 @@
 const childSessions = new Set()
 const sessionsWithCancelledTurnWaitingForIdle = new Set()
+const replyDeadlines = new Map()
+
+const REPLY_SUPPRESSION_MS = 1500
+const MAX_BODY_LENGTH = 200
+const PERMISSION_DETAIL_FIELDS = [
+  "command",
+  "pattern",
+  "path",
+  "filePath",
+  "url",
+  "title",
+]
+
+function sanitize(text) {
+  if (typeof text !== "string") return ""
+  return text.replace(/[\n\r|]+/g, " ").trim().slice(0, MAX_BODY_LENGTH)
+}
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim()
+  }
+  return ""
+}
+
+function permissionBody(properties) {
+  const tool = firstNonEmpty(properties.tool)
+  const metadata = properties.metadata || {}
+  const detailFromMetadata = firstNonEmpty(
+    ...PERMISSION_DETAIL_FIELDS.map((key) => metadata[key]),
+  )
+  const detailFromPatterns = Array.isArray(properties.patterns)
+    ? firstNonEmpty(...properties.patterns)
+    : ""
+  const detail = detailFromMetadata || detailFromPatterns
+  if (tool && detail) return `Permission needed: ${tool} - ${detail}`
+  if (tool) return `Permission needed: ${tool}`
+  if (detail) return `Permission needed: ${detail}`
+  return "Permission needed"
+}
+
+function questionBody(properties) {
+  const list = Array.isArray(properties.questions) ? properties.questions : []
+  const first = list[0] || {}
+  const header = firstNonEmpty(first.header)
+  const text = firstNonEmpty(first.question, first.prompt, first.text)
+  const more = list.length > 1 ? ` (+${list.length - 1} more)` : ""
+  if (header && text) return `Question: ${header} - ${text}${more}`
+  if (text) return `Question: ${text}${more}`
+  if (header) return `Question: ${header}${more}`
+  return "Question waiting"
+}
+
+function markRecentReply(sessionID) {
+  if (!sessionID) return
+  replyDeadlines.set(sessionID, Date.now() + REPLY_SUPPRESSION_MS)
+}
+
+function consumeRecentReply(sessionID) {
+  const deadline = replyDeadlines.get(sessionID)
+  if (deadline === undefined) return false
+  replyDeadlines.delete(sessionID)
+  return Date.now() <= deadline
+}
+
+async function sendNotification(socketPath, paneID, body) {
+  const payload = `opencode|${paneID}|OpenCode|${sanitize(body)}`
+  try {
+    const { createConnection } = await import("net")
+    const conn = createConnection({ path: socketPath })
+    conn.on("error", () => {})
+    conn.write(payload, () => conn.end())
+    await new Promise((resolve) => {
+      conn.on("close", resolve)
+      setTimeout(resolve, 3000)
+    })
+  } catch {}
+}
 
 export const MuxyNotificationPlugin = async ({ client }) => ({
   event: async ({ event }) => {
@@ -18,8 +96,29 @@ export const MuxyNotificationPlugin = async ({ client }) => ({
       const err = event.properties.error
       if (err?.name === "MessageAbortedError") {
         if (sessionID) sessionsWithCancelledTurnWaitingForIdle.add(sessionID)
-        return
       }
+      return
+    }
+
+    if (event.type === "permission.asked") {
+      if (childSessions.has(event.properties.sessionID)) return
+      await sendNotification(socketPath, paneID, permissionBody(event.properties))
+      return
+    }
+
+    if (event.type === "permission.replied") {
+      markRecentReply(event.properties.sessionID)
+      return
+    }
+
+    if (event.type === "question.asked") {
+      if (childSessions.has(event.properties.sessionID)) return
+      await sendNotification(socketPath, paneID, questionBody(event.properties))
+      return
+    }
+
+    if (event.type === "question.replied" || event.type === "question.rejected") {
+      markRecentReply(event.properties.sessionID)
       return
     }
 
@@ -32,6 +131,7 @@ export const MuxyNotificationPlugin = async ({ client }) => ({
       return
     }
     if (childSessions.has(sessionID)) return
+    if (consumeRecentReply(sessionID)) return
 
     let body = "Session completed"
 
@@ -49,23 +149,10 @@ export const MuxyNotificationPlugin = async ({ client }) => ({
           (p) => p.type === "text",
         )
         const text = textParts.map((p) => p.text || "").join("")
-        if (text) {
-          body = text.replace(/[\n\r|]+/g, " ").slice(0, 200)
-        }
+        if (text) body = text
       }
     } catch {}
 
-    const payload = `opencode|${paneID}|OpenCode|${body}`
-
-    try {
-      const { createConnection } = await import("net")
-      const conn = createConnection({ path: socketPath })
-      conn.on("error", () => {})
-      conn.write(payload, () => conn.end())
-      await new Promise((resolve) => {
-        conn.on("close", resolve)
-        setTimeout(resolve, 3000)
-      })
-    } catch {}
+    await sendNotification(socketPath, paneID, body)
   },
 })


### PR DESCRIPTION
## Summary

Plugin to send notification to OpenCode when the agent is stuck asking for permissions or waiting for user input.

## Changes

Added the possibility to trigger a notification in `opencode-muxy-plugin.js` when agent is waiting for permission or user input.

## Testing

- [X] `scripts/checks.sh` passes
- [X] Tested manually on macOS

## Screenshots


https://github.com/user-attachments/assets/9e01afe8-6ee2-49f8-bcc9-1b2a84704044


