### PR TITLE
fix: resolve cross-worktree pane lookup in splitArea

### DIFF
--- a/Muxy/Models/WorkspaceReducer/SplitReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/SplitReducer.swift
@@ -3,18 +3,17 @@ import Foundation
 @MainActor
 enum SplitReducer {
     static func splitArea(_ request: AppState.SplitAreaRequest, state: inout WorkspaceState) {
-        guard let key = WorkspaceReducerShared.activeKey(projectID: request.projectID, state: state),
-              let root = state.workspaceRoots[key]
+        guard let entry = state.workspaceRoots.first(where: { $0.value.containsArea(id: request.areaID) })
         else { return }
-        let (newRoot, newAreaID) = root.splitting(
+        let (newRoot, newAreaID) = entry.value.splitting(
             areaID: request.areaID,
             direction: request.direction,
             position: request.position,
             command: request.command
         )
-        state.workspaceRoots[key] = newRoot
+        state.workspaceRoots[entry.key] = newRoot
         guard let newAreaID else { return }
-        FocusReducer.focusArea(newAreaID, key: key, state: &state)
+        FocusReducer.focusArea(newAreaID, key: entry.key, state: &state)
     }
 
     static func closeArea(

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -212,6 +212,7 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private func readFromSession(_ session: ClientSession) {
         var buffer = [UInt8](repeating: 0, count: 4096)
+        var reachedEOF = false
         while true {
             let bytesRead = read(session.fd, &buffer, buffer.count)
             if bytesRead > 0 {
@@ -221,11 +222,12 @@ final class NotificationSocketServer: @unchecked Sendable {
                     disposeSession(session)
                     return
                 }
+                processBufferedLines(session: session)
                 continue
             }
             if bytesRead == 0 {
-                disposeSession(session)
-                return
+                reachedEOF = true
+                break
             }
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 break
@@ -234,6 +236,14 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
 
+        processBufferedLines(session: session)
+
+        if reachedEOF {
+            disposeSession(session)
+        }
+    }
+
+    private func processBufferedLines(session: ClientSession) {
         while let newlineRange = session.inputBuffer.range(of: Data([UInt8(ascii: "\n")])) {
             let lineData = session.inputBuffer.subdata(in: 0 ..< newlineRange.lowerBound)
             session.inputBuffer.removeSubrange(0 ..< newlineRange.upperBound)


### PR DESCRIPTION
## Problem

`split-right` / `split-down` silently fail when executed from a pane in a background (inactive) worktree. The resulting `send` returns `"pane not found"` because the new pane was never created.

## Root Cause

`SplitReducer.splitArea` resolved the workspace root via `activeKey()`, which always points to the active project's worktree. When the from-pane belongs to a different (but still open) worktree, the target `areaID` doesn't exist in the active root, so the split silently returns without creating anything.

## Fix

Search all workspace roots for the one that actually contains the target `areaID`, instead of assuming it lives under the active project's worktree key.