### PR TITLE
Install extensions from the marketplace

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
     static let openProjectPicker = Notification.Name("MuxyOpenProjectPicker")
     static let openSettingsModal = Notification.Name("MuxyOpenSettingsModal")
     static let openExtensionsModal = Notification.Name("MuxyOpenExtensionsModal")
+    static let openExtensionInstall = Notification.Name("MuxyOpenExtensionInstall")
     static let openExtensionDirectoryAsProject = Notification.Name("MuxyOpenExtensionDirectoryAsProject")
     static let focusProjectPickerDefaultLocation = Notification.Name("MuxyFocusProjectPickerDefaultLocation")
     static let saveActiveEditor = Notification.Name("MuxySaveActiveEditor")
@@ -37,4 +38,8 @@ enum ExternalDragHoverUserInfoKey {
 
 enum OpenExtensionDirectoryUserInfoKey {
     static let path = "path"
+}
+
+enum ExtensionInstallUserInfoKey {
+    static let name = "name"
 }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -337,7 +337,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: ["ApplePressAndHoldEnabled": false])
-        registerURLEventHandler()
         SentryService.shared.start()
         NSWindow.allowsAutomaticWindowTabbing = false
         NSApp.setActivationPolicy(.regular)

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -1,5 +1,8 @@
 import AppKit
+import os
 import SwiftUI
+
+private let deepLinkLogger = Logger(subsystem: "app.muxy", category: "DeepLink")
 
 @main
 struct MuxyApp: App {
@@ -184,6 +187,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var openProjectFromPath: ((String) -> Void)?
 
     private var pendingOpenPaths: [String] = []
+    private var pendingInstallName: String?
+    private var isReadyForModals = false
     private var systemAppearanceObserver: NSObjectProtocol?
     private var settingsObserver: NSObjectProtocol?
     private var extensionsObserver: NSObjectProtocol?
@@ -213,6 +218,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         for path in queued {
             handler(path)
         }
+        isReadyForModals = true
+        if let name = pendingInstallName {
+            pendingInstallName = nil
+            presentExtensionsModal(installName: name)
+        }
+    }
+
+    @MainActor
+    func handleInstallExtension(name: String) {
+        guard isReadyForModals else {
+            pendingInstallName = name
+            return
+        }
+        presentExtensionsModal(installName: name)
     }
 
     nonisolated static func resolveProjectPath(from url: URL) -> String? {
@@ -253,12 +272,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         return standardized
     }
 
+    nonisolated static func resolveInstallName(from url: URL) -> String? {
+        guard url.scheme == "muxy", url.host == "extensions" else { return nil }
+        let segments = url.pathComponents.filter { $0 != "/" }
+        guard segments.first == "install" else { return nil }
+        guard let raw = segments.dropFirst().first?.removingPercentEncoding, !raw.isEmpty else { return nil }
+        return raw
+    }
+
     @MainActor
     func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls {
-            guard let path = Self.resolveProjectPath(from: url) else { continue }
-            handleOpenProjectPath(path)
+            handleIncomingURL(url)
         }
+    }
+
+    @MainActor
+    func handleIncomingURL(_ url: URL) {
+        deepLinkLogger.log("incoming url: \(url.absoluteString, privacy: .public)")
+        if let name = Self.resolveInstallName(from: url) {
+            handleInstallExtension(name: name)
+            return
+        }
+        guard let path = Self.resolveProjectPath(from: url) else { return }
+        handleOpenProjectPath(path)
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
@@ -274,8 +311,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     @MainActor
+    private func registerURLEventHandler() {
+        NSAppleEventManager.shared().setEventHandler(
+            self,
+            andSelector: #selector(handleURLEvent(_:withReplyEvent:)),
+            forEventClass: AEEventClass(kInternetEventClass),
+            andEventID: AEEventID(kAEGetURL)
+        )
+    }
+
+    @MainActor
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        registerURLEventHandler()
+    }
+
+    @MainActor
+    @objc
+    private func handleURLEvent(_ event: NSAppleEventDescriptor, withReplyEvent _: NSAppleEventDescriptor) {
+        guard let string = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
+              let url = URL(string: string)
+        else { return }
+        handleIncomingURL(url)
+    }
+
+    @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: ["ApplePressAndHoldEnabled": false])
+        registerURLEventHandler()
         SentryService.shared.start()
         NSWindow.allowsAutomaticWindowTabbing = false
         NSApp.setActivationPolicy(.regular)
@@ -291,6 +353,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         NotificationSocketServer.shared.openProjectHandler = { [weak self] path in
             Task { @MainActor [weak self] in
                 self?.handleOpenProjectPath(path)
+            }
+        }
+        NotificationSocketServer.shared.installExtensionHandler = { [weak self] name in
+            Task { @MainActor [weak self] in
+                self?.handleInstallExtension(name: name)
             }
         }
         NotificationSocketServer.shared.start()
@@ -317,6 +384,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         NSApp.windows.first { window in
             window !== excludedWindow && window.identifier == ShortcutContext.mainWindowIdentifier
         }
+    }
+
+    @MainActor
+    @discardableResult
+    static func activateMainWindowOnCurrentSpace() -> NSWindow? {
+        NSApp.activate(ignoringOtherApps: true)
+        guard let window = mainAppWindow() else { return nil }
+        let previousBehavior = window.collectionBehavior
+        window.collectionBehavior.insert(.moveToActiveSpace)
+        window.makeKeyAndOrderFront(nil)
+        window.collectionBehavior = previousBehavior
+        return window
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -475,7 +554,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     @MainActor
-    private func presentExtensionsModal() {
+    private func presentExtensionsModal(installName: String? = nil) {
         let config = AppModalConfig(
             title: "Extensions",
             size: CGSize(width: 880, height: 620),
@@ -484,7 +563,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             onClosed: { [weak self] in self?.extensionsWindow = nil }
         )
         extensionsWindow = AppModalPresenter.present(config) {
-            ExtensionsView()
+            ExtensionsView(installName: installName)
+        }
+        if let installName {
+            NotificationCenter.default.post(
+                name: .openExtensionInstall,
+                object: nil,
+                userInfo: [ExtensionInstallUserInfoKey.name: installName]
+            )
         }
     }
 

--- a/Muxy/Services/ExtensionMarketplaceService.swift
+++ b/Muxy/Services/ExtensionMarketplaceService.swift
@@ -1,0 +1,160 @@
+import CryptoKit
+import Foundation
+
+struct MarketplaceExtensionAuthor: Decodable, Equatable {
+    let name: String?
+    let github: String?
+}
+
+struct MarketplaceExtension: Decodable, Equatable {
+    let name: String
+    let description: String?
+    let permissions: [String]
+    let author: MarketplaceExtensionAuthor?
+    let homepage: String?
+    let repository: String?
+    let categories: [String]
+    let iconURL: String?
+    let screenshotPaths: [String]
+    let downloads: Int
+    let currentVersion: String
+    let sha256: String
+    let size: Int
+    let downloadURL: String
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case permissions
+        case author
+        case homepage
+        case repository
+        case categories
+        case iconURL = "icon_url"
+        case screenshotPaths = "screenshot_paths"
+        case downloads
+        case currentVersion = "current_version"
+        case sha256
+        case size
+        case downloadURL = "download_url"
+    }
+
+    var resolvedPermissions: [ExtensionPermission] {
+        permissions.compactMap(ExtensionPermission.init(rawValue:))
+    }
+}
+
+enum MarketplaceError: LocalizedError, Equatable {
+    case notFound
+    case network(String)
+    case hashMismatch
+    case sizeMismatch
+    case invalidArchive
+    case unpackFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notFound:
+            "This extension is no longer available in the marketplace."
+        case let .network(message):
+            "Could not reach the marketplace: \(message)"
+        case .hashMismatch:
+            "The downloaded extension failed integrity verification and was not installed."
+        case .sizeMismatch:
+            "The downloaded extension did not match the expected size and was not installed."
+        case .invalidArchive:
+            "The downloaded extension package is not a valid Muxy extension."
+        case let .unpackFailed(message):
+            "Could not unpack the extension: \(message)"
+        }
+    }
+}
+
+actor ExtensionMarketplaceService {
+    static let shared = ExtensionMarketplaceService()
+
+    private struct Envelope<T: Decodable>: Decodable {
+        let data: T
+    }
+
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(
+        baseURL: URL = ExtensionMarketplaceService.productionBaseURL,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    private static var productionBaseURL: URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "muxy.app"
+        return components.url ?? URL(fileURLWithPath: "/")
+    }
+
+    func fetch(name: String) async throws -> MarketplaceExtension {
+        let url = baseURL
+            .appendingPathComponent("api")
+            .appendingPathComponent("extensions")
+            .appendingPathComponent(name)
+
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 404 {
+            throw MarketplaceError.notFound
+        }
+        try ensureSuccess(response)
+
+        do {
+            return try JSONDecoder().decode(Envelope<MarketplaceExtension>.self, from: data).data
+        } catch {
+            throw MarketplaceError.network(error.localizedDescription)
+        }
+    }
+
+    func download(_ ext: MarketplaceExtension) async throws -> Data {
+        guard let url = URL(string: ext.downloadURL) else {
+            throw MarketplaceError.invalidArchive
+        }
+
+        let (data, response) = try await self.data(for: URLRequest(url: url))
+        if let http = response as? HTTPURLResponse, http.statusCode == 404 {
+            throw MarketplaceError.notFound
+        }
+        try ensureSuccess(response)
+
+        guard data.count == ext.size else {
+            throw MarketplaceError.sizeMismatch
+        }
+        guard Self.sha256Hex(data) == ext.sha256.lowercased() else {
+            throw MarketplaceError.hashMismatch
+        }
+        return data
+    }
+
+    private func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch let error as MarketplaceError {
+            throw error
+        } catch {
+            throw MarketplaceError.network(error.localizedDescription)
+        }
+    }
+
+    private func ensureSuccess(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse else { return }
+        guard (200 ..< 300).contains(http.statusCode) else {
+            throw MarketplaceError.network("HTTP \(http.statusCode)")
+        }
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Muxy/Services/ExtensionMarketplaceService.swift
+++ b/Muxy/Services/ExtensionMarketplaceService.swift
@@ -77,6 +77,8 @@ actor ExtensionMarketplaceService {
         let data: T
     }
 
+    private static let maximumDownloadBytes = 100 * 1024 * 1024
+
     private let baseURL: URL
     private let session: URLSession
 
@@ -118,11 +120,14 @@ actor ExtensionMarketplaceService {
     }
 
     func download(_ ext: MarketplaceExtension) async throws -> Data {
+        guard ext.size > 0, ext.size <= Self.maximumDownloadBytes else {
+            throw MarketplaceError.sizeMismatch
+        }
         guard let url = URL(string: ext.downloadURL) else {
             throw MarketplaceError.invalidArchive
         }
 
-        let (data, response) = try await self.data(for: URLRequest(url: url))
+        let (data, response) = try await bytes(for: URLRequest(url: url), limit: ext.size)
         if let http = response as? HTTPURLResponse, http.statusCode == 404 {
             throw MarketplaceError.notFound
         }
@@ -140,6 +145,25 @@ actor ExtensionMarketplaceService {
     private func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         do {
             return try await session.data(for: request)
+        } catch let error as MarketplaceError {
+            throw error
+        } catch {
+            throw MarketplaceError.network(error.localizedDescription)
+        }
+    }
+
+    private func bytes(for request: URLRequest, limit: Int) async throws -> (Data, URLResponse) {
+        do {
+            let (stream, response) = try await session.bytes(for: request)
+            var data = Data()
+            data.reserveCapacity(limit)
+            for try await byte in stream {
+                data.append(byte)
+                guard data.count <= limit else {
+                    throw MarketplaceError.sizeMismatch
+                }
+            }
+            return (data, response)
         } catch let error as MarketplaceError {
             throw error
         } catch {

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -106,7 +106,9 @@ final class ExtensionStore {
     }
 
     func install(expectedName: String, zip: Data) async throws {
-        let staged = try await Self.unpackAndValidate(expectedName: expectedName, zip: zip)
+        let staged = try await Task.detached {
+            try Self.unpackAndValidate(expectedName: expectedName, zip: zip)
+        }.value
         defer { try? FileManager.default.removeItem(at: staged.workspace) }
 
         let target = rootDirectoryURL.appendingPathComponent(expectedName, isDirectory: true)
@@ -132,7 +134,7 @@ final class ExtensionStore {
         let workspace: URL
     }
 
-    nonisolated private static func unpackAndValidate(expectedName: String, zip: Data) async throws -> StagedExtension {
+    nonisolated private static func unpackAndValidate(expectedName: String, zip: Data) throws -> StagedExtension {
         let fileManager = FileManager.default
         let workspace = fileManager.temporaryDirectory
             .appendingPathComponent("muxy-ext-install-\(UUID().uuidString)", isDirectory: true)

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -105,6 +105,93 @@ final class ExtensionStore {
         startAll()
     }
 
+    func install(expectedName: String, zip: Data) async throws {
+        let staged = try await Self.unpackAndValidate(expectedName: expectedName, zip: zip)
+        defer { try? FileManager.default.removeItem(at: staged.workspace) }
+
+        let target = rootDirectoryURL.appendingPathComponent(expectedName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: rootDirectoryURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
+        )
+
+        if statuses.contains(where: { $0.id == expectedName }) {
+            stopProcess(extensionID: expectedName)
+        }
+        if FileManager.default.fileExists(atPath: target.path) {
+            try FileManager.default.removeItem(at: target)
+        }
+        try FileManager.default.moveItem(at: staged.manifestRoot, to: target)
+
+        reload()
+    }
+
+    private struct StagedExtension {
+        let manifestRoot: URL
+        let workspace: URL
+    }
+
+    nonisolated private static func unpackAndValidate(expectedName: String, zip: Data) async throws -> StagedExtension {
+        let fileManager = FileManager.default
+        let workspace = fileManager.temporaryDirectory
+            .appendingPathComponent("muxy-ext-install-\(UUID().uuidString)", isDirectory: true)
+        let extractDir = workspace.appendingPathComponent("extract", isDirectory: true)
+        let archiveURL = workspace.appendingPathComponent("\(expectedName).zip")
+
+        do {
+            try fileManager.createDirectory(at: extractDir, withIntermediateDirectories: true)
+            try zip.write(to: archiveURL)
+            try runUnzip(archiveURL: archiveURL, destination: extractDir)
+
+            let manifestRoot = try locateManifestRoot(in: extractDir)
+            let loaded = try ExtensionManifestLoader.load(from: manifestRoot)
+            guard loaded.id == expectedName else {
+                throw MarketplaceError.invalidArchive
+            }
+            return StagedExtension(manifestRoot: manifestRoot, workspace: workspace)
+        } catch {
+            try? fileManager.removeItem(at: workspace)
+            if error is MarketplaceError { throw error }
+            if error is ExtensionLoadError { throw MarketplaceError.invalidArchive }
+            throw MarketplaceError.unpackFailed(error.localizedDescription)
+        }
+    }
+
+    nonisolated private static func runUnzip(archiveURL: URL, destination: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-o", "-q", archiveURL.path, "-d", destination.path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw MarketplaceError.unpackFailed("unzip exited with status \(process.terminationStatus)")
+        }
+    }
+
+    nonisolated private static func locateManifestRoot(in directory: URL) throws -> URL {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: directory.appendingPathComponent("manifest.json").path) {
+            return directory
+        }
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        let directories = entries.filter { url in
+            (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        }
+        guard directories.count == 1,
+              fileManager.fileExists(atPath: directories[0].appendingPathComponent("manifest.json").path)
+        else {
+            throw MarketplaceError.invalidArchive
+        }
+        return directories[0]
+    }
+
     func setEnabled(_ enabled: Bool, for extensionID: String) {
         guard let index = statuses.firstIndex(where: { $0.id == extensionID }) else { return }
         ExtensionEnabledStore.setEnabled(enabled, extensionID: extensionID)

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -46,6 +46,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private var inProcessObservers: [UUID: @Sendable (ExtensionEvent) -> Void] = [:]
 
     var openProjectHandler: (@Sendable (String) -> Void)?
+    var installExtensionHandler: (@Sendable (String) -> Void)?
     var commandHandler: (@Sendable (String, ClientContext) async -> String)?
 
     struct ClientContext {
@@ -403,6 +404,18 @@ final class NotificationSocketServer: @unchecked Sendable {
             }
             logger.info("Received open-project request via socket")
             openProjectHandler?(path)
+            return
+        }
+
+        let installPrefix = "install-extension|"
+        if message.hasPrefix(installPrefix) {
+            let name = String(message.dropFirst(installPrefix.count))
+            guard !name.isEmpty else {
+                logger.warning("Ignoring install-extension for empty name")
+                return
+            }
+            logger.info("Received install-extension request via socket")
+            installExtensionHandler?(name)
             return
         }
 

--- a/Muxy/Views/Components/AppModalWindow.swift
+++ b/Muxy/Views/Components/AppModalWindow.swift
@@ -59,10 +59,16 @@ enum AppModalPresenter {
         @ViewBuilder content: () -> some View
     ) -> NSWindow? {
         if let existing = config.existing {
+            NSApp.activate(ignoringOtherApps: true)
+            let previousBehavior = existing.collectionBehavior
+            existing.collectionBehavior.insert(.moveToActiveSpace)
             existing.makeKeyAndOrderFront(nil)
+            existing.collectionBehavior = previousBehavior
             return existing
         }
-        guard let parent = NSApp.keyWindow ?? NSApp.mainWindow else { return nil }
+        guard let parent = AppDelegate.activateMainWindowOnCurrentSpace()
+            ?? NSApp.keyWindow ?? NSApp.mainWindow
+        else { return nil }
         let host = NSHostingController(
             rootView: content()
                 .frame(width: config.size.width, height: config.size.height)

--- a/Muxy/Views/Extensions/ExtensionInstallPage.swift
+++ b/Muxy/Views/Extensions/ExtensionInstallPage.swift
@@ -1,0 +1,400 @@
+import SwiftUI
+
+struct ExtensionInstallPage: View {
+    let name: String
+    let store: ExtensionStore
+    let onInstalled: (String) -> Void
+
+    @State private var phase: Phase = .loading
+    @State private var isInstalling = false
+    @State private var installError: String?
+
+    private enum Phase {
+        case loading
+        case failed(String)
+        case loaded(MarketplaceExtension)
+    }
+
+    private var isInstalled: Bool {
+        store.statuses.contains { $0.id == name }
+    }
+
+    private var installedVersion: String? {
+        store.statuses.first { $0.id == name }?.muxyExtension.manifest.version
+    }
+
+    var body: some View {
+        ScrollView {
+            content
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .task(id: name) { await load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch phase {
+        case .loading:
+            loadingState
+        case let .failed(message):
+            failedState(message)
+        case let .loaded(ext):
+            loadedState(ext)
+        }
+    }
+
+    private var loadingState: some View {
+        HStack(spacing: 10) {
+            ProgressView().controlSize(.small)
+            Text("Loading \(name)…")
+                .font(.system(size: 12))
+                .foregroundStyle(MuxyTheme.fgMuted)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 80)
+    }
+
+    private func failedState(_ message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 28))
+                .foregroundStyle(MuxyTheme.fgDim)
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            Button {
+                Task { await load() }
+            } label: {
+                Text("Retry")
+                    .font(.system(size: 12))
+                    .foregroundStyle(MuxyTheme.accent)
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func loadedState(_ ext: MarketplaceExtension) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            heroBlock(ext)
+            if let description = ext.description, !description.isEmpty {
+                Text(description)
+                    .font(.system(size: 13))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            permissionsBlock(ext)
+            safetyNotice
+            if let error = installError {
+                errorBlock(error)
+            }
+            installAction(ext)
+        }
+    }
+
+    private func heroBlock(_ ext: MarketplaceExtension) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            ExtensionInstallIcon(urlString: ext.iconURL)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(ext.name)
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(MuxyTheme.fg)
+                    Text("v\(ext.currentVersion)")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                }
+                if let author = ext.author?.name, !author.isEmpty {
+                    Text("by \(author)")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                }
+                HStack(spacing: 12) {
+                    Label("\(ext.downloads)", systemImage: "arrow.down.circle")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuxyTheme.fgDim)
+                    ForEach(externalLinks(ext), id: \.title) { link in
+                        Link(link.title, destination: link.url)
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuxyTheme.accent)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func permissionsBlock(_ ext: MarketplaceExtension) -> some View {
+        InstallSection(title: "Permissions") {
+            if ext.permissions.isEmpty {
+                Text("This extension requests no permissions.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgDim)
+            } else {
+                ExtensionInstallPermissionFlow(permissions: ext.permissions)
+            }
+        }
+    }
+
+    private var safetyNotice: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "lock.shield")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(MuxyTheme.accent)
+            Text("No extension can run a command on your computer without you approving each command first.")
+                .font(.system(size: 12))
+                .foregroundStyle(MuxyTheme.fg)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MuxyTheme.accentSoft, in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(MuxyTheme.accent.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private func errorBlock(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: 11))
+            .foregroundStyle(MuxyTheme.diffRemoveFg)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(MuxyTheme.diffRemoveBg, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func installAction(_ ext: MarketplaceExtension) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                Task { await install(ext) }
+            } label: {
+                HStack(spacing: 6) {
+                    if isInstalling {
+                        ProgressView().controlSize(.small)
+                    }
+                    Text(installButtonTitle)
+                        .font(.system(size: 13, weight: .semibold))
+                }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(MuxyTheme.accent, in: RoundedRectangle(cornerRadius: 8))
+                .opacity(isInstalling ? 0.7 : 1)
+            }
+            .buttonStyle(.plain)
+            .disabled(isInstalling)
+            if isInstalled, let version = installedVersion {
+                Text("Installed v\(version)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+            }
+            Spacer()
+        }
+    }
+
+    private var installButtonTitle: String {
+        if isInstalling { return isInstalled ? "Reinstalling…" : "Installing…" }
+        return isInstalled ? "Reinstall" : "Install"
+    }
+
+    private func externalLinks(_ ext: MarketplaceExtension) -> [(title: String, url: URL)] {
+        var links: [(String, URL)] = []
+        if let repository = ext.repository, let url = URL(string: repository) {
+            links.append(("Repository", url))
+        }
+        if let homepage = ext.homepage, let url = URL(string: homepage) {
+            links.append(("Homepage", url))
+        }
+        return links
+    }
+
+    private func load() async {
+        phase = .loading
+        installError = nil
+        do {
+            let ext = try await ExtensionMarketplaceService.shared.fetch(name: name)
+            phase = .loaded(ext)
+        } catch {
+            phase = .failed(message(for: error))
+        }
+    }
+
+    private func install(_ ext: MarketplaceExtension) async {
+        isInstalling = true
+        installError = nil
+        defer { isInstalling = false }
+        do {
+            let zip = try await ExtensionMarketplaceService.shared.download(ext)
+            try await store.install(expectedName: ext.name, zip: zip)
+            onInstalled(ext.name)
+        } catch {
+            installError = message(for: error)
+        }
+    }
+
+    private func message(for error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
+}
+
+private struct InstallSection<Content: View>: View {
+    let title: String
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .textCase(.uppercase)
+                .tracking(0.6)
+            content
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MuxyTheme.surface.opacity(0.5), in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(MuxyTheme.border, lineWidth: 1)
+        )
+    }
+}
+
+private struct ExtensionInstallIcon: View {
+    let urlString: String?
+
+    var body: some View {
+        Group {
+            if let urlString, let url = URL(string: urlString) {
+                AsyncImage(url: url) { image in
+                    image.resizable().scaledToFit()
+                } placeholder: {
+                    placeholder
+                }
+            } else {
+                placeholder
+            }
+        }
+        .frame(width: 48, height: 48)
+        .background(MuxyTheme.bg, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(MuxyTheme.border, lineWidth: 1)
+        )
+    }
+
+    private var placeholder: some View {
+        Image(systemName: "puzzlepiece.extension")
+            .font(.system(size: 20))
+            .foregroundStyle(MuxyTheme.fgDim)
+    }
+}
+
+private struct ExtensionInstallPermissionFlow: View {
+    let permissions: [String]
+
+    var body: some View {
+        FlowLayout(spacing: 6, lineSpacing: 6) {
+            ForEach(permissions, id: \.self) { permission in
+                ExtensionInstallPermissionTag(permission: permission)
+            }
+        }
+    }
+}
+
+private struct ExtensionInstallPermissionTag: View {
+    let permission: String
+
+    var body: some View {
+        let color = tagColor
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 5, height: 5)
+            Text(permission)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(color.opacity(0.1), in: RoundedRectangle(cornerRadius: 5))
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(color.opacity(0.35), lineWidth: 1)
+        )
+    }
+
+    private var tagColor: Color {
+        guard let kind = ExtensionPermission(rawValue: permission)?.kind else {
+            return MuxyTheme.fgMuted
+        }
+        switch kind {
+        case .read: return MuxyTheme.warning
+        case .write: return MuxyTheme.diffRemoveFg
+        case .action: return MuxyTheme.accent
+        }
+    }
+}
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat
+    var lineSpacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let layout = arrange(subviews: subviews, in: maxWidth)
+        return CGSize(width: maxWidth.isFinite ? maxWidth : layout.width, height: layout.height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        let layout = arrange(subviews: subviews, in: bounds.width)
+        for placement in layout.placements {
+            subviews[placement.index].place(
+                at: CGPoint(x: bounds.minX + placement.point.x, y: bounds.minY + placement.point.y),
+                proposal: ProposedViewSize(placement.size)
+            )
+        }
+    }
+
+    private struct Placement {
+        let index: Int
+        let point: CGPoint
+        let size: CGSize
+    }
+
+    private struct ArrangedLayout {
+        let width: CGFloat
+        let height: CGFloat
+        let placements: [Placement]
+    }
+
+    private func arrange(subviews: Subviews, in maxWidth: CGFloat) -> ArrangedLayout {
+        var placements: [Placement] = []
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var widest: CGFloat = 0
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            if currentX > 0, currentX + size.width > maxWidth {
+                currentY += lineHeight + lineSpacing
+                currentX = 0
+                lineHeight = 0
+            }
+            placements.append(Placement(index: index, point: CGPoint(x: currentX, y: currentY), size: size))
+            currentX += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+            widest = max(widest, currentX - spacing)
+        }
+        return ArrangedLayout(width: widest, height: currentY + lineHeight, placements: placements)
+    }
+}

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -2,10 +2,20 @@ import AppKit
 import SwiftUI
 
 struct ExtensionsView: View {
+    let installName: String?
+
     @State private var store = ExtensionStore.shared
     @State private var grantStore = ExtensionGrantStore.shared
     @State private var selectedExtensionID: String?
+    @State private var activeInstallName: String?
     @State private var showCreateSheet = false
+
+    init(installName: String? = nil) {
+        self.installName = installName
+        _activeInstallName = State(initialValue: installName)
+    }
+
+    private var isShowingInstallPage: Bool { activeInstallName != nil }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,11 +34,25 @@ struct ExtensionsView: View {
                 onFinish: { showCreateSheet = false }
             )
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openExtensionInstall)) { notification in
+            guard let name = notification.userInfo?[ExtensionInstallUserInfoKey.name] as? String else { return }
+            selectedExtensionID = nil
+            activeInstallName = name
+        }
     }
 
     @ViewBuilder
     private var content: some View {
-        if let id = selectedExtensionID, let status = store.statuses.first(where: { $0.id == id }) {
+        if let name = activeInstallName {
+            ExtensionInstallPage(
+                name: name,
+                store: store,
+                onInstalled: { installedID in
+                    activeInstallName = nil
+                    selectedExtensionID = installedID
+                }
+            )
+        } else if let id = selectedExtensionID, let status = store.statuses.first(where: { $0.id == id }) {
             ExtensionDetailPage(
                 status: status,
                 store: store,
@@ -44,9 +68,10 @@ struct ExtensionsView: View {
 
     private var header: some View {
         HStack(spacing: 10) {
-            if selectedExtensionID != nil {
+            if selectedExtensionID != nil || isShowingInstallPage {
                 Button {
                     selectedExtensionID = nil
+                    activeInstallName = nil
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "chevron.left")
@@ -73,7 +98,7 @@ struct ExtensionsView: View {
                 }
             }
             Spacer()
-            if selectedExtensionID == nil {
+            if selectedExtensionID == nil, !isShowingInstallPage {
                 Button {
                     showCreateSheet = true
                 } label: {

--- a/Tests/MuxyTests/Services/ExtensionMarketplaceServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionMarketplaceServiceTests.swift
@@ -1,0 +1,138 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionMarketplaceService", .serialized)
+struct ExtensionMarketplaceServiceTests {
+    @Test("decodes the data envelope for a single extension")
+    func fetchDecodesEnvelope() async throws {
+        let json = """
+        {
+            "data": {
+                "name": "git-status",
+                "description": "Show branch info.",
+                "permissions": ["tabs:read", "tabs:write"],
+                "author": { "name": "Saeed", "github": "saeedvaziry" },
+                "homepage": "https://muxy.app",
+                "repository": "https://github.com/muxy-app/git-status",
+                "categories": ["git"],
+                "icon_url": "https://muxy.app/extensions/git-status/icon",
+                "screenshot_paths": [],
+                "downloads": 10,
+                "current_version": "1.4.2",
+                "sha256": "abc",
+                "size": 100,
+                "download_url": "https://muxy.app/api/extensions/git-status/download"
+            }
+        }
+        """
+        let service = makeService { _ in (200, Data(json.utf8)) }
+
+        let ext = try await service.fetch(name: "git-status")
+
+        #expect(ext.name == "git-status")
+        #expect(ext.currentVersion == "1.4.2")
+        #expect(ext.resolvedPermissions == [.tabsRead, .tabsWrite])
+    }
+
+    @Test("maps 404 to notFound")
+    func fetchMapsNotFound() async throws {
+        let service = makeService { _ in (404, Data(#"{"message":"Not Found"}"#.utf8)) }
+
+        await #expect(throws: MarketplaceError.notFound) {
+            _ = try await service.fetch(name: "missing")
+        }
+    }
+
+    @Test("download rejects a hash mismatch")
+    func downloadRejectsHashMismatch() async throws {
+        let payload = Data("zip-bytes".utf8)
+        let service = makeService { _ in (200, payload) }
+        let ext = makeExtension(sha256: "deadbeef", size: payload.count)
+
+        await #expect(throws: MarketplaceError.hashMismatch) {
+            _ = try await service.download(ext)
+        }
+    }
+
+    @Test("download rejects a size mismatch")
+    func downloadRejectsSizeMismatch() async throws {
+        let payload = Data("zip-bytes".utf8)
+        let service = makeService { _ in (200, payload) }
+        let ext = makeExtension(sha256: sha256Hex(payload), size: payload.count + 1)
+
+        await #expect(throws: MarketplaceError.sizeMismatch) {
+            _ = try await service.download(ext)
+        }
+    }
+
+    @Test("download returns verified bytes")
+    func downloadReturnsVerifiedBytes() async throws {
+        let payload = Data("zip-bytes".utf8)
+        let service = makeService { _ in (200, payload) }
+        let ext = makeExtension(sha256: sha256Hex(payload), size: payload.count)
+
+        let data = try await service.download(ext)
+
+        #expect(data == payload)
+    }
+
+    private func makeService(handler: @escaping @Sendable (URLRequest) -> (Int, Data)) -> ExtensionMarketplaceService {
+        StubURLProtocol.handler = handler
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return ExtensionMarketplaceService(
+            baseURL: URL(string: "https://muxy.test")!,
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    private func makeExtension(sha256: String, size: Int) -> MarketplaceExtension {
+        let json = """
+        {
+            "name": "demo",
+            "description": null,
+            "permissions": [],
+            "author": null,
+            "homepage": null,
+            "repository": null,
+            "categories": [],
+            "icon_url": null,
+            "screenshot_paths": [],
+            "downloads": 0,
+            "current_version": "1.0.0",
+            "sha256": "\(sha256)",
+            "size": \(size),
+            "download_url": "https://muxy.test/download"
+        }
+        """
+        return try! JSONDecoder().decode(MarketplaceExtension.self, from: Data(json.utf8))
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+private final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) -> (Int, Data))?
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler, let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let (status, data) = handler(request)
+        let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/MuxyTests/Services/ExtensionStoreInstallTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreInstallTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionStore install")
+@MainActor
+struct ExtensionStoreInstallTests {
+    @Test("unzips, validates, and registers the installed extension")
+    func installsExtension() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root)
+
+        let zip = try makeExtensionZip(name: "demo-ext", version: "1.0.0")
+
+        try await store.install(expectedName: "demo-ext", zip: zip)
+
+        #expect(store.statuses.contains { $0.id == "demo-ext" })
+        let manifest = root.appendingPathComponent("demo-ext/manifest.json")
+        #expect(FileManager.default.fileExists(atPath: manifest.path))
+    }
+
+    @Test("reinstall overwrites the existing directory")
+    func reinstallOverwrites() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root)
+
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext", version: "1.0.0"))
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext", version: "2.0.0"))
+
+        let status = try #require(store.statuses.first { $0.id == "demo-ext" })
+        #expect(status.muxyExtension.manifest.version == "2.0.0")
+    }
+
+    @Test("rejects a package whose manifest name does not match")
+    func rejectsNameMismatch() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root)
+
+        let zip = try makeExtensionZip(name: "other-name", version: "1.0.0")
+
+        await #expect(throws: MarketplaceError.self) {
+            try await store.install(expectedName: "demo-ext", zip: zip)
+        }
+        #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent("demo-ext").path))
+    }
+
+    private func makeRoot() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("install-root-\(UUID().uuidString)")
+    }
+
+    private func makeStore(root: URL) -> ExtensionStore {
+        ExtensionStore.makeForTesting(
+            rootDirectory: root,
+            snapshotSink: NoopSnapshotSink(),
+            resolveHostURL: { URL(fileURLWithPath: "/usr/bin/true") }
+        )
+    }
+
+    private func makeExtensionZip(name: String, version: String) throws -> Data {
+        let fileManager = FileManager.default
+        let workspace = fileManager.temporaryDirectory.appendingPathComponent("zip-src-\(UUID().uuidString)")
+        let source = workspace.appendingPathComponent(name)
+        try fileManager.createDirectory(at: source, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: workspace) }
+
+        let manifest = """
+        {
+            "name": "\(name)",
+            "version": "\(version)",
+            "background": "background.js"
+        }
+        """
+        try Data(manifest.utf8).write(to: source.appendingPathComponent("manifest.json"))
+        try Data("console.log('hi')\n".utf8).write(to: source.appendingPathComponent("background.js"))
+
+        let archive = workspace.appendingPathComponent("\(name).zip")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.arguments = ["-q", "-r", archive.path, name]
+        process.currentDirectoryURL = workspace
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+        return try Data(contentsOf: archive)
+    }
+}
+
+@MainActor
+private final class NoopSnapshotSink: ExtensionSnapshotSink {
+    nonisolated func applyExtensionSnapshot(_: NotificationSocketServer.ExtensionSnapshot) {}
+}

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -54,6 +54,40 @@ struct AppDelegateResolveProjectPathTests {
     }
 }
 
+@Suite("AppDelegate.resolveInstallName")
+struct AppDelegateResolveInstallNameTests {
+    @Test("muxy://extensions/install/<name> resolves the extension name")
+    func resolvesName() {
+        let url = URL(string: "muxy://extensions/install/git-status")!
+        #expect(AppDelegate.resolveInstallName(from: url) == "git-status")
+    }
+
+    @Test("percent-encoded name is decoded")
+    func decodesName() {
+        let url = URL(string: "muxy://extensions/install/git%2Dstatus")!
+        #expect(AppDelegate.resolveInstallName(from: url) == "git-status")
+    }
+
+    @Test("missing name is rejected")
+    func rejectsMissingName() {
+        let url = URL(string: "muxy://extensions/install")!
+        #expect(AppDelegate.resolveInstallName(from: url) == nil)
+    }
+
+    @Test("non-install extensions path is rejected")
+    func rejectsOtherExtensionsPath() {
+        let url = URL(string: "muxy://extensions/git-status")!
+        #expect(AppDelegate.resolveInstallName(from: url) == nil)
+    }
+
+    @Test("project path URLs are not treated as install URLs")
+    func ignoresProjectPaths() {
+        let url = URL(string: "muxy://Users/alice/projects/repo")!
+        #expect(AppDelegate.resolveInstallName(from: url) == nil)
+        #expect(AppDelegate.resolveProjectPath(from: url) == "/Users/alice/projects/repo")
+    }
+}
+
 @Suite("Muxy CLI launch resources")
 struct MuxyCLILaunchResourceTests {
     @Test("CLI sends project opens to the running app before using macOS open")


### PR DESCRIPTION
Adds a muxy:// deep link that opens an Extensions install page with metadata,
  permissions, and a per-command approval notice. Install downloads, verifies
  SHA-256/size, unzips, and reloads. URLs delivered via kAEGetURL so the modal
  opens reliably across Spaces without spawning transient windows.