### PR TITLE
Add extension update checking and UI

### DIFF
--- a/Muxy/Models/SemanticVersion.swift
+++ b/Muxy/Models/SemanticVersion.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct SemanticVersion: Comparable, Equatable {
+    let components: [Int]
+
+    init?(_ string: String) {
+        let core = string.split(separator: "+", maxSplits: 1).first ?? Substring(string)
+        let release = core.split(separator: "-", maxSplits: 1).first ?? core
+        let parsed = release.split(separator: ".").map { Int($0) }
+        guard !parsed.isEmpty, parsed.allSatisfy({ $0 != nil }) else { return nil }
+        components = parsed.compactMap(\.self)
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+        for index in 0 ..< count where lhs.component(at: index) != rhs.component(at: index) {
+            return lhs.component(at: index) < rhs.component(at: index)
+        }
+        return false
+    }
+
+    static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+        return (0 ..< count).allSatisfy { lhs.component(at: $0) == rhs.component(at: $0) }
+    }
+
+    private func component(at index: Int) -> Int {
+        index < components.count ? components[index] : 0
+    }
+
+    static func isUpdate(installed: String, available: String) -> Bool {
+        guard let installed = SemanticVersion(installed),
+              let available = SemanticVersion(available)
+        else { return false }
+        return available > installed
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -176,6 +176,7 @@ struct MuxyApp: App {
             AIProviderRegistry.shared.installAll()
             LoginShellPath.hydrateInBackground()
             ExtensionStore.shared.startAll()
+            await ExtensionStore.shared.checkForUpdates()
         }
     }
 }

--- a/Muxy/Services/ExtensionMarketplaceService.swift
+++ b/Muxy/Services/ExtensionMarketplaceService.swift
@@ -78,6 +78,7 @@ actor ExtensionMarketplaceService {
     }
 
     private static let maximumDownloadBytes = 100 * 1024 * 1024
+    private static let versionsBatchLimit = 100
 
     private let baseURL: URL
     private let session: URLSession
@@ -95,6 +96,42 @@ actor ExtensionMarketplaceService {
         components.scheme = "https"
         components.host = "muxy.app"
         return components.url ?? URL(fileURLWithPath: "/")
+    }
+
+    func resolveVersions(names: [String]) async throws -> [String: String] {
+        let unique = Array(Set(names))
+        guard !unique.isEmpty else { return [:] }
+
+        var resolved: [String: String] = [:]
+        for batch in stride(from: 0, to: unique.count, by: Self.versionsBatchLimit) {
+            let slice = Array(unique[batch ..< min(batch + Self.versionsBatchLimit, unique.count)])
+            let chunk = try await resolveVersionsBatch(names: slice)
+            resolved.merge(chunk) { _, new in new }
+        }
+        return resolved
+    }
+
+    private func resolveVersionsBatch(names: [String]) async throws -> [String: String] {
+        let url = baseURL
+            .appendingPathComponent("api")
+            .appendingPathComponent("extensions")
+            .appendingPathComponent("versions")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["names": names])
+
+        let (data, response) = try await data(for: request)
+        try ensureSuccess(response)
+
+        do {
+            let map = try JSONDecoder().decode([String: String?].self, from: data)
+            return map.compactMapValues { $0 }
+        } catch {
+            throw MarketplaceError.network(error.localizedDescription)
+        }
     }
 
     func fetch(name: String) async throws -> MarketplaceExtension {

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -38,6 +38,7 @@ final class ExtensionStore {
 
     private(set) var statuses: [ExtensionStatus] = []
     private(set) var loadFailures: [LoadFailure] = []
+    private(set) var availableUpdates: [String: String] = [:]
 
     private var processes: [String: Process] = [:]
     private var tokens: [String: String] = [:]
@@ -45,26 +46,38 @@ final class ExtensionStore {
     private let rootDirectoryURL: URL
     private let snapshotSink: ExtensionSnapshotSink
     private let resolveHostURL: @MainActor () -> URL?
+    private let marketplace: ExtensionMarketplaceService
 
     nonisolated private static let processTerminationGracePeriod: TimeInterval = 2
 
     private init(
         rootDirectory: URL = ExtensionStore.defaultRootDirectory,
         snapshotSink: ExtensionSnapshotSink = NotificationSocketServer.shared,
-        resolveHostURL: @escaping @MainActor () -> URL? = { ExtensionHostLocator.hostURL() }
+        resolveHostURL: @escaping @MainActor () -> URL? = { ExtensionHostLocator.hostURL() },
+        marketplace: ExtensionMarketplaceService = .shared
     ) {
         rootDirectoryURL = rootDirectory
         self.snapshotSink = snapshotSink
         self.resolveHostURL = resolveHostURL
+        self.marketplace = marketplace
     }
 
     static func makeForTesting(
         rootDirectory: URL,
         snapshotSink: ExtensionSnapshotSink,
-        resolveHostURL: @escaping @MainActor () -> URL?
+        resolveHostURL: @escaping @MainActor () -> URL?,
+        marketplace: ExtensionMarketplaceService = .shared
     ) -> ExtensionStore {
-        ExtensionStore(rootDirectory: rootDirectory, snapshotSink: snapshotSink, resolveHostURL: resolveHostURL)
+        ExtensionStore(
+            rootDirectory: rootDirectory,
+            snapshotSink: snapshotSink,
+            resolveHostURL: resolveHostURL,
+            marketplace: marketplace
+        )
     }
+
+    var hasUpdates: Bool { !availableUpdates.isEmpty }
+    var updateCount: Int { availableUpdates.count }
 
     func hasSpawnedProcessForTesting(extensionID: String) -> Bool {
         processes[extensionID] != nil
@@ -127,6 +140,55 @@ final class ExtensionStore {
         try FileManager.default.moveItem(at: staged.manifestRoot, to: target)
 
         reload()
+    }
+
+    func availableUpdateVersion(for extensionID: String) -> String? {
+        availableUpdates[extensionID]
+    }
+
+    func checkForUpdates() async {
+        let installed = statuses.map(\.id)
+        guard !installed.isEmpty else {
+            availableUpdates = [:]
+            return
+        }
+        guard let remote = try? await marketplace.resolveVersions(names: installed) else { return }
+
+        var updates: [String: String] = [:]
+        for status in statuses {
+            guard let remoteVersion = remote[status.id] else { continue }
+            let installedVersion = status.muxyExtension.manifest.version
+            if SemanticVersion.isUpdate(installed: installedVersion, available: remoteVersion) {
+                updates[status.id] = remoteVersion
+            }
+        }
+        availableUpdates = updates
+    }
+
+    func update(extensionID: String) async throws {
+        let ext = try await marketplace.fetch(name: extensionID)
+        let zip = try await marketplace.download(ext)
+        try await install(expectedName: ext.name, zip: zip)
+        availableUpdates.removeValue(forKey: extensionID)
+    }
+
+    struct UpdateAllResult {
+        var succeeded: [String] = []
+        var failed: [(id: String, message: String)] = []
+    }
+
+    func updateAll() async -> UpdateAllResult {
+        var result = UpdateAllResult()
+        for extensionID in availableUpdates.keys.sorted() {
+            do {
+                try await update(extensionID: extensionID)
+                result.succeeded.append(extensionID)
+            } catch {
+                let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                result.failed.append((id: extensionID, message: message))
+            }
+        }
+        return result
     }
 
     private struct StagedExtension {
@@ -522,6 +584,16 @@ final class ExtensionStore {
                 ))
                 logger.error("Failed to load extension at \(url.path): \(error.localizedDescription)")
             }
+        }
+        pruneResolvedUpdates()
+    }
+
+    private func pruneResolvedUpdates() {
+        guard !availableUpdates.isEmpty else { return }
+        availableUpdates = availableUpdates.filter { id, remoteVersion in
+            guard let installed = statuses.first(where: { $0.id == id })?.muxyExtension.manifest.version
+            else { return false }
+            return SemanticVersion.isUpdate(installed: installed, available: remoteVersion)
         }
     }
 

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -152,7 +152,13 @@ final class ExtensionStore {
             availableUpdates = [:]
             return
         }
-        guard let remote = try? await marketplace.resolveVersions(names: installed) else { return }
+        let remote: [String: String]
+        do {
+            remote = try await marketplace.resolveVersions(names: installed)
+        } catch {
+            logger.error("Failed to check for extension updates: \(error.localizedDescription)")
+            return
+        }
 
         var updates: [String: String] = [:]
         for status in statuses {

--- a/Muxy/Views/Components/IconButton.swift
+++ b/Muxy/Views/Components/IconButton.swift
@@ -5,6 +5,7 @@ struct IconButton: View {
     var size: CGFloat = 13
     var color: Color = MuxyTheme.fgMuted
     var hoverColor: Color = MuxyTheme.fg
+    var showsBadge = false
     let accessibilityLabel: String
     let action: () -> Void
 
@@ -17,7 +18,24 @@ struct IconButton: View {
         ) {
             Image(systemName: symbol)
                 .font(.system(size: UIMetrics.scaled(size), weight: .semibold))
+                .overlay(alignment: .topTrailing) {
+                    if showsBadge {
+                        IconButtonBadge()
+                    }
+                }
         }
+    }
+}
+
+private struct IconButtonBadge: View {
+    var body: some View {
+        Circle()
+            .fill(MuxyTheme.accent)
+            .frame(width: UIMetrics.scaled(6), height: UIMetrics.scaled(6))
+            .overlay(
+                Circle().stroke(MuxyTheme.bg, lineWidth: UIMetrics.scaled(1.5))
+            )
+            .offset(x: UIMetrics.scaled(4), y: UIMetrics.scaled(-4))
     }
 }
 

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -9,6 +9,7 @@ struct ExtensionsView: View {
     @State private var selectedExtensionID: String?
     @State private var activeInstallName: String?
     @State private var showCreateSheet = false
+    @State private var isUpdatingAll = false
 
     init(installName: String? = nil) {
         self.installName = installName
@@ -38,6 +39,9 @@ struct ExtensionsView: View {
             guard let name = notification.userInfo?[ExtensionInstallUserInfoKey.name] as? String else { return }
             selectedExtensionID = nil
             activeInstallName = name
+        }
+        .task {
+            await store.checkForUpdates()
         }
     }
 
@@ -99,6 +103,27 @@ struct ExtensionsView: View {
             }
             Spacer()
             if selectedExtensionID == nil, !isShowingInstallPage {
+                if store.hasUpdates {
+                    Button {
+                        Task { await updateAll() }
+                    } label: {
+                        HStack(spacing: 5) {
+                            if isUpdatingAll {
+                                ProgressView().controlSize(.small)
+                            }
+                            Text(isUpdatingAll ? "Updating…" : "Update All (\(store.updateCount))")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(MuxyTheme.accent, in: RoundedRectangle(cornerRadius: 6))
+                        .opacity(isUpdatingAll ? 0.7 : 1)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isUpdatingAll)
+                    .help("Update all extensions with available updates")
+                }
                 Button {
                     showCreateSheet = true
                 } label: {
@@ -143,6 +168,21 @@ struct ExtensionsView: View {
         .frame(height: 56)
         .background(MuxyTheme.bg)
     }
+
+    private func updateAll() async {
+        isUpdatingAll = true
+        defer { isUpdatingAll = false }
+        let result = await store.updateAll()
+        if result.failed.isEmpty {
+            ToastState.shared.show("Updated \(result.succeeded.count) extension\(result.succeeded.count == 1 ? "" : "s")")
+        } else {
+            let names = result.failed.map(\.id).joined(separator: ", ")
+            ToastState.shared.show(
+                title: "Some extensions failed to update",
+                body: names
+            )
+        }
+    }
 }
 
 private struct ExtensionsDivider: View {
@@ -156,6 +196,7 @@ private struct ExtensionsDivider: View {
 private struct ExtensionsListPage: View {
     let store: ExtensionStore
     let onSelect: (String) -> Void
+    @State private var updatingIDs: Set<String> = []
 
     var body: some View {
         ScrollView {
@@ -169,9 +210,13 @@ private struct ExtensionsListPage: View {
                 } else {
                     VStack(spacing: 0) {
                         ForEach(Array(store.statuses.enumerated()), id: \.element.id) { index, status in
-                            ExtensionRow(status: status) {
-                                onSelect(status.id)
-                            }
+                            ExtensionRow(
+                                status: status,
+                                availableVersion: store.availableUpdateVersion(for: status.id),
+                                isUpdating: updatingIDs.contains(status.id),
+                                onUpdate: { Task { await updateOne(status.id) } },
+                                onOpen: { onSelect(status.id) }
+                            )
                             if index < store.statuses.count - 1 {
                                 Rectangle()
                                     .fill(MuxyTheme.border)
@@ -188,6 +233,17 @@ private struct ExtensionsListPage: View {
             }
             .padding(20)
             .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private func updateOne(_ extensionID: String) async {
+        updatingIDs.insert(extensionID)
+        defer { updatingIDs.remove(extensionID) }
+        do {
+            try await store.update(extensionID: extensionID)
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            ToastState.shared.show(title: "Could not update \(extensionID)", body: message)
         }
     }
 
@@ -251,51 +307,93 @@ private struct LoadFailuresBlock: View {
 
 private struct ExtensionRow: View {
     let status: ExtensionStore.ExtensionStatus
+    var availableVersion: String?
+    var isUpdating = false
+    var onUpdate: () -> Void = {}
     let onOpen: () -> Void
     @State private var hovered = false
 
     private var ext: MuxyExtension { status.muxyExtension }
 
     var body: some View {
-        Button(action: onOpen) {
-            HStack(spacing: 12) {
-                Image(systemName: "puzzlepiece.extension.fill")
-                    .font(.system(size: 16))
-                    .foregroundStyle(MuxyTheme.fgMuted)
-                    .frame(width: 22)
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(alignment: .firstTextBaseline, spacing: 6) {
-                        Text(ext.displayName)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(MuxyTheme.fg)
-                            .lineLimit(1)
-                        Text("v\(ext.manifest.version)")
-                            .font(.system(size: 11))
-                            .foregroundStyle(MuxyTheme.fgMuted)
-                        ExtensionStatusBadge(status: status)
-                    }
-                    if let description = ext.manifest.description, !description.isEmpty {
-                        Text(description)
-                            .font(.system(size: 11))
-                            .foregroundStyle(MuxyTheme.fgMuted)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-                Spacer(minLength: 12)
-                ExtensionPermissionSummary(permissions: ext.manifest.permissions)
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(MuxyTheme.fgDim)
+        HStack(spacing: 12) {
+            Button(action: onOpen) {
+                rowContent
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(hovered ? MuxyTheme.hover : Color.clear)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            if let availableVersion {
+                ExtensionUpdateButton(version: availableVersion, isUpdating: isUpdating, action: onUpdate)
+                    .padding(.trailing, 14)
+            }
+        }
+        .background(hovered ? MuxyTheme.hover : Color.clear)
+        .onHover { hovered = $0 }
+    }
+
+    private var rowContent: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "puzzlepiece.extension.fill")
+                .font(.system(size: 16))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(ext.displayName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .lineLimit(1)
+                    Text("v\(ext.manifest.version)")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                    ExtensionStatusBadge(status: status)
+                }
+                if let description = ext.manifest.description, !description.isEmpty {
+                    Text(description)
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            Spacer(minLength: 12)
+            ExtensionPermissionSummary(permissions: ext.manifest.permissions)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgDim)
+        }
+        .padding(.leading, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+    }
+}
+
+private struct ExtensionUpdateButton: View {
+    let version: String
+    let isUpdating: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                if isUpdating {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .font(.system(size: 11))
+                }
+                Text(isUpdating ? "Updating…" : "Update v\(version)")
+                    .font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(MuxyTheme.accent, in: RoundedRectangle(cornerRadius: 6))
+            .opacity(isUpdating ? 0.7 : 1)
         }
         .buttonStyle(.plain)
-        .onHover { hovered = $0 }
+        .disabled(isUpdating)
+        .help("Update to v\(version)")
     }
 }
 
@@ -501,8 +599,13 @@ private struct ExtensionDetailPage: View {
     let store: ExtensionStore
     let grantStore: ExtensionGrantStore
     @State private var showLogs = false
+    @State private var isUpdating = false
 
     private var ext: MuxyExtension { status.muxyExtension }
+
+    private var availableVersion: String? {
+        store.availableUpdateVersion(for: status.id)
+    }
 
     private var grantRules: [ExtensionGrantRule] {
         grantStore.rules.filter { $0.extensionID == status.id }
@@ -539,6 +642,13 @@ private struct ExtensionDetailPage: View {
                     .foregroundStyle(MuxyTheme.fgMuted)
                 ExtensionStatusBadge(status: status)
                 Spacer()
+                if let availableVersion {
+                    ExtensionUpdateButton(
+                        version: availableVersion,
+                        isUpdating: isUpdating,
+                        action: { Task { await update() } }
+                    )
+                }
                 Toggle("", isOn: enabledBinding)
                     .labelsHidden()
                     .toggleStyle(.switch)
@@ -775,6 +885,17 @@ private struct ExtensionDetailPage: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(MuxyTheme.border, lineWidth: 1)
         )
+    }
+
+    private func update() async {
+        isUpdating = true
+        defer { isUpdating = false }
+        do {
+            try await store.update(extensionID: status.id)
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            ToastState.shared.show(title: "Could not update \(status.id)", body: message)
+        }
     }
 
     private var enabledBinding: Binding<Bool> {

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -342,6 +342,7 @@ struct SidebarFooter: View {
     var sidebarExpanded = false
     @State private var showThemePicker = false
     @State private var showNotifications = false
+    @State private var extensionStore = ExtensionStore.shared
 
     private var notificationStore: NotificationStore { NotificationStore.shared }
 
@@ -381,6 +382,16 @@ struct SidebarFooter: View {
         NotificationCenter.default.post(name: .openExtensionsModal, object: nil)
     }
 
+    private var extensionsHelp: String {
+        guard extensionStore.hasUpdates else { return "Extensions" }
+        let count = extensionStore.updateCount
+        return count == 1 ? "Extensions (1 update available)" : "Extensions (\(count) updates available)"
+    }
+
+    private var extensionsAccessibilityLabel: String {
+        extensionStore.hasUpdates ? "Extensions, updates available" : "Extensions"
+    }
+
     private var collapsedFooter: some View {
         VStack(spacing: UIMetrics.spacing2) {
             IconButton(symbol: notificationBellIcon, accessibilityLabel: "Notifications") { showNotifications.toggle() }
@@ -388,8 +399,12 @@ struct SidebarFooter: View {
                 .popover(isPresented: $showNotifications) {
                     NotificationPanel(onDismiss: { showNotifications = false })
                 }
-            IconButton(symbol: "puzzlepiece.extension", accessibilityLabel: "Extensions") { openExtensions() }
-                .help("Extensions")
+            IconButton(
+                symbol: "puzzlepiece.extension",
+                showsBadge: extensionStore.hasUpdates,
+                accessibilityLabel: extensionsAccessibilityLabel
+            ) { openExtensions() }
+                .help(extensionsHelp)
             IconButton(symbol: "paintpalette", accessibilityLabel: "Theme Picker") { showThemePicker.toggle() }
                 .help("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
                 .popover(isPresented: $showThemePicker) { ThemePicker(mode: .sidebar) }
@@ -411,8 +426,12 @@ struct SidebarFooter: View {
                 .popover(isPresented: $showNotifications) {
                     NotificationPanel(onDismiss: { showNotifications = false })
                 }
-            IconButton(symbol: "puzzlepiece.extension", accessibilityLabel: "Extensions") { openExtensions() }
-                .help("Extensions")
+            IconButton(
+                symbol: "puzzlepiece.extension",
+                showsBadge: extensionStore.hasUpdates,
+                accessibilityLabel: extensionsAccessibilityLabel
+            ) { openExtensions() }
+                .help(extensionsHelp)
             IconButton(symbol: "paintpalette", accessibilityLabel: "Theme Picker") { showThemePicker.toggle() }
                 .help("Theme Picker (\(KeyBindingStore.shared.combo(for: .toggleThemePicker).displayString))")
                 .popover(isPresented: $showThemePicker) { ThemePicker(mode: .sidebar) }

--- a/Tests/MuxyTests/Models/SemanticVersionTests.swift
+++ b/Tests/MuxyTests/Models/SemanticVersionTests.swift
@@ -1,0 +1,39 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("SemanticVersion")
+struct SemanticVersionTests {
+    @Test("orders by numeric component")
+    func ordersByComponent() {
+        #expect(SemanticVersion("1.2.0")! < SemanticVersion("1.10.0")!)
+        #expect(SemanticVersion("2.0.0")! > SemanticVersion("1.9.9")!)
+    }
+
+    @Test("treats missing components as zero")
+    func paddingShorterVersion() {
+        #expect(SemanticVersion("1.2")! < SemanticVersion("1.2.1")!)
+        #expect(SemanticVersion("1.2")! == SemanticVersion("1.2.0")!)
+    }
+
+    @Test("ignores prerelease and build metadata")
+    func stripsSuffixes() {
+        #expect(SemanticVersion("1.4.2-beta.1")!.components == [1, 4, 2])
+        #expect(SemanticVersion("1.4.2+build9")!.components == [1, 4, 2])
+    }
+
+    @Test("rejects malformed versions")
+    func rejectsMalformed() {
+        #expect(SemanticVersion("") == nil)
+        #expect(SemanticVersion("abc") == nil)
+        #expect(SemanticVersion("1.x.0") == nil)
+    }
+
+    @Test("isUpdate only when available exceeds installed")
+    func updateDetection() {
+        #expect(SemanticVersion.isUpdate(installed: "1.0.0", available: "1.0.1"))
+        #expect(!SemanticVersion.isUpdate(installed: "1.0.1", available: "1.0.1"))
+        #expect(!SemanticVersion.isUpdate(installed: "2.0.0", available: "1.9.9"))
+        #expect(!SemanticVersion.isUpdate(installed: "1.0.0", available: "garbage"))
+    }
+}

--- a/Tests/MuxyTests/Services/ExtensionMarketplaceServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionMarketplaceServiceTests.swift
@@ -37,6 +37,29 @@ struct ExtensionMarketplaceServiceTests {
         #expect(ext.resolvedPermissions == [.tabsRead, .tabsWrite])
     }
 
+    @Test("resolveVersions decodes the flat version map and drops nulls")
+    func resolveVersionsDecodesMap() async throws {
+        let json = """
+        { "git-status": "1.4.2", "dracula-theme": "0.9.1", "ghost": null }
+        """
+        let service = makeService { _ in (200, Data(json.utf8)) }
+
+        let map = try await service.resolveVersions(names: ["git-status", "dracula-theme", "ghost"])
+
+        #expect(map["git-status"] == "1.4.2")
+        #expect(map["dracula-theme"] == "0.9.1")
+        #expect(map["ghost"] == nil)
+    }
+
+    @Test("resolveVersions returns empty for no names without a request")
+    func resolveVersionsEmpty() async throws {
+        let service = makeService { _ in (500, Data()) }
+
+        let map = try await service.resolveVersions(names: [])
+
+        #expect(map.isEmpty)
+    }
+
     @Test("maps 404 to notFound")
     func fetchMapsNotFound() async throws {
         let service = makeService { _ in (404, Data(#"{"message":"Not Found"}"#.utf8)) }

--- a/Tests/MuxyTests/Services/ExtensionStoreUpdateTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreUpdateTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionStore updates", .serialized)
+@MainActor
+struct ExtensionStoreUpdateTests {
+    @Test("flags an extension whose remote version is newer")
+    func detectsAvailableUpdate() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root, versions: ["demo-ext": "2.0.0"])
+
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext", version: "1.0.0"))
+        await store.checkForUpdates()
+
+        #expect(store.hasUpdates)
+        #expect(store.availableUpdateVersion(for: "demo-ext") == "2.0.0")
+    }
+
+    @Test("does not flag when remote version matches installed")
+    func ignoresUpToDate() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root, versions: ["demo-ext": "1.0.0"])
+
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext", version: "1.0.0"))
+        await store.checkForUpdates()
+
+        #expect(!store.hasUpdates)
+    }
+
+    @Test("clears a stale update entry after reinstalling a newer version")
+    func prunesAfterReinstall() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root, versions: ["demo-ext": "2.0.0"])
+
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext", version: "1.0.0"))
+        await store.checkForUpdates()
+        #expect(store.hasUpdates)
+
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext", version: "2.0.0"))
+
+        #expect(!store.hasUpdates)
+    }
+
+    private func makeRoot() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("update-root-\(UUID().uuidString)")
+    }
+
+    private func makeStore(root: URL, versions: [String: String]) -> ExtensionStore {
+        StubVersionsURLProtocol.versions = versions
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubVersionsURLProtocol.self]
+        let marketplace = ExtensionMarketplaceService(
+            baseURL: URL(string: "https://muxy.test")!,
+            session: URLSession(configuration: configuration)
+        )
+        return ExtensionStore.makeForTesting(
+            rootDirectory: root,
+            snapshotSink: NoopUpdateSnapshotSink(),
+            resolveHostURL: { URL(fileURLWithPath: "/usr/bin/true") },
+            marketplace: marketplace
+        )
+    }
+
+    private func makeExtensionZip(name: String, version: String) throws -> Data {
+        let fileManager = FileManager.default
+        let workspace = fileManager.temporaryDirectory.appendingPathComponent("zip-src-\(UUID().uuidString)")
+        let source = workspace.appendingPathComponent(name)
+        try fileManager.createDirectory(at: source, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: workspace) }
+
+        let manifest = """
+        {
+            "name": "\(name)",
+            "version": "\(version)",
+            "background": "background.js"
+        }
+        """
+        try Data(manifest.utf8).write(to: source.appendingPathComponent("manifest.json"))
+        try Data("console.log('hi')\n".utf8).write(to: source.appendingPathComponent("background.js"))
+
+        let archive = workspace.appendingPathComponent("\(name).zip")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.arguments = ["-q", "-r", archive.path, name]
+        process.currentDirectoryURL = workspace
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+        return try Data(contentsOf: archive)
+    }
+}
+
+@MainActor
+private final class NoopUpdateSnapshotSink: ExtensionSnapshotSink {
+    nonisolated func applyExtensionSnapshot(_: NotificationSocketServer.ExtensionSnapshot) {}
+}
+
+private final class StubVersionsURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var versions: [String: String] = [:]
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let map = Self.versions.mapValues { Optional($0) }
+        let data = (try? JSONSerialization.data(withJSONObject: map)) ?? Data("{}".utf8)
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/MuxyTests/Services/ExtensionStoreUpdateTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreUpdateTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 
@@ -46,14 +47,52 @@ struct ExtensionStoreUpdateTests {
         #expect(!store.hasUpdates)
     }
 
+    @Test("update installs the remote version and clears the flag")
+    func updateInstallsRemoteVersion() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root, versions: ["demo-ext": "2.0.0"])
+        StubMarketplaceURLProtocol.packages["demo-ext"] = try makeExtensionZip(name: "demo-ext", version: "2.0.0")
+
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext", version: "1.0.0"))
+        await store.checkForUpdates()
+        #expect(store.hasUpdates)
+
+        try await store.update(extensionID: "demo-ext")
+
+        #expect(!store.hasUpdates)
+        #expect(store.statuses.first(where: { $0.id == "demo-ext" })?.muxyExtension.manifest.version == "2.0.0")
+    }
+
+    @Test("updateAll reports successes and failures separately")
+    func updateAllAggregatesResults() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root, versions: ["ok-ext": "2.0.0", "fail-ext": "2.0.0"])
+        StubMarketplaceURLProtocol.packages["ok-ext"] = try makeExtensionZip(name: "ok-ext", version: "2.0.0")
+
+        try await store.install(expectedName: "ok-ext", zip: makeExtensionZip(name: "ok-ext", version: "1.0.0"))
+        try await store.install(expectedName: "fail-ext", zip: makeExtensionZip(name: "fail-ext", version: "1.0.0"))
+        await store.checkForUpdates()
+        #expect(store.updateCount == 2)
+
+        let result = await store.updateAll()
+
+        #expect(result.succeeded == ["ok-ext"])
+        #expect(result.failed.map(\.id) == ["fail-ext"])
+        #expect(store.availableUpdateVersion(for: "ok-ext") == nil)
+        #expect(store.availableUpdateVersion(for: "fail-ext") == "2.0.0")
+    }
+
     private func makeRoot() -> URL {
         FileManager.default.temporaryDirectory.appendingPathComponent("update-root-\(UUID().uuidString)")
     }
 
     private func makeStore(root: URL, versions: [String: String]) -> ExtensionStore {
-        StubVersionsURLProtocol.versions = versions
+        StubMarketplaceURLProtocol.reset()
+        StubMarketplaceURLProtocol.versions = versions
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [StubVersionsURLProtocol.self]
+        configuration.protocolClasses = [StubMarketplaceURLProtocol.self]
         let marketplace = ExtensionMarketplaceService(
             baseURL: URL(string: "https://muxy.test")!,
             session: URLSession(configuration: configuration)
@@ -100,8 +139,16 @@ private final class NoopUpdateSnapshotSink: ExtensionSnapshotSink {
     nonisolated func applyExtensionSnapshot(_: NotificationSocketServer.ExtensionSnapshot) {}
 }
 
-private final class StubVersionsURLProtocol: URLProtocol {
+private final class StubMarketplaceURLProtocol: URLProtocol {
     nonisolated(unsafe) static var versions: [String: String] = [:]
+    nonisolated(unsafe) static var packages: [String: Data] = [:]
+
+    static func reset() {
+        versions = [:]
+        packages = [:]
+    }
+
+    static func downloadURL(for name: String) -> String { "https://muxy.test/download/\(name)" }
 
     override class func canInit(with _: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -111,13 +158,56 @@ private final class StubVersionsURLProtocol: URLProtocol {
             client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
             return
         }
-        let map = Self.versions.mapValues { Optional($0) }
-        let data = (try? JSONSerialization.data(withJSONObject: map)) ?? Data("{}".utf8)
-        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let (status, data) = response(for: url)
+        let httpResponse = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
         client?.urlProtocolDidFinishLoading(self)
     }
 
     override func stopLoading() {}
+
+    private func response(for url: URL) -> (Int, Data) {
+        let path = url.path
+        if path.hasSuffix("/api/extensions/versions") {
+            let map = Self.versions.mapValues { Optional($0) }
+            return (200, (try? JSONSerialization.data(withJSONObject: map)) ?? Data("{}".utf8))
+        }
+        if path.hasPrefix("/download/") {
+            let name = url.lastPathComponent
+            guard let package = Self.packages[name] else { return (404, Data()) }
+            return (200, package)
+        }
+        if path.hasPrefix("/api/extensions/") {
+            let name = url.lastPathComponent
+            guard let package = Self.packages[name] else { return (404, Data("{}".utf8)) }
+            return (200, Self.envelope(name: name, package: package))
+        }
+        return (404, Data())
+    }
+
+    private static func envelope(name: String, package: Data) -> Data {
+        let sha = SHA256.hash(data: package).map { String(format: "%02x", $0) }.joined()
+        let json = """
+        {
+            "data": {
+                "name": "\(name)",
+                "description": null,
+                "permissions": [],
+                "author": null,
+                "homepage": null,
+                "repository": null,
+                "categories": [],
+                "icon_url": null,
+                "screenshot_paths": [],
+                "downloads": 0,
+                "current_version": "2.0.0",
+                "sha256": "\(sha)",
+                "size": \(package.count),
+                "download_url": "\(downloadURL(for: name))"
+            }
+        }
+        """
+        return Data(json.utf8)
+    }
 }


### PR DESCRIPTION
Extensions can now check for available updates on startup and update individually or in bulk. Version comparison uses semantic versioning; update state is displayed as badges and buttons in the sidebar and extensions panel.