### PR TITLE
Enforce command permission checks before execution

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -292,6 +292,20 @@ enum ExtensionCommandAction: Codable, Equatable {
         return false
     }
 
+    var requiredPermission: ExtensionPermission? {
+        switch self {
+        case .event:
+            nil
+        case .openTab:
+            .tabsWrite
+        case .togglePanel,
+             .openPopover:
+            .panelsWrite
+        case .runScript:
+            .commandsRunScript
+        }
+    }
+
     private enum CodingKeys: String, CodingKey {
         case kind
         case tabType

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -371,6 +371,7 @@ final class ExtensionStore {
         guard let command = muxyExtension.manifest.commands.first(where: { $0.id == commandID }),
               case let .openPopover(popoverID) = command.action
         else { return nil }
+        guard commandCanRun(command, extensionID: muxyExtension.id, logFailure: false) else { return nil }
         return muxyExtension.manifest.popover(id: popoverID)
     }
 
@@ -440,9 +441,10 @@ final class ExtensionStore {
     }
 
     func triggerCommand(_ invocation: CommandInvocation) {
-        guard let muxyExtension = statuses.first(where: { $0.id == invocation.extensionID })?.muxyExtension,
+        guard let muxyExtension = loadedExtension(id: invocation.extensionID),
               let command = muxyExtension.manifest.commands.first(where: { $0.id == invocation.commandID })
         else { return }
+        guard commandCanRun(command, extensionID: invocation.extensionID) else { return }
 
         switch command.action {
         case .event:
@@ -473,18 +475,29 @@ final class ExtensionStore {
         }
     }
 
+    private func commandCanRun(
+        _ command: ExtensionPaletteCommand,
+        extensionID: String,
+        logFailure: Bool = true
+    ) -> Bool {
+        guard let permission = command.action.requiredPermission else { return true }
+        guard extensionHasPermission(id: extensionID, permission: permission) else {
+            if logFailure {
+                ExtensionLogStore.shared.append(
+                    extensionID: extensionID,
+                    line: "[muxy] command \(command.id) blocked: missing \(permission.rawValue) permission"
+                )
+            }
+            return false
+        }
+        return true
+    }
+
     private func runExtensionScript(
         script: String,
         in muxyExtension: MuxyExtension,
         invocation: CommandInvocation
     ) {
-        guard extensionHasPermission(id: invocation.extensionID, permission: .commandsRunScript) else {
-            ExtensionLogStore.shared.append(
-                extensionID: invocation.extensionID,
-                line: "[muxy] runScript blocked: missing commands:run-script permission"
-            )
-            return
-        }
         guard let scriptURL = muxyExtension.resolveResource(script) else {
             ExtensionLogStore.shared.append(
                 extensionID: invocation.extensionID,

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -14,11 +14,12 @@ enum SocketCommandHandler {
             return "error:empty command"
         }
 
-        if let extensionID = clientContext.extensionID,
-           let required = MuxyAPI.Permissions.required(for: cmd),
-           !ExtensionStore.shared.extensionHasPermission(id: extensionID, permission: required)
-        {
-            return "error:permission denied (\(required.rawValue))"
+        if let extensionID = clientContext.extensionID {
+            for required in requiredPermissions(command: cmd, parts: parts)
+                where !ExtensionStore.shared.extensionHasPermission(id: extensionID, permission: required)
+            {
+                return "error:permission denied (\(required.rawValue))"
+            }
         }
 
         switch cmd {
@@ -420,6 +421,16 @@ enum SocketCommandHandler {
             return (fromPane, parts.dropFirst(1).dropLast().joined(separator: "|"))
         }
         return (nil, parts.dropFirst(1).joined(separator: "|"))
+    }
+
+    static func requiredPermissions(command: String, parts: [String]) -> [ExtensionPermission] {
+        var permissions = MuxyAPI.Permissions.required(for: command).map { [$0] } ?? []
+        guard command == "split-right" || command == "split-down" else { return permissions }
+        let splitRequest = parseSplitRequest(parts: parts)
+        let trimmedCommand = splitRequest.command?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedCommand?.isEmpty == false else { return permissions }
+        permissions.append(.commandsExec)
+        return permissions
     }
 
     private static func serialize<T>(

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -646,6 +646,15 @@ struct ExtensionManifestTests {
         #expect(!ExtensionCommandAction.runScript(script: "s.js").isAnchored)
     }
 
+    @Test("command actions declare required manifest permissions")
+    func actionRequiredPermissions() {
+        #expect(ExtensionCommandAction.event.requiredPermission == nil)
+        #expect(ExtensionCommandAction.openTab(tabType: "logs", data: nil).requiredPermission == .tabsWrite)
+        #expect(ExtensionCommandAction.togglePanel(panel: "dashboard").requiredPermission == .panelsWrite)
+        #expect(ExtensionCommandAction.openPopover(popover: "usage").requiredPermission == .panelsWrite)
+        #expect(ExtensionCommandAction.runScript(script: "s.js").requiredPermission == .commandsRunScript)
+    }
+
     private func makeTemporaryExtension(
         manifest: String,
         files: [String: String] = [:]

--- a/Tests/MuxyTests/Services/ExtensionStoreCommandPermissionTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreCommandPermissionTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionStore command permissions")
+@MainActor
+struct ExtensionStoreCommandPermissionTests {
+    @Test("openTab commands require tabs write permission")
+    func openTabRequiresTabsWritePermission() throws {
+        let store = try makeStore(
+            name: "open-tab-denied-\(UUID().uuidString)",
+            permissions: [],
+            action: #"{"kind":"openTab","tabType":"logs"}"#,
+            extraManifest: #""tabTypes":[{"id":"logs","title":"Logs","entry":"tabs/logs.html"}],"#,
+            files: ["tabs/logs.html": "<html></html>"]
+        )
+        let appState = makeAppState()
+        let projectID = try #require(appState.activeProjectID)
+        let before = try #require(appState.focusedArea(for: projectID)).tabs.count
+        let extensionID = try #require(store.statuses.first?.id)
+
+        store.triggerCommand(.init(extensionID: extensionID, commandID: "run", appState: appState))
+
+        #expect(appState.focusedArea(for: projectID)?.tabs.count == before)
+    }
+
+    @Test("openTab commands run with tabs write permission")
+    func openTabRunsWithTabsWritePermission() throws {
+        let store = try makeStore(
+            name: "open-tab-allowed-\(UUID().uuidString)",
+            permissions: ["tabs:write"],
+            action: #"{"kind":"openTab","tabType":"logs"}"#,
+            extraManifest: #""tabTypes":[{"id":"logs","title":"Logs","entry":"tabs/logs.html"}],"#,
+            files: ["tabs/logs.html": "<html></html>"]
+        )
+        let appState = makeAppState()
+        let projectID = try #require(appState.activeProjectID)
+        let before = try #require(appState.focusedArea(for: projectID)).tabs.count
+        let extensionID = try #require(store.statuses.first?.id)
+
+        store.triggerCommand(.init(extensionID: extensionID, commandID: "run", appState: appState))
+
+        #expect(appState.focusedArea(for: projectID)?.tabs.count == before + 1)
+    }
+
+    @Test("popover commands require panels write permission")
+    func popoverRequiresPanelsWritePermission() throws {
+        let store = try makeStore(
+            name: "popover-denied-\(UUID().uuidString)",
+            permissions: [],
+            action: #"{"kind":"openPopover","popover":"summary"}"#,
+            extraManifest: #""popovers":[{"id":"summary","entry":"popovers/summary.html"}],"#,
+            files: ["popovers/summary.html": "<html></html>"]
+        )
+        let muxyExtension = try #require(store.statuses.first?.muxyExtension)
+
+        #expect(store.popover(for: muxyExtension, command: "run") == nil)
+    }
+
+    @Test("togglePanel commands require panels write permission")
+    func togglePanelRequiresPanelsWritePermission() throws {
+        let store = try makeStore(
+            name: "panel-denied-\(UUID().uuidString)",
+            permissions: [],
+            action: #"{"kind":"togglePanel","panel":"summary"}"#,
+            extraManifest: #""panels":[{"id":"summary","entry":"panels/summary.html"}],"#,
+            files: ["panels/summary.html": "<html></html>"]
+        )
+        let appState = makeAppState()
+        let extensionID = try #require(store.statuses.first?.id)
+
+        store.triggerCommand(.init(extensionID: extensionID, commandID: "run", appState: appState))
+
+        let hostPanelID = ExtensionPanelState.hostPanelID(extensionID: extensionID, panelID: "summary")
+        #expect(ExtensionPanelRegistry.shared.state(forHostPanelID: hostPanelID) == nil)
+    }
+
+    private func makeStore(
+        name: String,
+        permissions: [String],
+        action: String,
+        extraManifest: String,
+        files: [String: String]
+    ) throws -> ExtensionStore {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("exts-\(UUID().uuidString)")
+        let directory = root.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let permissionJSON = permissions.map { "\"\($0)\"" }.joined(separator: ",")
+        let manifest = """
+        {
+            "name": "\(name)",
+            "version": "1.0.0",
+            "permissions": [\(permissionJSON)],
+            \(extraManifest)
+            "commands": [{"id":"run","title":"Run","action":\(action)}]
+        }
+        """
+        try Data(manifest.utf8).write(to: directory.appendingPathComponent("manifest.json"))
+        for (path, contents) in files {
+            let url = directory.appendingPathComponent(path)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data(contents.utf8).write(to: url)
+        }
+        let store = ExtensionStore.makeForTesting(
+            rootDirectory: root,
+            snapshotSink: NoopExtensionSnapshotSink(),
+            resolveHostURL: { nil }
+        )
+        store.startAll()
+        return store
+    }
+
+    private func makeAppState() -> AppState {
+        let appState = AppState(
+            selectionStore: CommandPermissionSelectionStore(),
+            terminalViews: CommandPermissionTerminalViews(),
+            workspacePersistence: CommandPermissionWorkspacePersistence()
+        )
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: "/tmp/test")
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        return appState
+    }
+}
+
+private final class NoopExtensionSnapshotSink: ExtensionSnapshotSink {
+    nonisolated func applyExtensionSnapshot(_: NotificationSocketServer.ExtensionSnapshot) {}
+}
+
+private final class CommandPermissionWorkspacePersistence: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class CommandPermissionSelectionStore: ActiveProjectSelectionStoring {
+    func loadActiveProjectID() -> UUID? { nil }
+    func saveActiveProjectID(_: UUID?) {}
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { [:] }
+    func saveActiveWorktreeIDs(_: [UUID: UUID]) {}
+}
+
+@MainActor
+private final class CommandPermissionTerminalViews: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -48,6 +48,26 @@ struct SocketCommandHandlerTests {
         #expect(paneID.flatMap { pane(with: $0, appState: appState)?.startupCommand } == "(echo a | wc); exec \"$0\" -l")
     }
 
+    @Test("split with startup command requires exec permission")
+    func splitWithCommandRequiresExecPermission() {
+        let plainSplit = SocketCommandHandler.requiredPermissions(
+            command: "split-right",
+            parts: ["split-right"]
+        )
+        let commandSplit = SocketCommandHandler.requiredPermissions(
+            command: "split-right",
+            parts: ["split-right", "", "echo hello"]
+        )
+        let whitespaceCommandSplit = SocketCommandHandler.requiredPermissions(
+            command: "split-down",
+            parts: ["split-down", "", "   "]
+        )
+
+        #expect(plainSplit == [.panesWrite])
+        #expect(commandSplit == [.panesWrite, .commandsExec])
+        #expect(whitespaceCommandSplit == [.panesWrite])
+    }
+
     @Test("split fails without active project")
     func splitFailsWithoutActiveProject() async {
         let appState = AppState(

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -12,7 +12,7 @@ Permissions apply only to identified callers. The host identifies itself on beha
 | Permission | Grants |
 | --- | --- |
 | `panes:read` | `read-screen`, `list-panes` |
-| `panes:write` | `split-right`, `split-down`, `send`, `send-keys`, `close-pane`, `rename-pane` |
+| `panes:write` | `split-right`, `split-down`, `send`, `send-keys`, `close-pane`, `rename-pane`. Split requests with a startup command also require `commands:exec`. |
 | `tabs:read` | `list-tabs` |
 | `tabs:write` | `switch-tab`, `new-tab`, `next-tab`, `previous-tab`, `open-tab` |
 | `projects:read` | `list-projects` |


### PR DESCRIPTION
Add permission validation to all extension command actions. Commands now check required permissions (e.g., `tabs:write` for `openTab`, `panels:write` for `openPopover`) before running, with failures logged. Includes comprehensive test coverage for permission enforcement across all command types.