### PR TITLE
fix: route pane I/O to a headless surface when the worktree is in the background

### DIFF
--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -814,6 +814,11 @@ private func waitForView(
     if let appState, locateTab(paneID: paneID, appState: appState) == nil {
         return nil
     }
+    if let appState,
+       let view = TerminalViewMaterializer.ensureMaterialized(paneID: paneID, appState: appState)
+    {
+        return view
+    }
     let deadline = ContinuousClock.now + timeout
     while ContinuousClock.now < deadline {
         if let view = TerminalViewRegistry.shared.existingView(for: paneID) {

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -290,25 +290,10 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     }
 
     private func ensureTerminalView(paneID: UUID) {
-        if TerminalViewRegistry.shared.existingView(for: paneID) != nil { return }
-        guard let location = appState.locatePane(paneID: paneID) else {
+        guard TerminalViewRegistry.shared.existingView(for: paneID) == nil else { return }
+        guard TerminalViewMaterializer.ensureMaterialized(paneID: paneID, appState: appState) != nil else {
             logger.warning("Cannot materialize pane \(paneID): no matching tab in workspace")
             return
-        }
-        let pane = location.pane
-        let view = TerminalViewRegistry.shared.view(
-            for: paneID,
-            workingDirectory: pane.currentWorkingDirectory ?? pane.projectPath,
-            command: pane.startupCommand,
-            commandInteractive: pane.startupCommandInteractive,
-            closesOnCommandExit: pane.closesOnStartupCommandExit
-        )
-        if view.envVars.isEmpty {
-            view.envVars = TerminalEnvVarBuilder.build(paneID: paneID, worktreeKey: location.worktreeKey)
-        }
-        view.materializeHeadless()
-        if view.surface == nil {
-            logger.warning("Headless materialization left pane \(paneID) without a surface")
         }
     }
 

--- a/Muxy/Services/TerminalViewMaterializer.swift
+++ b/Muxy/Services/TerminalViewMaterializer.swift
@@ -1,0 +1,32 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "TerminalViewMaterializer")
+
+@MainActor
+enum TerminalViewMaterializer {
+    static func ensureMaterialized(paneID: UUID, appState: AppState) -> GhosttyTerminalNSView? {
+        if let existing = TerminalViewRegistry.shared.existingView(for: paneID) {
+            return existing
+        }
+        guard let location = appState.locatePane(paneID: paneID) else {
+            return nil
+        }
+        let pane = location.pane
+        let view = TerminalViewRegistry.shared.view(
+            for: paneID,
+            workingDirectory: pane.currentWorkingDirectory ?? pane.projectPath,
+            command: pane.startupCommand,
+            commandInteractive: pane.startupCommandInteractive,
+            closesOnCommandExit: pane.closesOnStartupCommandExit
+        )
+        if view.envVars.isEmpty {
+            view.envVars = TerminalEnvVarBuilder.build(paneID: paneID, worktreeKey: location.worktreeKey)
+        }
+        view.materializeHeadless()
+        if view.surface == nil {
+            logger.warning("Headless materialization left pane \(paneID) without a surface")
+        }
+        return view
+    }
+}

--- a/Tests/MuxyTests/Services/MuxyAPIPaneBackgroundTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPIPaneBackgroundTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("MuxyAPI.Panes with background worktree")
+@MainActor
+struct MuxyAPIPaneBackgroundTests {
+    @Test("send to a background worktree pane does not return paneNotFound")
+    func sendToBackgroundWorktreePane() async {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let backgroundWorktreeID = UUID()
+        let appState = makeAppState(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: backgroundWorktreeID
+        )
+        let backgroundPaneID = paneID(in: appState, worktreeID: backgroundWorktreeID)
+
+        let result = await MuxyAPI.Panes.send(
+            paneIDString: backgroundPaneID.uuidString,
+            text: "hello",
+            appState: appState
+        )
+
+        guard case .success = result else {
+            Issue.record("expected success for background pane, got \(result)")
+            return
+        }
+    }
+
+    @Test("sendKeys to a background worktree pane does not return paneNotFound")
+    func sendKeysToBackgroundWorktreePane() async {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let backgroundWorktreeID = UUID()
+        let appState = makeAppState(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: backgroundWorktreeID
+        )
+        let backgroundPaneID = paneID(in: appState, worktreeID: backgroundWorktreeID)
+
+        let result = await MuxyAPI.Panes.sendKeys(
+            paneIDString: backgroundPaneID.uuidString,
+            key: "enter",
+            appState: appState
+        )
+
+        guard case .success = result else {
+            Issue.record("expected success for background pane, got \(result)")
+            return
+        }
+    }
+
+    @Test("readScreen on a background worktree pane does not return paneNotFound")
+    func readScreenOnBackgroundWorktreePane() async {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let backgroundWorktreeID = UUID()
+        let appState = makeAppState(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: backgroundWorktreeID
+        )
+        let backgroundPaneID = paneID(in: appState, worktreeID: backgroundWorktreeID)
+
+        let result = await MuxyAPI.Panes.readScreen(
+            paneIDString: backgroundPaneID.uuidString,
+            lines: 10,
+            appState: appState
+        )
+
+        guard case .success = result else {
+            Issue.record("expected success for background pane, got \(result)")
+            return
+        }
+    }
+
+    @Test("send still returns paneNotFound for truly orphaned pane ids")
+    func sendReturnsPaneNotFoundForOrphanedPane() async {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let appState = makeAppState(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: nil
+        )
+        let orphanPaneID = UUID()
+
+        let result = await MuxyAPI.Panes.send(
+            paneIDString: orphanPaneID.uuidString,
+            text: "hello",
+            appState: appState
+        )
+
+        guard case let .failure(error) = result else {
+            Issue.record("expected failure")
+            return
+        }
+        guard case .paneNotFound = error else {
+            Issue.record("expected paneNotFound, got \(error)")
+            return
+        }
+    }
+
+    @Test("active worktree pane is unaffected by the materializer path")
+    func activeWorktreePaneUnaffected() async {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let appState = makeAppState(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: nil
+        )
+        let activePaneID = paneID(in: appState, worktreeID: activeWorktreeID)
+
+        let result = await MuxyAPI.Panes.send(
+            paneIDString: activePaneID.uuidString,
+            text: "hello",
+            appState: appState
+        )
+
+        guard case .success = result else {
+            Issue.record("expected success for active pane, got \(result)")
+            return
+        }
+    }
+
+    private func paneID(in appState: AppState, worktreeID: UUID) -> UUID {
+        for (key, root) in appState.workspaceRoots where key.worktreeID == worktreeID {
+            for area in root.allAreas() {
+                for tab in area.tabs {
+                    if let pane = tab.content.pane { return pane.id }
+                }
+            }
+        }
+        Issue.record("no pane found for worktree \(worktreeID)")
+        return UUID()
+    }
+
+    private func makeAppState(
+        projectID: UUID,
+        activeWorktreeID: UUID,
+        backgroundWorktreeID: UUID?
+    ) -> AppState {
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let activeKey = WorktreeKey(projectID: projectID, worktreeID: activeWorktreeID)
+        let activeArea = TabArea(projectPath: "/tmp/active")
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = activeWorktreeID
+        appState.workspaceRoots[activeKey] = .tabArea(activeArea)
+        appState.focusedAreaID[activeKey] = activeArea.id
+
+        if let backgroundWorktreeID {
+            let backgroundKey = WorktreeKey(projectID: projectID, worktreeID: backgroundWorktreeID)
+            let backgroundArea = TabArea(projectPath: "/tmp/background")
+            appState.workspaceRoots[backgroundKey] = .tabArea(backgroundArea)
+            appState.focusedAreaID[backgroundKey] = backgroundArea.id
+        }
+        return appState
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}

--- a/Tests/MuxyTests/Services/TerminalViewMaterializerTests.swift
+++ b/Tests/MuxyTests/Services/TerminalViewMaterializerTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalViewMaterializer")
+@MainActor
+struct TerminalViewMaterializerTests {
+    @Test("returns nil when pane id has no matching tab in any worktree")
+    func returnsNilForUnknownPane() {
+        let appState = makeAppState()
+        let orphanPaneID = UUID()
+
+        let result = TerminalViewMaterializer.ensureMaterialized(
+            paneID: orphanPaneID,
+            appState: appState
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("materializes a headless view when pane exists in a background worktree")
+    func materializesHeadlessViewForBackgroundWorktree() {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let backgroundWorktreeID = UUID()
+        let appState = makeAppStateWithWorktrees(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: backgroundWorktreeID
+        )
+        let backgroundKey = WorktreeKey(projectID: projectID, worktreeID: backgroundWorktreeID)
+        let backgroundPaneID = appState.workspaceRoots[backgroundKey]!
+            .allAreas()[0]
+            .tabs[0]
+            .content
+            .pane!
+            .id
+
+        #expect(TerminalViewRegistry.shared.existingView(for: backgroundPaneID) == nil)
+
+        let result = TerminalViewMaterializer.ensureMaterialized(
+            paneID: backgroundPaneID,
+            appState: appState
+        )
+
+        #expect(result != nil)
+        #expect(TerminalViewRegistry.shared.existingView(for: backgroundPaneID) === result)
+    }
+
+    @Test("returns the existing view when one is already registered")
+    func returnsExistingViewWithoutRecreating() {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let backgroundWorktreeID = UUID()
+        let appState = makeAppStateWithWorktrees(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: backgroundWorktreeID
+        )
+        let backgroundKey = WorktreeKey(projectID: projectID, worktreeID: backgroundWorktreeID)
+        let backgroundPaneID = appState.workspaceRoots[backgroundKey]!
+            .allAreas()[0]
+            .tabs[0]
+            .content
+            .pane!
+            .id
+        let first = TerminalViewMaterializer.ensureMaterialized(
+            paneID: backgroundPaneID,
+            appState: appState
+        )
+        let second = TerminalViewMaterializer.ensureMaterialized(
+            paneID: backgroundPaneID,
+            appState: appState
+        )
+
+        #expect(first === second)
+    }
+
+    @Test("populates worktree env vars on first materialization")
+    func populatesWorktreeEnvVars() {
+        let projectID = UUID()
+        let activeWorktreeID = UUID()
+        let backgroundWorktreeID = UUID()
+        let appState = makeAppStateWithWorktrees(
+            projectID: projectID,
+            activeWorktreeID: activeWorktreeID,
+            backgroundWorktreeID: backgroundWorktreeID
+        )
+        let backgroundKey = WorktreeKey(projectID: projectID, worktreeID: backgroundWorktreeID)
+        let backgroundPaneID = appState.workspaceRoots[backgroundKey]!
+            .allAreas()[0]
+            .tabs[0]
+            .content
+            .pane!
+            .id
+
+        let view = TerminalViewMaterializer.ensureMaterialized(
+            paneID: backgroundPaneID,
+            appState: appState
+        )
+
+        let envKeys = Set(view?.envVars.map(\.key) ?? [])
+        #expect(envKeys.contains("MUXY_PANE_ID"))
+        #expect(envKeys.contains("MUXY_PROJECT_ID"))
+        #expect(envKeys.contains("MUXY_WORKTREE_ID"))
+    }
+
+    private func makeAppState() -> AppState {
+        AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+    }
+
+    private func makeAppStateWithWorktrees(
+        projectID: UUID,
+        activeWorktreeID: UUID,
+        backgroundWorktreeID: UUID
+    ) -> AppState {
+        let appState = makeAppState()
+        let activeKey = WorktreeKey(projectID: projectID, worktreeID: activeWorktreeID)
+        let backgroundKey = WorktreeKey(projectID: projectID, worktreeID: backgroundWorktreeID)
+        let activeArea = TabArea(projectPath: "/tmp/active")
+        let backgroundArea = TabArea(projectPath: "/tmp/background")
+
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = activeWorktreeID
+        appState.workspaceRoots[activeKey] = .tabArea(activeArea)
+        appState.workspaceRoots[backgroundKey] = .tabArea(backgroundArea)
+        appState.focusedAreaID[activeKey] = activeArea.id
+        appState.focusedAreaID[backgroundKey] = backgroundArea.id
+        return appState
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws { snapshots = workspaces }
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for paneID: UUID) {}
+    func needsConfirmQuit(for paneID: UUID) -> Bool { false }
+}


### PR DESCRIPTION
## Summary

Routes pane I/O through a headless surface when the target pane belongs to a backgrounded worktree, so `muxy send`/`send-keys`/`read-screen` keep working after the user switches worktrees.

## Root cause

`MainWindow.mountedWorktreeKeys` only mounts the active worktree's `TerminalArea`, so background worktrees' `TerminalPane` → `TerminalBridge` is never instantiated and `TerminalViewRegistry` has no NSView. `MuxyAPI.Panes.*` funnels through `waitForView`, which only spins for 3 s before returning `paneNotFound`. `AppState.workspaceRoots` still holds the pane, so `locateTab` keeps succeeding — the symptom is intermittent and only hits CLI users.

## Fix

In `waitForView`, when `locateTab` succeeds but no view is registered, call the new `TerminalViewMaterializer.ensureMaterialized` to spin up a headless 1×1 surface (the same path `RemoteServerDelegate.takeOverPane` already uses). Switching back to the worktree reuses the same view via `TerminalViewRegistry.view(for:)`'s early-return path, so the shell isn't restarted. The helper is shared with `RemoteServerDelegate` to avoid the duplication that previously lived there.

## Tests

9 new cases (1430/1430 total) cover the materializer and confirm `send`/`sendKeys`/`readScreen` no longer return `paneNotFound` for background worktree panes while still returning it for truly orphaned ids.