### PR TITLE
Add extension-registered keyboard shortcuts

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -372,19 +372,28 @@ struct ExtensionPaletteCommand: Codable, Equatable, Identifiable {
     let title: String
     let subtitle: String?
     let action: ExtensionCommandAction
+    let defaultShortcut: String?
 
     private enum CodingKeys: String, CodingKey {
         case id
         case title
         case subtitle
         case action
+        case defaultShortcut
     }
 
-    init(id: String, title: String, subtitle: String? = nil, action: ExtensionCommandAction = .event) {
+    init(
+        id: String,
+        title: String,
+        subtitle: String? = nil,
+        action: ExtensionCommandAction = .event,
+        defaultShortcut: String? = nil
+    ) {
         self.id = id
         self.title = title
         self.subtitle = subtitle
         self.action = action
+        self.defaultShortcut = defaultShortcut
     }
 
     init(from decoder: Decoder) throws {
@@ -393,9 +402,14 @@ struct ExtensionPaletteCommand: Codable, Equatable, Identifiable {
         title = try container.decode(String.self, forKey: .title)
         subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
         action = try container.decodeIfPresent(ExtensionCommandAction.self, forKey: .action) ?? .event
+        defaultShortcut = try container.decodeIfPresent(String.self, forKey: .defaultShortcut)
     }
 
     var eventName: String { "command.\(id)" }
+
+    var defaultCombo: KeyCombo? {
+        defaultShortcut.flatMap(KeyCombo.init(parsing:))
+    }
 }
 
 struct ExtensionManifest: Codable, Equatable {

--- a/Muxy/Models/ExtensionShortcut.swift
+++ b/Muxy/Models/ExtensionShortcut.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct ExtensionShortcut: Codable, Identifiable, Equatable {
+    let extensionID: String
+    let commandID: String
+    var combo: KeyCombo
+
+    var id: String { "\(extensionID):\(commandID)" }
+}

--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -149,6 +149,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
             }
         }
 
+        guard command || control || option else { return nil }
         guard let key = Self.parsedKey(from: rawKey) else { return nil }
         self.init(key: key, command: command, shift: shift, control: control, option: option)
         guard isAssigned else { return nil }

--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -121,6 +121,58 @@ struct KeyCombo: Codable, Equatable, Hashable {
         self.modifiers = flags
     }
 
+    init?(parsing description: String) {
+        let tokens = description
+            .lowercased()
+            .split(whereSeparator: { $0 == "+" || $0 == "-" })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard let rawKey = tokens.last else { return nil }
+
+        var command = false
+        var shift = false
+        var control = false
+        var option = false
+        for token in tokens.dropLast() {
+            switch token {
+            case "cmd",
+                 "command",
+                 "meta",
+                 "super": command = true
+            case "shift": shift = true
+            case "ctrl",
+                 "control": control = true
+            case "opt",
+                 "option",
+                 "alt": option = true
+            default: return nil
+            }
+        }
+
+        guard let key = Self.parsedKey(from: rawKey) else { return nil }
+        self.init(key: key, command: command, shift: shift, control: control, option: option)
+        guard isAssigned else { return nil }
+    }
+
+    private static func parsedKey(from token: String) -> String? {
+        switch token {
+        case "left",
+             leftArrowKey: leftArrowKey
+        case "right",
+             rightArrowKey: rightArrowKey
+        case "up",
+             upArrowKey: upArrowKey
+        case "down",
+             downArrowKey: downArrowKey
+        case "tab",
+             tabKey: tabKey
+        case "return",
+             "enter",
+             returnKey: returnKey
+        default: token.count == 1 ? token : nil
+        }
+    }
+
     var nsModifierFlags: NSEvent.ModifierFlags {
         NSEvent.ModifierFlags(rawValue: modifiers).intersection(Self.supportedModifierMask)
     }

--- a/Muxy/Services/ExtensionShortcutStore.swift
+++ b/Muxy/Services/ExtensionShortcutStore.swift
@@ -1,0 +1,174 @@
+import AppKit
+import os
+
+private let extensionShortcutLogger = Logger(subsystem: "app.muxy", category: "ExtensionShortcutStore")
+
+protocol ExtensionShortcutPersisting {
+    func loadShortcuts() throws -> [ExtensionShortcut]
+    func saveShortcuts(_ shortcuts: [ExtensionShortcut]) throws
+}
+
+final class FileExtensionShortcutPersistence: ExtensionShortcutPersisting {
+    private let store: CodableFileStore<[ExtensionShortcut]>
+
+    init(fileURL: URL = MuxyFileStorage.fileURL(filename: "extension-shortcuts.json")) {
+        store = CodableFileStore(
+            fileURL: fileURL,
+            options: CodableFileStoreOptions(
+                prettyPrinted: true,
+                sortedKeys: true,
+                filePermissions: FilePermissions.privateFile
+            )
+        )
+    }
+
+    func loadShortcuts() throws -> [ExtensionShortcut] {
+        try store.load() ?? []
+    }
+
+    func saveShortcuts(_ shortcuts: [ExtensionShortcut]) throws {
+        try store.save(shortcuts)
+    }
+}
+
+@MainActor
+@Observable
+final class ExtensionShortcutStore {
+    static let shared = ExtensionShortcutStore()
+
+    private(set) var shortcuts: [ExtensionShortcut] = []
+    private let persistence: any ExtensionShortcutPersisting
+
+    init(persistence: any ExtensionShortcutPersisting = FileExtensionShortcutPersistence()) {
+        self.persistence = persistence
+        load()
+    }
+
+    func shortcut(extensionID: String, commandID: String) -> ExtensionShortcut? {
+        shortcuts.first { $0.extensionID == extensionID && $0.commandID == commandID }
+    }
+
+    func updateCombo(extensionID: String, commandID: String, combo: KeyCombo) {
+        guard let index = shortcuts.firstIndex(where: {
+            $0.extensionID == extensionID && $0.commandID == commandID
+        })
+        else { return }
+        shortcuts[index].combo = combo
+        save()
+    }
+
+    func resetCombo(extensionID: String, commandID: String, defaultCombo: KeyCombo?) {
+        let combo = defaultCombo.flatMap { isComboFree($0, extensionID: extensionID, commandID: commandID) ? $0 : nil }
+        updateCombo(extensionID: extensionID, commandID: commandID, combo: combo ?? KeyCombo(key: "", modifiers: 0))
+    }
+
+    func unassign(extensionID: String, commandID: String) {
+        updateCombo(extensionID: extensionID, commandID: commandID, combo: KeyCombo(key: "", modifiers: 0))
+    }
+
+    func match(event: NSEvent, scopes: Set<ShortcutScope>) -> ExtensionShortcut? {
+        guard scopes.contains(.mainWindow) else { return nil }
+        let normalizedKey = KeyCombo.normalized(
+            key: event.charactersIgnoringModifiers ?? "",
+            keyCode: event.keyCode
+        )
+        let flags = event.modifierFlags.intersection(KeyCombo.supportedModifierMask).rawValue
+        return shortcuts.first { shortcut in
+            shortcut.combo.isAssigned
+                && shortcut.combo.key == normalizedKey
+                && shortcut.combo.modifiers == flags
+        }
+    }
+
+    func isRegisteredShortcut(event: NSEvent, scopes: Set<ShortcutScope>) -> Bool {
+        match(event: event, scopes: scopes) != nil
+    }
+
+    func conflictMessage(for combo: KeyCombo, extensionID: String, commandID: String) -> String? {
+        guard combo.isAssigned else { return nil }
+        if let action = KeyBindingStore.shared.conflictingAction(for: combo, excluding: ShortcutAction?.none) {
+            return "Conflicts with \"\(action.displayName)\""
+        }
+        if CommandShortcutStore.shared.conflictingShortcut(for: combo, excluding: UUID()) != nil {
+            return "Conflicts with a custom command"
+        }
+        let conflictsWithOther = shortcuts.contains {
+            $0.combo == combo && !($0.extensionID == extensionID && $0.commandID == commandID)
+        }
+        return conflictsWithOther ? "Conflicts with another extension shortcut" : nil
+    }
+
+    func syncBindings(for extensions: [MuxyExtension]) {
+        var resolved: [ExtensionShortcut] = []
+        let stored = Dictionary(uniqueKeysWithValues: shortcuts.map { ($0.id, $0) })
+
+        for muxyExtension in extensions {
+            for command in muxyExtension.manifest.commands where command.defaultShortcut != nil {
+                let key = "\(muxyExtension.id):\(command.id)"
+                if let existing = stored[key] {
+                    resolved.append(existing)
+                    continue
+                }
+                let combo = autoAssignCombo(
+                    command.defaultCombo,
+                    extensionID: muxyExtension.id,
+                    commandID: command.id,
+                    claimed: resolved
+                )
+                resolved.append(ExtensionShortcut(
+                    extensionID: muxyExtension.id,
+                    commandID: command.id,
+                    combo: combo
+                ))
+            }
+        }
+
+        guard resolved != shortcuts else { return }
+        shortcuts = resolved
+        save()
+    }
+
+    private func autoAssignCombo(
+        _ defaultCombo: KeyCombo?,
+        extensionID: String,
+        commandID: String,
+        claimed: [ExtensionShortcut]
+    ) -> KeyCombo {
+        guard let defaultCombo else { return KeyCombo(key: "", modifiers: 0) }
+        let conflictsWithClaimed = claimed.contains { $0.combo == defaultCombo }
+        guard !conflictsWithClaimed,
+              isComboFree(defaultCombo, extensionID: extensionID, commandID: commandID)
+        else { return KeyCombo(key: "", modifiers: 0) }
+        return defaultCombo
+    }
+
+    private func isComboFree(_ combo: KeyCombo, extensionID: String, commandID: String) -> Bool {
+        guard combo.isAssigned else { return false }
+        guard KeyBindingStore.shared.conflictingAction(for: combo, excluding: ShortcutAction?.none) == nil else {
+            return false
+        }
+        guard CommandShortcutStore.shared.conflictingShortcut(for: combo, excluding: UUID()) == nil else {
+            return false
+        }
+        return !shortcuts.contains {
+            $0.combo == combo && !($0.extensionID == extensionID && $0.commandID == commandID)
+        }
+    }
+
+    private func load() {
+        do {
+            shortcuts = try persistence.loadShortcuts()
+        } catch {
+            extensionShortcutLogger.error("Failed to load extension shortcuts: \(error.localizedDescription)")
+            shortcuts = []
+        }
+    }
+
+    private func save() {
+        do {
+            try persistence.saveShortcuts(shortcuts)
+        } catch {
+            extensionShortcutLogger.error("Failed to save extension shortcuts: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -96,6 +96,7 @@ final class ExtensionStore {
             startExtension(at: index)
         }
         rebuildExtensionUICache()
+        syncExtensionShortcuts()
         publishSnapshot()
     }
 
@@ -280,6 +281,7 @@ final class ExtensionStore {
             PopoverHost.shared.close(extensionID: extensionID)
         }
         rebuildExtensionUICache()
+        syncExtensionShortcuts()
         publishSnapshot()
     }
 
@@ -401,6 +403,11 @@ final class ExtensionStore {
         topbarItems = topbar
         leftStatusBarItems = left
         rightStatusBarItems = right
+    }
+
+    private func syncExtensionShortcuts() {
+        let enabled = statuses.filter(\.isEnabled).map(\.muxyExtension)
+        ExtensionShortcutStore.shared.syncBindings(for: enabled)
     }
 
     func setStatusBarText(extensionID: String, itemID: String, text: String?) -> Bool {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -179,6 +179,7 @@ struct MainWindow: View {
         .background(MainWindowShortcutInterceptor(
             onShortcut: { action in handleShortcutAction(action) },
             onCommandShortcut: { shortcut in handleCommandShortcut(shortcut) },
+            onExtensionShortcut: { shortcut in handleExtensionShortcut(shortcut) },
             onMouseBack: { appState.goBack() },
             onMouseForward: { appState.goForward() }
         ))
@@ -960,6 +961,17 @@ struct MainWindow: View {
         return true
     }
 
+    private func handleExtensionShortcut(_ shortcut: ExtensionShortcut) -> Bool {
+        ExtensionStore.shared.triggerCommand(.init(
+            extensionID: shortcut.extensionID,
+            commandID: shortcut.commandID,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        ))
+        return true
+    }
+
     private var activeProjectHasSplitWorkspace: Bool {
         guard let project = activeProject,
               let root = appState.workspaceRoot(for: project.id)
@@ -1672,6 +1684,7 @@ private struct NavigationArrowButton: View {
 private struct MainWindowShortcutInterceptor: NSViewRepresentable {
     let onShortcut: (ShortcutAction) -> Bool
     let onCommandShortcut: (CommandShortcut) -> Bool
+    let onExtensionShortcut: (ExtensionShortcut) -> Bool
     let onMouseBack: () -> Void
     let onMouseForward: () -> Void
 
@@ -1679,6 +1692,7 @@ private struct MainWindowShortcutInterceptor: NSViewRepresentable {
         let view = ShortcutInterceptingView()
         view.onShortcut = onShortcut
         view.onCommandShortcut = onCommandShortcut
+        view.onExtensionShortcut = onExtensionShortcut
         view.onMouseBack = onMouseBack
         view.onMouseForward = onMouseForward
         return view
@@ -1687,6 +1701,7 @@ private struct MainWindowShortcutInterceptor: NSViewRepresentable {
     func updateNSView(_ nsView: ShortcutInterceptingView, context: Context) {
         nsView.onShortcut = onShortcut
         nsView.onCommandShortcut = onCommandShortcut
+        nsView.onExtensionShortcut = onExtensionShortcut
         nsView.onMouseBack = onMouseBack
         nsView.onMouseForward = onMouseForward
     }
@@ -1695,6 +1710,7 @@ private struct MainWindowShortcutInterceptor: NSViewRepresentable {
 private final class ShortcutInterceptingView: NSView {
     var onShortcut: ((ShortcutAction) -> Bool)?
     var onCommandShortcut: ((CommandShortcut) -> Bool)?
+    var onExtensionShortcut: ((ExtensionShortcut) -> Bool)?
     var onMouseBack: (() -> Void)?
     var onMouseForward: (() -> Void)?
     private var mouseMonitor: Any?
@@ -1733,6 +1749,12 @@ private final class ShortcutInterceptingView: NSView {
 
         if let action = KeyBindingStore.shared.action(for: event, scopes: scopes) {
             if onShortcut?(action) == true {
+                return true
+            }
+        }
+
+        if let shortcut = ExtensionShortcutStore.shared.match(event: event, scopes: scopes) {
+            if onExtensionShortcut?(shortcut) == true {
                 return true
             }
         }

--- a/Muxy/Views/Settings/ExtensionShortcutGroup.swift
+++ b/Muxy/Views/Settings/ExtensionShortcutGroup.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct ExtensionShortcutEntry: Identifiable, Equatable {
+    let extensionID: String
+    let commandID: String
+    let commandTitle: String
+    let combo: KeyCombo
+    let defaultCombo: KeyCombo?
+
+    var id: String { "\(extensionID):\(commandID)" }
+}
+
+struct ExtensionShortcutGroup: Identifiable, Equatable {
+    let extensionID: String
+    let extensionName: String
+    let entries: [ExtensionShortcutEntry]
+
+    var id: String { extensionID }
+
+    @MainActor
+    static func build(
+        shortcuts: [ExtensionShortcut],
+        statuses: [ExtensionStore.ExtensionStatus]
+    ) -> [ExtensionShortcutGroup] {
+        let enabled = statuses.filter(\.isEnabled)
+        return enabled.compactMap { status in
+            let manifest = status.muxyExtension.manifest
+            let entries = manifest.commands.compactMap { command -> ExtensionShortcutEntry? in
+                guard command.defaultShortcut != nil,
+                      let shortcut = shortcuts.first(where: {
+                          $0.extensionID == status.id && $0.commandID == command.id
+                      })
+                else { return nil }
+                return ExtensionShortcutEntry(
+                    extensionID: status.id,
+                    commandID: command.id,
+                    commandTitle: command.title,
+                    combo: shortcut.combo,
+                    defaultCombo: command.defaultCombo
+                )
+            }
+            guard !entries.isEmpty else { return nil }
+            return ExtensionShortcutGroup(
+                extensionID: status.id,
+                extensionName: status.muxyExtension.displayName,
+                entries: entries
+            )
+        }
+    }
+}

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -35,9 +35,12 @@ struct KeyboardShortcutsSettingsView: View {
     @State private var commandConflictWarning: (id: UUID, message: String)?
     @State private var deleteAllCommandShortcutsSecondsRemaining = 0
     @State private var deleteAllCommandShortcutsTask: Task<Void, Never>?
+    @State private var recordingExtensionShortcutID: String?
+    @State private var extensionConflictWarning: (id: String, message: String)?
 
     private var store: KeyBindingStore { KeyBindingStore.shared }
     private var commandStore: CommandShortcutStore { CommandShortcutStore.shared }
+    private var extensionStore: ExtensionShortcutStore { ExtensionShortcutStore.shared }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -125,16 +128,91 @@ struct KeyboardShortcutsSettingsView: View {
 
     private var appShortcutsList: some View {
         let visibleCategories = ShortcutAction.categories.filter { !filteredActions(for: $0).isEmpty }
+        let extensionGroups = filteredExtensionGroups
         return ScrollView(.vertical, showsIndicators: true) {
             VStack(spacing: 0) {
                 ForEach(visibleCategories, id: \.self) { category in
                     categorySection(
                         title: category,
                         actions: filteredActions(for: category),
-                        isLast: category == visibleCategories.last
+                        isLast: category == visibleCategories.last && extensionGroups.isEmpty
                     )
                 }
+                ForEach(extensionGroups) { group in
+                    extensionSection(group: group, isLast: group.id == extensionGroups.last?.id)
+                }
             }
+        }
+    }
+
+    private func extensionSection(group: ExtensionShortcutGroup, isLast: Bool) -> some View {
+        SettingsSection(group.extensionName, showsDivider: !isLast) {
+            ForEach(group.entries) { entry in
+                ShortcutRow(
+                    title: entry.commandTitle,
+                    combo: entry.combo,
+                    isRecording: recordingExtensionShortcutID == entry.id,
+                    conflictMessage: extensionConflictWarning?.id == entry.id ? extensionConflictWarning?.message : nil,
+                    onStartRecording: {
+                        discardPendingCommandShortcut()
+                        recordingAction = nil
+                        recordingCommandPrefix = false
+                        recordingCommandShortcutID = nil
+                        recordingExtensionShortcutID = entry.id
+                        extensionConflictWarning = nil
+                    },
+                    onRecord: { combo in handleRecord(extensionEntry: entry, combo: combo) },
+                    onCancel: {
+                        recordingExtensionShortcutID = nil
+                        extensionConflictWarning = nil
+                    },
+                    onReset: {
+                        extensionStore.resetCombo(
+                            extensionID: entry.extensionID,
+                            commandID: entry.commandID,
+                            defaultCombo: entry.defaultCombo
+                        )
+                        recordingExtensionShortcutID = nil
+                        extensionConflictWarning = nil
+                    },
+                    onUnassign: {
+                        extensionStore.unassign(extensionID: entry.extensionID, commandID: entry.commandID)
+                        recordingExtensionShortcutID = nil
+                        extensionConflictWarning = nil
+                    }
+                )
+            }
+        }
+        .environment(\.settingsSearchQuery, "")
+    }
+
+    private func handleRecord(extensionEntry entry: ExtensionShortcutEntry, combo: KeyCombo) {
+        if let message = extensionStore.conflictMessage(
+            for: combo,
+            extensionID: entry.extensionID,
+            commandID: entry.commandID
+        ) {
+            extensionConflictWarning = (id: entry.id, message: "\(message) — press a different shortcut or Esc to cancel")
+            return
+        }
+        extensionStore.updateCombo(extensionID: entry.extensionID, commandID: entry.commandID, combo: combo)
+        recordingExtensionShortcutID = nil
+        extensionConflictWarning = nil
+    }
+
+    private var filteredExtensionGroups: [ExtensionShortcutGroup] {
+        let groups = ExtensionShortcutGroup.build(
+            shortcuts: extensionStore.shortcuts,
+            statuses: ExtensionStore.shared.statuses
+        )
+        guard !searchText.isEmpty else { return groups }
+        return groups.compactMap { group in
+            let entries = group.entries.filter {
+                $0.commandTitle.localizedCaseInsensitiveContains(searchText)
+                    || group.extensionName.localizedCaseInsensitiveContains(searchText)
+            }
+            guard !entries.isEmpty else { return nil }
+            return ExtensionShortcutGroup(extensionID: group.extensionID, extensionName: group.extensionName, entries: entries)
         }
     }
 
@@ -148,10 +226,12 @@ struct KeyboardShortcutsSettingsView: View {
         SettingsSection(title, showsDivider: !isLast) {
             ForEach(actions) { action in
                 ShortcutRow(
-                    action: action,
+                    title: action.displayName,
                     combo: store.combo(for: action),
                     isRecording: recordingAction == action,
-                    conflictAction: conflictWarning?.action == action ? conflictWarning?.existing : nil,
+                    conflictMessage: conflictWarning?.action == action
+                        ? "Conflicts with \"\(conflictWarning?.existing.displayName ?? "")\" — press a different shortcut or Esc to cancel"
+                        : nil,
                     onStartRecording: {
                         discardPendingCommandShortcut()
                         recordingAction = action
@@ -383,10 +463,10 @@ struct KeyboardShortcutsSettingsView: View {
 }
 
 private struct ShortcutRow: View {
-    let action: ShortcutAction
+    let title: String
     let combo: KeyCombo
     let isRecording: Bool
-    let conflictAction: ShortcutAction?
+    let conflictMessage: String?
     let onStartRecording: () -> Void
     let onRecord: (KeyCombo) -> Void
     let onCancel: () -> Void
@@ -397,7 +477,7 @@ private struct ShortcutRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                Text(action.displayName)
+                Text(title)
                     .font(.system(size: SettingsMetrics.labelFontSize))
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -408,8 +488,8 @@ private struct ShortcutRow: View {
                 }
             }
 
-            if let conflictAction {
-                Text("Conflicts with \"\(conflictAction.displayName)\" — press a different shortcut or Esc to cancel")
+            if let conflictMessage {
+                Text(conflictMessage)
                     .font(.system(size: 10))
                     .foregroundStyle(SettingsStyle.warning)
             }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -393,6 +393,7 @@ final class GhosttyTerminalNSView: NSView {
         let scopes = ShortcutContext.activeScopes(for: window)
         return KeyBindingStore.shared.isRegisteredShortcut(event: event, scopes: scopes)
             || CommandShortcutStore.shared.isRegisteredShortcut(event: event, scopes: scopes)
+            || ExtensionShortcutStore.shared.isRegisteredShortcut(event: event, scopes: scopes)
     }
 
     private static let systemShortcutKeys: Set<String> = ["q", "h", "m", ","]

--- a/Tests/MuxyTests/Services/ExtensionShortcutStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionShortcutStoreTests.swift
@@ -93,6 +93,13 @@ struct KeyComboParsingTests {
         #expect(KeyCombo(parsing: "cmd+return") == KeyCombo(key: KeyCombo.returnKey, command: true))
     }
 
+    @Test("rejects combos without a command, control, or option modifier")
+    func rejectsModifierlessCombos() {
+        #expect(KeyCombo(parsing: "e") == nil)
+        #expect(KeyCombo(parsing: "shift+e") == nil)
+        #expect(KeyCombo(parsing: "return") == nil)
+    }
+
     @Test("returns nil for unparseable strings")
     func rejectsInvalid() {
         #expect(KeyCombo(parsing: "") == nil)

--- a/Tests/MuxyTests/Services/ExtensionShortcutStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionShortcutStoreTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionShortcutStore")
+@MainActor
+struct ExtensionShortcutStoreTests {
+    @Test("syncBindings auto-assigns a free default combo")
+    func autoAssignsFreeCombo() {
+        let persistence = InMemoryExtensionShortcutPersistence()
+        let store = ExtensionShortcutStore(persistence: persistence)
+        let ext = makeExtension(id: "alpha", commandID: "open", shortcut: "ctrl+opt+shift+1")
+
+        store.syncBindings(for: [ext])
+
+        let shortcut = store.shortcut(extensionID: "alpha", commandID: "open")
+        #expect(shortcut?.combo == KeyCombo(key: "1", shift: true, control: true, option: true))
+        #expect(persistence.savedShortcuts?.count == 1)
+    }
+
+    @Test("syncBindings registers later extension unassigned when combo already claimed")
+    func registersUnassignedOnConflict() {
+        let store = ExtensionShortcutStore(persistence: InMemoryExtensionShortcutPersistence())
+        let first = makeExtension(id: "alpha", commandID: "open", shortcut: "ctrl+opt+shift+2")
+        let second = makeExtension(id: "beta", commandID: "open", shortcut: "ctrl+opt+shift+2")
+
+        store.syncBindings(for: [first, second])
+
+        #expect(store.shortcut(extensionID: "alpha", commandID: "open")?.combo.isAssigned == true)
+        #expect(store.shortcut(extensionID: "beta", commandID: "open")?.combo.isAssigned == false)
+    }
+
+    @Test("syncBindings preserves stored user-assigned combos")
+    func preservesStoredCombo() {
+        let stored = ExtensionShortcut(
+            extensionID: "alpha",
+            commandID: "open",
+            combo: KeyCombo(key: "9", command: true)
+        )
+        let persistence = InMemoryExtensionShortcutPersistence(shortcuts: [stored])
+        let store = ExtensionShortcutStore(persistence: persistence)
+        let ext = makeExtension(id: "alpha", commandID: "open", shortcut: "ctrl+opt+shift+3")
+
+        store.syncBindings(for: [ext])
+
+        #expect(store.shortcut(extensionID: "alpha", commandID: "open")?.combo == KeyCombo(key: "9", command: true))
+    }
+
+    @Test("syncBindings drops shortcuts for commands no longer present")
+    func dropsRemovedCommands() {
+        let stored = ExtensionShortcut(
+            extensionID: "alpha",
+            commandID: "gone",
+            combo: KeyCombo(key: "9", command: true)
+        )
+        let store = ExtensionShortcutStore(persistence: InMemoryExtensionShortcutPersistence(shortcuts: [stored]))
+
+        store.syncBindings(for: [])
+
+        #expect(store.shortcuts.isEmpty)
+    }
+
+    @Test("unassign clears the combo")
+    func unassignClearsCombo() {
+        let stored = ExtensionShortcut(
+            extensionID: "alpha",
+            commandID: "open",
+            combo: KeyCombo(key: "9", command: true)
+        )
+        let persistence = InMemoryExtensionShortcutPersistence(shortcuts: [stored])
+        let store = ExtensionShortcutStore(persistence: persistence)
+
+        store.unassign(extensionID: "alpha", commandID: "open")
+
+        #expect(store.shortcut(extensionID: "alpha", commandID: "open")?.combo.isAssigned == false)
+        #expect(persistence.savedShortcuts?.first?.combo.isAssigned == false)
+    }
+
+    private func makeExtension(id: String, commandID: String, shortcut: String) -> MuxyExtension {
+        let command = ExtensionPaletteCommand(id: commandID, title: commandID, defaultShortcut: shortcut)
+        let manifest = ExtensionManifest(name: id, version: "1.0.0", commands: [command])
+        return MuxyExtension(id: id, directory: URL(fileURLWithPath: "/tmp/\(id)"), manifest: manifest)
+    }
+}
+
+@Suite("KeyCombo parsing")
+struct KeyComboParsingTests {
+    @Test("parses modifiers and key from string")
+    func parsesCombo() {
+        #expect(KeyCombo(parsing: "cmd+shift+e") == KeyCombo(key: "e", command: true, shift: true))
+        #expect(KeyCombo(parsing: "ctrl+opt+k") == KeyCombo(key: "k", command: false, control: true, option: true))
+        #expect(KeyCombo(parsing: "cmd+return") == KeyCombo(key: KeyCombo.returnKey, command: true))
+    }
+
+    @Test("returns nil for unparseable strings")
+    func rejectsInvalid() {
+        #expect(KeyCombo(parsing: "") == nil)
+        #expect(KeyCombo(parsing: "cmd+bogus") == nil)
+        #expect(KeyCombo(parsing: "cmd+") == nil)
+    }
+}
+
+private final class InMemoryExtensionShortcutPersistence: ExtensionShortcutPersisting {
+    var shortcuts: [ExtensionShortcut]
+    var savedShortcuts: [ExtensionShortcut]?
+
+    init(shortcuts: [ExtensionShortcut] = []) {
+        self.shortcuts = shortcuts
+    }
+
+    func loadShortcuts() throws -> [ExtensionShortcut] {
+        shortcuts
+    }
+
+    func saveShortcuts(_ shortcuts: [ExtensionShortcut]) throws {
+        savedShortcuts = shortcuts
+    }
+}

--- a/docs/extensions/palette-commands.md
+++ b/docs/extensions/palette-commands.md
@@ -27,7 +27,8 @@ Extensions can declare commands that appear in Muxy's command palette. Picking a
 
 ## Keyboard shortcuts
 
-A command may declare a `defaultShortcut` (e.g. `"cmd+ctrl+p"`). On load Muxy
+A command may declare a `defaultShortcut` (e.g. `"cmd+ctrl+p"`). It must include
+at least one of `cmd`, `ctrl`, or `opt`; bare keys are ignored. On load Muxy
 auto-assigns it when the combo is free; if it is already taken (by an app
 shortcut, a custom command, or another extension), the command registers
 **unassigned**. The first extension to claim a combo keeps it. Users view and

--- a/docs/extensions/palette-commands.md
+++ b/docs/extensions/palette-commands.md
@@ -23,6 +23,17 @@ Extensions can declare commands that appear in Muxy's command palette. Picking a
 | `title` | string | yes | The palette row title. |
 | `subtitle` | string | no | Dimmer second line. Defaults to the extension's display name. |
 | `action` | object | no | What happens when picked. Defaults to `{ "kind": "event" }`. |
+| `defaultShortcut` | string | no | A keyboard shortcut that runs the command, e.g. `"cmd+shift+e"`. See below. |
+
+## Keyboard shortcuts
+
+A command may declare a `defaultShortcut` (e.g. `"cmd+ctrl+p"`). On load Muxy
+auto-assigns it when the combo is free; if it is already taken (by an app
+shortcut, a custom command, or another extension), the command registers
+**unassigned**. The first extension to claim a combo keeps it. Users view and
+rebind these under **Settings → Keyboard Shortcuts → App Shortcuts**, grouped by
+extension name. Pressing the shortcut runs the command's `action`, exactly as
+picking it from the palette does.
 
 ## Actions
 

--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -210,7 +210,12 @@
         "id": { "type": "string", "minLength": 1 },
         "title": { "type": "string" },
         "subtitle": { "type": "string" },
-        "action": { "$ref": "#/$defs/commandAction" }
+        "action": { "$ref": "#/$defs/commandAction" },
+        "defaultShortcut": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Default keyboard shortcut for this command, e.g. \"cmd+shift+e\". Auto-assigned on load when free; registered unassigned when the combo is already taken. Editable in Settings → Keyboard Shortcuts."
+        }
       }
     },
     "commandAction": {

--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -214,7 +214,7 @@
         "defaultShortcut": {
           "type": "string",
           "minLength": 1,
-          "description": "Default keyboard shortcut for this command, e.g. \"cmd+shift+e\". Auto-assigned on load when free; registered unassigned when the combo is already taken. Editable in Settings → Keyboard Shortcuts."
+          "description": "Default keyboard shortcut for this command, e.g. \"cmd+shift+e\". Must include at least one of cmd, ctrl, or opt; bare keys are ignored. Auto-assigned on load when free; registered unassigned when the combo is already taken. Editable in Settings → Keyboard Shortcuts."
         }
       }
     },


### PR DESCRIPTION
Extensions can declare a defaultShortcut on a palette command; pressing it runs
  that command's action (event/openTab/togglePanel/runScript). Combos auto-assign
  when free and register unassigned when taken (first extension wins), and are
  rebindable in Settings → Keyboard Shortcuts.