### PR TITLE
Extensions can serve a remote API to the mobile app

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -66,6 +66,7 @@ enum ExtensionPermission: String, Codable, CaseIterable {
     case panelsWrite = "panels:write"
     case commandsRunScript = "commands:run-script"
     case commandsExec = "commands:exec"
+    case remoteServe = "remote:serve"
 
     enum Kind {
         case read
@@ -88,7 +89,8 @@ enum ExtensionPermission: String, Codable, CaseIterable {
              .panelsWrite:
             .write
         case .commandsRunScript,
-             .commandsExec:
+             .commandsExec,
+             .remoteServe:
             .action
         }
     }
@@ -398,6 +400,11 @@ struct ExtensionPaletteCommand: Codable, Equatable, Identifiable {
     var eventName: String { "command.\(id)" }
 }
 
+struct ExtensionRemoteMethod: Codable, Equatable, Identifiable {
+    let id: String
+    let description: String?
+}
+
 struct ExtensionManifest: Codable, Equatable {
     let name: String
     let version: String
@@ -412,6 +419,7 @@ struct ExtensionManifest: Codable, Equatable {
     let topbarItems: [ExtensionTopbarItem]
     let statusBarItems: [ExtensionStatusBarItem]
     let settings: [ExtensionSettingEntry]
+    let remoteMethods: [ExtensionRemoteMethod]
 
     private enum CodingKeys: String, CodingKey {
         case name
@@ -427,6 +435,7 @@ struct ExtensionManifest: Codable, Equatable {
         case topbarItems
         case statusBarItems
         case settings
+        case remoteMethods
     }
 
     init(
@@ -442,7 +451,8 @@ struct ExtensionManifest: Codable, Equatable {
         permissions: [ExtensionPermission] = [],
         topbarItems: [ExtensionTopbarItem] = [],
         statusBarItems: [ExtensionStatusBarItem] = [],
-        settings: [ExtensionSettingEntry] = []
+        settings: [ExtensionSettingEntry] = [],
+        remoteMethods: [ExtensionRemoteMethod] = []
     ) {
         self.name = name
         self.version = version
@@ -457,6 +467,7 @@ struct ExtensionManifest: Codable, Equatable {
         self.topbarItems = topbarItems
         self.statusBarItems = statusBarItems
         self.settings = settings
+        self.remoteMethods = remoteMethods
     }
 
     init(from decoder: Decoder) throws {
@@ -474,6 +485,7 @@ struct ExtensionManifest: Codable, Equatable {
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
         settings = try container.decodeIfPresent([ExtensionSettingEntry].self, forKey: .settings) ?? []
+        remoteMethods = try container.decodeIfPresent([ExtensionRemoteMethod].self, forKey: .remoteMethods) ?? []
     }
 
     init(package: PackageManifest) {
@@ -491,6 +503,7 @@ struct ExtensionManifest: Codable, Equatable {
         topbarItems = muxy.topbarItems
         statusBarItems = muxy.statusBarItems
         settings = muxy.settings
+        remoteMethods = muxy.remoteMethods
     }
 
     func tabType(id: String) -> ExtensionTabType? {
@@ -511,6 +524,10 @@ struct ExtensionManifest: Codable, Equatable {
 
     func statusBarItem(id: String) -> ExtensionStatusBarItem? {
         statusBarItems.first { $0.id == id }
+    }
+
+    func remoteMethod(id: String) -> ExtensionRemoteMethod? {
+        remoteMethods.first { $0.id == id }
     }
 }
 
@@ -538,6 +555,7 @@ struct MuxyManifestBody: Codable, Equatable {
     let topbarItems: [ExtensionTopbarItem]
     let statusBarItems: [ExtensionStatusBarItem]
     let settings: [ExtensionSettingEntry]
+    let remoteMethods: [ExtensionRemoteMethod]
 
     private enum CodingKeys: String, CodingKey {
         case description
@@ -551,6 +569,7 @@ struct MuxyManifestBody: Codable, Equatable {
         case topbarItems
         case statusBarItems
         case settings
+        case remoteMethods
     }
 
     init(from decoder: Decoder) throws {
@@ -566,6 +585,7 @@ struct MuxyManifestBody: Codable, Equatable {
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
         settings = try container.decodeIfPresent([ExtensionSettingEntry].self, forKey: .settings) ?? []
+        remoteMethods = try container.decodeIfPresent([ExtensionRemoteMethod].self, forKey: .remoteMethods) ?? []
     }
 }
 
@@ -605,6 +625,8 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case statusBarItemSVGOutsideDirectory(itemID: String, url: URL)
     case settingEmptyKey
     case duplicateSettingKey(String)
+    case remoteMethodEmptyID
+    case duplicateRemoteMethod(String)
 
     var errorDescription: String? {
         switch self {
@@ -678,6 +700,10 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Setting key must not be empty"
         case let .duplicateSettingKey(key):
             "Duplicate setting key '\(key)'"
+        case .remoteMethodEmptyID:
+            "Remote method id must not be empty"
+        case let .duplicateRemoteMethod(id):
+            "Duplicate remote method '\(id)'"
         }
     }
 }
@@ -759,6 +785,7 @@ enum ExtensionManifestLoader {
         try validateTopbarItems(manifest: manifest, in: muxyExtension)
         try validateStatusBarItems(manifest: manifest, in: muxyExtension)
         try validateSettings(manifest: manifest)
+        try validateRemoteMethods(manifest: manifest)
 
         migrateLegacyEnabledFlag(rawManifest: data, extensionID: manifest.name)
 
@@ -962,6 +989,16 @@ enum ExtensionManifestLoader {
             guard !entry.key.isEmpty else { throw ExtensionLoadError.settingEmptyKey }
             guard seen.insert(entry.key).inserted else {
                 throw ExtensionLoadError.duplicateSettingKey(entry.key)
+            }
+        }
+    }
+
+    private static func validateRemoteMethods(manifest: ExtensionManifest) throws {
+        var seen = Set<String>()
+        for method in manifest.remoteMethods {
+            guard !method.id.isEmpty else { throw ExtensionLoadError.remoteMethodEmptyID }
+            guard seen.insert(method.id).inserted else {
+                throw ExtensionLoadError.duplicateRemoteMethod(method.id)
             }
         }
     }

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -94,6 +94,13 @@ enum ExtensionPermission: String, Codable, CaseIterable {
             .action
         }
     }
+
+    var displayName: String {
+        switch self {
+        case .remoteServe: "remote-api"
+        default: rawValue
+        }
+    }
 }
 
 struct ExtensionTabType: Codable, Equatable, Identifiable {
@@ -626,6 +633,7 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case settingEmptyKey
     case duplicateSettingKey(String)
     case remoteMethodEmptyID
+    case remoteMethodInvalidID(String)
     case duplicateRemoteMethod(String)
 
     var errorDescription: String? {
@@ -702,6 +710,8 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Duplicate setting key '\(key)'"
         case .remoteMethodEmptyID:
             "Remote method id must not be empty"
+        case let .remoteMethodInvalidID(id):
+            "Remote method id '\(id)' must not contain control characters or '|'"
         case let .duplicateRemoteMethod(id):
             "Duplicate remote method '\(id)'"
         }
@@ -997,6 +1007,9 @@ enum ExtensionManifestLoader {
         var seen = Set<String>()
         for method in manifest.remoteMethods {
             guard !method.id.isEmpty else { throw ExtensionLoadError.remoteMethodEmptyID }
+            guard !method.id.unicodeScalars.contains(where: { $0 == "|" || CharacterSet.controlCharacters.contains($0) }) else {
+                throw ExtensionLoadError.remoteMethodInvalidID(method.id)
+            }
             guard seen.insert(method.id).inserted else {
                 throw ExtensionLoadError.duplicateRemoteMethod(method.id)
             }

--- a/Muxy/Services/ExtensionConsentService.swift
+++ b/Muxy/Services/ExtensionConsentService.swift
@@ -223,6 +223,8 @@ enum ExtensionConsentRequestBuilder {
             return ("read screen of pane \(id)", ["pane: \(id)"])
         case let (.tabsOpenForeign, .foreignTab(target, tab)):
             return ("open \(target) tab \(tab)", ["extension: \(target)", "tab type: \(tab)"])
+        case let (.remoteInvoke, .remote(action, deviceName)):
+            return ("\(deviceName) calls \(action)", ["device: \(deviceName)", "action: \(action)"])
         default:
             return ("(unknown)", [])
         }

--- a/Muxy/Services/ExtensionGrantStore.swift
+++ b/Muxy/Services/ExtensionGrantStore.swift
@@ -14,6 +14,7 @@ enum ExtensionGatedVerb: String, Codable, CaseIterable {
     case panesSendKeys = "panes.sendKeys"
     case panesReadScreen = "panes.readScreen"
     case tabsOpenForeign = "tabs.openForeign"
+    case remoteInvoke = "remote.invoke"
 }
 
 enum ExtensionGrantMatch: Codable, Equatable {
@@ -23,6 +24,7 @@ enum ExtensionGrantMatch: Codable, Equatable {
     case shellExact(String)
     case paneEquals(String)
     case foreignTabEquals(targetExtensionID: String, tabTypeID: String)
+    case remoteActionEquals(String)
 
     private enum CodingKeys: String, CodingKey {
         case kind
@@ -38,6 +40,7 @@ enum ExtensionGrantMatch: Codable, Equatable {
         case shellExact
         case paneEquals
         case foreignTabEquals
+        case remoteActionEquals
     }
 
     init(from decoder: Decoder) throws {
@@ -59,6 +62,8 @@ enum ExtensionGrantMatch: Codable, Equatable {
                 targetExtensionID: container.decode(String.self, forKey: .target),
                 tabTypeID: container.decode(String.self, forKey: .string)
             )
+        case .remoteActionEquals:
+            self = try .remoteActionEquals(container.decode(String.self, forKey: .string))
         }
     }
 
@@ -83,6 +88,9 @@ enum ExtensionGrantMatch: Codable, Equatable {
             try container.encode(Kind.foreignTabEquals, forKey: .kind)
             try container.encode(target, forKey: .target)
             try container.encode(tab, forKey: .string)
+        case let .remoteActionEquals(action):
+            try container.encode(Kind.remoteActionEquals, forKey: .kind)
+            try container.encode(action, forKey: .string)
         }
     }
 
@@ -91,6 +99,7 @@ enum ExtensionGrantMatch: Codable, Equatable {
         case .any: 0
         case .paneEquals,
              .shellExact: 100
+        case .remoteActionEquals: 120
         case .foreignTabEquals: 150
         case let .argvPrefix(tokens): 50 + tokens.count
         case let .argvExact(tokens): 200 + tokens.count
@@ -105,6 +114,7 @@ enum ExtensionGrantMatch: Codable, Equatable {
         case let .shellExact(value): "sh: \(value)"
         case let .paneEquals(value): "pane: \(value)"
         case let .foreignTabEquals(target, tab): "tab: \(target)/\(tab)"
+        case let .remoteActionEquals(action): "action: \(action)"
         }
     }
 }
@@ -113,6 +123,7 @@ enum ExtensionGatedPayload {
     case exec(argv: [String]?, shell: String?)
     case pane(id: String)
     case foreignTab(targetExtensionID: String, tabTypeID: String)
+    case remote(action: String, deviceName: String)
 
     func matches(_ match: ExtensionGrantMatch) -> Bool {
         switch (self, match) {
@@ -130,6 +141,8 @@ enum ExtensionGatedPayload {
             return id == expected
         case let (.foreignTab(target, tab), .foreignTabEquals(expectedTarget, expectedTab)):
             return target == expectedTarget && tab == expectedTab
+        case let (.remote(action, _), .remoteActionEquals(expected)):
+            return action == expected
         default:
             return false
         }
@@ -275,6 +288,8 @@ enum ExtensionGrantSuggestion {
             }
             if let shell { return .shellExact(shell) }
             return .any
+        case let (.remoteInvoke, .remote(action, _)):
+            return .remoteActionEquals(action)
         case (.panesSend, _),
              (.panesSendKeys, _),
              (.panesReadScreen, _),

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -42,6 +42,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "app.muxy.notificationSocket")
     private var subscribers: [ObjectIdentifier: ClientSession] = [:]
+    private var liveSessionByExtension: [String: ClientSession] = [:]
     private var readSources: [ObjectIdentifier: DispatchSourceRead] = [:]
     private var extensionSnapshot = ExtensionSnapshot(entries: [:])
     private var inProcessObservers: [UUID: @Sendable (ExtensionEvent) -> Void] = [:]
@@ -169,7 +170,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     }
 
     private func session(forExtension extensionID: String) -> ClientSession? {
-        subscribers.values.first { $0.extensionID == extensionID }
+        liveSessionByExtension[extensionID]
     }
 
     struct InvokeResult: Equatable {
@@ -390,6 +391,7 @@ final class NotificationSocketServer: @unchecked Sendable {
                 return "error:invalid extension token"
             }
             session.extensionID = claimedID
+            liveSessionByExtension[claimedID] = session
             return "ok"
         case "subscribe":
             let parts = message.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false).map(String.init)
@@ -605,6 +607,9 @@ final class NotificationSocketServer: @unchecked Sendable {
     }
 
     private func closeSession(_ session: ClientSession) {
+        if let extensionID = session.extensionID, liveSessionByExtension[extensionID] === session {
+            liveSessionByExtension.removeValue(forKey: extensionID)
+        }
         failPendingInvokes(for: session)
         session.writeSource?.cancel()
         session.writeSource = nil

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MuxyShared
 import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "NotificationSocketServer")
@@ -44,6 +45,8 @@ final class NotificationSocketServer: @unchecked Sendable {
     private var readSources: [ObjectIdentifier: DispatchSourceRead] = [:]
     private var extensionSnapshot = ExtensionSnapshot(entries: [:])
     private var inProcessObservers: [UUID: @Sendable (ExtensionEvent) -> Void] = [:]
+    private var pendingInvokes: [String: CheckedContinuation<Data, Error>] = [:]
+    private var invokeOwner: [String: ObjectIdentifier] = [:]
 
     var openProjectHandler: (@Sendable (String) -> Void)?
     var installExtensionHandler: (@Sendable (String) -> Void)?
@@ -124,6 +127,87 @@ final class NotificationSocketServer: @unchecked Sendable {
     func removeInProcessObserver(_ token: UUID) {
         queue.async { [weak self] in
             self?.inProcessObservers.removeValue(forKey: token)
+        }
+    }
+
+    static let invokeTimeout: Duration = .seconds(15)
+
+    func invokeRemote(extensionID: String, action: String, payload: Data) async throws -> Data {
+        let callID = UUID().uuidString
+        let base64 = payload.base64EncodedString()
+
+        let invokeTask = Task {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
+                queue.async { [weak self] in
+                    guard let self else {
+                        continuation.resume(throwing: MuxyError.extensionUnavailable)
+                        return
+                    }
+                    guard let session = self.session(forExtension: extensionID) else {
+                        continuation.resume(throwing: MuxyError.extensionUnavailable)
+                        return
+                    }
+                    self.pendingInvokes[callID] = continuation
+                    self.invokeOwner[callID] = ObjectIdentifier(session)
+                    self.enqueueWrite(session: session, text: "invoke|\(callID)|\(action)|\(base64)\n")
+                }
+            }
+        }
+
+        let timeoutTask = Task {
+            try? await Task.sleep(for: Self.invokeTimeout)
+            guard !Task.isCancelled else { return }
+            self.queue.async { [weak self] in
+                guard let self, let continuation = self.pendingInvokes.removeValue(forKey: callID) else { return }
+                self.invokeOwner.removeValue(forKey: callID)
+                continuation.resume(throwing: MuxyError.timeout)
+            }
+        }
+
+        defer { timeoutTask.cancel() }
+        return try await invokeTask.value
+    }
+
+    private func session(forExtension extensionID: String) -> ClientSession? {
+        subscribers.values.first { $0.extensionID == extensionID }
+    }
+
+    struct InvokeResult: Equatable {
+        let callID: String
+        let ok: Bool
+        let body: Data
+    }
+
+    static func parseInvokeResult(_ message: String) -> InvokeResult? {
+        let parts = message.split(separator: "|", maxSplits: 3, omittingEmptySubsequences: false).map(String.init)
+        guard parts.count >= 3, parts[0] == "invoke-result", !parts[1].isEmpty else { return nil }
+        let status = parts[2]
+        guard status == "ok" || status == "err" else { return nil }
+        let body = parts.count >= 4 ? (Data(base64Encoded: parts[3]) ?? Data()) : Data()
+        return InvokeResult(callID: parts[1], ok: status == "ok", body: body)
+    }
+
+    private func handleInvokeResult(_ message: String, session: ClientSession) {
+        guard let parsed = Self.parseInvokeResult(message) else { return }
+        guard let owner = invokeOwner[parsed.callID], owner == ObjectIdentifier(session) else { return }
+        guard let continuation = pendingInvokes.removeValue(forKey: parsed.callID) else { return }
+        invokeOwner.removeValue(forKey: parsed.callID)
+
+        if parsed.ok {
+            continuation.resume(returning: parsed.body)
+            return
+        }
+        let messageText = String(data: parsed.body, encoding: .utf8) ?? "extension error"
+        continuation.resume(throwing: MuxyError.extensionError(messageText))
+    }
+
+    private func failPendingInvokes(for session: ClientSession) {
+        let owner = ObjectIdentifier(session)
+        let callIDs = invokeOwner.filter { $0.value == owner }.map(\.key)
+        for callID in callIDs {
+            invokeOwner.removeValue(forKey: callID)
+            guard let continuation = pendingInvokes.removeValue(forKey: callID) else { continue }
+            continuation.resume(throwing: MuxyError.extensionUnavailable)
         }
     }
 
@@ -281,6 +365,11 @@ final class NotificationSocketServer: @unchecked Sendable {
 
         if Self.commandNames.contains(head) {
             processCommand(trimmed, session: session)
+            return
+        }
+
+        if head == "invoke-result" {
+            handleInvokeResult(trimmed, session: session)
             return
         }
 
@@ -516,6 +605,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     }
 
     private func closeSession(_ session: ClientSession) {
+        failPendingInvokes(for: session)
         session.writeSource?.cancel()
         session.writeSource = nil
         if session.fd >= 0, !session.pendingClose {

--- a/Muxy/Services/PaneOwnershipStore.swift
+++ b/Muxy/Services/PaneOwnershipStore.swift
@@ -47,6 +47,10 @@ final class PaneOwnershipStore {
         deviceNames[clientID] = name
     }
 
+    func deviceName(for clientID: UUID) -> String? {
+        deviceNames[clientID]
+    }
+
     func assign(paneID: UUID, to clientID: UUID) {
         let name = deviceNames[clientID] ?? "Mobile"
         if case let .remote(existing, _) = owners[paneID], existing != clientID {

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -782,6 +782,55 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         NotificationStore.shared.markAsRead(notificationID)
     }
 
+    func extensionRequest(
+        extension extensionID: String,
+        action: String,
+        payload: MuxyJSON,
+        clientID: UUID
+    ) async -> Result<MuxyJSON, MuxyError> {
+        guard let loaded = ExtensionStore.shared.loadedExtension(id: extensionID) else {
+            return .failure(.notFound)
+        }
+        guard loaded.manifest.remoteMethod(id: action) != nil else {
+            return .failure(.notFound)
+        }
+        guard ExtensionStore.shared.extensionHasPermission(id: extensionID, permission: .remoteServe) else {
+            return .failure(.forbidden)
+        }
+
+        let deviceName = PaneOwnershipStore.shared.deviceName(for: clientID) ?? "Mobile"
+        let consent = ExtensionConsentRequestBuilder.make(
+            extensionID: extensionID,
+            verb: .remoteInvoke,
+            payload: .remote(action: action, deviceName: deviceName),
+            source: "remote-server"
+        )
+        guard await ExtensionConsentService.shared.gate(consent) == .allow else {
+            return .failure(.forbidden)
+        }
+
+        let payloadData: Data
+        do {
+            payloadData = try payload.encoded()
+        } catch {
+            return .failure(.invalidParams)
+        }
+
+        do {
+            let resultData = try await NotificationSocketServer.shared.invokeRemote(
+                extensionID: extensionID,
+                action: action,
+                payload: payloadData
+            )
+            let value = try MuxyJSON.decoded(from: resultData)
+            return .success(value)
+        } catch let error as MuxyError {
+            return .failure(error)
+        } catch {
+            return .failure(.extensionError(error.localizedDescription))
+        }
+    }
+
     private func resolveWorktreePath(projectID: UUID) -> String? {
         guard let worktreeID = appState.activeWorktreeID[projectID],
               let worktree = worktreeStore.worktree(projectID: projectID, worktreeID: worktreeID)

--- a/Muxy/Views/Extensions/ExtensionConsentDialog.swift
+++ b/Muxy/Views/Extensions/ExtensionConsentDialog.swift
@@ -242,6 +242,7 @@ struct ExtensionConsentDialog: View {
              .panesSendKeys: "keyboard.fill"
         case .panesReadScreen: "eye.fill"
         case .tabsOpenForeign: "rectangle.stack.fill"
+        case .remoteInvoke: "antenna.radiowaves.left.and.right"
         }
     }
 
@@ -252,6 +253,7 @@ struct ExtensionConsentDialog: View {
         case .panesSendKeys: "wants to press keys in a terminal"
         case .panesReadScreen: "wants to read terminal output"
         case .tabsOpenForeign: "wants to open another extension's tab"
+        case .remoteInvoke: "wants to serve a mobile request"
         }
     }
 }

--- a/Muxy/Views/Extensions/ExtensionInstallPage.swift
+++ b/Muxy/Views/Extensions/ExtensionInstallPage.swift
@@ -320,7 +320,7 @@ private struct ExtensionInstallPermissionTag: View {
         let color = tagColor
         HStack(spacing: 4) {
             Circle().fill(color).frame(width: 5, height: 5)
-            Text(permission)
+            Text(ExtensionPermission(rawValue: permission)?.displayName ?? permission)
                 .font(.system(size: 10, weight: .medium, design: .monospaced))
                 .foregroundStyle(color)
         }

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -215,7 +215,8 @@ private struct ExtensionsListPage: View {
                                 availableVersion: store.availableUpdateVersion(for: status.id),
                                 isUpdating: updatingIDs.contains(status.id),
                                 onUpdate: { Task { await updateOne(status.id) } },
-                                onOpen: { onSelect(status.id) }
+                                onOpen: { onSelect(status.id) },
+                                onSetEnabled: { store.setEnabled($0, for: status.id) }
                             )
                             if index < store.statuses.count - 1 {
                                 Rectangle()
@@ -311,9 +312,14 @@ private struct ExtensionRow: View {
     var isUpdating = false
     var onUpdate: () -> Void = {}
     let onOpen: () -> Void
+    var onSetEnabled: (Bool) -> Void = { _ in }
     @State private var hovered = false
 
     private var ext: MuxyExtension { status.muxyExtension }
+
+    private var enabledBinding: Binding<Bool> {
+        Binding(get: { status.isEnabled }, set: onSetEnabled)
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -323,8 +329,13 @@ private struct ExtensionRow: View {
             .buttonStyle(.plain)
             if let availableVersion {
                 ExtensionUpdateButton(version: availableVersion, isUpdating: isUpdating, action: onUpdate)
-                    .padding(.trailing, 14)
             }
+            Toggle("", isOn: enabledBinding)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .help(status.isEnabled ? "Disable extension" : "Enable extension")
+                .padding(.trailing, 14)
         }
         .background(hovered ? MuxyTheme.hover : Color.clear)
         .onHover { hovered = $0 }
@@ -500,7 +511,7 @@ private struct ExtensionPermissionTag: View {
             Circle()
                 .fill(color)
                 .frame(width: 5, height: 5)
-            Text(permission.rawValue)
+            Text(permission.displayName)
                 .font(.system(size: 10, weight: .medium, design: .monospaced))
                 .foregroundStyle(color)
             if let kindLabel {
@@ -533,9 +544,9 @@ private struct ExtensionPermissionTag: View {
 
     private var helpText: String {
         switch permission.kind {
-        case .read: "Read access: \(permission.rawValue)"
-        case .write: "Write access: \(permission.rawValue)"
-        case .action: "Action: \(permission.rawValue)"
+        case .read: "Read access: \(permission.displayName)"
+        case .write: "Write access: \(permission.displayName)"
+        case .action: "Action: \(permission.displayName)"
         }
     }
 }

--- a/MuxyExtensionHost/HostBridge.swift
+++ b/MuxyExtensionHost/HostBridge.swift
@@ -30,14 +30,32 @@ final class HostBridge: @unchecked Sendable {
         }
         context.setObject(subscribe, forKeyedSubscript: "__muxySubscribe" as NSString)
 
+        let invokeResolve: @convention(block) (String, String) -> Void = { [weak self] callID, json in
+            self?.sendInvokeResult(callID: callID, ok: true, payload: Data(json.utf8))
+        }
+        context.setObject(invokeResolve, forKeyedSubscript: "__muxyInvokeResolve" as NSString)
+
+        let invokeReject: @convention(block) (String, String) -> Void = { [weak self] callID, message in
+            self?.sendInvokeResult(callID: callID, ok: false, payload: Data(message.utf8))
+        }
+        context.setObject(invokeReject, forKeyedSubscript: "__muxyInvokeReject" as NSString)
+
         context.evaluateScript(ExtensionBridgeJS.script(extensionID: extensionID, surface: .background))
     }
 
     private func dispatch(verb: String, args: JSValue?) -> Any {
-        guard verb == "exec" else {
+        let dict = (args?.toDictionary() as? [String: Any]) ?? [:]
+        switch verb {
+        case "exec":
+            return dispatchExec(dict)
+        case "notifications.notify":
+            return dispatchNotify(dict)
+        default:
             return ["ok": false, "error": "verb '\(verb)' is not available in background context"]
         }
-        let dict = (args?.toDictionary() as? [String: Any]) ?? [:]
+    }
+
+    private func dispatchExec(_ dict: [String: Any]) -> Any {
         guard let payload = try? JSONSerialization.data(withJSONObject: dict) else {
             return ["ok": false, "error": "could not encode exec payload"]
         }
@@ -58,6 +76,28 @@ final class HostBridge: @unchecked Sendable {
         }
     }
 
+    private func dispatchNotify(_ dict: [String: Any]) -> Any {
+        let title = sanitize(dict["title"] as? String ?? "")
+        let body = sanitize(dict["body"] as? String ?? "")
+        guard !title.isEmpty || !body.isEmpty else {
+            return ["ok": false, "error": "notification requires title or body"]
+        }
+        let paneID = sanitize(dict["paneID"] as? String ?? "")
+        let line = "\(sanitize(extensionID))|\(paneID)|\(title)|\(body)"
+        do {
+            try client.send(line)
+            return ["ok": true, "value": NSNull()]
+        } catch {
+            return ["ok": false, "error": "\(error)"]
+        }
+    }
+
+    private func sanitize(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "|", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+
     private func subscribe(name: String) {
         do {
             let reply = try client.sendAndWaitReply("subscribe|\(name)")
@@ -68,6 +108,47 @@ final class HostBridge: @unchecked Sendable {
         } catch {
             FileHandle.standardError.write(Data("[muxy-extension-host] subscribe \(name) error: \(error)\n".utf8))
         }
+    }
+
+    func handleInvokeLine(_ line: String) {
+        guard let parsed = Self.parseInvoke(line) else { return }
+        let payloadValue: Any = if let data = Data(base64Encoded: parsed.payload),
+                                   let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        {
+            object
+        } else {
+            NSNull()
+        }
+        let box = ContextBox(context)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let handlers = box.context.objectForKeyedSubscript("__muxyRemoteHandlers")
+            let handler = handlers?.objectForKeyedSubscript(parsed.action)
+            guard let handler, !handler.isUndefined, !handler.isNull else {
+                self.sendInvokeResult(callID: parsed.callID, ok: false, payload: Data("no handler registered for '\(parsed.action)'".utf8))
+                return
+            }
+            let argument = JSValue(object: payloadValue, in: box.context) ?? JSValue(nullIn: box.context)
+            let returned = handler.call(withArguments: [argument as Any])
+            let resolver = box.context.objectForKeyedSubscript("__muxyResolveInvoke")
+            resolver?.call(withArguments: [parsed.callID, returned as Any])
+        }
+    }
+
+    private func sendInvokeResult(callID: String, ok: Bool, payload: Data) {
+        let status = ok ? "ok" : "err"
+        let line = "invoke-result|\(callID)|\(status)|\(payload.base64EncodedString())"
+        try? client.send(line)
+    }
+
+    static func parseInvoke(_ line: String) -> (callID: String, action: String, payload: String)? {
+        let parts = line.components(separatedBy: "|")
+        guard parts.count >= 4, parts[0] == "invoke" else { return nil }
+        let callID = parts[1]
+        let action = parts[2]
+        guard !callID.isEmpty, !action.isEmpty else { return nil }
+        let payload = parts[3]
+        return (callID, action, payload)
     }
 
     func handleEventLine(_ line: String) {

--- a/MuxyExtensionHost/HostBridge.swift
+++ b/MuxyExtensionHost/HostBridge.swift
@@ -120,18 +120,10 @@ final class HostBridge: @unchecked Sendable {
             NSNull()
         }
         let box = ContextBox(context)
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            let handlers = box.context.objectForKeyedSubscript("__muxyRemoteHandlers")
-            let handler = handlers?.objectForKeyedSubscript(parsed.action)
-            guard let handler, !handler.isUndefined, !handler.isNull else {
-                self.sendInvokeResult(callID: parsed.callID, ok: false, payload: Data("no handler registered for '\(parsed.action)'".utf8))
-                return
-            }
+        DispatchQueue.main.async {
             let argument = JSValue(object: payloadValue, in: box.context) ?? JSValue(nullIn: box.context)
-            let returned = handler.call(withArguments: [argument as Any])
-            let resolver = box.context.objectForKeyedSubscript("__muxyResolveInvoke")
-            resolver?.call(withArguments: [parsed.callID, returned as Any])
+            let dispatcher = box.context.objectForKeyedSubscript("__muxyDispatchInvoke")
+            dispatcher?.call(withArguments: [parsed.callID, parsed.action, argument as Any])
         }
     }
 
@@ -142,7 +134,7 @@ final class HostBridge: @unchecked Sendable {
     }
 
     static func parseInvoke(_ line: String) -> (callID: String, action: String, payload: String)? {
-        let parts = line.components(separatedBy: "|")
+        let parts = line.split(separator: "|", maxSplits: 3, omittingEmptySubsequences: false).map(String.init)
         guard parts.count >= 4, parts[0] == "invoke" else { return nil }
         let callID = parts[1]
         let action = parts[2]

--- a/MuxyExtensionHost/HostSocketClient.swift
+++ b/MuxyExtensionHost/HostSocketClient.swift
@@ -16,6 +16,7 @@ final class HostSocketClient: @unchecked Sendable {
     private var closed = false
     private var readBuffer = Data()
     private var eventHandler: ((String) -> Void)?
+    private var invokeHandler: ((String) -> Void)?
 
     init(socketPath: String) throws {
         let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
@@ -49,6 +50,10 @@ final class HostSocketClient: @unchecked Sendable {
 
     func onEvent(_ handler: @escaping (String) -> Void) {
         eventHandler = handler
+    }
+
+    func onInvoke(_ handler: @escaping (String) -> Void) {
+        invokeHandler = handler
     }
 
     func startReading() {
@@ -122,6 +127,10 @@ final class HostSocketClient: @unchecked Sendable {
     private func deliver(_ line: String) {
         if line.hasPrefix("event|") {
             eventHandler?(line)
+            return
+        }
+        if line.hasPrefix("invoke|") {
+            invokeHandler?(line)
             return
         }
         replyLock.lock()

--- a/MuxyExtensionHost/main.swift
+++ b/MuxyExtensionHost/main.swift
@@ -45,6 +45,10 @@ client.onEvent { [weak bridge] line in
     bridge?.handleEventLine(line)
 }
 
+client.onInvoke { [weak bridge] line in
+    bridge?.handleInvokeLine(line)
+}
+
 client.startReading()
 
 do {

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -75,6 +75,7 @@ public protocol MuxyRemoteServerDelegate: AnyObject {
     func getProjectLogo(projectID: UUID) -> ProjectLogoDTO?
     func listNotifications() -> [NotificationDTO]
     func markNotificationRead(_ notificationID: UUID)
+    func extensionRequest(extension: String, action: String, payload: MuxyJSON, clientID: UUID) async -> Result<MuxyJSON, MuxyError>
 }
 
 public final class MuxyRemoteServer: @unchecked Sendable {
@@ -703,6 +704,23 @@ public final class MuxyRemoteServer: @unchecked Sendable {
             }
             delegate.releasePane(paneID: params.paneID, clientID: clientID)
             return MuxyResponse(id: request.id, result: .ok)
+
+        case .extensionRequest:
+            guard case let .extensionRequest(params) = request.params else {
+                return MuxyResponse(id: request.id, error: .invalidParams)
+            }
+            let result = await delegate.extensionRequest(
+                extension: params.extension,
+                action: params.action,
+                payload: params.payload,
+                clientID: clientID
+            )
+            switch result {
+            case let .success(payload):
+                return MuxyResponse(id: request.id, result: .extensionResult(ExtensionResultDTO(payload: payload)))
+            case let .failure(error):
+                return MuxyResponse(id: request.id, error: error)
+            }
         }
     }
 

--- a/MuxyShared/ExtensionBridgeJS.swift
+++ b/MuxyShared/ExtensionBridgeJS.swift
@@ -18,7 +18,7 @@ public enum ExtensionBridgeJS {
             const muxy = {
                 extensionID: \(extLiteral),
                 \(surface == .inProcess ? "toast: (opts) => dispatch('toast', opts || {})," : "")
-                \(surface == .inProcess ? "notifications: { notify: (opts) => dispatch('notifications.notify', opts || {}) }," : "")
+                notifications: { notify: (opts) => dispatch('notifications.notify', opts || {}) },
                 exec(argvOrOptions, maybeOptions) {
                     let payload;
                     if (Array.isArray(argvOrOptions)) {
@@ -43,10 +43,12 @@ public enum ExtensionBridgeJS {
             };
         \(surface == .inProcess ? workspaceBlock : "")
         \(surface == .background ? eventsBlock : "")
+        \(surface == .background ? remoteBlock : "")
             \(surface == .inProcess ?
-            "Object.freeze(muxy.notifications); Object.freeze(muxy.tabs); Object.freeze(muxy.panes); Object.freeze(muxy.projects); Object.freeze(muxy.worktrees);" :
+            "Object.freeze(muxy.tabs); Object.freeze(muxy.panes); Object.freeze(muxy.projects); Object.freeze(muxy.worktrees);" :
             "")
-            \(surface == .background ? "Object.freeze(muxy.events);" : "")
+            Object.freeze(muxy.notifications);
+            \(surface == .background ? "Object.freeze(muxy.events); Object.freeze(muxy.remote);" : "")
             Object.freeze(muxy);
             this.muxy = muxy;
 
@@ -133,6 +135,36 @@ public enum ExtensionBridgeJS {
                     const index = list.indexOf(handler);
                     if (index >= 0) list.splice(index, 1);
                 },
+            };
+    """
+
+    private static let remoteBlock = """
+            const remoteHandlers = {};
+            this.__muxyRemoteHandlers = remoteHandlers;
+            muxy.remote = {
+                handle(action, handler) {
+                    remoteHandlers[String(action)] = handler;
+                },
+                unhandle(action) {
+                    delete remoteHandlers[String(action)];
+                },
+            };
+            this.__muxyResolveInvoke = (callID, valueOrPromise) => {
+                Promise.resolve(valueOrPromise).then(
+                    (value) => {
+                        let json;
+                        try {
+                            json = JSON.stringify(value === undefined ? null : value);
+                        } catch (e) {
+                            __muxyInvokeReject(callID, 'result is not serializable');
+                            return;
+                        }
+                        __muxyInvokeResolve(callID, json == null ? 'null' : json);
+                    },
+                    (error) => {
+                        __muxyInvokeReject(callID, String((error && error.message) || error));
+                    }
+                );
             };
     """
 

--- a/MuxyShared/ExtensionBridgeJS.swift
+++ b/MuxyShared/ExtensionBridgeJS.swift
@@ -149,8 +149,20 @@ public enum ExtensionBridgeJS {
                     delete remoteHandlers[String(action)];
                 },
             };
-            this.__muxyResolveInvoke = (callID, valueOrPromise) => {
-                Promise.resolve(valueOrPromise).then(
+            this.__muxyDispatchInvoke = (callID, action, argument) => {
+                const handler = remoteHandlers[String(action)];
+                if (typeof handler !== 'function') {
+                    __muxyInvokeReject(callID, "no handler registered for '" + action + "'");
+                    return;
+                }
+                let result;
+                try {
+                    result = handler(argument);
+                } catch (error) {
+                    __muxyInvokeReject(callID, String((error && error.message) || error));
+                    return;
+                }
+                Promise.resolve(result).then(
                     (value) => {
                         let json;
                         try {

--- a/MuxyShared/MuxyJSON.swift
+++ b/MuxyShared/MuxyJSON.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum MuxyJSON: Codable, Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([MuxyJSON])
+    case object([String: MuxyJSON])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+            return
+        }
+        if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+            return
+        }
+        if let number = try? container.decode(Double.self) {
+            self = .number(number)
+            return
+        }
+        if let string = try? container.decode(String.self) {
+            self = .string(string)
+            return
+        }
+        if let array = try? container.decode([MuxyJSON].self) {
+            self = .array(array)
+            return
+        }
+        if let object = try? container.decode([String: MuxyJSON].self) {
+            self = .object(object)
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "Unsupported JSON value"
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case let .bool(value): try container.encode(value)
+        case let .number(value): try container.encode(value)
+        case let .string(value): try container.encode(value)
+        case let .array(value): try container.encode(value)
+        case let .object(value): try container.encode(value)
+        }
+    }
+
+    public func encoded() throws -> Data {
+        try JSONEncoder().encode(self)
+    }
+
+    public static func decoded(from data: Data) throws -> MuxyJSON {
+        try JSONDecoder().decode(MuxyJSON.self, from: data)
+    }
+}

--- a/MuxyShared/MuxyProtocol.swift
+++ b/MuxyShared/MuxyProtocol.swift
@@ -40,7 +40,7 @@ public struct MuxyEvent: Codable, Sendable {
     }
 }
 
-public struct MuxyError: Codable, Sendable {
+public struct MuxyError: Codable, Sendable, Error {
     public let code: Int
     public let message: String
 
@@ -55,6 +55,13 @@ public struct MuxyError: Codable, Sendable {
     public static let unauthorized = MuxyError(code: 401, message: "Authentication required")
     public static let pairingDenied = MuxyError(code: 403, message: "Pairing denied")
     public static let pairingTimeout = MuxyError(code: 408, message: "Pairing request timed out")
+    public static let forbidden = MuxyError(code: 403, message: "Forbidden")
+    public static let extensionUnavailable = MuxyError(code: 503, message: "Extension unavailable")
+    public static let timeout = MuxyError(code: 504, message: "Request timed out")
+
+    public static func extensionError(_ message: String) -> MuxyError {
+        MuxyError(code: 502, message: message)
+    }
 }
 
 public enum MuxyMethod: String, Codable, Sendable {
@@ -99,6 +106,7 @@ public enum MuxyMethod: String, Codable, Sendable {
     case markNotificationRead
     case subscribe
     case unsubscribe
+    case extensionRequest
 }
 
 public enum MuxyParams: Codable, Sendable {
@@ -141,6 +149,7 @@ public enum MuxyParams: Codable, Sendable {
     case markNotificationRead(MarkNotificationReadParams)
     case subscribe(SubscribeParams)
     case unsubscribe(UnsubscribeParams)
+    case extensionRequest(ExtensionRequestParams)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -190,6 +199,7 @@ public enum MuxyParams: Codable, Sendable {
         case "markNotificationRead": self = try .markNotificationRead(container.decode(MarkNotificationReadParams.self, forKey: .value))
         case "subscribe": self = try .subscribe(container.decode(SubscribeParams.self, forKey: .value))
         case "unsubscribe": self = try .unsubscribe(container.decode(UnsubscribeParams.self, forKey: .value))
+        case "extensionRequest": self = try .extensionRequest(container.decode(ExtensionRequestParams.self, forKey: .value))
         default: throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown param type: \(type)")
         }
     }
@@ -275,6 +285,8 @@ public enum MuxyParams: Codable, Sendable {
             try container.encode(v, forKey: .value)
         case let .unsubscribe(v): try container.encode("unsubscribe", forKey: .type)
             try container.encode(v, forKey: .value)
+        case let .extensionRequest(v): try container.encode("extensionRequest", forKey: .type)
+            try container.encode(v, forKey: .value)
         }
     }
 }
@@ -295,6 +307,7 @@ public enum MuxyResult: Codable, Sendable {
     case vcsDiff(VCSDiffDTO)
     case projectLogo(ProjectLogoDTO)
     case notifications([NotificationDTO])
+    case extensionResult(ExtensionResultDTO)
     case ok
 
     private enum CodingKeys: String, CodingKey {
@@ -321,6 +334,7 @@ public enum MuxyResult: Codable, Sendable {
         case "vcsDiff": self = try .vcsDiff(container.decode(VCSDiffDTO.self, forKey: .value))
         case "projectLogo": self = try .projectLogo(container.decode(ProjectLogoDTO.self, forKey: .value))
         case "notifications": self = try .notifications(container.decode([NotificationDTO].self, forKey: .value))
+        case "extensionResult": self = try .extensionResult(container.decode(ExtensionResultDTO.self, forKey: .value))
         case "ok": self = .ok
         default: throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown result type: \(type)")
         }
@@ -358,6 +372,8 @@ public enum MuxyResult: Codable, Sendable {
         case let .projectLogo(v): try container.encode("projectLogo", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .notifications(v): try container.encode("notifications", forKey: .type)
+            try container.encode(v, forKey: .value)
+        case let .extensionResult(v): try container.encode("extensionResult", forKey: .type)
             try container.encode(v, forKey: .value)
         case .ok: try container.encode("ok", forKey: .type)
         }

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -7,6 +7,26 @@ public struct SelectProjectParams: Codable, Sendable {
     }
 }
 
+public struct ExtensionRequestParams: Codable, Sendable {
+    public let `extension`: String
+    public let action: String
+    public let payload: MuxyJSON
+
+    public init(extension: String, action: String, payload: MuxyJSON = .null) {
+        self.extension = `extension`
+        self.action = action
+        self.payload = payload
+    }
+}
+
+public struct ExtensionResultDTO: Codable, Sendable {
+    public let payload: MuxyJSON
+
+    public init(payload: MuxyJSON) {
+        self.payload = payload
+    }
+}
+
 public struct ListWorktreesParams: Codable, Sendable {
     public let projectID: UUID
     public init(projectID: UUID) {

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -356,6 +356,78 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("defaults remoteMethods to empty when absent")
+    func defaultsRemoteMethodsEmpty() throws {
+        let json = #"""
+        {
+            "name": "hello",
+            "version": "1.0.0"
+        }
+        """#
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+        #expect(manifest.remoteMethods.isEmpty)
+    }
+
+    @Test("decodes remoteMethods and remote:serve permission")
+    func decodesRemoteMethods() throws {
+        let json = #"""
+        {
+            "name": "weather",
+            "version": "1.0.0",
+            "background": "background.js",
+            "permissions": ["remote:serve"],
+            "remoteMethods": [
+                { "id": "forecast", "description": "Get forecast" },
+                { "id": "current" }
+            ]
+        }
+        """#
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+        #expect(manifest.permissions == [.remoteServe])
+        #expect(manifest.remoteMethods.map(\.id) == ["forecast", "current"])
+        #expect(manifest.remoteMethod(id: "forecast")?.description == "Get forecast")
+        #expect(manifest.remoteMethod(id: "missing") == nil)
+    }
+
+    @Test("rejects duplicate remote method ids")
+    func rejectsDuplicateRemoteMethods() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "remote-dup",
+                "version": "1.0.0",
+                "remoteMethods": [
+                    { "id": "ping" },
+                    { "id": "ping" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects empty remote method id")
+    func rejectsEmptyRemoteMethodID() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "remote-empty",
+                "version": "1.0.0",
+                "remoteMethods": [
+                    { "id": "" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     @Test("decodes panels with defaults and explicit values")
     func decodesPanels() throws {
         let json = #"""
@@ -701,6 +773,7 @@ struct ExtensionPermissionKindTests {
     func mapsActionPermissions() {
         #expect(ExtensionPermission.commandsRunScript.kind == .action)
         #expect(ExtensionPermission.commandsExec.kind == .action)
+        #expect(ExtensionPermission.remoteServe.kind == .action)
     }
 
     @Test("covers every permission case")

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -428,6 +428,25 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("rejects remote method id containing the wire delimiter")
+    func rejectsDelimiterRemoteMethodID() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "remote-pipe",
+                "version": "1.0.0",
+                "remoteMethods": [
+                    { "id": "a|b" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(throws: ExtensionLoadError.remoteMethodInvalidID("a|b")) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     @Test("decodes panels with defaults and explicit values")
     func decodesPanels() throws {
         let json = #"""
@@ -781,5 +800,11 @@ struct ExtensionPermissionKindTests {
         for permission in ExtensionPermission.allCases {
             _ = permission.kind
         }
+    }
+
+    @Test("remote:serve displays as remote-api and others use the raw value")
+    func permissionDisplayName() {
+        #expect(ExtensionPermission.remoteServe.displayName == "remote-api")
+        #expect(ExtensionPermission.commandsExec.displayName == "commands:exec")
     }
 }

--- a/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
@@ -39,6 +39,18 @@ struct MuxyProtocolVariantTests {
         }
     }
 
+    @Test("MuxyJSON round-trips nested values")
+    func muxyJSONRoundTrips() throws {
+        let value = MuxyJSON.object([
+            "name": .string("muxy"),
+            "count": .number(3),
+            "ok": .bool(true),
+            "tags": .array([.string("a"), .null]),
+        ])
+        let decoded = try MuxyJSON.decoded(from: value.encoded())
+        #expect(decoded == value)
+    }
+
     @Test("pane owner display name uses local and remote names")
     func paneOwnerDisplayName() {
         #expect(PaneOwnerDTO.mac(deviceName: "Mac").displayName == "Mac")
@@ -115,6 +127,7 @@ struct MuxyProtocolVariantTests {
             ProtocolSample(.markNotificationRead(MarkNotificationReadParams(notificationID: ids.notificationID)), caseName: ".markNotificationRead"),
             ProtocolSample(.subscribe(SubscribeParams(events: [.workspaceChanged, .themeChanged])), caseName: ".subscribe"),
             ProtocolSample(.unsubscribe(UnsubscribeParams(events: [.terminalOutput])), caseName: ".unsubscribe"),
+            ProtocolSample(.extensionRequest(ExtensionRequestParams(extension: "weather", action: "forecast", payload: .object(["city": .string("Berlin")]))), caseName: ".extensionRequest"),
         ]
     }
 
@@ -136,6 +149,7 @@ struct MuxyProtocolVariantTests {
             ProtocolSample(.vcsDiff(diff), caseName: ".vcsDiff"),
             ProtocolSample(.projectLogo(ProjectLogoDTO(projectID: ids.projectID, pngData: "base64")), caseName: ".projectLogo"),
             ProtocolSample(.notifications([notification(ids)]), caseName: ".notifications"),
+            ProtocolSample(.extensionResult(ExtensionResultDTO(payload: .array([.number(1), .bool(true), .null]))), caseName: ".extensionResult"),
             ProtocolSample(.ok, caseName: ".ok"),
         ]
     }

--- a/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
@@ -181,6 +181,14 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
     func markNotificationRead(_ notificationID: UUID) {
         markNotificationReadCalls.append(notificationID)
     }
+
+    var extensionRequestCalls: [(extension: String, action: String, payload: MuxyJSON, clientID: UUID)] = []
+    var stubExtensionResult: Result<MuxyJSON, MuxyError> = .success(.null)
+
+    func extensionRequest(extension: String, action: String, payload: MuxyJSON, clientID: UUID) async -> Result<MuxyJSON, MuxyError> {
+        extensionRequestCalls.append((`extension`, action, payload, clientID))
+        return stubExtensionResult
+    }
 }
 
 @Suite("MuxyRemoteServer routing")
@@ -626,6 +634,68 @@ struct MuxyRemoteServerRoutingTests {
             Issue.record("expected ok for both subscribe and unsubscribe")
             return
         }
+    }
+
+    @Test("extensionRequest forwards params and returns delegate payload")
+    func extensionRequestRoutes() async {
+        let (server, delegate) = makeServer()
+        delegate.stubExtensionResult = .success(.object(["pong": .number(42)]))
+
+        let response = await server.processRequest(
+            MuxyRequest(
+                id: "12",
+                method: .extensionRequest,
+                params: .extensionRequest(ExtensionRequestParams(
+                    extension: "weather",
+                    action: "forecast",
+                    payload: .object(["city": .string("Berlin")])
+                ))
+            ),
+            clientID: authedClient(on: server)
+        )
+
+        #expect(delegate.extensionRequestCalls.first?.extension == "weather")
+        #expect(delegate.extensionRequestCalls.first?.action == "forecast")
+        guard case let .extensionResult(result) = response.result else {
+            Issue.record("expected extensionResult result")
+            return
+        }
+        #expect(result.payload == .object(["pong": .number(42)]))
+    }
+
+    @Test("extensionRequest surfaces delegate failure as the mapped error")
+    func extensionRequestFailure() async {
+        let (server, delegate) = makeServer()
+        delegate.stubExtensionResult = .failure(.forbidden)
+
+        let response = await server.processRequest(
+            MuxyRequest(
+                id: "13",
+                method: .extensionRequest,
+                params: .extensionRequest(ExtensionRequestParams(extension: "x", action: "y", payload: .null))
+            ),
+            clientID: authedClient(on: server)
+        )
+
+        #expect(response.result == nil)
+        #expect(response.error?.code == 403)
+    }
+
+    @Test("extensionRequest requires authentication")
+    func extensionRequestRequiresAuth() async {
+        let (server, delegate) = makeServer()
+
+        let response = await server.processRequest(
+            MuxyRequest(
+                id: "14",
+                method: .extensionRequest,
+                params: .extensionRequest(ExtensionRequestParams(extension: "x", action: "y", payload: .null))
+            ),
+            clientID: UUID()
+        )
+
+        #expect(delegate.extensionRequestCalls.isEmpty)
+        #expect(response.error?.code == 401)
     }
 
     @Test("missing delegate returns internal error")

--- a/Tests/MuxyTests/Services/ExtensionGrantStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionGrantStoreTests.swift
@@ -277,6 +277,37 @@ struct ExtensionGrantStoreTests {
         #expect(match == .any)
     }
 
+    @Test("remoteActionEquals rule matches only the same action")
+    func remoteActionEqualsMatch() {
+        let store = makeStore()
+        let rule = ExtensionGrantRule(
+            extensionID: "ext",
+            verb: .remoteInvoke,
+            match: .remoteActionEquals("forecast"),
+            decision: .allow
+        )
+        store.add(rule)
+        #expect(store.evaluate(
+            extensionID: "ext",
+            verb: .remoteInvoke,
+            payload: .remote(action: "forecast", deviceName: "iPad")
+        ) == .allow(ruleID: rule.id))
+        #expect(store.evaluate(
+            extensionID: "ext",
+            verb: .remoteInvoke,
+            payload: .remote(action: "other", deviceName: "iPad")
+        ) == .ask)
+    }
+
+    @Test("remote invoke default remember match scopes to the action")
+    func remoteInvokeDefaultRemember() {
+        let match = ExtensionGrantSuggestion.defaultRememberMatch(
+            verb: .remoteInvoke,
+            payload: .remote(action: "forecast", deviceName: "iPad")
+        )
+        #expect(match == .remoteActionEquals("forecast"))
+    }
+
     private func makeStore() -> ExtensionGrantStore {
         ExtensionGrantStore(fileURL: tempURL())
     }

--- a/Tests/MuxyTests/Services/ExtensionHostBridgeTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionHostBridgeTests.swift
@@ -43,6 +43,22 @@ struct ExtensionHostBridgeTests {
         #expect(object?["paneID"] == "abc")
         #expect(object?["title"] == "hi")
     }
+
+    @Test("parses an invoke line with call id, action and payload")
+    func parsesInvoke() {
+        let parsed = HostBridge.parseInvoke("invoke|call-1|forecast|eyJjaXR5IjoiQmVybGluIn0=")
+        let result = try? #require(parsed)
+        #expect(result?.callID == "call-1")
+        #expect(result?.action == "forecast")
+        #expect(result?.payload == "eyJjaXR5IjoiQmVybGluIn0=")
+    }
+
+    @Test("rejects malformed invoke lines")
+    func rejectsMalformedInvoke() {
+        #expect(HostBridge.parseInvoke("invoke|call-1") == nil)
+        #expect(HostBridge.parseInvoke("invoke||forecast|payload") == nil)
+        #expect(HostBridge.parseInvoke("event|forecast|payload") == nil)
+    }
 }
 
 @Suite("MuxyExtensionHost socket client")
@@ -93,6 +109,27 @@ struct ExtensionHostSocketClientTests {
         let reply = try client.sendAndWaitReply("exec|payload")
         #expect(reply == "ok")
         #expect(received.lines.contains("event|pane.created|paneID=abc"))
+    }
+
+    @Test("an interleaved invoke line is routed to onInvoke and does not satisfy a reply")
+    func invokeDoesNotSatisfyReply() throws {
+        let (client, server) = makePair()
+        defer { close(server) }
+
+        let received = EventBox()
+        client.onInvoke { received.append($0) }
+        client.startReading()
+
+        Thread.detachNewThread { [server] in
+            var buffer = [UInt8](repeating: 0, count: 256)
+            _ = read(server, &buffer, buffer.count)
+            self.writeLine("invoke|call-1|forecast|cGF5bG9hZA==", to: server)
+            self.writeLine("ok", to: server)
+        }
+
+        let reply = try client.sendAndWaitReply("exec|payload")
+        #expect(reply == "ok")
+        #expect(received.lines.contains("invoke|call-1|forecast|cGF5bG9hZA=="))
     }
 
     @Test("EOF wakes a blocked sendAndWaitReply")

--- a/Tests/MuxyTests/Services/ExtensionHostBridgeTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionHostBridgeTests.swift
@@ -59,6 +59,14 @@ struct ExtensionHostBridgeTests {
         #expect(HostBridge.parseInvoke("invoke||forecast|payload") == nil)
         #expect(HostBridge.parseInvoke("event|forecast|payload") == nil)
     }
+
+    @Test("keeps the payload intact when it would otherwise contain delimiters")
+    func parsesInvokePreservesPayload() {
+        let parsed = HostBridge.parseInvoke("invoke|call-1|forecast|a|b|c")
+        let result = try? #require(parsed)
+        #expect(result?.action == "forecast")
+        #expect(result?.payload == "a|b|c")
+    }
 }
 
 @Suite("MuxyExtensionHost socket client")

--- a/Tests/MuxyTests/Services/ExtensionRemoteBridgeJSTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionRemoteBridgeJSTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import JavaScriptCore
+import MuxyShared
+import Testing
+
+@Suite("Extension background remote bridge JS")
+struct ExtensionRemoteBridgeJSTests {
+    private final class Capture {
+        var resolvedCallID: String?
+        var resolvedJSON: String?
+        var rejectedCallID: String?
+        var rejectedMessage: String?
+    }
+
+    private func makeContext() -> (JSContext, Capture) {
+        let context = JSContext()!
+        let capture = Capture()
+
+        let dispatch: @convention(block) (String, [String: Any]) -> [String: Any] = { _, _ in ["ok": true, "value": NSNull()] }
+        context.setObject(dispatch, forKeyedSubscript: "__muxyDispatch" as NSString)
+        let subscribe: @convention(block) (String) -> Void = { _ in }
+        context.setObject(subscribe, forKeyedSubscript: "__muxySubscribe" as NSString)
+
+        let resolve: @convention(block) (String, String) -> Void = { callID, json in
+            capture.resolvedCallID = callID
+            capture.resolvedJSON = json
+        }
+        context.setObject(resolve, forKeyedSubscript: "__muxyInvokeResolve" as NSString)
+        let reject: @convention(block) (String, String) -> Void = { callID, message in
+            capture.rejectedCallID = callID
+            capture.rejectedMessage = message
+        }
+        context.setObject(reject, forKeyedSubscript: "__muxyInvokeReject" as NSString)
+
+        context.evaluateScript(ExtensionBridgeJS.script(extensionID: "demo", surface: .background))
+        return (context, capture)
+    }
+
+    private func dispatchInvoke(_ context: JSContext, callID: String, action: String, argument: Any) {
+        let dispatcher = context.objectForKeyedSubscript("__muxyDispatchInvoke")
+        let value = JSValue(object: argument, in: context) ?? JSValue(nullIn: context)
+        dispatcher?.call(withArguments: [callID, action, value as Any])
+    }
+
+    @Test("resolves with the handler's JSON return value")
+    func resolvesReturnValue() {
+        let (context, capture) = makeContext()
+        context.evaluateScript("muxy.remote.handle('ping', (p) => ({ pong: p.n }));")
+        dispatchInvoke(context, callID: "c1", action: "ping", argument: ["n": 7])
+        #expect(capture.resolvedCallID == "c1")
+        #expect(capture.resolvedJSON == #"{"pong":7}"#)
+        #expect(capture.rejectedMessage == nil)
+    }
+
+    @Test("rejects when the handler throws synchronously")
+    func rejectsSynchronousThrow() {
+        let (context, capture) = makeContext()
+        context.evaluateScript("muxy.remote.handle('boom', () => { throw new Error('nope'); });")
+        dispatchInvoke(context, callID: "c2", action: "boom", argument: NSNull())
+        #expect(capture.resolvedJSON == nil)
+        #expect(capture.rejectedCallID == "c2")
+        #expect(capture.rejectedMessage == "nope")
+    }
+
+    @Test("rejects when no handler is registered")
+    func rejectsUnknownAction() {
+        let (context, capture) = makeContext()
+        dispatchInvoke(context, callID: "c3", action: "missing", argument: NSNull())
+        #expect(capture.resolvedJSON == nil)
+        #expect(capture.rejectedCallID == "c3")
+        #expect(capture.rejectedMessage == "no handler registered for 'missing'")
+    }
+
+    @Test("unhandle removes a registered handler")
+    func unhandleRemovesHandler() {
+        let (context, capture) = makeContext()
+        context.evaluateScript("muxy.remote.handle('ping', () => 1); muxy.remote.unhandle('ping');")
+        dispatchInvoke(context, callID: "c4", action: "ping", argument: NSNull())
+        #expect(capture.rejectedMessage == "no handler registered for 'ping'")
+    }
+}

--- a/Tests/MuxyTests/Services/NotificationSocketInvokeTests.swift
+++ b/Tests/MuxyTests/Services/NotificationSocketInvokeTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("NotificationSocketServer invoke-result parsing")
+struct NotificationSocketInvokeTests {
+    @Test("parses a successful invoke-result with base64 payload")
+    func parsesOk() throws {
+        let payload = Data(#"{"pong":42}"#.utf8)
+        let line = "invoke-result|call-1|ok|\(payload.base64EncodedString())"
+        let parsed = try #require(NotificationSocketServer.parseInvokeResult(line))
+        #expect(parsed.callID == "call-1")
+        #expect(parsed.ok)
+        #expect(parsed.body == payload)
+    }
+
+    @Test("parses an error invoke-result carrying a message")
+    func parsesError() throws {
+        let message = Data("handler threw".utf8)
+        let line = "invoke-result|call-2|err|\(message.base64EncodedString())"
+        let parsed = try #require(NotificationSocketServer.parseInvokeResult(line))
+        #expect(parsed.callID == "call-2")
+        #expect(!parsed.ok)
+        #expect(String(data: parsed.body, encoding: .utf8) == "handler threw")
+    }
+
+    @Test("rejects malformed invoke-result lines")
+    func rejectsMalformed() {
+        #expect(NotificationSocketServer.parseInvokeResult("invoke-result|call-1") == nil)
+        #expect(NotificationSocketServer.parseInvokeResult("invoke-result||ok|x") == nil)
+        #expect(NotificationSocketServer.parseInvokeResult("invoke-result|call-1|maybe|x") == nil)
+        #expect(NotificationSocketServer.parseInvokeResult("event|call-1|ok|x") == nil)
+    }
+}

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -76,6 +76,7 @@ flowchart TD
 | [Topbar](topbar.md) | Attach icons to the tab strip that trigger a command |
 | [Status Bar](statusbar.md) | Attach icons to the footer status bar; update text live |
 | [Settings](settings.md) | Declare typed settings and read/write them at runtime |
+| [Remote Methods](remote-methods.md) | Serve named API methods to the mobile app via the remote server |
 | [Scripts](scripts.md) | Run JS files as palette commands in a per-extension JSContext |
 | [Logs](logs.md) | Where logs live on disk, console.* bridge, size cap and trim policy |
 | [Contributing](contributing.md) | Create, validate, and publish an extension |

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -2,7 +2,7 @@
 
 Every extension is an npm + [Vite](https://vitejs.dev) project. Its manifest is the `muxy` object inside the `package.json` at the root of its directory.
 
-Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `panels`, `popovers`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `marketplace`) lives under the `muxy` key.
+Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `panels`, `popovers`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
 
 `package.json` must also declare a `build` script. The publishing pipeline runs `npm run build` (Vite) and ships the build output directory, `dist/`. The app installs and reads from `dist/`, so every entry/asset path inside `muxy` (popover/tab `entry`, `background`, marketplace `icon`/`screenshots`) resolves against the build output, not your source tree.
 
@@ -54,6 +54,7 @@ All Muxy-specific manifest fields live under the `muxy` object.
 | `topbarItems` | object[] | no | Icons attached to the tab strip. See [Topbar](topbar.md). |
 | `statusBarItems` | object[] | no | Icons attached to the footer status bar. See [Status Bar](statusbar.md). |
 | `settings` | object[] | no | Typed settings shown in the Settings sidebar. See [Settings](settings.md). |
+| `remoteMethods` | object[] | no | Named API methods served to the mobile app. Requires `remote:serve`. See [Remote Methods](remote-methods.md). |
 | `marketplace` | object | no | Listing metadata (icon, screenshots, author, categories) used by the marketplace. Ignored by the app loader. |
 
 Extensions are enabled by default after loading. The Settings → Extensions toggle is persisted in `UserDefaults` under `muxy.ext.enabled.<extension-id>` and survives launches. A legacy `enabled` manifest field is no longer part of the schema; if present with no user override, it is migrated into that UserDefaults entry on first load and otherwise ignored.

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -23,6 +23,7 @@ Permissions apply only to identified callers. The host identifies itself on beha
 | `panels:write` | `panel.open`, `panel.toggle`, `panel.close` for declared [panels](panels.md); `popover.resize`, `popover.close` for the extension's open [popover](popovers.md). |
 | `commands:run-script` | Execute `runScript` palette command actions in the per-extension JavaScriptCore context. |
 | `commands:exec` | Run shell commands via `muxy.exec` (subprocess execution with stdout/stderr capture). |
+| `remote:serve` | Serve [remote methods](remote-methods.md) declared in `remoteMethods` to the mobile app over the remote server. Each call also prompts for runtime consent. |
 
 ## Runtime consent
 
@@ -34,6 +35,7 @@ These verbs prompt the user at runtime even when the manifest permission is gran
 | `panes.send` | Typing arbitrary text into an active terminal. |
 | `panes.sendKeys` | Pressing keys (including Ctrl+C, Enter) in an active terminal. |
 | `panes.readScreen` | Reading the visible contents of a terminal. |
+| `remote.invoke` | Running an extension's [remote method](remote-methods.md) handler in response to a mobile request. Remembered per action. |
 
 The prompt shows the extension, the verb, and the literal payload (full argv, the keystroke, or the pane id). The user picks:
 

--- a/docs/extensions/remote-methods.md
+++ b/docs/extensions/remote-methods.md
@@ -1,0 +1,67 @@
+# Remote Methods
+
+An extension can serve named API methods to the Muxy mobile app. The mobile app calls a stable endpoint on the desktop; Muxy decides whether the request belongs to an extension and, if so, proxies it into the extension's background script, awaits the result, and returns it to the device. The mobile app never needs to know which extensions are installed.
+
+Requires the [`remote:serve`](permissions.md) permission, and every call prompts the user for [consent](permissions.md#runtime-consent) (remembered per action) before the handler runs.
+
+```json
+{
+  "permissions": ["remote:serve"],
+  "remoteMethods": [
+    { "id": "forecast", "description": "Return the weather forecast for a city." }
+  ]
+}
+```
+
+## Declaration fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Unique within the extension. The action name the device addresses. |
+| `description` | string | no | Human-readable summary for documentation. |
+
+The manifest is the source of truth for which actions exist: an action that is not declared, or an extension that lacks `remote:serve`, is rejected by Muxy before the background script is ever reached.
+
+## Serving a method
+
+Register a handler in your background script with `muxy.remote.handle`. The handler receives the request payload and returns a JSON-serializable value (or a `Promise` of one).
+
+```js
+muxy.remote.handle('forecast', async (payload) => {
+  const city = payload.city;
+  const res = await muxy.exec(['curl', '-s', `https://api.example.com/${city}`]);
+  muxy.notifications.notify({ title: 'Forecast requested', body: city });
+  return JSON.parse(res.stdout);
+});
+```
+
+The background script can surface a notification with `muxy.notifications.notify({ title, body })` (requires the `notifications:write` permission).
+
+- The payload is the JSON the device sent (any JSON value).
+- The return value is JSON-encoded and sent back to the device.
+- Throwing (or rejecting) returns an error to the device.
+- `muxy.remote.unhandle(id)` removes a handler.
+- The first call to an action prompts the user; choosing "Allow & remember" whitelists that action. A denied call returns `403` to the device.
+
+Remote handlers run in the same background JavaScript context as your event handlers and are serialized with them.
+
+## How the device reaches it
+
+The mobile app sends one request over the [remote server](../remote-server/methods.md):
+
+```json
+{
+  "method": "extensionRequest",
+  "params": { "extension": "<extension-id>", "action": "forecast", "payload": { "city": "Berlin" } }
+}
+```
+
+The device must already be paired and authenticated. On success the response carries the handler's value; on failure it carries a `MuxyError`:
+
+| Code | Meaning |
+| --- | --- |
+| 404 | Extension not loaded, or the action is not declared in `remoteMethods`. |
+| 403 | The extension lacks the `remote:serve` permission, or the user denied consent. |
+| 503 | The extension is not running / has no live background script. |
+| 502 | The handler threw, rejected, or is not registered. |
+| 504 | The handler did not reply in time. |

--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -85,6 +85,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/setting" }
         },
+        "remoteMethods": {
+          "type": "array",
+          "description": "Named API methods this extension serves to the mobile app via the remote server. Requires the `remote:serve` permission. Handlers are registered in the background script with `muxy.remote.handle(id, fn)`.",
+          "items": { "$ref": "#/$defs/remoteMethod" }
+        },
         "marketplace": {
           "type": "object",
           "description": "Listing metadata used by the marketplace. Required: icon + at least one screenshot. Ignored by the app loader. The pricing key is reserved for a future paid-extensions feature and is not yet enforced.",
@@ -138,7 +143,8 @@
         "notifications:write",
         "panels:write",
         "commands:run-script",
-        "commands:exec"
+        "commands:exec",
+        "remote:serve"
       ]
     },
     "icon": {
@@ -308,6 +314,15 @@
         "description": { "type": "string" },
         "type": { "enum": ["string", "bool", "number"] },
         "defaultValue": {}
+      }
+    },
+    "remoteMethod": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" }
       }
     }
   }

--- a/docs/remote-server/methods.md
+++ b/docs/remote-server/methods.md
@@ -51,6 +51,14 @@ Notes:
 
 `subscribe` / `unsubscribe` are accepted for compatibility, but clients should still be prepared to receive all broadcast event types.
 
+## Extensions
+
+| Method | Parameters | Result |
+| --- | --- | --- |
+| `extensionRequest` | `extension`, `action`, `payload` | `extensionResult` |
+
+`extensionRequest` proxies a call to an installed extension that serves the named `action`. `payload` and the `extensionResult.payload` are arbitrary JSON. The desktop resolves the handler, prompts the user for consent, runs it in the extension's background script, and returns its value. Errors: `404` (unknown extension or undeclared action), `403` (extension lacks `remote:serve` or consent denied), `503` (extension not running), `502` (handler failed), `504` (handler timed out). See [extension remote methods](../extensions/remote-methods.md).
+
 ## Git & worktrees
 
 | Method | Parameters | Result |


### PR DESCRIPTION
Extensions declare `remoteMethods` and register `muxy.remote.handle(action, fn)` in their background script. The mobile app hits one fixed `extensionRequest` endpoint; the desktop consent-gates it and proxies the call into the extension's handler, returning its result.

Background handlers can now also `muxy.notifications.notify(...)` to show a toast.

Test: load `remote-demo` from `~/.config/muxy/extensions`, then `node client.mjs pair` and `node client.mjs call`.