### PR TITLE
Load extensions from dist/ build output when present

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -765,9 +765,11 @@ enum ExtensionManifestLoader {
     }()
 
     static let manifestFileName = "package.json"
+    static let buildOutputDirectoryName = "dist"
 
     static func load(from directory: URL) throws -> MuxyExtension {
-        let manifestURL = directory.appendingPathComponent(manifestFileName)
+        let root = resolvedRoot(for: directory)
+        let manifestURL = root.appendingPathComponent(manifestFileName)
         guard FileManager.default.fileExists(atPath: manifestURL.path) else {
             throw ExtensionLoadError.manifestMissing(manifestURL)
         }
@@ -789,12 +791,12 @@ enum ExtensionManifestLoader {
 
         try validate(name: manifest.name)
 
-        let muxyExtension = MuxyExtension(id: manifest.name, directory: directory, manifest: manifest)
+        let muxyExtension = MuxyExtension(id: manifest.name, directory: root, manifest: manifest)
 
         if let background = manifest.background {
             guard let backgroundURL = muxyExtension.resolveResource(background) else {
                 throw ExtensionLoadError.backgroundScriptOutsideDirectory(
-                    directory.appendingPathComponent(background)
+                    root.appendingPathComponent(background)
                 )
             }
             guard FileManager.default.fileExists(atPath: backgroundURL.path) else {
@@ -814,6 +816,13 @@ enum ExtensionManifestLoader {
         migrateLegacyEnabledFlag(rawManifest: data, extensionID: manifest.name)
 
         return muxyExtension
+    }
+
+    static func resolvedRoot(for directory: URL) -> URL {
+        let buildOutput = directory.appendingPathComponent(buildOutputDirectoryName)
+        let buildManifest = buildOutput.appendingPathComponent(manifestFileName)
+        guard FileManager.default.fileExists(atPath: buildManifest.path) else { return directory }
+        return buildOutput
     }
 
     private static func migrateLegacyEnabledFlag(rawManifest: Data, extensionID: String) {

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -69,6 +69,52 @@ struct ExtensionManifestTests {
         #expect(ext.backgroundScriptURL != nil)
     }
 
+    @Test("loads from the dist build output when present")
+    func loadsFromBuildOutput() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("ext-\(UUID().uuidString)")
+        let distDirectory = directory.appendingPathComponent("dist")
+        try FileManager.default.createDirectory(at: distDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try ExtensionManifestFixture.write(
+            flatManifest: """
+            { "name": "built-ext", "version": "1.0.0" }
+            """,
+            to: directory
+        )
+        try ExtensionManifestFixture.write(
+            flatManifest: """
+            {
+                "name": "built-ext",
+                "version": "1.0.0",
+                "background": "background.js"
+            }
+            """,
+            to: distDirectory
+        )
+        try Data("console.log('hi')\n".utf8)
+            .write(to: distDirectory.appendingPathComponent("background.js"))
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ext.directory.path == distDirectory.path)
+        #expect(ext.backgroundScriptURL?.path == distDirectory.appendingPathComponent("background.js").path)
+    }
+
+    @Test("loads from the directory root when no dist build output exists")
+    func loadsFromRootWithoutBuildOutput() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            { "name": "root-ext", "version": "1.0.0" }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ext.directory == directory)
+    }
+
     @Test("loads without a background script")
     func loadsWithoutBackground() throws {
         let directory = try makeTemporaryExtension(

--- a/docs/extensions/contributing.md
+++ b/docs/extensions/contributing.md
@@ -78,8 +78,9 @@ npm run build
 
 ## 4. Test in Muxy
 
-Build first (`npm run build`), then load the unpacked extension's `dist/` from Muxy's
-developer settings and iterate. During development, `npm run dev` runs Vite's dev server.
+Put your project in `~/.config/muxy/extensions/<name>/` (the directory name must match the
+package `name`) and run `npm run build`. Muxy loads from the `dist/` build output when it
+exists, so you can keep your source alongside it and just rebuild to pick up changes.
 
 ## 5. Validate and publish
 

--- a/docs/extensions/examples/hello-world/vite.config.js
+++ b/docs/extensions/examples/hello-world/vite.config.js
@@ -1,14 +1,6 @@
+import { copyFileSync } from "node:fs";
 import { defineConfig } from "vite";
 
-// The installed extension directory IS Vite's `dist/` output, so every path
-// in package.json's `muxy` block resolves against `dist/`.
-//
-// - `tabs/index.html` is a Rollup input, so Vite emits `dist/tabs/index.html`
-//   (with its CSS/JS hashed and rewritten) at the same relative path the
-//   `muxy` block references.
-// - Listing assets (icon + screenshot) live in `public/assets/`. Vite copies
-//   everything under `publicDir` verbatim into `dist/`, producing
-//   `dist/assets/icon.svg` and `dist/assets/screenshot-1.png` untouched.
 export default defineConfig({
   build: {
     outDir: "dist",
@@ -20,4 +12,12 @@ export default defineConfig({
       },
     },
   },
+  plugins: [
+    {
+      name: "muxy-manifest",
+      closeBundle() {
+        copyFileSync("package.json", "dist/package.json");
+      },
+    },
+  ],
 });


### PR DESCRIPTION
Extension dev loop broke when the project lived in ~/.config/muxy/extensions/<name>/:
  the loader read source paths from the root instead of the built dist/. It now serves
  from dist/ when dist/package.json exists, and the example build copies package.json                                 into dist/ so the folder is self-contained.