### PR TITLE
Emit file.changed event to extensions on watched file changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ Run `scripts/checks.sh --fix` after every task.
 - Low memory and CPU usage is one of the key factors
 - Simpler, flexible and scalable approaches are key factors
 
+## Extensions
+
+- When providing API or hook or features to extensions, Make sure we update the extension SKILL and docs.
+- Extension features usually need testing, offer a demo extension at ~/.config/muxy/extensions to the user.
+
 ## Code Review
 
 - Review the PRs/Code against the purpose of the PR/Issue/Asked. If you find unrelated issues to the PR during the review, Report them in a separate section.

--- a/Muxy/Models/ExtensionEvent.swift
+++ b/Muxy/Models/ExtensionEvent.swift
@@ -32,4 +32,5 @@ enum ExtensionEventName {
     static let projectSwitched = "project.switched"
     static let worktreeSwitched = "worktree.switched"
     static let notificationPosted = "notification.posted"
+    static let fileChanged = "file.changed"
 }

--- a/Muxy/Models/FileTreeState.swift
+++ b/Muxy/Models/FileTreeState.swift
@@ -436,7 +436,9 @@ final class FileTreeState {
     }
 
     private func installWatcher() {
-        watcher = FileSystemWatcher(directoryPath: rootPath) { [weak self] in
+        let path = rootPath
+        watcher = FileSystemWatcher(directoryPath: path) { [weak self] changedPaths in
+            ExtensionFileEventEmitter.emit(paths: changedPaths, projectPath: path)
             Task { @MainActor [weak self] in
                 self?.refresh()
             }

--- a/Muxy/Models/VCSTabState.swift
+++ b/Muxy/Models/VCSTabState.swift
@@ -247,7 +247,9 @@ final class VCSTabState {
     }
 
     private func startWatching() {
-        watcher = FileSystemWatcher(directoryPath: projectPath) { [weak self] in
+        let path = projectPath
+        watcher = FileSystemWatcher(directoryPath: path) { [weak self] changedPaths in
+            ExtensionFileEventEmitter.emit(paths: changedPaths, projectPath: path)
             Task { @MainActor [weak self] in
                 self?.watcherDidFire()
             }

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -141,7 +141,7 @@ Field-by-field:
 - `muxy.description` — optional one-line summary shown in the Extensions modal.
 - `muxy.background` — optional relative path (resolved against `dist/`) to a JavaScript file. When present it must exist inside `dist/`; Muxy runs it in a long-lived host process for the lifetime of the extension. Provide it only to receive pushed events (`muxy.events.subscribe`) or run background shell commands (`muxy.exec`) — command, topbar, status bar, tab, and `runScript` extensions need none, and omitting it means Muxy keeps no resident process.
 - `muxy.permissions` — array of permission strings. Declare only what the background script or tabs actually use.
-- `muxy.events` — array of event names this extension subscribes to (for example `pane.created`, `tab.focused`, `pane.closed`). Command events (`command.<id>`) are auto-allowed.
+- `muxy.events` — array of event names this extension subscribes to (for example `pane.created`, `tab.focused`, `pane.closed`, `file.changed`). Command events (`command.<id>`) are auto-allowed. `file.changed` fires when a file under a watched project/worktree root changes (debounced ~0.3s, Git-internal lock/dir noise skipped); its payload is `{ path, projectPath }` — one event per changed `path`, `projectPath` being the watched root.
 - `muxy.tabTypes` — declares HTML pages (in `dist/`) renderable as tabs. A tab fills its whole region with one webview, so the page renders all of its own chrome — including, by recommendation, a [topbar](#tab-topbar-recommended) matching the app's native tabs.
 - `muxy.panels` — declares HTML pages renderable as dockable/floating panels (`position`: `right`|`bottom`, `mode`: `floating`|`pinned`, optional `icon`/`title`/`hiddenControls`, or `hideTopbar: true` to drop the whole header and render edge-to-edge — the page must then close itself). Requires `panels:write` to open/close at runtime. One pinned and one floating panel per position; opening another in that slot replaces it.
 - `muxy.popovers` — declares HTML pages renderable as transient popovers anchored to a topbar/status-bar item (`entry` required; optional `title`, `width`, `height` defaulting to 320×360). Frameless, auto-dismiss on outside click, at most one open at a time. Opened via an `openPopover` command bound to a topbar/status-bar item; the page sizes itself with `muxy.popover.resize()` (needs `panels:write`).
@@ -193,6 +193,10 @@ muxy.events.subscribe('pane.created', async (payload) => {
   console.log('pane created', payload.paneID);
   const result = await muxy.exec(['git', 'status', '--short']);
   console.log(result.stdout);
+});
+
+muxy.events.subscribe('file.changed', (payload) => {
+  console.log('file changed', payload.path, 'in', payload.projectPath);
 });
 ```
 

--- a/Muxy/Services/ExtensionFileEventEmitter.swift
+++ b/Muxy/Services/ExtensionFileEventEmitter.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum ExtensionFileEventEmitter {
+    static func emit(paths: [String], projectPath: String) {
+        let server = NotificationSocketServer.shared
+        for path in paths {
+            server.broadcast(event: ExtensionEvent(
+                name: ExtensionEventName.fileChanged,
+                payload: [
+                    "path": path,
+                    "projectPath": projectPath,
+                ]
+            ))
+        }
+    }
+}

--- a/Muxy/Services/ExtensionFileEventEmitter.swift
+++ b/Muxy/Services/ExtensionFileEventEmitter.swift
@@ -1,9 +1,23 @@
 import Foundation
 
-enum ExtensionFileEventEmitter {
+final class ExtensionFileEventEmitter: @unchecked Sendable {
+    static let shared = ExtensionFileEventEmitter()
+
+    private let window: TimeInterval = 0.3
+    private let lock = NSLock()
+    private var lastEmitted: [String: TimeInterval] = [:]
+
     static func emit(paths: [String], projectPath: String) {
+        shared.emit(paths: paths, projectPath: projectPath)
+    }
+
+    func emit(paths: [String], projectPath: String) {
+        let now = ProcessInfo.processInfo.systemUptime
+        let fresh = deduplicate(paths: paths, projectPath: projectPath, now: now)
+        guard !fresh.isEmpty else { return }
+
         let server = NotificationSocketServer.shared
-        for path in paths {
+        for path in fresh {
             server.broadcast(event: ExtensionEvent(
                 name: ExtensionEventName.fileChanged,
                 payload: [
@@ -12,5 +26,21 @@ enum ExtensionFileEventEmitter {
                 ]
             ))
         }
+    }
+
+    private func deduplicate(paths: [String], projectPath: String, now: TimeInterval) -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        lastEmitted = lastEmitted.filter { now - $0.value < window }
+
+        var fresh: [String] = []
+        for path in paths {
+            let key = "\(projectPath)\u{0}\(path)"
+            if let last = lastEmitted[key], now - last < window { continue }
+            lastEmitted[key] = now
+            fresh.append(path)
+        }
+        return fresh
     }
 }

--- a/Muxy/Services/FileSystemWatcher.swift
+++ b/Muxy/Services/FileSystemWatcher.swift
@@ -5,9 +5,10 @@ final class FileSystemWatcher: @unchecked Sendable {
     private let queue = DispatchQueue(label: "app.muxy.fs-watcher", qos: .utility)
     private var stream: FSEventStreamRef?
     private var debounceWork: DispatchWorkItem?
-    private var handler: (@Sendable () -> Void)?
+    private var pendingPaths = Set<String>()
+    private var handler: (@Sendable ([String]) -> Void)?
 
-    init?(directoryPath: String, handler: @escaping @Sendable () -> Void) {
+    init?(directoryPath: String, handler: @escaping @Sendable ([String]) -> Void) {
         guard FileManager.default.fileExists(atPath: directoryPath) else { return nil }
 
         self.handler = handler
@@ -25,14 +26,16 @@ final class FileSystemWatcher: @unchecked Sendable {
                 else { return }
                 let flags = Array(UnsafeBufferPointer(start: eventFlags, count: numEvents))
 
-                let dominated = zip(paths, flags).allSatisfy { path, flag in
+                let relevant = zip(paths, flags).compactMap { path, flag -> String? in
                     let isGitInternal = path.contains("/.git/")
                     let isLockFile = path.hasSuffix(".lock")
-                    return isGitInternal && isLockFile || flag & UInt32(kFSEventStreamEventFlagItemIsDir) != 0 && isGitInternal
+                    let isDirectory = flag & UInt32(kFSEventStreamEventFlagItemIsDir) != 0
+                    if isGitInternal, isLockFile || isDirectory { return nil }
+                    return path
                 }
-                guard !dominated else { return }
+                guard !relevant.isEmpty else { return }
 
-                watcher.scheduleRefresh()
+                watcher.scheduleRefresh(paths: relevant)
             },
             &context,
             paths,
@@ -56,10 +59,14 @@ final class FileSystemWatcher: @unchecked Sendable {
         FSEventStreamRelease(stream)
     }
 
-    private func scheduleRefresh() {
+    private func scheduleRefresh(paths: [String]) {
+        pendingPaths.formUnion(paths)
         debounceWork?.cancel()
         let work = DispatchWorkItem { [weak self] in
-            self?.handler?()
+            guard let self else { return }
+            let changed = Array(pendingPaths)
+            pendingPaths.removeAll()
+            handler?(changed)
         }
         debounceWork = work
         queue.asyncAfter(deadline: .now() + 0.3, execute: work)

--- a/Tests/MuxyTests/Services/ExtensionFileEventEmitterTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionFileEventEmitterTests.swift
@@ -41,6 +41,25 @@ struct ExtensionFileEventEmitterTests {
         #expect(collector.count(forProjectPath: "/empty-repo") == 0)
     }
 
+    @Test("collapses duplicate path within the dedupe window")
+    func dropsDuplicateWithinWindow() async {
+        let collector = EventCollector()
+        let token = NotificationSocketServer.shared.addInProcessObserver { event in
+            collector.add(event)
+        }
+        defer { NotificationSocketServer.shared.removeInProcessObserver(token) }
+
+        ExtensionFileEventEmitter.emit(paths: ["/dup-repo/a.txt"], projectPath: "/dup-repo")
+        ExtensionFileEventEmitter.emit(paths: ["/dup-repo/a.txt"], projectPath: "/dup-repo")
+
+        let delivered = await waitFor(timeout: 2.0) {
+            collector.count(forProjectPath: "/dup-repo") == 1
+        }
+        #expect(delivered)
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        #expect(collector.count(forProjectPath: "/dup-repo") == 1)
+    }
+
     private func waitFor(timeout: TimeInterval, condition: () -> Bool) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {

--- a/Tests/MuxyTests/Services/ExtensionFileEventEmitterTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionFileEventEmitterTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionFileEventEmitter")
+struct ExtensionFileEventEmitterTests {
+    @Test("emits one file.changed event per path with path and projectPath")
+    func emitsPerPath() async {
+        let collector = EventCollector()
+        let token = NotificationSocketServer.shared.addInProcessObserver { event in
+            collector.add(event)
+        }
+        defer { NotificationSocketServer.shared.removeInProcessObserver(token) }
+
+        ExtensionFileEventEmitter.emit(
+            paths: ["/per-path-repo/a.txt", "/per-path-repo/b.txt"],
+            projectPath: "/per-path-repo"
+        )
+
+        let delivered = await waitFor(timeout: 2.0) {
+            collector.count(forProjectPath: "/per-path-repo") == 2
+        }
+        #expect(delivered)
+
+        let events = collector.events(forProjectPath: "/per-path-repo")
+        #expect(Set(events.map { $0.payload["path"] ?? "" }) == ["/per-path-repo/a.txt", "/per-path-repo/b.txt"])
+    }
+
+    @Test("emits nothing for an empty path list")
+    func emitsNothingWhenEmpty() async {
+        let collector = EventCollector()
+        let token = NotificationSocketServer.shared.addInProcessObserver { event in
+            collector.add(event)
+        }
+        defer { NotificationSocketServer.shared.removeInProcessObserver(token) }
+
+        ExtensionFileEventEmitter.emit(paths: [], projectPath: "/empty-repo")
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        #expect(collector.count(forProjectPath: "/empty-repo") == 0)
+    }
+
+    private func waitFor(timeout: TimeInterval, condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return condition()
+    }
+}
+
+private final class EventCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [ExtensionEvent] = []
+
+    func add(_ event: ExtensionEvent) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func events(forProjectPath projectPath: String) -> [ExtensionEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events.filter {
+            $0.name == ExtensionEventName.fileChanged && $0.payload["projectPath"] == projectPath
+        }
+    }
+
+    func count(forProjectPath projectPath: String) -> Int {
+        events(forProjectPath: projectPath).count
+    }
+}

--- a/Tests/MuxyTests/Services/FileSystemWatcherTests.swift
+++ b/Tests/MuxyTests/Services/FileSystemWatcherTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("FileSystemWatcher")
+struct FileSystemWatcherTests {
+    private func makeTempDir() async -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileSystemWatcherTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        return dir
+    }
+
+    @Test("init returns nil for a missing directory")
+    func initRejectsMissingDirectory() {
+        let watcher = FileSystemWatcher(directoryPath: "/this/path/does/not/exist") { _ in }
+        #expect(watcher == nil)
+    }
+
+    @Test("delivers changed file paths to the handler")
+    func deliversChangedPaths() async throws {
+        let dir = await makeTempDir()
+        let collector = PathCollector()
+        let watcher = FileSystemWatcher(directoryPath: dir.path) { paths in
+            collector.add(paths)
+        }
+        #expect(watcher != nil)
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+        let target = dir.appendingPathComponent("note.txt")
+        try "hello".data(using: .utf8)!.write(to: target)
+
+        let fired = await waitFor(timeout: 5.0) { collector.contains(target.path) }
+        #expect(fired)
+        _ = watcher
+    }
+
+    @Test("skips Git internal lock-file noise")
+    func skipsGitLockNoise() async throws {
+        let dir = await makeTempDir()
+        let gitDir = dir.appendingPathComponent(".git", isDirectory: true)
+        try? FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let collector = PathCollector()
+        let watcher = FileSystemWatcher(directoryPath: dir.path) { paths in
+            collector.add(paths)
+        }
+        #expect(watcher != nil)
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+        let lock = gitDir.appendingPathComponent("index.lock")
+        try "lock".data(using: .utf8)!.write(to: lock)
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+
+        #expect(collector.count == 0)
+        _ = watcher
+    }
+
+    private func waitFor(timeout: TimeInterval, condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return condition()
+    }
+}
+
+private final class PathCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var paths: [String] = []
+
+    func add(_ values: [String]) {
+        lock.lock()
+        paths.append(contentsOf: values)
+        lock.unlock()
+    }
+
+    func contains(_ value: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let resolved = (value as NSString).resolvingSymlinksInPath
+        return paths.contains { ($0 as NSString).resolvingSymlinksInPath == resolved }
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return paths.count
+    }
+}

--- a/docs/extensions/events.md
+++ b/docs/extensions/events.md
@@ -16,7 +16,7 @@ Events originate in the main process from `ExtensionEventEmitter`, which diffs w
 
 ## Subscribing
 
-- **Workspace events** (`pane.*`, `tab.*`, `project.*`, `worktree.*`, `notification.posted`) must be listed in your manifest `events` array before you can subscribe. Subscribing to anything not declared is rejected.
+- **Workspace events** (`pane.*`, `tab.*`, `project.*`, `worktree.*`, `notification.posted`, `file.changed`) must be listed in your manifest `events` array before you can subscribe. Subscribing to anything not declared is rejected.
 - **Command events** (`command.<id>`) are auto-allowed: declaring a command in `manifest.commands` is implicit consent to receive its trigger, so you do not add it to `events`.
 
 ```json
@@ -39,6 +39,9 @@ When an extension is reloaded or disabled, its subscriptions are dropped and re-
 | `project.switched` | `projectID` | `events: ["project.switched"]` |
 | `worktree.switched` | `projectID`, `worktreeID` | `events: ["worktree.switched"]` |
 | `notification.posted` | `paneID`, `projectID`, `tabID`, `title` | `events: ["notification.posted"]` |
+| `file.changed` | `path`, `projectPath` | `events: ["file.changed"]` |
 | `command.<id>` | `command`, `extension` | Auto-allowed when `commands[].id == <id>` |
+
+`file.changed` fires for files under a watched project/worktree root (the same watcher the source-control and file-tree views use). It is debounced (~0.3s) and skips Git-internal noise (`.git/` lock files and directories); one event is delivered per changed `path`, with `projectPath` set to the watched root.
 
 See [Permissions](permissions.md) for how `events` fits the manifest, and [Palette Commands](palette-commands.md) for `command.<id>`.


### PR DESCRIPTION
Surfaces the project/worktree FileSystemWatcher's changed paths as a debounced                                      `file.changed` extension event ({ path, projectPath }), reusing the existing
  broadcast pipeline. Git-internal lock/dir noise is filtered out.
  Updates the extension SKILL and docs.