### PR TITLE
Serve extension resources from dist/ whenever the directory exists

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -773,8 +773,7 @@ enum ExtensionManifestLoader {
     static let buildOutputDirectoryName = "dist"
 
     static func load(from directory: URL) throws -> MuxyExtension {
-        let root = resolvedRoot(for: directory)
-        let manifestURL = root.appendingPathComponent(manifestFileName)
+        let manifestURL = resolveManifestURL(in: directory)
         guard FileManager.default.fileExists(atPath: manifestURL.path) else {
             throw ExtensionLoadError.manifestMissing(manifestURL)
         }
@@ -796,12 +795,13 @@ enum ExtensionManifestLoader {
 
         try validate(name: manifest.name)
 
-        let muxyExtension = MuxyExtension(id: manifest.name, directory: root, manifest: manifest)
+        let resourceRoot = resolveResourceRoot(for: directory)
+        let muxyExtension = MuxyExtension(id: manifest.name, directory: resourceRoot, manifest: manifest)
 
         if let background = manifest.background {
             guard let backgroundURL = muxyExtension.resolveResource(background) else {
                 throw ExtensionLoadError.backgroundScriptOutsideDirectory(
-                    root.appendingPathComponent(background)
+                    resourceRoot.appendingPathComponent(background)
                 )
             }
             guard FileManager.default.fileExists(atPath: backgroundURL.path) else {
@@ -823,11 +823,23 @@ enum ExtensionManifestLoader {
         return muxyExtension
     }
 
-    static func resolvedRoot(for directory: URL) -> URL {
+    static func resolveResourceRoot(for directory: URL) -> URL {
         let buildOutput = directory.appendingPathComponent(buildOutputDirectoryName)
-        let buildManifest = buildOutput.appendingPathComponent(manifestFileName)
-        guard FileManager.default.fileExists(atPath: buildManifest.path) else { return directory }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: buildOutput.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else { return directory }
         return buildOutput
+    }
+
+    private static func resolveManifestURL(in directory: URL) -> URL {
+        let buildManifest = directory
+            .appendingPathComponent(buildOutputDirectoryName)
+            .appendingPathComponent(manifestFileName)
+        guard FileManager.default.fileExists(atPath: buildManifest.path) else {
+            return directory.appendingPathComponent(manifestFileName)
+        }
+        return buildManifest
     }
 
     private static func migrateLegacyEnabledFlag(rawManifest: Data, extensionID: String) {

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -101,6 +101,32 @@ struct ExtensionManifestTests {
         #expect(ext.backgroundScriptURL?.path == distDirectory.appendingPathComponent("background.js").path)
     }
 
+    @Test("resolves resources from dist when present but the manifest stays at the root")
+    func resolvesResourcesFromBuildOutputWithoutDistManifest() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("ext-\(UUID().uuidString)")
+        let distDirectory = directory.appendingPathComponent("dist")
+        try FileManager.default.createDirectory(at: distDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try ExtensionManifestFixture.write(
+            flatManifest: """
+            {
+                "name": "built-ext",
+                "version": "1.0.0",
+                "background": "background.js"
+            }
+            """,
+            to: directory
+        )
+        try Data("console.log('hi')\n".utf8)
+            .write(to: distDirectory.appendingPathComponent("background.js"))
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ext.directory.path == distDirectory.path)
+        #expect(ext.backgroundScriptURL?.path == distDirectory.appendingPathComponent("background.js").path)
+    }
+
     @Test("loads from the directory root when no dist build output exists")
     func loadsFromRootWithoutBuildOutput() throws {
         let directory = try makeTemporaryExtension(

--- a/docs/extensions/examples/hello-world/vite.config.js
+++ b/docs/extensions/examples/hello-world/vite.config.js
@@ -1,6 +1,14 @@
-import { copyFileSync } from "node:fs";
 import { defineConfig } from "vite";
 
+// Muxy serves resources from `dist/` when it exists, so every path in
+// package.json's `muxy` block resolves against the build output.
+//
+// - `tabs/index.html` is a Rollup input, so Vite emits `dist/tabs/index.html`
+//   (with its CSS/JS hashed and rewritten) at the same relative path the
+//   `muxy` block references.
+// - Listing assets (icon + screenshot) live in `public/assets/`. Vite copies
+//   everything under `publicDir` verbatim into `dist/`, producing
+//   `dist/assets/icon.svg` and `dist/assets/screenshot-1.png` untouched.
 export default defineConfig({
   build: {
     outDir: "dist",
@@ -12,12 +20,4 @@ export default defineConfig({
       },
     },
   },
-  plugins: [
-    {
-      name: "muxy-manifest",
-      closeBundle() {
-        copyFileSync("package.json", "dist/package.json");
-      },
-    },
-  ],
 });


### PR DESCRIPTION
Extensions that build into dist/ without copying package.json there (git, ai-usage) silently fell back to serving
  unbuilt source. Resources now resolve from dist/ whenever the directory exists; the manifest is read from
  dist/package.json if present, else root.