### PR TITLE
Add singleton mode for extension tabs

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -27,6 +27,7 @@ final class AppState {
         let tabTypeID: String
         let title: String
         let data: ExtensionJSON?
+        let singleton: Bool
     }
 
     enum Action {

--- a/Muxy/Models/ExtensionTabState.swift
+++ b/Muxy/Models/ExtensionTabState.swift
@@ -7,7 +7,7 @@ final class ExtensionTabState: Identifiable {
     let extensionID: String
     let tabTypeID: String
     let projectPath: String
-    let initialData: ExtensionJSON?
+    var data: ExtensionJSON?
 
     var customTitle: String?
     var defaultTitle: String
@@ -21,12 +21,12 @@ final class ExtensionTabState: Identifiable {
         tabTypeID: String,
         projectPath: String,
         defaultTitle: String,
-        initialData: ExtensionJSON? = nil
+        data: ExtensionJSON? = nil
     ) {
         self.extensionID = extensionID
         self.tabTypeID = tabTypeID
         self.projectPath = projectPath
         self.defaultTitle = defaultTitle
-        self.initialData = initialData
+        self.data = data
     }
 }

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -165,13 +165,20 @@ final class TabArea: Identifiable {
         )))
     }
 
+    func findExtensionTab(extensionID: String, tabTypeID: String) -> TerminalTab? {
+        tabs.first { tab in
+            guard let state = tab.content.extensionState else { return false }
+            return state.extensionID == extensionID && state.tabTypeID == tabTypeID
+        }
+    }
+
     func createExtensionTab(extensionID: String, tabTypeID: String, title: String, data: ExtensionJSON?) {
         let state = ExtensionTabState(
             extensionID: extensionID,
             tabTypeID: tabTypeID,
             projectPath: projectPath,
             defaultTitle: title,
-            initialData: data
+            data: data
         )
         insertTab(TerminalTab(extensionState: state))
     }

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -182,7 +182,7 @@ final class TerminalTab: Identifiable {
                     tabTypeID: tabTypeID,
                     projectPath: snapshot.projectPath,
                     defaultTitle: snapshot.paneTitle,
-                    initialData: snapshot.extensionTabData
+                    data: snapshot.extensionTabData
                 ))
             } else {
                 content = .terminal(TerminalPaneState(projectPath: snapshot.projectPath, title: snapshot.paneTitle))
@@ -204,7 +204,7 @@ final class TerminalTab: Identifiable {
             currentWorkingDirectory: content.pane?.currentWorkingDirectory,
             extensionID: content.extensionState?.extensionID,
             extensionTabTypeID: content.extensionState?.tabTypeID,
-            extensionTabData: content.extensionState?.initialData
+            extensionTabData: content.extensionState?.data
         )
     }
 

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -129,8 +129,22 @@ enum TabReducer {
         state: inout WorkspaceState
     ) {
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
+              let root = state.workspaceRoots[key],
               let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
         else { return }
+        if request.singleton {
+            for existingArea in root.allAreas() {
+                guard let existing = existingArea.findExtensionTab(
+                    extensionID: request.extensionID,
+                    tabTypeID: request.tabTypeID
+                )
+                else { continue }
+                existing.content.extensionState?.data = request.data
+                FocusReducer.focusArea(existingArea.id, key: key, state: &state)
+                existingArea.selectTab(existing.id)
+                return
+            }
+        }
         FocusReducer.focusArea(area.id, key: key, state: &state)
         area.createExtensionTab(
             extensionID: request.extensionID,

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -248,6 +248,13 @@ await muxy.tabs.open({
     data: { source: 'self', when: new Date().toISOString() },
   },
 });
+
+// singleton: reuse one tab per tabType instead of duplicating. If it's already
+// open, Muxy focuses it and pushes the new data into the live page (muxy.onDataChange).
+await muxy.tabs.open({
+  kind: 'extensionWebView',
+  extension: { id: muxy.extensionID, tabType: 'dashboard', singleton: true, data: { prNumber: 42 } },
+});
 ```
 
 ### Tab topbar (recommended)
@@ -384,7 +391,7 @@ muxy.tabs.open({
 });
 ```
 
-Receive the payload in the tab as `muxy.data`.
+Receive the payload in the tab as `muxy.data`. For `singleton` tabs that get reopened with new data, react to the update with `muxy.onDataChange((data) => render(data))`.
 
 ## Theming — adapt to the user's current Muxy theme
 

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -557,7 +557,8 @@ final class ExtensionStore {
                 extensionID: extensionID,
                 tabTypeID: tabTypeID,
                 title: tabType.title,
-                data: data ?? tabType.defaultData
+                data: data ?? tabType.defaultData,
+                singleton: false
             )
         ))
     }

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -99,6 +99,29 @@ struct OpenTabRequest: Decodable {
         let id: String
         let tabType: String
         let data: ExtensionJSON?
+        let singleton: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case tabType
+            case data
+            case singleton
+        }
+
+        init(id: String, tabType: String, data: ExtensionJSON?, singleton: Bool = false) {
+            self.id = id
+            self.tabType = tabType
+            self.data = data
+            self.singleton = singleton
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            tabType = try container.decode(String.self, forKey: .tabType)
+            data = try container.decodeIfPresent(ExtensionJSON.self, forKey: .data)
+            singleton = try container.decodeIfPresent(Bool.self, forKey: .singleton) ?? false
+        }
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -713,7 +736,8 @@ enum MuxyAPI {
                         extensionID: payload.id,
                         tabTypeID: payload.tabType,
                         title: tabType.title,
-                        data: payload.data ?? tabType.defaultData
+                        data: payload.data ?? tabType.defaultData,
+                        singleton: payload.singleton
                     )
                 ))
                 return .success(())

--- a/Muxy/Views/Extensions/ExtensionWebBridge.swift
+++ b/Muxy/Views/Extensions/ExtensionWebBridge.swift
@@ -30,6 +30,16 @@ enum ExtensionWebBridge {
             const themeListeners = new Set();
             let currentTheme = \(themeLiteral);
 
+            const dataListeners = new Set();
+            let currentData = \(encodedData);
+
+            window.__muxyApplyData = (data) => {
+                currentData = data ?? null;
+                for (const listener of dataListeners) {
+                    try { listener(currentData); } catch (_) {}
+                }
+            };
+
             const writeThemeToDocument = (theme) => {
                 const root = document.documentElement;
                 if (!root) return;
@@ -64,7 +74,12 @@ enum ExtensionWebBridge {
             const muxy = {
                 extensionID: \(extensionLiteral),
                 tabInstanceID: \(instanceLiteral),
-                data: \(encodedData),
+                get data() { return currentData; },
+                onDataChange(callback) {
+                    if (typeof callback !== 'function') return () => {};
+                    dataListeners.add(callback);
+                    return () => dataListeners.delete(callback);
+                },
                 get theme() { return currentTheme; },
                 onThemeChange(callback) {
                     if (typeof callback !== 'function') return () => {};
@@ -222,6 +237,17 @@ enum ExtensionWebBridge {
         (() => {
             if (typeof window.__muxyApplyTheme === 'function') {
                 window.__muxyApplyTheme(\(literal));
+            }
+        })();
+        """
+    }
+
+    static func dataUpdateScript(data: ExtensionJSON?) -> String {
+        let literal = encodeAsLiteral(data)
+        return """
+        (() => {
+            if (typeof window.__muxyApplyData === 'function') {
+                window.__muxyApplyData(\(literal));
             }
         })();
         """

--- a/Muxy/Views/Extensions/ExtensionWebView.swift
+++ b/Muxy/Views/Extensions/ExtensionWebView.swift
@@ -80,7 +80,6 @@ struct ExtensionWebView: NSViewRepresentable {
         var consoleHandler: ExtensionConsoleHandler?
         let onFocus: () -> Void
         private weak var webView: WKWebView?
-        private weak var userContent: WKUserContentController?
         private var themeObserver: NSObjectProtocol?
         private var extensionID: String = ""
         private var tabInstanceID: String = ""
@@ -101,12 +100,6 @@ struct ExtensionWebView: NSViewRepresentable {
         }
 
         func installBridgeScript(into userContent: WKUserContentController) {
-            self.userContent = userContent
-            reinstallBridgeScript()
-        }
-
-        private func reinstallBridgeScript() {
-            guard let userContent else { return }
             userContent.removeAllUserScripts()
             userContent.addUserScript(WKUserScript(
                 source: ExtensionWebBridge.script(
@@ -123,7 +116,6 @@ struct ExtensionWebView: NSViewRepresentable {
         func applyDataIfChanged(_ data: ExtensionJSON?, in webView: WKWebView) {
             guard data != initialData else { return }
             initialData = data
-            reinstallBridgeScript()
             let script = ExtensionWebBridge.dataUpdateScript(data: data)
             webView.evaluateJavaScript(script, completionHandler: nil)
         }

--- a/Muxy/Views/Extensions/ExtensionWebView.swift
+++ b/Muxy/Views/Extensions/ExtensionWebView.swift
@@ -61,7 +61,9 @@ struct ExtensionWebView: NSViewRepresentable {
         return webView
     }
 
-    func updateNSView(_: WKWebView, context _: Context) {}
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        context.coordinator.applyDataIfChanged(initialData, in: webView)
+    }
 
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
         coordinator.stopObservingThemeChanges()
@@ -116,6 +118,14 @@ struct ExtensionWebView: NSViewRepresentable {
                 injectionTime: .atDocumentStart,
                 forMainFrameOnly: true
             ))
+        }
+
+        func applyDataIfChanged(_ data: ExtensionJSON?, in webView: WKWebView) {
+            guard data != initialData else { return }
+            initialData = data
+            reinstallBridgeScript()
+            let script = ExtensionWebBridge.dataUpdateScript(data: data)
+            webView.evaluateJavaScript(script, completionHandler: nil)
         }
 
         func observeThemeChanges(for webView: WKWebView) {

--- a/Muxy/Views/Extensions/ExtensionWebViewPane.swift
+++ b/Muxy/Views/Extensions/ExtensionWebViewPane.swift
@@ -19,7 +19,7 @@ struct ExtensionWebViewPane: View {
                     extensionID: muxyExtension.id,
                     instanceID: state.id.uuidString,
                     entryURL: entryURL,
-                    initialData: state.initialData,
+                    initialData: state.data,
                     appState: appState,
                     projectStore: projectStore,
                     worktreeStore: worktreeStore,

--- a/Tests/MuxyTests/Models/ExtensionTabAPITests.swift
+++ b/Tests/MuxyTests/Models/ExtensionTabAPITests.swift
@@ -251,16 +251,16 @@ struct ExtensionTabStateTests {
         #expect(state.displayTitle == "Renamed")
     }
 
-    @Test("initialData is preserved")
-    func initialDataPreserved() {
+    @Test("data is preserved")
+    func dataPreserved() {
         let state = ExtensionTabState(
             extensionID: "ext",
             tabTypeID: "viewer",
             projectPath: "/tmp",
             defaultTitle: "Viewer",
-            initialData: .object(["n": .number(1)])
+            data: .object(["n": .number(1)])
         )
-        #expect(state.initialData == .object(["n": .number(1)]))
+        #expect(state.data == .object(["n": .number(1)]))
     }
 }
 
@@ -274,7 +274,7 @@ struct TerminalTabExtensionRoundTrip {
             tabTypeID: "pr-viewer",
             projectPath: "/tmp/test",
             defaultTitle: "PR Viewer",
-            initialData: .object(["prNumber": .number(42)])
+            data: .object(["prNumber": .number(42)])
         )
         let tab = TerminalTab(extensionState: state)
         let snapshot = tab.snapshot()
@@ -304,7 +304,7 @@ struct TerminalTabExtensionRoundTrip {
         #expect(restored?.extensionID == "pr-tools")
         #expect(restored?.tabTypeID == "pr-viewer")
         #expect(restored?.defaultTitle == "PR Viewer")
-        #expect(restored?.initialData == .object(["prNumber": .number(7)]))
+        #expect(restored?.data == .object(["prNumber": .number(7)]))
     }
 
     @Test("restored extensionWebView falls back to terminal when fields missing")
@@ -416,6 +416,19 @@ struct OpenTabRequestTests {
         #expect(payload.id == "pr-tools")
         #expect(payload.tabType == "pr-viewer")
         #expect(payload.data == .object(["prNumber": .number(42)]))
+        #expect(payload.singleton == false)
+    }
+
+    @Test("decodes singleton flag on extension payload")
+    func singletonRequest() throws {
+        let request = try decode("""
+        {
+          "kind": "extensionWebView",
+          "extension": { "id": "pr-tools", "tabType": "pr-viewer", "singleton": true }
+        }
+        """)
+        let payload = try #require(request.extensionPayload)
+        #expect(payload.singleton == true)
     }
 
     private func decode(_ json: String) throws -> OpenTabRequest {

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -203,6 +203,73 @@ struct WorkspaceReducerTests {
         #expect(area?.activeTabID == firstTabID)
     }
 
+    @Test("createExtensionTab adds extension tab")
+    func createExtensionTab() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+
+        let action = extensionTabAction(projectID: projectID, data: .object(["pr": .number(1)]), singleton: false)
+        _ = WorkspaceReducer.reduce(action: action, state: &state)
+
+        let area = focusedArea(in: state, projectID: projectID)
+        #expect(area?.activeTab?.kind == .extensionWebView)
+        #expect(area?.activeTab?.content.extensionState?.data == .object(["pr": .number(1)]))
+    }
+
+    @Test("non-singleton extension tab opens a duplicate every time")
+    func createExtensionTabDuplicates() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+
+        let action = extensionTabAction(projectID: projectID, data: nil, singleton: false)
+        _ = WorkspaceReducer.reduce(action: action, state: &state)
+        _ = WorkspaceReducer.reduce(action: action, state: &state)
+
+        let area = focusedArea(in: state, projectID: projectID)
+        #expect(area?.tabs.filter { $0.kind == .extensionWebView }.count == 2)
+    }
+
+    @Test("singleton extension tab focuses existing tab and reloads its data")
+    func createExtensionTabSingletonReuses() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+
+        let first = extensionTabAction(projectID: projectID, data: .object(["pr": .number(1)]), singleton: true)
+        _ = WorkspaceReducer.reduce(action: first, state: &state)
+        let area = focusedArea(in: state, projectID: projectID)
+        let firstTabID = area?.activeTabID
+
+        area?.createTab()
+
+        let second = extensionTabAction(projectID: projectID, data: .object(["pr": .number(2)]), singleton: true)
+        _ = WorkspaceReducer.reduce(action: second, state: &state)
+
+        #expect(area?.tabs.filter { $0.kind == .extensionWebView }.count == 1)
+        #expect(area?.activeTabID == firstTabID)
+        #expect(area?.activeTab?.content.extensionState?.data == .object(["pr": .number(2)]))
+    }
+
+    private func extensionTabAction(
+        projectID: UUID,
+        data: ExtensionJSON?,
+        singleton: Bool
+    ) -> AppState.Action {
+        .createExtensionTab(
+            projectID: projectID,
+            areaID: nil,
+            request: AppState.CreateExtensionTabRequest(
+                extensionID: "pr-tools",
+                tabTypeID: "pr-viewer",
+                title: "PR Viewer",
+                data: data,
+                singleton: singleton
+            )
+        )
+    }
+
     @Test("createEditorTab adds editor tab")
     func createEditorTab() {
         let projectID = UUID()

--- a/docs/extensions/tabs.md
+++ b/docs/extensions/tabs.md
@@ -83,6 +83,7 @@ window.muxy = {
   extensionID: string,
   tabInstanceID: string,
   data: object | null,                 // payload the tab was opened with (or defaultData)
+  onDataChange(callback): unsubscribe, // fires when a singleton tab is reopened with new data
 
   notifications: {
     notify({ title, body?, paneID? }): Promise<void>,   // requires notifications:write
@@ -136,6 +137,17 @@ await muxy.tabs.open({
 ```
 
 `extensionWebView` requires the target extension to be loaded and the named tab type to exist.
+
+By default every `open` creates a new tab. Pass `singleton: true` to keep one tab per tab type instead — if a tab of that type is already open, Muxy focuses it and pushes the new `data` into the live page rather than duplicating it. The page receives the new payload through `muxy.onDataChange`:
+
+```js
+await muxy.tabs.open({
+  kind: 'extensionWebView',
+  extension: { id: 'pr-tools', tabType: 'pr-viewer', singleton: true, data: { prNumber: 42 } },
+});
+
+muxy.onDataChange((data) => render(data));
+```
 
 ### Running shell commands
 


### PR DESCRIPTION
Extension tabs can now opt into singleton mode via `muxy.tabs.open({ singleton: true })` — if a tab of that type is already open, Muxy focuses it and pushes new data to the live page instead of duplicating it. Pages receive updates through `muxy.onDataChange(callback)`.

- Rename `ExtensionTabState.initialData` → `data` (now mutable to support live updates)
- Add `findExtensionTab()` to locate existing tabs by extension + type
- Update tab data in-place when singleton tab is reopened; focus existing instead of creating duplicate