### PR TITLE
Add native dialog/alert API for extensions

### DIFF
--- a/Muxy/Services/ExtensionDialogService.swift
+++ b/Muxy/Services/ExtensionDialogService.swift
@@ -33,7 +33,7 @@ enum ExtensionDialogService {
         for (button, equivalent) in zip(buttons, equivalents) {
             button.keyEquivalent = equivalent
         }
-        let result = await runModal(alert)
+        let result = try await runModal(alert)
         guard let index = buttonIndex(for: result, buttonCount: request.buttons.count) else {
             return nil
         }
@@ -49,7 +49,7 @@ enum ExtensionDialogService {
         defer { release(request.extensionID) }
         let alert = makeAlert(title: request.title, message: request.message, style: request.style)
         alert.addButton(withTitle: "OK")
-        _ = await runModal(alert)
+        _ = try await runModal(alert)
     }
 
     static func makeConfirmRequest(extensionID: String, args: [String: Any]) throws -> ConfirmRequest {
@@ -92,8 +92,8 @@ enum ExtensionDialogService {
 
     static func keyEquivalents(for request: ConfirmRequest) -> [String] {
         request.buttons.enumerated().map { index, label in
-            if label == request.cancelButton { return "\u{1B}" }
             if index == 0 { return "\r" }
+            if label == request.cancelButton { return "\u{1B}" }
             return ""
         }
     }
@@ -137,9 +137,9 @@ enum ExtensionDialogService {
         return index
     }
 
-    private static func runModal(_ alert: NSAlert) async -> NSApplication.ModalResponse {
+    private static func runModal(_ alert: NSAlert) async throws -> NSApplication.ModalResponse {
         guard let parent = parentWindow() else {
-            return alert.runModal()
+            throw APIError.invalidArguments("no window available to present the dialog")
         }
         return await withCheckedContinuation { continuation in
             alert.beginSheetModal(for: parent) { response in

--- a/Muxy/Services/ExtensionDialogService.swift
+++ b/Muxy/Services/ExtensionDialogService.swift
@@ -1,0 +1,135 @@
+import AppKit
+
+@MainActor
+enum ExtensionDialogService {
+    struct ConfirmRequest: Equatable {
+        let title: String
+        let message: String
+        let buttons: [String]
+        let defaultButton: String?
+        let cancelButton: String?
+        let style: NSAlert.Style
+    }
+
+    struct AlertRequest: Equatable {
+        let title: String
+        let message: String
+        let style: NSAlert.Style
+    }
+
+    static func confirm(_ request: ConfirmRequest) async -> String? {
+        let alert = NSAlert()
+        alert.alertStyle = request.style
+        alert.messageText = request.title
+        alert.informativeText = request.message
+        let buttons = request.buttons.map { alert.addButton(withTitle: $0) }
+        let equivalents = keyEquivalents(for: request)
+        for (button, equivalent) in zip(buttons, equivalents) {
+            button.keyEquivalent = equivalent
+        }
+        let result = await runModal(alert)
+        guard let index = buttonIndex(for: result, buttonCount: request.buttons.count) else {
+            return nil
+        }
+        let label = request.buttons[index]
+        if let cancel = request.cancelButton, label == cancel {
+            return nil
+        }
+        return label
+    }
+
+    static func alert(_ request: AlertRequest) async {
+        let alert = NSAlert()
+        alert.alertStyle = request.style
+        alert.messageText = request.title
+        alert.informativeText = request.message
+        alert.addButton(withTitle: "OK")
+        _ = await runModal(alert)
+    }
+
+    static func makeConfirmRequest(args: [String: Any]) throws -> ConfirmRequest {
+        let title = string(args, "title") ?? ""
+        let message = string(args, "message") ?? ""
+        guard !title.isEmpty || !message.isEmpty else {
+            throw APIError.invalidArguments("dialog requires title or message")
+        }
+        var buttons = (args["buttons"] as? [Any])?.compactMap { $0 as? String } ?? []
+        buttons = buttons.filter { !$0.isEmpty }
+        if buttons.isEmpty {
+            buttons = ["OK", "Cancel"]
+        }
+        let defaultButton = string(args, "default")
+        return ConfirmRequest(
+            title: title,
+            message: message,
+            buttons: orderedButtons(buttons, defaultLabel: defaultButton),
+            defaultButton: defaultButton,
+            cancelButton: string(args, "cancel"),
+            style: style(from: string(args, "style"))
+        )
+    }
+
+    static func makeAlertRequest(args: [String: Any]) throws -> AlertRequest {
+        let title = string(args, "title") ?? ""
+        let message = string(args, "message") ?? ""
+        guard !title.isEmpty || !message.isEmpty else {
+            throw APIError.invalidArguments("alert requires title or message")
+        }
+        return AlertRequest(
+            title: title,
+            message: message,
+            style: style(from: string(args, "style"))
+        )
+    }
+
+    static func keyEquivalents(for request: ConfirmRequest) -> [String] {
+        request.buttons.enumerated().map { index, label in
+            if label == request.cancelButton { return "\u{1B}" }
+            if index == 0 { return "\r" }
+            return ""
+        }
+    }
+
+    private static func orderedButtons(_ buttons: [String], defaultLabel: String?) -> [String] {
+        guard let defaultLabel, let index = buttons.firstIndex(of: defaultLabel), index != 0 else {
+            return buttons
+        }
+        var reordered = buttons
+        reordered.remove(at: index)
+        reordered.insert(defaultLabel, at: 0)
+        return reordered
+    }
+
+    private static func buttonIndex(for response: NSApplication.ModalResponse, buttonCount: Int) -> Int? {
+        let index = response.rawValue - NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
+        guard index >= 0, index < buttonCount else { return nil }
+        return index
+    }
+
+    private static func runModal(_ alert: NSAlert) async -> NSApplication.ModalResponse {
+        guard let parent = parentWindow() else {
+            return alert.runModal()
+        }
+        return await withCheckedContinuation { continuation in
+            alert.beginSheetModal(for: parent) { response in
+                continuation.resume(returning: response)
+            }
+        }
+    }
+
+    private static func parentWindow() -> NSWindow? {
+        NSApp.windows.first { $0.identifier == ShortcutContext.mainWindowIdentifier }
+    }
+
+    private static func style(from raw: String?) -> NSAlert.Style {
+        switch raw {
+        case "warning": .warning
+        case "critical": .critical
+        default: .informational
+        }
+    }
+
+    private static func string(_ args: [String: Any], _ key: String) -> String? {
+        args[key] as? String
+    }
+}

--- a/Muxy/Services/ExtensionDialogService.swift
+++ b/Muxy/Services/ExtensionDialogService.swift
@@ -3,6 +3,7 @@ import AppKit
 @MainActor
 enum ExtensionDialogService {
     struct ConfirmRequest: Equatable {
+        let extensionID: String
         let title: String
         let message: String
         let buttons: [String]
@@ -12,16 +13,21 @@ enum ExtensionDialogService {
     }
 
     struct AlertRequest: Equatable {
+        let extensionID: String
         let title: String
         let message: String
         let style: NSAlert.Style
     }
 
-    static func confirm(_ request: ConfirmRequest) async -> String? {
-        let alert = NSAlert()
-        alert.alertStyle = request.style
-        alert.messageText = request.title
-        alert.informativeText = request.message
+    static let maxTextLength = 2000
+    static let maxButtonCount = 3
+
+    private static var busyExtensionIDs: Set<String> = []
+
+    static func confirm(_ request: ConfirmRequest) async throws -> String? {
+        try claim(request.extensionID)
+        defer { release(request.extensionID) }
+        let alert = makeAlert(title: request.title, message: request.message, style: request.style)
         let buttons = request.buttons.map { alert.addButton(withTitle: $0) }
         let equivalents = keyEquivalents(for: request)
         for (button, equivalent) in zip(buttons, equivalents) {
@@ -38,44 +44,46 @@ enum ExtensionDialogService {
         return label
     }
 
-    static func alert(_ request: AlertRequest) async {
-        let alert = NSAlert()
-        alert.alertStyle = request.style
-        alert.messageText = request.title
-        alert.informativeText = request.message
+    static func alert(_ request: AlertRequest) async throws {
+        try claim(request.extensionID)
+        defer { release(request.extensionID) }
+        let alert = makeAlert(title: request.title, message: request.message, style: request.style)
         alert.addButton(withTitle: "OK")
         _ = await runModal(alert)
     }
 
-    static func makeConfirmRequest(args: [String: Any]) throws -> ConfirmRequest {
-        let title = string(args, "title") ?? ""
-        let message = string(args, "message") ?? ""
+    static func makeConfirmRequest(extensionID: String, args: [String: Any]) throws -> ConfirmRequest {
+        let title = clamped(string(args, "title") ?? "")
+        let message = clamped(string(args, "message") ?? "")
         guard !title.isEmpty || !message.isEmpty else {
             throw APIError.invalidArguments("dialog requires title or message")
         }
         var buttons = (args["buttons"] as? [Any])?.compactMap { $0 as? String } ?? []
-        buttons = buttons.filter { !$0.isEmpty }
+        buttons = buttons.map(clamped).filter { !$0.isEmpty }
         if buttons.isEmpty {
             buttons = ["OK", "Cancel"]
         }
-        let defaultButton = string(args, "default")
+        buttons = Array(buttons.prefix(maxButtonCount))
+        let defaultButton = string(args, "default").map(clamped)
         return ConfirmRequest(
+            extensionID: extensionID,
             title: title,
             message: message,
             buttons: orderedButtons(buttons, defaultLabel: defaultButton),
             defaultButton: defaultButton,
-            cancelButton: string(args, "cancel"),
+            cancelButton: string(args, "cancel").map(clamped),
             style: style(from: string(args, "style"))
         )
     }
 
-    static func makeAlertRequest(args: [String: Any]) throws -> AlertRequest {
-        let title = string(args, "title") ?? ""
-        let message = string(args, "message") ?? ""
+    static func makeAlertRequest(extensionID: String, args: [String: Any]) throws -> AlertRequest {
+        let title = clamped(string(args, "title") ?? "")
+        let message = clamped(string(args, "message") ?? "")
         guard !title.isEmpty || !message.isEmpty else {
             throw APIError.invalidArguments("alert requires title or message")
         }
         return AlertRequest(
+            extensionID: extensionID,
             title: title,
             message: message,
             style: style(from: string(args, "style"))
@@ -88,6 +96,29 @@ enum ExtensionDialogService {
             if index == 0 { return "\r" }
             return ""
         }
+    }
+
+    private static func makeAlert(title: String, message: String, style: NSAlert.Style) -> NSAlert {
+        let alert = NSAlert()
+        alert.alertStyle = style
+        alert.messageText = title
+        alert.informativeText = message
+        return alert
+    }
+
+    private static func claim(_ extensionID: String) throws {
+        guard !busyExtensionIDs.contains(extensionID) else {
+            throw APIError.invalidArguments("a dialog is already open for this extension")
+        }
+        busyExtensionIDs.insert(extensionID)
+    }
+
+    private static func release(_ extensionID: String) {
+        busyExtensionIDs.remove(extensionID)
+    }
+
+    private static func clamped(_ value: String) -> String {
+        String(value.prefix(maxTextLength))
     }
 
     private static func orderedButtons(_ buttons: [String], defaultLabel: String?) -> [String] {

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -158,6 +158,8 @@ enum MuxyAPI {
 
         private static let extensionVerbs: Set<String> = [
             "exec",
+            "dialog.confirm",
+            "dialog.alert",
             "extension.settings.get",
             "extension.settings.set",
             "extension.statusbar.set",

--- a/Muxy/Services/MuxyAPIDispatcher.swift
+++ b/Muxy/Services/MuxyAPIDispatcher.swift
@@ -54,11 +54,11 @@ enum MuxyAPIDispatcher {
         case "exec":
             return try await handleExec(args: args, context: context)
         case "dialog.confirm":
-            let request = try ExtensionDialogService.makeConfirmRequest(args: args)
-            return await ExtensionDialogService.confirm(request) ?? NSNull()
+            let request = try ExtensionDialogService.makeConfirmRequest(extensionID: context.extensionID, args: args)
+            return try await ExtensionDialogService.confirm(request) ?? NSNull()
         case "dialog.alert":
-            let request = try ExtensionDialogService.makeAlertRequest(args: args)
-            await ExtensionDialogService.alert(request)
+            let request = try ExtensionDialogService.makeAlertRequest(extensionID: context.extensionID, args: args)
+            try await ExtensionDialogService.alert(request)
             return NSNull()
         case "tabs.list":
             return try unwrap(MuxyAPI.Tabs.list(appState: context.appState)).map(tabDict)

--- a/Muxy/Services/MuxyAPIDispatcher.swift
+++ b/Muxy/Services/MuxyAPIDispatcher.swift
@@ -53,6 +53,13 @@ enum MuxyAPIDispatcher {
             return NSNull()
         case "exec":
             return try await handleExec(args: args, context: context)
+        case "dialog.confirm":
+            let request = try ExtensionDialogService.makeConfirmRequest(args: args)
+            return await ExtensionDialogService.confirm(request) ?? NSNull()
+        case "dialog.alert":
+            let request = try ExtensionDialogService.makeAlertRequest(args: args)
+            await ExtensionDialogService.alert(request)
+            return NSNull()
         case "tabs.list":
             return try unwrap(MuxyAPI.Tabs.list(appState: context.appState)).map(tabDict)
         case "tabs.switch":

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -232,6 +232,12 @@ enum SocketCommandHandler {
                 worktreeStore: worktreeStore,
                 extensionID: clientContext.extensionID
             )
+        case "dialog.confirm":
+            guard parts.count >= 2 else { return "error:usage dialog.confirm|<base64-json>" }
+            return await handleDialogConfirm(base64Payload: parts[1])
+        case "dialog.alert":
+            guard parts.count >= 2 else { return "error:usage dialog.alert|<base64-json>" }
+            return await handleDialogAlert(base64Payload: parts[1])
         default:
             return "error:unknown command \(cmd)"
         }
@@ -273,6 +279,48 @@ enum SocketCommandHandler {
         } catch {
             return "error:\(error.localizedDescription)"
         }
+    }
+
+    private static func handleDialogConfirm(base64Payload: String) async -> String {
+        guard let args = decodeJSONObject(base64Payload) else {
+            return "error:invalid dialog payload"
+        }
+        let request: ExtensionDialogService.ConfirmRequest
+        do {
+            request = try ExtensionDialogService.makeConfirmRequest(args: args)
+        } catch {
+            return "error:\((error as? APIError)?.message ?? error.localizedDescription)"
+        }
+        let choice = await ExtensionDialogService.confirm(request)
+        return encodeJSONFragment(choice ?? NSNull())
+    }
+
+    private static func handleDialogAlert(base64Payload: String) async -> String {
+        guard let args = decodeJSONObject(base64Payload) else {
+            return "error:invalid alert payload"
+        }
+        let request: ExtensionDialogService.AlertRequest
+        do {
+            request = try ExtensionDialogService.makeAlertRequest(args: args)
+        } catch {
+            return "error:\((error as? APIError)?.message ?? error.localizedDescription)"
+        }
+        await ExtensionDialogService.alert(request)
+        return encodeJSONFragment(NSNull())
+    }
+
+    private static func decodeJSONObject(_ base64Payload: String) -> [String: Any]? {
+        guard let data = Data(base64Encoded: base64Payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return json
+    }
+
+    private static func encodeJSONFragment(_ value: Any) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed]) else {
+            return "error:dialog result encoding failed"
+        }
+        return data.base64EncodedString()
     }
 
     private static func handlePanelOpen(

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -234,10 +234,10 @@ enum SocketCommandHandler {
             )
         case "dialog.confirm":
             guard parts.count >= 2 else { return "error:usage dialog.confirm|<base64-json>" }
-            return await handleDialogConfirm(base64Payload: parts[1])
+            return await handleDialogConfirm(base64Payload: parts[1], extensionID: clientContext.extensionID)
         case "dialog.alert":
             guard parts.count >= 2 else { return "error:usage dialog.alert|<base64-json>" }
-            return await handleDialogAlert(base64Payload: parts[1])
+            return await handleDialogAlert(base64Payload: parts[1], extensionID: clientContext.extensionID)
         default:
             return "error:unknown command \(cmd)"
         }
@@ -281,32 +281,32 @@ enum SocketCommandHandler {
         }
     }
 
-    private static func handleDialogConfirm(base64Payload: String) async -> String {
+    private static func handleDialogConfirm(base64Payload: String, extensionID: String?) async -> String {
+        guard let extensionID else { return "error:identify required" }
         guard let args = decodeJSONObject(base64Payload) else {
             return "error:invalid dialog payload"
         }
-        let request: ExtensionDialogService.ConfirmRequest
         do {
-            request = try ExtensionDialogService.makeConfirmRequest(args: args)
+            let request = try ExtensionDialogService.makeConfirmRequest(extensionID: extensionID, args: args)
+            let choice = try await ExtensionDialogService.confirm(request)
+            return encodeJSONFragment(choice ?? NSNull())
         } catch {
             return "error:\((error as? APIError)?.message ?? error.localizedDescription)"
         }
-        let choice = await ExtensionDialogService.confirm(request)
-        return encodeJSONFragment(choice ?? NSNull())
     }
 
-    private static func handleDialogAlert(base64Payload: String) async -> String {
+    private static func handleDialogAlert(base64Payload: String, extensionID: String?) async -> String {
+        guard let extensionID else { return "error:identify required" }
         guard let args = decodeJSONObject(base64Payload) else {
             return "error:invalid alert payload"
         }
-        let request: ExtensionDialogService.AlertRequest
         do {
-            request = try ExtensionDialogService.makeAlertRequest(args: args)
+            let request = try ExtensionDialogService.makeAlertRequest(extensionID: extensionID, args: args)
+            try await ExtensionDialogService.alert(request)
+            return encodeJSONFragment(NSNull())
         } catch {
             return "error:\((error as? APIError)?.message ?? error.localizedDescription)"
         }
-        await ExtensionDialogService.alert(request)
-        return encodeJSONFragment(NSNull())
     }
 
     private static func decodeJSONObject(_ base64Payload: String) -> [String: Any]? {

--- a/Muxy/Views/Extensions/ExtensionWebBridge.swift
+++ b/Muxy/Views/Extensions/ExtensionWebBridge.swift
@@ -123,6 +123,27 @@ enum ExtensionWebBridge {
                     close() { return send('popover.close', {}); },
                     resize(width, height) { return send('popover.resize', { width: Number(width), height: Number(height) }); },
                 },
+                dialog: {
+                    confirm(opts) {
+                        const o = opts || {};
+                        const payload = {};
+                        if (o.title != null) payload.title = String(o.title);
+                        if (o.message != null) payload.message = String(o.message);
+                        if (Array.isArray(o.buttons)) payload.buttons = o.buttons.map(String);
+                        if (o.default != null) payload.default = String(o.default);
+                        if (o.cancel != null) payload.cancel = String(o.cancel);
+                        if (o.style != null) payload.style = String(o.style);
+                        return send('dialog.confirm', payload);
+                    },
+                    alert(opts) {
+                        const o = opts || {};
+                        const payload = {};
+                        if (o.title != null) payload.title = String(o.title);
+                        if (o.message != null) payload.message = String(o.message);
+                        if (o.style != null) payload.style = String(o.style);
+                        return send('dialog.alert', payload);
+                    },
+                },
                 exec(argvOrOptions, maybeOptions) {
                     let payload;
                     if (Array.isArray(argvOrOptions)) {
@@ -188,6 +209,7 @@ enum ExtensionWebBridge {
             Object.freeze(muxy.projects);
             Object.freeze(muxy.panels);
             Object.freeze(muxy.popover);
+            Object.freeze(muxy.dialog);
             Object.freeze(muxy.worktrees);
             Object.freeze(muxy.events);
             Object.freeze(muxy);

--- a/MuxyExtensionHost/HostBridge.swift
+++ b/MuxyExtensionHost/HostBridge.swift
@@ -50,6 +50,9 @@ final class HostBridge: @unchecked Sendable {
             return dispatchExec(dict)
         case "notifications.notify":
             return dispatchNotify(dict)
+        case "dialog.confirm",
+             "dialog.alert":
+            return dispatchDialog(verb: verb, dict: dict)
         default:
             return ["ok": false, "error": "verb '\(verb)' is not available in background context"]
         }
@@ -69,6 +72,27 @@ final class HostBridge: @unchecked Sendable {
                   let value = try? JSONSerialization.jsonObject(with: data)
             else {
                 return ["ok": false, "error": "invalid exec reply"]
+            }
+            return ["ok": true, "value": value]
+        } catch {
+            return ["ok": false, "error": "\(error)"]
+        }
+    }
+
+    private func dispatchDialog(verb: String, dict: [String: Any]) -> Any {
+        guard let payload = try? JSONSerialization.data(withJSONObject: dict) else {
+            return ["ok": false, "error": "could not encode dialog payload"]
+        }
+        let line = "\(verb)|\(payload.base64EncodedString())"
+        do {
+            let reply = try client.sendAndWaitReply(line)
+            if reply.hasPrefix("error:") {
+                return ["ok": false, "error": String(reply.dropFirst("error:".count))]
+            }
+            guard let data = Data(base64Encoded: reply),
+                  let value = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+            else {
+                return ["ok": false, "error": "invalid dialog reply"]
             }
             return ["ok": true, "value": value]
         } catch {

--- a/MuxyShared/ExtensionBridgeJS.swift
+++ b/MuxyShared/ExtensionBridgeJS.swift
@@ -40,6 +40,27 @@ public enum ExtensionBridgeJS {
                     }
                     return dispatch('exec', payload);
                 },
+                dialog: {
+                    confirm(opts) {
+                        const o = opts || {};
+                        const payload = {};
+                        if (o.title != null) payload.title = String(o.title);
+                        if (o.message != null) payload.message = String(o.message);
+                        if (Array.isArray(o.buttons)) payload.buttons = o.buttons.map(String);
+                        if (o.default != null) payload.default = String(o.default);
+                        if (o.cancel != null) payload.cancel = String(o.cancel);
+                        if (o.style != null) payload.style = String(o.style);
+                        return dispatch('dialog.confirm', payload);
+                    },
+                    alert(opts) {
+                        const o = opts || {};
+                        const payload = {};
+                        if (o.title != null) payload.title = String(o.title);
+                        if (o.message != null) payload.message = String(o.message);
+                        if (o.style != null) payload.style = String(o.style);
+                        return dispatch('dialog.alert', payload);
+                    },
+                },
             };
         \(surface == .inProcess ? workspaceBlock : "")
         \(surface == .background ? eventsBlock : "")
@@ -48,6 +69,7 @@ public enum ExtensionBridgeJS {
             "Object.freeze(muxy.tabs); Object.freeze(muxy.panes); Object.freeze(muxy.projects); Object.freeze(muxy.worktrees);" :
             "")
             Object.freeze(muxy.notifications);
+            Object.freeze(muxy.dialog);
             \(surface == .background ? "Object.freeze(muxy.events); Object.freeze(muxy.remote);" : "")
             Object.freeze(muxy);
             this.muxy = muxy;

--- a/Tests/MuxyTests/Services/ExtensionDialogServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionDialogServiceTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+@Suite("Extension dialog service")
+@MainActor
+struct ExtensionDialogServiceTests {
+    @Test("dialog verbs are recognized and ungated")
+    func dialogVerbsAreUngated() {
+        let verbs = MuxyAPI.Permissions.verbNames
+        #expect(verbs.contains("dialog.confirm"))
+        #expect(verbs.contains("dialog.alert"))
+        #expect(MuxyAPI.Permissions.required(for: "dialog.confirm") == nil)
+        #expect(MuxyAPI.Permissions.required(for: "dialog.alert") == nil)
+    }
+
+    @Test("confirm parses fields and styles")
+    func confirmParsesFields() throws {
+        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+            "title": "Delete branch?",
+            "message": "Cannot be undone.",
+            "buttons": ["Delete", "Cancel"],
+            "cancel": "Cancel",
+            "style": "warning",
+        ])
+        #expect(request.title == "Delete branch?")
+        #expect(request.message == "Cannot be undone.")
+        #expect(request.buttons == ["Delete", "Cancel"])
+        #expect(request.cancelButton == "Cancel")
+        #expect(request.style == .warning)
+    }
+
+    @Test("confirm moves the default button to the front")
+    func confirmReordersDefault() throws {
+        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+            "title": "Proceed?",
+            "buttons": ["Delete", "Cancel"],
+            "default": "Cancel",
+        ])
+        #expect(request.buttons == ["Cancel", "Delete"])
+        #expect(request.defaultButton == "Cancel")
+    }
+
+    @Test("confirm defaults buttons and drops empties")
+    func confirmDefaultsButtons() throws {
+        let fallback = try ExtensionDialogService.makeConfirmRequest(args: ["title": "Hi"])
+        #expect(fallback.buttons == ["OK", "Cancel"])
+
+        let filtered = try ExtensionDialogService.makeConfirmRequest(args: [
+            "title": "Hi",
+            "buttons": ["Yes", "", "No"],
+        ])
+        #expect(filtered.buttons == ["Yes", "No"])
+    }
+
+    @Test("confirm requires title or message")
+    func confirmRequiresContent() {
+        #expect(throws: APIError.self) {
+            try ExtensionDialogService.makeConfirmRequest(args: [:])
+        }
+    }
+
+    @Test("alert parses fields and defaults to informational")
+    func alertParsesFields() throws {
+        let request = try ExtensionDialogService.makeAlertRequest(args: [
+            "message": "Build finished",
+        ])
+        #expect(request.title.isEmpty)
+        #expect(request.message == "Build finished")
+        #expect(request.style == .informational)
+    }
+
+    @Test("alert maps critical style")
+    func alertCriticalStyle() throws {
+        let request = try ExtensionDialogService.makeAlertRequest(args: [
+            "title": "Failure",
+            "style": "critical",
+        ])
+        #expect(request.style == .critical)
+    }
+
+    @Test("alert requires title or message")
+    func alertRequiresContent() {
+        #expect(throws: APIError.self) {
+            try ExtensionDialogService.makeAlertRequest(args: [:])
+        }
+    }
+
+    @Test("Return maps to the first button and Esc to the cancel label")
+    func keyEquivalentsMapReturnAndEscape() throws {
+        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+            "title": "Proceed?",
+            "buttons": ["Discard", "Keep"],
+            "default": "Keep",
+            "cancel": "Discard",
+        ])
+        #expect(request.buttons == ["Keep", "Discard"])
+        #expect(ExtensionDialogService.keyEquivalents(for: request) == ["\r", "\u{1B}"])
+    }
+
+    @Test("without a cancel label only the default button is bound")
+    func keyEquivalentsDefaultOnly() throws {
+        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+            "title": "Proceed?",
+            "buttons": ["Yes", "No"],
+        ])
+        #expect(ExtensionDialogService.keyEquivalents(for: request) == ["\r", ""])
+    }
+}

--- a/Tests/MuxyTests/Services/ExtensionDialogServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionDialogServiceTests.swift
@@ -120,6 +120,18 @@ struct ExtensionDialogServiceTests {
         #expect(ExtensionDialogService.keyEquivalents(for: request) == ["\r", "\u{1B}"])
     }
 
+    @Test("when default and cancel are the same label Return wins")
+    func keyEquivalentsDefaultEqualsCancel() throws {
+        let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
+            "title": "Proceed?",
+            "buttons": ["Delete", "Cancel"],
+            "default": "Cancel",
+            "cancel": "Cancel",
+        ])
+        #expect(request.buttons == ["Cancel", "Delete"])
+        #expect(ExtensionDialogService.keyEquivalents(for: request) == ["\r", ""])
+    }
+
     @Test("without a cancel label only the default button is bound")
     func keyEquivalentsDefaultOnly() throws {
         let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [

--- a/Tests/MuxyTests/Services/ExtensionDialogServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionDialogServiceTests.swift
@@ -17,7 +17,7 @@ struct ExtensionDialogServiceTests {
 
     @Test("confirm parses fields and styles")
     func confirmParsesFields() throws {
-        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+        let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
             "title": "Delete branch?",
             "message": "Cannot be undone.",
             "buttons": ["Delete", "Cancel"],
@@ -33,7 +33,7 @@ struct ExtensionDialogServiceTests {
 
     @Test("confirm moves the default button to the front")
     func confirmReordersDefault() throws {
-        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+        let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
             "title": "Proceed?",
             "buttons": ["Delete", "Cancel"],
             "default": "Cancel",
@@ -44,26 +44,47 @@ struct ExtensionDialogServiceTests {
 
     @Test("confirm defaults buttons and drops empties")
     func confirmDefaultsButtons() throws {
-        let fallback = try ExtensionDialogService.makeConfirmRequest(args: ["title": "Hi"])
+        let fallback = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: ["title": "Hi"])
         #expect(fallback.buttons == ["OK", "Cancel"])
 
-        let filtered = try ExtensionDialogService.makeConfirmRequest(args: [
+        let filtered = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
             "title": "Hi",
             "buttons": ["Yes", "", "No"],
         ])
         #expect(filtered.buttons == ["Yes", "No"])
     }
 
+    @Test("confirm caps the button count")
+    func confirmCapsButtonCount() throws {
+        let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
+            "title": "Pick",
+            "buttons": ["A", "B", "C", "D", "E"],
+        ])
+        #expect(request.buttons.count == ExtensionDialogService.maxButtonCount)
+        #expect(request.buttons == ["A", "B", "C"])
+    }
+
+    @Test("confirm clamps oversized text")
+    func confirmClampsText() throws {
+        let long = String(repeating: "x", count: ExtensionDialogService.maxTextLength + 500)
+        let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
+            "title": long,
+            "message": long,
+        ])
+        #expect(request.title.count == ExtensionDialogService.maxTextLength)
+        #expect(request.message.count == ExtensionDialogService.maxTextLength)
+    }
+
     @Test("confirm requires title or message")
     func confirmRequiresContent() {
         #expect(throws: APIError.self) {
-            try ExtensionDialogService.makeConfirmRequest(args: [:])
+            try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [:])
         }
     }
 
     @Test("alert parses fields and defaults to informational")
     func alertParsesFields() throws {
-        let request = try ExtensionDialogService.makeAlertRequest(args: [
+        let request = try ExtensionDialogService.makeAlertRequest(extensionID: "ext", args: [
             "message": "Build finished",
         ])
         #expect(request.title.isEmpty)
@@ -73,7 +94,7 @@ struct ExtensionDialogServiceTests {
 
     @Test("alert maps critical style")
     func alertCriticalStyle() throws {
-        let request = try ExtensionDialogService.makeAlertRequest(args: [
+        let request = try ExtensionDialogService.makeAlertRequest(extensionID: "ext", args: [
             "title": "Failure",
             "style": "critical",
         ])
@@ -83,13 +104,13 @@ struct ExtensionDialogServiceTests {
     @Test("alert requires title or message")
     func alertRequiresContent() {
         #expect(throws: APIError.self) {
-            try ExtensionDialogService.makeAlertRequest(args: [:])
+            try ExtensionDialogService.makeAlertRequest(extensionID: "ext", args: [:])
         }
     }
 
     @Test("Return maps to the first button and Esc to the cancel label")
     func keyEquivalentsMapReturnAndEscape() throws {
-        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+        let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
             "title": "Proceed?",
             "buttons": ["Discard", "Keep"],
             "default": "Keep",
@@ -101,7 +122,7 @@ struct ExtensionDialogServiceTests {
 
     @Test("without a cancel label only the default button is bound")
     func keyEquivalentsDefaultOnly() throws {
-        let request = try ExtensionDialogService.makeConfirmRequest(args: [
+        let request = try ExtensionDialogService.makeConfirmRequest(extensionID: "ext", args: [
             "title": "Proceed?",
             "buttons": ["Yes", "No"],
         ])

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -73,6 +73,7 @@ flowchart TD
 | [Tabs](tabs.md) | Register webview tab types and the injected `window.muxy` JS API |
 | [Panels](panels.md) | Register dockable/floating webview panels and the placement rules |
 | [Popovers](popovers.md) | Anchor a transient webview popover to a topbar/status bar item |
+| [Dialogs](dialogs.md) | Present native confirm/alert sheets on the main window |
 | [Topbar](topbar.md) | Attach icons to the tab strip that trigger a command |
 | [Status Bar](statusbar.md) | Attach icons to the footer status bar; update text live |
 | [Settings](settings.md) | Declare typed settings and read/write them at runtime |
@@ -93,7 +94,7 @@ flowchart TD
 - Manifest: the `muxy` object in `package.json` (`name`/`version` stay top-level)
 - Install path: `~/.config/muxy/extensions/<name>/` (the installed `dist/`)
 - Background script: optional `muxy.background` JS, run in a host process that injects the `muxy` global
-- Background API: `muxy.extensionID`, `muxy.events.subscribe`, `muxy.exec`, `console.*`
+- Background API: `muxy.extensionID`, `muxy.events.subscribe`, `muxy.exec`, `muxy.dialog`, `console.*`
 - See [the muxy CLI feature page](../features/muxy-cli.md) for the verb vocabulary
 
 ## Minimal example

--- a/docs/extensions/dialogs.md
+++ b/docs/extensions/dialogs.md
@@ -1,0 +1,56 @@
+# Extension Dialogs
+
+Native macOS sheets an extension can present on the main window: a multi-button **confirm** dialog and a single-button **alert**. Both render as a real `NSAlert` sheet attached to the Muxy window — they look identical to the app's own prompts and block until the user responds.
+
+`dialog` is available on both surfaces: the in-process [`window.muxy`](tabs.md#windowmuxy) bridge (tabs, panels, popovers) and the [background script](manifest.md) `muxy` global. It needs **no permission** — the user has to dismiss every dialog themselves, so there is nothing to gate ([what permissions don't gate](permissions.md#what-permissions-dont-gate)).
+
+## confirm
+
+Shows a dialog with up to your supplied buttons and resolves with the **label** of the button the user clicked, or `null` if they cancelled (Esc, or the `cancel` button).
+
+```js
+const choice = await muxy.dialog.confirm({
+  title: 'Delete branch?',
+  message: 'This permanently removes feature/login and cannot be undone.',
+  buttons: ['Delete', 'Cancel'],
+  default: 'Cancel',   // the focused (Return) button
+  cancel: 'Cancel',    // Esc maps here; clicking it resolves null
+  style: 'warning',    // 'info' (default) | 'warning' | 'critical'
+});
+
+if (choice === 'Delete') { /* … */ }
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `title` | string | one of title/message | The bold heading line. |
+| `message` | string | one of title/message | The informative body text. |
+| `buttons` | string[] | no | Button labels, left to right. Defaults to `['OK', 'Cancel']`. |
+| `default` | string | no | Label of the button focused and triggered by Return. Moved to the front so macOS highlights it. |
+| `cancel` | string | no | Label that Esc maps to; clicking it resolves `null` instead of the label. |
+| `style` | string | no | `'info'`, `'warning'`, or `'critical'`. Defaults to `'info'`. |
+
+The resolved value is always the exact label string you passed (or `null`), so compare against your own labels rather than an index.
+
+## alert
+
+Shows a single **OK** dialog and resolves once the user dismisses it.
+
+```js
+await muxy.dialog.alert({
+  title: 'Build finished',
+  message: 'All 42 tests passed.',
+  style: 'info',
+});
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `title` | string | one of title/message | The bold heading line. |
+| `message` | string | one of title/message | The informative body text. |
+| `style` | string | no | `'info'`, `'warning'`, or `'critical'`. Defaults to `'info'`. |
+
+## Notes
+
+- The call blocks the caller until the user responds. From a background script this pauses that script's event loop the same way `exec` does, so don't open a dialog from a hot event path.
+- Dialogs present on the main Muxy window; if no window is available the sheet falls back to an application-modal dialog.

--- a/docs/extensions/dialogs.md
+++ b/docs/extensions/dialogs.md
@@ -53,4 +53,6 @@ await muxy.dialog.alert({
 ## Notes
 
 - The call blocks the caller until the user responds. From a background script this pauses that script's event loop the same way `exec` does, so don't open a dialog from a hot event path.
+- Only **one dialog per extension** can be open at a time; a second call while one is showing rejects rather than stacking sheets.
+- `title`, `message`, and each button label are capped at 2000 characters, and `buttons` is limited to the first 3.
 - Dialogs present on the main Muxy window; if no window is available the sheet falls back to an application-modal dialog.

--- a/docs/extensions/dialogs.md
+++ b/docs/extensions/dialogs.md
@@ -55,4 +55,4 @@ await muxy.dialog.alert({
 - The call blocks the caller until the user responds. From a background script this pauses that script's event loop the same way `exec` does, so don't open a dialog from a hot event path.
 - Only **one dialog per extension** can be open at a time; a second call while one is showing rejects rather than stacking sheets.
 - `title`, `message`, and each button label are capped at 2000 characters, and `buttons` is limited to the first 3.
-- Dialogs present on the main Muxy window; if no window is available the sheet falls back to an application-modal dialog.
+- Dialogs present as a sheet on the main Muxy window; if no window is available the call rejects rather than presenting a blocking dialog.

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -62,5 +62,6 @@ Rules can be reviewed, refined, or removed in `Settings → Extensions → Permi
 
 - **Subscribing to events** is gated separately by the manifest `events` array — see [Events](events.md). The caller's identity, not a `permissions` entry, decides what it can subscribe to.
 - **Receiving palette command triggers.** Once an extension declares a command in `commands`, it can subscribe to its own `command.<id>` event without listing it under `events`.
+- **Native dialogs.** `muxy.dialog.confirm` / `muxy.dialog.alert` present a sheet the user must dismiss — see [Dialogs](dialogs.md). Being user-driven and UI-only, they need no permission.
 
 Permissions are coarse (verb groups, not individual verbs) on purpose while the API is in flux. Expect the list to expand and possibly split (e.g. `panes:send` vs `panes:close`) once a dedicated extension API layer lands.

--- a/docs/extensions/tabs.md
+++ b/docs/extensions/tabs.md
@@ -90,6 +90,11 @@ window.muxy = {
   },
   toast({ title, body?, paneID? }): Promise<void>,        // same as notifications.notify
 
+  dialog: {                                               // native sheets — see dialogs.md
+    confirm(opts): Promise<string | null>,                // resolves the chosen button label, null on cancel
+    alert(opts): Promise<void>,
+  },
+
   tabs: {
     open(request): Promise<void>,       // see "Opening another tab"
     list(): Promise<TabInfo[]>,


### PR DESCRIPTION
Extensions can now call muxy.dialog.confirm (multi-button, focused default, Esc→cancel, resolves the chosen label or
  null) and muxy.dialog.alert (single OK) on both the in-process and background surfaces.
  Renders a native NSAlert sheet on the main window; UI-only, so no permission gate.
  Docs added at docs/extensions/dialogs.md.