### PR TITLE
Exit extension host when parent process dies

### DIFF
--- a/MuxyExtensionHost/ParentDeathMonitor.swift
+++ b/MuxyExtensionHost/ParentDeathMonitor.swift
@@ -2,20 +2,15 @@ import Darwin
 import Foundation
 
 final class ParentDeathMonitor {
-    private let parentPID: pid_t
     private var source: DispatchSourceProcess?
 
-    init() {
-        parentPID = getppid()
-    }
-
     func start() {
-        guard parentPID > 1 else {
+        guard getppid() > 1 else {
             exit(0)
         }
 
         let monitor = DispatchSource.makeProcessSource(
-            identifier: parentPID,
+            identifier: getppid(),
             eventMask: .exit,
             queue: .global(qos: .utility)
         )

--- a/MuxyExtensionHost/ParentDeathMonitor.swift
+++ b/MuxyExtensionHost/ParentDeathMonitor.swift
@@ -1,0 +1,32 @@
+import Darwin
+import Foundation
+
+final class ParentDeathMonitor {
+    private let parentPID: pid_t
+    private var source: DispatchSourceProcess?
+
+    init() {
+        parentPID = getppid()
+    }
+
+    func start() {
+        guard parentPID > 1 else {
+            exit(0)
+        }
+
+        let monitor = DispatchSource.makeProcessSource(
+            identifier: parentPID,
+            eventMask: .exit,
+            queue: .global(qos: .utility)
+        )
+        monitor.setEventHandler {
+            exit(0)
+        }
+        monitor.resume()
+        source = monitor
+
+        if getppid() <= 1 {
+            exit(0)
+        }
+    }
+}

--- a/MuxyExtensionHost/main.swift
+++ b/MuxyExtensionHost/main.swift
@@ -27,6 +27,9 @@ guard let source = try? String(contentsOfFile: scriptPath, encoding: .utf8) else
     fail("could not read background script at \(scriptPath)")
 }
 
+let parentDeathMonitor = ParentDeathMonitor()
+parentDeathMonitor.start()
+
 let client: HostSocketClient
 do {
     client = try HostSocketClient(socketPath: socketPath)

--- a/MuxyExtensionHost/main.swift
+++ b/MuxyExtensionHost/main.swift
@@ -7,6 +7,9 @@ func fail(_ message: String) -> Never {
     exit(1)
 }
 
+let parentDeathMonitor = ParentDeathMonitor()
+parentDeathMonitor.start()
+
 let environment = ProcessInfo.processInfo.environment
 
 guard let scriptPath = CommandLine.arguments.dropFirst().first else {
@@ -26,9 +29,6 @@ let token = environment["MUXY_EXTENSION_TOKEN"] ?? ""
 guard let source = try? String(contentsOfFile: scriptPath, encoding: .utf8) else {
     fail("could not read background script at \(scriptPath)")
 }
-
-let parentDeathMonitor = ParentDeathMonitor()
-parentDeathMonitor.start()
 
 let client: HostSocketClient
 do {


### PR DESCRIPTION
Extension host subprocesses now self-exit when Muxy dies, via a process
  monitor on the parent PID. Previously they relied only on socket EOF,
  which the kernel doesn't deliver reliably on force-kill/crash, leaving
  orphaned MuxyExtensionHost processes to pile up.