### PR TITLE
fix(remote): Fix blank terminal when a terminal tab is created from the mobile app

### DIFF
--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -225,19 +225,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     }
 
     private func applyPTYSize(paneID: UUID, cols: UInt32, rows: UInt32) {
-        guard let view = TerminalViewRegistry.shared.existingView(for: paneID),
-              let surface = view.surface
-        else { return }
-
-        let size = ghostty_surface_size(surface)
-        guard size.cell_width_px > 0, size.cell_height_px > 0 else {
-            logger.warning("Cannot resize pane \(paneID): cell metrics not yet available")
-            return
-        }
-
-        let w = cols * size.cell_width_px
-        let h = rows * size.cell_height_px
-        ghostty_surface_set_size(surface, w, h)
+        TerminalViewRegistry.shared.existingView(for: paneID)?.setRemoteGrid(cols: cols, rows: rows)
     }
 
     func registerDevice(clientID: UUID, name: String) {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -36,6 +36,7 @@ final class GhosttyTerminalNSView: NSView {
 
     private var isPaneVisible = true
     private var isWindowVisible = true
+    private var remoteGrid: (cols: UInt32, rows: UInt32)?
     nonisolated(unsafe) private var occlusionObserver: NSObjectProtocol?
 
     var closesOnCommandExit: Bool {
@@ -184,6 +185,7 @@ final class GhosttyTerminalNSView: NSView {
         }
 
         applyOcclusionState()
+        applyRemoteGrid()
     }
 
     func destroySurface() {
@@ -368,12 +370,31 @@ final class GhosttyTerminalNSView: NSView {
         updateMetalLayerSize(deferred: false)
     }
 
+    private static let headlessDefaultSize = NSSize(width: 800, height: 480)
+
     func materializeHeadless() {
         guard surface == nil else { return }
         if frame.size.width <= 0 || frame.size.height <= 0 {
-            setFrameSize(NSSize(width: 1, height: 1))
+            setFrameSize(Self.headlessDefaultSize)
         }
         createSurface()
+    }
+
+    func setRemoteGrid(cols: UInt32, rows: UInt32) {
+        guard cols > 0, rows > 0 else { return }
+        remoteGrid = (cols, rows)
+        applyRemoteGrid()
+    }
+
+    private func applyRemoteGrid() {
+        guard let surface, let remoteGrid else { return }
+        let size = ghostty_surface_size(surface)
+        guard size.cell_width_px > 0, size.cell_height_px > 0 else { return }
+        ghostty_surface_set_size(
+            surface,
+            remoteGrid.cols * size.cell_width_px,
+            remoteGrid.rows * size.cell_height_px
+        )
     }
 
     private func backingPixelSize() -> (width: UInt32, height: UInt32)? {


### PR DESCRIPTION
## Summary

  Creating a terminal tab from the mobile app showed a blank screen — the desktop tab existed but the shell produced no output until I focused the desktop window, at which point the shell initialized and the prompt appeared.

  When a pane is created headlessly for a remote client, the surface was created at a 1×1 size, so libghostty never computed cell metrics. `applyPTYSize` needs those metrics to size the PTY and bailed out when they were missing, so the PTY was never sized to the client's requested grid and the shell produced no output until the desktop rendered the surface for real.

  ## Testing

  - [x] `scripts/checks.sh` passes
  - [x] Tested manually on macOS and iOS (use store version)
