### PR TITLE
Fix extension webview reverting to stale theme on reload

### DIFF
--- a/Muxy/Views/Extensions/ExtensionWebView.swift
+++ b/Muxy/Views/Extensions/ExtensionWebView.swift
@@ -178,6 +178,7 @@ struct ExtensionWebView: NSViewRepresentable {
 
         func webView(_: WKWebView, didCommit _: WKNavigation!) {
             bridge?.dropAllEventSubscriptions()
+            pushThemeUpdate()
         }
     }
 }


### PR DESCRIPTION
On reload, WebKit re-ran the cached document-start bootstrap with its baked-in theme literal, leaving the page on the old theme. `didCommit` now re-pushes the live theme after each navigation.