### PR TITLE
Add "block all" option to extension permission prompts

### DIFF
--- a/Muxy/Services/ExtensionConsentService.swift
+++ b/Muxy/Services/ExtensionConsentService.swift
@@ -134,7 +134,7 @@ final class ExtensionConsentService {
             recordAudit(request: request, decision: .deny, ruleID: rule.id)
         case .blockKind:
             let ruleID = grantStore.blockKind(extensionID: request.extensionID, verb: request.verb)
-            recordAudit(request: request, decision: .deny, ruleID: ruleID)
+            recordAudit(request: request, decision: .blocked, ruleID: ruleID)
         }
     }
 

--- a/Muxy/Services/ExtensionConsentService.swift
+++ b/Muxy/Services/ExtensionConsentService.swift
@@ -20,6 +20,7 @@ enum ExtensionConsentChoice {
     case allowAndRemember
     case denyOnce
     case denyAndRemember
+    case blockKind
 }
 
 @MainActor
@@ -97,7 +98,8 @@ final class ExtensionConsentService {
         case .allowOnce,
              .allowAndRemember: return .allow
         case .denyOnce,
-             .denyAndRemember: return .deny
+             .denyAndRemember,
+             .blockKind: return .deny
         }
     }
 
@@ -130,6 +132,9 @@ final class ExtensionConsentService {
             )
             grantStore.add(rule)
             recordAudit(request: request, decision: .deny, ruleID: rule.id)
+        case .blockKind:
+            let ruleID = grantStore.blockKind(extensionID: request.extensionID, verb: request.verb)
+            recordAudit(request: request, decision: .deny, ruleID: ruleID)
         }
     }
 

--- a/Muxy/Services/ExtensionGrantStore.swift
+++ b/Muxy/Services/ExtensionGrantStore.swift
@@ -17,6 +17,19 @@ enum ExtensionGatedVerb: String, Codable, CaseIterable {
     case remoteInvoke = "remote.invoke"
     case gitWrite = "git.write"
     case filesWrite = "files.write"
+
+    var kindDisplayName: String {
+        switch self {
+        case .exec: "shell commands"
+        case .panesSend: "terminal input"
+        case .panesSendKeys: "terminal keystrokes"
+        case .panesReadScreen: "terminal output reads"
+        case .tabsOpenForeign: "foreign tab opens"
+        case .remoteInvoke: "mobile requests"
+        case .gitWrite: "git changes"
+        case .filesWrite: "file changes"
+        }
+    }
 }
 
 enum ExtensionGrantMatch: Codable, Equatable {
@@ -275,6 +288,15 @@ final class ExtensionGrantStore {
     func removeAll(for extensionID: String) {
         rules.removeAll { $0.extensionID == extensionID }
         save()
+    }
+
+    @discardableResult
+    func blockKind(extensionID: String, verb: ExtensionGatedVerb) -> UUID {
+        rules.removeAll { $0.extensionID == extensionID && $0.verb == verb }
+        let rule = ExtensionGrantRule(extensionID: extensionID, verb: verb, match: .any, decision: .deny)
+        rules.append(rule)
+        save()
+        return rule.id
     }
 
     private func load() {

--- a/Muxy/Services/ExtensionGrantStore.swift
+++ b/Muxy/Services/ExtensionGrantStore.swift
@@ -6,6 +6,7 @@ private let logger = Logger(subsystem: "app.muxy", category: "ExtensionGrantStor
 enum ExtensionGrantDecision: String, Codable, Equatable {
     case allow
     case deny
+    case blocked
 }
 
 enum ExtensionGatedVerb: String, Codable, CaseIterable {
@@ -261,7 +262,7 @@ final class ExtensionGrantStore {
                 return lhs.match.specificity > rhs.match.specificity
             }
             if lhs.decision != rhs.decision {
-                return lhs.decision == .deny
+                return rhs.decision == .allow
             }
             return lhs.createdAt < rhs.createdAt
         }
@@ -293,7 +294,7 @@ final class ExtensionGrantStore {
     @discardableResult
     func blockKind(extensionID: String, verb: ExtensionGatedVerb) -> UUID {
         rules.removeAll { $0.extensionID == extensionID && $0.verb == verb }
-        let rule = ExtensionGrantRule(extensionID: extensionID, verb: verb, match: .any, decision: .deny)
+        let rule = ExtensionGrantRule(extensionID: extensionID, verb: verb, match: .any, decision: .blocked)
         rules.append(rule)
         save()
         return rule.id

--- a/Muxy/Views/Extensions/ExtensionConsentDialog.swift
+++ b/Muxy/Views/Extensions/ExtensionConsentDialog.swift
@@ -156,11 +156,13 @@ struct ExtensionConsentDialog: View {
     let request: ExtensionConsentRequest
     let onChoice: (ExtensionConsentChoice) -> Void
 
+    @State private var blockKind = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             header
             payloadBox
-            rememberHint
+            blockToggle
             buttons
         }
         .padding(20)
@@ -204,34 +206,49 @@ struct ExtensionConsentDialog: View {
         .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
     }
 
-    private var rememberHint: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "info.circle")
-                .font(.system(size: UIMetrics.fontCaption))
-                .foregroundStyle(MuxyTheme.fgMuted)
-            Text("\"Remember\" saves rule: ")
-                .font(.system(size: UIMetrics.fontCaption))
-                .foregroundStyle(MuxyTheme.fgMuted)
-                + Text(request.suggestedMatch.displayString)
-                .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
-                .foregroundStyle(MuxyTheme.fg)
-            Spacer()
+    private var blockToggle: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: $blockKind) {
+                Text("Block all \(request.verb.kindDisplayName) from this extension")
+                    .font(.system(size: UIMetrics.fontCaption))
+                    .foregroundStyle(MuxyTheme.fg)
+            }
+            .toggleStyle(.checkbox)
+            HStack(spacing: 6) {
+                Image(systemName: "info.circle")
+                    .font(.system(size: UIMetrics.fontCaption))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                Text("\"Remember\" saves rule: ")
+                    .font(.system(size: UIMetrics.fontCaption))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    + Text(rememberRuleDescription)
+                    .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
+                    .foregroundStyle(MuxyTheme.fg)
+                Spacer()
+            }
         }
+    }
+
+    private var rememberRuleDescription: String {
+        blockKind ? "all \(request.verb.kindDisplayName)" : request.suggestedMatch.displayString
     }
 
     private var buttons: some View {
         HStack(spacing: 8) {
-            Button("Deny & remember") { onChoice(.denyAndRemember) }
+            Button("Deny & remember") { onChoice(blockKind ? .blockKind : .denyAndRemember) }
                 .buttonStyle(.bordered)
+                .tint(blockKind ? MuxyTheme.diffRemoveFg : nil)
             Spacer()
             Button("Cancel") { onChoice(.denyOnce) }
                 .keyboardShortcut(.escape, modifiers: [])
                 .buttonStyle(.bordered)
             Button("Allow") { onChoice(.allowOnce) }
                 .buttonStyle(.bordered)
+                .disabled(blockKind)
             Button("Allow & remember") { onChoice(.allowAndRemember) }
                 .keyboardShortcut(.return, modifiers: [])
                 .buttonStyle(.borderedProminent)
+                .disabled(blockKind)
         }
     }
 

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -976,7 +976,7 @@ private struct ExtensionGrantRuleRow: View {
     }
 
     private var isBlocked: Bool {
-        rule.decision == .deny && rule.match == .any
+        rule.decision == .blocked
     }
 
     private var decisionBadge: some View {

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -956,7 +956,7 @@ private struct ExtensionGrantRuleRow: View {
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(MuxyTheme.fg)
                 .frame(width: 130, alignment: .leading)
-            Text(rule.match.displayString)
+            Text(isBlocked ? "blocks all \(rule.verb.kindDisplayName)" : rule.match.displayString)
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .lineLimit(1)
@@ -975,9 +975,13 @@ private struct ExtensionGrantRuleRow: View {
         .background(MuxyTheme.bg.opacity(0.5), in: RoundedRectangle(cornerRadius: 5))
     }
 
+    private var isBlocked: Bool {
+        rule.decision == .deny && rule.match == .any
+    }
+
     private var decisionBadge: some View {
         let isAllow = rule.decision == .allow
-        let label = isAllow ? "allow" : "deny"
+        let label = isAllow ? "allow" : (isBlocked ? "blocked" : "deny")
         let color = isAllow ? MuxyTheme.diffAddFg : MuxyTheme.diffRemoveFg
         return Text(label)
             .font(.system(size: 10, weight: .semibold))

--- a/Tests/MuxyTests/Services/ExtensionConsentServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionConsentServiceTests.swift
@@ -88,6 +88,44 @@ struct ExtensionConsentServiceTests {
         #expect(grantStore.rules.isEmpty)
     }
 
+    @Test("blockKind overrides existing allow rules and silences future prompts")
+    func blockKindBlocksWholeVerb() async {
+        let grantStore = makeGrantStore()
+        let service = ExtensionConsentService(grantStore: grantStore, auditLog: makeAuditLog())
+        grantStore.add(ExtensionGrantRule(
+            extensionID: "ext",
+            verb: .exec,
+            match: .argvPrefix(["git"]),
+            decision: .allow
+        ))
+        let request = ExtensionConsentRequestBuilder.make(
+            extensionID: "ext",
+            verb: .exec,
+            payload: .exec(argv: ["npm", "install"], shell: nil),
+            source: "test"
+        )
+
+        async let decision = service.gate(request)
+        await waitUntil { service.pendingPrompt?.id == request.id }
+        service.respond(requestID: request.id, choice: .blockKind)
+
+        let resolved = await decision
+        #expect(resolved == .deny)
+        #expect(grantStore.rules.count == 1)
+        #expect(grantStore.rules.first?.match == .any)
+        #expect(grantStore.rules.first?.decision == .deny)
+
+        let previouslyAllowed = ExtensionConsentRequestBuilder.make(
+            extensionID: "ext",
+            verb: .exec,
+            payload: .exec(argv: ["git", "status"], shell: nil),
+            source: "test"
+        )
+        let allowedDecision = await service.gate(previouslyAllowed)
+        #expect(allowedDecision == .deny)
+        #expect(service.pendingPrompt == nil)
+    }
+
     @Test("queue flood for one extension auto-denies excess")
     func queueFloodAutoDenies() async {
         let grantStore = makeGrantStore()

--- a/Tests/MuxyTests/Services/ExtensionConsentServiceTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionConsentServiceTests.swift
@@ -113,7 +113,7 @@ struct ExtensionConsentServiceTests {
         #expect(resolved == .deny)
         #expect(grantStore.rules.count == 1)
         #expect(grantStore.rules.first?.match == .any)
-        #expect(grantStore.rules.first?.decision == .deny)
+        #expect(grantStore.rules.first?.decision == .blocked)
 
         let previouslyAllowed = ExtensionConsentRequestBuilder.make(
             extensionID: "ext",

--- a/Tests/MuxyTests/Services/ExtensionGrantStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionGrantStoreTests.swift
@@ -339,6 +339,40 @@ struct ExtensionGrantStoreTests {
         #expect(match == .gitOperationEquals("push"))
     }
 
+    @Test("blockKind replaces every rule for the verb with a blocked any-deny")
+    func blockKindReplacesRules() {
+        let store = makeStore()
+        store.add(ExtensionGrantRule(
+            extensionID: "ext",
+            verb: .exec,
+            match: .argvExact(["git", "status"]),
+            decision: .allow
+        ))
+        store.blockKind(extensionID: "ext", verb: .exec)
+
+        #expect(store.rules.count == 1)
+        let rule = store.rules.first
+        #expect(rule?.match == .any)
+        #expect(rule?.decision == .blocked)
+        #expect(store.evaluate(
+            extensionID: "ext",
+            verb: .exec,
+            payload: .exec(argv: ["git", "status"], shell: nil)
+        ) == .deny(ruleID: rule!.id))
+    }
+
+    @Test("deny-remember on an any-default verb stays deny, not blocked")
+    func denyRememberStaysDeny() {
+        let store = makeStore()
+        store.add(ExtensionGrantRule(
+            extensionID: "ext",
+            verb: .panesSend,
+            match: .any,
+            decision: .deny
+        ))
+        #expect(store.rules.first?.decision == .deny)
+    }
+
     private func makeStore() -> ExtensionGrantStore {
         ExtensionGrantStore(fileURL: tempURL())
     }

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -50,7 +50,7 @@ The prompt shows the extension, the verb, and the literal payload (full argv, th
 - **Cancel** — denies this one call, asks again next time.
 - **Deny & remember** — denies and writes a deny rule for that payload pattern.
 
-Ticking **Block all … from this extension** before choosing **Deny & remember** widens the rule to an `any` deny for the whole verb, so the extension can never prompt for that kind again (e.g. blocking `exec` once stops all future command prompts, regardless of the command). It replaces any earlier rules for that verb.
+Ticking **Block all … from this extension** before choosing **Deny & remember** writes a `blocked` rule for the whole verb, so the extension can never prompt for that kind again (e.g. blocking `exec` once stops all future command prompts, regardless of the command). It replaces any earlier rules for that verb, including allow rules.
 
 A prompt left unanswered for 60 seconds is denied automatically.
 

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -48,7 +48,9 @@ The prompt shows the extension, the verb, and the literal payload (full argv, th
 - **Allow & remember** — runs the call and writes an allow rule.
 - **Allow** — runs this one call, asks again next time.
 - **Cancel** — denies this one call, asks again next time.
-- **Deny & remember** — denies and writes a deny rule.
+- **Deny & remember** — denies and writes a deny rule for that payload pattern.
+
+Ticking **Block all … from this extension** before choosing **Deny & remember** widens the rule to an `any` deny for the whole verb, so the extension can never prompt for that kind again (e.g. blocking `exec` once stops all future command prompts, regardless of the command). It replaces any earlier rules for that verb.
 
 A prompt left unanswered for 60 seconds is denied automatically.
 


### PR DESCRIPTION
Adds a checkbox to the extension consent prompt that permanently blocks an extension from prompting for an entire permission kind (e.g. all exec, regardless of command). Ticking it widens "Deny & remember" into an absolute any-deny rule that replaces prior rules for that verb.