### PR TITLE
Add custom header buttons to extension panels

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -126,6 +126,7 @@ struct ExtensionPanel: Codable, Equatable, Identifiable {
     let position: PanelPosition
     let mode: PanelMode
     let hiddenControls: [PanelHeaderControl]
+    let headerButtons: [ExtensionPanelHeaderButton]
     let hideTopbar: Bool
     let defaultData: ExtensionJSON?
 
@@ -137,6 +138,7 @@ struct ExtensionPanel: Codable, Equatable, Identifiable {
         case position
         case mode
         case hiddenControls
+        case headerButtons
         case hideTopbar
         case defaultData
     }
@@ -149,6 +151,7 @@ struct ExtensionPanel: Codable, Equatable, Identifiable {
         position: PanelPosition = .right,
         mode: PanelMode = .floating,
         hiddenControls: [PanelHeaderControl] = [],
+        headerButtons: [ExtensionPanelHeaderButton] = [],
         hideTopbar: Bool = false,
         defaultData: ExtensionJSON? = nil
     ) {
@@ -159,6 +162,7 @@ struct ExtensionPanel: Codable, Equatable, Identifiable {
         self.position = position
         self.mode = mode
         self.hiddenControls = hiddenControls
+        self.headerButtons = headerButtons
         self.hideTopbar = hideTopbar
         self.defaultData = defaultData
     }
@@ -172,6 +176,7 @@ struct ExtensionPanel: Codable, Equatable, Identifiable {
         position = try container.decodeIfPresent(PanelPosition.self, forKey: .position) ?? .right
         mode = try container.decodeIfPresent(PanelMode.self, forKey: .mode) ?? .floating
         hiddenControls = try container.decodeIfPresent([PanelHeaderControl].self, forKey: .hiddenControls) ?? []
+        headerButtons = try container.decodeIfPresent([ExtensionPanelHeaderButton].self, forKey: .headerButtons) ?? []
         hideTopbar = try container.decodeIfPresent(Bool.self, forKey: .hideTopbar) ?? false
         defaultData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .defaultData)
     }
@@ -297,6 +302,13 @@ struct ExtensionStatusBarItem: Codable, Equatable, Identifiable {
     let text: String?
     let tooltip: String?
     let side: Side
+    let command: String
+}
+
+struct ExtensionPanelHeaderButton: Codable, Equatable, Identifiable {
+    let id: String
+    let icon: ExtensionIcon
+    let tooltip: String?
     let command: String
 }
 
@@ -657,6 +669,11 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case duplicatePanel(String)
     case panelSVGMissing(panelID: String, url: URL)
     case panelSVGOutsideDirectory(panelID: String, url: URL)
+    case panelHeaderButtonEmptyID(panelID: String)
+    case duplicatePanelHeaderButton(panelID: String, buttonID: String)
+    case panelHeaderButtonReferencesUnknownCommand(panelID: String, buttonID: String, command: String)
+    case panelHeaderButtonSVGMissing(panelID: String, buttonID: String, url: URL)
+    case panelHeaderButtonSVGOutsideDirectory(panelID: String, buttonID: String, url: URL)
     case popoverEntryMissing(popoverID: String, url: URL)
     case popoverEntryOutsideDirectory(popoverID: String, url: URL)
     case duplicatePopover(String)
@@ -713,6 +730,16 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Panel '\(panelID)' icon SVG not found at \(url.path)"
         case let .panelSVGOutsideDirectory(panelID, url):
             "Panel '\(panelID)' icon SVG at \(url.path) escapes the extension directory"
+        case let .panelHeaderButtonEmptyID(panelID):
+            "Panel '\(panelID)' has a header button with an empty id"
+        case let .duplicatePanelHeaderButton(panelID, buttonID):
+            "Panel '\(panelID)' has a duplicate header button '\(buttonID)'"
+        case let .panelHeaderButtonReferencesUnknownCommand(panelID, buttonID, command):
+            "Panel '\(panelID)' header button '\(buttonID)' references unknown command '\(command)'"
+        case let .panelHeaderButtonSVGMissing(panelID, buttonID, url):
+            "Panel '\(panelID)' header button '\(buttonID)' icon SVG not found at \(url.path)"
+        case let .panelHeaderButtonSVGOutsideDirectory(panelID, buttonID, url):
+            "Panel '\(panelID)' header button '\(buttonID)' icon SVG at \(url.path) escapes the extension directory"
         case let .popoverEntryMissing(popoverID, url):
             "Popover '\(popoverID)' entry not found at \(url.path)"
         case let .popoverEntryOutsideDirectory(popoverID, url):
@@ -903,6 +930,7 @@ enum ExtensionManifestLoader {
     }
 
     private static func validatePanels(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
+        let commandIDs = Set(manifest.commands.map(\.id))
         var seen = Set<String>()
         for panel in manifest.panels {
             guard seen.insert(panel.id).inserted else {
@@ -923,6 +951,28 @@ enum ExtensionManifestLoader {
                     in: muxyExtension,
                     missing: { ExtensionLoadError.panelSVGMissing(panelID: panel.id, url: $0) },
                     outside: { ExtensionLoadError.panelSVGOutsideDirectory(panelID: panel.id, url: $0) }
+                )
+            }
+            var seenButtons = Set<String>()
+            for button in panel.headerButtons {
+                guard !button.id.isEmpty else {
+                    throw ExtensionLoadError.panelHeaderButtonEmptyID(panelID: panel.id)
+                }
+                guard seenButtons.insert(button.id).inserted else {
+                    throw ExtensionLoadError.duplicatePanelHeaderButton(panelID: panel.id, buttonID: button.id)
+                }
+                guard commandIDs.contains(button.command) else {
+                    throw ExtensionLoadError.panelHeaderButtonReferencesUnknownCommand(
+                        panelID: panel.id,
+                        buttonID: button.id,
+                        command: button.command
+                    )
+                }
+                try validateIcon(
+                    button.icon,
+                    in: muxyExtension,
+                    missing: { ExtensionLoadError.panelHeaderButtonSVGMissing(panelID: panel.id, buttonID: button.id, url: $0) },
+                    outside: { ExtensionLoadError.panelHeaderButtonSVGOutsideDirectory(panelID: panel.id, buttonID: button.id, url: $0) }
                 )
             }
         }

--- a/Muxy/Models/Panel.swift
+++ b/Muxy/Models/Panel.swift
@@ -34,22 +34,38 @@ enum PanelHeaderControl: String, CaseIterable, Codable {
     case position
 }
 
+enum PanelHeaderButtonIcon: Equatable {
+    case symbol(String)
+    case extensionIcon(ExtensionIcon, MuxyExtension)
+
+    static func == (lhs: PanelHeaderButtonIcon, rhs: PanelHeaderButtonIcon) -> Bool {
+        switch (lhs, rhs) {
+        case let (.symbol(left), .symbol(right)):
+            left == right
+        case let (.extensionIcon(leftIcon, leftExtension), .extensionIcon(rightIcon, rightExtension)):
+            leftIcon == rightIcon && leftExtension.id == rightExtension.id
+        default:
+            false
+        }
+    }
+}
+
 struct PanelHeaderButton: Identifiable, Equatable {
     let id: String
-    let symbol: String
+    let icon: PanelHeaderButtonIcon
     let label: String
     let isActive: Bool
     let action: () -> Void
 
     init(
         id: String,
-        symbol: String,
+        icon: PanelHeaderButtonIcon,
         label: String,
         isActive: Bool = false,
         action: @escaping () -> Void
     ) {
         self.id = id
-        self.symbol = symbol
+        self.icon = icon
         self.label = label
         self.isActive = isActive
         self.action = action
@@ -57,7 +73,7 @@ struct PanelHeaderButton: Identifiable, Equatable {
 
     static func == (lhs: PanelHeaderButton, rhs: PanelHeaderButton) -> Bool {
         lhs.id == rhs.id
-            && lhs.symbol == rhs.symbol
+            && lhs.icon == rhs.icon
             && lhs.label == rhs.label
             && lhs.isActive == rhs.isActive
     }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1039,9 +1039,9 @@ struct MainWindow: View {
     private var richInputBroadcastButton: PanelHeaderButton {
         PanelHeaderButton(
             id: "richInput.broadcast",
-            symbol: richInputBroadcast
+            icon: .symbol(richInputBroadcast
                 ? "dot.radiowaves.left.and.right"
-                : "antenna.radiowaves.left.and.right.slash",
+                : "antenna.radiowaves.left.and.right.slash"),
             label: richInputBroadcast
                 ? "Broadcast On — Send to All Split Panes"
                 : "Broadcast Off — Send to Active Pane",

--- a/Muxy/Views/Panels/ExtensionPanelView.swift
+++ b/Muxy/Views/Panels/ExtensionPanelView.swift
@@ -41,7 +41,32 @@ struct ExtensionPanelView: View {
             iconSymbol: panel.icon.flatMap(symbol(from:)),
             title: panel.title,
             hiddenControls: Set(panel.hiddenControls),
+            trailingButtons: headerButtons(for: panel),
             hidesHeader: panel.hideTopbar
+        )
+    }
+
+    private func headerButtons(for panel: ExtensionPanel) -> [PanelHeaderButton] {
+        panel.headerButtons.compactMap { button in
+            guard let symbol = symbol(from: button.icon) else { return nil }
+            return PanelHeaderButton(
+                id: button.id,
+                symbol: symbol,
+                label: button.tooltip ?? button.id,
+                action: { trigger(command: button.command) }
+            )
+        }
+    }
+
+    private func trigger(command commandID: String) {
+        ExtensionStore.shared.triggerCommand(
+            ExtensionStore.CommandInvocation(
+                extensionID: state.extensionID,
+                commandID: commandID,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
         )
     }
 

--- a/Muxy/Views/Panels/ExtensionPanelView.swift
+++ b/Muxy/Views/Panels/ExtensionPanelView.swift
@@ -14,7 +14,7 @@ struct ExtensionPanelView: View {
            let entryURL = ExtensionWebView.entryURL(for: muxyExtension, entry: panel.entry)
         {
             PanelContainer(
-                chrome: chrome(for: panel),
+                chrome: chrome(for: panel, in: muxyExtension),
                 mode: placement.mode,
                 position: placement.position,
                 onClose: { ExtensionPanelRegistry.shared.close(hostPanelID: state.hostPanelID) },
@@ -36,22 +36,21 @@ struct ExtensionPanelView: View {
         }
     }
 
-    private func chrome(for panel: ExtensionPanel) -> PanelChrome {
+    private func chrome(for panel: ExtensionPanel, in muxyExtension: MuxyExtension) -> PanelChrome {
         PanelChrome(
             iconSymbol: panel.icon.flatMap(symbol(from:)),
             title: panel.title,
             hiddenControls: Set(panel.hiddenControls),
-            trailingButtons: headerButtons(for: panel),
+            trailingButtons: headerButtons(for: panel, in: muxyExtension),
             hidesHeader: panel.hideTopbar
         )
     }
 
-    private func headerButtons(for panel: ExtensionPanel) -> [PanelHeaderButton] {
-        panel.headerButtons.compactMap { button in
-            guard let symbol = symbol(from: button.icon) else { return nil }
-            return PanelHeaderButton(
+    private func headerButtons(for panel: ExtensionPanel, in muxyExtension: MuxyExtension) -> [PanelHeaderButton] {
+        panel.headerButtons.map { button in
+            PanelHeaderButton(
                 id: button.id,
-                symbol: symbol,
+                icon: .extensionIcon(button.icon, muxyExtension),
                 label: button.tooltip ?? button.id,
                 action: { trigger(command: button.command) }
             )

--- a/Muxy/Views/Panels/PanelContainer.swift
+++ b/Muxy/Views/Panels/PanelContainer.swift
@@ -64,15 +64,29 @@ struct PanelContainer<Content: View>: View {
         .background(MuxyTheme.bg)
     }
 
+    @ViewBuilder
     private func customButton(_ button: PanelHeaderButton) -> some View {
-        IconButton(
-            symbol: button.symbol,
-            color: button.isActive ? MuxyTheme.accent : MuxyTheme.fgMuted,
-            hoverColor: button.isActive ? MuxyTheme.accent : MuxyTheme.fg,
-            accessibilityLabel: button.label,
-            action: button.action
-        )
-        .help(button.label)
+        switch button.icon {
+        case let .symbol(name):
+            IconButton(
+                symbol: name,
+                color: button.isActive ? MuxyTheme.accent : MuxyTheme.fgMuted,
+                hoverColor: button.isActive ? MuxyTheme.accent : MuxyTheme.fg,
+                accessibilityLabel: button.label,
+                action: button.action
+            )
+            .help(button.label)
+        case let .extensionIcon(icon, muxyExtension):
+            ExtensionIconButton(
+                icon: icon,
+                muxyExtension: muxyExtension,
+                color: button.isActive ? MuxyTheme.accent : MuxyTheme.fgMuted,
+                hoverColor: button.isActive ? MuxyTheme.accent : MuxyTheme.fg,
+                accessibilityLabel: button.label,
+                action: button.action
+            )
+            .help(button.label)
+        }
     }
 
     private func control(symbol: String, label: String, action: @escaping () -> Void) -> some View {

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -386,6 +386,61 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("rejects panel header button referencing unknown command")
+    func rejectsPanelHeaderButtonUnknownCommand() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-hb-bad",
+                "version": "1.0.0",
+                "panels": [
+                    {
+                        "id": "side",
+                        "entry": "panels/side.html",
+                        "headerButtons": [
+                            { "id": "prs", "icon": "arrow.triangle.pull", "command": "missing" }
+                        ]
+                    }
+                ]
+            }
+            """,
+            files: ["panels/side.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("loads a panel with a valid header button")
+    func loadsPanelHeaderButton() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-hb-ok",
+                "version": "1.0.0",
+                "commands": [ { "id": "show-prs", "title": "PRs" } ],
+                "panels": [
+                    {
+                        "id": "side",
+                        "entry": "panels/side.html",
+                        "headerButtons": [
+                            { "id": "prs", "icon": "arrow.triangle.pull", "command": "show-prs" }
+                        ]
+                    }
+                ]
+            }
+            """,
+            files: ["panels/side.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+        let panel = try #require(ext.manifest.panel(id: "side"))
+        #expect(panel.headerButtons.map(\.id) == ["prs"])
+    }
+
     @Test("rejects topbar item with missing SVG")
     func rejectsTopbarMissingSVG() throws {
         let directory = try makeTemporaryExtension(
@@ -535,6 +590,9 @@ struct ExtensionManifestTests {
                     "position": "bottom",
                     "mode": "pinned",
                     "hiddenControls": ["pin", "position"],
+                    "headerButtons": [
+                        { "id": "prs", "icon": { "symbol": "arrow.triangle.pull" }, "tooltip": "PRs", "command": "show-prs" }
+                    ],
                     "hideTopbar": true
                 }
             ]
@@ -546,12 +604,16 @@ struct ExtensionManifestTests {
         #expect(minimal.position == .right)
         #expect(minimal.mode == .floating)
         #expect(minimal.hiddenControls.isEmpty)
+        #expect(minimal.headerButtons.isEmpty)
         #expect(!minimal.hideTopbar)
         let full = try #require(manifest.panel(id: "full"))
         #expect(full.title == "Sidebar")
         #expect(full.position == .bottom)
         #expect(full.mode == .pinned)
         #expect(full.hiddenControls == [.pin, .position])
+        #expect(full.headerButtons == [
+            ExtensionPanelHeaderButton(id: "prs", icon: .symbol("arrow.triangle.pull"), tooltip: "PRs", command: "show-prs")
+        ])
         #expect(full.hideTopbar)
     }
 

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -441,6 +441,122 @@ struct ExtensionManifestTests {
         #expect(panel.headerButtons.map(\.id) == ["prs"])
     }
 
+    @Test("rejects panel header button with empty id")
+    func rejectsPanelHeaderButtonEmptyID() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-hb-empty",
+                "version": "1.0.0",
+                "commands": [ { "id": "show-prs", "title": "PRs" } ],
+                "panels": [
+                    {
+                        "id": "side",
+                        "entry": "panels/side.html",
+                        "headerButtons": [
+                            { "id": "", "icon": "arrow.triangle.pull", "command": "show-prs" }
+                        ]
+                    }
+                ]
+            }
+            """,
+            files: ["panels/side.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects duplicate panel header button ids")
+    func rejectsDuplicatePanelHeaderButton() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-hb-dup",
+                "version": "1.0.0",
+                "commands": [ { "id": "show-prs", "title": "PRs" } ],
+                "panels": [
+                    {
+                        "id": "side",
+                        "entry": "panels/side.html",
+                        "headerButtons": [
+                            { "id": "prs", "icon": "arrow.triangle.pull", "command": "show-prs" },
+                            { "id": "prs", "icon": "pencil", "command": "show-prs" }
+                        ]
+                    }
+                ]
+            }
+            """,
+            files: ["panels/side.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects panel header button with missing SVG")
+    func rejectsPanelHeaderButtonMissingSVG() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-hb-svg",
+                "version": "1.0.0",
+                "commands": [ { "id": "show-prs", "title": "PRs" } ],
+                "panels": [
+                    {
+                        "id": "side",
+                        "entry": "panels/side.html",
+                        "headerButtons": [
+                            { "id": "prs", "icon": { "svg": "assets/missing.svg" }, "command": "show-prs" }
+                        ]
+                    }
+                ]
+            }
+            """,
+            files: ["panels/side.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("loads a panel header button with an SVG icon")
+    func loadsPanelHeaderButtonSVG() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "panel-hb-svg-ok",
+                "version": "1.0.0",
+                "commands": [ { "id": "show-prs", "title": "PRs" } ],
+                "panels": [
+                    {
+                        "id": "side",
+                        "entry": "panels/side.html",
+                        "headerButtons": [
+                            { "id": "prs", "icon": { "svg": "assets/prs.svg" }, "command": "show-prs" }
+                        ]
+                    }
+                ]
+            }
+            """,
+            files: [
+                "panels/side.html": "<html></html>",
+                "assets/prs.svg": "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>",
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+        let panel = try #require(ext.manifest.panel(id: "side"))
+        #expect(panel.headerButtons.first?.icon == .svg("assets/prs.svg"))
+    }
+
     @Test("rejects topbar item with missing SVG")
     func rejectsTopbarMissingSVG() throws {
         let directory = try makeTemporaryExtension(

--- a/docs/extensions/panels.md
+++ b/docs/extensions/panels.md
@@ -79,11 +79,11 @@ A panel may declare custom icon buttons that sit in its native header, just left
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `id` | string | yes | Unique within the panel. |
-| `icon` | object | yes | `{ "symbol": "<sf-symbol>" }`. SVG icons are not yet supported in the header; declare an SF Symbol. |
+| `icon` | object | yes | `{ "symbol": "<sf-symbol>" }` or `{ "svg": "icons/foo.svg" }`, same as topbar and status-bar icons. |
 | `tooltip` | string | no | Hover tooltip / accessibility label. Defaults to the `id`. |
 | `command` | string | yes | Must reference a declared `commands[].id`. |
 
-A header button with an `event` command fires `command.<id>` to your pages — the panel webview subscribes with `muxy.events.subscribe('command.<id>', …)` to react (e.g. switch the active view). Header buttons are hidden when `hideTopbar` is `true`, since there is no header to host them.
+A header button with an `event` command fires `command.<id>` to your pages — the panel webview subscribes with `muxy.events.subscribe('command.<id>', …)` to react (e.g. switch the active view). `openPopover` commands do nothing from a header button, since the button is not a popover anchor; use `event`, `togglePanel`, `openTab`, or `runScript`. Header buttons are hidden when `hideTopbar` is `true`, since there is no header to host them.
 
 Set `hideTopbar: true` to drop the header entirely — no icon, title, or controls — and render the panel as a single edge-to-edge webview. The panel must then provide its own way to close itself (e.g. a `togglePanel` command, or `window.muxy.panels.close`).
 

--- a/docs/extensions/panels.md
+++ b/docs/extensions/panels.md
@@ -42,12 +42,48 @@ Every panel, built-in or extension, follows the same placement rules per positio
 | `position` | string | no | `right` or `bottom`. Defaults to `right`. |
 | `mode` | string | no | `floating` or `pinned`. Defaults to `floating`. |
 | `hiddenControls` | string[] | no | Header controls to hide: any of `close`, `pin`, `position`. Defaults to none hidden. |
+| `headerButtons` | object[] | no | Custom action icons in the panel header, left of the built-in controls. See [Header buttons](#header-buttons). |
 | `hideTopbar` | boolean | no | Hide the entire panel header, including icon, title, and all controls. Your webview fills the whole panel. Defaults to `false`. |
 | `defaultData` | object | no | JSON merged into `window.muxy.data` when no explicit data is passed. |
 
 ## Header controls
 
-The host owns the panel header: optional icon and title on the left; on the right (unless hidden via `hiddenControls`) a position toggle (right ⇄ bottom), a pin toggle (float ⇄ dock), and a close button. Your webview fills the rest.
+The host owns the panel header: optional icon and title on the left; on the right (unless hidden via `hiddenControls`) any custom `headerButtons`, then a position toggle (right ⇄ bottom), a pin toggle (float ⇄ dock), and a close button. Your webview fills the rest.
+
+## Header buttons
+
+A panel may declare custom icon buttons that sit in its native header, just left of the position/pin/close controls. Each button runs one of the extension's [commands](palette-commands.md) when clicked — the same dispatch path as a topbar or status-bar item. Use them for in-header view switches or actions that should stay visible regardless of what the webview scrolls.
+
+```json
+{
+  "panels": [
+    {
+      "id": "scm",
+      "title": "Source Control",
+      "entry": "panel/index.html",
+      "position": "right",
+      "mode": "pinned",
+      "headerButtons": [
+        { "id": "changes", "icon": { "symbol": "pencil" }, "tooltip": "Changes", "command": "show-changes" },
+        { "id": "prs", "icon": { "symbol": "arrow.triangle.pull" }, "tooltip": "Pull Requests", "command": "show-prs" }
+      ]
+    }
+  ],
+  "commands": [
+    { "id": "show-changes", "title": "Git: Changes" },
+    { "id": "show-prs", "title": "Git: Pull Requests" }
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Unique within the panel. |
+| `icon` | object | yes | `{ "symbol": "<sf-symbol>" }`. SVG icons are not yet supported in the header; declare an SF Symbol. |
+| `tooltip` | string | no | Hover tooltip / accessibility label. Defaults to the `id`. |
+| `command` | string | yes | Must reference a declared `commands[].id`. |
+
+A header button with an `event` command fires `command.<id>` to your pages — the panel webview subscribes with `muxy.events.subscribe('command.<id>', …)` to react (e.g. switch the active view). Header buttons are hidden when `hideTopbar` is `true`, since there is no header to host them.
 
 Set `hideTopbar: true` to drop the header entirely — no icon, title, or controls — and render the panel as a single edge-to-edge webview. The panel must then provide its own way to close itself (e.g. a `togglePanel` command, or `window.muxy.panels.close`).
 

--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -194,7 +194,22 @@
           "items": { "enum": ["close", "pin", "position"] },
           "uniqueItems": true
         },
+        "headerButtons": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/panelHeaderButton" }
+        },
         "defaultData": {}
+      }
+    },
+    "panelHeaderButton": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "icon", "command"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "icon": { "$ref": "#/$defs/icon" },
+        "tooltip": { "type": "string" },
+        "command": { "type": "string", "minLength": 1 }
       }
     },
     "popover": {


### PR DESCRIPTION
Extensions can declare `headerButtons` on a panel — icon buttons in the native header that dispatch a declared command on click, same path as topbar/status-bar items.

Validated at load (unique id, known command, icon present); docs, manifest schema, and tests updated.