### PR TITLE
Fix extension panel and topbar chrome

### DIFF
--- a/Muxy/Models/Panel.swift
+++ b/Muxy/Models/Panel.swift
@@ -29,6 +29,8 @@ enum PanelMode: String, CaseIterable, Identifiable, Codable {
 }
 
 enum PanelHeaderControl: String, CaseIterable, Codable {
+    case icon
+    case title
     case close
     case pin
     case position
@@ -104,11 +106,21 @@ struct PanelChrome {
         !hiddenControls.contains(control)
     }
 
+    var showsIcon: Bool {
+        iconSymbol != nil && shows(.icon)
+    }
+
+    var showsTitle: Bool {
+        title != nil && shows(.title)
+    }
+
     var hasHeaderContent: Bool {
         guard !hidesHeader else { return false }
-        return iconSymbol != nil
-            || title != nil
+        return showsIcon
+            || showsTitle
             || !trailingButtons.isEmpty
-            || !hiddenControls.isSuperset(of: PanelHeaderControl.allCases)
+            || shows(.close)
+            || shows(.pin)
+            || shows(.position)
     }
 }

--- a/Muxy/Views/Components/ExtensionTopbarItems.swift
+++ b/Muxy/Views/Components/ExtensionTopbarItems.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ExtensionTopbarItems: View {
+    @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
+    @Environment(ExtensionStore.self) private var extensionStore
+    @State private var popoverHost = PopoverHost.shared
+
+    var body: some View {
+        ForEach(extensionStore.topbarItems) { binding in
+            ExtensionIconButton(
+                icon: binding.displayIcon,
+                muxyExtension: binding.muxyExtension,
+                accessibilityLabel: binding.item.tooltip ?? binding.item.id,
+                action: { triggerCommand(binding: binding) }
+            )
+            .help(binding.item.tooltip ?? binding.item.id)
+            .extensionPopover(anchorID: binding.id, host: popoverHost)
+        }
+    }
+
+    private func triggerCommand(binding: ExtensionStore.TopbarItemBinding) {
+        if let popover = extensionStore.popover(for: binding.muxyExtension, command: binding.item.command) {
+            popoverHost.toggle(
+                anchorID: binding.id,
+                extensionID: binding.muxyExtension.id,
+                popover: popover,
+                data: nil
+            )
+            return
+        }
+        extensionStore.triggerCommand(
+            ExtensionStore.CommandInvocation(
+                extensionID: binding.muxyExtension.id,
+                commandID: binding.item.command,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+        )
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -522,6 +522,7 @@ struct MainWindow: View {
                             }
                             .help("Quick Open (\(KeyBindingStore.shared.combo(for: .quickOpen).displayString))")
                         }
+                        ExtensionTopbarItems()
                     }
                     .padding(.trailing, UIMetrics.spacing2)
                 }
@@ -1026,6 +1027,7 @@ struct MainWindow: View {
                 state: state,
                 placement: PanelPlacement(panelID: panelID, position: position, mode: mode)
             )
+            .id(panelID)
             .modifier(PanelFrame(
                 position: position,
                 size: position == .bottom ? $extensionPanelHeight : $extensionPanelWidth,

--- a/Muxy/Views/Panels/PanelContainer.swift
+++ b/Muxy/Views/Panels/PanelContainer.swift
@@ -23,12 +23,12 @@ struct PanelContainer<Content: View>: View {
 
     private var header: some View {
         HStack(spacing: UIMetrics.spacing2) {
-            if let symbol = chrome.iconSymbol {
+            if chrome.showsIcon, let symbol = chrome.iconSymbol {
                 Image(systemName: symbol)
                     .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fgMuted)
             }
-            if let title = chrome.title {
+            if chrome.showsTitle, let title = chrome.title {
                 Text(title)
                     .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg)

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -41,11 +41,6 @@ struct PaneTabStrip: View {
     let onSetColorID: (UUID, String?) -> Void
     let onReorderTab: (IndexSet, Int) -> Void
     @Environment(TabDragCoordinator.self) private var dragCoordinator
-    @Environment(AppState.self) private var appState
-    @Environment(ProjectStore.self) private var projectStore
-    @Environment(WorktreeStore.self) private var worktreeStore
-    @Environment(ExtensionStore.self) private var extensionStore
-    @State private var popoverHost = PopoverHost.shared
     @State private var dragState = TabDragState()
 
     static func snapshots(from tabs: [TerminalTab]) -> [TabSnapshot] {
@@ -92,6 +87,7 @@ struct PaneTabStrip: View {
                         cursorProvider: openInIDECursorProvider
                     )
                     LayoutPickerMenu(projectID: projectID)
+                    ExtensionTopbarItems()
                 }
                 if showMaximizeButton || isMaximized, let onToggleMaximize {
                     let symbol = isMaximized
@@ -100,16 +96,6 @@ struct PaneTabStrip: View {
                     let label = isMaximized ? "Restore Pane" : "Maximize Pane"
                     IconButton(symbol: symbol, accessibilityLabel: label, action: onToggleMaximize)
                         .help(shortcutTooltip("Toggle Maximize Pane", for: .toggleMaximizePane))
-                }
-                ForEach(extensionStore.topbarItems) { binding in
-                    ExtensionIconButton(
-                        icon: binding.displayIcon,
-                        muxyExtension: binding.muxyExtension,
-                        accessibilityLabel: binding.item.tooltip ?? binding.item.id,
-                        action: { triggerExtensionCommand(binding: binding) }
-                    )
-                    .help(binding.item.tooltip ?? binding.item.id)
-                    .extensionPopover(anchorID: binding.id, host: popoverHost)
                 }
                 IconButton(symbol: "square.split.2x1", accessibilityLabel: "Split Right") { onSplit(.horizontal) }
                     .help(shortcutTooltip("Split Right", for: .splitRight))
@@ -207,27 +193,6 @@ struct PaneTabStrip: View {
 
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {
         "\(name) (\(KeyBindingStore.shared.combo(for: action).displayString))"
-    }
-
-    private func triggerExtensionCommand(binding: ExtensionStore.TopbarItemBinding) {
-        if let popover = extensionStore.popover(for: binding.muxyExtension, command: binding.item.command) {
-            popoverHost.toggle(
-                anchorID: binding.id,
-                extensionID: binding.muxyExtension.id,
-                popover: popover,
-                data: nil
-            )
-            return
-        }
-        extensionStore.triggerCommand(
-            ExtensionStore.CommandInvocation(
-                extensionID: binding.muxyExtension.id,
-                commandID: binding.item.command,
-                appState: appState,
-                projectStore: projectStore,
-                worktreeStore: worktreeStore
-            )
-        )
     }
 
     private var developmentBadge: some View {

--- a/docs/extensions/panels.md
+++ b/docs/extensions/panels.md
@@ -41,14 +41,14 @@ Every panel, built-in or extension, follows the same placement rules per positio
 | `icon` | string \| object | no | SF Symbol name, or `{ "svg": "assets/icon.svg" }`. Shown in the header. |
 | `position` | string | no | `right` or `bottom`. Defaults to `right`. |
 | `mode` | string | no | `floating` or `pinned`. Defaults to `floating`. |
-| `hiddenControls` | string[] | no | Header controls to hide: any of `close`, `pin`, `position`. Defaults to none hidden. |
+| `hiddenControls` | string[] | no | Header elements to hide individually: any of `icon`, `title`, `close`, `pin`, `position`. Defaults to none hidden. |
 | `headerButtons` | object[] | no | Custom action icons in the panel header, left of the built-in controls. See [Header buttons](#header-buttons). |
 | `hideTopbar` | boolean | no | Hide the entire panel header, including icon, title, and all controls. Your webview fills the whole panel. Defaults to `false`. |
 | `defaultData` | object | no | JSON merged into `window.muxy.data` when no explicit data is passed. |
 
 ## Header controls
 
-The host owns the panel header: optional icon and title on the left; on the right (unless hidden via `hiddenControls`) any custom `headerButtons`, then a position toggle (right ⇄ bottom), a pin toggle (float ⇄ dock), and a close button. Your webview fills the rest.
+The host owns the panel header: optional icon and title on the left; on the right, any custom `headerButtons`, then a position toggle (right ⇄ bottom), a pin toggle (float ⇄ dock), and a close button. Hide any element individually via `hiddenControls` (`icon`, `title`, `close`, `pin`, `position`) — or drop the whole header with `hideTopbar`. Your webview fills the rest.
 
 ## Header buttons
 

--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -191,7 +191,7 @@
         "mode": { "enum": ["pinned", "floating"] },
         "hiddenControls": {
           "type": "array",
-          "items": { "enum": ["close", "pin", "position"] },
+          "items": { "enum": ["icon", "title", "close", "pin", "position"] },
           "uniqueItems": true
         },
         "headerButtons": {


### PR DESCRIPTION
Extension topbar items now render in the real window title bar instead of per-pane tab strips.
Extension panels are keyed by panelID so switching extensions reloads the webview content.
Extensions can hide the panel header icon/title individually via `hiddenControls`.