### PR TITLE
Fix extension host socket connect race

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -148,6 +148,7 @@ struct MuxyApp: App {
             UpdateService.shared.start()
             AIProviderRegistry.shared.installAll()
             LoginShellPath.hydrateInBackground()
+            await NotificationSocketServer.shared.awaitReady()
             ExtensionStore.shared.startAll()
             await ExtensionStore.shared.checkForUpdates()
         }

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -40,6 +40,8 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private var serverFD: Int32 = -1
     private var acceptSource: DispatchSourceRead?
+    private var didFinishListening = false
+    private var readyContinuations: [CheckedContinuation<Void, Never>] = []
     private let queue = DispatchQueue(label: "app.muxy.notificationSocket")
     private var subscribers: [ObjectIdentifier: ClientSession] = [:]
     private var liveSessionByExtension: [String: ClientSession] = [:]
@@ -68,6 +70,22 @@ final class NotificationSocketServer: @unchecked Sendable {
     func start() {
         queue.async { [weak self] in
             self?.startListening()
+        }
+    }
+
+    func awaitReady() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            queue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                guard !self.didFinishListening else {
+                    continuation.resume()
+                    return
+                }
+                self.readyContinuations.append(continuation)
+            }
         }
     }
 
@@ -213,6 +231,7 @@ final class NotificationSocketServer: @unchecked Sendable {
     }
 
     private func startListening() {
+        defer { markListeningFinished() }
         let path = Self.socketPath
         unlink(path)
 
@@ -615,6 +634,15 @@ final class NotificationSocketServer: @unchecked Sendable {
         session.writeSource = nil
         if session.fd >= 0, !session.pendingClose {
             close(session.fd)
+        }
+    }
+
+    private func markListeningFinished() {
+        didFinishListening = true
+        let waiters = readyContinuations
+        readyContinuations.removeAll()
+        for waiter in waiters {
+            waiter.resume()
         }
     }
 

--- a/MuxyExtensionHost/HostSocketClient.swift
+++ b/MuxyExtensionHost/HostSocketClient.swift
@@ -18,19 +18,23 @@ final class HostSocketClient: @unchecked Sendable {
     private var eventHandler: ((String) -> Void)?
     private var invokeHandler: ((String) -> Void)?
 
-    static let maxConnectAttempts = 50
+    static let maxConnectAttempts = 15
     static let connectRetryDelay: TimeInterval = 0.1
 
-    init(socketPath: String) throws {
+    init(
+        socketPath: String,
+        maxConnectAttempts: Int = HostSocketClient.maxConnectAttempts,
+        connectRetryDelay: TimeInterval = HostSocketClient.connectRetryDelay
+    ) throws {
         var lastError = ""
-        for attempt in 1 ... Self.maxConnectAttempts {
+        for attempt in 1 ... maxConnectAttempts {
             do {
                 fd = try Self.connect(to: socketPath)
                 return
             } catch let ClientError.connectFailed(reason) {
                 lastError = reason
-                guard attempt < Self.maxConnectAttempts else { break }
-                Thread.sleep(forTimeInterval: Self.connectRetryDelay)
+                guard attempt < maxConnectAttempts else { break }
+                Thread.sleep(forTimeInterval: connectRetryDelay)
             }
         }
         throw ClientError.connectFailed(lastError)

--- a/MuxyExtensionHost/HostSocketClient.swift
+++ b/MuxyExtensionHost/HostSocketClient.swift
@@ -18,7 +18,25 @@ final class HostSocketClient: @unchecked Sendable {
     private var eventHandler: ((String) -> Void)?
     private var invokeHandler: ((String) -> Void)?
 
+    static let maxConnectAttempts = 50
+    static let connectRetryDelay: TimeInterval = 0.1
+
     init(socketPath: String) throws {
+        var lastError = ""
+        for attempt in 1 ... Self.maxConnectAttempts {
+            do {
+                fd = try Self.connect(to: socketPath)
+                return
+            } catch let ClientError.connectFailed(reason) {
+                lastError = reason
+                guard attempt < Self.maxConnectAttempts else { break }
+                Thread.sleep(forTimeInterval: Self.connectRetryDelay)
+            }
+        }
+        throw ClientError.connectFailed(lastError)
+    }
+
+    private static func connect(to socketPath: String) throws -> Int32 {
         let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
         guard descriptor >= 0 else {
             throw ClientError.connectFailed(String(cString: strerror(errno)))
@@ -33,7 +51,7 @@ final class HostSocketClient: @unchecked Sendable {
 
         let result = withUnsafePointer(to: &addr) { ptr in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
             }
         }
         guard result == 0 else {
@@ -41,7 +59,7 @@ final class HostSocketClient: @unchecked Sendable {
             throw ClientError.connectFailed(String(cString: strerror(errno)))
         }
 
-        fd = descriptor
+        return descriptor
     }
 
     init(fileDescriptor: Int32) {

--- a/Tests/MuxyTests/Services/HostSocketClientTests.swift
+++ b/Tests/MuxyTests/Services/HostSocketClientTests.swift
@@ -25,7 +25,7 @@ struct HostSocketClientTests {
 
         var thrown: HostSocketClient.ClientError?
         do {
-            _ = try HostSocketClient(socketPath: path)
+            _ = try HostSocketClient(socketPath: path, maxConnectAttempts: 3, connectRetryDelay: 0.01)
         } catch let error as HostSocketClient.ClientError {
             thrown = error
         } catch {}

--- a/Tests/MuxyTests/Services/HostSocketClientTests.swift
+++ b/Tests/MuxyTests/Services/HostSocketClientTests.swift
@@ -1,0 +1,65 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import MuxyExtensionHost
+
+@Suite("HostSocketClient connection retry")
+struct HostSocketClientTests {
+    @Test("connects to a listening server")
+    func connectsToListeningServer() throws {
+        let path = Self.temporarySocketPath()
+        let listener = try Self.bindListener(at: path)
+        defer {
+            close(listener)
+            unlink(path)
+        }
+
+        let client = try HostSocketClient(socketPath: path)
+        #expect(client.isClosed == false)
+    }
+
+    @Test("gives up with connectFailed when no server appears")
+    func givesUpWhenServerNeverAppears() {
+        let path = Self.temporarySocketPath()
+
+        var thrown: HostSocketClient.ClientError?
+        do {
+            _ = try HostSocketClient(socketPath: path)
+        } catch let error as HostSocketClient.ClientError {
+            thrown = error
+        } catch {}
+
+        guard case .connectFailed = thrown else {
+            Issue.record("expected connectFailed, got \(String(describing: thrown))")
+            return
+        }
+    }
+
+    private static func temporarySocketPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-host-test-\(UUID().uuidString).sock")
+            .path
+    }
+
+    private static func bindListener(at path: String) throws -> Int32 {
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            let bound = ptr.withMemoryRebound(to: CChar.self, capacity: 104) { $0 }
+            _ = path.withCString { strncpy(bound, $0, 103) }
+        }
+
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard result == 0, listen(descriptor, 5) == 0 else {
+            close(descriptor)
+            throw HostSocketClient.ClientError.connectFailed(String(cString: strerror(errno)))
+        }
+        return descriptor
+    }
+}

--- a/Tests/MuxyTests/Services/NotificationSocketReadyTests.swift
+++ b/Tests/MuxyTests/Services/NotificationSocketReadyTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("NotificationSocketServer readiness gate")
+struct NotificationSocketReadyTests {
+    @Test("awaitReady resolves once the server finishes listening")
+    func resolvesAfterStart() async throws {
+        let server = NotificationSocketServer.shared
+        server.start()
+
+        try await Self.withTimeout(seconds: 5) {
+            await server.awaitReady()
+        }
+    }
+
+    @Test("awaitReady resolves immediately when listening already finished")
+    func resolvesImmediatelyWhenAlreadyReady() async throws {
+        let server = NotificationSocketServer.shared
+        server.start()
+        await server.awaitReady()
+
+        try await Self.withTimeout(seconds: 1) {
+            await server.awaitReady()
+        }
+    }
+
+    private static func withTimeout(
+        seconds: TimeInterval,
+        _ operation: @escaping @Sendable () async -> Void
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(seconds))
+                throw CancellationError()
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
+}


### PR DESCRIPTION
Extension hosts connected to the Muxy socket exactly once and died with `connectFailed("No such file or directory")` when they spawned before the socket was bound, requiring an app restart.

The host now retries the connect (~5s) so it self-heals on startup and on extension reload.