### PR TITLE
Show app & subprocess resource usage in the status bar

### DIFF
--- a/Muxy/Models/ProcessUsage.swift
+++ b/Muxy/Models/ProcessUsage.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+enum ProcessGroup: String, CaseIterable {
+    case app
+    case extensionHost
+    case orphan
+
+    var title: String {
+        switch self {
+        case .app: "App"
+        case .extensionHost: "Extensions"
+        case .orphan: "Orphans"
+        }
+    }
+}
+
+struct ProcessUsageRow: Identifiable, Equatable {
+    let pid: pid_t
+    let name: String
+    let cpuPercent: Double?
+    let memoryBytes: UInt64
+    let group: ProcessGroup
+
+    var id: pid_t { pid }
+}
+
+struct ProcessUsageSnapshot: Equatable {
+    let rows: [ProcessUsageRow]
+    let totalCPUPercent: Double?
+    let totalMemoryBytes: UInt64
+
+    static let empty = ProcessUsageSnapshot(rows: [], totalCPUPercent: nil, totalMemoryBytes: 0)
+
+    func rows(in group: ProcessGroup) -> [ProcessUsageRow] {
+        rows.filter { $0.group == group }
+    }
+
+    static func make(from rows: [ProcessUsageRow]) -> ProcessUsageSnapshot {
+        let sorted = rows.sorted { lhs, rhs in
+            if lhs.group != rhs.group {
+                return groupOrder(lhs.group) < groupOrder(rhs.group)
+            }
+            if (lhs.cpuPercent ?? 0) != (rhs.cpuPercent ?? 0) {
+                return (lhs.cpuPercent ?? 0) > (rhs.cpuPercent ?? 0)
+            }
+            return lhs.memoryBytes > rhs.memoryBytes
+        }
+        let cpuValues = rows.compactMap(\.cpuPercent)
+        let totalCPU = cpuValues.isEmpty ? nil : cpuValues.reduce(0, +)
+        let totalMemory = rows.reduce(UInt64(0)) { $0 + $1.memoryBytes }
+        return ProcessUsageSnapshot(rows: sorted, totalCPUPercent: totalCPU, totalMemoryBytes: totalMemory)
+    }
+
+    private static func groupOrder(_ group: ProcessGroup) -> Int {
+        switch group {
+        case .app: 0
+        case .extensionHost: 1
+        case .orphan: 2
+        }
+    }
+}
+
+enum ProcessUsageFormat {
+    static func compactMemory(_ bytes: UInt64) -> String {
+        let units = ["B", "K", "M", "G", "T"]
+        var value = Double(bytes)
+        var unit = 0
+        while value >= 1024, unit < units.count - 1 {
+            value /= 1024
+            unit += 1
+        }
+        if unit == 0 {
+            return "\(Int(value))\(units[unit])"
+        }
+        let format = value < 10 ? "%.1f%@" : "%.0f%@"
+        return String(format: format, value, units[unit])
+    }
+
+    static func compactCPU(_ percent: Double?) -> String {
+        guard let percent else { return "—" }
+        return "\(Int(percent.rounded()))%"
+    }
+}

--- a/Muxy/Models/ResourceUsagePreferences.swift
+++ b/Muxy/Models/ResourceUsagePreferences.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum ResourceUsagePreferences {
+    static let visibleKey = "muxy.showResourceUsageInStatusBar"
+    static let defaultVisible = true
+}

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -41,6 +41,7 @@ final class ExtensionStore {
     private(set) var availableUpdates: [String: String] = [:]
 
     private var processes: [String: Process] = [:]
+    private(set) var spawnedHostPGIDs: Set<pid_t> = []
     private var tokens: [String: String] = [:]
     private var intentionalStops: Set<String> = []
     private var crashRestartAttempts: [String: Int] = [:]
@@ -86,6 +87,10 @@ final class ExtensionStore {
 
     func hasSpawnedProcessForTesting(extensionID: String) -> Bool {
         processes[extensionID] != nil
+    }
+
+    func spawnedHostPIDs() -> Set<pid_t> {
+        Set(processes.values.map(\.processIdentifier))
     }
 
     static var defaultRootDirectory: URL {
@@ -748,6 +753,7 @@ final class ExtensionStore {
         do {
             try process.run()
             processes[ext.id] = process
+            spawnedHostPGIDs.insert(getpgid(process.processIdentifier))
             statuses[index].isRunning = true
             statuses[index].lastError = nil
             scheduleCrashCounterReset(extensionID: ext.id, process: process)

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -41,7 +41,8 @@ final class ExtensionStore {
     private(set) var availableUpdates: [String: String] = [:]
 
     private var processes: [String: Process] = [:]
-    private(set) var spawnedHostPGIDs: Set<pid_t> = []
+    private var hostPGIDs: [String: pid_t] = [:]
+    var spawnedHostPGIDs: Set<pid_t> { Set(hostPGIDs.values) }
     private var tokens: [String: String] = [:]
     private var intentionalStops: Set<String> = []
     private var crashRestartAttempts: [String: Int] = [:]
@@ -753,7 +754,10 @@ final class ExtensionStore {
         do {
             try process.run()
             processes[ext.id] = process
-            spawnedHostPGIDs.insert(getpgid(process.processIdentifier))
+            let processGroupID = getpgid(process.processIdentifier)
+            if processGroupID > 0 {
+                hostPGIDs[ext.id] = processGroupID
+            }
             statuses[index].isRunning = true
             statuses[index].lastError = nil
             scheduleCrashCounterReset(extensionID: ext.id, process: process)
@@ -791,6 +795,7 @@ final class ExtensionStore {
         crashRestartAttempts.removeValue(forKey: extensionID)
         ExtensionScriptRunner.shared.evict(extensionID: extensionID)
         tokens.removeValue(forKey: extensionID)
+        hostPGIDs.removeValue(forKey: extensionID)
         guard let process = processes.removeValue(forKey: extensionID) else { return }
         if process.isRunning {
             intentionalStops.insert(extensionID)

--- a/Muxy/Services/ProcSampling.swift
+++ b/Muxy/Services/ProcSampling.swift
@@ -13,20 +13,25 @@ enum ProcSampling {
         let cpuNanos: UInt64
     }
 
-    static func snapshotAll() -> [ProcSnapshot] {
-        listAllPIDs().compactMap(snapshot(for:))
+    static func topology() -> [ProcTopology] {
+        listAllPIDs().compactMap(topology(for:))
     }
 
-    private static func snapshot(for pid: pid_t) -> ProcSnapshot? {
-        guard pid > 0, let bsd = bsdInfo(pid), let usage = usage(for: pid) else { return nil }
+    static func enrich(_ topology: ProcTopology) -> ProcSnapshot? {
+        guard let usage = usage(for: topology.pid) else { return nil }
         return ProcSnapshot(
-            pid: pid,
-            ppid: bsd.ppid,
-            pgid: bsd.pgid,
-            name: name(pid, fallback: bsd.comm),
+            pid: topology.pid,
+            ppid: topology.ppid,
+            pgid: topology.pgid,
+            name: name(topology.pid, fallback: topology.comm),
             memoryBytes: usage.footprintBytes,
             cpuTimeNanos: usage.cpuNanos
         )
+    }
+
+    private static func topology(for pid: pid_t) -> ProcTopology? {
+        guard pid > 0, let bsd = bsdInfo(pid) else { return nil }
+        return ProcTopology(pid: pid, ppid: bsd.ppid, pgid: bsd.pgid, comm: bsd.comm)
     }
 
     static func listAllPIDs() -> [pid_t] {

--- a/Muxy/Services/ProcSampling.swift
+++ b/Muxy/Services/ProcSampling.swift
@@ -1,0 +1,75 @@
+import Darwin
+import Foundation
+
+enum ProcSampling {
+    private struct BSDInfo {
+        let ppid: pid_t
+        let pgid: pid_t
+        let comm: String
+    }
+
+    private struct Usage {
+        let footprintBytes: UInt64
+        let cpuNanos: UInt64
+    }
+
+    static func snapshotAll() -> [ProcSnapshot] {
+        listAllPIDs().compactMap(snapshot(for:))
+    }
+
+    private static func snapshot(for pid: pid_t) -> ProcSnapshot? {
+        guard pid > 0, let bsd = bsdInfo(pid), let usage = usage(for: pid) else { return nil }
+        return ProcSnapshot(
+            pid: pid,
+            ppid: bsd.ppid,
+            pgid: bsd.pgid,
+            name: name(pid, fallback: bsd.comm),
+            memoryBytes: usage.footprintBytes,
+            cpuTimeNanos: usage.cpuNanos
+        )
+    }
+
+    static func listAllPIDs() -> [pid_t] {
+        let needed = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+        guard needed > 0 else { return [] }
+        let capacity = Int(needed) / MemoryLayout<pid_t>.stride + 16
+        var pids = [pid_t](repeating: 0, count: capacity)
+        let written = proc_listpids(UInt32(PROC_ALL_PIDS), 0, &pids, Int32(capacity * MemoryLayout<pid_t>.stride))
+        guard written > 0 else { return [] }
+        let count = Int(written) / MemoryLayout<pid_t>.stride
+        return Array(pids.prefix(count)).filter { $0 > 0 }
+    }
+
+    private static func usage(for pid: pid_t) -> Usage? {
+        var info = rusage_info_v4()
+        let result = withUnsafeMutablePointer(to: &info) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { rebound in
+                proc_pid_rusage(pid, RUSAGE_INFO_V4, rebound)
+            }
+        }
+        guard result == 0 else { return nil }
+        return Usage(footprintBytes: info.ri_phys_footprint, cpuNanos: info.ri_user_time &+ info.ri_system_time)
+    }
+
+    private static func bsdInfo(_ pid: pid_t) -> BSDInfo? {
+        var info = proc_bsdinfo()
+        let size = Int32(MemoryLayout<proc_bsdinfo>.size)
+        let result = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size)
+        guard result == size else { return nil }
+        let comm = withUnsafeBytes(of: info.pbi_comm) { raw -> String in
+            let bytes = Array(raw.prefix { $0 != 0 })
+            return String(bytes: bytes, encoding: .utf8) ?? ""
+        }
+        return BSDInfo(ppid: pid_t(info.pbi_ppid), pgid: pid_t(info.pbi_pgid), comm: comm)
+    }
+
+    private static func name(_ pid: pid_t, fallback: String) -> String {
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        let length = proc_name(Int32(pid), &buffer, UInt32(buffer.count))
+        if length > 0 {
+            let bytes = Array(buffer.prefix { $0 != 0 })
+            if let name = String(bytes: bytes, encoding: .utf8), !name.isEmpty { return name }
+        }
+        return fallback.isEmpty ? "pid \(pid)" : fallback
+    }
+}

--- a/Muxy/Services/ProcessResourceMonitor.swift
+++ b/Muxy/Services/ProcessResourceMonitor.swift
@@ -13,7 +13,7 @@ final class ProcessResourceMonitor {
     }
 
     private static let samplingInterval: TimeInterval = 2
-    private static let rootPID = getpid()
+    nonisolated private static let rootPID = getpid()
 
     private(set) var snapshot: ProcessUsageSnapshot = .empty
 

--- a/Muxy/Services/ProcessResourceMonitor.swift
+++ b/Muxy/Services/ProcessResourceMonitor.swift
@@ -20,6 +20,7 @@ final class ProcessResourceMonitor {
     private let queue = DispatchQueue(label: "app.muxy.resource-monitor", qos: .utility)
     private var timer: DispatchSourceTimer?
     private var observerCount = 0
+    private var isSampling = false
     private var previous: [pid_t: Baseline] = [:]
 
     private init() {}
@@ -36,18 +37,31 @@ final class ProcessResourceMonitor {
         observerCount -= 1
         guard observerCount == 0 else { return }
         stopTimer()
+        isSampling = false
         previous = [:]
         snapshot = .empty
     }
 
     func refreshNow() {
+        guard !isSampling else { return }
+        isSampling = true
         let hostPIDs = ExtensionStore.shared.spawnedHostPIDs()
         let hostPGIDs = ExtensionStore.shared.spawnedHostPGIDs
         queue.async { [weak self] in
-            let procs = ProcSampling.snapshotAll()
+            let topology = ProcSampling.topology()
+            let groups = ProcessTree.classify(
+                rootPID: Self.rootPID,
+                procs: topology,
+                knownHostPIDs: hostPIDs,
+                knownHostPGIDs: hostPGIDs,
+                hostBinaryName: ExtensionHostLocator.binaryName
+            )
+            let procs = topology
+                .filter { groups[$0.pid] != nil }
+                .compactMap(ProcSampling.enrich)
             let wallNanos = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
             Task { @MainActor [weak self] in
-                self?.apply(procs: procs, wallNanos: wallNanos, hostPIDs: hostPIDs, hostPGIDs: hostPGIDs)
+                self?.apply(procs: procs, groups: groups, wallNanos: wallNanos)
             }
         }
     }
@@ -69,13 +83,8 @@ final class ProcessResourceMonitor {
         timer = nil
     }
 
-    private func apply(procs: [ProcSnapshot], wallNanos: UInt64, hostPIDs: Set<pid_t>, hostPGIDs: Set<pid_t>) {
-        let groups = ProcessTree.classify(
-            rootPID: Self.rootPID,
-            procs: procs,
-            knownHostPIDs: hostPIDs,
-            knownHostPGIDs: hostPGIDs
-        )
+    private func apply(procs: [ProcSnapshot], groups: [pid_t: ProcessGroup], wallNanos: UInt64) {
+        defer { isSampling = false }
 
         var rows: [ProcessUsageRow] = []
         var nextPrevious: [pid_t: Baseline] = [:]

--- a/Muxy/Services/ProcessResourceMonitor.swift
+++ b/Muxy/Services/ProcessResourceMonitor.swift
@@ -1,0 +1,116 @@
+import Darwin
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ProcessResourceMonitor {
+    static let shared = ProcessResourceMonitor()
+
+    private struct Baseline {
+        let cpuNanos: UInt64
+        let wallNanos: UInt64
+    }
+
+    private static let samplingInterval: TimeInterval = 2
+    private static let rootPID = getpid()
+
+    private(set) var snapshot: ProcessUsageSnapshot = .empty
+
+    private let queue = DispatchQueue(label: "app.muxy.resource-monitor", qos: .utility)
+    private var timer: DispatchSourceTimer?
+    private var observerCount = 0
+    private var previous: [pid_t: Baseline] = [:]
+
+    private init() {}
+
+    func beginObserving() {
+        observerCount += 1
+        guard observerCount == 1 else { return }
+        startTimer()
+        refreshNow()
+    }
+
+    func endObserving() {
+        guard observerCount > 0 else { return }
+        observerCount -= 1
+        guard observerCount == 0 else { return }
+        stopTimer()
+        previous = [:]
+        snapshot = .empty
+    }
+
+    func refreshNow() {
+        let hostPIDs = ExtensionStore.shared.spawnedHostPIDs()
+        let hostPGIDs = ExtensionStore.shared.spawnedHostPGIDs
+        queue.async { [weak self] in
+            let procs = ProcSampling.snapshotAll()
+            let wallNanos = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+            Task { @MainActor [weak self] in
+                self?.apply(procs: procs, wallNanos: wallNanos, hostPIDs: hostPIDs, hostPGIDs: hostPGIDs)
+            }
+        }
+    }
+
+    private func startTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + Self.samplingInterval, repeating: Self.samplingInterval)
+        timer.setEventHandler { [weak self] in
+            MainActor.assumeIsolated {
+                self?.refreshNow()
+            }
+        }
+        timer.resume()
+        self.timer = timer
+    }
+
+    private func stopTimer() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    private func apply(procs: [ProcSnapshot], wallNanos: UInt64, hostPIDs: Set<pid_t>, hostPGIDs: Set<pid_t>) {
+        let groups = ProcessTree.classify(
+            rootPID: Self.rootPID,
+            procs: procs,
+            knownHostPIDs: hostPIDs,
+            knownHostPGIDs: hostPGIDs
+        )
+
+        var rows: [ProcessUsageRow] = []
+        var nextPrevious: [pid_t: Baseline] = [:]
+        for proc in procs {
+            guard let group = groups[proc.pid] else { continue }
+            let baseline = previous[proc.pid]
+            let cpu = Self.cpuPercent(
+                prevNanos: baseline?.cpuNanos,
+                nowNanos: proc.cpuTimeNanos,
+                prevWall: baseline?.wallNanos,
+                nowWall: wallNanos
+            )
+            nextPrevious[proc.pid] = Baseline(cpuNanos: proc.cpuTimeNanos, wallNanos: wallNanos)
+            rows.append(ProcessUsageRow(
+                pid: proc.pid,
+                name: proc.name,
+                cpuPercent: cpu,
+                memoryBytes: proc.memoryBytes,
+                group: group
+            ))
+        }
+
+        previous = nextPrevious
+        snapshot = .make(from: rows)
+    }
+
+    private static func cpuPercent(prevNanos: UInt64?, nowNanos: UInt64, prevWall: UInt64?, nowWall: UInt64) -> Double? {
+        guard let prevNanos, let prevWall else { return nil }
+        return cpuPercentForTesting(prevNanos: prevNanos, nowNanos: nowNanos, prevWall: prevWall, nowWall: nowWall)
+    }
+
+    nonisolated static func cpuPercentForTesting(prevNanos: UInt64, nowNanos: UInt64, prevWall: UInt64, nowWall: UInt64) -> Double? {
+        guard nowWall > prevWall, nowNanos >= prevNanos else { return nil }
+        let cpuDelta = Double(nowNanos - prevNanos)
+        let wallDelta = Double(nowWall - prevWall)
+        return cpuDelta / wallDelta * 100
+    }
+}

--- a/Muxy/Services/ProcessTree.swift
+++ b/Muxy/Services/ProcessTree.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+struct ProcSnapshot: Equatable {
+    let pid: pid_t
+    let ppid: pid_t
+    let pgid: pid_t
+    let name: String
+    let memoryBytes: UInt64
+    let cpuTimeNanos: UInt64
+}
+
+enum ProcessTree {
+    static func descendants(of root: pid_t, in procs: [ProcSnapshot]) -> Set<pid_t> {
+        var childrenByParent: [pid_t: [pid_t]] = [:]
+        for proc in procs where proc.pid != proc.ppid {
+            childrenByParent[proc.ppid, default: []].append(proc.pid)
+        }
+
+        var result: Set<pid_t> = [root]
+        var queue = [root]
+        while let current = queue.popLast() {
+            for child in childrenByParent[current] ?? [] where !result.contains(child) {
+                result.insert(child)
+                queue.append(child)
+            }
+        }
+        return result
+    }
+
+    static func classify(
+        rootPID: pid_t,
+        procs: [ProcSnapshot],
+        knownHostPIDs: Set<pid_t>,
+        knownHostPGIDs: Set<pid_t>
+    ) -> [pid_t: ProcessGroup] {
+        let byPID = Dictionary(procs.map { ($0.pid, $0) }, uniquingKeysWith: { first, _ in first })
+        let subtree = descendants(of: rootPID, in: procs)
+
+        var groups: [pid_t: ProcessGroup] = [:]
+        for pid in subtree {
+            groups[pid] = hasHostAncestor(pid: pid, rootPID: rootPID, byPID: byPID, knownHostPIDs: knownHostPIDs)
+                ? .extensionHost
+                : .app
+        }
+
+        for proc in procs where !subtree.contains(proc.pid) && knownHostPGIDs.contains(proc.pgid) {
+            groups[proc.pid] = .orphan
+        }
+
+        return groups
+    }
+
+    private static func hasHostAncestor(
+        pid: pid_t,
+        rootPID: pid_t,
+        byPID: [pid_t: ProcSnapshot],
+        knownHostPIDs: Set<pid_t>
+    ) -> Bool {
+        var current: pid_t? = pid
+        var visited: Set<pid_t> = []
+        while let value = current, value != rootPID, visited.insert(value).inserted {
+            if knownHostPIDs.contains(value) { return true }
+            current = byPID[value]?.ppid
+        }
+        return false
+    }
+}

--- a/Muxy/Services/ProcessTree.swift
+++ b/Muxy/Services/ProcessTree.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+struct ProcTopology: Equatable {
+    let pid: pid_t
+    let ppid: pid_t
+    let pgid: pid_t
+    let comm: String
+}
+
 struct ProcSnapshot: Equatable {
     let pid: pid_t
     let ppid: pid_t
@@ -10,7 +17,7 @@ struct ProcSnapshot: Equatable {
 }
 
 enum ProcessTree {
-    static func descendants(of root: pid_t, in procs: [ProcSnapshot]) -> Set<pid_t> {
+    static func descendants(of root: pid_t, in procs: [ProcTopology]) -> Set<pid_t> {
         var childrenByParent: [pid_t: [pid_t]] = [:]
         for proc in procs where proc.pid != proc.ppid {
             childrenByParent[proc.ppid, default: []].append(proc.pid)
@@ -29,9 +36,10 @@ enum ProcessTree {
 
     static func classify(
         rootPID: pid_t,
-        procs: [ProcSnapshot],
+        procs: [ProcTopology],
         knownHostPIDs: Set<pid_t>,
-        knownHostPGIDs: Set<pid_t>
+        knownHostPGIDs: Set<pid_t>,
+        hostBinaryName: String
     ) -> [pid_t: ProcessGroup] {
         let byPID = Dictionary(procs.map { ($0.pid, $0) }, uniquingKeysWith: { first, _ in first })
         let subtree = descendants(of: rootPID, in: procs)
@@ -43,17 +51,29 @@ enum ProcessTree {
                 : .app
         }
 
-        for proc in procs where !subtree.contains(proc.pid) && knownHostPGIDs.contains(proc.pgid) {
+        for proc in procs where isOrphan(proc, subtree: subtree, knownHostPGIDs: knownHostPGIDs, hostBinaryName: hostBinaryName) {
             groups[proc.pid] = .orphan
         }
 
         return groups
     }
 
+    private static func isOrphan(
+        _ proc: ProcTopology,
+        subtree: Set<pid_t>,
+        knownHostPGIDs: Set<pid_t>,
+        hostBinaryName: String
+    ) -> Bool {
+        !subtree.contains(proc.pid)
+            && knownHostPGIDs.contains(proc.pgid)
+            && hostBinaryName.hasPrefix(proc.comm)
+            && !proc.comm.isEmpty
+    }
+
     private static func hasHostAncestor(
         pid: pid_t,
         rootPID: pid_t,
-        byPID: [pid_t: ProcSnapshot],
+        byPID: [pid_t: ProcTopology],
         knownHostPIDs: Set<pid_t>
     ) -> Bool {
         var current: pid_t? = pid

--- a/Muxy/Views/Components/ResourceUsageButton.swift
+++ b/Muxy/Views/Components/ResourceUsageButton.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct ResourceUsageButton: View {
+    @State private var monitor = ProcessResourceMonitor.shared
+    @State private var showingPopover = false
+    @State private var hovered = false
+
+    var body: some View {
+        Button {
+            showingPopover.toggle()
+        } label: {
+            Image(systemName: "cpu")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
+                .padding(.horizontal, 4)
+                .frame(maxHeight: .infinity)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .help("App & subprocess resource usage")
+        .accessibilityLabel("Resource usage")
+        .onAppear { monitor.beginObserving() }
+        .onDisappear { monitor.endObserving() }
+        .popover(isPresented: $showingPopover, arrowEdge: .bottom) {
+            ResourceUsagePopover(onClose: { showingPopover = false })
+                .onAppear { monitor.refreshNow() }
+        }
+    }
+}
+
+private struct ResourceUsagePopover: View {
+    let onClose: () -> Void
+
+    @State private var monitor = ProcessResourceMonitor.shared
+    @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+            header
+            ScrollView {
+                VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+                    ForEach(ProcessGroup.allCases, id: \.self) { group in
+                        groupSection(group)
+                    }
+                }
+            }
+            .frame(maxHeight: UIMetrics.scaled(360))
+            Divider()
+            hideButton
+        }
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(260))
+        .background(MuxyTheme.bg)
+    }
+
+    private var hideButton: some View {
+        Button {
+            showResourceUsage = false
+            onClose()
+        } label: {
+            HStack(spacing: UIMetrics.spacing3) {
+                Image(systemName: "eye.slash")
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                Text("Hide from status bar")
+                    .font(.system(size: UIMetrics.fontFootnote))
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(MuxyTheme.fgMuted)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Hide resource usage. Re-enable it in Settings → Interface.")
+    }
+
+    private var header: some View {
+        HStack(spacing: UIMetrics.spacing3) {
+            Image(systemName: "cpu")
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                .foregroundStyle(MuxyTheme.accent)
+            Text("Resources")
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+            Spacer(minLength: UIMetrics.spacing6)
+            Text(totalLabel)
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .monospaced))
+                .monospacedDigit()
+                .foregroundStyle(MuxyTheme.fg)
+        }
+    }
+
+    private var totalLabel: String {
+        let cpu = ProcessUsageFormat.compactCPU(monitor.snapshot.totalCPUPercent)
+        let memory = ProcessUsageFormat.compactMemory(monitor.snapshot.totalMemoryBytes)
+        return "\(cpu) · \(memory)"
+    }
+
+    @ViewBuilder
+    private func groupSection(_ group: ProcessGroup) -> some View {
+        let rows = monitor.snapshot.rows(in: group)
+        if !rows.isEmpty {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
+                Text(group.title.uppercased())
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                    .foregroundStyle(MuxyTheme.fgDim)
+                ForEach(rows) { row in
+                    processRow(row)
+                }
+            }
+        }
+    }
+
+    private func processRow(_ row: ProcessUsageRow) -> some View {
+        HStack(spacing: UIMetrics.spacing3) {
+            Text(row.name)
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fg)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Text("\(row.pid)")
+                .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
+                .foregroundStyle(MuxyTheme.fgDim)
+            Spacer(minLength: UIMetrics.spacing4)
+            Text(ProcessUsageFormat.compactCPU(row.cpuPercent))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .monospaced))
+                .monospacedDigit()
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.scaled(34), alignment: .trailing)
+            Text(ProcessUsageFormat.compactMemory(row.memoryBytes))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .monospaced))
+                .monospacedDigit()
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.scaled(42), alignment: .trailing)
+        }
+    }
+}

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -7,6 +7,7 @@ struct InterfaceSettingsView: View {
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyle = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyle = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
+    @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
 
     var body: some View {
         SettingsContainer {
@@ -23,6 +24,8 @@ struct InterfaceSettingsView: View {
                 }
 
                 SettingsToggleRow(label: "Show Status Bar", isOn: $showStatusBar)
+
+                SettingsToggleRow(label: "Show Resource Usage in Status Bar", isOn: $showResourceUsage)
             }
 
             SettingsSection("Sidebar", showsDivider: false) {

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -234,6 +234,14 @@ enum SettingsCatalog {
             defaultValue: true
         ),
         SettingsCatalogItem(
+            key: ResourceUsagePreferences.visibleKey,
+            title: "Show Resource Usage in Status Bar",
+            description: "Shows app and subprocess CPU and memory usage in the status bar. Disabling it stops the sampling.",
+            category: .appearance,
+            section: "Interface",
+            defaultValue: ResourceUsagePreferences.defaultVisible
+        ),
+        SettingsCatalogItem(
             key: "muxy.theme.light",
             title: "Light Terminal Theme",
             description: "Chooses the terminal theme for light appearance.",

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -16,6 +16,7 @@ struct ProjectStatusBar: View {
     var onTriggerExtensionCommand: ((ExtensionStore.StatusBarItemBinding) -> Void)?
     @Environment(ExtensionStore.self) private var extensionStore
     @State private var popoverHost = PopoverHost.shared
+    @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
 
     private var richInputShortcutLabel: String {
         KeyBindingStore.shared.combo(for: .toggleRichInput).displayString
@@ -74,6 +75,10 @@ struct ProjectStatusBar: View {
                 richInputToggleButton
                 separator
                 voiceRecordingButton
+            }
+            if showResourceUsage {
+                separator
+                ResourceUsageButton()
             }
         }
     }

--- a/Tests/MuxyTests/Models/ProcessUsageTests.swift
+++ b/Tests/MuxyTests/Models/ProcessUsageTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProcessUsage")
+struct ProcessUsageTests {
+    private func row(_ pid: pid_t, cpu: Double?, mem: UInt64, group: ProcessGroup) -> ProcessUsageRow {
+        ProcessUsageRow(pid: pid, name: "p\(pid)", cpuPercent: cpu, memoryBytes: mem, group: group)
+    }
+
+    @Test("compactCPU formats nil as em dash and rounds percent")
+    func cpuFormatting() {
+        #expect(ProcessUsageFormat.compactCPU(nil) == "—")
+        #expect(ProcessUsageFormat.compactCPU(12.4) == "12%")
+        #expect(ProcessUsageFormat.compactCPU(12.6) == "13%")
+    }
+
+    @Test("compactMemory uses single-letter units with minimal width")
+    func compactMemoryFormatting() {
+        #expect(ProcessUsageFormat.compactMemory(512) == "512B")
+        #expect(ProcessUsageFormat.compactMemory(2048) == "2.0K")
+        #expect(ProcessUsageFormat.compactMemory(15 * 1024) == "15K")
+        #expect(ProcessUsageFormat.compactMemory(1_572_864) == "1.5M")
+        #expect(ProcessUsageFormat.compactMemory(750 * 1_048_576) == "750M")
+        #expect(ProcessUsageFormat.compactMemory(3 * 1_073_741_824) == "3.0G")
+    }
+
+    @Test("snapshot sorts by group then cpu then memory")
+    func snapshotSorting() {
+        let rows = [
+            row(3, cpu: 5, mem: 100, group: .orphan),
+            row(1, cpu: 1, mem: 100, group: .app),
+            row(2, cpu: 9, mem: 100, group: .extensionHost),
+            row(4, cpu: 9, mem: 500, group: .extensionHost),
+        ]
+        let snapshot = ProcessUsageSnapshot.make(from: rows)
+        #expect(snapshot.rows.map(\.pid) == [1, 4, 2, 3])
+    }
+
+    @Test("totalCPU is nil when every row is cold, otherwise the sum of known values")
+    func totalCPUAggregation() {
+        let cold = ProcessUsageSnapshot.make(from: [row(1, cpu: nil, mem: 0, group: .app)])
+        #expect(cold.totalCPUPercent == nil)
+
+        let warm = ProcessUsageSnapshot.make(from: [
+            row(1, cpu: 4, mem: 0, group: .app),
+            row(2, cpu: nil, mem: 0, group: .app),
+            row(3, cpu: 6, mem: 0, group: .app),
+        ])
+        #expect(warm.totalCPUPercent == 10)
+    }
+
+    @Test("totalMemory sums RSS across rows")
+    func totalMemoryAggregation() {
+        let snapshot = ProcessUsageSnapshot.make(from: [
+            row(1, cpu: nil, mem: 100, group: .app),
+            row(2, cpu: nil, mem: 250, group: .extensionHost),
+        ])
+        #expect(snapshot.totalMemoryBytes == 350)
+    }
+
+    @Test("rows(in:) filters by group")
+    func rowsByGroup() {
+        let snapshot = ProcessUsageSnapshot.make(from: [
+            row(1, cpu: nil, mem: 0, group: .app),
+            row(2, cpu: nil, mem: 0, group: .orphan),
+        ])
+        #expect(snapshot.rows(in: .orphan).map(\.pid) == [2])
+        #expect(snapshot.rows(in: .extensionHost).isEmpty)
+    }
+
+    @Test("cpuPercentForTesting computes the delta ratio")
+    func cpuDeltaMath() {
+        let value = ProcessResourceMonitor.cpuPercentForTesting(
+            prevNanos: 0, nowNanos: 500_000_000, prevWall: 0, nowWall: 1_000_000_000
+        )
+        #expect(value == 50)
+    }
+
+    @Test("cpuPercentForTesting returns nil on zero wall delta")
+    func cpuZeroWall() {
+        #expect(ProcessResourceMonitor.cpuPercentForTesting(prevNanos: 0, nowNanos: 1, prevWall: 5, nowWall: 5) == nil)
+    }
+
+    @Test("cpuPercentForTesting returns nil when the cpu counter decreases")
+    func cpuCounterReset() {
+        #expect(ProcessResourceMonitor.cpuPercentForTesting(prevNanos: 10, nowNanos: 5, prevWall: 0, nowWall: 10) == nil)
+    }
+}

--- a/Tests/MuxyTests/Services/ProcessTreeTests.swift
+++ b/Tests/MuxyTests/Services/ProcessTreeTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProcessTree")
+struct ProcessTreeTests {
+    private func proc(_ pid: pid_t, ppid: pid_t, pgid: pid_t = 0) -> ProcSnapshot {
+        ProcSnapshot(pid: pid, ppid: ppid, pgid: pgid, name: "proc\(pid)", memoryBytes: 0, cpuTimeNanos: 0)
+    }
+
+    @Test("descendants walks a linear chain")
+    func descendantsChain() {
+        let procs = [proc(1, ppid: 0), proc(10, ppid: 1), proc(11, ppid: 10), proc(12, ppid: 11)]
+        #expect(ProcessTree.descendants(of: 10, in: procs) == [10, 11, 12])
+    }
+
+    @Test("descendants covers a branching tree")
+    func descendantsBranching() {
+        let procs = [proc(10, ppid: 1), proc(11, ppid: 10), proc(12, ppid: 10), proc(13, ppid: 11)]
+        #expect(ProcessTree.descendants(of: 10, in: procs) == [10, 11, 12, 13])
+    }
+
+    @Test("descendants is cycle-safe and ignores self-parenting")
+    func descendantsCycleSafe() {
+        let procs = [proc(10, ppid: 10), proc(11, ppid: 10), proc(10, ppid: 11)]
+        #expect(ProcessTree.descendants(of: 10, in: procs).contains(10))
+    }
+
+    @Test("descendants of a leaf returns only itself")
+    func descendantsLeaf() {
+        #expect(ProcessTree.descendants(of: 10, in: [proc(10, ppid: 1)]) == [10])
+    }
+
+    @Test("classify marks the root subtree as app when no hosts")
+    func classifyAppOnly() {
+        let procs = [proc(100, ppid: 1), proc(101, ppid: 100), proc(102, ppid: 101)]
+        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [])
+        #expect(groups == [100: .app, 101: .app, 102: .app])
+    }
+
+    @Test("classify marks a host and its descendants as extensionHost")
+    func classifyExtensionSubtree() {
+        let procs = [proc(100, ppid: 1), proc(200, ppid: 100), proc(201, ppid: 200), proc(300, ppid: 100)]
+        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [200], knownHostPGIDs: [])
+        #expect(groups[200] == .extensionHost)
+        #expect(groups[201] == .extensionHost)
+        #expect(groups[100] == .app)
+        #expect(groups[300] == .app)
+    }
+
+    @Test("classify marks a reparented child with a known pgid as orphan")
+    func classifyOrphanByPGID() {
+        let procs = [proc(100, ppid: 1), proc(500, ppid: 1, pgid: 200)]
+        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200])
+        #expect(groups[500] == .orphan)
+    }
+
+    @Test("classify ignores a reparented child that changed its process group")
+    func classifyNotOrphanWhenGroupChanged() {
+        let procs = [proc(100, ppid: 1), proc(500, ppid: 1, pgid: 999)]
+        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200])
+        #expect(groups[500] == nil)
+    }
+
+    @Test("classify keeps subtree classification over orphan for live pids")
+    func classifySubtreeWins() {
+        let procs = [proc(100, ppid: 1, pgid: 200), proc(101, ppid: 100, pgid: 200)]
+        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200])
+        #expect(groups[101] == .app)
+    }
+}

--- a/Tests/MuxyTests/Services/ProcessTreeTests.swift
+++ b/Tests/MuxyTests/Services/ProcessTreeTests.swift
@@ -5,8 +5,10 @@ import Testing
 
 @Suite("ProcessTree")
 struct ProcessTreeTests {
-    private func proc(_ pid: pid_t, ppid: pid_t, pgid: pid_t = 0) -> ProcSnapshot {
-        ProcSnapshot(pid: pid, ppid: ppid, pgid: pgid, name: "proc\(pid)", memoryBytes: 0, cpuTimeNanos: 0)
+    private let hostName = "MuxyExtensionHost"
+
+    private func proc(_ pid: pid_t, ppid: pid_t, pgid: pid_t = 0, comm: String = "") -> ProcTopology {
+        ProcTopology(pid: pid, ppid: ppid, pgid: pgid, comm: comm)
     }
 
     @Test("descendants walks a linear chain")
@@ -35,38 +37,57 @@ struct ProcessTreeTests {
     @Test("classify marks the root subtree as app when no hosts")
     func classifyAppOnly() {
         let procs = [proc(100, ppid: 1), proc(101, ppid: 100), proc(102, ppid: 101)]
-        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [])
+        let groups = ProcessTree.classify(
+            rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [], hostBinaryName: hostName
+        )
         #expect(groups == [100: .app, 101: .app, 102: .app])
     }
 
     @Test("classify marks a host and its descendants as extensionHost")
     func classifyExtensionSubtree() {
         let procs = [proc(100, ppid: 1), proc(200, ppid: 100), proc(201, ppid: 200), proc(300, ppid: 100)]
-        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [200], knownHostPGIDs: [])
+        let groups = ProcessTree.classify(
+            rootPID: 100, procs: procs, knownHostPIDs: [200], knownHostPGIDs: [], hostBinaryName: hostName
+        )
         #expect(groups[200] == .extensionHost)
         #expect(groups[201] == .extensionHost)
         #expect(groups[100] == .app)
         #expect(groups[300] == .app)
     }
 
-    @Test("classify marks a reparented child with a known pgid as orphan")
+    @Test("classify marks a reparented host with a known pgid as orphan")
     func classifyOrphanByPGID() {
-        let procs = [proc(100, ppid: 1), proc(500, ppid: 1, pgid: 200)]
-        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200])
+        let procs = [proc(100, ppid: 1), proc(500, ppid: 1, pgid: 200, comm: "MuxyExtensionHos")]
+        let groups = ProcessTree.classify(
+            rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200], hostBinaryName: hostName
+        )
         #expect(groups[500] == .orphan)
+    }
+
+    @Test("classify ignores a known-pgid process whose name is not the host binary")
+    func classifyNotOrphanWhenNameMismatch() {
+        let procs = [proc(100, ppid: 1), proc(500, ppid: 1, pgid: 200, comm: "someoneElse")]
+        let groups = ProcessTree.classify(
+            rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200], hostBinaryName: hostName
+        )
+        #expect(groups[500] == nil)
     }
 
     @Test("classify ignores a reparented child that changed its process group")
     func classifyNotOrphanWhenGroupChanged() {
-        let procs = [proc(100, ppid: 1), proc(500, ppid: 1, pgid: 999)]
-        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200])
+        let procs = [proc(100, ppid: 1), proc(500, ppid: 1, pgid: 999, comm: "MuxyExtensionHos")]
+        let groups = ProcessTree.classify(
+            rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200], hostBinaryName: hostName
+        )
         #expect(groups[500] == nil)
     }
 
     @Test("classify keeps subtree classification over orphan for live pids")
     func classifySubtreeWins() {
-        let procs = [proc(100, ppid: 1, pgid: 200), proc(101, ppid: 100, pgid: 200)]
-        let groups = ProcessTree.classify(rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200])
+        let procs = [proc(100, ppid: 1, pgid: 200), proc(101, ppid: 100, pgid: 200, comm: "MuxyExtensionHos")]
+        let groups = ProcessTree.classify(
+            rootPID: 100, procs: procs, knownHostPIDs: [], knownHostPGIDs: [200], hostBinaryName: hostName
+        )
         #expect(groups[101] == .app)
     }
 }


### PR DESCRIPTION
Adds a status-bar indicator with a popover showing per-process CPU and memory (App / Extensions / Orphans), sampled via libproc (phys_footprint to match Activity Monitor).

Sampling only runs while visible; toggle off in Settings → Interface to stop it entirely. Refs #615.