### PR TITLE
Fix extension host identify race on startup

### DIFF
--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -6,6 +6,17 @@ private let logger = Logger(subsystem: "app.muxy", category: "ExtensionStore")
 
 protocol ExtensionSnapshotSink: Sendable {
     func applyExtensionSnapshot(_ snapshot: NotificationSocketServer.ExtensionSnapshot)
+    /// Commit synchronously: must return only once the snapshot is visible to the
+    /// socket server's identify handler. Used before spawning an extension host so the
+    /// host's token is present when it identifies. See `applyExtensionSnapshotSync`.
+    func applyExtensionSnapshotSync(_ snapshot: NotificationSocketServer.ExtensionSnapshot)
+}
+
+extension ExtensionSnapshotSink {
+    // Fakes that don't need ordering can rely on the async path.
+    func applyExtensionSnapshotSync(_ snapshot: NotificationSocketServer.ExtensionSnapshot) {
+        applyExtensionSnapshot(snapshot)
+    }
 }
 
 extension NotificationSocketServer: ExtensionSnapshotSink {}
@@ -319,6 +330,12 @@ final class ExtensionStore {
 
     private func publishSnapshot() {
         snapshotSink.applyExtensionSnapshot(snapshotForSocketServer())
+    }
+
+    /// Publish and block until the snapshot is committed. Use before spawning a host so
+    /// the host's token is guaranteed visible to the identify handler.
+    private func publishSnapshotSync() {
+        snapshotSink.applyExtensionSnapshotSync(snapshotForSocketServer())
     }
 
     static func buildSnapshotForTesting(
@@ -724,7 +741,10 @@ final class ExtensionStore {
 
         let token = Self.generateToken()
         tokens[ext.id] = token
-        publishSnapshot()
+        // Commit synchronously so the token is visible to the socket server's identify
+        // handler before the host we're about to spawn can connect and identify.
+        // Otherwise the host loses the race and is rejected as `unknown extension`.
+        publishSnapshotSync()
 
         var environment = ProcessInfo.processInfo.environment
         environment["MUXY_SOCKET_PATH"] = NotificationSocketServer.socketPath

--- a/Muxy/Services/NotificationSocketServer.swift
+++ b/Muxy/Services/NotificationSocketServer.swift
@@ -98,18 +98,34 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     func applyExtensionSnapshot(_ snapshot: ExtensionSnapshot) {
         queue.async { [weak self] in
-            guard let self else { return }
-            self.extensionSnapshot = snapshot
-            for session in self.subscribers.values {
-                guard let extensionID = session.extensionID else { continue }
-                guard let entry = snapshot.entries[extensionID] else {
-                    session.extensionID = nil
-                    session.subscriptions.removeAll()
-                    continue
-                }
-                session.subscriptions = session.subscriptions.filter { event in
-                    Self.canSubscribe(entry: entry, to: event)
-                }
+            self?.commitSnapshot(snapshot)
+        }
+    }
+
+    /// Synchronous variant: commits the snapshot on `queue` and only returns once
+    /// `extensionSnapshot` reflects it. `ExtensionStore.startExtension` must call this
+    /// (not the async form) BEFORE spawning the host, otherwise the freshly-spawned
+    /// host can send `identify|<id>|<token>` before the async write lands, the lookup
+    /// in `extensionSnapshot.entries` misses, and the host is rejected with
+    /// `unknown extension` and exits — the long-standing startup race.
+    func applyExtensionSnapshotSync(_ snapshot: ExtensionSnapshot) {
+        queue.sync { [weak self] in
+            self?.commitSnapshot(snapshot)
+        }
+    }
+
+    /// Must run on `queue`.
+    private func commitSnapshot(_ snapshot: ExtensionSnapshot) {
+        extensionSnapshot = snapshot
+        for session in subscribers.values {
+            guard let extensionID = session.extensionID else { continue }
+            guard let entry = snapshot.entries[extensionID] else {
+                session.extensionID = nil
+                session.subscriptions.removeAll()
+                continue
+            }
+            session.subscriptions = session.subscriptions.filter { event in
+                Self.canSubscribe(entry: entry, to: event)
             }
         }
     }

--- a/MuxyExtensionHost/HostSocketClient.swift
+++ b/MuxyExtensionHost/HostSocketClient.swift
@@ -23,6 +23,13 @@ final class HostSocketClient: @unchecked Sendable {
     static let maxConnectAttempts = 15
     static let connectRetryDelay: TimeInterval = 0.1
 
+    /// True when an identify reply indicates the token snapshot simply hasn't landed
+    /// yet (a spawn/publish ordering race) and a retry may succeed. A bad token
+    /// (`invalid extension token`) is a real failure and is NOT transient.
+    static func isTransientIdentifyRejection(_ reply: String) -> Bool {
+        reply.hasPrefix("error:unknown extension")
+    }
+
     init(
         socketPath: String,
         maxConnectAttempts: Int = HostSocketClient.maxConnectAttempts,

--- a/MuxyExtensionHost/main.swift
+++ b/MuxyExtensionHost/main.swift
@@ -58,9 +58,20 @@ client.onInvoke { [weak bridge] line in
 
 client.startReading()
 
+// Identify, retrying a transient `unknown extension` rejection for a short window.
+// That reply means our token snapshot hasn't landed in the socket server yet (a
+// spawn/publish ordering race); the app-side fix publishes synchronously before
+// spawning us, and this retry is belt-and-suspenders for any remaining async path.
+// `invalid extension token` is a real auth failure, so we fail fast on it.
 do {
-    let reply = try client.sendAndWaitReply("identify|\(extensionID)|\(token)")
-    guard reply == "ok" else {
+    let deadline = Date().addingTimeInterval(2.0)
+    while true {
+        let reply = try client.sendAndWaitReply("identify|\(extensionID)|\(token)")
+        if reply == "ok" { break }
+        if HostSocketClient.isTransientIdentifyRejection(reply), Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.1)
+            continue
+        }
         fail("identify rejected: \(reply)")
     }
 } catch {

--- a/Tests/MuxyTests/Services/HostSocketClientTests.swift
+++ b/Tests/MuxyTests/Services/HostSocketClientTests.swift
@@ -19,6 +19,16 @@ struct HostSocketClientTests {
         #expect(client.isClosed == false)
     }
 
+    @Test("classifies only `unknown extension` identify rejections as transient")
+    func classifiesTransientIdentifyRejections() {
+        // The token snapshot hasn't landed yet — retrying may succeed.
+        #expect(HostSocketClient.isTransientIdentifyRejection("error:unknown extension git"))
+        // A real auth failure — must not be retried.
+        #expect(!HostSocketClient.isTransientIdentifyRejection("error:invalid extension token"))
+        #expect(!HostSocketClient.isTransientIdentifyRejection("ok"))
+        #expect(!HostSocketClient.isTransientIdentifyRejection("error:usage identify|<extension-id>|<token>"))
+    }
+
     @Test("gives up with connectFailed when no server appears")
     func givesUpWhenServerNeverAppears() {
         let path = Self.temporarySocketPath()


### PR DESCRIPTION
## Problem

Extension hosts (e.g. `git`) intermittently crash on launch with `identify rejected: error:unknown extension <id>` and the #678 crash-restarter can't recover them — the extension stays dead until Muxy is fully restarted. This has recurred despite several adjacent fixes.

**Root cause:** `ExtensionStore.startExtension` published the token snapshot to `NotificationSocketServer` via `queue.async` (`applyExtensionSnapshot`) and then immediately called `process.run()`. The freshly-spawned host connects and sends `identify|<id>|<token>` — which can reach the identify handler *before* the async write commits to `extensionSnapshot.entries`. The lookup misses → `unknown extension` → host `exit(1)`. The crash-restarter then races the same window on every attempt (1s backoff < 30s stability), exhausts its budget, and gives up.

**Why it kept coming back:** the original fix (commit a852b51 on `fix-extension-host-reload-44xwt`) was never merged — that branch predates the event system (#682) and would revert it. #678/#680/#682 fixed *adjacent* races (auto-restart, connect failure, events), never the snapshot-ordering one. So `main` still has it.

**Tell for diagnosis:** the extension's own `logs/output.log` stays empty (the host dies before `[muxy] started`), and running `MuxyExtensionHost dist/background.js` directly reaches the socket-connect step — proving the bundle isn't at fault.

## Fix (two layers)

1. **Publish synchronously before spawn.** New `NotificationSocketServer.applyExtensionSnapshotSync` (`queue.sync` → shared `commitSnapshot`); `startExtension` calls `publishSnapshotSync()` before `process.run()`, so the token is guaranteed visible when the host identifies. The `ExtensionSnapshotSink` protocol gets a default `applyExtensionSnapshotSync` that falls back to the async path, so existing test fakes need no change.
2. **Host retries a transient rejection.** `main.swift` retries an `error:unknown extension` identify for up to 2s (`HostSocketClient.isTransientIdentifyRejection`), but fails fast on `error:invalid extension token` (a real auth failure). Belt-and-suspenders for any remaining async publish path.

## Tests

- Pre-existing `ExtensionStoreStartOrderingTests` ("publishes the token snapshot before the host process is spawned") passes.
- New `HostSocketClientTests` case covering the transient-vs-real rejection classifier.
- `swift build` clean; filtered suites green (18 tests).

No changes to the event system.