### PR TITLE
Disable newly discovered extensions by default

### DIFF
--- a/Muxy/Services/ExtensionEnabledStore.swift
+++ b/Muxy/Services/ExtensionEnabledStore.swift
@@ -5,7 +5,7 @@ enum ExtensionEnabledStore {
 
     static func isEnabled(extensionID: String, defaults: UserDefaults = .standard) -> Bool {
         let key = storageKey(extensionID: extensionID)
-        guard defaults.object(forKey: key) != nil else { return true }
+        guard defaults.object(forKey: key) != nil else { return false }
         return defaults.bool(forKey: key)
     }
 

--- a/Tests/MuxyTests/Services/ExtensionEnabledStoreTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionEnabledStoreTests.swift
@@ -5,10 +5,10 @@ import Testing
 
 @Suite("ExtensionEnabledStore")
 struct ExtensionEnabledStoreTests {
-    @Test("defaults to enabled when no value is stored")
-    func defaultsToEnabledWhenUnset() {
+    @Test("defaults to disabled when no value is stored")
+    func defaultsToDisabledWhenUnset() {
         let defaults = makeIsolatedDefaults()
-        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+        #expect(!ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
     }
 
     @Test("persists disabled state and reads it back")
@@ -29,17 +29,17 @@ struct ExtensionEnabledStoreTests {
     @Test("clear removes the stored override")
     func clearResetsToDefault() {
         let defaults = makeIsolatedDefaults()
-        ExtensionEnabledStore.setEnabled(false, extensionID: "ext-a", defaults: defaults)
+        ExtensionEnabledStore.setEnabled(true, extensionID: "ext-a", defaults: defaults)
         ExtensionEnabledStore.clear(extensionID: "ext-a", defaults: defaults)
-        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+        #expect(!ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
     }
 
     @Test("isolates state per extension id")
     func isolatesPerExtension() {
         let defaults = makeIsolatedDefaults()
-        ExtensionEnabledStore.setEnabled(false, extensionID: "ext-a", defaults: defaults)
-        #expect(!ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
-        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-b", defaults: defaults))
+        ExtensionEnabledStore.setEnabled(true, extensionID: "ext-a", defaults: defaults)
+        #expect(ExtensionEnabledStore.isEnabled(extensionID: "ext-a", defaults: defaults))
+        #expect(!ExtensionEnabledStore.isEnabled(extensionID: "ext-b", defaults: defaults))
     }
 
     @Test("hasOverride reflects whether a value has been stored")

--- a/Tests/MuxyTests/Services/ExtensionStoreCommandPermissionTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreCommandPermissionTests.swift
@@ -105,6 +105,7 @@ struct ExtensionStoreCommandPermissionTests {
             )
             try Data(contents.utf8).write(to: url)
         }
+        ExtensionEnabledStore.setEnabled(true, extensionID: name)
         let store = ExtensionStore.makeForTesting(
             rootDirectory: root,
             snapshotSink: NoopExtensionSnapshotSink(),

--- a/Tests/MuxyTests/Services/ExtensionStoreStartOrderingTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreStartOrderingTests.swift
@@ -9,7 +9,11 @@ struct ExtensionStoreStartOrderingTests {
     @Test("publishes the token snapshot before the host process is spawned")
     func publishesTokenBeforeSpawn() throws {
         let directory = try makeBackgroundExtension(name: "ordered-ext")
-        defer { try? FileManager.default.removeItem(at: directory.parent) }
+        ExtensionEnabledStore.setEnabled(true, extensionID: "ordered-ext")
+        defer {
+            ExtensionEnabledStore.clear(extensionID: "ordered-ext")
+            try? FileManager.default.removeItem(at: directory.parent)
+        }
 
         let recorder = SnapshotOrderRecorder()
         let store = ExtensionStore.makeForTesting(
@@ -34,7 +38,11 @@ struct ExtensionStoreStartOrderingTests {
     @Test("removes the token from the snapshot when the host fails to spawn")
     func removesTokenWhenSpawnFails() throws {
         let directory = try makeBackgroundExtension(name: "failing-ext")
-        defer { try? FileManager.default.removeItem(at: directory.parent) }
+        ExtensionEnabledStore.setEnabled(true, extensionID: "failing-ext")
+        defer {
+            ExtensionEnabledStore.clear(extensionID: "failing-ext")
+            try? FileManager.default.removeItem(at: directory.parent)
+        }
 
         let recorder = SnapshotOrderRecorder()
         let store = ExtensionStore.makeForTesting(

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -59,7 +59,7 @@ All Muxy-specific manifest fields live under the `muxy` object.
 | `remoteMethods` | object[] | no | Named API methods served to the mobile app. Requires `remote:serve`. See [Remote Methods](remote-methods.md). |
 | `marketplace` | object | no | Listing metadata (icon, screenshots, author, categories) used by the marketplace. Ignored by the app loader. |
 
-Extensions are enabled by default after loading. The Settings → Extensions toggle is persisted in `UserDefaults` under `muxy.ext.enabled.<extension-id>` and survives launches. A legacy `enabled` manifest field is no longer part of the schema; if present with no user override, it is migrated into that UserDefaults entry on first load and otherwise ignored.
+Extensions are disabled by default after loading and must be enabled explicitly from Settings → Extensions. The toggle is persisted in `UserDefaults` under `muxy.ext.enabled.<extension-id>` and survives launches. A legacy `enabled` manifest field is no longer part of the schema; if present with no user override, it is migrated into that UserDefaults entry on first load and otherwise ignored.
 
 ## Icons
 


### PR DESCRIPTION
Extensions appearing in the extensions folder for the first time were auto-enabled and auto-started, a security
  risk. They now default to disabled and require explicit opt-in from Settings → Extensions. Existing enabled
  extensions are unaffected.