### PR TITLE
fix: scope Find shortcut to focused terminal

### DIFF
--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -175,7 +175,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .selectProject7: ShortcutMetadata(displayName: "Project 7", category: "Project Navigation", scope: .mainWindow)
         case .selectProject8: ShortcutMetadata(displayName: "Project 8", category: "Project Navigation", scope: .mainWindow)
         case .selectProject9: ShortcutMetadata(displayName: "Project 9", category: "Project Navigation", scope: .mainWindow)
-        case .findInTerminal: ShortcutMetadata(displayName: "Find", category: "Terminal", scope: .mainWindow)
+        case .findInTerminal: ShortcutMetadata(displayName: "Find", category: "Terminal", scope: .terminal)
         case .toggleRichInput: ShortcutMetadata(displayName: "Toggle Rich Input", category: "Rich Input", scope: .mainWindow)
         case .submitRichInput: ShortcutMetadata(displayName: "Send", category: "Rich Input", scope: .richInput)
         case .submitRichInputWithoutReturn: ShortcutMetadata(

--- a/Muxy/Models/KeyCombo.swift
+++ b/Muxy/Models/KeyCombo.swift
@@ -6,6 +6,7 @@ enum ShortcutScope: String, Codable, CaseIterable {
     case global
     case mainWindow
     case richInput
+    case terminal
 }
 
 struct KeyCombo: Codable, Equatable, Hashable {

--- a/Muxy/Services/ShortcutContext.swift
+++ b/Muxy/Services/ShortcutContext.swift
@@ -8,10 +8,12 @@ enum ShortcutContext {
         window?.identifier == mainWindowIdentifier
     }
 
-    static func activeScopes(for window: NSWindow?) -> Set<ShortcutScope> {
-        if isMainWindow(window) {
-            return [.global, .mainWindow]
+    static func activeScopes(for window: NSWindow?, isTerminalFocused: Bool) -> Set<ShortcutScope> {
+        guard isMainWindow(window) else { return [.global] }
+        var scopes: Set<ShortcutScope> = [.global, .mainWindow]
+        if isTerminalFocused {
+            scopes.insert(.terminal)
         }
-        return [.global]
+        return scopes
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -157,6 +157,7 @@ struct MainWindow: View {
         .coordinateSpace(name: DragCoordinateSpace.mainWindow)
         .environment(dragCoordinator)
         .background(MainWindowShortcutInterceptor(
+            isTerminalFocused: { isTerminalPaneFocused },
             onShortcut: { action in handleShortcutAction(action) },
             onCommandShortcut: { shortcut in handleCommandShortcut(shortcut) },
             onExtensionShortcut: { shortcut in handleExtensionShortcut(shortcut) },
@@ -819,6 +820,11 @@ struct MainWindow: View {
         return [activeKey]
     }
 
+    private var isTerminalPaneFocused: Bool {
+        guard let projectID = appState.activeProjectID else { return false }
+        return appState.activeTab(for: projectID)?.content.pane != nil
+    }
+
     private func handleShortcutAction(_ action: ShortcutAction) -> Bool {
         if action == .toggleVoiceRecording {
             return openVoiceRecorder()
@@ -1277,6 +1283,7 @@ private struct NavigationArrowButton: View {
 }
 
 private struct MainWindowShortcutInterceptor: NSViewRepresentable {
+    let isTerminalFocused: () -> Bool
     let onShortcut: (ShortcutAction) -> Bool
     let onCommandShortcut: (CommandShortcut) -> Bool
     let onExtensionShortcut: (ExtensionShortcut) -> Bool
@@ -1285,6 +1292,7 @@ private struct MainWindowShortcutInterceptor: NSViewRepresentable {
 
     func makeNSView(context: Context) -> ShortcutInterceptingView {
         let view = ShortcutInterceptingView()
+        view.isTerminalFocused = isTerminalFocused
         view.onShortcut = onShortcut
         view.onCommandShortcut = onCommandShortcut
         view.onExtensionShortcut = onExtensionShortcut
@@ -1294,6 +1302,7 @@ private struct MainWindowShortcutInterceptor: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: ShortcutInterceptingView, context: Context) {
+        nsView.isTerminalFocused = isTerminalFocused
         nsView.onShortcut = onShortcut
         nsView.onCommandShortcut = onCommandShortcut
         nsView.onExtensionShortcut = onExtensionShortcut
@@ -1303,6 +1312,7 @@ private struct MainWindowShortcutInterceptor: NSViewRepresentable {
 }
 
 private final class ShortcutInterceptingView: NSView {
+    var isTerminalFocused: (() -> Bool)?
     var onShortcut: ((ShortcutAction) -> Bool)?
     var onCommandShortcut: ((CommandShortcut) -> Bool)?
     var onExtensionShortcut: ((ExtensionShortcut) -> Bool)?
@@ -1324,7 +1334,7 @@ private final class ShortcutInterceptingView: NSView {
               ShortcutContext.isMainWindow(window)
         else { return super.performKeyEquivalent(with: event) }
 
-        let scopes = ShortcutContext.activeScopes(for: window)
+        let scopes = ShortcutContext.activeScopes(for: window, isTerminalFocused: isTerminalFocused?() ?? false)
         let layerWasActive = CommandShortcutStore.shared.isLayerActive
         if let shortcut = CommandShortcutStore.shared.shortcut(for: event, scopes: scopes) {
             CommandShortcutStore.shared.deactivateLayer()

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -390,7 +390,7 @@ final class GhosttyTerminalNSView: NSView {
         if modifiers == .command, Self.systemShortcutKeys.contains(key) {
             return true
         }
-        let scopes = ShortcutContext.activeScopes(for: window)
+        let scopes = ShortcutContext.activeScopes(for: window, isTerminalFocused: true)
         return KeyBindingStore.shared.isRegisteredShortcut(event: event, scopes: scopes)
             || CommandShortcutStore.shared.isRegisteredShortcut(event: event, scopes: scopes)
             || ExtensionShortcutStore.shared.isRegisteredShortcut(event: event, scopes: scopes)

--- a/Tests/MuxyTests/Services/ShortcutContextTests.swift
+++ b/Tests/MuxyTests/Services/ShortcutContextTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("ShortcutContext")
+struct ShortcutContextTests {
+    private func mainWindow() -> NSWindow {
+        let window = NSWindow()
+        window.identifier = ShortcutContext.mainWindowIdentifier
+        return window
+    }
+
+    @Test("non-main window only exposes the global scope")
+    func nonMainWindowScopes() {
+        let scopes = ShortcutContext.activeScopes(for: NSWindow(), isTerminalFocused: true)
+        #expect(scopes == [.global])
+    }
+
+    @Test("main window without a focused terminal omits the terminal scope")
+    func mainWindowWithoutTerminal() {
+        let scopes = ShortcutContext.activeScopes(for: mainWindow(), isTerminalFocused: false)
+        #expect(scopes == [.global, .mainWindow])
+    }
+
+    @Test("main window with a focused terminal includes the terminal scope")
+    func mainWindowWithTerminal() {
+        let scopes = ShortcutContext.activeScopes(for: mainWindow(), isTerminalFocused: true)
+        #expect(scopes == [.global, .mainWindow, .terminal])
+    }
+
+    @Test("find action is gated to the terminal scope")
+    func findActionScope() {
+        #expect(ShortcutAction.findInTerminal.scope == .terminal)
+    }
+}


### PR DESCRIPTION
Adds a `.terminal` shortcut scope so cmd+f only fires when a terminal pane is focused; otherwise it falls through
  as unassigned.
  Scope is derived from the focused tab's content, making it reusable for other terminal-only shortcuts.