### PR TITLE
fix: keep emptied project open without auto-creating a tab

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -194,6 +194,12 @@ final class AppState {
         ))
     }
 
+    func openInitialTab(projectID: UUID, worktree: Worktree) {
+        selectWorktree(projectID: projectID, worktree: worktree)
+        guard !hasTabs(for: projectID) else { return }
+        createTab(projectID: projectID)
+    }
+
     func focusedArea(for projectID: UUID) -> TabArea? {
         guard let key = activeWorktreeKey(for: projectID),
               let root = workspaceRoots[key],
@@ -205,6 +211,10 @@ final class AppState {
     func allAreas(for projectID: UUID) -> [TabArea] {
         guard let key = activeWorktreeKey(for: projectID) else { return [] }
         return workspaceRoots[key]?.allAreas() ?? []
+    }
+
+    func hasTabs(for projectID: UUID) -> Bool {
+        allAreas(for: projectID).contains { !$0.tabs.isEmpty }
     }
 
     func locatePane(paneID: UUID) -> (worktreeKey: WorktreeKey, pane: TerminalPaneState)? {

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -142,6 +142,7 @@ enum TabReducer {
         }
 
         guard area.tabs.isEmpty else { return }
+        guard !state.keepProjectOpenWhenEmpty else { return }
         WorkspaceReducerShared.clearWorkspace(key: key, state: &state)
         WorkspaceReducerShared.handleProjectEmptiedIfNeeded(
             projectID: key.projectID,

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -309,13 +309,13 @@ struct MainWindow: View {
                 ZStack {
                     MuxyTheme.bg
                     if let project = activeProject,
-                       appState.workspaceRoot(for: project.id) == nil,
+                       !appState.hasTabs(for: project.id),
                        let worktree = resolvedActiveWorktree(for: project)
                     {
                         EmptyProjectPlaceholder(project: project) {
-                            appState.selectWorktree(projectID: project.id, worktree: worktree)
+                            appState.openInitialTab(projectID: project.id, worktree: worktree)
                         }
-                    } else if projectsWithWorkspaces.isEmpty {
+                    } else if projectsWithTabs.isEmpty {
                         WelcomeView()
                     } else if let project = activeProjectWithWorkspace,
                               let activeKey = appState.activeWorktreeKey(for: project.id)
@@ -861,8 +861,8 @@ struct MainWindow: View {
         return true
     }
 
-    private var projectsWithWorkspaces: [Project] {
-        projectStore.projects.filter { appState.workspaceRoot(for: $0.id) != nil }
+    private var projectsWithTabs: [Project] {
+        projectStore.projects.filter { appState.hasTabs(for: $0.id) }
     }
 
     var richInputPanelVisible: Bool { panelHost.isOpen(BuiltinPanel.richInput) }

--- a/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceReducerTests.swift
@@ -304,6 +304,49 @@ struct WorkspaceReducerTests {
         #expect(effects.projectIDsToRemove.contains(projectID))
     }
 
+    @Test("closeTab last tab keeps empty workspace when keepProjectOpenWhenEmpty is on")
+    func closeTabLastTabKeepsEmptyWorkspace() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        state.keepProjectOpenWhenEmpty = true
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let areaID = state.focusedAreaID[key]!
+        let area = state.workspaceRoots[key]!.findArea(id: areaID)!
+        let tabID = area.tabs[0].id
+
+        let effects = WorkspaceReducer.reduce(
+            action: .closeTab(projectID: projectID, areaID: areaID, tabID: tabID),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[key] != nil)
+        #expect(state.workspaceRoots[key]?.findArea(id: areaID)?.tabs.isEmpty == true)
+        #expect(!effects.projectIDsToRemove.contains(projectID))
+    }
+
+    @Test("selectProject does not create a tab for an emptied workspace")
+    func selectProjectKeepsEmptyWorkspace() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+        state.keepProjectOpenWhenEmpty = true
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let areaID = state.focusedAreaID[key]!
+        let tabID = state.workspaceRoots[key]!.findArea(id: areaID)!.tabs[0].id
+
+        _ = WorkspaceReducer.reduce(
+            action: .closeTab(projectID: projectID, areaID: areaID, tabID: tabID),
+            state: &state
+        )
+        _ = WorkspaceReducer.reduce(
+            action: .selectProject(projectID: projectID, worktreeID: worktreeID, worktreePath: testPath),
+            state: &state
+        )
+
+        #expect(state.workspaceRoots[key]?.findArea(id: areaID)?.tabs.isEmpty == true)
+    }
+
     @Test("selectTab changes activeTabID")
     func selectTab() {
         let projectID = UUID()


### PR DESCRIPTION
When "keep project open when empty" is on, closing the last tab now keeps an empty workspace instead of recreating
  a tab on revisit.
  
  The empty-project placeholder shows whenever a project has no tabs, with a New Tab button to start one.
  
  Closes #434