### PR TITLE
Run full teardown + sidebar sync on extension worktree removal

### DIFF
--- a/Muxy/Services/MuxyAPIGit.swift
+++ b/Muxy/Services/MuxyAPIGit.swift
@@ -568,6 +568,10 @@ extension MuxyAPI {
                 }
             }
 
+            if !force, await GitWorktreeService.shared.hasUncommittedChanges(worktreePath: tracked.worktree.path) {
+                return .failure(.invalidArguments("worktree has uncommitted changes; pass force to remove it"))
+            }
+
             let result = await write(projectIdentifier, operation: "worktree.remove", context: context) { _ in
                 try await WorktreeStore.cleanupOnDisk(worktree: tracked.worktree, repoPath: tracked.project.path)
             }

--- a/Muxy/Services/MuxyAPIGit.swift
+++ b/Muxy/Services/MuxyAPIGit.swift
@@ -556,13 +556,49 @@ extension MuxyAPI {
         ) async -> Result<Void, APIError> {
             let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmedPath.isEmpty else { return .failure(.invalidArguments("path is required")) }
-            return await write(projectIdentifier, operation: "worktree.remove", context: context) { repoPath in
-                try await GitWorktreeService.shared.removeWorktree(
-                    repoPath: repoPath,
-                    path: NSString(string: trimmedPath).expandingTildeInPath,
-                    force: force
-                )
+            let expandedPath = NSString(string: trimmedPath).expandingTildeInPath
+
+            guard let tracked = trackedWorktree(path: expandedPath, context: context) else {
+                return await write(projectIdentifier, operation: "worktree.remove", context: context) { repoPath in
+                    try await GitWorktreeService.shared.removeWorktree(
+                        repoPath: repoPath,
+                        path: expandedPath,
+                        force: force
+                    )
+                }
             }
+
+            let result = await write(projectIdentifier, operation: "worktree.remove", context: context) { _ in
+                try await WorktreeStore.cleanupOnDisk(worktree: tracked.worktree, repoPath: tracked.project.path)
+            }
+            if case .success = result {
+                forgetWorktree(project: tracked.project, worktree: tracked.worktree, context: context)
+            }
+            return result
+        }
+
+        static func trackedWorktree(
+            path: String,
+            context: Context
+        ) -> (project: Project, worktree: Worktree)? {
+            let target = GitWorktreeService.canonicalPath(path)
+            for project in context.projectStore.projects {
+                guard let worktree = context.worktreeStore.list(for: project.id).first(where: {
+                    GitWorktreeService.canonicalPath($0.path) == target
+                }), worktree.canBeRemoved
+                else { continue }
+                return (project, worktree)
+            }
+            return nil
+        }
+
+        static func forgetWorktree(project: Project, worktree: Worktree, context: Context) {
+            let remaining = context.worktreeStore.list(for: project.id).filter { $0.id != worktree.id }
+            let replacement = remaining.first { $0.id == context.appState.activeWorktreeID[project.id] }
+                ?? remaining.first { $0.isPrimary }
+                ?? remaining.first
+            context.appState.removeWorktree(projectID: project.id, worktree: worktree, replacement: replacement)
+            context.worktreeStore.remove(worktreeID: worktree.id, from: project.id)
         }
 
         private static func diffHints(staged: Bool?) -> GitRepositoryService.DiffHints {

--- a/Tests/MuxyTests/Services/MuxyAPIGitWorktreeTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPIGitWorktreeTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("MuxyAPI.Git worktree removal")
+@MainActor
+struct MuxyAPIGitWorktreeTests {
+    @Test("a removed worktree resolves to its project so teardown runs against the primary repo")
+    func resolvesTrackedWorktreeForCleanup() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let prWorktree = Worktree(
+            name: "PR 42",
+            path: "/tmp/repo-pr-42",
+            branch: "pr-42",
+            source: .muxy,
+            isPrimary: false
+        )
+        let context = makeContext(project: project, worktrees: [primary, prWorktree])
+
+        let tracked = MuxyAPI.Git.trackedWorktree(path: prWorktree.path, context: context)
+
+        #expect(tracked?.worktree.id == prWorktree.id)
+        #expect(tracked?.project.path == project.path)
+    }
+
+    @Test("the primary worktree never resolves for removal")
+    func primaryWorktreeIsNotRemovable() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let context = makeContext(project: project, worktrees: [primary])
+
+        #expect(MuxyAPI.Git.trackedWorktree(path: primary.path, context: context) == nil)
+    }
+
+    @Test("an untracked path does not resolve, leaving the git fallback to handle it")
+    func untrackedPathDoesNotResolve() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let context = makeContext(project: project, worktrees: [primary])
+
+        #expect(MuxyAPI.Git.trackedWorktree(path: "/tmp/repo-unknown", context: context) == nil)
+    }
+
+    @Test("forgetting a worktree drops it and switches to the replacement")
+    func forgetSwitchesToReplacement() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let prWorktree = Worktree(
+            name: "PR 42",
+            path: "/tmp/repo-pr-42",
+            branch: "pr-42",
+            source: .muxy,
+            isPrimary: false
+        )
+        let context = makeContext(project: project, worktrees: [primary, prWorktree])
+        context.appState.selectProject(project, worktree: prWorktree)
+
+        MuxyAPI.Git.forgetWorktree(project: project, worktree: prWorktree, context: context)
+
+        let remaining = context.worktreeStore.list(for: project.id)
+        #expect(!remaining.contains { $0.id == prWorktree.id })
+        #expect(context.appState.activeWorktreeID[project.id] == primary.id)
+    }
+
+    private func makeContext(project: Project, worktrees: [Worktree]) -> MuxyAPI.Git.Context {
+        let projectStore = ProjectStore(persistence: ProjectPersistenceStub())
+        projectStore.add(project)
+        let worktreeStore = WorktreeStore(
+            persistence: WorktreePersistenceStub(initial: [project.id: worktrees]),
+            projects: [project]
+        )
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        return MuxyAPI.Git.Context(
+            extensionID: "test",
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        )
+    }
+}
+
+private final class ProjectPersistenceStub: ProjectPersisting {
+    private var projects: [Project] = []
+    func loadProjects() throws -> [Project] { projects }
+    func saveProjects(_ projects: [Project]) throws { self.projects = projects }
+}
+
+private final class WorktreePersistenceStub: WorktreePersisting {
+    private var storage: [UUID: [Worktree]]
+    init(initial: [UUID: [Worktree]]) { storage = initial }
+    func loadWorktrees(projectID: UUID) throws -> [Worktree] { storage[projectID] ?? [] }
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws { storage[projectID] = worktrees }
+    func removeWorktrees(projectID: UUID) throws { storage.removeValue(forKey: projectID) }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws { snapshots = workspaces }
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for paneID: UUID) {}
+    func needsConfirmQuit(for paneID: UUID) -> Bool { false }
+}

--- a/docs/extensions/git.md
+++ b/docs/extensions/git.md
@@ -177,4 +177,5 @@ try {
 
 - `muxy.git` is available to extension **tabs**, **panels**, **popovers**, **`runScript` commands**, and **background scripts** — the same API and permissions everywhere. Calls return a `Promise` on webview pages and are synchronous in `runScript` and background scripts.
 - The app continues to own the worktree lifecycle it shows in the sidebar; `git.worktree.*` operates on the same underlying git worktrees, so changes are reflected after a refresh.
+- `worktree.remove` runs the app's full teardown (hooks, branch, directory) and updates the sidebar. With `force: false` it rejects a worktree that has uncommitted changes; pass `force: true` to discard them.
 - There are no AI helpers here — generate commit messages or PR bodies with your own model via `muxy.exec` if you need them.


### PR DESCRIPTION
`git.worktree.remove` only ran the bare git command, so merging a PR from a worktree left the worktree in the sidebar and skipped teardown hooks.

It now routes through the same `cleanupOnDisk` path as the sidebar delete (teardown, branch + dir cleanup) and syncs app state so the worktree disappears and the project switches to the replacement.