### PR TITLE
Free idle background terminal surfaces to reclaim memory

### DIFF
--- a/Muxy/Models/TerminalOfflinePreferences.swift
+++ b/Muxy/Models/TerminalOfflinePreferences.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum TerminalOfflinePreferences {
+    static let enabledKey = "muxy.terminalOffline.enabled"
+    static let idleThresholdKey = "muxy.terminalOffline.idleThresholdSeconds"
+
+    static let defaultIsEnabled = true
+    static let defaultIdleThreshold: TimeInterval = 300
+
+    static var isEnabled: Bool {
+        get {
+            let defaults = UserDefaults.standard
+            if defaults.object(forKey: enabledKey) == nil { return defaultIsEnabled }
+            return defaults.bool(forKey: enabledKey)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: enabledKey) }
+    }
+
+    static var idleThreshold: TimeInterval {
+        get {
+            let defaults = UserDefaults.standard
+            guard defaults.object(forKey: idleThresholdKey) != nil else { return defaultIdleThreshold }
+            let stored = defaults.double(forKey: idleThresholdKey)
+            return stored > 0 ? stored : defaultIdleThreshold
+        }
+        set { UserDefaults.standard.set(newValue, forKey: idleThresholdKey) }
+    }
+}

--- a/Muxy/Models/TerminalOfflineTimeout.swift
+++ b/Muxy/Models/TerminalOfflineTimeout.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum TerminalOfflineTimeout: String, CaseIterable, Identifiable {
+    case tenSeconds = "10 seconds"
+    case thirtySeconds = "30 seconds"
+    case oneMinute = "1 minute"
+    case twoMinutes = "2 minutes"
+    case fiveMinutes = "5 minutes"
+    case tenMinutes = "10 minutes"
+    case fifteenMinutes = "15 minutes"
+    case thirtyMinutes = "30 minutes"
+
+    var id: String { rawValue }
+
+    var seconds: TimeInterval {
+        switch self {
+        case .tenSeconds: 10
+        case .thirtySeconds: 30
+        case .oneMinute: 60
+        case .twoMinutes: 120
+        case .fiveMinutes: 300
+        case .tenMinutes: 600
+        case .fifteenMinutes: 900
+        case .thirtyMinutes: 1800
+        }
+    }
+
+    static func closest(to seconds: TimeInterval) -> TerminalOfflineTimeout {
+        allCases.min(by: { abs($0.seconds - seconds) < abs($1.seconds - seconds) }) ?? .fiveMinutes
+    }
+}

--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -21,6 +21,7 @@ final class TerminalPaneState: Identifiable {
     var activeRestoredCommand: String?
     var restoreDecision: TerminalSessionRestoreDecision = .none
     var restoreConsumed = false
+    var isOffline = false
     let searchState = TerminalSearchState()
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
 

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -146,6 +146,7 @@ struct MuxyApp: App {
             SettingsJSONStore.beginAutomaticUserSettingsSync()
             try? await Task.sleep(for: .seconds(2))
             UpdateService.shared.start()
+            TerminalOfflineService.shared.start()
             AIProviderRegistry.shared.installAll()
             LoginShellPath.hydrateInBackground()
             await NotificationSocketServer.shared.awaitReady()

--- a/Muxy/Services/TerminalOfflinePolicy.swift
+++ b/Muxy/Services/TerminalOfflinePolicy.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum TerminalOfflinePolicy {
+    struct Candidate {
+        let hasLiveSurface: Bool
+        let isAlreadyOffline: Bool
+        let invisibleDuration: TimeInterval?
+        let isIdle: Bool
+    }
+
+    static func isIdle(hasRunningProcess: Bool, isAlternateScreen: Bool) -> Bool {
+        !hasRunningProcess && !isAlternateScreen
+    }
+
+    static func shouldTakeOffline(
+        _ candidate: Candidate,
+        isEnabled: Bool,
+        idleThreshold: TimeInterval
+    ) -> Bool {
+        guard isEnabled, candidate.hasLiveSurface, !candidate.isAlreadyOffline else { return false }
+        guard let invisibleDuration = candidate.invisibleDuration, invisibleDuration >= idleThreshold else {
+            return false
+        }
+        return candidate.isIdle
+    }
+}

--- a/Muxy/Services/TerminalOfflineService.swift
+++ b/Muxy/Services/TerminalOfflineService.swift
@@ -1,0 +1,81 @@
+import Foundation
+import os
+
+@MainActor
+final class TerminalOfflineService {
+    static let shared = TerminalOfflineService()
+
+    nonisolated private static let minScanInterval: TimeInterval = 5
+    nonisolated private static let maxScanInterval: TimeInterval = 30
+
+    private let logger = Logger(subsystem: "app.muxy", category: "TerminalOffline")
+    private var timer: DispatchSourceTimer?
+
+    private init() {}
+
+    nonisolated static func scanInterval(for idleThreshold: TimeInterval) -> TimeInterval {
+        min(maxScanInterval, max(minScanInterval, idleThreshold))
+    }
+
+    func start() {
+        reload()
+    }
+
+    func reload() {
+        stopTimer()
+        guard TerminalOfflinePreferences.isEnabled else { return }
+        startTimer()
+    }
+
+    private func startTimer() {
+        guard timer == nil else { return }
+        let interval = Self.scanInterval(for: TerminalOfflinePreferences.idleThreshold)
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak self] in
+            MainActor.assumeIsolated {
+                self?.scan()
+            }
+        }
+        timer.resume()
+        self.timer = timer
+    }
+
+    private func stopTimer() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    private func scan() {
+        guard TerminalOfflinePreferences.isEnabled else {
+            stopTimer()
+            return
+        }
+        let idleThreshold = TerminalOfflinePreferences.idleThreshold
+        let now = Date()
+        var freed = 0
+        for view in TerminalViewRegistry.shared.liveViews {
+            guard view.hasLiveSurface, !view.isTakenOffline, !view.isOfflineBlockedByRemote else { continue }
+            guard let invisibleSince = view.offlineInvisibleSince else { continue }
+            let invisibleDuration = now.timeIntervalSince(invisibleSince)
+            guard invisibleDuration >= idleThreshold else { continue }
+            let candidate = TerminalOfflinePolicy.Candidate(
+                hasLiveSurface: true,
+                isAlreadyOffline: false,
+                invisibleDuration: invisibleDuration,
+                isIdle: view.isTerminalIdle()
+            )
+            guard TerminalOfflinePolicy.shouldTakeOffline(
+                candidate,
+                isEnabled: true,
+                idleThreshold: idleThreshold
+            )
+            else { continue }
+            view.takeOffline()
+            freed += 1
+        }
+        if freed > 0 {
+            logger.debug("Took \(freed) idle terminal(s) offline")
+        }
+    }
+}

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -331,6 +331,22 @@ enum SettingsCatalog {
             defaultValue: SessionRestorePreferences.defaultExcludedCommands
         ),
         SettingsCatalogItem(
+            key: TerminalOfflinePreferences.enabledKey,
+            title: "Free Idle Background Terminals",
+            description: "Frees a background tab's terminal after it stays idle, reclaiming memory.",
+            category: .terminal,
+            section: "Memory",
+            defaultValue: TerminalOfflinePreferences.defaultIsEnabled
+        ),
+        SettingsCatalogItem(
+            key: TerminalOfflinePreferences.idleThresholdKey,
+            title: "Idle Timeout (seconds)",
+            description: "How long a background tab stays idle before its terminal is freed.",
+            category: .terminal,
+            section: "Memory",
+            defaultValue: TerminalOfflinePreferences.defaultIdleThreshold
+        ),
+        SettingsCatalogItem(
             key: "shortcuts.app",
             title: "App Shortcuts",
             description: "Configures Muxy keyboard shortcuts.",

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -12,7 +12,22 @@ struct TerminalSettingsView: View {
     private var confirmRunningProcess = true
     @AppStorage(SessionRestorePreferences.enabledKey)
     private var restoreSessionsEnabled = SessionRestorePreferences.defaultIsEnabled
+    @AppStorage(TerminalOfflinePreferences.enabledKey)
+    private var freeIdleTerminalsEnabled = TerminalOfflinePreferences.defaultIsEnabled
+    @AppStorage(TerminalOfflinePreferences.idleThresholdKey)
+    private var idleThresholdSeconds = TerminalOfflinePreferences.defaultIdleThreshold
     @State private var excludedCommands = SessionRestorePreferences.excludedCommandsText
+
+    private var idleTimeoutSelection: Binding<String> {
+        Binding(
+            get: { TerminalOfflineTimeout.closest(to: idleThresholdSeconds).rawValue },
+            set: { rawValue in
+                guard let option = TerminalOfflineTimeout(rawValue: rawValue) else { return }
+                idleThresholdSeconds = option.seconds
+                TerminalOfflineService.shared.reload()
+            }
+        )
+    }
 
     var body: some View {
         SettingsContainer {
@@ -48,6 +63,26 @@ struct TerminalSettingsView: View {
                     label: "Confirm before closing a tab with a running process",
                     isOn: $confirmRunningProcess
                 )
+            }
+
+            SettingsSection(
+                "Memory",
+                footer: "Frees an idle background tab's terminal to reclaim memory. It reopens in the same "
+                    + "folder when you return. Tabs running a process or a full-screen app are never touched."
+            ) {
+                SettingsToggleRow(
+                    label: "Free idle background terminals",
+                    isOn: $freeIdleTerminalsEnabled
+                )
+                .onChange(of: freeIdleTerminalsEnabled) { _, _ in
+                    TerminalOfflineService.shared.reload()
+                }
+                SettingsPickerRow<TerminalOfflineTimeout>(
+                    label: "Free after idle for",
+                    selection: idleTimeoutSelection,
+                    width: 140
+                )
+                .disabled(!freeIdleTerminalsEnabled)
             }
 
             SettingsSection(

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -6,7 +6,7 @@ import UniformTypeIdentifiers
 final class GhosttyTerminalNSView: NSView {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
     private var surfaceFocused: Bool?
-    private let workingDirectory: String
+    private var workingDirectory: String
     private let command: String?
     private let commandInteractive: Bool
     private let commandClosesOnExit: Bool
@@ -33,6 +33,14 @@ final class GhosttyTerminalNSView: NSView {
     var overlayActive: Bool = false
 
     var processExitHandled = false
+
+    var onOfflineChange: ((Bool) -> Void)?
+    private var hasMaterializedOnce = false
+    private var isOfflinedState = false
+    private var offlineInvisibleAt: Date?
+
+    var isTakenOffline: Bool { isOfflinedState }
+    var offlineInvisibleSince: Date? { offlineInvisibleAt }
 
     private var isPaneVisible = true
     private var isWindowVisible = true
@@ -111,6 +119,8 @@ final class GhosttyTerminalNSView: NSView {
         }
         pendingSurfaceCreation = false
 
+        let launchCommand = hasMaterializedOnce ? nil : command
+
         var config = ghostty_surface_config_new()
         config.platform_tag = GHOSTTY_PLATFORM_MACOS
         config.platform = ghostty_platform_u(
@@ -127,7 +137,7 @@ final class GhosttyTerminalNSView: NSView {
         surfaceCStringPointers.append(workingDirectoryPointer)
         config.working_directory = UnsafePointer(workingDirectoryPointer)
 
-        if let command,
+        if let command = launchCommand,
            let loginWrapped = strdup(TerminalLaunchCommand.shellCommand(
                interactive: commandInteractive,
                keepsShellOpen: !commandClosesOnExit
@@ -163,6 +173,14 @@ final class GhosttyTerminalNSView: NSView {
         }
 
         guard let surface else { return }
+
+        hasMaterializedOnce = true
+        if isOfflinedState {
+            isOfflinedState = false
+            processExitHandled = false
+            onOfflineChange?(false)
+        }
+        resetOfflineVisibilityClock()
 
         let scale = Double(window?.backingScaleFactor ?? 2.0)
         ghostty_surface_set_content_scale(surface, scale, scale)
@@ -259,9 +277,11 @@ final class GhosttyTerminalNSView: NSView {
         delayedResizeWorkItem?.cancel()
         delayedResizeWorkItem = nil
 
+        updateOfflineVisibilityClock()
+
         guard let window else { return }
 
-        if surface == nil {
+        if surface == nil, !isOfflinedState || isPaneVisible {
             createSurface()
         }
 
@@ -305,6 +325,7 @@ final class GhosttyTerminalNSView: NSView {
     func setVisible(_ visible: Bool) {
         guard isPaneVisible != visible else { return }
         isPaneVisible = visible
+        updateOfflineVisibilityClock()
         applyOcclusionState()
     }
 
@@ -317,7 +338,43 @@ final class GhosttyTerminalNSView: NSView {
         let visible = window?.occlusionState.contains(.visible) ?? true
         guard isWindowVisible != visible else { return }
         isWindowVisible = visible
+        updateOfflineVisibilityClock()
         applyOcclusionState()
+    }
+
+    private func updateOfflineVisibilityClock() {
+        if window != nil, isPaneVisible, isWindowVisible {
+            offlineInvisibleAt = nil
+        } else if offlineInvisibleAt == nil {
+            offlineInvisibleAt = Date()
+        }
+    }
+
+    private func resetOfflineVisibilityClock() {
+        offlineInvisibleAt = window != nil && isPaneVisible && isWindowVisible ? nil : Date()
+    }
+
+    func updateResumeWorkingDirectory(_ directory: String) {
+        workingDirectory = directory
+    }
+
+    func isTerminalIdle() -> Bool {
+        guard let surface else { return true }
+        if ghostty_surface_needs_confirm_quit(surface) { return false }
+        return !isAlternateScreenActive(surface: surface)
+    }
+
+    var isOfflineBlockedByRemote: Bool {
+        guard let paneID = TerminalViewRegistry.shared.paneID(for: self) else { return false }
+        return TerminalViewRegistry.shared.isOwnedByRemote(paneID)
+    }
+
+    func takeOffline() {
+        guard surface != nil, offlineInvisibleAt != nil, !isOfflineBlockedByRemote, isTerminalIdle() else { return }
+        processExitHandled = true
+        destroySurface()
+        isOfflinedState = true
+        onOfflineChange?(true)
     }
 
     func applyColorScheme(isDark: Bool) {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -164,6 +164,10 @@ struct TerminalBridge: NSViewRepresentable {
                 state?.setWorkingDirectory(path)
             }
         }
+        view.onOfflineChange = { [weak state] offline in
+            state?.isOffline = offline
+        }
+        view.updateResumeWorkingDirectory(state.currentWorkingDirectory ?? state.projectPath)
         configureSearchCallbacks(view)
         configureFileOpenCallback(view)
         configureProgressCallback(view)
@@ -187,6 +191,10 @@ struct TerminalBridge: NSViewRepresentable {
             nsView.envVars = TerminalEnvVarBuilder.build(paneID: state.id, worktreeKey: key)
         }
         nsView.overlayActive = overlayActive
+        nsView.updateResumeWorkingDirectory(state.currentWorkingDirectory ?? state.projectPath)
+        if visible, nsView.isTakenOffline, nsView.surface == nil {
+            nsView.createSurface()
+        }
         nsView.setVisible(visible)
         nsView.onFocus = onFocus
         nsView.onProcessExit = onProcessExit
@@ -201,6 +209,9 @@ struct TerminalBridge: NSViewRepresentable {
             DispatchQueue.main.async {
                 state?.setWorkingDirectory(path)
             }
+        }
+        nsView.onOfflineChange = { [weak state] offline in
+            state?.isOffline = offline
         }
         configureSearchCallbacks(nsView)
         configureFileOpenCallback(nsView)

--- a/Muxy/Views/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Views/Terminal/TerminalViewRegistry.swift
@@ -63,6 +63,10 @@ final class TerminalViewRegistry {
         }
     }
 
+    var liveViews: [GhosttyTerminalNSView] {
+        Array(views.values)
+    }
+
     var liveViewCount: Int {
         views.count
     }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -13,6 +13,7 @@ struct PaneTabStrip: View {
         let colorID: String?
         let extensionID: String?
         let customIcon: ExtensionIcon?
+        let isOffline: Bool
     }
 
     let areaID: UUID
@@ -54,7 +55,8 @@ struct PaneTabStrip: View {
                 hasCustomTitle: tab.customTitle != nil,
                 colorID: tab.colorID,
                 extensionID: tab.content.extensionState?.extensionID,
-                customIcon: tab.content.extensionState?.customIcon
+                customIcon: tab.content.extensionState?.customIcon,
+                isOffline: tab.content.pane?.isOffline ?? false
             )
         }
     }
@@ -617,6 +619,7 @@ private struct TabCell: View {
         case .extensionWebView: label += ", Extension"
         }
         if tab.isPinned { label += ", Pinned" }
+        if tab.isOffline, !active { label += ", Idle" }
         if hasUnread { label += ", Unread" }
         return label
     }
@@ -630,6 +633,10 @@ private struct TabCell: View {
         } else if tab.isPinned {
             Image(systemName: "pin.fill")
                 .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+        } else if tab.isOffline, !active {
+            Image(systemName: "moon.zzz")
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                .help("Idle — terminal freed to save memory. Reopens when selected.")
         } else {
             switch tab.kind {
             case .terminal:

--- a/Tests/MuxyTests/Models/TerminalOfflineTimeoutTests.swift
+++ b/Tests/MuxyTests/Models/TerminalOfflineTimeoutTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalOfflineTimeout")
+struct TerminalOfflineTimeoutTests {
+    @Test("maps each option to its duration in seconds")
+    func mapsSeconds() {
+        #expect(TerminalOfflineTimeout.tenSeconds.seconds == 10)
+        #expect(TerminalOfflineTimeout.fiveMinutes.seconds == 300)
+        #expect(TerminalOfflineTimeout.thirtyMinutes.seconds == 1800)
+    }
+
+    @Test("closest picks the nearest option to an arbitrary duration")
+    func closestPicksNearest() {
+        #expect(TerminalOfflineTimeout.closest(to: 9) == .tenSeconds)
+        #expect(TerminalOfflineTimeout.closest(to: 55) == .oneMinute)
+        #expect(TerminalOfflineTimeout.closest(to: 280) == .fiveMinutes)
+        #expect(TerminalOfflineTimeout.closest(to: 100_000) == .thirtyMinutes)
+    }
+
+    @Test("default idle threshold maps to a real option")
+    func defaultMapsToOption() {
+        #expect(TerminalOfflineTimeout.closest(to: TerminalOfflinePreferences.defaultIdleThreshold) == .fiveMinutes)
+    }
+}

--- a/Tests/MuxyTests/Services/TerminalOfflinePolicyTests.swift
+++ b/Tests/MuxyTests/Services/TerminalOfflinePolicyTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalOfflinePolicy")
+struct TerminalOfflinePolicyTests {
+    private func candidate(
+        hasLiveSurface: Bool = true,
+        isAlreadyOffline: Bool = false,
+        invisibleDuration: TimeInterval? = 600,
+        isIdle: Bool = true
+    ) -> TerminalOfflinePolicy.Candidate {
+        TerminalOfflinePolicy.Candidate(
+            hasLiveSurface: hasLiveSurface,
+            isAlreadyOffline: isAlreadyOffline,
+            invisibleDuration: invisibleDuration,
+            isIdle: isIdle
+        )
+    }
+
+    @Test("idle requires no running process and no alternate screen")
+    func idleRequiresNoProcessAndNoAltScreen() {
+        #expect(TerminalOfflinePolicy.isIdle(hasRunningProcess: false, isAlternateScreen: false))
+        #expect(!TerminalOfflinePolicy.isIdle(hasRunningProcess: true, isAlternateScreen: false))
+        #expect(!TerminalOfflinePolicy.isIdle(hasRunningProcess: false, isAlternateScreen: true))
+        #expect(!TerminalOfflinePolicy.isIdle(hasRunningProcess: true, isAlternateScreen: true))
+    }
+
+    @Test("takes an idle hidden surface offline once the idle threshold elapses")
+    func takesIdleHiddenSurfaceOffline() {
+        #expect(TerminalOfflinePolicy.shouldTakeOffline(
+            candidate(invisibleDuration: 300),
+            isEnabled: true,
+            idleThreshold: 300
+        ))
+    }
+
+    @Test("never offlines while disabled")
+    func neverOfflinesWhileDisabled() {
+        #expect(!TerminalOfflinePolicy.shouldTakeOffline(
+            candidate(invisibleDuration: 9999),
+            isEnabled: false,
+            idleThreshold: 300
+        ))
+    }
+
+    @Test("never offlines a visible surface")
+    func neverOfflinesVisibleSurface() {
+        #expect(!TerminalOfflinePolicy.shouldTakeOffline(
+            candidate(invisibleDuration: nil),
+            isEnabled: true,
+            idleThreshold: 300
+        ))
+    }
+
+    @Test("never offlines before the threshold elapses")
+    func waitsForThreshold() {
+        #expect(!TerminalOfflinePolicy.shouldTakeOffline(
+            candidate(invisibleDuration: 120),
+            isEnabled: true,
+            idleThreshold: 300
+        ))
+    }
+
+    @Test("never offlines a busy surface")
+    func neverOfflinesBusySurface() {
+        #expect(!TerminalOfflinePolicy.shouldTakeOffline(
+            candidate(isIdle: false),
+            isEnabled: true,
+            idleThreshold: 300
+        ))
+    }
+
+    @Test("never offlines without a live surface or when already offline")
+    func skipsWhenNoSurfaceOrAlreadyOffline() {
+        #expect(!TerminalOfflinePolicy.shouldTakeOffline(
+            candidate(hasLiveSurface: false),
+            isEnabled: true,
+            idleThreshold: 300
+        ))
+        #expect(!TerminalOfflinePolicy.shouldTakeOffline(
+            candidate(isAlreadyOffline: true),
+            isEnabled: true,
+            idleThreshold: 300
+        ))
+    }
+}

--- a/Tests/MuxyTests/Services/TerminalOfflineServiceTests.swift
+++ b/Tests/MuxyTests/Services/TerminalOfflineServiceTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalOfflineService")
+struct TerminalOfflineServiceTests {
+    @Test("scan interval follows the idle threshold, clamped to 5...30 seconds")
+    func scanIntervalFollowsThreshold() {
+        #expect(TerminalOfflineService.scanInterval(for: 10) == 10)
+        #expect(TerminalOfflineService.scanInterval(for: 30) == 30)
+    }
+
+    @Test("scan interval is clamped for very small and very large thresholds")
+    func scanIntervalClamped() {
+        #expect(TerminalOfflineService.scanInterval(for: 3) == 5)
+        #expect(TerminalOfflineService.scanInterval(for: 300) == 30)
+        #expect(TerminalOfflineService.scanInterval(for: 1800) == 30)
+    }
+}


### PR DESCRIPTION
Idle background tabs (no running process, no TUI) free their Ghostty surface (~100MB) after a configurable idle
  timeout, reopening in the same folder when reselected. On by default with a Terminal-settings toggle and timeout
  picker (10s–30m).