### PR TITLE
Allow deleting installed extensions and drop the global DEV badge

### DIFF
--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -179,6 +179,25 @@ final class ExtensionStore {
         reload()
     }
 
+    func delete(extensionID: String) throws {
+        guard let status = statuses.first(where: { $0.id == extensionID }) else { return }
+        guard !status.isDev else { throw ExtensionDeleteError.devExtension }
+
+        stopProcess(extensionID: extensionID)
+
+        let target = rootDirectoryURL.appendingPathComponent(extensionID, isDirectory: true)
+        if FileManager.default.fileExists(atPath: target.path) {
+            try FileManager.default.removeItem(at: target)
+        }
+
+        ExtensionEnabledStore.clear(extensionID: extensionID)
+        ExtensionSettingsStore.shared.clearAll(extensionID: extensionID)
+        ExtensionGrantStore.shared.removeAll(for: extensionID)
+        availableUpdates.removeValue(forKey: extensionID)
+
+        reload()
+    }
+
     func availableUpdateVersion(for extensionID: String) -> String? {
         availableUpdates[extensionID]
     }
@@ -950,5 +969,16 @@ final class ExtensionStore {
         if wasIntentional { return .stopped }
         if terminationStatus == 0 { return .exitedCleanly }
         return .exitedWithStatus(terminationStatus)
+    }
+}
+
+enum ExtensionDeleteError: LocalizedError, Equatable {
+    case devExtension
+
+    var errorDescription: String? {
+        switch self {
+        case .devExtension:
+            "Unpacked extensions can only be removed with “Remove from Muxy”."
+        }
     }
 }

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -74,7 +74,8 @@ struct ExtensionsView: View {
             ExtensionDetailPage(
                 status: status,
                 store: store,
-                grantStore: grantStore
+                grantStore: grantStore,
+                onDeleted: { selectedExtensionID = nil }
             )
         } else if tab == .browse {
             ExtensionStorePage(
@@ -120,7 +121,6 @@ struct ExtensionsView: View {
                     Text("Extensions")
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundStyle(MuxyTheme.fg)
-                    SettingsDevelopmentBadge(text: "DEV")
                 }
             }
             if !isShowingSubPage {
@@ -312,7 +312,6 @@ private struct ExtensionsListPage: View {
 
     private var developmentBanner: some View {
         HStack(alignment: .top, spacing: 8) {
-            SettingsDevelopmentBadge(text: "DEV")
             Text("Extensions are under active development. APIs, manifest format, and behavior may change without notice.")
                 .font(.system(size: 11))
                 .foregroundStyle(MuxyTheme.fgMuted)
@@ -674,8 +673,10 @@ private struct ExtensionDetailPage: View {
     let status: ExtensionStore.ExtensionStatus
     let store: ExtensionStore
     let grantStore: ExtensionGrantStore
+    var onDeleted: () -> Void = {}
     @State private var showLogs = false
     @State private var isUpdating = false
+    @State private var showDeleteConfirmation = false
 
     private var ext: MuxyExtension { status.muxyExtension }
 
@@ -753,8 +754,8 @@ private struct ExtensionDetailPage: View {
                     .foregroundStyle(MuxyTheme.fgDim)
                     .lineLimit(1)
                     .truncationMode(.middle)
+                Spacer(minLength: 12)
                 if status.isDev {
-                    Spacer(minLength: 12)
                     Button {
                         store.removeDevPath(status.devSourcePath ?? ext.directory.path)
                     } label: {
@@ -764,12 +765,32 @@ private struct ExtensionDetailPage: View {
                     }
                     .buttonStyle(.plain)
                     .help("Stop loading this dev extension. Your folder is left untouched.")
+                } else {
+                    Button {
+                        showDeleteConfirmation = true
+                    } label: {
+                        Text("Delete")
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuxyTheme.diffRemoveFg)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Delete this extension and its data from Muxy.")
                 }
             }
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 10))
+        .confirmationDialog(
+            "Delete \(ext.displayName)?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { performDelete() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the extension and its settings, permissions, and shortcuts. This cannot be undone.")
+        }
     }
 
     private func errorBlock(_ error: String) -> some View {
@@ -986,6 +1007,18 @@ private struct ExtensionDetailPage: View {
         } catch {
             let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             ToastState.shared.show(title: "Could not update \(status.id)", body: message)
+        }
+    }
+
+    private func performDelete() {
+        let name = ext.displayName
+        do {
+            try store.delete(extensionID: status.id)
+            onDeleted()
+            ToastState.shared.show("Deleted \(name)")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            ToastState.shared.show(title: "Could not delete \(name)", body: message)
         }
     }
 

--- a/Tests/MuxyTests/Services/ExtensionStoreDeleteTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreDeleteTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionStore delete")
+@MainActor
+struct ExtensionStoreDeleteTests {
+    @Test("removes the installed folder and drops the status")
+    func deletesInstalledExtension() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root)
+
+        try await store.install(expectedName: "demo-ext", zip: makeExtensionZip(name: "demo-ext"))
+        let directory = root.appendingPathComponent("demo-ext")
+        #expect(FileManager.default.fileExists(atPath: directory.path))
+
+        try store.delete(extensionID: "demo-ext")
+
+        #expect(!FileManager.default.fileExists(atPath: directory.path))
+        #expect(!store.statuses.contains { $0.id == "demo-ext" })
+    }
+
+    @Test("purges enabled state, settings, and permission grants")
+    func purgesPersistedState() async throws {
+        let root = makeRoot()
+        let extensionID = "delete-state-ext"
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            ExtensionEnabledStore.clear(extensionID: extensionID)
+            ExtensionSettingsStore.shared.clearAll(extensionID: extensionID)
+            ExtensionGrantStore.shared.removeAll(for: extensionID)
+        }
+        let store = makeStore(root: root)
+        try await store.install(expectedName: extensionID, zip: makeExtensionZip(name: extensionID))
+
+        ExtensionEnabledStore.setEnabled(true, extensionID: extensionID)
+        ExtensionSettingsStore.shared.setValue(.string("dark"), extensionID: extensionID, key: "theme")
+        ExtensionGrantStore.shared.add(ExtensionGrantRule(
+            extensionID: extensionID,
+            verb: .exec,
+            match: .argvExact(["git", "status"]),
+            decision: .allow
+        ))
+
+        try store.delete(extensionID: extensionID)
+
+        #expect(!ExtensionEnabledStore.hasOverride(extensionID: extensionID))
+        #expect(ExtensionSettingsStore.shared.value(extensionID: extensionID, key: "theme") == nil)
+        #expect(ExtensionGrantStore.shared.rules(for: extensionID).isEmpty)
+    }
+
+    @Test("is a no-op for an unknown extension")
+    func ignoresUnknownExtension() throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = makeStore(root: root)
+
+        try store.delete(extensionID: "missing")
+
+        #expect(store.statuses.isEmpty)
+    }
+
+    @Test("refuses to delete a dev extension and leaves its folder untouched")
+    func rejectsDevExtension() throws {
+        let root = makeRoot()
+        let devParent = makeRoot()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: devParent)
+        }
+        let devDir = try makeExtensionDirectory(name: "dev-ext", in: devParent)
+        let store = makeStore(root: root, devPaths: [devDir.path])
+        store.startAll()
+        #expect(store.statuses.first { $0.id == "dev-ext" }?.isDev == true)
+
+        #expect(throws: ExtensionDeleteError.devExtension) {
+            try store.delete(extensionID: "dev-ext")
+        }
+        #expect(FileManager.default.fileExists(atPath: devDir.path))
+        #expect(store.statuses.contains { $0.id == "dev-ext" })
+    }
+
+    private func makeRoot() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("delete-root-\(UUID().uuidString)")
+    }
+
+    private func makeStore(root: URL, devPaths: [String] = []) -> ExtensionStore {
+        ExtensionStore.makeForTesting(
+            rootDirectory: root,
+            snapshotSink: NoopDeleteSnapshotSink(),
+            resolveHostURL: { URL(fileURLWithPath: "/usr/bin/true") },
+            devPathsProvider: { devPaths }
+        )
+    }
+
+    @discardableResult
+    private func makeExtensionDirectory(name: String, in parent: URL) throws -> URL {
+        let directory = parent.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let manifest = """
+        {
+            "name": "\(name)",
+            "version": "1.0.0"
+        }
+        """
+        try ExtensionManifestFixture.write(flatManifest: manifest, to: directory)
+        return directory
+    }
+
+    private func makeExtensionZip(name: String) throws -> Data {
+        let fileManager = FileManager.default
+        let workspace = fileManager.temporaryDirectory.appendingPathComponent("zip-src-\(UUID().uuidString)")
+        let source = workspace.appendingPathComponent(name)
+        try fileManager.createDirectory(at: source, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: workspace) }
+
+        let manifest = """
+        {
+            "name": "\(name)",
+            "version": "1.0.0",
+            "background": "background.js"
+        }
+        """
+        try ExtensionManifestFixture.write(flatManifest: manifest, to: source)
+        try Data("console.log('hi')\n".utf8).write(to: source.appendingPathComponent("background.js"))
+
+        let archive = workspace.appendingPathComponent("\(name).zip")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.arguments = ["-q", "-r", archive.path, name]
+        process.currentDirectoryURL = workspace
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+        return try Data(contentsOf: archive)
+    }
+}
+
+@MainActor
+private final class NoopDeleteSnapshotSink: ExtensionSnapshotSink {
+    nonisolated func applyExtensionSnapshot(_: NotificationSocketServer.ExtensionSnapshot) {}
+}


### PR DESCRIPTION
Add a Delete action (behind a confirmation) on the extension detail page that removes the installed folder and
  purges its enabled state, settings, and permission grants. Dev/unpacked extensions keep the non-destructive
  "Remove from Muxy".