### PR TITLE
Remove git branch subtitle from sidebar worktree rows

### DIFF
--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -495,13 +495,6 @@ private struct ExpandedWorktreeRow: View {
         return worktree.name
     }
 
-    private var branchLabel: String? {
-        guard !worktree.isPrimary else { return nil }
-        guard let branch = worktree.branch, !branch.isEmpty else { return nil }
-        guard branch.caseInsensitiveCompare(displayName) != .orderedSame else { return nil }
-        return branch
-    }
-
     var body: some View {
         HStack(spacing: UIMetrics.spacing3) {
             leadingIndicator
@@ -515,25 +508,15 @@ private struct ExpandedWorktreeRow: View {
                     .onSubmit { commitRename() }
                     .onExitCommand { cancelRename() }
             } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: UIMetrics.spacing2) {
-                        Text(displayName)
-                            .font(.system(size: UIMetrics.fontBody, weight: activeStyle ? .semibold : .regular))
-                            .foregroundStyle(MuxyTheme.fg)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                HStack(spacing: UIMetrics.spacing2) {
+                    Text(displayName)
+                        .font(.system(size: UIMetrics.fontBody, weight: activeStyle ? .semibold : .regular))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
 
-                        if worktree.isPrimary {
-                            PrimaryBadge()
-                        }
-                    }
-
-                    if let branch = branchLabel {
-                        Text(branch)
-                            .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
-                            .foregroundStyle(MuxyTheme.fg)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+                    if worktree.isPrimary {
+                        PrimaryBadge()
                     }
                 }
             }
@@ -571,7 +554,6 @@ private struct ExpandedWorktreeRow: View {
     private var worktreeAccessibilityLabel: String {
         var label = displayName
         if worktree.isPrimary { label += ", primary" }
-        if let branch = branchLabel { label += ", branch: \(branch)" }
         return label
     }
 

--- a/Muxy/Views/Sidebar/WorktreePopover.swift
+++ b/Muxy/Views/Sidebar/WorktreePopover.swift
@@ -127,12 +127,6 @@ private struct WorktreePopoverRow: View {
         return worktree.name
     }
 
-    private var branchSubtitle: String? {
-        guard let branch = worktree.branch, !branch.isEmpty else { return nil }
-        guard branch.caseInsensitiveCompare(displayName) != .orderedSame else { return nil }
-        return branch
-    }
-
     var body: some View {
         HStack(spacing: UIMetrics.spacing5) {
             indicator
@@ -162,13 +156,6 @@ private struct WorktreePopoverRow: View {
                                 .background(MuxyTheme.surface, in: Capsule())
                         }
                     }
-                }
-                if let branch = branchSubtitle, !isRenaming {
-                    Text(branch)
-                        .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
-                        .foregroundStyle(MuxyTheme.fgDim)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
                 }
             }
             Spacer(minLength: 4)


### PR DESCRIPTION
Worktree rows no longer render the git branch name as a second line when it
  differs from the worktree name. Each row now shows a single line — the worktree
  name — in both the sidebar and the Switch Worktree popover.