### PR TITLE
Sleep idle inactive split panes and add a click-to-wake fallback

### DIFF
--- a/Muxy/Services/TerminalOfflinePolicy.swift
+++ b/Muxy/Services/TerminalOfflinePolicy.swift
@@ -12,6 +12,10 @@ enum TerminalOfflinePolicy {
         !hasRunningProcess && !isAlternateScreen
     }
 
+    static func keepsAwake(isOnScreen: Bool, isFocused: Bool) -> Bool {
+        isOnScreen && isFocused
+    }
+
     static func shouldTakeOffline(
         _ candidate: Candidate,
         isEnabled: Bool,
@@ -22,5 +26,12 @@ enum TerminalOfflinePolicy {
             return false
         }
         return candidate.isIdle
+    }
+}
+
+enum SleepingTabPlaceholderPolicy {
+    static func shouldPresent(isVisible: Bool, isOffline: Bool, isRemotelyOwned: Bool) -> Bool {
+        guard isVisible, isOffline, !isRemotelyOwned else { return false }
+        return true
     }
 }

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -67,11 +67,12 @@ struct TerminalSettingsView: View {
 
             SettingsSection(
                 "Memory",
-                footer: "Frees an idle background tab's terminal to reclaim memory. It reopens in the same "
-                    + "folder when you return. Tabs running a process or a full-screen app are never touched."
+                footer: "Frees an idle terminal you are not actively using to reclaim memory, including "
+                    + "visible split panes that are not focused. It reopens in the same folder when you return. "
+                    + "Tabs running a process or a full-screen app are never touched."
             ) {
                 SettingsToggleRow(
-                    label: "Free idle background terminals",
+                    label: "Free idle inactive terminals",
                     isOn: $freeIdleTerminalsEnabled
                 )
                 .onChange(of: freeIdleTerminalsEnabled) { _, _ in

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -43,6 +43,7 @@ final class GhosttyTerminalNSView: NSView {
     var offlineInvisibleSince: Date? { offlineInvisibleAt }
 
     private var isPaneVisible = true
+    private var isPaneFocused = false
     private var isWindowVisible = true
     nonisolated(unsafe) private var occlusionObserver: NSObjectProtocol?
 
@@ -336,6 +337,13 @@ final class GhosttyTerminalNSView: NSView {
         applyOcclusionState()
     }
 
+    func setFocused(_ focused: Bool) {
+        guard isPaneFocused != focused else { return }
+        isPaneFocused = focused
+        updateOfflineVisibilityClock()
+        reviveSurfaceIfNeeded()
+    }
+
     private func applyOcclusionState() {
         guard let surface else { return }
         ghostty_surface_set_occlusion(surface, isPaneVisible && isWindowVisible)
@@ -351,16 +359,29 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private func reviveSurfaceIfNeeded() {
-        guard isOfflinedState, surface == nil, isCurrentlyVisible else { return }
+        guard isOfflinedState, surface == nil, keepsAwake else { return }
         createSurface()
+    }
+
+    func wake() {
+        guard isOfflinedState, surface == nil else { return }
+        isPaneVisible = true
+        isPaneFocused = true
+        updateOfflineVisibilityClock()
+        createSurface()
+        applyOcclusionState()
     }
 
     private var isCurrentlyVisible: Bool {
         window != nil && isPaneVisible && isWindowVisible
     }
 
+    private var keepsAwake: Bool {
+        TerminalOfflinePolicy.keepsAwake(isOnScreen: isCurrentlyVisible, isFocused: isPaneFocused)
+    }
+
     private func updateOfflineVisibilityClock() {
-        if isCurrentlyVisible {
+        if keepsAwake {
             offlineInvisibleAt = nil
         } else if offlineInvisibleAt == nil {
             offlineInvisibleAt = Date()
@@ -368,7 +389,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private func resetOfflineVisibilityClock() {
-        offlineInvisibleAt = isCurrentlyVisible ? nil : Date()
+        offlineInvisibleAt = keepsAwake ? nil : Date()
     }
 
     func updateResumeWorkingDirectory(_ directory: String) {
@@ -398,7 +419,7 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private var isEligibleForOffline: Bool {
-        surface != nil && !isCurrentlyVisible && offlineInvisibleAt != nil
+        surface != nil && !keepsAwake && offlineInvisibleAt != nil
             && !isOfflineBlockedByRemote && isTerminalIdle()
     }
 

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -17,6 +17,23 @@ struct TerminalPane: View {
         if case let .remote(_, name) = ownership.owner(for: state.id) { name } else { nil }
     }
 
+    private var showsSleepingPlaceholder: Bool {
+        SleepingTabPlaceholderPolicy.shouldPresent(
+            isVisible: visible,
+            isOffline: state.isOffline,
+            isRemotelyOwned: remoteOwnerName != nil
+        )
+    }
+
+    private func wakePane() {
+        let view = TerminalViewRegistry.shared.existingView(for: state.id)
+        view?.wake()
+        onFocus()
+        DispatchQueue.main.async { [weak view] in
+            view?.window?.makeFirstResponder(view)
+        }
+    }
+
     var body: some View {
         terminalLayer
             .onReceive(NotificationCenter.default.publisher(for: .refocusActiveTerminal)) { _ in
@@ -73,7 +90,52 @@ struct TerminalPane: View {
                 )
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
+
+            if showsSleepingPlaceholder {
+                SleepingTabPlaceholder(onWake: wakePane)
+                    .transition(.opacity)
+            }
         }
+    }
+}
+
+struct SleepingTabPlaceholder: View {
+    let onWake: () -> Void
+
+    var body: some View {
+        VStack(spacing: UIMetrics.spacing7) {
+            Spacer()
+            Image(systemName: "moon.zzz")
+                .font(.system(size: UIMetrics.fontMega))
+                .foregroundStyle(MuxyTheme.fgMuted)
+            Text("Tab is asleep")
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+            Text("This terminal was freed to save memory. Wake it to resume your session.")
+                .font(.system(size: UIMetrics.fontBody))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: UIMetrics.scaled(360))
+            Button(action: onWake) {
+                HStack(spacing: UIMetrics.spacing4) {
+                    Text("Wake")
+                    Text("⏎")
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
+                        .opacity(0.72)
+                }
+            }
+            .keyboardShortcut(.return, modifiers: [])
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(MuxyTheme.bg)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onWake)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("Tab is asleep")
+        .accessibilityHint("Wake the terminal to resume your session")
     }
 }
 
@@ -150,6 +212,7 @@ struct TerminalBridge: NSViewRepresentable {
         view.isFocused = focused
         view.overlayActive = overlayActive
         view.setVisible(visible)
+        view.setFocused(focused)
         view.onFocus = onFocus
         view.onProcessExit = onProcessExit
         view.onSplitRequest = onSplitRequest
@@ -193,6 +256,7 @@ struct TerminalBridge: NSViewRepresentable {
         nsView.overlayActive = overlayActive
         nsView.updateResumeWorkingDirectory(state.currentWorkingDirectory ?? state.projectPath)
         nsView.setVisible(visible)
+        nsView.setFocused(focused)
         nsView.onFocus = onFocus
         nsView.onProcessExit = onProcessExit
         nsView.onSplitRequest = onSplitRequest

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -26,12 +26,8 @@ struct TerminalPane: View {
     }
 
     private func wakePane() {
-        let view = TerminalViewRegistry.shared.existingView(for: state.id)
-        view?.wake()
+        TerminalViewRegistry.shared.existingView(for: state.id)?.wake()
         onFocus()
-        DispatchQueue.main.async { [weak view] in
-            view?.window?.makeFirstResponder(view)
-        }
     }
 
     var body: some View {
@@ -92,7 +88,7 @@ struct TerminalPane: View {
             }
 
             if showsSleepingPlaceholder {
-                SleepingTabPlaceholder(onWake: wakePane)
+                SleepingTabPlaceholder(isFocused: focused, onWake: wakePane)
                     .transition(.opacity)
             }
         }
@@ -100,6 +96,7 @@ struct TerminalPane: View {
 }
 
 struct SleepingTabPlaceholder: View {
+    let isFocused: Bool
     let onWake: () -> Void
 
     var body: some View {
@@ -119,12 +116,14 @@ struct SleepingTabPlaceholder: View {
             Button(action: onWake) {
                 HStack(spacing: UIMetrics.spacing4) {
                     Text("Wake")
-                    Text("⏎")
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
-                        .opacity(0.72)
+                    if isFocused {
+                        Text("⏎")
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
+                            .opacity(0.72)
+                    }
                 }
             }
-            .keyboardShortcut(.return, modifiers: [])
+            .keyboardShortcut(isFocused ? KeyboardShortcut(.return, modifiers: []) : nil)
             .buttonStyle(.borderedProminent)
             Spacer()
         }

--- a/Tests/MuxyTests/Services/TerminalOfflinePolicyTests.swift
+++ b/Tests/MuxyTests/Services/TerminalOfflinePolicyTests.swift
@@ -27,6 +27,14 @@ struct TerminalOfflinePolicyTests {
         #expect(!TerminalOfflinePolicy.isIdle(hasRunningProcess: true, isAlternateScreen: true))
     }
 
+    @Test("a pane keeps awake only while on screen and focused")
+    func keepsAwakeOnlyWhenOnScreenAndFocused() {
+        #expect(TerminalOfflinePolicy.keepsAwake(isOnScreen: true, isFocused: true))
+        #expect(!TerminalOfflinePolicy.keepsAwake(isOnScreen: true, isFocused: false))
+        #expect(!TerminalOfflinePolicy.keepsAwake(isOnScreen: false, isFocused: true))
+        #expect(!TerminalOfflinePolicy.keepsAwake(isOnScreen: false, isFocused: false))
+    }
+
     @Test("takes an idle hidden surface offline once the idle threshold elapses")
     func takesIdleHiddenSurfaceOffline() {
         #expect(TerminalOfflinePolicy.shouldTakeOffline(

--- a/Tests/MuxyTests/Views/SleepingTabPlaceholderPolicyTests.swift
+++ b/Tests/MuxyTests/Views/SleepingTabPlaceholderPolicyTests.swift
@@ -1,0 +1,42 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("SleepingTabPlaceholderPolicy")
+struct SleepingTabPlaceholderPolicyTests {
+    @Test("presents when a visible local pane is offline")
+    func presentsWhenVisibleOfflineLocal() {
+        #expect(SleepingTabPlaceholderPolicy.shouldPresent(
+            isVisible: true,
+            isOffline: true,
+            isRemotelyOwned: false
+        ))
+    }
+
+    @Test("hides while the pane is not visible")
+    func hidesWhenNotVisible() {
+        #expect(!SleepingTabPlaceholderPolicy.shouldPresent(
+            isVisible: false,
+            isOffline: true,
+            isRemotelyOwned: false
+        ))
+    }
+
+    @Test("hides while the pane is online")
+    func hidesWhenOnline() {
+        #expect(!SleepingTabPlaceholderPolicy.shouldPresent(
+            isVisible: true,
+            isOffline: false,
+            isRemotelyOwned: false
+        ))
+    }
+
+    @Test("hides while the pane is owned by a remote device")
+    func hidesWhenRemotelyOwned() {
+        #expect(!SleepingTabPlaceholderPolicy.shouldPresent(
+            isVisible: true,
+            isOffline: true,
+            isRemotelyOwned: true
+        ))
+    }
+}


### PR DESCRIPTION
Idle split panes that are visible but not focused now sleep to free memory,
  matching the window-occlusion behavior. A "Tab is asleep" placeholder lets you
  wake a slept pane via click, Return, or the button — which also focuses it.