### PR TITLE
fix: stop -50 dialog on unresolvable terminal file links

### DIFF
--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -344,11 +344,16 @@ struct TerminalBridge: NSViewRepresentable {
         let column: Int?
     }
 
-    static let externalLinkSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms", "facetime", "facetime-audio"]
-
     static func isExternalLink(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased() else { return false }
-        return url.host != nil || externalLinkSchemes.contains(scheme)
+        guard url.scheme != nil else { return false }
+        guard !isLocalPathCandidate(url) else { return false }
+        return true
+    }
+
+    static func isLocalPathCandidate(_ url: URL) -> Bool {
+        guard !url.isFileURL, url.host == nil, !url.absoluteString.contains("//") else { return false }
+        let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
+        return url.scheme == nil || stripLineColumnSuffix(from: raw) != nil
     }
 
     static func resolveFilePath(_ token: String, projectPath: String) -> String? {
@@ -375,7 +380,7 @@ struct TerminalBridge: NSViewRepresentable {
             guard !isDirectory.boolValue else { return nil }
             return path
         }
-        guard url.scheme == nil else { return nil }
+        guard isLocalPathCandidate(url) else { return nil }
         let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
         return resolveFilePath(raw, projectPath: projectPath)
     }
@@ -384,7 +389,7 @@ struct TerminalBridge: NSViewRepresentable {
         if let path = resolveLocalFilePath(from: url, projectPath: projectPath) {
             return ResolvedFileLocation(path: path, line: nil, column: nil)
         }
-        guard !url.isFileURL, url.scheme == nil else { return nil }
+        guard isLocalPathCandidate(url) else { return nil }
         let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
         guard let stripped = stripLineColumnSuffix(from: raw) else { return nil }
         guard let path = resolveFilePath(stripped.path, projectPath: projectPath) else { return nil }

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -322,11 +322,33 @@ struct TerminalBridge: NSViewRepresentable {
             _ = IDEIntegrationService.shared.openProject(at: projectPath, highlightingFileAt: resolved)
         }
         view.onOpenURL = { url in
-            guard let resolved = Self.resolveLocalFilePath(from: url, projectPath: projectPath) else {
-                return NSWorkspace.shared.open(url)
+            if let location = Self.resolveFileLocation(from: url, projectPath: projectPath) {
+                return IDEIntegrationService.shared.openProject(
+                    at: projectPath,
+                    highlightingFileAt: location.path,
+                    line: location.line,
+                    column: location.column
+                )
             }
-            return IDEIntegrationService.shared.openProject(at: projectPath, highlightingFileAt: resolved)
+            guard Self.isExternalLink(url) else {
+                ToastState.shared.show("File not found")
+                return false
+            }
+            return NSWorkspace.shared.open(url)
         }
+    }
+
+    struct ResolvedFileLocation: Equatable {
+        let path: String
+        let line: Int?
+        let column: Int?
+    }
+
+    static let externalLinkSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms", "facetime", "facetime-audio"]
+
+    static func isExternalLink(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return url.host != nil || externalLinkSchemes.contains(scheme)
     }
 
     static func resolveFilePath(_ token: String, projectPath: String) -> String? {
@@ -356,6 +378,44 @@ struct TerminalBridge: NSViewRepresentable {
         guard url.scheme == nil else { return nil }
         let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
         return resolveFilePath(raw, projectPath: projectPath)
+    }
+
+    static func resolveFileLocation(from url: URL, projectPath: String) -> ResolvedFileLocation? {
+        if let path = resolveLocalFilePath(from: url, projectPath: projectPath) {
+            return ResolvedFileLocation(path: path, line: nil, column: nil)
+        }
+        guard !url.isFileURL, url.scheme == nil else { return nil }
+        let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
+        guard let stripped = stripLineColumnSuffix(from: raw) else { return nil }
+        guard let path = resolveFilePath(stripped.path, projectPath: projectPath) else { return nil }
+        return ResolvedFileLocation(path: path, line: stripped.line, column: stripped.column)
+    }
+
+    static func stripLineColumnSuffix(from token: String) -> ResolvedFileLocation? {
+        let components = token.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        guard components.count >= 2 else { return nil }
+
+        if components.count >= 3,
+           let line = numericComponent(components[components.count - 2]),
+           let column = numericComponent(components[components.count - 1])
+        {
+            let path = components.dropLast(2).joined(separator: ":")
+            guard !path.isEmpty else { return nil }
+            return ResolvedFileLocation(path: path, line: line, column: column)
+        }
+
+        if let line = numericComponent(components[components.count - 1]) {
+            let path = components.dropLast().joined(separator: ":")
+            guard !path.isEmpty else { return nil }
+            return ResolvedFileLocation(path: path, line: line, column: nil)
+        }
+
+        return nil
+    }
+
+    private static func numericComponent(_ component: String) -> Int? {
+        guard !component.isEmpty, component.allSatisfy(\.isNumber) else { return nil }
+        return Int(component)
     }
 
     private func configureProgressCallback(_ view: GhosttyTerminalNSView) {

--- a/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
+++ b/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
@@ -134,6 +134,33 @@ struct TerminalBridgeResolveFilePathTests {
         #expect(location == .init(path: file, line: 12, column: nil))
     }
 
+    @Test func resolvesFileLocationRootLevelDottedNameWithLineSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "README.md")
+        let url = try #require(URL(string: "README.md:10"))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 10, column: nil))
+    }
+
+    @Test func resolvesFileLocationRootLevelDottedNameWithLineAndColumnSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "main.swift")
+        let url = try #require(URL(string: "main.swift:42:7"))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 42, column: 7))
+    }
+
+    @Test func resolvesFileLocationRootLevelExtensionlessNameWithLineSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "Makefile")
+        let url = try #require(URL(string: "Makefile:12"))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 12, column: nil))
+    }
+
     @Test func resolvesFileLocationWithoutSuffix() throws {
         let dir = makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -175,11 +202,15 @@ struct TerminalBridgeResolveFilePathTests {
         #expect(TerminalBridge.isExternalLink(try #require(URL(string: "mailto:a@b.com"))))
         #expect(TerminalBridge.isExternalLink(try #require(URL(string: "tel:+123"))))
         #expect(TerminalBridge.isExternalLink(try #require(URL(string: "vscode://file/x"))))
+        #expect(TerminalBridge.isExternalLink(try #require(URL(string: "ssh:host"))))
+        #expect(TerminalBridge.isExternalLink(try #require(URL(string: "spotify:track:abc"))))
     }
 
     @Test func treatsSchemelessAndMisparsedPathsAsNonExternal() throws {
         #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "/tmp/x.md:12"))))
         #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "notes.md:5"))))
         #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "reviews/results.md:12"))))
+        #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "main.swift:42:7"))))
+        #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "Makefile:12"))))
     }
 }

--- a/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
+++ b/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
@@ -104,4 +104,82 @@ struct TerminalBridgeResolveFilePathTests {
         let url = URL(fileURLWithPath: dir.path)
         #expect(TerminalBridge.resolveLocalFilePath(from: url, projectPath: "/unused") == nil)
     }
+
+    @Test func resolvesFileLocationWithLineSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "results.md")
+        let url = try #require(URL(string: "\(file):12"))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: "/unused")
+        #expect(location == .init(path: file, line: 12, column: nil))
+    }
+
+    @Test func resolvesFileLocationWithLineAndColumnSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "main.swift")
+        let url = try #require(URL(string: "\(file):42:7"))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: "/unused")
+        #expect(location == .init(path: file, line: 42, column: 7))
+    }
+
+    @Test func resolvesFileLocationRelativeWithLineSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sub = dir.appendingPathComponent("reviews")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        let file = writeFile(sub, name: "results.md")
+        let url = try #require(URL(string: "reviews/results.md:12"))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 12, column: nil))
+    }
+
+    @Test func resolvesFileLocationWithoutSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "plain.md")
+        let url = try #require(URL(string: file))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: "/unused")
+        #expect(location == .init(path: file, line: nil, column: nil))
+    }
+
+    @Test func resolvesFileLocationPrefersRealFileWithColonInName() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "foo:12")
+        let url = try #require(URL(string: file))
+        let location = TerminalBridge.resolveFileLocation(from: url, projectPath: "/unused")
+        #expect(location == .init(path: file, line: nil, column: nil))
+    }
+
+    @Test func resolvesFileLocationRejectsUnresolvableSchemeless() throws {
+        let url = try #require(URL(string: "/tmp/does-not-exist-\(UUID().uuidString).md:12"))
+        #expect(TerminalBridge.resolveFileLocation(from: url, projectPath: "/unused") == nil)
+    }
+
+    @Test func resolvesFileLocationRejectsHttpURL() throws {
+        let url = try #require(URL(string: "https://example.com/readme.md:12"))
+        #expect(TerminalBridge.resolveFileLocation(from: url, projectPath: "/tmp") == nil)
+    }
+
+    @Test func stripsLineSuffixOnlyWhenTrailingNumeric() {
+        #expect(TerminalBridge.stripLineColumnSuffix(from: "a.txt:12") == .init(path: "a.txt", line: 12, column: nil))
+        #expect(TerminalBridge.stripLineColumnSuffix(from: "a.txt:12:7") == .init(path: "a.txt", line: 12, column: 7))
+        #expect(TerminalBridge.stripLineColumnSuffix(from: "a.txt:12:notnum") == nil)
+        #expect(TerminalBridge.stripLineColumnSuffix(from: "a.txt") == nil)
+        #expect(TerminalBridge.stripLineColumnSuffix(from: ":12") == nil)
+    }
+
+    @Test func treatsWebAndOpaqueSchemesAsExternalLinks() throws {
+        #expect(TerminalBridge.isExternalLink(try #require(URL(string: "https://example.com/x"))))
+        #expect(TerminalBridge.isExternalLink(try #require(URL(string: "mailto:a@b.com"))))
+        #expect(TerminalBridge.isExternalLink(try #require(URL(string: "tel:+123"))))
+        #expect(TerminalBridge.isExternalLink(try #require(URL(string: "vscode://file/x"))))
+    }
+
+    @Test func treatsSchemelessAndMisparsedPathsAsNonExternal() throws {
+        #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "/tmp/x.md:12"))))
+        #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "notes.md:5"))))
+        #expect(!TerminalBridge.isExternalLink(try #require(URL(string: "reviews/results.md:12"))))
+    }
 }


### PR DESCRIPTION
Route scheme-less file links with :line(:col) to the editor and gate NSWorkspace to real external links, so
  unresolvable paths show a toast instead of the macOS -50 dialog.
  
  Closes #691