### PR TITLE
Add a permanent Home project pinned to the top of the sidebar

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -175,6 +175,12 @@ struct MuxyCommands: Commands {
             }
             .shortcut(for: .newTab, store: keyBindings)
 
+            Button("New Home Tab") {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.newHomeTab)
+            }
+            .shortcut(for: .newHomeTab, store: keyBindings)
+
             Menu("Custom Commands") {
                 if commandShortcuts.shortcuts.isEmpty {
                     Button("No Custom Commands") {}

--- a/Muxy/Models/HomeProjectPreferences.swift
+++ b/Muxy/Models/HomeProjectPreferences.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum HomeProjectPreferences {
+    static let visibleKey = "muxy.showHomeProject"
+    static let defaultVisible = true
+
+    static var isVisible: Bool {
+        get {
+            let defaults = UserDefaults.standard
+            if defaults.object(forKey: visibleKey) == nil { return defaultVisible }
+            return defaults.bool(forKey: visibleKey)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: visibleKey) }
+    }
+}

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -9,6 +9,7 @@ private struct ShortcutMetadata {
 
 enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case newTab
+    case newHomeTab
     case reopenClosedTerminalTab
     case closeTab
     case renameTab
@@ -68,6 +69,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
 
     static let allCases: [Self] = [
         .newTab,
+        .newHomeTab,
         .reopenClosedTerminalTab,
         .closeTab,
         .renameTab,
@@ -130,6 +132,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     private var metadata: ShortcutMetadata {
         switch self {
         case .newTab: ShortcutMetadata(displayName: "New Tab", category: "Tabs", scope: .mainWindow)
+        case .newHomeTab: ShortcutMetadata(displayName: "New Home Tab", category: "Tabs", scope: .mainWindow)
         case .reopenClosedTerminalTab: ShortcutMetadata(
                 displayName: "Reopen Closed Terminal Tab",
                 category: "Tabs",
@@ -294,6 +297,7 @@ struct KeyBinding: Codable, Identifiable {
 
     static let defaults: [Self] = [
         Self(action: .newTab, combo: KeyCombo(key: "t", command: true)),
+        Self(action: .newHomeTab, combo: KeyCombo(key: "n", command: true)),
         Self(action: .reopenClosedTerminalTab, combo: KeyCombo(key: "t", command: true, shift: true)),
         Self(action: .closeTab, combo: KeyCombo(key: "w", command: true)),
         Self(action: .renameTab, combo: KeyCombo(key: "t", shift: true, option: true)),

--- a/Muxy/Models/Project.swift
+++ b/Muxy/Models/Project.swift
@@ -37,12 +37,10 @@ extension Project {
     static let homeName = "Home"
     static let homeIcon = "house.fill"
 
-    static func makeHome() -> Project {
-        Project(
-            id: homeID,
-            name: homeName,
-            path: FileManager.default.homeDirectoryForCurrentUser.path,
-            sortOrder: Int.min
-        )
-    }
+    static let home = Project(
+        id: homeID,
+        name: homeName,
+        path: FileManager.default.homeDirectoryForCurrentUser.path,
+        sortOrder: Int.min
+    )
 }

--- a/Muxy/Models/Project.swift
+++ b/Muxy/Models/Project.swift
@@ -11,8 +11,8 @@ struct Project: Identifiable, Codable, Hashable {
     var iconColor: String?
     var preferredWorktreeParentPath: String?
 
-    init(name: String, path: String, sortOrder: Int = 0) {
-        self.id = UUID()
+    init(id: UUID = UUID(), name: String, path: String, sortOrder: Int = 0) {
+        self.id = id
         self.name = name
         self.path = path
         self.sortOrder = sortOrder
@@ -25,5 +25,24 @@ struct Project: Identifiable, Codable, Hashable {
 
     var pathExists: Bool {
         FileManager.default.fileExists(atPath: path)
+    }
+
+    var isHome: Bool {
+        id == Project.homeID
+    }
+}
+
+extension Project {
+    static let homeID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+    static let homeName = "Home"
+    static let homeIcon = "house.fill"
+
+    static func makeHome() -> Project {
+        Project(
+            id: homeID,
+            name: homeName,
+            path: FileManager.default.homeDirectoryForCurrentUser.path,
+            sortOrder: Int.min
+        )
     }
 }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -96,7 +96,7 @@ struct MuxyApp: App {
                         return delegate
                     }
                     appState.onProjectsEmptied = { [projectStore, worktreeStore] projectIDs in
-                        for id in projectIDs {
+                        for id in projectIDs where id != Project.homeID {
                             guard let project = projectStore.projects.first(where: { $0.id == id }) else {
                                 worktreeStore.removeProject(id)
                                 continue

--- a/Muxy/Services/HomeProjectService.swift
+++ b/Muxy/Services/HomeProjectService.swift
@@ -7,7 +7,7 @@ enum HomeProjectService {
         appState: AppState,
         worktreeStore: WorktreeStore
     ) -> Bool {
-        let home = Project.makeHome()
+        let home = Project.home
         worktreeStore.ensurePrimary(for: home)
         guard let worktree = worktreeStore.preferred(
             for: home.id,

--- a/Muxy/Services/HomeProjectService.swift
+++ b/Muxy/Services/HomeProjectService.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@MainActor
+enum HomeProjectService {
+    @discardableResult
+    static func openHomeTab(
+        appState: AppState,
+        worktreeStore: WorktreeStore
+    ) -> Bool {
+        let home = Project.makeHome()
+        worktreeStore.ensurePrimary(for: home)
+        guard let worktree = worktreeStore.preferred(
+            for: home.id,
+            matching: appState.activeWorktreeID[home.id]
+        )
+        else { return false }
+        let hadWorkspace = appState.workspaceRoot(for: home.id) != nil
+        appState.selectProject(home, worktree: worktree)
+        guard hadWorkspace else { return true }
+        appState.createTab(projectID: home.id)
+        return true
+    }
+}

--- a/Muxy/Services/HomeProjectService.swift
+++ b/Muxy/Services/HomeProjectService.swift
@@ -2,8 +2,22 @@ import Foundation
 
 @MainActor
 enum HomeProjectService {
+    private static var homeDirectory: String {
+        FileManager.default.homeDirectoryForCurrentUser.path
+    }
+
     @discardableResult
     static func openHomeTab(
+        appState: AppState,
+        worktreeStore: WorktreeStore
+    ) -> Bool {
+        guard HomeProjectPreferences.isVisible else {
+            return openHomeDirectoryTabInActiveProject(appState: appState, worktreeStore: worktreeStore)
+        }
+        return openHomeProjectTab(appState: appState, worktreeStore: worktreeStore)
+    }
+
+    private static func openHomeProjectTab(
         appState: AppState,
         worktreeStore: WorktreeStore
     ) -> Bool {
@@ -18,6 +32,23 @@ enum HomeProjectService {
         appState.selectProject(home, worktree: worktree)
         guard hadWorkspace else { return true }
         appState.createTab(projectID: home.id)
+        return true
+    }
+
+    private static func openHomeDirectoryTabInActiveProject(
+        appState: AppState,
+        worktreeStore: WorktreeStore
+    ) -> Bool {
+        guard let projectID = appState.activeProjectID else { return false }
+        if appState.workspaceRoot(for: projectID) == nil {
+            guard let worktree = worktreeStore.preferred(
+                for: projectID,
+                matching: appState.activeWorktreeID[projectID]
+            )
+            else { return false }
+            appState.selectWorktree(projectID: projectID, worktree: worktree)
+        }
+        appState.dispatch(.createTabInDirectory(projectID: projectID, areaID: nil, directory: homeDirectory))
         return true
     }
 }

--- a/Muxy/Services/ProjectGroupStore.swift
+++ b/Muxy/Services/ProjectGroupStore.swift
@@ -54,6 +54,7 @@ final class ProjectGroupStore {
     }
 
     func addProject(projectID: UUID, toGroup groupID: UUID) {
+        guard projectID != Project.homeID else { return }
         guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
         for otherIndex in groups.indices where otherIndex != index {
             groups[otherIndex].projectIDs.removeAll { $0 == projectID }

--- a/Muxy/Services/ProjectStore.swift
+++ b/Muxy/Services/ProjectStore.swift
@@ -16,7 +16,7 @@ final class ProjectStore {
     }
 
     var projects: [Project] {
-        [Project.makeHome()] + storedProjects
+        [Project.home] + storedProjects
     }
 
     func add(_ project: Project) {

--- a/Muxy/Services/ProjectStore.swift
+++ b/Muxy/Services/ProjectStore.swift
@@ -6,7 +6,7 @@ private let logger = Logger(subsystem: "app.muxy", category: "ProjectStore")
 @MainActor
 @Observable
 final class ProjectStore {
-    private(set) var projects: [Project] = []
+    private(set) var storedProjects: [Project] = []
     private let persistence: any ProjectPersisting
     var onProjectRemoved: ((UUID) -> Void)?
 
@@ -15,61 +15,66 @@ final class ProjectStore {
         load()
     }
 
+    var projects: [Project] {
+        [Project.makeHome()] + storedProjects
+    }
+
     func add(_ project: Project) {
-        projects.append(project)
+        storedProjects.append(project)
         save()
     }
 
     func remove(id: UUID) {
-        projects.removeAll { $0.id == id }
+        guard id != Project.homeID else { return }
+        storedProjects.removeAll { $0.id == id }
         save()
         onProjectRemoved?(id)
     }
 
     func rename(id: UUID, to newName: String) {
-        guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
-        projects[index].name = newName
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
+        storedProjects[index].name = newName
         save()
     }
 
     func setLogo(id: UUID, to logo: String?) {
-        guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         if logo == nil {
             ProjectLogoStorage.remove(forProjectID: id)
         }
-        projects[index].logo = logo
+        storedProjects[index].logo = logo
         save()
     }
 
     func setIcon(id: UUID, to icon: String?) {
-        guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
-        projects[index].icon = icon
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
+        storedProjects[index].icon = icon
         save()
     }
 
     func setIconColor(id: UUID, to color: String?) {
-        guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
-        projects[index].iconColor = color
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
+        storedProjects[index].iconColor = color
         save()
     }
 
     func setPreferredWorktreeParentPath(id: UUID, to path: String?) {
-        guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
-        projects[index].preferredWorktreeParentPath = WorktreeLocationResolver.normalizedPath(path)
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
+        storedProjects[index].preferredWorktreeParentPath = WorktreeLocationResolver.normalizedPath(path)
         save()
     }
 
     func reorder(fromOffsets source: IndexSet, toOffset destination: Int) {
-        projects.move(fromOffsets: source, toOffset: destination)
-        for index in projects.indices {
-            projects[index].sortOrder = index
+        storedProjects.move(fromOffsets: source, toOffset: destination)
+        for index in storedProjects.indices {
+            storedProjects[index].sortOrder = index
         }
         save()
     }
 
     func save() {
         do {
-            try persistence.saveProjects(projects)
+            try persistence.saveProjects(storedProjects)
         } catch {
             logger.error("Failed to save projects: \(error)")
         }
@@ -77,8 +82,8 @@ final class ProjectStore {
 
     private func load() {
         do {
-            projects = try persistence.loadProjects()
-            projects.sort { $0.sortOrder < $1.sortOrder }
+            storedProjects = try persistence.loadProjects().filter { !$0.isHome }
+            storedProjects.sort { $0.sortOrder < $1.sortOrder }
         } catch {
             logger.error("Failed to load projects: \(error)")
         }

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -27,11 +27,9 @@ struct ShortcutActionDispatcher {
     }
 
     private var navigableProjects: [Project] {
-        let filtered = projectGroupStore.filteredProjects(from: projectStore.projects).filter { !$0.isHome }
-        guard HomeProjectPreferences.isVisible,
-              let home = projectStore.projects.first(where: { $0.isHome })
-        else { return filtered }
-        return [home] + filtered
+        let filtered = projectGroupStore.filteredProjects(from: projectStore.storedProjects)
+        guard HomeProjectPreferences.isVisible else { return filtered }
+        return [Project.home] + filtered
     }
 
     func perform(_ action: ShortcutAction, activeProject: Project?) -> Bool {

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -27,7 +27,11 @@ struct ShortcutActionDispatcher {
     }
 
     private var navigableProjects: [Project] {
-        projectGroupStore.filteredProjects(from: projectStore.projects)
+        let filtered = projectGroupStore.filteredProjects(from: projectStore.projects).filter { !$0.isHome }
+        guard HomeProjectPreferences.isVisible,
+              let home = projectStore.projects.first(where: { $0.isHome })
+        else { return filtered }
+        return [home] + filtered
     }
 
     func perform(_ action: ShortcutAction, activeProject: Project?) -> Bool {
@@ -52,6 +56,11 @@ struct ShortcutActionDispatcher {
             }
             appState.createTab(projectID: projectID)
             return true
+        case .newHomeTab:
+            return HomeProjectService.openHomeTab(
+                appState: appState,
+                worktreeStore: worktreeStore
+            )
         case .reopenClosedTerminalTab:
             return appState.reopenLastClosedTerminalTab()
         case .closeTab:

--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -15,6 +15,7 @@ enum MuxyTheme {
 
     @MainActor static var accent: Color { snapshot.accent }
     @MainActor static var accentSoft: Color { snapshot.accentSoft }
+    @MainActor static var accentForeground: Color { snapshot.accentForeground }
     @MainActor static var warning: Color { snapshot.warning }
 
     @MainActor static var diffAddFg: Color { snapshot.diffAddFg }
@@ -66,6 +67,7 @@ extension MuxyTheme {
         let hover: Color
         let accent: Color
         let accentSoft: Color
+        let accentForeground: Color
         let warning: Color
         let diffAddFg: Color
         let diffRemoveFg: Color
@@ -107,6 +109,7 @@ extension MuxyTheme {
             hover = Color(nsColor: fgColor.withAlphaComponent(0.06))
             accent = Color(nsColor: accentColor)
             accentSoft = Color(nsColor: accentColor.withAlphaComponent(0.1))
+            accentForeground = Color(nsColor: Snapshot.contrastingForeground(for: accentColor))
             warning = Color(nsColor: resolvedPalette.paletteColor(at: 3) ?? NSColor.systemYellow)
 
             let addColor = resolvedPalette.paletteColor(at: 2) ?? NSColor.systemGreen
@@ -134,6 +137,14 @@ extension MuxyTheme {
                 0
             }
             colorScheme = luminance > 0.5 ? .light : .dark
+        }
+
+        static func contrastingForeground(for color: NSColor) -> NSColor {
+            guard let srgb = color.usingColorSpace(.sRGB) else { return .white }
+            let luminance = 0.2126 * srgb.redComponent
+                + 0.7152 * srgb.greenComponent
+                + 0.0722 * srgb.blueComponent
+            return luminance > 0.6 ? .black : .white
         }
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -74,6 +74,7 @@ struct MainWindow: View {
     @State private var isFullScreen = false
     @AppStorage("muxy.sidebarExpanded") private var sidebarExpanded = false
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
+    @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
     @AppStorage("muxy.extensionOutputSelected") private var extensionOutputSelectedStored = ""
     @AppStorage("muxy.extensionConsoleHeight") private var extensionConsoleHeight: Double = PanelLayoutMetrics.consoleDefaultHeight
     @State private var extensionOutputSelected: String?
@@ -627,14 +628,18 @@ struct MainWindow: View {
         return scope
     }
 
+    private var omniboxProjects: [Project] {
+        showHomeProject ? projectStore.projects : projectStore.storedProjects
+    }
+
     private var terminalOmniboxProjects: [TerminalOmniboxProjectItem] {
-        projectStore.projects.map {
+        omniboxProjects.map {
             TerminalOmniboxProjectItem(projectID: $0.id, name: $0.name, path: $0.path)
         }
     }
 
     private var terminalOmniboxWorktrees: [TerminalOmniboxWorktreeItem] {
-        projectStore.projects.flatMap { project in
+        omniboxProjects.flatMap { project in
             worktreeStore.list(for: project.id).map { worktree in
                 TerminalOmniboxWorktreeItem(
                     projectID: project.id,
@@ -649,18 +654,18 @@ struct MainWindow: View {
     }
 
     private var terminalOmniboxOpenTabs: [OpenTerminalTabItem] {
-        projectStore.projects.flatMap { appState.allOpenTerminalTabItems(for: $0.id) }
+        omniboxProjects.flatMap { appState.allOpenTerminalTabItems(for: $0.id) }
     }
 
     private var terminalOmniboxClosedTabs: [ClosedTerminalTabSnapshot] {
-        let projectIDs = Set(projectStore.projects.map(\.id))
+        let projectIDs = Set(omniboxProjects.map(\.id))
         return TerminalSessionStore.shared.closedTerminalTabs.filter {
             projectIDs.contains($0.projectID)
         }
     }
 
     private var terminalOmniboxCommandProjectIDs: Set<UUID> {
-        Set(projectStore.projects.compactMap { project in
+        Set(omniboxProjects.compactMap { project in
             worktreeStore.preferred(for: project.id, matching: appState.activeWorktreeID[project.id]) == nil
                 ? nil
                 : project.id

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -8,6 +8,7 @@ struct InterfaceSettingsView: View {
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyle = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
     @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
+    @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
 
     var body: some View {
         SettingsContainer {
@@ -29,6 +30,8 @@ struct InterfaceSettingsView: View {
             }
 
             SettingsSection("Sidebar", showsDivider: false) {
+                SettingsToggleRow(label: "Show Home", isOn: $showHomeProject)
+
                 SettingsToggleRow(
                     label: "Auto-expand worktrees on project switch",
                     isOn: $autoExpandWorktrees

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -49,6 +49,7 @@ struct Sidebar: View {
     let expandedCustomWidth: CGFloat
     @AppStorage(SidebarCollapsedStyle.storageKey) private var collapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var expandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
+    @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
 
     private var collapsedStyle: SidebarCollapsedStyle {
         SidebarCollapsedStyle(rawValue: collapsedStyleRaw) ?? .defaultValue
@@ -116,8 +117,13 @@ struct Sidebar: View {
         .help(shortcutTooltip("Add Project", for: .openProject))
     }
 
+    private var homeProject: Project? {
+        guard showHomeProject else { return nil }
+        return projectStore.projects.first(where: { $0.isHome })
+    }
+
     private var displayedProjects: [Project] {
-        projectGroupStore.filteredProjects(from: projectStore.projects)
+        projectGroupStore.filteredProjects(from: projectStore.projects).filter { !$0.isHome }
     }
 
     private var projectList: some View {
@@ -125,45 +131,23 @@ struct Sidebar: View {
             LazyVStack(spacing: UIMetrics.spacing3) {
                 WorkspaceSwitcher(isWide: isWide)
 
+                if let homeProject {
+                    projectRow(for: homeProject, shortcutIndex: 1)
+                }
+
                 ForEach(Array(displayedProjects.enumerated()), id: \.element.id) { offset, project in
-                    Group {
-                        if isWide {
-                            ExpandedProjectRow(
-                                project: project,
-                                shortcutIndex: offset < 9 ? offset + 1 : nil,
-                                isAnyDragging: dragState.draggedID != nil,
-                                onSelect: { select(project) },
-                                onRemove: { remove(project) },
-                                onRename: { projectStore.rename(id: project.id, to: $0) },
-                                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
-                                onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
-                                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
-                            )
-                        } else {
-                            ProjectRow(
-                                project: project,
-                                shortcutIndex: offset < 9 ? offset + 1 : nil,
-                                isAnyDragging: dragState.draggedID != nil,
-                                onSelect: { select(project) },
-                                onRemove: { remove(project) },
-                                onRename: { projectStore.rename(id: project.id, to: $0) },
-                                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
-                                onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
-                                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
-                            )
-                        }
-                    }
-                    .background {
-                        if dragState.draggedID != nil {
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: UUIDFramePreferenceKey<SidebarFrameTag>.self,
-                                    value: [project.id: geo.frame(in: .named("sidebar"))]
-                                )
+                    projectRow(for: project, shortcutIndex: shortcutIndex(forRowAt: offset))
+                        .background {
+                            if dragState.draggedID != nil {
+                                GeometryReader { geo in
+                                    Color.clear.preference(
+                                        key: UUIDFramePreferenceKey<SidebarFrameTag>.self,
+                                        value: [project.id: geo.frame(in: .named("sidebar"))]
+                                    )
+                                }
                             }
                         }
-                    }
-                    .gesture(projectDragGesture(for: project))
+                        .gesture(projectDragGesture(for: project))
                 }
 
                 addButton
@@ -176,6 +160,40 @@ struct Sidebar: View {
             }
         }
         .coordinateSpace(name: "sidebar")
+    }
+
+    @ViewBuilder
+    private func projectRow(for project: Project, shortcutIndex: Int?) -> some View {
+        if isWide {
+            ExpandedProjectRow(
+                project: project,
+                shortcutIndex: shortcutIndex,
+                isAnyDragging: dragState.draggedID != nil,
+                onSelect: { select(project) },
+                onRemove: { remove(project) },
+                onRename: { projectStore.rename(id: project.id, to: $0) },
+                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
+                onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
+                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
+            )
+        } else {
+            ProjectRow(
+                project: project,
+                shortcutIndex: shortcutIndex,
+                isAnyDragging: dragState.draggedID != nil,
+                onSelect: { select(project) },
+                onRemove: { remove(project) },
+                onRename: { projectStore.rename(id: project.id, to: $0) },
+                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
+                onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
+                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
+            )
+        }
+    }
+
+    private func shortcutIndex(forRowAt offset: Int) -> Int? {
+        let index = homeProject == nil ? offset + 1 : offset + 2
+        return index <= 9 ? index : nil
     }
 
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {
@@ -259,8 +277,8 @@ struct Sidebar: View {
             hoveredTargetID = id
             guard dragState.lastReorderTargetID != id else { return }
 
-            guard let sourceIndex = projectStore.projects.firstIndex(where: { $0.id == draggedID }),
-                  let destIndex = projectStore.projects.firstIndex(where: { $0.id == id })
+            guard let sourceIndex = projectStore.storedProjects.firstIndex(where: { $0.id == draggedID }),
+                  let destIndex = projectStore.storedProjects.firstIndex(where: { $0.id == id })
             else { return }
 
             dragState.lastReorderTargetID = id

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -118,12 +118,11 @@ struct Sidebar: View {
     }
 
     private var homeProject: Project? {
-        guard showHomeProject else { return nil }
-        return projectStore.projects.first(where: { $0.isHome })
+        showHomeProject ? Project.home : nil
     }
 
     private var displayedProjects: [Project] {
-        projectGroupStore.filteredProjects(from: projectStore.projects).filter { !$0.isHome }
+        projectGroupStore.filteredProjects(from: projectStore.storedProjects)
     }
 
     private var projectList: some View {

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -58,6 +58,10 @@ struct ExpandedProjectRow: View {
         String(project.name.prefix(1)).uppercased()
     }
 
+    private func hideHome() {
+        HomeProjectPreferences.isVisible = false
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             projectHeader
@@ -66,6 +70,10 @@ struct ExpandedProjectRow: View {
             }
         }
         .task(id: project.path) {
+            guard !project.isHome else {
+                isCheckingGitRepo = false
+                return
+            }
             isCheckingGitRepo = true
             try? await Task.sleep(for: .seconds(2))
             guard !Task.isCancelled else { return }
@@ -82,35 +90,11 @@ struct ExpandedProjectRow: View {
             }
         }
         .contextMenu {
-            Button("Set Logo...") { pickLogoImage() }
-            if project.logo != nil {
-                Button("Remove Logo") { onSetLogo(nil) }
+            if project.isHome {
+                Button("Hide Home") { hideHome() }
+            } else {
+                projectContextMenu
             }
-            Button("Set Icon...") { showSymbolPicker = true }
-            if project.icon != nil {
-                Button("Remove Icon") { onSetIcon(nil) }
-            }
-            Button("Set Icon Color...") { showColorPicker = true }
-            if project.iconColor != nil {
-                Button("Reset Icon Color") { onSetIconColor(nil) }
-            }
-            Divider()
-            Button("Rename Project") { startRename() }
-            if isGitRepo {
-                Divider()
-                Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
-                Button("New Worktree…") { showCreateWorktreeSheet = true }
-            } else if isCheckingGitRepo {
-                Divider()
-                Button("Loading Worktrees…") {}
-                    .disabled(true)
-            }
-            if !projectGroupStore.groups.isEmpty {
-                Divider()
-                ProjectGroupMembershipMenu(project: project)
-            }
-            Divider()
-            Button("Remove Project", role: .destructive, action: onRemove)
         }
         .sheet(isPresented: $showCreateWorktreeSheet) {
             CreateWorktreeSheet(project: project) { result in
@@ -268,7 +252,11 @@ struct ExpandedProjectRow: View {
             RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 .fill(iconBackground(hasLogo: logo != nil))
 
-            if let logo {
+            if project.isHome {
+                Image(systemName: Project.homeIcon)
+                    .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))
+                    .foregroundStyle(MuxyTheme.accentForeground)
+            } else if let logo {
                 Image(nsImage: logo)
                     .resizable()
                     .scaledToFill()
@@ -338,12 +326,48 @@ struct ExpandedProjectRow: View {
         return label
     }
 
+    @ViewBuilder
+    private var projectContextMenu: some View {
+        Button("Set Logo...") { pickLogoImage() }
+        if project.logo != nil {
+            Button("Remove Logo") { onSetLogo(nil) }
+        }
+        Button("Set Icon...") { showSymbolPicker = true }
+        if project.icon != nil {
+            Button("Remove Icon") { onSetIcon(nil) }
+        }
+        Button("Set Icon Color...") { showColorPicker = true }
+        if project.iconColor != nil {
+            Button("Reset Icon Color") { onSetIconColor(nil) }
+        }
+        Divider()
+        Button("Rename Project") { startRename() }
+        if isGitRepo {
+            Divider()
+            Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
+            Button("New Worktree…") { showCreateWorktreeSheet = true }
+        } else if isCheckingGitRepo {
+            Divider()
+            Button("Loading Worktrees…") {}
+                .disabled(true)
+        }
+        if !projectGroupStore.groups.isEmpty {
+            Divider()
+            ProjectGroupMembershipMenu(project: project)
+        }
+        Divider()
+        Button("Remove Project", role: .destructive, action: onRemove)
+    }
+
     private var resolvedLogo: NSImage? {
         guard let filename = project.logo else { return nil }
         return NSImage(contentsOfFile: ProjectLogoStorage.logoPath(for: filename))
     }
 
     private func iconBackground(hasLogo: Bool) -> AnyShapeStyle {
+        if project.isHome {
+            return AnyShapeStyle(hovered ? MuxyTheme.accent.opacity(0.85) : MuxyTheme.accent)
+        }
         if hasLogo { return AnyShapeStyle(Color.clear) }
         if let tint = ProjectIconColor.color(for: project.iconColor) {
             return AnyShapeStyle(hovered ? tint.opacity(0.85) : tint)

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -46,6 +46,10 @@ struct ProjectRow: View {
         String(project.name.prefix(1)).uppercased()
     }
 
+    private func hideHome() {
+        HomeProjectPreferences.isVisible = false
+    }
+
     var body: some View {
         projectIcon
             .help(project.name)
@@ -67,6 +71,10 @@ struct ProjectRow: View {
                 onSelect()
             }
             .task(id: project.path) {
+                guard !project.isHome else {
+                    isCheckingGitRepo = false
+                    return
+                }
                 isCheckingGitRepo = true
                 try? await Task.sleep(for: .seconds(2))
                 guard !Task.isCancelled else { return }
@@ -74,43 +82,11 @@ struct ProjectRow: View {
                 isCheckingGitRepo = false
             }
             .contextMenu {
-                Button("Set Logo...") { pickLogoImage() }
-                if project.logo != nil {
-                    Button("Remove Logo") { onSetLogo(nil) }
+                if project.isHome {
+                    Button("Hide Home") { hideHome() }
+                } else {
+                    projectContextMenu
                 }
-                Button("Set Icon...") { showSymbolPicker = true }
-                if project.icon != nil {
-                    Button("Remove Icon") { onSetIcon(nil) }
-                }
-                Button("Set Icon Color...") { showColorPicker = true }
-                if project.iconColor != nil {
-                    Button("Reset Icon Color") { onSetIconColor(nil) }
-                }
-                Divider()
-                Button("Rename Project") { startRename() }
-                if isGitRepo {
-                    Divider()
-                    Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
-                    Button("New Worktree…") { showCreateWorktreeSheet = true }
-                    if worktrees.count > 1 {
-                        Button("Switch Worktree…") { showWorktreePopover = true }
-                    }
-                } else if isCheckingGitRepo {
-                    Divider()
-                    Button("Loading Worktrees…") {}
-                        .disabled(true)
-                } else if hasWorktreeUI {
-                    Divider()
-                    if worktrees.count > 1 {
-                        Button("Switch Worktree…") { showWorktreePopover = true }
-                    }
-                }
-                if !projectGroupStore.groups.isEmpty {
-                    Divider()
-                    ProjectGroupMembershipMenu(project: project)
-                }
-                Divider()
-                Button("Remove Project", role: .destructive, action: onRemove)
             }
             .popover(isPresented: $showWorktreePopover, arrowEdge: .trailing) {
                 WorktreePopover(
@@ -178,6 +154,47 @@ struct ProjectRow: View {
             }
     }
 
+    @ViewBuilder
+    private var projectContextMenu: some View {
+        Button("Set Logo...") { pickLogoImage() }
+        if project.logo != nil {
+            Button("Remove Logo") { onSetLogo(nil) }
+        }
+        Button("Set Icon...") { showSymbolPicker = true }
+        if project.icon != nil {
+            Button("Remove Icon") { onSetIcon(nil) }
+        }
+        Button("Set Icon Color...") { showColorPicker = true }
+        if project.iconColor != nil {
+            Button("Reset Icon Color") { onSetIconColor(nil) }
+        }
+        Divider()
+        Button("Rename Project") { startRename() }
+        if isGitRepo {
+            Divider()
+            Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
+            Button("New Worktree…") { showCreateWorktreeSheet = true }
+            if worktrees.count > 1 {
+                Button("Switch Worktree…") { showWorktreePopover = true }
+            }
+        } else if isCheckingGitRepo {
+            Divider()
+            Button("Loading Worktrees…") {}
+                .disabled(true)
+        } else if hasWorktreeUI {
+            Divider()
+            if worktrees.count > 1 {
+                Button("Switch Worktree…") { showWorktreePopover = true }
+            }
+        }
+        if !projectGroupStore.groups.isEmpty {
+            Divider()
+            ProjectGroupMembershipMenu(project: project)
+        }
+        Divider()
+        Button("Remove Project", role: .destructive, action: onRemove)
+    }
+
     private var resolvedLogo: NSImage? {
         guard let filename = project.logo else { return nil }
         return NSImage(contentsOfFile: ProjectLogoStorage.logoPath(for: filename))
@@ -191,7 +208,11 @@ struct ProjectRow: View {
             RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 .fill(iconBackground(hasLogo: logo != nil))
 
-            if let logo {
+            if project.isHome {
+                Image(systemName: Project.homeIcon)
+                    .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))
+                    .foregroundStyle(MuxyTheme.accentForeground)
+            } else if let logo {
                 Image(nsImage: logo)
                     .resizable()
                     .scaledToFill()
@@ -235,6 +256,9 @@ struct ProjectRow: View {
     }
 
     private func iconBackground(hasLogo: Bool) -> AnyShapeStyle {
+        if project.isHome {
+            return AnyShapeStyle(hovered ? MuxyTheme.accent.opacity(0.85) : MuxyTheme.accent)
+        }
         if hasLogo { return AnyShapeStyle(Color.clear) }
         if let tint = ProjectIconColor.color(for: project.iconColor) {
             return AnyShapeStyle(hovered ? tint.opacity(0.85) : tint)

--- a/Tests/MuxyTests/Models/ProjectTests.swift
+++ b/Tests/MuxyTests/Models/ProjectTests.swift
@@ -26,9 +26,9 @@ struct ProjectTests {
         #expect(project.preferredWorktreeParentPath == nil)
     }
 
-    @Test("makeHome uses the reserved id, home name and expanded home path")
-    func makeHomeIdentity() {
-        let home = Project.makeHome()
+    @Test("home uses the reserved id, home name and expanded home path")
+    func homeIdentity() {
+        let home = Project.home
 
         #expect(home.id == Project.homeID)
         #expect(home.isHome)

--- a/Tests/MuxyTests/Models/ProjectTests.swift
+++ b/Tests/MuxyTests/Models/ProjectTests.swift
@@ -25,4 +25,21 @@ struct ProjectTests {
 
         #expect(project.preferredWorktreeParentPath == nil)
     }
+
+    @Test("makeHome uses the reserved id, home name and expanded home path")
+    func makeHomeIdentity() {
+        let home = Project.makeHome()
+
+        #expect(home.id == Project.homeID)
+        #expect(home.isHome)
+        #expect(home.name == Project.homeName)
+        #expect(home.path == FileManager.default.homeDirectoryForCurrentUser.path)
+    }
+
+    @Test("isHome is false for ordinary projects")
+    func ordinaryProjectIsNotHome() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+
+        #expect(!project.isHome)
+    }
 }

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -174,7 +174,7 @@ struct CLIAccessorOpenProjectFromPathTests {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
-        #expect(projectStore.projects.isEmpty)
+        #expect(projectStore.storedProjects.isEmpty)
     }
 
     @Test("regular file is ignored")
@@ -192,7 +192,7 @@ struct CLIAccessorOpenProjectFromPathTests {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
-        #expect(projectStore.projects.isEmpty)
+        #expect(projectStore.storedProjects.isEmpty)
     }
 
     @Test("new directory is added as project")
@@ -210,9 +210,9 @@ struct CLIAccessorOpenProjectFromPathTests {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
-        #expect(projectStore.projects.count == 1)
+        #expect(projectStore.storedProjects.count == 1)
         let standardized = URL(fileURLWithPath: dir.path).standardizedFileURL.path
-        #expect(projectStore.projects.first?.path == standardized)
+        #expect(projectStore.storedProjects.first?.path == standardized)
     }
 
     @Test("opening the same path twice does not duplicate the project")
@@ -237,7 +237,7 @@ struct CLIAccessorOpenProjectFromPathTests {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
-        #expect(projectStore.projects.count == 1)
+        #expect(projectStore.storedProjects.count == 1)
     }
 
     @Test("existing project is added to selected group")
@@ -263,7 +263,7 @@ struct CLIAccessorOpenProjectFromPathTests {
             projectGroupStore: projectGroupStore
         )
 
-        #expect(projectStore.projects.count == 1)
+        #expect(projectStore.storedProjects.count == 1)
         #expect(groupPersistence.savedGroups?.first?.projectIDs == [project.id])
     }
 }

--- a/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
@@ -79,6 +79,17 @@ struct ProjectGroupStoreTests {
         #expect(persistence.savedGroups?.first?.projectIDs == [projectID])
     }
 
+    @Test("addProject never adds the Home project to a group")
+    func addProjectIgnoresHome() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = ProjectGroupStore(persistence: persistence)
+
+        store.addProject(projectID: Project.homeID, toGroup: group.id)
+
+        #expect(store.groups.first?.projectIDs.isEmpty == true)
+    }
+
     @Test("addProject ignores duplicate projectID")
     func addProjectDuplicate() {
         let projectID = UUID()

--- a/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
+++ b/Tests/MuxyTests/Services/ProjectOpenServiceTests.swift
@@ -23,8 +23,8 @@ struct ProjectOpenServiceTests {
         )
 
         #expect(didConfirm)
-        #expect(projectStore.projects.count == 1)
-        #expect(appState.activeProjectID == projectStore.projects.first?.id)
+        #expect(projectStore.storedProjects.count == 1)
+        #expect(appState.activeProjectID == projectStore.storedProjects.first?.id)
     }
 
     @Test("new project is added to selected group")
@@ -47,10 +47,9 @@ struct ProjectOpenServiceTests {
             projectGroupStore: projectGroupStore
         )
 
-        let addedProject = try #require(projectStore.projects.first)
+        let addedProject = try #require(projectStore.storedProjects.first)
         #expect(didConfirm)
-        #expect(projectStore.projects.count == 1)
-        #expect(projectGroupStore.filteredProjects(from: projectStore.projects).first?.id == addedProject.id)
+        #expect(projectStore.storedProjects.count == 1)
         #expect(groupPersistence.savedGroups?.first?.projectIDs == [addedProject.id])
     }
 
@@ -73,8 +72,9 @@ struct ProjectOpenServiceTests {
             projectGroupStore: projectGroupStore
         )
 
+        let addedProject = try #require(projectStore.storedProjects.first)
         #expect(didConfirm)
-        #expect(projectGroupStore.filteredProjects(from: projectStore.projects).count == 1)
+        #expect(projectGroupStore.filteredProjects(from: projectStore.projects).contains { $0.id == addedProject.id })
         #expect(groupPersistence.savedGroups == nil)
     }
 
@@ -102,8 +102,8 @@ struct ProjectOpenServiceTests {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         ))
-        #expect(projectStore.projects.count == 1)
-        #expect(appState.activeProjectID == projectStore.projects.first?.id)
+        #expect(projectStore.storedProjects.count == 1)
+        #expect(appState.activeProjectID == projectStore.storedProjects.first?.id)
     }
 
     @Test("already-added path is added to selected group")
@@ -129,7 +129,7 @@ struct ProjectOpenServiceTests {
         )
 
         #expect(didConfirm)
-        #expect(projectStore.projects.count == 1)
+        #expect(projectStore.storedProjects.count == 1)
         #expect(groupPersistence.savedGroups?.first?.projectIDs == [project.id])
     }
 
@@ -152,7 +152,7 @@ struct ProjectOpenServiceTests {
         )
 
         #expect(didConfirm)
-        #expect(projectStore.projects.count == 1)
+        #expect(projectStore.storedProjects.count == 1)
         #expect(worktreeStore.primary(for: project.id) != nil)
         #expect(appState.activeProjectID == project.id)
     }
@@ -176,7 +176,7 @@ struct ProjectOpenServiceTests {
         )
 
         #expect(result == .success)
-        #expect(projectStore.projects.count == 1)
+        #expect(projectStore.storedProjects.count == 1)
         #expect(appState.activeProjectID == project.id)
     }
 
@@ -206,7 +206,7 @@ struct ProjectOpenServiceTests {
             projectGroupStore: projectGroupStore,
             createIfMissing: true
         ))
-        #expect(projectStore.projects.isEmpty)
+        #expect(projectStore.storedProjects.isEmpty)
         #expect(appState.activeProjectID == nil)
     }
 
@@ -227,7 +227,7 @@ struct ProjectOpenServiceTests {
 
         #expect(!didConfirm)
         #expect(!FileManager.default.fileExists(atPath: dir.path))
-        #expect(projectStore.projects.isEmpty)
+        #expect(projectStore.storedProjects.isEmpty)
         #expect(appState.activeProjectID == nil)
     }
 
@@ -249,7 +249,7 @@ struct ProjectOpenServiceTests {
 
         #expect(didConfirm)
         #expect(FileManager.default.fileExists(atPath: dir.path))
-        #expect(projectStore.projects.first?.path == dir.standardizedFileURL.path)
+        #expect(projectStore.storedProjects.first?.path == dir.standardizedFileURL.path)
     }
 
     @Test("create failure returns create failed without adding a project")
@@ -269,7 +269,7 @@ struct ProjectOpenServiceTests {
         let result = service.confirm(path: "/tmp/muxy-create-failure", createIfMissing: true)
 
         #expect(result == .createFailed)
-        #expect(projectStore.projects.isEmpty)
+        #expect(projectStore.storedProjects.isEmpty)
         #expect(appState.activeProjectID == nil)
     }
 

--- a/Tests/MuxyTests/Services/ProjectStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectStoreTests.swift
@@ -47,7 +47,7 @@ struct ProjectStoreTests {
 
     @Test("load drops any persisted Home record")
     func loadDropsPersistedHome() {
-        let persistence = ProjectPersistenceStub(initial: [Project.makeHome(), Project(name: "Repo", path: "/tmp/repo")])
+        let persistence = ProjectPersistenceStub(initial: [Project.home, Project(name: "Repo", path: "/tmp/repo")])
         let store = ProjectStore(persistence: persistence)
 
         #expect(store.storedProjects.contains(where: { $0.isHome }) == false)

--- a/Tests/MuxyTests/Services/ProjectStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectStoreTests.swift
@@ -14,7 +14,8 @@ struct ProjectStoreTests {
 
         store.setPreferredWorktreeParentPath(id: project.id, to: " ~/worktrees ")
 
-        #expect(store.projects.first?.preferredWorktreeParentPath == NSString(string: "~/worktrees").expandingTildeInPath)
+        let stored = store.storedProjects.first { $0.id == project.id }
+        #expect(stored?.preferredWorktreeParentPath == NSString(string: "~/worktrees").expandingTildeInPath)
         #expect(persistence.projects.first?.preferredWorktreeParentPath == NSString(string: "~/worktrees").expandingTildeInPath)
     }
 
@@ -27,8 +28,40 @@ struct ProjectStoreTests {
 
         store.setPreferredWorktreeParentPath(id: project.id, to: " ")
 
-        #expect(store.projects.first?.preferredWorktreeParentPath == nil)
+        let stored = store.storedProjects.first { $0.id == project.id }
+        #expect(stored?.preferredWorktreeParentPath == nil)
         #expect(persistence.projects.first?.preferredWorktreeParentPath == nil)
+    }
+
+    @Test("projects always exposes Home at the front without persisting it")
+    func projectsSynthesizesHome() {
+        let existing = Project(name: "Repo", path: "/tmp/repo")
+        let persistence = ProjectPersistenceStub(initial: [existing])
+        let store = ProjectStore(persistence: persistence)
+
+        #expect(store.projects.first?.isHome == true)
+        #expect(store.projects.count == 2)
+        #expect(store.storedProjects.contains(where: { $0.isHome }) == false)
+        #expect(persistence.projects.contains(where: { $0.isHome }) == false)
+    }
+
+    @Test("load drops any persisted Home record")
+    func loadDropsPersistedHome() {
+        let persistence = ProjectPersistenceStub(initial: [Project.makeHome(), Project(name: "Repo", path: "/tmp/repo")])
+        let store = ProjectStore(persistence: persistence)
+
+        #expect(store.storedProjects.contains(where: { $0.isHome }) == false)
+        #expect(store.projects.filter(\.isHome).count == 1)
+    }
+
+    @Test("remove never deletes the Home project")
+    func removeIgnoresHome() {
+        let persistence = ProjectPersistenceStub(initial: [])
+        let store = ProjectStore(persistence: persistence)
+
+        store.remove(id: Project.homeID)
+
+        #expect(store.projects.contains { $0.isHome })
     }
 }
 

--- a/Tests/MuxyTests/Views/SidebarGroupTests.swift
+++ b/Tests/MuxyTests/Views/SidebarGroupTests.swift
@@ -65,7 +65,7 @@ struct SidebarGroupTests {
 
         store.remove(id: project.id)
 
-        #expect(store.projects.isEmpty)
+        #expect(store.storedProjects.isEmpty)
     }
 
     @Test("group selection survives unrelated group renames")


### PR DESCRIPTION
Adds a static "Home" project (house icon, accent color, ~ path) pinned above all
  projects and visible in every workspace. Cmd+N opens a new ~ tab in it; hide it via
  right-click or Settings → Interface.