### PR TITLE
feat(sidebar): auto-refresh external worktree changes

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -13,6 +13,7 @@ struct MuxyApp: App {
     @State private var projectStore: ProjectStore
     @State private var worktreeStore: WorktreeStore
     @State private var projectGroupStore: ProjectGroupStore
+    @State private var worktreeAutoRefresher: VCSWorktreeAutoRefresher?
     @State private var didStartDeferredServices = false
 
     init() {
@@ -57,6 +58,7 @@ struct MuxyApp: App {
                 .preferredColorScheme(MuxyTheme.colorScheme)
                 .onAppear {
                     startDeferredServicesIfNeeded()
+                    startWorktreeAutoRefreshIfNeeded()
                     NotificationStore.shared.appState = appState
                     NotificationStore.shared.worktreeStore = worktreeStore
                     NotificationStore.shared.markAllAsRead()
@@ -153,6 +155,15 @@ struct MuxyApp: App {
             ExtensionStore.shared.startAll()
             await ExtensionStore.shared.checkForUpdates()
         }
+    }
+
+    private func startWorktreeAutoRefreshIfNeeded() {
+        guard worktreeAutoRefresher == nil else { return }
+        worktreeAutoRefresher = VCSWorktreeAutoRefresher(
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        )
     }
 }
 

--- a/Muxy/Services/GitWorktreesWatcher.swift
+++ b/Muxy/Services/GitWorktreesWatcher.swift
@@ -1,0 +1,108 @@
+import CoreServices
+import Foundation
+
+final class GitWorktreesWatcher: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "app.muxy.worktrees-watcher", qos: .utility)
+    private var stream: FSEventStreamRef?
+    private var debounceWork: DispatchWorkItem?
+    private var handler: (@Sendable () -> Void)?
+
+    init?(repoPath: String, handler: @escaping @Sendable () -> Void) {
+        guard let gitDirectory = Self.resolveGitDirectory(forRepoPath: repoPath) else { return nil }
+
+        self.handler = handler
+
+        var context = FSEventStreamContext()
+        context.info = Unmanaged.passUnretained(self).toOpaque()
+
+        let paths = [gitDirectory] as CFArray
+        guard let stream = FSEventStreamCreate(
+            nil,
+            { _, clientInfo, numEvents, eventPaths, eventFlags, _ in
+                guard let clientInfo, numEvents > 0 else { return }
+                let watcher = Unmanaged<GitWorktreesWatcher>.fromOpaque(clientInfo).takeUnretainedValue()
+                guard let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String]
+                else { return }
+                let flags = Array(UnsafeBufferPointer(start: eventFlags, count: numEvents))
+
+                let isRelevant = zip(paths, flags).contains { path, flag in
+                    GitWorktreesWatcher.isRelevantChange(path: path, flag: flag)
+                }
+                guard isRelevant else { return }
+
+                watcher.scheduleRefresh()
+            },
+            &context,
+            paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.3,
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes)
+        )
+        else { return nil }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+    }
+
+    deinit {
+        handler = nil
+        debounceWork?.cancel()
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+    }
+
+    static func isRelevantChange(path: String, flag: FSEventStreamEventFlags) -> Bool {
+        isWorktreeStructuralChange(path: path, flag: flag) || isHeadReferenceChange(path: path)
+    }
+
+    static func isHeadReferenceChange(path: String) -> Bool {
+        guard path.hasSuffix("/HEAD") else { return false }
+        return !path.contains("/logs/")
+    }
+
+    static func isWorktreeStructuralChange(path: String, flag: FSEventStreamEventFlags) -> Bool {
+        guard path.contains("/worktrees/") else { return false }
+        guard flag & FSEventStreamEventFlags(kFSEventStreamEventFlagItemIsDir) != 0 else { return false }
+        let structuralMask = FSEventStreamEventFlags(
+            kFSEventStreamEventFlagItemCreated
+                | kFSEventStreamEventFlagItemRemoved
+                | kFSEventStreamEventFlagItemRenamed
+        )
+        return flag & structuralMask != 0
+    }
+
+    static func resolveGitDirectory(forRepoPath repoPath: String) -> String? {
+        let manager = FileManager.default
+        let repoURL = URL(fileURLWithPath: repoPath).standardizedFileURL
+        let dotGitURL = repoURL.appendingPathComponent(".git")
+        let dotGit = dotGitURL.path
+        var isDirectory: ObjCBool = false
+        guard manager.fileExists(atPath: dotGit, isDirectory: &isDirectory) else { return nil }
+        if isDirectory.boolValue { return dotGit }
+
+        guard let contents = try? String(contentsOfFile: dotGit, encoding: .utf8) else { return nil }
+        guard let line = contents
+            .split(whereSeparator: \.isNewline)
+            .map({ $0.trimmingCharacters(in: .whitespaces) })
+            .first(where: { $0.hasPrefix("gitdir:") })
+        else { return nil }
+
+        let target = line.dropFirst("gitdir:".count).trimmingCharacters(in: .whitespaces)
+        let targetURL = URL(fileURLWithPath: target, relativeTo: repoURL).standardizedFileURL
+        let targetPath = targetURL.path
+        guard let range = targetPath.range(of: "/worktrees/") else { return nil }
+        return String(targetPath[..<range.lowerBound])
+    }
+
+    private func scheduleRefresh() {
+        debounceWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.handler?()
+        }
+        debounceWork = work
+        queue.asyncAfter(deadline: .now() + 0.3, execute: work)
+    }
+}

--- a/Muxy/Services/VCSWorktreeAutoRefresher.swift
+++ b/Muxy/Services/VCSWorktreeAutoRefresher.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+@MainActor
+final class VCSWorktreeAutoRefresher {
+    private let appState: AppState
+    private let projectStore: ProjectStore
+    private let worktreeStore: WorktreeStore
+    nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
+    private var inFlight: Set<UUID> = []
+    private var pending: Set<UUID> = []
+    private var watchers: [UUID: GitWorktreesWatcher] = [:]
+
+    init(appState: AppState, projectStore: ProjectStore, worktreeStore: WorktreeStore) {
+        self.appState = appState
+        self.projectStore = projectStore
+        self.worktreeStore = worktreeStore
+        observe(.vcsDidRefresh)
+        observe(.vcsRepoDidChange)
+        syncWatchers()
+    }
+
+    deinit {
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    private func observe(_ name: Notification.Name) {
+        let token = NotificationCenter.default.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let path = notification.userInfo?["repoPath"] as? String else { return }
+            MainActor.assumeIsolated {
+                self?.handleRefresh(repoPath: path)
+            }
+        }
+        observers.append(token)
+    }
+
+    private func handleRefresh(repoPath: String) {
+        guard let projectID = worktreeStore.projectID(forWorktreePath: repoPath) else { return }
+        handleRefresh(projectID: projectID)
+    }
+
+    private func handleRefresh(projectID: UUID) {
+        guard let project = projectStore.projects.first(where: { $0.id == projectID }) else { return }
+        guard !inFlight.contains(projectID) else {
+            pending.insert(projectID)
+            return
+        }
+        runRefresh(project: project)
+    }
+
+    private func syncWatchers() {
+        withObservationTracking {
+            reconcileWatchers()
+        } onChange: {
+            Task { @MainActor [weak self] in
+                self?.syncWatchers()
+            }
+        }
+    }
+
+    private func reconcileWatchers() {
+        let projects = projectStore.projects
+        let currentIDs = Set(projects.map(\.id))
+
+        for projectID in Array(watchers.keys) where !currentIDs.contains(projectID) {
+            watchers.removeValue(forKey: projectID)
+        }
+
+        for project in projects where watchers[project.id] == nil {
+            let projectID = project.id
+            let watcher = GitWorktreesWatcher(repoPath: project.path) { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.handleRefresh(projectID: projectID)
+                }
+            }
+            guard let watcher else { continue }
+            watchers[projectID] = watcher
+        }
+    }
+
+    private func runRefresh(project: Project) {
+        inFlight.insert(project.id)
+        Task { [appState, worktreeStore, projectStore] in
+            await WorktreeRefreshHelper.refresh(
+                project: project,
+                appState: appState,
+                worktreeStore: worktreeStore,
+                isRefreshing: nil,
+                presentErrors: false
+            )
+            inFlight.remove(project.id)
+            guard pending.remove(project.id) != nil else { return }
+            guard let updated = projectStore.projects.first(where: { $0.id == project.id }) else { return }
+            runRefresh(project: updated)
+        }
+    }
+}

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -167,11 +167,13 @@ final class WorktreeStore {
             if let existing = existingByKey[recordKey],
                let index = list.firstIndex(where: { $0.id == existing.id })
             {
-                list[index].branch = record.branch
                 if list[index].isPrimary {
                     list[index].name = project.name
                     list[index].path = project.path
+                } else if list[index].name == list[index].branch {
+                    list[index].name = defaultName(for: record)
                 }
+                list[index].branch = record.branch
                 continue
             }
 

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -170,7 +170,7 @@ final class WorktreeStore {
                 if list[index].isPrimary {
                     list[index].name = project.name
                     list[index].path = project.path
-                } else if list[index].name == list[index].branch {
+                } else if record.branch != nil, list[index].name == list[index].branch {
                     list[index].name = defaultName(for: record)
                 }
                 list[index].branch = record.branch

--- a/Tests/MuxyTests/Services/GitWorktreesWatcherTests.swift
+++ b/Tests/MuxyTests/Services/GitWorktreesWatcherTests.swift
@@ -1,0 +1,188 @@
+import CoreServices
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitWorktreesWatcher")
+struct GitWorktreesWatcherTests {
+    private func makeTempRepo() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreesWatcherTests-\(UUID().uuidString)", isDirectory: true)
+        let gitDir = dir.appendingPathComponent(".git", isDirectory: true)
+        try? FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func flags(_ values: Int...) -> FSEventStreamEventFlags {
+        FSEventStreamEventFlags(values.reduce(0, |))
+    }
+
+    @Test("structural change requires a directory event under worktrees")
+    func structuralChangeFilter() {
+        let created = flags(kFSEventStreamEventFlagItemIsDir, kFSEventStreamEventFlagItemCreated)
+        let removed = flags(kFSEventStreamEventFlagItemIsDir, kFSEventStreamEventFlagItemRemoved)
+        let renamed = flags(kFSEventStreamEventFlagItemIsDir, kFSEventStreamEventFlagItemRenamed)
+
+        #expect(GitWorktreesWatcher.isWorktreeStructuralChange(
+            path: "/repo/.git/worktrees/feature", flag: created
+        ))
+        #expect(GitWorktreesWatcher.isWorktreeStructuralChange(
+            path: "/repo/.git/worktrees/feature", flag: removed
+        ))
+        #expect(GitWorktreesWatcher.isWorktreeStructuralChange(
+            path: "/repo/.git/worktrees/feature", flag: renamed
+        ))
+    }
+
+    @Test("ignores file writes inside worktree admin dir")
+    func ignoresFileWrites() {
+        let fileWrite = flags(kFSEventStreamEventFlagItemCreated, kFSEventStreamEventFlagItemModified)
+        #expect(!GitWorktreesWatcher.isWorktreeStructuralChange(
+            path: "/repo/.git/worktrees/feature/HEAD", flag: fileWrite
+        ))
+    }
+
+    @Test("ignores directory modifications that are not create/remove/rename")
+    func ignoresNonStructuralDirEvents() {
+        let modified = flags(kFSEventStreamEventFlagItemIsDir, kFSEventStreamEventFlagItemModified)
+        #expect(!GitWorktreesWatcher.isWorktreeStructuralChange(
+            path: "/repo/.git/worktrees/feature", flag: modified
+        ))
+    }
+
+    @Test("ignores directory events outside the worktrees path")
+    func ignoresOtherGitDirs() {
+        let created = flags(kFSEventStreamEventFlagItemIsDir, kFSEventStreamEventFlagItemCreated)
+        #expect(!GitWorktreesWatcher.isWorktreeStructuralChange(
+            path: "/repo/.git/refs/heads/feature", flag: created
+        ))
+    }
+
+    @Test("treats HEAD changes as relevant for primary and linked worktrees")
+    func detectsHeadReferenceChanges() {
+        #expect(GitWorktreesWatcher.isHeadReferenceChange(path: "/repo/.git/HEAD"))
+        #expect(GitWorktreesWatcher.isHeadReferenceChange(path: "/repo/.git/worktrees/feature/HEAD"))
+    }
+
+    @Test("ignores reflog and lock writes so commits do not trigger refreshes")
+    func ignoresReflogAndLockWrites() {
+        #expect(!GitWorktreesWatcher.isHeadReferenceChange(path: "/repo/.git/logs/HEAD"))
+        #expect(!GitWorktreesWatcher.isHeadReferenceChange(path: "/repo/.git/worktrees/feature/logs/HEAD"))
+        #expect(!GitWorktreesWatcher.isHeadReferenceChange(path: "/repo/.git/HEAD.lock"))
+    }
+
+    @Test("resolves the .git directory for a primary repo")
+    func resolvesPrimaryGitDirectory() {
+        let repo = makeTempRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let resolved = GitWorktreesWatcher.resolveGitDirectory(forRepoPath: repo.path)
+        #expect(resolved == repo.appendingPathComponent(".git").path)
+    }
+
+    @Test("resolves the common .git directory when .git is a linked-worktree gitfile")
+    func resolvesLinkedWorktreeGitDirectory() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreesWatcherTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let gitFile = dir.appendingPathComponent(".git")
+        try? "gitdir: /main/checkout/.git/worktrees/feature\n".data(using: .utf8)?.write(to: gitFile)
+
+        let resolved = GitWorktreesWatcher.resolveGitDirectory(forRepoPath: dir.path)
+        #expect(resolved == "/main/checkout/.git")
+    }
+
+    @Test("resolves relative linked-worktree gitfile targets")
+    func resolvesRelativeLinkedWorktreeGitDirectory() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreesWatcherTests-\(UUID().uuidString)", isDirectory: true)
+        let mainGit = root.appendingPathComponent("main/.git", isDirectory: true)
+        let worktree = root.appendingPathComponent("feature", isDirectory: true)
+        try? FileManager.default.createDirectory(at: mainGit, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let gitFile = worktree.appendingPathComponent(".git")
+        try? "gitdir: ../main/.git/worktrees/feature\n".data(using: .utf8)?.write(to: gitFile)
+
+        let resolved = GitWorktreesWatcher.resolveGitDirectory(forRepoPath: worktree.path)
+        #expect(resolved == mainGit.path)
+    }
+
+    @Test("returns nil when there is no git directory")
+    func returnsNilForNonRepo() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreesWatcherTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        #expect(GitWorktreesWatcher.resolveGitDirectory(forRepoPath: dir.path) == nil)
+    }
+
+    @Test("fires when a worktree admin directory is created")
+    func firesOnWorktreeDirectoryCreation() async throws {
+        let repo = makeTempRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let counter = FireCounter()
+        let watcher = GitWorktreesWatcher(repoPath: repo.path) { counter.increment() }
+        #expect(watcher != nil)
+
+        try await Task.sleep(nanoseconds: 400_000_000)
+        let worktreeDir = repo.appendingPathComponent(".git/worktrees/feature", isDirectory: true)
+        try FileManager.default.createDirectory(at: worktreeDir, withIntermediateDirectories: true)
+
+        let fired = await waitFor(timeout: 5.0) { counter.value > 0 }
+        #expect(fired)
+        _ = watcher
+    }
+
+    @Test("fires when HEAD changes (branch switch or rename)")
+    func firesOnHeadChange() async throws {
+        let repo = makeTempRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = repo.appendingPathComponent(".git/HEAD")
+        try "ref: refs/heads/old\n".data(using: .utf8)!.write(to: head)
+
+        let counter = FireCounter()
+        let watcher = GitWorktreesWatcher(repoPath: repo.path) { counter.increment() }
+        #expect(watcher != nil)
+
+        try await Task.sleep(nanoseconds: 400_000_000)
+        try "ref: refs/heads/new\n".data(using: .utf8)!.write(to: head)
+
+        let fired = await waitFor(timeout: 5.0) { counter.value > 0 }
+        #expect(fired)
+        _ = watcher
+    }
+
+    private func waitFor(timeout: TimeInterval, condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return condition()
+    }
+}
+
+private final class FireCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}

--- a/Tests/MuxyTests/Services/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeStoreTests.swift
@@ -193,6 +193,59 @@ struct WorktreeStoreTests {
         #expect(custom.name == "My Feature")
     }
 
+    @Test("refreshFromGit keeps a branch-derived name when the worktree goes detached")
+    func refreshFromGitKeepsNameOnDetachedHead() async throws {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let persistence = WorktreePersistenceStub(
+            initial: [
+                project.id: [
+                    Worktree(
+                        name: project.name,
+                        path: project.path,
+                        branch: "main",
+                        isPrimary: true
+                    ),
+                    Worktree(
+                        name: "passion729/regulus",
+                        path: "/tmp/repo-wt1",
+                        branch: "passion729/regulus",
+                        source: .external,
+                        isPrimary: false
+                    ),
+                ]
+            ]
+        )
+        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+            project.path: [
+                GitWorktreeRecord(
+                    path: project.path,
+                    branch: "main",
+                    head: nil,
+                    isBare: false,
+                    isDetached: false
+                ),
+                GitWorktreeRecord(
+                    path: "/tmp/repo-wt1",
+                    branch: nil,
+                    head: "abc123",
+                    isBare: false,
+                    isDetached: true
+                ),
+            ]
+        ])
+        let store = WorktreeStore(
+            persistence: persistence,
+            listGitWorktrees: gitService.listWorktrees,
+            projects: [project]
+        )
+
+        let worktrees = try await store.refreshFromGit(project: project)
+
+        let detached = try #require(worktrees.first(where: { $0.path == "/tmp/repo-wt1" }))
+        #expect(detached.branch == nil)
+        #expect(detached.name == "passion729/regulus")
+    }
+
     @Test("refreshFromGit keeps missing Muxy-managed worktrees")
     func refreshFromGitKeepsMissingMuxyManagedEntries() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")

--- a/Tests/MuxyTests/Services/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/WorktreeStoreTests.swift
@@ -122,6 +122,77 @@ struct WorktreeStoreTests {
         #expect(imported.isExternallyManaged)
     }
 
+    @Test("refreshFromGit re-syncs branch-derived name on branch rename but keeps custom names")
+    func refreshFromGitSyncsBranchDerivedName() async throws {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let persistence = WorktreePersistenceStub(
+            initial: [
+                project.id: [
+                    Worktree(
+                        name: project.name,
+                        path: project.path,
+                        branch: "main",
+                        isPrimary: true
+                    ),
+                    Worktree(
+                        name: "passion729/regulus",
+                        path: "/tmp/repo-wt1",
+                        branch: "passion729/regulus",
+                        source: .external,
+                        isPrimary: false
+                    ),
+                    Worktree(
+                        name: "My Feature",
+                        path: "/tmp/repo-wt2",
+                        branch: "feature-old",
+                        source: .external,
+                        isPrimary: false
+                    ),
+                ]
+            ]
+        )
+        let gitService = GitWorktreeListingStub(recordsByRepoPath: [
+            project.path: [
+                GitWorktreeRecord(
+                    path: project.path,
+                    branch: "main",
+                    head: nil,
+                    isBare: false,
+                    isDetached: false
+                ),
+                GitWorktreeRecord(
+                    path: "/tmp/repo-wt1",
+                    branch: "passion729/greeting",
+                    head: nil,
+                    isBare: false,
+                    isDetached: false
+                ),
+                GitWorktreeRecord(
+                    path: "/tmp/repo-wt2",
+                    branch: "feature-new",
+                    head: nil,
+                    isBare: false,
+                    isDetached: false
+                ),
+            ]
+        ])
+        let store = WorktreeStore(
+            persistence: persistence,
+            listGitWorktrees: gitService.listWorktrees,
+            projects: [project]
+        )
+
+        let worktrees = try await store.refreshFromGit(project: project)
+
+        let tracked = try #require(worktrees.first(where: { $0.path == "/tmp/repo-wt1" }))
+        #expect(tracked.branch == "passion729/greeting")
+        #expect(tracked.name == "passion729/greeting")
+
+        let custom = try #require(worktrees.first(where: { $0.path == "/tmp/repo-wt2" }))
+        #expect(custom.branch == "feature-new")
+        #expect(custom.name == "My Feature")
+    }
+
     @Test("refreshFromGit keeps missing Muxy-managed worktrees")
     func refreshFromGitKeepsMissingMuxyManagedEntries() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")


### PR DESCRIPTION
## Summary
Replaces #605 with a clean branch history and no bundled `rg` binary.
Auto-refreshes worktrees when external `git worktree` changes or branch switches/renames update `.git`.
Uses native FSEvents only, and keeps branch-derived worktree names synced while preserving custom names.

## Testing
`mise exec swiftformat@0.60.1 swiftlint@0.57.1 -- scripts/checks.sh --fix`
