### PR TITLE
Add optional client-driven terminal colors over the remote server

### DIFF
--- a/Muxy/Services/ClientThemeApplier.swift
+++ b/Muxy/Services/ClientThemeApplier.swift
@@ -5,51 +5,23 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "ClientThemeApplier")
 
-@MainActor
 enum ClientThemeApplier {
-    private static let cacheLimit = 8
-    private static var cachedConfigs: [ClientThemeDTO: ghostty_config_t] = [:]
-    private static var cachedConfigVersion = -1
-
+    @MainActor
     static func apply(_ theme: ClientThemeDTO, to surface: ghostty_surface_t) {
-        guard let config = config(for: theme) else { return }
+        guard let base = GhosttyService.shared.config,
+              let config = ghostty_config_clone(base)
+        else { return }
+        defer { ghostty_config_free(config) }
+
+        guard loadColors(theme, into: config) else { return }
+        ghostty_config_finalize(config)
         ghostty_surface_update_config(surface, config)
     }
 
+    @MainActor
     static func revert(_ surface: ghostty_surface_t) {
         guard let base = GhosttyService.shared.config else { return }
         ghostty_surface_update_config(surface, base)
-    }
-
-    static func invalidate() {
-        for config in cachedConfigs.values {
-            ghostty_config_free(config)
-        }
-        cachedConfigs.removeAll(keepingCapacity: true)
-    }
-
-    private static func config(for theme: ClientThemeDTO) -> ghostty_config_t? {
-        if cachedConfigVersion != GhosttyService.shared.configVersion {
-            invalidate()
-            cachedConfigVersion = GhosttyService.shared.configVersion
-        }
-        if let cached = cachedConfigs[theme] { return cached }
-        guard let config = buildConfig(for: theme) else { return nil }
-        if cachedConfigs.count >= cacheLimit { invalidate() }
-        cachedConfigs[theme] = config
-        return config
-    }
-
-    private static func buildConfig(for theme: ClientThemeDTO) -> ghostty_config_t? {
-        guard let base = GhosttyService.shared.config,
-              let config = ghostty_config_clone(base)
-        else { return nil }
-        guard loadColors(theme, into: config) else {
-            ghostty_config_free(config)
-            return nil
-        }
-        ghostty_config_finalize(config)
-        return config
     }
 
     private static func loadColors(_ theme: ClientThemeDTO, into config: ghostty_config_t) -> Bool {

--- a/Muxy/Services/ClientThemeApplier.swift
+++ b/Muxy/Services/ClientThemeApplier.swift
@@ -1,0 +1,67 @@
+import Foundation
+import GhosttyKit
+import MuxyShared
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "ClientThemeApplier")
+
+enum ClientThemeApplier {
+    @MainActor
+    static func apply(_ theme: ClientThemeDTO, to surface: ghostty_surface_t) {
+        guard let base = GhosttyService.shared.config,
+              let config = ghostty_config_clone(base)
+        else { return }
+        defer { ghostty_config_free(config) }
+
+        guard loadColors(theme, into: config) else { return }
+        ghostty_config_finalize(config)
+        ghostty_surface_update_config(surface, config)
+    }
+
+    @MainActor
+    static func revert(_ surface: ghostty_surface_t) {
+        guard let base = GhosttyService.shared.config else { return }
+        ghostty_surface_update_config(surface, base)
+    }
+
+    private static func loadColors(_ theme: ClientThemeDTO, into config: ghostty_config_t) -> Bool {
+        let contents = configText(for: theme)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-client-theme-\(UUID().uuidString).conf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        do {
+            try Data(contents.utf8).write(to: url, options: .atomic)
+        } catch {
+            logger.error("Failed to write client theme config: \(error)")
+            return false
+        }
+        url.path.withCString { ghostty_config_load_file(config, $0) }
+        return true
+    }
+
+    static func configText(for theme: ClientThemeDTO) -> String {
+        var lines: [String] = []
+        for (index, color) in theme.palette.prefix(16).enumerated() {
+            lines.append("palette = \(index)=\(hex(color))")
+        }
+        lines.append("background = \(hex(theme.bg))")
+        lines.append("foreground = \(hex(theme.fg))")
+        appendColor(theme.cursorColor, key: "cursor-color", to: &lines)
+        appendColor(theme.cursorText, key: "cursor-text", to: &lines)
+        appendColor(theme.selectionBackground, key: "selection-background", to: &lines)
+        appendColor(theme.selectionForeground, key: "selection-foreground", to: &lines)
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func appendColor(_ value: UInt32?, key: String, to lines: inout [String]) {
+        guard let value else { return }
+        lines.append("\(key) = \(hex(value))")
+    }
+
+    private static func hex(_ value: UInt32) -> String {
+        let r = (value >> 16) & 0xFF
+        let g = (value >> 8) & 0xFF
+        let b = value & 0xFF
+        return String(format: "#%02x%02x%02x", r, g, b)
+    }
+}

--- a/Muxy/Services/ClientThemeApplier.swift
+++ b/Muxy/Services/ClientThemeApplier.swift
@@ -5,23 +5,51 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "ClientThemeApplier")
 
+@MainActor
 enum ClientThemeApplier {
-    @MainActor
-    static func apply(_ theme: ClientThemeDTO, to surface: ghostty_surface_t) {
-        guard let base = GhosttyService.shared.config,
-              let config = ghostty_config_clone(base)
-        else { return }
-        defer { ghostty_config_free(config) }
+    private static let cacheLimit = 8
+    private static var cachedConfigs: [ClientThemeDTO: ghostty_config_t] = [:]
+    private static var cachedConfigVersion = -1
 
-        guard loadColors(theme, into: config) else { return }
-        ghostty_config_finalize(config)
+    static func apply(_ theme: ClientThemeDTO, to surface: ghostty_surface_t) {
+        guard let config = config(for: theme) else { return }
         ghostty_surface_update_config(surface, config)
     }
 
-    @MainActor
     static func revert(_ surface: ghostty_surface_t) {
         guard let base = GhosttyService.shared.config else { return }
         ghostty_surface_update_config(surface, base)
+    }
+
+    static func invalidate() {
+        for config in cachedConfigs.values {
+            ghostty_config_free(config)
+        }
+        cachedConfigs.removeAll(keepingCapacity: true)
+    }
+
+    private static func config(for theme: ClientThemeDTO) -> ghostty_config_t? {
+        if cachedConfigVersion != GhosttyService.shared.configVersion {
+            invalidate()
+            cachedConfigVersion = GhosttyService.shared.configVersion
+        }
+        if let cached = cachedConfigs[theme] { return cached }
+        guard let config = buildConfig(for: theme) else { return nil }
+        if cachedConfigs.count >= cacheLimit { invalidate() }
+        cachedConfigs[theme] = config
+        return config
+    }
+
+    private static func buildConfig(for theme: ClientThemeDTO) -> ghostty_config_t? {
+        guard let base = GhosttyService.shared.config,
+              let config = ghostty_config_clone(base)
+        else { return nil }
+        guard loadColors(theme, into: config) else {
+            ghostty_config_free(config)
+            return nil
+        }
+        ghostty_config_finalize(config)
+        return config
     }
 
     private static func loadColors(_ theme: ClientThemeDTO, into config: ghostty_config_t) -> Bool {
@@ -41,7 +69,7 @@ enum ClientThemeApplier {
 
     static func configText(for theme: ClientThemeDTO) -> String {
         var lines: [String] = []
-        for (index, color) in theme.palette.prefix(16).enumerated() {
+        for (index, color) in theme.palette.prefix(ClientThemeDTO.paletteLimit).enumerated() {
             lines.append("palette = \(index)=\(hex(color))")
         }
         lines.append("background = \(hex(theme.bg))")

--- a/Muxy/Services/ClientThemeStore.swift
+++ b/Muxy/Services/ClientThemeStore.swift
@@ -10,7 +10,7 @@ final class ClientThemeStore {
     private init() {}
 
     func setTheme(_ theme: ClientThemeDTO?, for clientID: UUID) {
-        themes[clientID] = theme
+        themes[clientID] = theme?.capped()
     }
 
     func theme(for clientID: UUID) -> ClientThemeDTO? {

--- a/Muxy/Services/ClientThemeStore.swift
+++ b/Muxy/Services/ClientThemeStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+import MuxyShared
+
+@MainActor
+final class ClientThemeStore {
+    static let shared = ClientThemeStore()
+
+    private var themes: [UUID: ClientThemeDTO] = [:]
+
+    private init() {}
+
+    func setTheme(_ theme: ClientThemeDTO?, for clientID: UUID) {
+        themes[clientID] = theme
+    }
+
+    func theme(for clientID: UUID) -> ClientThemeDTO? {
+        themes[clientID]
+    }
+
+    func clear(for clientID: UUID) {
+        themes.removeValue(forKey: clientID)
+    }
+}

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -137,6 +137,7 @@ final class GhosttyService {
         config = newConfig
         if let oldConfig { ghostty_config_free(oldConfig) }
         configVersion += 1
+        TerminalViewRegistry.shared.reapplyClientThemes()
         if postThemeChangeNotification {
             NotificationCenter.default.post(name: .themeDidChange, object: nil)
         }

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -137,7 +137,6 @@ final class GhosttyService {
         config = newConfig
         if let oldConfig { ghostty_config_free(oldConfig) }
         configVersion += 1
-        ClientThemeApplier.invalidate()
         TerminalViewRegistry.shared.reapplyClientThemes()
         if postThemeChangeNotification {
             NotificationCenter.default.post(name: .themeDidChange, object: nil)

--- a/Muxy/Services/GhosttyService.swift
+++ b/Muxy/Services/GhosttyService.swift
@@ -137,6 +137,7 @@ final class GhosttyService {
         config = newConfig
         if let oldConfig { ghostty_config_free(oldConfig) }
         configVersion += 1
+        ClientThemeApplier.invalidate()
         TerminalViewRegistry.shared.reapplyClientThemes()
         if postThemeChangeNotification {
             NotificationCenter.default.post(name: .themeDidChange, object: nil)

--- a/Muxy/Services/PaneOwnershipStore.swift
+++ b/Muxy/Services/PaneOwnershipStore.swift
@@ -43,6 +43,10 @@ final class PaneOwnershipStore {
         return nil
     }
 
+    func panes(ownedBy clientID: UUID) -> [UUID] {
+        Array(ownedPanesByClient[clientID] ?? [])
+    }
+
     func registerDevice(clientID: UUID, name: String) {
         deviceNames[clientID] = name
     }

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -315,8 +315,9 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
 
     func setClientTheme(_ theme: ClientThemeDTO?, clientID: UUID) {
         ClientThemeStore.shared.setTheme(theme, for: clientID)
+        let stored = ClientThemeStore.shared.theme(for: clientID)
         for paneID in PaneOwnershipStore.shared.panes(ownedBy: clientID) {
-            TerminalViewRegistry.shared.existingView(for: paneID)?.applyClientTheme(theme)
+            TerminalViewRegistry.shared.existingView(for: paneID)?.applyClientTheme(stored)
         }
     }
 

--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -25,6 +25,7 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         self.worktreeStore = worktreeStore
         PaneOwnershipStore.shared.onOwnershipChanged = { [weak self] paneID, owner in
             TerminalViewRegistry.shared.existingView(for: paneID)?.remoteOwnershipDidChange()
+            self?.applyOwnerTheme(paneID: paneID, owner: owner)
             self?.broadcastOwnership(paneID: paneID, owner: owner)
         }
         NotificationCenter.default.addObserver(
@@ -43,6 +44,15 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     private func broadcastOwnership(paneID: UUID, owner: PaneOwnerDTO) {
         let dto = PaneOwnershipEventDTO(paneID: paneID, owner: owner)
         server?.broadcast(MuxyEvent(event: .paneOwnershipChanged, data: .paneOwnership(dto)))
+    }
+
+    private func applyOwnerTheme(paneID: UUID, owner: PaneOwnerDTO) {
+        let theme: ClientThemeDTO? = if case let .remote(clientID, _) = owner {
+            ClientThemeStore.shared.theme(for: clientID)
+        } else {
+            nil
+        }
+        TerminalViewRegistry.shared.existingView(for: paneID)?.applyClientTheme(theme)
     }
 
     private func broadcastTheme() {
@@ -303,8 +313,16 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         PaneOwnershipStore.shared.releaseToMac(paneID: paneID)
     }
 
+    func setClientTheme(_ theme: ClientThemeDTO?, clientID: UUID) {
+        ClientThemeStore.shared.setTheme(theme, for: clientID)
+        for paneID in PaneOwnershipStore.shared.panes(ownedBy: clientID) {
+            TerminalViewRegistry.shared.existingView(for: paneID)?.applyClientTheme(theme)
+        }
+    }
+
     func clientDisconnected(clientID: UUID) {
         PaneOwnershipStore.shared.releaseAll(clientID: clientID)
+        ClientThemeStore.shared.clear(for: clientID)
     }
 
     func getPaneOwner(paneID: UUID) -> PaneOwnerDTO? {

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -189,7 +189,7 @@ final class GhosttyTerminalNSView: NSView {
 
         ghostty_surface_set_size(surface, backingSize.width, backingSize.height)
 
-        applyColorScheme(isDark: ThemeService.isCurrentAppearanceDark())
+        reapplyActiveColors()
 
         if let screen = window?.screen ?? NSScreen.main,
            let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? UInt32

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Darwin
 import GhosttyKit
+import MuxyShared
 import UniformTypeIdentifiers
 
 final class GhosttyTerminalNSView: NSView {
@@ -434,6 +435,37 @@ final class GhosttyTerminalNSView: NSView {
     func applyColorScheme(isDark: Bool) {
         guard let surface else { return }
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
+    }
+
+    func applyClientTheme(_ theme: ClientThemeDTO?) {
+        guard let surface else { return }
+        if let theme {
+            ClientThemeApplier.apply(theme, to: surface)
+            return
+        }
+        ClientThemeApplier.revert(surface)
+        applyColorScheme(isDark: ThemeService.isCurrentAppearanceDark())
+    }
+
+    func reapplyActiveColors() {
+        guard surface != nil else { return }
+        if let theme = activeClientTheme() {
+            applyClientTheme(theme)
+            return
+        }
+        applyColorScheme(isDark: ThemeService.isCurrentAppearanceDark())
+    }
+
+    func reapplyClientThemeIfOwned() {
+        guard surface != nil, let theme = activeClientTheme() else { return }
+        applyClientTheme(theme)
+    }
+
+    private func activeClientTheme() -> ClientThemeDTO? {
+        guard let paneID = TerminalViewRegistry.shared.paneID(for: self),
+              let clientID = PaneOwnershipStore.shared.remoteOwner(for: paneID)
+        else { return nil }
+        return ClientThemeStore.shared.theme(for: clientID)
     }
 
     private func updateMetalLayerSize(deferred: Bool) {

--- a/Muxy/Views/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Views/Terminal/TerminalViewRegistry.swift
@@ -57,9 +57,15 @@ final class TerminalViewRegistry {
         paneIDs[ObjectIdentifier(view)]
     }
 
-    func applyColorSchemeToAllViews(isDark: Bool) {
+    func applyColorSchemeToAllViews(isDark _: Bool) {
         for view in views.values {
-            view.applyColorScheme(isDark: isDark)
+            view.reapplyActiveColors()
+        }
+    }
+
+    func reapplyClientThemes() {
+        for view in views.values {
+            view.reapplyClientThemeIfOwned()
         }
     }
 

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -44,6 +44,7 @@ public protocol MuxyRemoteServerDelegate: AnyObject {
     func getTerminalContent(paneID: UUID) -> TerminalCellsDTO?
     func takeOverPane(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32)
     func releasePane(paneID: UUID, clientID: UUID)
+    func setClientTheme(_ theme: ClientThemeDTO?, clientID: UUID)
     func registerDevice(clientID: UUID, name: String)
     func authenticateDevice(deviceID: UUID, token: String, name: String) -> DeviceAuthDecision
     func requestPairing(deviceID: UUID, token: String, name: String) async -> DeviceAuthDecision
@@ -294,7 +295,8 @@ public final class MuxyRemoteServer: @unchecked Sendable {
                 requestID: request.id,
                 clientID: clientID,
                 deviceID: params.deviceID,
-                decision: decision
+                decision: decision,
+                clientTheme: params.theme
             )
 
         case .authenticateDevice:
@@ -310,7 +312,8 @@ public final class MuxyRemoteServer: @unchecked Sendable {
                 requestID: request.id,
                 clientID: clientID,
                 deviceID: params.deviceID,
-                decision: decision
+                decision: decision,
+                clientTheme: params.theme
             )
 
         default:
@@ -705,6 +708,13 @@ public final class MuxyRemoteServer: @unchecked Sendable {
             delegate.releasePane(paneID: params.paneID, clientID: clientID)
             return MuxyResponse(id: request.id, result: .ok)
 
+        case .setClientTheme:
+            guard case let .setClientTheme(params) = request.params else {
+                return MuxyResponse(id: request.id, error: .invalidParams)
+            }
+            delegate.setClientTheme(params.theme, clientID: clientID)
+            return MuxyResponse(id: request.id, result: .ok)
+
         case .extensionRequest:
             guard case let .extensionRequest(params) = request.params else {
                 return MuxyResponse(id: request.id, error: .invalidParams)
@@ -729,12 +739,16 @@ public final class MuxyRemoteServer: @unchecked Sendable {
         requestID: String,
         clientID: UUID,
         deviceID: UUID,
-        decision: DeviceAuthDecision
+        decision: DeviceAuthDecision,
+        clientTheme: ClientThemeDTO?
     ) -> MuxyResponse {
         switch decision {
         case let .approved(deviceName):
             markAuthenticated(clientID, deviceID: deviceID)
             delegate?.registerDevice(clientID: clientID, name: deviceName)
+            if let clientTheme {
+                delegate?.setClientTheme(clientTheme, clientID: clientID)
+            }
             let theme = delegate?.getDeviceTheme()
             let result = PairingResultDTO(
                 clientID: clientID,

--- a/MuxyShared/MuxyProtocol.swift
+++ b/MuxyShared/MuxyProtocol.swift
@@ -85,6 +85,7 @@ public enum MuxyMethod: String, Codable, Sendable {
     case authenticateDevice
     case takeOverPane
     case releasePane
+    case setClientTheme
     case getVCSStatus
     case vcsRefresh
     case vcsCommit
@@ -129,6 +130,7 @@ public enum MuxyParams: Codable, Sendable {
     case authenticateDevice(AuthenticateDeviceParams)
     case takeOverPane(TakeOverPaneParams)
     case releasePane(ReleasePaneParams)
+    case setClientTheme(SetClientThemeParams)
     case getVCSStatus(GetVCSStatusParams)
     case vcsRefresh(VCSRefreshParams)
     case vcsCommit(VCSCommitParams)
@@ -178,6 +180,7 @@ public enum MuxyParams: Codable, Sendable {
         case "authenticateDevice": self = try .authenticateDevice(container.decode(AuthenticateDeviceParams.self, forKey: .value))
         case "takeOverPane": self = try .takeOverPane(container.decode(TakeOverPaneParams.self, forKey: .value))
         case "releasePane": self = try .releasePane(container.decode(ReleasePaneParams.self, forKey: .value))
+        case "setClientTheme": self = try .setClientTheme(container.decode(SetClientThemeParams.self, forKey: .value))
         case "getTerminalContent": self = try .getTerminalContent(container.decode(GetTerminalContentParams.self, forKey: .value))
         case "getVCSStatus": self = try .getVCSStatus(container.decode(GetVCSStatusParams.self, forKey: .value))
         case "vcsRefresh": self = try .vcsRefresh(container.decode(VCSRefreshParams.self, forKey: .value))
@@ -242,6 +245,8 @@ public enum MuxyParams: Codable, Sendable {
         case let .takeOverPane(v): try container.encode("takeOverPane", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .releasePane(v): try container.encode("releasePane", forKey: .type)
+            try container.encode(v, forKey: .value)
+        case let .setClientTheme(v): try container.encode("setClientTheme", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .getTerminalContent(v): try container.encode("getTerminalContent", forKey: .type)
             try container.encode(v, forKey: .value)

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -252,7 +252,9 @@ public struct DeviceThemeEventDTO: Codable, Sendable {
     }
 }
 
-public struct ClientThemeDTO: Codable, Sendable, Equatable {
+public struct ClientThemeDTO: Codable, Sendable, Equatable, Hashable {
+    public static let paletteLimit = 16
+
     public let fg: UInt32
     public let bg: UInt32
     public let palette: [UInt32]
@@ -276,6 +278,19 @@ public struct ClientThemeDTO: Codable, Sendable, Equatable {
         self.cursorText = cursorText
         self.selectionBackground = selectionBackground
         self.selectionForeground = selectionForeground
+    }
+
+    public func capped() -> ClientThemeDTO {
+        guard palette.count > Self.paletteLimit else { return self }
+        return ClientThemeDTO(
+            fg: fg,
+            bg: bg,
+            palette: Array(palette.prefix(Self.paletteLimit)),
+            cursorColor: cursorColor,
+            cursorText: cursorText,
+            selectionBackground: selectionBackground,
+            selectionForeground: selectionForeground
+        )
     }
 }
 

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -252,7 +252,7 @@ public struct DeviceThemeEventDTO: Codable, Sendable {
     }
 }
 
-public struct ClientThemeDTO: Codable, Sendable, Equatable, Hashable {
+public struct ClientThemeDTO: Codable, Sendable, Equatable {
     public static let paletteLimit = 16
 
     public let fg: UInt32

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -150,10 +150,12 @@ public struct PairDeviceParams: Codable, Sendable {
     public let deviceID: UUID
     public let deviceName: String
     public let token: String
-    public init(deviceID: UUID, deviceName: String, token: String) {
+    public let theme: ClientThemeDTO?
+    public init(deviceID: UUID, deviceName: String, token: String, theme: ClientThemeDTO? = nil) {
         self.deviceID = deviceID
         self.deviceName = deviceName
         self.token = token
+        self.theme = theme
     }
 }
 
@@ -161,10 +163,12 @@ public struct AuthenticateDeviceParams: Codable, Sendable {
     public let deviceID: UUID
     public let deviceName: String
     public let token: String
-    public init(deviceID: UUID, deviceName: String, token: String) {
+    public let theme: ClientThemeDTO?
+    public init(deviceID: UUID, deviceName: String, token: String, theme: ClientThemeDTO? = nil) {
         self.deviceID = deviceID
         self.deviceName = deviceName
         self.token = token
+        self.theme = theme
     }
 }
 
@@ -245,6 +249,40 @@ public struct DeviceThemeEventDTO: Codable, Sendable {
         self.fg = fg
         self.bg = bg
         self.palette = palette
+    }
+}
+
+public struct ClientThemeDTO: Codable, Sendable, Equatable {
+    public let fg: UInt32
+    public let bg: UInt32
+    public let palette: [UInt32]
+    public let cursorColor: UInt32?
+    public let cursorText: UInt32?
+    public let selectionBackground: UInt32?
+    public let selectionForeground: UInt32?
+    public init(
+        fg: UInt32,
+        bg: UInt32,
+        palette: [UInt32],
+        cursorColor: UInt32? = nil,
+        cursorText: UInt32? = nil,
+        selectionBackground: UInt32? = nil,
+        selectionForeground: UInt32? = nil
+    ) {
+        self.fg = fg
+        self.bg = bg
+        self.palette = palette
+        self.cursorColor = cursorColor
+        self.cursorText = cursorText
+        self.selectionBackground = selectionBackground
+        self.selectionForeground = selectionForeground
+    }
+}
+
+public struct SetClientThemeParams: Codable, Sendable {
+    public let theme: ClientThemeDTO?
+    public init(theme: ClientThemeDTO?) {
+        self.theme = theme
     }
 }
 

--- a/Tests/MuxyTests/Remote/ClientThemeTests.swift
+++ b/Tests/MuxyTests/Remote/ClientThemeTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import MuxyShared
+import Testing
+@testable import Muxy
+
+@Suite("Client theme")
+@MainActor
+struct ClientThemeTests {
+    private func makeTheme(
+        cursorColor: UInt32? = nil,
+        cursorText: UInt32? = nil,
+        selectionBackground: UInt32? = nil,
+        selectionForeground: UInt32? = nil
+    ) -> ClientThemeDTO {
+        ClientThemeDTO(
+            fg: 0xD4D4D4,
+            bg: 0x141414,
+            palette: (0 ..< 16).map { UInt32($0) },
+            cursorColor: cursorColor,
+            cursorText: cursorText,
+            selectionBackground: selectionBackground,
+            selectionForeground: selectionForeground
+        )
+    }
+
+    @Test("config text serializes the full color set in ghostty format")
+    func configTextFullSet() {
+        let theme = makeTheme(
+            cursorColor: 0xD4D4D4,
+            cursorText: 0x141414,
+            selectionBackground: 0x2C2C2C,
+            selectionForeground: 0xE4E4E4
+        )
+        let text = ClientThemeApplier.configText(for: theme)
+
+        #expect(text.contains("palette = 0=#000000"))
+        #expect(text.contains("palette = 15=#00000f"))
+        #expect(text.contains("background = #141414"))
+        #expect(text.contains("foreground = #d4d4d4"))
+        #expect(text.contains("cursor-color = #d4d4d4"))
+        #expect(text.contains("cursor-text = #141414"))
+        #expect(text.contains("selection-background = #2c2c2c"))
+        #expect(text.contains("selection-foreground = #e4e4e4"))
+    }
+
+    @Test("config text omits unset optional colors")
+    func configTextOmitsOptionalColors() {
+        let text = ClientThemeApplier.configText(for: makeTheme())
+
+        #expect(text.contains("background = #141414"))
+        #expect(text.contains("foreground = #d4d4d4"))
+        #expect(!text.contains("cursor-color"))
+        #expect(!text.contains("cursor-text"))
+        #expect(!text.contains("selection-background"))
+        #expect(!text.contains("selection-foreground"))
+    }
+
+    @Test("config text caps palette at 16 entries")
+    func configTextCapsPalette() {
+        let theme = ClientThemeDTO(fg: 1, bg: 2, palette: (0 ..< 32).map { UInt32($0) })
+        let text = ClientThemeApplier.configText(for: theme)
+
+        #expect(text.contains("palette = 15="))
+        #expect(!text.contains("palette = 16="))
+    }
+
+    @Test("client theme DTO round-trips with and without optionals")
+    func dtoRoundTrip() throws {
+        for theme in [makeTheme(), makeTheme(cursorColor: 0xFFFFFF, selectionBackground: 0x101010)] {
+            let data = try JSONEncoder().encode(theme)
+            let decoded = try JSONDecoder().decode(ClientThemeDTO.self, from: data)
+            #expect(decoded == theme)
+        }
+    }
+
+    @Test("set client theme params encode a nil theme as a clear")
+    func clearParamsRoundTrip() throws {
+        let params = SetClientThemeParams(theme: nil)
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(SetClientThemeParams.self, from: data)
+        #expect(decoded.theme == nil)
+    }
+
+    @Test("client-owned pane resolves to the client theme, mac-owned resolves to none")
+    func ownershipResolvesActiveTheme() {
+        let ownership = PaneOwnershipStore.shared
+        let store = ClientThemeStore.shared
+        let clientID = UUID()
+        let ownedPane = UUID()
+        let macPane = UUID()
+        let theme = makeTheme()
+        defer {
+            ownership.releaseAll(clientID: clientID)
+            ownership.releaseToMac(paneID: macPane)
+            store.clear(for: clientID)
+        }
+
+        store.setTheme(theme, for: clientID)
+        ownership.assign(paneID: ownedPane, to: clientID)
+
+        #expect(resolveActiveTheme(ownership: ownership, store: store, paneID: ownedPane) == theme)
+        #expect(resolveActiveTheme(ownership: ownership, store: store, paneID: macPane) == nil)
+
+        ownership.releaseToMac(paneID: ownedPane)
+        #expect(resolveActiveTheme(ownership: ownership, store: store, paneID: ownedPane) == nil)
+    }
+
+    private func resolveActiveTheme(
+        ownership: PaneOwnershipStore,
+        store: ClientThemeStore,
+        paneID: UUID
+    ) -> ClientThemeDTO? {
+        guard let clientID = ownership.remoteOwner(for: paneID) else { return nil }
+        return store.theme(for: clientID)
+    }
+}

--- a/Tests/MuxyTests/Remote/ClientThemeTests.swift
+++ b/Tests/MuxyTests/Remote/ClientThemeTests.swift
@@ -105,6 +105,23 @@ struct ClientThemeTests {
         #expect(resolveActiveTheme(ownership: ownership, store: store, paneID: ownedPane) == nil)
     }
 
+    @Test("store caps an oversized palette so retained themes stay bounded")
+    func storeCapsOversizedPalette() {
+        let store = ClientThemeStore.shared
+        let clientID = UUID()
+        defer { store.clear(for: clientID) }
+
+        store.setTheme(ClientThemeDTO(fg: 1, bg: 2, palette: (0 ..< 64).map { UInt32($0) }), for: clientID)
+
+        #expect(store.theme(for: clientID)?.palette.count == ClientThemeDTO.paletteLimit)
+    }
+
+    @Test("capped is a no-op for an in-range palette")
+    func cappedKeepsInRangePalette() {
+        let theme = makeTheme()
+        #expect(theme.capped() == theme)
+    }
+
     private func resolveActiveTheme(
         ownership: PaneOwnershipStore,
         store: ClientThemeStore,

--- a/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
@@ -107,6 +107,7 @@ struct MuxyProtocolVariantTests {
             ProtocolSample(.authenticateDevice(AuthenticateDeviceParams(deviceID: ids.deviceID, deviceName: "iPhone", token: "token")), caseName: ".authenticateDevice"),
             ProtocolSample(.takeOverPane(TakeOverPaneParams(paneID: ids.paneID, cols: 80, rows: 24)), caseName: ".takeOverPane"),
             ProtocolSample(.releasePane(ReleasePaneParams(paneID: ids.paneID)), caseName: ".releasePane"),
+            ProtocolSample(.setClientTheme(SetClientThemeParams(theme: ClientThemeDTO(fg: 0xD4D4D4, bg: 0x141414, palette: Array(repeating: 0x242424, count: 16), cursorColor: 0xD4D4D4, cursorText: 0x141414, selectionBackground: 0x2C2C2C, selectionForeground: 0xE4E4E4))), caseName: ".setClientTheme"),
             ProtocolSample(.getVCSStatus(GetVCSStatusParams(projectID: ids.projectID)), caseName: ".getVCSStatus"),
             ProtocolSample(.vcsRefresh(VCSRefreshParams(projectID: ids.projectID)), caseName: ".vcsRefresh"),
             ProtocolSample(.vcsCommit(VCSCommitParams(projectID: ids.projectID, message: "Commit", stageAll: true)), caseName: ".vcsCommit"),

--- a/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
@@ -11,6 +11,7 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
     var terminalInputCalls: [(paneID: UUID, bytes: Data, clientID: UUID)] = []
     var takeOverCalls: [(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32)] = []
     var releasePaneCalls: [(paneID: UUID, clientID: UUID)] = []
+    var setClientThemeCalls: [(theme: ClientThemeDTO?, clientID: UUID)] = []
     var registerDeviceCalls: [(clientID: UUID, name: String)] = []
     var clientDisconnectedCalls: [UUID] = []
     var markNotificationReadCalls: [UUID] = []
@@ -71,6 +72,10 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
 
     func releasePane(paneID: UUID, clientID: UUID) {
         releasePaneCalls.append((paneID, clientID))
+    }
+
+    func setClientTheme(_ theme: ClientThemeDTO?, clientID: UUID) {
+        setClientThemeCalls.append((theme, clientID))
     }
 
     func registerDevice(clientID: UUID, name: String) {
@@ -313,6 +318,66 @@ struct MuxyRemoteServerRoutingTests {
         #expect(call?.clientID == clientID)
         #expect(call?.cols == 80)
         #expect(call?.rows == 24)
+    }
+
+    @Test("setClientTheme threads theme and clientID through")
+    func setClientThemeRoutes() async {
+        let (server, delegate) = makeServer()
+        let clientID = authedClient(on: server)
+        let theme = ClientThemeDTO(fg: 0xD4D4D4, bg: 0x141414, palette: Array(repeating: 0x242424, count: 16))
+
+        let response = await server.processRequest(
+            MuxyRequest(
+                id: "set-theme",
+                method: .setClientTheme,
+                params: .setClientTheme(SetClientThemeParams(theme: theme))
+            ),
+            clientID: clientID
+        )
+
+        #expect(delegate.setClientThemeCalls.count == 1)
+        #expect(delegate.setClientThemeCalls.first?.clientID == clientID)
+        #expect(delegate.setClientThemeCalls.first?.theme == theme)
+        guard case .ok = response.result else {
+            Issue.record("expected ok result")
+            return
+        }
+    }
+
+    @Test("setClientTheme requires authentication")
+    func setClientThemeRequiresAuth() async {
+        let (server, delegate) = makeServer()
+
+        let response = await server.processRequest(
+            MuxyRequest(
+                id: "set-theme-unauth",
+                method: .setClientTheme,
+                params: .setClientTheme(SetClientThemeParams(theme: nil))
+            ),
+            clientID: UUID()
+        )
+
+        #expect(delegate.setClientThemeCalls.isEmpty)
+        #expect(response.error?.code == 401)
+    }
+
+    @Test("authenticateDevice stashes the client theme on approval")
+    func authenticateDeviceStashesTheme() async {
+        let (server, delegate) = makeServer()
+        let theme = ClientThemeDTO(fg: 1, bg: 2, palette: Array(repeating: 3, count: 16))
+
+        _ = await server.processRequest(
+            MuxyRequest(
+                id: "auth-theme",
+                method: .authenticateDevice,
+                params: .authenticateDevice(
+                    AuthenticateDeviceParams(deviceID: UUID(), deviceName: "iPhone", token: "token", theme: theme)
+                )
+            ),
+            clientID: UUID()
+        )
+
+        #expect(delegate.setClientThemeCalls.first?.theme == theme)
     }
 
     @Test("registerDevice returns device info with clientID")

--- a/docs/remote-server/data-objects.md
+++ b/docs/remote-server/data-objects.md
@@ -120,6 +120,26 @@ A `tabArea` node is encoded as `{ "type": "tabArea", "tabArea": { … } }`; a `s
 - `altScreen`, `cursorKeys`, `bracketedPaste`, `focusEvent` are terminal mode flags the client needs to encode input correctly.
 - `mouseEvent` and `mouseFormat` mirror the pane's active mouse-tracking mode and encoding.
 
+## Client theme
+
+The `theme` carried by [`setClientTheme`](methods.md) and the pairing/authenticate requests. All colors are unsigned 32-bit integers in `0xRRGGBB` form.
+
+```json
+{
+  "fg": 13948116,
+  "bg": 1315860,
+  "palette": [2368548, 16542083, "… 16 entries …"],
+  "cursorColor": 13948116,
+  "cursorText": 1315860,
+  "selectionBackground": 2894892,
+  "selectionForeground": 14998740
+}
+```
+
+- `fg`, `bg`, and `palette` are required; `palette` should hold 16 entries (indices 0–15) and anything past 16 is ignored.
+- `cursorColor`, `cursorText`, `selectionBackground`, and `selectionForeground` are optional and omitted when unset.
+- Send the whole object as `null` (`{ "theme": null }`) to clear and revert the owned panes to the Mac theme.
+
 ## Notification
 
 ```json

--- a/docs/remote-server/methods.md
+++ b/docs/remote-server/methods.md
@@ -32,6 +32,7 @@ Enums:
 | --- | --- | --- |
 | `takeOverPane` | `paneID`, `cols`, `rows` | `ok` |
 | `releasePane` | `paneID` | `ok` |
+| `setClientTheme` | `theme?` | `ok` |
 | `terminalInput` | `paneID`, `bytes` | `ok` |
 | `terminalResize` | `paneID`, `cols`, `rows` | `ok` |
 | `terminalScroll` | `paneID`, `deltaX`, `deltaY`, `precise` | `ok` |
@@ -43,6 +44,7 @@ Notes:
 - `takeOverPane` immediately pushes a [`terminalSnapshot`](events.md) event to the calling client, then streams [`terminalOutput`](events.md) until released.
 - `terminalInput.bytes` is base64-encoded raw bytes delivered verbatim to the PTY. The client encodes escape sequences, control codes, and mouse reports itself. `terminalInput` is fire-and-forget — the server does **not** send a response for it.
 - `getTerminalContent` is a one-shot pull that returns the rendered grid as [`terminalCells`](data-objects.md#terminal-cells). New clients should instead render the pane with their own VT emulator fed by the `terminalOutput` stream; use the pull only for an initial paint or debugging. It returns `404` if the pane has no live surface.
+- `setClientTheme` recolors the live Ghostty surfaces of the panes this client **owns** — both currently owned panes and any taken over afterward — with the client's [`clientTheme`](data-objects.md#client-theme). It is optional: clients that never send it keep the Mac theme. Colors revert to the Mac theme when the pane is released or the client disconnects. Send `theme: null` to clear and revert immediately. The theme can also be supplied at [pairing](pairing.md) time.
 
 ## Notifications & visual data
 

--- a/docs/remote-server/pairing.md
+++ b/docs/remote-server/pairing.md
@@ -48,10 +48,13 @@ Authenticates a previously approved device.
   "value": {
     "deviceID": "2f8d1f9f-e065-4f62-af30-8c4b3d0bfc53",
     "deviceName": "Pixel 9",
-    "token": "random-secret-token"
+    "token": "random-secret-token",
+    "theme": null
   }
 }
 ```
+
+`theme` is an optional [`clientTheme`](data-objects.md#client-theme). When present, the colors are stored for this connection and applied to every pane the client takes over (see [`setClientTheme`](methods.md)). It is the client→server counterpart to the `theme*` fields the server returns below, and may be omitted entirely. `pairDevice` accepts the same optional field.
 
 Outcomes:
 


### PR DESCRIPTION
Clients can send a theme (palette, bg/fg, cursor, selection) that's applied live to the Ghostty surfaces of panes
  they take over, reverting to the Mac theme on release or disconnect.
  Optional and seamless: panes without a client theme keep the Mac theme, and system dark/light changes no longer
  override a client-controlled terminal.
  Adds the `setClientTheme` request (also accepted at pairing), with protocol/server/app wiring, docs, and tests