### PR TITLE
Move custom commands into their own Commands settings section

### DIFF
--- a/Muxy/Views/Settings/CommandsSettingsView.swift
+++ b/Muxy/Views/Settings/CommandsSettingsView.swift
@@ -1,0 +1,444 @@
+import SwiftUI
+
+struct CommandsSettingsView: View {
+    @State private var recordingCommandPrefix = false
+    @State private var recordingCommandShortcutID: UUID?
+    @State private var pendingCommandShortcutID: UUID?
+    @State private var searchText = ""
+    @State private var commandPrefixConflictWarning: String?
+    @State private var commandConflictWarning: (id: UUID, message: String)?
+    @State private var deleteAllCommandShortcutsSecondsRemaining = 0
+    @State private var deleteAllCommandShortcutsTask: Task<Void, Never>?
+
+    private var commandStore: CommandShortcutStore { CommandShortcutStore.shared }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            SettingsDivider()
+            list
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                TextField("Search commands", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .foregroundStyle(SettingsStyle.foreground)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
+
+            Button {
+                searchText = ""
+                discardPendingCommandShortcut()
+                let shortcut = commandStore.addShortcut()
+                pendingCommandShortcutID = shortcut.id
+                recordingCommandPrefix = false
+                recordingCommandShortcutID = shortcut.id
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .help("Add Command")
+            .accessibilityLabel("Add Command")
+        }
+        .padding(SettingsMetrics.horizontalPadding)
+    }
+
+    private var list: some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            commandShortcutsSection
+        }
+    }
+
+    private var commandShortcutsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Press the command layer shortcut, then a command key to open a new terminal tab.")
+                .font(.system(size: SettingsMetrics.footnoteFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                .padding(.top, SettingsMetrics.sectionHeaderTopPadding)
+                .padding(.bottom, SettingsMetrics.sectionHeaderBottomPadding)
+
+            CommandPrefixRow(
+                combo: commandStore.prefixCombo,
+                isRecording: recordingCommandPrefix,
+                conflictMessage: commandPrefixConflictWarning,
+                onStartRecording: {
+                    discardPendingCommandShortcut()
+                    recordingCommandPrefix = true
+                    recordingCommandShortcutID = nil
+                    commandPrefixConflictWarning = nil
+                    commandConflictWarning = nil
+                },
+                onRecord: handleRecord(prefixCombo:),
+                onCancel: {
+                    recordingCommandPrefix = false
+                    commandPrefixConflictWarning = nil
+                },
+                onReset: {
+                    commandStore.resetPrefixCombo()
+                    recordingCommandPrefix = false
+                    commandPrefixConflictWarning = nil
+                }
+            )
+
+            ForEach(filteredCommandShortcuts) { shortcut in
+                CommandShortcutRow(
+                    shortcut: binding(for: shortcut),
+                    prefixCombo: commandStore.prefixCombo,
+                    isRecording: recordingCommandShortcutID == shortcut.id,
+                    conflictMessage: commandConflictWarning?.id == shortcut.id ? commandConflictWarning?.message : nil,
+                    onStartRecording: {
+                        if pendingCommandShortcutID != shortcut.id {
+                            discardPendingCommandShortcut()
+                        }
+                        recordingCommandPrefix = false
+                        recordingCommandShortcutID = shortcut.id
+                        commandConflictWarning = nil
+                    },
+                    onRecord: { combo in handleRecord(shortcutID: shortcut.id, combo: combo) },
+                    onCancel: {
+                        cancelCommandShortcutRecording(shortcutID: shortcut.id)
+                    },
+                    onDelete: {
+                        commandStore.deleteShortcut(id: shortcut.id)
+                        if recordingCommandShortcutID == shortcut.id {
+                            recordingCommandShortcutID = nil
+                        }
+                        if pendingCommandShortcutID == shortcut.id {
+                            pendingCommandShortcutID = nil
+                        }
+                        if commandConflictWarning?.id == shortcut.id {
+                            commandConflictWarning = nil
+                        }
+                    }
+                )
+            }
+
+            if !commandStore.shortcuts.isEmpty {
+                DeleteAllCommandShortcutsRow(
+                    secondsRemaining: deleteAllCommandShortcutsSecondsRemaining,
+                    action: handleDeleteAllCommandShortcuts
+                )
+            }
+        }
+        .onDisappear {
+            discardPendingCommandShortcut()
+            cancelDeleteAllCommandShortcutsConfirmation()
+        }
+    }
+
+    private var filteredCommandShortcuts: [CommandShortcut] {
+        guard !searchText.isEmpty else { return commandStore.shortcuts }
+        return commandStore.shortcuts.filter {
+            $0.displayName.localizedCaseInsensitiveContains(searchText)
+                || $0.command.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    private func handleRecord(prefixCombo combo: KeyCombo) {
+        commandStore.updatePrefixCombo(combo)
+        recordingCommandPrefix = false
+        commandPrefixConflictWarning = nil
+    }
+
+    private func handleRecord(shortcutID: UUID, combo: KeyCombo) {
+        if let existing = commandStore.conflictingShortcut(for: combo, excluding: shortcutID) {
+            commandConflictWarning = (id: shortcutID, message: "Conflicts with \"\(existing.displayName)\"")
+            return
+        }
+        guard var shortcut = commandStore.shortcuts.first(where: { $0.id == shortcutID }) else { return }
+        shortcut.combo = combo
+        commandStore.updateShortcut(shortcut)
+        if pendingCommandShortcutID == shortcutID {
+            pendingCommandShortcutID = nil
+        }
+        recordingCommandShortcutID = nil
+        commandConflictWarning = nil
+    }
+
+    private func cancelCommandShortcutRecording(shortcutID: UUID) {
+        if pendingCommandShortcutID == shortcutID {
+            commandStore.deleteShortcut(id: shortcutID)
+            pendingCommandShortcutID = nil
+        }
+        recordingCommandShortcutID = nil
+        commandConflictWarning = nil
+    }
+
+    private func discardPendingCommandShortcut() {
+        guard let shortcutID = pendingCommandShortcutID else { return }
+        commandStore.deleteShortcut(id: shortcutID)
+        pendingCommandShortcutID = nil
+        if recordingCommandShortcutID == shortcutID {
+            recordingCommandShortcutID = nil
+        }
+        if commandConflictWarning?.id == shortcutID {
+            commandConflictWarning = nil
+        }
+    }
+
+    private func binding(for shortcut: CommandShortcut) -> Binding<CommandShortcut> {
+        Binding {
+            commandStore.shortcuts.first { $0.id == shortcut.id } ?? shortcut
+        } set: { updated in
+            commandStore.updateShortcut(updated)
+        }
+    }
+
+    private func handleDeleteAllCommandShortcuts() {
+        guard deleteAllCommandShortcutsSecondsRemaining == 0 else {
+            commandStore.deleteAllShortcuts()
+            pendingCommandShortcutID = nil
+            recordingCommandShortcutID = nil
+            commandConflictWarning = nil
+            cancelDeleteAllCommandShortcutsConfirmation()
+            return
+        }
+
+        startDeleteAllCommandShortcutsConfirmation()
+    }
+
+    private func startDeleteAllCommandShortcutsConfirmation() {
+        deleteAllCommandShortcutsTask?.cancel()
+        deleteAllCommandShortcutsTask = Task { @MainActor in
+            for seconds in stride(from: 5, through: 1, by: -1) {
+                deleteAllCommandShortcutsSecondsRemaining = seconds
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+            }
+            deleteAllCommandShortcutsSecondsRemaining = 0
+            deleteAllCommandShortcutsTask = nil
+        }
+    }
+
+    private func cancelDeleteAllCommandShortcutsConfirmation() {
+        deleteAllCommandShortcutsTask?.cancel()
+        deleteAllCommandShortcutsTask = nil
+        deleteAllCommandShortcutsSecondsRemaining = 0
+    }
+}
+
+private struct CommandPrefixRow: View {
+    let combo: KeyCombo
+    let isRecording: Bool
+    let conflictMessage: String?
+    let onStartRecording: () -> Void
+    let onRecord: (KeyCombo) -> Void
+    let onCancel: () -> Void
+    let onReset: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Command Layer")
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if isRecording {
+                    recordingView
+                } else {
+                    comboDisplay
+                }
+            }
+
+            if let conflictMessage {
+                Text("\(conflictMessage) — press a different shortcut or Esc to cancel")
+                    .font(.system(size: 10))
+                    .foregroundStyle(SettingsStyle.warning)
+            }
+        }
+        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+        .background(hovered ? SettingsStyle.hover : .clear)
+        .onHover { hovered = $0 }
+    }
+
+    private var comboDisplay: some View {
+        HStack(spacing: 6) {
+            if hovered {
+                Button(action: onReset) {
+                    Image(systemName: "arrow.counterclockwise")
+                        .font(.system(size: 10))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Reset Shortcut")
+            }
+
+            Button(action: onStartRecording) {
+                Text(combo.displayString)
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
+                    .foregroundStyle(SettingsStyle.foreground)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var recordingView: some View {
+        ZStack {
+            ShortcutRecorderView(onRecord: onRecord, onCancel: onCancel)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+
+            Text("Press shortcut…")
+                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                .foregroundStyle(SettingsStyle.warning)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
+        }
+    }
+}
+
+private struct CommandShortcutRow: View {
+    private enum Metrics {
+        static let deleteButtonSize: CGFloat = 18
+        static let shortcutControlWidth: CGFloat = 130
+    }
+
+    @Binding var shortcut: CommandShortcut
+    let prefixCombo: KeyCombo
+    let isRecording: Bool
+    let conflictMessage: String?
+    let onStartRecording: () -> Void
+    let onRecord: (KeyCombo) -> Void
+    let onCancel: () -> Void
+    let onDelete: () -> Void
+    @State private var hovered = false
+    @State private var deleteButtonHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                TextField("Name", text: $shortcut.name)
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .settingsTextInput(width: 120)
+
+                TextField("Command", text: $shortcut.command)
+                    .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
+                    .settingsTextInput(maxWidth: .infinity)
+
+                if isRecording {
+                    recordingView
+                } else {
+                    comboDisplay
+                }
+            }
+
+            if let conflictMessage {
+                Text("\(conflictMessage) — press a different shortcut or Esc to cancel")
+                    .font(.system(size: 10))
+                    .foregroundStyle(SettingsStyle.warning)
+            }
+        }
+        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+        .background(hovered ? SettingsStyle.hover : .clear)
+        .onHover { hovered = $0 }
+    }
+
+    private var comboDisplay: some View {
+        HStack(spacing: 6) {
+            Button(action: onStartRecording) {
+                Text("\(prefixCombo.displayString) \(shortcut.combo.displayString)")
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
+                    .foregroundStyle(SettingsStyle.foreground)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .font(.system(size: 10))
+                    .foregroundStyle(
+                        deleteButtonHovered ? AnyShapeStyle(SettingsStyle.destructive) : AnyShapeStyle(SettingsStyle.mutedForeground)
+                    )
+                    .frame(width: Metrics.deleteButtonSize, height: Metrics.deleteButtonSize)
+            }
+            .buttonStyle(.plain)
+            .background(
+                deleteButtonHovered ? AnyShapeStyle(SettingsStyle.destructiveSoft) : AnyShapeStyle(SettingsStyle.surface),
+                in: RoundedRectangle(cornerRadius: 5)
+            )
+            .onHover { isHovering in
+                deleteButtonHovered = isHovering
+            }
+            .accessibilityLabel("Delete Command")
+        }
+        .frame(alignment: .trailing)
+    }
+
+    private var recordingView: some View {
+        ZStack {
+            ShortcutRecorderView(onRecord: onRecord, onCancel: onCancel, requiresModifier: false)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+
+            Text("Press key…")
+                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                .foregroundStyle(SettingsStyle.warning)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
+        }
+    }
+}
+
+private struct DeleteAllCommandShortcutsRow: View {
+    let secondsRemaining: Int
+    let action: () -> Void
+
+    private var isConfirming: Bool {
+        secondsRemaining > 0
+    }
+
+    var body: some View {
+        HStack {
+            Spacer()
+
+            Button(action: action) {
+                Text(title)
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                    .foregroundStyle(isConfirming ? SettingsStyle.destructive : SettingsStyle.mutedForeground)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(backgroundStyle, in: RoundedRectangle(cornerRadius: 5))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+        }
+        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+    }
+
+    private var title: String {
+        if isConfirming {
+            return "Confirm Delete All (\(secondsRemaining))"
+        }
+        return "Delete All"
+    }
+
+    private var backgroundStyle: AnyShapeStyle {
+        isConfirming ? AnyShapeStyle(SettingsStyle.destructiveSoft) : AnyShapeStyle(SettingsStyle.surface)
+    }
+}

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -1,83 +1,20 @@
 import SwiftUI
 
 struct KeyboardShortcutsSettingsView: View {
-    @Environment(\.settingsSearchQuery) private var settingsSearchQuery
-
-    private enum ListSection: String, CaseIterable, Identifiable {
-        case app
-        case custom
-
-        var id: String { rawValue }
-
-        var title: String {
-            switch self {
-            case .app: "App Shortcuts"
-            case .custom: "Custom Commands"
-            }
-        }
-
-        var searchPlaceholder: String {
-            switch self {
-            case .app: "Search shortcuts"
-            case .custom: "Search commands"
-            }
-        }
-    }
-
-    @State private var section: ListSection = .app
     @State private var recordingAction: ShortcutAction?
-    @State private var recordingCommandPrefix = false
-    @State private var recordingCommandShortcutID: UUID?
-    @State private var pendingCommandShortcutID: UUID?
     @State private var searchText = ""
     @State private var conflictWarning: (action: ShortcutAction, existing: ShortcutAction)?
-    @State private var commandPrefixConflictWarning: String?
-    @State private var commandConflictWarning: (id: UUID, message: String)?
-    @State private var deleteAllCommandShortcutsSecondsRemaining = 0
-    @State private var deleteAllCommandShortcutsTask: Task<Void, Never>?
     @State private var recordingExtensionShortcutID: String?
     @State private var extensionConflictWarning: (id: String, message: String)?
 
     private var store: KeyBindingStore { KeyBindingStore.shared }
-    private var commandStore: CommandShortcutStore { CommandShortcutStore.shared }
     private var extensionStore: ExtensionShortcutStore { ExtensionShortcutStore.shared }
 
     var body: some View {
         VStack(spacing: 0) {
-            sectionPicker
-            SettingsDivider()
             header
             SettingsDivider()
-            switch section {
-            case .app: appShortcutsList
-            case .custom: customShortcutsList
-            }
-        }
-        .onChange(of: settingsSearchQuery) { _, query in
-            applyGlobalSearchSection(query)
-        }
-    }
-
-    private var sectionPicker: some View {
-        Picker("", selection: $section) {
-            ForEach(ListSection.allCases) { section in
-                Text(section.title).tag(section)
-            }
-        }
-        .labelsHidden()
-        .pickerStyle(.segmented)
-        .padding(.horizontal, SettingsMetrics.horizontalPadding)
-        .padding(.vertical, 10)
-        .onChange(of: section) { _, _ in
-            discardPendingCommandShortcut()
-            searchText = ""
-            recordingAction = nil
-            recordingCommandPrefix = false
-            recordingCommandShortcutID = nil
-            conflictWarning = nil
-            commandPrefixConflictWarning = nil
-            commandConflictWarning = nil
-            cancelDeleteAllCommandShortcutsConfirmation()
+            appShortcutsList
         }
     }
 
@@ -87,7 +24,7 @@ struct KeyboardShortcutsSettingsView: View {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(SettingsStyle.mutedForeground)
                     .font(.system(size: SettingsMetrics.labelFontSize))
-                TextField(section.searchPlaceholder, text: $searchText)
+                TextField("Search shortcuts", text: $searchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: SettingsMetrics.labelFontSize))
                     .foregroundStyle(SettingsStyle.foreground)
@@ -96,32 +33,14 @@ struct KeyboardShortcutsSettingsView: View {
             .padding(.vertical, 6)
             .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
 
-            switch section {
-            case .app:
-                Button("Reset All") {
-                    store.resetToDefaults()
-                    recordingAction = nil
-                    conflictWarning = nil
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: SettingsMetrics.footnoteFontSize))
-                .foregroundStyle(SettingsStyle.mutedForeground)
-            case .custom:
-                Button {
-                    searchText = ""
-                    discardPendingCommandShortcut()
-                    let shortcut = commandStore.addShortcut()
-                    pendingCommandShortcutID = shortcut.id
-                    recordingCommandPrefix = false
-                    recordingCommandShortcutID = shortcut.id
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
-                }
-                .buttonStyle(.plain)
-                .help("Add Command Shortcut")
-                .accessibilityLabel("Add Command Shortcut")
+            Button("Reset All") {
+                store.resetToDefaults()
+                recordingAction = nil
+                conflictWarning = nil
             }
+            .buttonStyle(.plain)
+            .font(.system(size: SettingsMetrics.footnoteFontSize))
+            .foregroundStyle(SettingsStyle.mutedForeground)
         }
         .padding(SettingsMetrics.horizontalPadding)
     }
@@ -154,10 +73,7 @@ struct KeyboardShortcutsSettingsView: View {
                     isRecording: recordingExtensionShortcutID == entry.id,
                     conflictMessage: extensionConflictWarning?.id == entry.id ? extensionConflictWarning?.message : nil,
                     onStartRecording: {
-                        discardPendingCommandShortcut()
                         recordingAction = nil
-                        recordingCommandPrefix = false
-                        recordingCommandShortcutID = nil
                         recordingExtensionShortcutID = entry.id
                         extensionConflictWarning = nil
                     },
@@ -216,12 +132,6 @@ struct KeyboardShortcutsSettingsView: View {
         }
     }
 
-    private var customShortcutsList: some View {
-        ScrollView(.vertical, showsIndicators: true) {
-            commandShortcutsSection
-        }
-    }
-
     private func categorySection(title: String, actions: [ShortcutAction], isLast: Bool) -> some View {
         SettingsSection(title, showsDivider: !isLast) {
             ForEach(actions) { action in
@@ -233,10 +143,7 @@ struct KeyboardShortcutsSettingsView: View {
                         ? "Conflicts with \"\(conflictWarning?.existing.displayName ?? "")\" — press a different shortcut or Esc to cancel"
                         : nil,
                     onStartRecording: {
-                        discardPendingCommandShortcut()
                         recordingAction = action
-                        recordingCommandPrefix = false
-                        recordingCommandShortcutID = nil
                         conflictWarning = nil
                     },
                     onRecord: { combo in handleRecord(action: action, combo: combo) },
@@ -263,101 +170,6 @@ struct KeyboardShortcutsSettingsView: View {
         return actions.filter { $0.displayName.localizedCaseInsensitiveContains(searchText) }
     }
 
-    private var filteredCommandShortcuts: [CommandShortcut] {
-        guard !searchText.isEmpty else { return commandStore.shortcuts }
-        return commandStore.shortcuts.filter {
-            $0.displayName.localizedCaseInsensitiveContains(searchText)
-                || $0.command.localizedCaseInsensitiveContains(searchText)
-        }
-    }
-
-    private var commandShortcutsSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Custom Commands")
-                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
-                .foregroundStyle(SettingsStyle.mutedForeground)
-                .padding(.horizontal, SettingsMetrics.horizontalPadding)
-                .padding(.top, SettingsMetrics.sectionHeaderTopPadding)
-                .padding(.bottom, 2)
-
-            Text("Press the command layer shortcut, then a command key to open a new terminal tab.")
-                .font(.system(size: SettingsMetrics.footnoteFontSize))
-                .foregroundStyle(SettingsStyle.mutedForeground)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, SettingsMetrics.horizontalPadding)
-                .padding(.bottom, SettingsMetrics.sectionHeaderBottomPadding)
-
-            CommandPrefixRow(
-                combo: commandStore.prefixCombo,
-                isRecording: recordingCommandPrefix,
-                conflictMessage: commandPrefixConflictWarning,
-                onStartRecording: {
-                    discardPendingCommandShortcut()
-                    recordingAction = nil
-                    recordingCommandPrefix = true
-                    recordingCommandShortcutID = nil
-                    commandPrefixConflictWarning = nil
-                    commandConflictWarning = nil
-                },
-                onRecord: handleRecord(prefixCombo:),
-                onCancel: {
-                    recordingCommandPrefix = false
-                    commandPrefixConflictWarning = nil
-                },
-                onReset: {
-                    commandStore.resetPrefixCombo()
-                    recordingCommandPrefix = false
-                    commandPrefixConflictWarning = nil
-                }
-            )
-
-            ForEach(filteredCommandShortcuts) { shortcut in
-                CommandShortcutRow(
-                    shortcut: binding(for: shortcut),
-                    prefixCombo: commandStore.prefixCombo,
-                    isRecording: recordingCommandShortcutID == shortcut.id,
-                    conflictMessage: commandConflictWarning?.id == shortcut.id ? commandConflictWarning?.message : nil,
-                    onStartRecording: {
-                        if pendingCommandShortcutID != shortcut.id {
-                            discardPendingCommandShortcut()
-                        }
-                        recordingAction = nil
-                        recordingCommandPrefix = false
-                        recordingCommandShortcutID = shortcut.id
-                        commandConflictWarning = nil
-                    },
-                    onRecord: { combo in handleRecord(shortcutID: shortcut.id, combo: combo) },
-                    onCancel: {
-                        cancelCommandShortcutRecording(shortcutID: shortcut.id)
-                    },
-                    onDelete: {
-                        commandStore.deleteShortcut(id: shortcut.id)
-                        if recordingCommandShortcutID == shortcut.id {
-                            recordingCommandShortcutID = nil
-                        }
-                        if pendingCommandShortcutID == shortcut.id {
-                            pendingCommandShortcutID = nil
-                        }
-                        if commandConflictWarning?.id == shortcut.id {
-                            commandConflictWarning = nil
-                        }
-                    }
-                )
-            }
-
-            if !commandStore.shortcuts.isEmpty {
-                DeleteAllCommandShortcutsRow(
-                    secondsRemaining: deleteAllCommandShortcutsSecondsRemaining,
-                    action: handleDeleteAllCommandShortcuts
-                )
-            }
-        }
-        .onDisappear {
-            discardPendingCommandShortcut()
-            cancelDeleteAllCommandShortcutsConfirmation()
-        }
-    }
-
     private func handleRecord(action: ShortcutAction, combo: KeyCombo) {
         if let existing = store.conflictingAction(for: combo, excluding: action) {
             conflictWarning = (action: action, existing: existing)
@@ -366,99 +178,6 @@ struct KeyboardShortcutsSettingsView: View {
         store.updateBinding(action: action, combo: combo)
         recordingAction = nil
         conflictWarning = nil
-    }
-
-    private func applyGlobalSearchSection(_ query: String) {
-        let sections = SettingsCatalog.matchingItems(query: query)
-            .filter { $0.category == .shortcuts }
-            .map(\.section)
-        guard sections.contains("Custom Commands") else { return }
-        section = .custom
-    }
-
-    private func handleRecord(prefixCombo combo: KeyCombo) {
-        commandStore.updatePrefixCombo(combo)
-        recordingCommandPrefix = false
-        commandPrefixConflictWarning = nil
-    }
-
-    private func handleRecord(shortcutID: UUID, combo: KeyCombo) {
-        if let existing = commandStore.conflictingShortcut(for: combo, excluding: shortcutID) {
-            commandConflictWarning = (id: shortcutID, message: "Conflicts with \"\(existing.displayName)\"")
-            return
-        }
-        guard var shortcut = commandStore.shortcuts.first(where: { $0.id == shortcutID }) else { return }
-        shortcut.combo = combo
-        commandStore.updateShortcut(shortcut)
-        if pendingCommandShortcutID == shortcutID {
-            pendingCommandShortcutID = nil
-        }
-        recordingCommandShortcutID = nil
-        commandConflictWarning = nil
-    }
-
-    private func cancelCommandShortcutRecording(shortcutID: UUID) {
-        if pendingCommandShortcutID == shortcutID {
-            commandStore.deleteShortcut(id: shortcutID)
-            pendingCommandShortcutID = nil
-        }
-        recordingCommandShortcutID = nil
-        commandConflictWarning = nil
-    }
-
-    private func discardPendingCommandShortcut() {
-        guard let shortcutID = pendingCommandShortcutID else { return }
-        commandStore.deleteShortcut(id: shortcutID)
-        pendingCommandShortcutID = nil
-        if recordingCommandShortcutID == shortcutID {
-            recordingCommandShortcutID = nil
-        }
-        if commandConflictWarning?.id == shortcutID {
-            commandConflictWarning = nil
-        }
-    }
-
-    private func binding(for shortcut: CommandShortcut) -> Binding<CommandShortcut> {
-        Binding {
-            commandStore.shortcuts.first { $0.id == shortcut.id } ?? shortcut
-        } set: { updated in
-            commandStore.updateShortcut(updated)
-        }
-    }
-
-    private func handleDeleteAllCommandShortcuts() {
-        guard deleteAllCommandShortcutsSecondsRemaining == 0 else {
-            commandStore.deleteAllShortcuts()
-            pendingCommandShortcutID = nil
-            recordingCommandShortcutID = nil
-            commandConflictWarning = nil
-            cancelDeleteAllCommandShortcutsConfirmation()
-            return
-        }
-
-        startDeleteAllCommandShortcutsConfirmation()
-    }
-
-    private func startDeleteAllCommandShortcutsConfirmation() {
-        deleteAllCommandShortcutsTask?.cancel()
-        deleteAllCommandShortcutsTask = Task { @MainActor in
-            for seconds in stride(from: 5, through: 1, by: -1) {
-                deleteAllCommandShortcutsSecondsRemaining = seconds
-                do {
-                    try await Task.sleep(for: .seconds(1))
-                } catch {
-                    return
-                }
-            }
-            deleteAllCommandShortcutsSecondsRemaining = 0
-            deleteAllCommandShortcutsTask = nil
-        }
-    }
-
-    private func cancelDeleteAllCommandShortcutsConfirmation() {
-        deleteAllCommandShortcutsTask?.cancel()
-        deleteAllCommandShortcutsTask = nil
-        deleteAllCommandShortcutsSecondsRemaining = 0
     }
 }
 
@@ -546,216 +265,5 @@ private struct ShortcutRow: View {
                 .padding(.vertical, 4)
                 .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
         }
-    }
-}
-
-private struct CommandPrefixRow: View {
-    let combo: KeyCombo
-    let isRecording: Bool
-    let conflictMessage: String?
-    let onStartRecording: () -> Void
-    let onRecord: (KeyCombo) -> Void
-    let onCancel: () -> Void
-    let onReset: () -> Void
-    @State private var hovered = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text("Command Layer")
-                    .font(.system(size: SettingsMetrics.labelFontSize))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                if isRecording {
-                    recordingView
-                } else {
-                    comboDisplay
-                }
-            }
-
-            if let conflictMessage {
-                Text("\(conflictMessage) — press a different shortcut or Esc to cancel")
-                    .font(.system(size: 10))
-                    .foregroundStyle(SettingsStyle.warning)
-            }
-        }
-        .padding(.horizontal, SettingsMetrics.horizontalPadding)
-        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
-        .background(hovered ? SettingsStyle.hover : .clear)
-        .onHover { hovered = $0 }
-    }
-
-    private var comboDisplay: some View {
-        HStack(spacing: 6) {
-            if hovered {
-                Button(action: onReset) {
-                    Image(systemName: "arrow.counterclockwise")
-                        .font(.system(size: 10))
-                        .foregroundStyle(SettingsStyle.mutedForeground)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Reset Shortcut")
-            }
-
-            Button(action: onStartRecording) {
-                Text(combo.displayString)
-                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
-                    .foregroundStyle(SettingsStyle.foreground)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
-            }
-            .buttonStyle(.plain)
-        }
-    }
-
-    private var recordingView: some View {
-        ZStack {
-            ShortcutRecorderView(onRecord: onRecord, onCancel: onCancel)
-                .frame(width: 0, height: 0)
-                .opacity(0)
-
-            Text("Press shortcut…")
-                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                .foregroundStyle(SettingsStyle.warning)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
-        }
-    }
-}
-
-private struct CommandShortcutRow: View {
-    private enum Metrics {
-        static let deleteButtonSize: CGFloat = 18
-        static let shortcutControlWidth: CGFloat = 130
-    }
-
-    @Binding var shortcut: CommandShortcut
-    let prefixCombo: KeyCombo
-    let isRecording: Bool
-    let conflictMessage: String?
-    let onStartRecording: () -> Void
-    let onRecord: (KeyCombo) -> Void
-    let onCancel: () -> Void
-    let onDelete: () -> Void
-    @State private var hovered = false
-    @State private var deleteButtonHovered = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
-                TextField("Name", text: $shortcut.name)
-                    .font(.system(size: SettingsMetrics.labelFontSize))
-                    .settingsTextInput(width: 120)
-
-                TextField("Command", text: $shortcut.command)
-                    .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
-                    .settingsTextInput(maxWidth: .infinity)
-
-                if isRecording {
-                    recordingView
-                } else {
-                    comboDisplay
-                }
-            }
-
-            if let conflictMessage {
-                Text("\(conflictMessage) — press a different shortcut or Esc to cancel")
-                    .font(.system(size: 10))
-                    .foregroundStyle(SettingsStyle.warning)
-            }
-        }
-        .padding(.horizontal, SettingsMetrics.horizontalPadding)
-        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
-        .background(hovered ? SettingsStyle.hover : .clear)
-        .onHover { hovered = $0 }
-    }
-
-    private var comboDisplay: some View {
-        HStack(spacing: 6) {
-            Button(action: onStartRecording) {
-                Text("\(prefixCombo.displayString) \(shortcut.combo.displayString)")
-                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium, design: .rounded))
-                    .foregroundStyle(SettingsStyle.foreground)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
-            }
-            .buttonStyle(.plain)
-
-            Button(action: onDelete) {
-                Image(systemName: "trash")
-                    .font(.system(size: 10))
-                    .foregroundStyle(
-                        deleteButtonHovered ? AnyShapeStyle(SettingsStyle.destructive) : AnyShapeStyle(SettingsStyle.mutedForeground)
-                    )
-                    .frame(width: Metrics.deleteButtonSize, height: Metrics.deleteButtonSize)
-            }
-            .buttonStyle(.plain)
-            .background(
-                deleteButtonHovered ? AnyShapeStyle(SettingsStyle.destructiveSoft) : AnyShapeStyle(SettingsStyle.surface),
-                in: RoundedRectangle(cornerRadius: 5)
-            )
-            .onHover { isHovering in
-                deleteButtonHovered = isHovering
-            }
-            .accessibilityLabel("Delete Command Shortcut")
-        }
-        .frame(alignment: .trailing)
-    }
-
-    private var recordingView: some View {
-        ZStack {
-            ShortcutRecorderView(onRecord: onRecord, onCancel: onCancel, requiresModifier: false)
-                .frame(width: 0, height: 0)
-                .opacity(0)
-
-            Text("Press key…")
-                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                .foregroundStyle(SettingsStyle.warning)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(SettingsStyle.warning.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
-        }
-    }
-}
-
-private struct DeleteAllCommandShortcutsRow: View {
-    let secondsRemaining: Int
-    let action: () -> Void
-
-    private var isConfirming: Bool {
-        secondsRemaining > 0
-    }
-
-    var body: some View {
-        HStack {
-            Spacer()
-
-            Button(action: action) {
-                Text(title)
-                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                    .foregroundStyle(isConfirming ? SettingsStyle.destructive : SettingsStyle.mutedForeground)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(backgroundStyle, in: RoundedRectangle(cornerRadius: 5))
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(title)
-        }
-        .padding(.horizontal, SettingsMetrics.horizontalPadding)
-        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
-    }
-
-    private var title: String {
-        if isConfirming {
-            return "Confirm Delete All (\(secondsRemaining))"
-        }
-        return "Delete All"
-    }
-
-    private var backgroundStyle: AnyShapeStyle {
-        isConfirming ? AnyShapeStyle(SettingsStyle.destructiveSoft) : AnyShapeStyle(SettingsStyle.surface)
     }
 }

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -8,6 +8,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case terminal
     case richInput
     case shortcuts
+    case commands
     case voice
     case notifications
     case mobile
@@ -23,6 +24,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .terminal: "Terminal"
         case .richInput: "Rich Input"
         case .shortcuts: "Shortcuts"
+        case .commands: "Commands"
         case .voice: "Voice"
         case .notifications: "Notifications"
         case .mobile: "Mobile"
@@ -38,6 +40,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .terminal: "terminal"
         case .richInput: "text.cursor"
         case .shortcuts: "keyboard"
+        case .commands: "command"
         case .voice: "mic"
         case .notifications: "bell"
         case .mobile: "iphone"
@@ -356,11 +359,11 @@ enum SettingsCatalog {
         ),
         SettingsCatalogItem(
             key: "shortcuts.customCommands",
-            title: "Custom Commands",
+            title: "Commands",
             description: "Configures shortcuts that open command tabs.",
-            category: .shortcuts,
-            section: "Custom Commands",
-            aliases: ["command layer"]
+            category: .commands,
+            section: "Commands",
+            aliases: ["command layer", "custom commands", "shortcuts"]
         ),
         SettingsCatalogItem(
             key: RecordingPreferences.autoSendKey,

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -123,6 +123,8 @@ struct SettingsView: View {
             RichInputSettingsView()
         case .shortcuts:
             KeyboardShortcutsSettingsView()
+        case .commands:
+            CommandsSettingsView()
         case .voice:
             RecordingSettingsView()
         case .notifications:

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -33,7 +33,7 @@ Use the `muxy` command to open projects and control panes from a shell or automa
 
 ## Custom command shortcuts
 
-Define reusable shell command shortcuts in **Settings → Keyboard Shortcuts → Custom Commands**:
+Define reusable shell command shortcuts in **Settings → Commands**:
 
 - Display name, command, optional icon, optional keybinding.
 - Triggering one creates a new tab and runs the command.

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -85,6 +85,6 @@ Mouse side buttons (3 / 4) and three‑finger horizontal trackpad swipes also na
 | --- | --- |
 | Toggle Extension Debug Bar | `Cmd+\`` |
 
-## Custom command shortcuts
+## Commands
 
-Define your own command shortcuts in **Settings → Keyboard Shortcuts → Custom Commands**. Each entry has a display name, a shell command, an optional icon, and an optional keybinding. Triggering one creates a tab and runs the command.
+Define your own command shortcuts in **Settings → Commands**. Each entry has a display name, a shell command, an optional icon, and an optional keybinding. Triggering one creates a tab and runs the command.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -39,9 +39,14 @@ See [Session Restore](../features/session-restore.md).
 ## Keyboard Shortcuts
 
 - All actions remappable via a key‑capture recorder.
-- **Custom Commands** — define reusable shell command shortcuts.
 
 See [Keyboard Shortcuts](keyboard-shortcuts.md).
+
+## Commands
+
+- Define reusable shell command shortcuts that open a new terminal tab.
+
+See [Keyboard Shortcuts](keyboard-shortcuts.md#commands).
 
 ## Recording
 


### PR DESCRIPTION
Custom commands are now a top-level "Commands" settings section instead of a tab inside Shortcuts.
  Shortcuts now shows app and extension shortcuts directly, without the segmented picker.
  Existing command-shortcuts data is unaffected.