### PR TITLE
Make worktrees opt-in per project in the sidebar

### DIFF
--- a/Muxy/Extensions/DTOConversions.swift
+++ b/Muxy/Extensions/DTOConversions.swift
@@ -12,7 +12,8 @@ extension Project {
             icon: icon,
             logo: logo,
             iconColor: iconColor,
-            preferredWorktreeParentPath: preferredWorktreeParentPath
+            preferredWorktreeParentPath: preferredWorktreeParentPath,
+            worktreesEnabled: worktreesEnabled
         )
     }
 }

--- a/Muxy/Models/Project.swift
+++ b/Muxy/Models/Project.swift
@@ -10,6 +10,7 @@ struct Project: Identifiable, Codable, Hashable {
     var logo: String?
     var iconColor: String?
     var preferredWorktreeParentPath: String?
+    var worktreesEnabled: Bool
 
     init(id: UUID = UUID(), name: String, path: String, sortOrder: Int = 0) {
         self.id = id
@@ -21,6 +22,21 @@ struct Project: Identifiable, Codable, Hashable {
         self.logo = nil
         self.iconColor = nil
         self.preferredWorktreeParentPath = nil
+        self.worktreesEnabled = false
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        path = try container.decode(String.self, forKey: .path)
+        sortOrder = try container.decode(Int.self, forKey: .sortOrder)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        logo = try container.decodeIfPresent(String.self, forKey: .logo)
+        iconColor = try container.decodeIfPresent(String.self, forKey: .iconColor)
+        preferredWorktreeParentPath = try container.decodeIfPresent(String.self, forKey: .preferredWorktreeParentPath)
+        worktreesEnabled = try container.decodeIfPresent(Bool.self, forKey: .worktreesEnabled) ?? false
     }
 
     var pathExists: Bool {

--- a/Muxy/Services/ProjectStore.swift
+++ b/Muxy/Services/ProjectStore.swift
@@ -58,6 +58,12 @@ final class ProjectStore {
         save()
     }
 
+    func setWorktreesEnabled(id: UUID, to enabled: Bool) {
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
+        storedProjects[index].worktreesEnabled = enabled
+        save()
+    }
+
     func setPreferredWorktreeParentPath(id: UUID, to path: String?) {
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].preferredWorktreeParentPath = WorktreeLocationResolver.normalizedPath(path)

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -173,7 +173,8 @@ struct Sidebar: View {
                 onRename: { projectStore.rename(id: project.id, to: $0) },
                 onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
                 onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
-                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
+                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) },
+                onSetWorktreesEnabled: { projectStore.setWorktreesEnabled(id: project.id, to: $0) }
             )
         } else {
             ProjectRow(
@@ -185,7 +186,8 @@ struct Sidebar: View {
                 onRename: { projectStore.rename(id: project.id, to: $0) },
                 onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
                 onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
-                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) }
+                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) },
+                onSetWorktreesEnabled: { projectStore.setWorktreesEnabled(id: project.id, to: $0) }
             )
         }
     }

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -12,6 +12,7 @@ struct ExpandedProjectRow: View {
     let onSetLogo: (String?) -> Void
     let onSetIcon: (String?) -> Void
     let onSetIconColor: (String?) -> Void
+    let onSetWorktreesEnabled: (Bool) -> Void
 
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -51,7 +52,7 @@ struct ExpandedProjectRow: View {
     }
 
     private var hasWorktreeUI: Bool {
-        isGitRepo || worktrees.count > 1
+        project.worktreesEnabled && (isGitRepo || worktrees.count > 1)
     }
 
     private var displayLetter: String {
@@ -60,6 +61,16 @@ struct ExpandedProjectRow: View {
 
     private func hideHome() {
         HomeProjectPreferences.isVisible = false
+    }
+
+    private var worktreesEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { project.worktreesEnabled },
+            set: { enabled in
+                onSetWorktreesEnabled(enabled)
+                if !enabled { worktreesExpanded = false }
+            }
+        )
     }
 
     var body: some View {
@@ -346,8 +357,11 @@ struct ExpandedProjectRow: View {
         Button("Rename Project") { startRename() }
         if isGitRepo {
             Divider()
-            Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
-            Button("New Worktree…") { showCreateWorktreeSheet = true }
+            Toggle("Worktrees", isOn: worktreesEnabledBinding)
+            if project.worktreesEnabled {
+                Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
+                Button("New Worktree…") { showCreateWorktreeSheet = true }
+            }
         } else if isCheckingGitRepo {
             Divider()
             Button("Loading Worktrees…") {}

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -12,6 +12,7 @@ struct ProjectRow: View {
     let onSetLogo: (String?) -> Void
     let onSetIcon: (String?) -> Void
     let onSetIconColor: (String?) -> Void
+    let onSetWorktreesEnabled: (Bool) -> Void
 
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -39,7 +40,14 @@ struct ProjectRow: View {
     }
 
     private var hasWorktreeUI: Bool {
-        isGitRepo || worktrees.count > 1
+        project.worktreesEnabled && (isGitRepo || worktrees.count > 1)
+    }
+
+    private var worktreesEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { project.worktreesEnabled },
+            set: { onSetWorktreesEnabled($0) }
+        )
     }
 
     private var displayLetter: String {
@@ -165,20 +173,18 @@ struct ProjectRow: View {
         Button("Rename Project") { startRename() }
         if isGitRepo {
             Divider()
-            Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
-            Button("New Worktree…") { showCreateWorktreeSheet = true }
-            if worktrees.count > 1 {
-                Button("Switch Worktree…") { showWorktreePopover = true }
+            Toggle("Worktrees", isOn: worktreesEnabledBinding)
+            if project.worktreesEnabled {
+                Button("Refresh Worktrees") { Task { await refreshWorktrees() } }
+                Button("New Worktree…") { showCreateWorktreeSheet = true }
+                if worktrees.count > 1 {
+                    Button("Switch Worktree…") { showWorktreePopover = true }
+                }
             }
         } else if isCheckingGitRepo {
             Divider()
             Button("Loading Worktrees…") {}
                 .disabled(true)
-        } else if hasWorktreeUI {
-            Divider()
-            if worktrees.count > 1 {
-                Button("Switch Worktree…") { showWorktreePopover = true }
-            }
         }
         if !projectGroupStore.groups.isEmpty {
             Divider()

--- a/MuxyShared/ProjectDTO.swift
+++ b/MuxyShared/ProjectDTO.swift
@@ -10,6 +10,7 @@ public struct ProjectDTO: Identifiable, Codable, Hashable, Sendable {
     public var logo: String?
     public var iconColor: String?
     public var preferredWorktreeParentPath: String?
+    public var worktreesEnabled: Bool
 
     public init(
         id: UUID,
@@ -20,7 +21,8 @@ public struct ProjectDTO: Identifiable, Codable, Hashable, Sendable {
         icon: String? = nil,
         logo: String? = nil,
         iconColor: String? = nil,
-        preferredWorktreeParentPath: String? = nil
+        preferredWorktreeParentPath: String? = nil,
+        worktreesEnabled: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -31,5 +33,6 @@ public struct ProjectDTO: Identifiable, Codable, Hashable, Sendable {
         self.logo = logo
         self.iconColor = iconColor
         self.preferredWorktreeParentPath = preferredWorktreeParentPath
+        self.worktreesEnabled = worktreesEnabled
     }
 }

--- a/Tests/MuxyTests/Models/ProjectTests.swift
+++ b/Tests/MuxyTests/Models/ProjectTests.swift
@@ -24,6 +24,28 @@ struct ProjectTests {
         let project = try decoder.decode(Project.self, from: Data(json.utf8))
 
         #expect(project.preferredWorktreeParentPath == nil)
+        #expect(!project.worktreesEnabled)
+    }
+
+    @Test("new projects default to worktrees disabled")
+    func newProjectDisablesWorktrees() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+
+        #expect(!project.worktreesEnabled)
+    }
+
+    @Test("worktreesEnabled survives an encode/decode round-trip")
+    func worktreesEnabledRoundTrips() throws {
+        var project = Project(name: "Repo", path: "/tmp/repo")
+        project.worktreesEnabled = true
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Project.self, from: encoder.encode(project))
+
+        #expect(decoded.worktreesEnabled)
     }
 
     @Test("home uses the reserved id, home name and expanded home path")

--- a/Tests/MuxyTests/Services/ProjectStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectStoreTests.swift
@@ -33,6 +33,18 @@ struct ProjectStoreTests {
         #expect(persistence.projects.first?.preferredWorktreeParentPath == nil)
     }
 
+    @Test("setWorktreesEnabled persists the new value")
+    func setWorktreesEnabled() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let store = ProjectStore(persistence: persistence)
+
+        store.setWorktreesEnabled(id: project.id, to: true)
+
+        #expect(store.storedProjects.first { $0.id == project.id }?.worktreesEnabled == true)
+        #expect(persistence.projects.first?.worktreesEnabled == true)
+    }
+
     @Test("projects always exposes Home at the front without persisting it")
     func projectsSynthesizesHome() {
         let existing = Project(name: "Repo", path: "/tmp/repo")

--- a/docs/remote-server/data-objects.md
+++ b/docs/remote-server/data-objects.md
@@ -14,11 +14,12 @@ Every object below is the exact wire shape produced by the desktop. All dates ar
   "icon": "hammer",
   "logo": "a1b2c3d4",
   "iconColor": "#7C3AED",
-  "preferredWorktreeParentPath": "/Users/example"
+  "preferredWorktreeParentPath": "/Users/example",
+  "worktreesEnabled": false
 }
 ```
 
-`icon`, `logo`, `iconColor`, and `preferredWorktreeParentPath` are optional and omitted when unset. `icon` is an SF Symbol name. `logo` is an opaque storage identifier — fetch the image with [`getProjectLogo`](methods.md). `iconColor` is a hex string or a palette id (`red`, `blue`, `violet`, …).
+`icon`, `logo`, `iconColor`, and `preferredWorktreeParentPath` are optional and omitted when unset. `icon` is an SF Symbol name. `logo` is an opaque storage identifier — fetch the image with [`getProjectLogo`](methods.md). `iconColor` is a hex string or a palette id (`red`, `blue`, `violet`, …). `worktreesEnabled` indicates whether the project exposes its worktrees in the sidebar; it defaults to `false`.
 
 ## Worktree
 


### PR DESCRIPTION
Adds a per-project "Worktrees" toggle in the sidebar context menu. When off, the project has no worktree
  opener/disclosure; new projects default to off.