### PR TITLE
Add "What's New" release notes modal

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -376,6 +376,10 @@ struct MuxyCommands: Commands {
 
             Divider()
 
+            Button("What's New?") {
+                NotificationCenter.default.post(name: .openWhatsNewModal, object: nil)
+            }
+
             Button("Report an Issue...") {
                 HelpLinks.openIssues()
             }

--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -10,6 +10,7 @@ extension Notification.Name {
     static let openProjectPicker = Notification.Name("MuxyOpenProjectPicker")
     static let openSettingsModal = Notification.Name("MuxyOpenSettingsModal")
     static let openExtensionsModal = Notification.Name("MuxyOpenExtensionsModal")
+    static let openWhatsNewModal = Notification.Name("MuxyOpenWhatsNewModal")
     static let openExtensionInstall = Notification.Name("MuxyOpenExtensionInstall")
     static let openExtensionDirectoryAsProject = Notification.Name("MuxyOpenExtensionDirectoryAsProject")
     static let focusProjectPickerDefaultLocation = Notification.Name("MuxyFocusProjectPickerDefaultLocation")

--- a/Muxy/Models/WhatsNewPreferences.swift
+++ b/Muxy/Models/WhatsNewPreferences.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum WhatsNewPreferences {
+    static let viewedVersionKey = "muxy.whatsNew.viewedVersion"
+
+    static var currentVersion: String? {
+        #if DEBUG
+        if let override = ProcessInfo.processInfo.environment["MUXY_WHATS_NEW_VERSION"],
+           !override.isEmpty
+        {
+            return override
+        }
+        #endif
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
+    static var viewedVersion: String? {
+        get { UserDefaults.standard.string(forKey: viewedVersionKey) }
+        set { UserDefaults.standard.set(newValue, forKey: viewedVersionKey) }
+    }
+
+    static var shouldAutoShow: Bool {
+        guard let currentVersion else { return false }
+        return currentVersion != viewedVersion
+    }
+
+    static func markCurrentVersionViewed() {
+        guard let currentVersion else { return }
+        viewedVersion = currentVersion
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -514,6 +514,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     @MainActor
     private func presentWhatsNewModal(preloadedMarkdown: String? = nil) {
         guard let version = WhatsNewPreferences.currentVersion else { return }
+        if preloadedMarkdown != nil {
+            whatsNewWindow?.close()
+            whatsNewWindow = nil
+        }
         let config = AppModalConfig(
             title: "What's New",
             size: CGSize(width: 806, height: 560),

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -152,6 +152,7 @@ struct MuxyApp: App {
             await NotificationSocketServer.shared.awaitReady()
             ExtensionStore.shared.startAll()
             await ExtensionStore.shared.checkForUpdates()
+            appDelegate.presentWhatsNewIfNeeded()
         }
     }
 }
@@ -167,9 +168,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var systemAppearanceObserver: NSObjectProtocol?
     private var settingsObserver: NSObjectProtocol?
     private var extensionsObserver: NSObjectProtocol?
+    private var whatsNewObserver: NSObjectProtocol?
     private var modalThemeObserver: NSObjectProtocol?
     private weak var settingsWindow: NSWindow?
     private weak var extensionsWindow: NSWindow?
+    private weak var whatsNewWindow: NSWindow?
 
     @MainActor
     func handleOpenProjectPath(_ path: String) {
@@ -413,6 +416,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             NotificationCenter.default.removeObserver(extensionsObserver)
             self.extensionsObserver = nil
         }
+        if let whatsNewObserver {
+            NotificationCenter.default.removeObserver(whatsNewObserver)
+            self.whatsNewObserver = nil
+        }
         if let modalThemeObserver {
             NotificationCenter.default.removeObserver(modalThemeObserver)
             self.modalThemeObserver = nil
@@ -447,6 +454,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 self?.presentExtensionsModal()
             }
         }
+        whatsNewObserver = NotificationCenter.default.addObserver(
+            forName: .openWhatsNewModal,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.presentWhatsNewModal()
+            }
+        }
         modalThemeObserver = NotificationCenter.default.addObserver(
             forName: .themeDidChange,
             object: nil,
@@ -455,6 +471,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             MainActor.assumeIsolated {
                 self?.settingsWindow?.backgroundColor = MuxyTheme.nsBg
                 self?.extensionsWindow?.backgroundColor = MuxyTheme.nsBg
+                self?.whatsNewWindow?.backgroundColor = MuxyTheme.nsBg
             }
         }
     }
@@ -494,10 +511,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    @MainActor
+    private func presentWhatsNewModal(preloadedMarkdown: String? = nil) {
+        guard let version = WhatsNewPreferences.currentVersion else { return }
+        let config = AppModalConfig(
+            title: "What's New",
+            size: CGSize(width: 806, height: 560),
+            existing: whatsNewWindow,
+            delegate: self,
+            onClosed: { [weak self] in self?.whatsNewWindow = nil }
+        )
+        whatsNewWindow = AppModalPresenter.present(config) {
+            WhatsNewView(version: version, preloadedMarkdown: preloadedMarkdown)
+        }
+    }
+
+    @MainActor
+    func presentWhatsNewIfNeeded() {
+        guard WhatsNewPreferences.shouldAutoShow,
+              let version = WhatsNewPreferences.currentVersion
+        else { return }
+        Task { @MainActor in
+            guard let markdown = try? await WhatsNewService.fetchReleaseNotes(version: version)
+            else { return }
+            presentWhatsNewModal(preloadedMarkdown: markdown)
+            WhatsNewPreferences.markCurrentVersionViewed()
+        }
+    }
+
     func windowWillClose(_ notification: Notification) {
         let closed = notification.object as? NSWindow
         if closed === settingsWindow { settingsWindow = nil }
         if closed === extensionsWindow { extensionsWindow = nil }
+        if closed === whatsNewWindow { whatsNewWindow = nil }
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {

--- a/Muxy/Services/ReleaseNotesMarkdown.swift
+++ b/Muxy/Services/ReleaseNotesMarkdown.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct ReleaseNotesSpan: Equatable {
+    let text: String
+    let isBold: Bool
+}
+
+enum ReleaseNotesBlock: Equatable {
+    case heading(level: Int, spans: [ReleaseNotesSpan])
+    case bullet(spans: [ReleaseNotesSpan])
+    case paragraph(spans: [ReleaseNotesSpan])
+}
+
+enum ReleaseNotesMarkdown {
+    static func parse(_ markdown: String) -> [ReleaseNotesBlock] {
+        var blocks: [ReleaseNotesBlock] = []
+
+        for rawLine in markdown.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+
+            if let heading = parseHeading(line) {
+                blocks.append(heading)
+                continue
+            }
+            if let bullet = parseBullet(line) {
+                blocks.append(bullet)
+                continue
+            }
+            blocks.append(.paragraph(spans: parseInline(line)))
+        }
+
+        return blocks
+    }
+
+    private static func parseHeading(_ line: String) -> ReleaseNotesBlock? {
+        var level = 0
+        var remainder = Substring(line)
+        while remainder.first == "#" {
+            level += 1
+            remainder = remainder.dropFirst()
+        }
+        guard level > 0, remainder.first == " " else { return nil }
+        let content = remainder.trimmingCharacters(in: .whitespaces)
+        guard !content.isEmpty else { return nil }
+        return .heading(level: min(level, 6), spans: parseInline(content))
+    }
+
+    private static func parseBullet(_ line: String) -> ReleaseNotesBlock? {
+        for marker in ["- ", "* ", "+ "] where line.hasPrefix(marker) {
+            let content = String(line.dropFirst(marker.count)).trimmingCharacters(in: .whitespaces)
+            guard !content.isEmpty else { return nil }
+            return .bullet(spans: parseInline(content))
+        }
+        return nil
+    }
+
+    private static func parseInline(_ text: String) -> [ReleaseNotesSpan] {
+        let stripped = stripLinks(text)
+        var spans: [ReleaseNotesSpan] = []
+        var buffer = ""
+        var isBold = false
+        var index = stripped.startIndex
+
+        while index < stripped.endIndex {
+            if stripped[index...].hasPrefix("**") {
+                if !buffer.isEmpty {
+                    spans.append(ReleaseNotesSpan(text: buffer, isBold: isBold))
+                    buffer = ""
+                }
+                isBold.toggle()
+                index = stripped.index(index, offsetBy: 2)
+                continue
+            }
+            buffer.append(stripped[index])
+            index = stripped.index(after: index)
+        }
+
+        if !buffer.isEmpty {
+            spans.append(ReleaseNotesSpan(text: buffer, isBold: isBold))
+        }
+        return spans
+    }
+
+    private static func stripLinks(_ text: String) -> String {
+        let pattern = #"\[([^\]]*)\]\([^)]*\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: "$1")
+    }
+}

--- a/Muxy/Services/WhatsNewService.swift
+++ b/Muxy/Services/WhatsNewService.swift
@@ -1,0 +1,41 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "WhatsNewService")
+
+enum WhatsNewError: Error {
+    case missingVersion
+    case releaseNotFound
+    case emptyNotes
+}
+
+enum WhatsNewService {
+    static func fetchReleaseNotes(
+        version: String,
+        session: URLSession = .shared
+    ) async throws -> String {
+        let url = releaseURL(for: version)
+        var request = URLRequest(url: url, timeoutInterval: 15)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            logger.error("Release notes fetch failed for \(version, privacy: .public)")
+            throw WhatsNewError.releaseNotFound
+        }
+
+        let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
+        let body = release.body?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !body.isEmpty else { throw WhatsNewError.emptyNotes }
+        return body
+    }
+
+    private static func releaseURL(for version: String) -> URL {
+        let base = "https://api.github.com/repos/muxy-app/muxy/releases/tags/v"
+        return URL(string: base + version) ?? URL(fileURLWithPath: "/")
+    }
+}
+
+private struct GitHubRelease: Decodable {
+    let body: String?
+}

--- a/Muxy/Views/WhatsNew/WhatsNewView.swift
+++ b/Muxy/Views/WhatsNew/WhatsNewView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct WhatsNewView: View {
+    let version: String
+    let preloadedMarkdown: String?
+
+    @State private var blocks: [ReleaseNotesBlock] = []
+    @State private var phase: Phase = .loading
+
+    private enum Phase: Equatable {
+        case loading
+        case loaded
+        case failed
+    }
+
+    private var releaseURL: URL {
+        let string = "https://github.com/muxy-app/muxy/releases/tag/v\(version)"
+        return URL(string: string) ?? HelpLinks.repoURL
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Rectangle()
+                .fill(SettingsStyle.border)
+                .frame(height: 1)
+            content
+        }
+        .background(SettingsStyle.background)
+        .task { await load() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(SettingsStyle.accent)
+
+            Text("What's New")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(SettingsStyle.foreground)
+
+            Text("v\(version)")
+                .font(.system(size: 12))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+
+            Spacer()
+
+            Button {
+                NSWorkspace.shared.open(releaseURL)
+            } label: {
+                Text("View on GitHub")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(SettingsStyle.accent)
+            }
+            .buttonStyle(.plain)
+            .help("Open this release on GitHub")
+
+            Button {
+                NSApp.keyWindow?.close()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                    .frame(width: 28, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Close")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(height: 56)
+        .background(SettingsStyle.background)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch phase {
+        case .loading:
+            centered { ProgressView().controlSize(.small) }
+        case .failed:
+            centered {
+                VStack(spacing: 12) {
+                    Text("Couldn't load the release notes.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                    Button("Retry") { Task { await reload() } }
+                }
+            }
+        case .loaded:
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                        ReleaseNotesBlockView(block: block)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(20)
+                .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func centered(@ViewBuilder _ inner: () -> some View) -> some View {
+        VStack { inner() }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func load() async {
+        if let preloadedMarkdown {
+            blocks = ReleaseNotesMarkdown.parse(preloadedMarkdown)
+            phase = .loaded
+            return
+        }
+        await reload()
+    }
+
+    private func reload() async {
+        phase = .loading
+        do {
+            let markdown = try await WhatsNewService.fetchReleaseNotes(version: version)
+            blocks = ReleaseNotesMarkdown.parse(markdown)
+            phase = .loaded
+        } catch {
+            phase = .failed
+        }
+    }
+}
+
+private struct ReleaseNotesBlockView: View {
+    let block: ReleaseNotesBlock
+
+    var body: some View {
+        switch block {
+        case let .heading(level, spans):
+            styledText(spans)
+                .font(.system(size: headingSize(for: level), weight: .semibold))
+                .foregroundStyle(SettingsStyle.foreground)
+                .padding(.top, level <= 2 ? 6 : 2)
+        case let .bullet(spans):
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("•")
+                    .font(.system(size: 12))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+                styledText(spans)
+                    .font(.system(size: 12))
+                    .foregroundStyle(SettingsStyle.foreground)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        case let .paragraph(spans):
+            styledText(spans)
+                .font(.system(size: 12))
+                .foregroundStyle(SettingsStyle.foreground)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func styledText(_ spans: [ReleaseNotesSpan]) -> Text {
+        spans.reduce(Text("")) { partial, span in
+            partial + Text(span.text).fontWeight(span.isBold ? .semibold : .regular)
+        }
+    }
+
+    private func headingSize(for level: Int) -> CGFloat {
+        switch level {
+        case 1: 16
+        case 2: 14
+        default: 13
+        }
+    }
+}

--- a/Tests/MuxyTests/Services/ReleaseNotesMarkdownTests.swift
+++ b/Tests/MuxyTests/Services/ReleaseNotesMarkdownTests.swift
@@ -1,0 +1,78 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("ReleaseNotesMarkdown")
+struct ReleaseNotesMarkdownTests {
+    @Test("parses headings with their level")
+    func headings() {
+        let blocks = ReleaseNotesMarkdown.parse("# Title\n## Section\n### Sub")
+        #expect(blocks == [
+            .heading(level: 1, spans: [ReleaseNotesSpan(text: "Title", isBold: false)]),
+            .heading(level: 2, spans: [ReleaseNotesSpan(text: "Section", isBold: false)]),
+            .heading(level: 3, spans: [ReleaseNotesSpan(text: "Sub", isBold: false)]),
+        ])
+    }
+
+    @Test("parses bullet points across markers")
+    func bullets() {
+        let blocks = ReleaseNotesMarkdown.parse("- one\n* two\n+ three")
+        #expect(blocks == [
+            .bullet(spans: [ReleaseNotesSpan(text: "one", isBold: false)]),
+            .bullet(spans: [ReleaseNotesSpan(text: "two", isBold: false)]),
+            .bullet(spans: [ReleaseNotesSpan(text: "three", isBold: false)]),
+        ])
+    }
+
+    @Test("parses bold spans inline")
+    func bold() {
+        let blocks = ReleaseNotesMarkdown.parse("Added **fast** mode")
+        #expect(blocks == [
+            .paragraph(spans: [
+                ReleaseNotesSpan(text: "Added ", isBold: false),
+                ReleaseNotesSpan(text: "fast", isBold: true),
+                ReleaseNotesSpan(text: " mode", isBold: false),
+            ]),
+        ])
+    }
+
+    @Test("strips links to plain text")
+    func links() {
+        let blocks = ReleaseNotesMarkdown.parse("- See [the docs](https://muxy.app/docs) now")
+        #expect(blocks == [
+            .bullet(spans: [ReleaseNotesSpan(text: "See the docs now", isBold: false)]),
+        ])
+    }
+
+    @Test("ignores blank lines")
+    func blankLines() {
+        let blocks = ReleaseNotesMarkdown.parse("# Title\n\n\n- item")
+        #expect(blocks == [
+            .heading(level: 1, spans: [ReleaseNotesSpan(text: "Title", isBold: false)]),
+            .bullet(spans: [ReleaseNotesSpan(text: "item", isBold: false)]),
+        ])
+    }
+
+    @Test("treats a hash without a space as a paragraph")
+    func hashWithoutSpace() {
+        let blocks = ReleaseNotesMarkdown.parse("#notaheading")
+        #expect(blocks == [
+            .paragraph(spans: [ReleaseNotesSpan(text: "#notaheading", isBold: false)]),
+        ])
+    }
+
+    @Test("handles carriage-return line endings")
+    func crlfLineEndings() {
+        let blocks = ReleaseNotesMarkdown.parse("# Title\r\n- item\r\n")
+        #expect(blocks == [
+            .heading(level: 1, spans: [ReleaseNotesSpan(text: "Title", isBold: false)]),
+            .bullet(spans: [ReleaseNotesSpan(text: "item", isBold: false)]),
+        ])
+    }
+
+    @Test("empty input yields no blocks")
+    func empty() {
+        #expect(ReleaseNotesMarkdown.parse("").isEmpty)
+        #expect(ReleaseNotesMarkdown.parse("\n\n").isEmpty)
+    }
+}


### PR DESCRIPTION
Adds a Help → "What's New?" menu item opening a modal that renders the current version's GitHub release notes via
  a minimal in-house markdown parser (headings, bullets, bold). Auto-shows once per new version on first launch,
  then caches it as viewed.