### PR TITLE
Add extension-provided sidebars with a dedicated Sidebar settings menu

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -229,6 +229,45 @@ struct ExtensionPopover: Codable, Equatable, Identifiable {
     }
 }
 
+struct ExtensionSidebar: Codable, Equatable, Identifiable {
+    let id: String
+    let title: String?
+    let icon: ExtensionIcon?
+    let entry: String
+    let defaultData: ExtensionJSON?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case icon
+        case entry
+        case defaultData
+    }
+
+    init(
+        id: String,
+        title: String? = nil,
+        icon: ExtensionIcon? = nil,
+        entry: String,
+        defaultData: ExtensionJSON? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.icon = icon
+        self.entry = entry
+        self.defaultData = defaultData
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        icon = try container.decodeIfPresent(ExtensionIcon.self, forKey: .icon)
+        entry = try container.decode(String.self, forKey: .entry)
+        defaultData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .defaultData)
+    }
+}
+
 enum ExtensionIcon: Codable, Equatable {
     case symbol(String)
     case svg(String)
@@ -523,6 +562,7 @@ struct ExtensionManifest: Codable, Equatable {
     let tabTypes: [ExtensionTabType]
     let panels: [ExtensionPanel]
     let popovers: [ExtensionPopover]
+    let sidebar: ExtensionSidebar?
     let permissions: [ExtensionPermission]
     let topbarItems: [ExtensionTopbarItem]
     let statusBarItems: [ExtensionStatusBarItem]
@@ -539,6 +579,7 @@ struct ExtensionManifest: Codable, Equatable {
         case tabTypes
         case panels
         case popovers
+        case sidebar
         case permissions
         case topbarItems
         case statusBarItems
@@ -556,6 +597,7 @@ struct ExtensionManifest: Codable, Equatable {
         tabTypes: [ExtensionTabType] = [],
         panels: [ExtensionPanel] = [],
         popovers: [ExtensionPopover] = [],
+        sidebar: ExtensionSidebar? = nil,
         permissions: [ExtensionPermission] = [],
         topbarItems: [ExtensionTopbarItem] = [],
         statusBarItems: [ExtensionStatusBarItem] = [],
@@ -571,6 +613,7 @@ struct ExtensionManifest: Codable, Equatable {
         self.tabTypes = tabTypes
         self.panels = panels
         self.popovers = popovers
+        self.sidebar = sidebar
         self.permissions = permissions
         self.topbarItems = topbarItems
         self.statusBarItems = statusBarItems
@@ -589,6 +632,7 @@ struct ExtensionManifest: Codable, Equatable {
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
         panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
         popovers = try container.decodeIfPresent([ExtensionPopover].self, forKey: .popovers) ?? []
+        sidebar = try container.decodeIfPresent(ExtensionSidebar.self, forKey: .sidebar)
         permissions = try container.decodeIfPresent([ExtensionPermission].self, forKey: .permissions) ?? []
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
@@ -607,6 +651,7 @@ struct ExtensionManifest: Codable, Equatable {
         tabTypes = muxy.tabTypes
         panels = muxy.panels
         popovers = muxy.popovers
+        sidebar = muxy.sidebar
         permissions = muxy.permissions
         topbarItems = muxy.topbarItems
         statusBarItems = muxy.statusBarItems
@@ -663,6 +708,7 @@ struct MuxyManifestBody: Codable, Equatable {
     let tabTypes: [ExtensionTabType]
     let panels: [ExtensionPanel]
     let popovers: [ExtensionPopover]
+    let sidebar: ExtensionSidebar?
     let permissions: [ExtensionPermission]
     let topbarItems: [ExtensionTopbarItem]
     let statusBarItems: [ExtensionStatusBarItem]
@@ -677,6 +723,7 @@ struct MuxyManifestBody: Codable, Equatable {
         case tabTypes
         case panels
         case popovers
+        case sidebar
         case permissions
         case topbarItems
         case statusBarItems
@@ -693,6 +740,7 @@ struct MuxyManifestBody: Codable, Equatable {
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
         panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
         popovers = try container.decodeIfPresent([ExtensionPopover].self, forKey: .popovers) ?? []
+        sidebar = try container.decodeIfPresent(ExtensionSidebar.self, forKey: .sidebar)
         permissions = try container.decodeIfPresent([ExtensionPermission].self, forKey: .permissions) ?? []
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
@@ -725,6 +773,10 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case popoverEntryMissing(popoverID: String, url: URL)
     case popoverEntryOutsideDirectory(popoverID: String, url: URL)
     case duplicatePopover(String)
+    case sidebarEntryMissing(sidebarID: String, url: URL)
+    case sidebarEntryOutsideDirectory(sidebarID: String, url: URL)
+    case sidebarSVGMissing(sidebarID: String, url: URL)
+    case sidebarSVGOutsideDirectory(sidebarID: String, url: URL)
     case commandReferencesUnknownTabType(commandID: String, tabType: String)
     case commandReferencesUnknownPanel(commandID: String, panel: String)
     case commandReferencesUnknownPopover(commandID: String, popover: String)
@@ -794,6 +846,14 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Popover '\(popoverID)' entry at \(url.path) escapes the extension directory"
         case let .duplicatePopover(id):
             "Duplicate popover '\(id)'"
+        case let .sidebarEntryMissing(sidebarID, url):
+            "Sidebar '\(sidebarID)' entry not found at \(url.path)"
+        case let .sidebarEntryOutsideDirectory(sidebarID, url):
+            "Sidebar '\(sidebarID)' entry at \(url.path) escapes the extension directory"
+        case let .sidebarSVGMissing(sidebarID, url):
+            "Sidebar '\(sidebarID)' icon SVG not found at \(url.path)"
+        case let .sidebarSVGOutsideDirectory(sidebarID, url):
+            "Sidebar '\(sidebarID)' icon SVG at \(url.path) escapes the extension directory"
         case let .commandReferencesUnknownTabType(commandID, tabType):
             "Command '\(commandID)' references unknown tab type '\(tabType)'"
         case let .commandReferencesUnknownPanel(commandID, panel):
@@ -913,6 +973,7 @@ enum ExtensionManifestLoader {
         try validateTabTypes(manifest: manifest, in: muxyExtension)
         try validatePanels(manifest: manifest, in: muxyExtension)
         try validatePopovers(manifest: manifest, in: muxyExtension)
+        try validateSidebar(manifest: manifest, in: muxyExtension)
         try validateCommands(manifest: manifest, in: muxyExtension)
         try validateTopbarItems(manifest: manifest, in: muxyExtension)
         try validateStatusBarItems(manifest: manifest, in: muxyExtension)
@@ -1023,6 +1084,27 @@ enum ExtensionManifestLoader {
                     outside: { ExtensionLoadError.panelHeaderButtonSVGOutsideDirectory(panelID: panel.id, buttonID: button.id, url: $0) }
                 )
             }
+        }
+    }
+
+    private static func validateSidebar(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
+        guard let sidebar = manifest.sidebar else { return }
+        guard let url = muxyExtension.resolveResource(sidebar.entry) else {
+            throw ExtensionLoadError.sidebarEntryOutsideDirectory(
+                sidebarID: sidebar.id,
+                url: muxyExtension.directory.appendingPathComponent(sidebar.entry)
+            )
+        }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ExtensionLoadError.sidebarEntryMissing(sidebarID: sidebar.id, url: url)
+        }
+        if let icon = sidebar.icon {
+            try validateIcon(
+                icon,
+                in: muxyExtension,
+                missing: { ExtensionLoadError.sidebarSVGMissing(sidebarID: sidebar.id, url: $0) },
+                outside: { ExtensionLoadError.sidebarSVGOutsideDirectory(sidebarID: sidebar.id, url: $0) }
+            )
         }
     }
 

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -773,6 +773,8 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case popoverEntryMissing(popoverID: String, url: URL)
     case popoverEntryOutsideDirectory(popoverID: String, url: URL)
     case duplicatePopover(String)
+    case sidebarEmptyID
+    case sidebarEntryEmpty(sidebarID: String)
     case sidebarEntryMissing(sidebarID: String, url: URL)
     case sidebarEntryOutsideDirectory(sidebarID: String, url: URL)
     case sidebarSVGMissing(sidebarID: String, url: URL)
@@ -846,6 +848,10 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Popover '\(popoverID)' entry at \(url.path) escapes the extension directory"
         case let .duplicatePopover(id):
             "Duplicate popover '\(id)'"
+        case .sidebarEmptyID:
+            "Sidebar id must not be empty"
+        case let .sidebarEntryEmpty(sidebarID):
+            "Sidebar '\(sidebarID)' entry must not be empty"
         case let .sidebarEntryMissing(sidebarID, url):
             "Sidebar '\(sidebarID)' entry not found at \(url.path)"
         case let .sidebarEntryOutsideDirectory(sidebarID, url):
@@ -1089,6 +1095,10 @@ enum ExtensionManifestLoader {
 
     private static func validateSidebar(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
         guard let sidebar = manifest.sidebar else { return }
+        guard !sidebar.id.isEmpty else { throw ExtensionLoadError.sidebarEmptyID }
+        guard !sidebar.entry.isEmpty else {
+            throw ExtensionLoadError.sidebarEntryEmpty(sidebarID: sidebar.id)
+        }
         guard let url = muxyExtension.resolveResource(sidebar.entry) else {
             throw ExtensionLoadError.sidebarEntryOutsideDirectory(
                 sidebarID: sidebar.id,

--- a/Muxy/Models/ExtensionLifecycle.swift
+++ b/Muxy/Models/ExtensionLifecycle.swift
@@ -4,6 +4,7 @@ enum LifecycleSurfaceKind: String {
     case tab
     case panel
     case popover
+    case sidebar
 }
 
 struct LifecycleSurfaceKey: Hashable {

--- a/Muxy/Models/SidebarSelection.swift
+++ b/Muxy/Models/SidebarSelection.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum SidebarSelection {
+    static let storageKey = "muxy.activeSidebar"
+    static let builtinValue = ""
+
+    @MainActor
+    static func resolvedExtensionID(
+        from storedValue: String,
+        store: ExtensionStore = .shared
+    ) -> String? {
+        guard !storedValue.isEmpty else { return nil }
+        guard let status = store.statuses.first(where: { $0.id == storedValue }),
+              status.isEnabled,
+              status.muxyExtension.manifest.sidebar != nil
+        else { return nil }
+        return storedValue
+    }
+
+    @MainActor
+    static func availableProviders(store: ExtensionStore = .shared) -> [ExtensionStore.ExtensionStatus] {
+        store.statuses.filter { $0.isEnabled && $0.muxyExtension.manifest.sidebar != nil }
+    }
+}

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -18,6 +18,7 @@ The goal of everything below: an extension should be indistinguishable from a na
 ## Pick the right surface
 
 - **Showing something to the user** → a **UI page** (tab, panel, or popover). Page scripts get the full `window.muxy` API.
+- **A persistent, full-height navigation or control surface that replaces the built-in left sidebar** → a **`sidebar`** (one per extension; the user selects it in Settings → Sidebar). It fills the entire region — the project list *and* the footer — so own your own navigation. Same `window.muxy` API and theme variables as a panel.
 - **Reacting durably to events, coordinating multiple webviews, or running shell commands headlessly** → a **`background.js`** script. It can also call `muxy.tabs.open` to show a result in the active workspace. Most extensions don't need one.
 - **One-shot logic from the palette** → a **`runScript`** command, not a hidden tab. Its `muxy.*` calls are **synchronous** (return values directly — no `await`). It has `tabs`/`panes`/`projects`/`worktrees`/`files`/`git`/`exec`/`dialog`/`modal`/`topbar`/`statusbar`/`notifications`, but **not** `http`, `events`, `remote`, `panels`, or `popover`. It can open a modal and act on the choice inline — no page or background listener needed.
 

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -48,6 +48,7 @@ final class ExtensionStore {
     private(set) var statuses: [ExtensionStatus] = []
     private(set) var loadFailures: [LoadFailure] = []
     private(set) var availableUpdates: [String: String] = [:]
+    private(set) var hasLoadedFromDisk = false
 
     private var processes: [String: Process] = [:]
     private var hostPGIDs: [String: pid_t] = [:]
@@ -724,6 +725,7 @@ final class ExtensionStore {
             )
         }
         pruneResolvedUpdates()
+        hasLoadedFromDisk = true
     }
 
     private func loadOne(

--- a/Muxy/Views/Extensions/ExtensionBridgeHandler.swift
+++ b/Muxy/Views/Extensions/ExtensionBridgeHandler.swift
@@ -133,6 +133,8 @@ final class ExtensionBridgeHandler: NSObject, WKScriptMessageHandlerWithReply, B
             ExtensionPanelRegistry.shared.forceClose(instanceID: surfaceKey.instanceID)
         case .popover:
             PopoverHost.shared.forceClose(instanceID: surfaceKey.instanceID)
+        case .sidebar:
+            break
         }
     }
 

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -2,17 +2,12 @@ import SwiftUI
 
 struct InterfaceSettingsView: View {
     @State private var uiScale = UIScale.shared
-    @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
-    private var autoExpandWorktrees = false
-    @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyle = SidebarCollapsedStyle.defaultValue.rawValue
-    @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyle = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
     @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
-    @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
 
     var body: some View {
         SettingsContainer {
-            SettingsSection("Interface") {
+            SettingsSection("Interface", showsDivider: false) {
                 SettingsRow("Size") {
                     Picker("", selection: $uiScale.preset) {
                         ForEach(UIScale.Preset.allCases) { preset in
@@ -27,45 +22,6 @@ struct InterfaceSettingsView: View {
                 SettingsToggleRow(label: "Show Status Bar", isOn: $showStatusBar)
 
                 SettingsToggleRow(label: "Show Resource Usage in Status Bar", isOn: $showResourceUsage)
-            }
-
-            SettingsSection("Sidebar", showsDivider: false) {
-                SettingsToggleRow(label: "Show Home", isOn: $showHomeProject)
-
-                SettingsToggleRow(
-                    label: "Auto-expand worktrees on project switch",
-                    isOn: $autoExpandWorktrees
-                )
-
-                SettingsRow("Collapsed Style") {
-                    HStack {
-                        Spacer()
-                        Picker("", selection: $sidebarCollapsedStyle) {
-                            ForEach(SidebarCollapsedStyle.allCases) { style in
-                                Text(style.title).tag(style.rawValue)
-                            }
-                        }
-                        .labelsHidden()
-                        .pickerStyle(.segmented)
-                        .fixedSize()
-                    }
-                    .frame(width: SettingsMetrics.controlWidth)
-                }
-
-                SettingsRow("Expanded Style") {
-                    HStack {
-                        Spacer()
-                        Picker("", selection: $sidebarExpandedStyle) {
-                            ForEach(SidebarExpandedStyle.allCases) { style in
-                                Text(style.title).tag(style.rawValue)
-                            }
-                        }
-                        .labelsHidden()
-                        .pickerStyle(.segmented)
-                        .fixedSize()
-                    }
-                    .frame(width: SettingsMetrics.controlWidth)
-                }
             }
         }
     }

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -5,6 +5,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case general
     case projects
     case appearance
+    case sidebar
     case terminal
     case richInput
     case shortcuts
@@ -21,6 +22,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .general: "App"
         case .projects: "Projects"
         case .appearance: "Interface"
+        case .sidebar: "Sidebar"
         case .terminal: "Terminal"
         case .richInput: "Rich Input"
         case .shortcuts: "Shortcuts"
@@ -37,6 +39,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .general: "gearshape"
         case .projects: "folder"
         case .appearance: "macwindow"
+        case .sidebar: "sidebar.left"
         case .terminal: "terminal"
         case .richInput: "text.cursor"
         case .shortcuts: "keyboard"
@@ -148,9 +151,26 @@ enum SettingsCatalog {
             key: GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch,
             title: "Auto-expand Worktrees",
             description: "Automatically reveals worktrees when switching projects.",
-            category: .appearance,
+            category: .sidebar,
             section: "Sidebar",
             defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: HomeProjectPreferences.visibleKey,
+            title: "Show Home",
+            description: "Shows the permanent Home project at the top of the sidebar.",
+            category: .sidebar,
+            section: "Sidebar",
+            defaultValue: HomeProjectPreferences.defaultVisible
+        ),
+        SettingsCatalogItem(
+            key: SidebarSelection.storageKey,
+            title: "Active Sidebar",
+            description: "Chooses the built-in sidebar or one provided by an extension.",
+            category: .sidebar,
+            section: "Sidebar",
+            defaultValue: SidebarSelection.builtinValue,
+            aliases: ["extension sidebar", "webview sidebar"]
         ),
         SettingsCatalogItem(
             key: ProjectPickerPreferences.storageKey,
@@ -264,7 +284,7 @@ enum SettingsCatalog {
             key: SidebarCollapsedStyle.storageKey,
             title: "Collapsed Sidebar Style",
             description: "Controls the sidebar appearance when collapsed.",
-            category: .appearance,
+            category: .sidebar,
             section: "Sidebar",
             defaultValue: SidebarCollapsedStyle.defaultValue.rawValue
         ),
@@ -272,7 +292,7 @@ enum SettingsCatalog {
             key: SidebarExpandedStyle.storageKey,
             title: "Expanded Sidebar Style",
             description: "Controls the sidebar appearance when expanded.",
-            category: .appearance,
+            category: .sidebar,
             section: "Sidebar",
             defaultValue: SidebarExpandedStyle.defaultValue.rawValue
         ),

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -117,6 +117,8 @@ struct SettingsView: View {
             ProjectsSettingsView()
         case .appearance:
             InterfaceSettingsView()
+        case .sidebar:
+            SidebarSettingsView()
         case .terminal:
             TerminalSettingsView()
         case .richInput:

--- a/Muxy/Views/Settings/SidebarSettingsView.swift
+++ b/Muxy/Views/Settings/SidebarSettingsView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct SidebarSettingsView: View {
+    @State private var extensionStore = ExtensionStore.shared
+    @AppStorage(GeneralSettingsKeys.autoExpandWorktreesOnProjectSwitch)
+    private var autoExpandWorktrees = false
+    @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyle = SidebarCollapsedStyle.defaultValue.rawValue
+    @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyle = SidebarExpandedStyle.defaultValue.rawValue
+    @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
+    @AppStorage(SidebarSelection.storageKey) private var activeSidebar = SidebarSelection.builtinValue
+
+    private var providers: [ExtensionStore.ExtensionStatus] {
+        SidebarSelection.availableProviders(store: extensionStore)
+    }
+
+    var body: some View {
+        SettingsContainer {
+            if !providers.isEmpty {
+                SettingsSection("Active Sidebar") {
+                    SettingsRow("Sidebar") {
+                        HStack {
+                            Spacer()
+                            Picker("", selection: $activeSidebar) {
+                                Text("Built-in").tag(SidebarSelection.builtinValue)
+                                ForEach(providers) { status in
+                                    Text(label(for: status)).tag(status.id)
+                                }
+                            }
+                            .labelsHidden()
+                            .fixedSize()
+                        }
+                        .frame(width: SettingsMetrics.controlWidth)
+                    }
+                }
+            }
+
+            SettingsSection("Layout", showsDivider: false) {
+                SettingsToggleRow(label: "Show Home", isOn: $showHomeProject)
+
+                SettingsToggleRow(
+                    label: "Auto-expand worktrees on project switch",
+                    isOn: $autoExpandWorktrees
+                )
+
+                SettingsRow("Collapsed Style") {
+                    HStack {
+                        Spacer()
+                        Picker("", selection: $sidebarCollapsedStyle) {
+                            ForEach(SidebarCollapsedStyle.allCases) { style in
+                                Text(style.title).tag(style.rawValue)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .fixedSize()
+                    }
+                    .frame(width: SettingsMetrics.controlWidth)
+                }
+
+                SettingsRow("Expanded Style") {
+                    HStack {
+                        Spacer()
+                        Picker("", selection: $sidebarExpandedStyle) {
+                            ForEach(SidebarExpandedStyle.allCases) { style in
+                                Text(style.title).tag(style.rawValue)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .fixedSize()
+                    }
+                    .frame(width: SettingsMetrics.controlWidth)
+                }
+            }
+        }
+    }
+
+    private func label(for status: ExtensionStore.ExtensionStatus) -> String {
+        status.muxyExtension.manifest.sidebar?.title ?? status.muxyExtension.displayName
+    }
+}

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -45,11 +45,21 @@ struct Sidebar: View {
     @Environment(WorktreeStore.self) private var worktreeStore
     @State private var dragState = ProjectDragState()
     @State private var projectPendingRemoval: Project?
+    @State private var extensionStore = ExtensionStore.shared
     let expanded: Bool
     let expandedCustomWidth: CGFloat
     @AppStorage(SidebarCollapsedStyle.storageKey) private var collapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var expandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
+    @AppStorage(SidebarSelection.storageKey) private var activeSidebarRaw = SidebarSelection.builtinValue
+
+    private var activeExtensionSidebarID: String? {
+        SidebarSelection.resolvedExtensionID(from: activeSidebarRaw, store: extensionStore)
+    }
+
+    private var awaitingExtensionSidebar: Bool {
+        activeSidebarRaw != SidebarSelection.builtinValue && !extensionStore.hasLoadedFromDisk
+    }
 
     private var collapsedStyle: SidebarCollapsedStyle {
         SidebarCollapsedStyle(rawValue: collapsedStyleRaw) ?? .defaultValue
@@ -68,40 +78,50 @@ struct Sidebar: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            projectList
-                .frame(minHeight: 0, maxHeight: .infinity, alignment: .top)
-                .clipped()
+        sidebarContent
+            .frame(maxHeight: .infinity, alignment: .bottom)
+            .frame(width: SidebarLayout.resolvedWidth(
+                expanded: expanded,
+                collapsedStyle: collapsedStyle,
+                expandedStyle: expandedStyle,
+                expandedCustomWidth: expandedCustomWidth
+            ))
+            .opacity(isHidden ? 0 : 1)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Sidebar")
+            .alert(
+                "Remove \"\(projectPendingRemoval?.name ?? "")\"?",
+                isPresented: removalAlertBinding,
+                presenting: projectPendingRemoval
+            ) { project in
+                Button("Remove", role: .destructive) {
+                    performRemove(project)
+                    projectPendingRemoval = nil
+                }
+                .keyboardShortcut(.defaultAction)
+                Button("Cancel", role: .cancel) {
+                    projectPendingRemoval = nil
+                }
+                .keyboardShortcut(.cancelAction)
+            } message: { _ in
+                Text("This will remove the project from Muxy. Project files on disk will not be deleted.")
+            }
+    }
 
-            SidebarFooter(isWide: isWide, sidebarExpanded: expanded)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxHeight: .infinity, alignment: .bottom)
-        .frame(width: SidebarLayout.resolvedWidth(
-            expanded: expanded,
-            collapsedStyle: collapsedStyle,
-            expandedStyle: expandedStyle,
-            expandedCustomWidth: expandedCustomWidth
-        ))
-        .opacity(isHidden ? 0 : 1)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Sidebar")
-        .alert(
-            "Remove \"\(projectPendingRemoval?.name ?? "")\"?",
-            isPresented: removalAlertBinding,
-            presenting: projectPendingRemoval
-        ) { project in
-            Button("Remove", role: .destructive) {
-                performRemove(project)
-                projectPendingRemoval = nil
+    @ViewBuilder private var sidebarContent: some View {
+        if let activeExtensionSidebarID {
+            ExtensionSidebarView(extensionID: activeExtensionSidebarID)
+        } else if awaitingExtensionSidebar {
+            Color.clear
+        } else {
+            VStack(spacing: 0) {
+                projectList
+                    .frame(minHeight: 0, maxHeight: .infinity, alignment: .top)
+                    .clipped()
+
+                SidebarFooter(isWide: isWide, sidebarExpanded: expanded)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .keyboardShortcut(.defaultAction)
-            Button("Cancel", role: .cancel) {
-                projectPendingRemoval = nil
-            }
-            .keyboardShortcut(.cancelAction)
-        } message: { _ in
-            Text("This will remove the project from Muxy. Project files on disk will not be deleted.")
         }
     }
 

--- a/Muxy/Views/Sidebar/ExtensionSidebarView.swift
+++ b/Muxy/Views/Sidebar/ExtensionSidebarView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ExtensionSidebarView: View {
+    let extensionID: String
+
+    @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
+    @Environment(WorktreeStore.self) private var worktreeStore
+
+    var body: some View {
+        if let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID),
+           let sidebar = muxyExtension.manifest.sidebar,
+           let entryURL = ExtensionWebView.entryURL(for: muxyExtension, entry: sidebar.entry)
+        {
+            ExtensionWebView(
+                extensionID: muxyExtension.id,
+                instanceID: instanceID(for: muxyExtension.id, sidebarID: sidebar.id),
+                surfaceKind: .sidebar,
+                entryURL: entryURL,
+                initialData: sidebar.defaultData,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                focused: true,
+                onFocus: {}
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func instanceID(for extensionID: String, sidebarID: String) -> String {
+        "sidebar:\(extensionID):\(sidebarID)"
+    }
+}

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -1079,6 +1079,43 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("rejects a sidebar with an empty id")
+    func rejectsSidebarEmptyID() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "sb-empty-id",
+                "version": "1.0.0",
+                "sidebar": { "id": "", "entry": "sidebar/index.html" }
+            }
+            """,
+            files: ["sidebar/index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.sidebarEmptyID) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects a sidebar with an empty entry")
+    func rejectsSidebarEmptyEntry() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "sb-empty-entry",
+                "version": "1.0.0",
+                "sidebar": { "id": "main", "entry": "" }
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.sidebarEntryEmpty(sidebarID: "main")) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     private func makeTemporaryExtension(
         manifest: String,
         files: [String: String] = [:]

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -999,6 +999,86 @@ struct ExtensionManifestTests {
         #expect(ExtensionCommandAction.runScript(script: "s.js").requiredPermission == .commandsRunScript)
     }
 
+    @Test("decodes a sidebar declaration")
+    func decodesSidebar() throws {
+        let json = #"""
+        {
+            "name": "sb-ext",
+            "version": "1.0.0",
+            "sidebar": {
+                "id": "main",
+                "title": "My Sidebar",
+                "icon": "sparkles",
+                "entry": "sidebar/index.html"
+            }
+        }
+        """#
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+
+        #expect(manifest.sidebar?.id == "main")
+        #expect(manifest.sidebar?.title == "My Sidebar")
+        #expect(manifest.sidebar?.icon == .symbol("sparkles"))
+        #expect(manifest.sidebar?.entry == "sidebar/index.html")
+    }
+
+    @Test("loads a sidebar and resolves its entry")
+    func loadsSidebar() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "sb-load",
+                "version": "1.0.0",
+                "sidebar": { "id": "main", "entry": "sidebar/index.html" }
+            }
+            """,
+            files: ["sidebar/index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ext.manifest.sidebar?.id == "main")
+    }
+
+    @Test("rejects a sidebar with a missing entry")
+    func rejectsSidebarMissingEntry() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "sb-missing",
+                "version": "1.0.0",
+                "sidebar": { "id": "main", "entry": "sidebar/index.html" }
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects a sidebar entry that escapes the extension directory")
+    func rejectsSidebarEntryOutsideDirectory() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "sb-escape",
+                "version": "1.0.0",
+                "sidebar": { "id": "main", "entry": "../escape.html" }
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.sidebarEntryOutsideDirectory(
+            sidebarID: "main",
+            url: directory.appendingPathComponent("../escape.html")
+        )) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     private func makeTemporaryExtension(
         manifest: String,
         files: [String: String] = [:]

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -83,6 +83,7 @@ flowchart TD
 | [Tabs](tabs.md) | Register webview tab types and the injected `window.muxy` JS API |
 | [Panels](panels.md) | Register dockable/floating webview panels and the placement rules |
 | [Popovers](popovers.md) | Anchor a transient webview popover to a topbar/status bar item |
+| [Sidebars](sidebars.md) | Replace the built-in left sidebar with a full-height webview |
 | [Topbar](topbar.md) | Attach icons to the tab strip that trigger a command |
 | [Status Bar](statusbar.md) | Attach icons to the footer status bar; update text live |
 | [Modal](modal.md) | Present a native searchable picker; resolves with the selected item |

--- a/docs/extensions/get-started.md
+++ b/docs/extensions/get-started.md
@@ -41,8 +41,9 @@ something real:
 - **Declare what it does** in `package.json` under the `muxy` key — see
   [Manifest](manifest.md).
 - **Add UI** with [Tabs](tabs.md), [Panels](panels.md), [Popovers](popovers.md),
-  [Topbar](topbar.md), and [Status Bar](statusbar.md) items, or run logic from
-  [Palette Commands](palette-commands.md) and [Scripts](scripts.md).
+  [Sidebars](sidebars.md), [Topbar](topbar.md), and [Status Bar](statusbar.md)
+  items, or run logic from [Palette Commands](palette-commands.md) and
+  [Scripts](scripts.md).
 - **Work with the workspace** through [Events](events.md), [Git](git.md),
   [Files](files.md), [HTTP](http.md), and [Settings](settings.md).
 - **Request the minimum** you need — see [Permissions](permissions.md).

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -2,7 +2,7 @@
 
 Every extension is an npm + [Vite](https://vitejs.dev) project. Its manifest is the `muxy` object inside the `package.json` at the root of its directory.
 
-Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `panels`, `popovers`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
+Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `panels`, `popovers`, `sidebar`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
 
 `package.json` must also declare a `build` script. The publishing pipeline runs `npm run build` (Vite) and ships the build output directory, `dist/`. The app installs and reads from `dist/`, so every entry/asset path inside `muxy` (popover/tab `entry`, `background`, marketplace `icon`/`screenshots`) resolves against the build output, not your source tree.
 
@@ -53,6 +53,7 @@ All Muxy-specific manifest fields live under the `muxy` object.
 | `tabTypes` | object[] | no | Webview tab types the extension exposes. See [Tabs](tabs.md). |
 | `panels` | object[] | no | Dockable/floating webview panels. See [Panels](panels.md). |
 | `popovers` | object[] | no | Transient webview popovers anchored to a topbar/status-bar item. See [Popovers](popovers.md). |
+| `sidebar` | object | no | A single full-height webview that replaces the built-in left sidebar when the user selects it. See [Sidebars](sidebars.md). |
 | `topbarItems` | object[] | no | Icons attached to the tab strip. See [Topbar](topbar.md). |
 | `statusBarItems` | object[] | no | Icons attached to the footer status bar. See [Status Bar](statusbar.md). |
 | `settings` | object[] | no | Typed settings shown in the Settings sidebar. See [Settings](settings.md). |

--- a/docs/extensions/sidebars.md
+++ b/docs/extensions/sidebars.md
@@ -1,0 +1,142 @@
+# Extension Sidebars
+
+A sidebar is a full-height webview that **replaces Muxy's built-in left sidebar** when the user selects it. An extension declares at most one; the user picks the active sidebar in **Settings → Sidebar**. Each sidebar is a `WKWebView` with the injected [`window.muxy`](tabs.md#windowmuxy) bridge, just like a [tab](tabs.md) or [panel](panels.md).
+
+When active, the extension webview fills the **entire** sidebar region — both the built-in project list and the bottom footer (extensions button, sidebar toggle, theme picker, notifications) are replaced. The extension owns its own navigation and controls.
+
+## Declaring a sidebar
+
+```json
+{
+  "name": "workspace-nav",
+  "version": "0.1.0",
+  "muxy": {
+    "sidebar": {
+      "id": "main",
+      "title": "My Sidebar",
+      "icon": "sparkles",
+      "entry": "sidebar/index.html",
+      "defaultData": {}
+    }
+  }
+}
+```
+
+`sidebar` is a single object, not an array — one sidebar per extension.
+
+### Fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Stable per extension. |
+| `entry` | string | yes | HTML path relative to the build output — any layout works (e.g. `sidebar/index.html`); not a fixed folder. Must resolve inside the extension directory (no `..` traversal). |
+| `title` | string | no | Shown next to the extension in the **Active Sidebar** dropdown. |
+| `icon` | string \| object | no | SF Symbol name, or `{ "svg": "assets/icon.svg" }`. Shown in the dropdown. |
+| `defaultData` | object | no | JSON exposed to the page as `window.muxy.data`. |
+
+## Activation
+
+The user chooses the active sidebar from an **Active Sidebar** dropdown in **Settings → Sidebar** — **Built-in** or any enabled extension that declares a sidebar. The dropdown only appears when at least one enabled extension declares a sidebar.
+
+The toggle-sidebar shortcut (`⌘B`) and the resize handle act on the whole sidebar region regardless of which sidebar is active. A sidebar cannot close or deselect itself — selection is controlled by the user in settings, so there is no `closeSelf` for this surface.
+
+## Theming
+
+The sidebar paints `--muxy-background` on the body, like [tabs](tabs.md) and [panels](panels.md). Use the injected `--muxy-*` theme variables for every color so it tracks the live theme and inverts for light/dark automatically.
+
+## window.muxy
+
+A sidebar page gets the same [`window.muxy`](tabs.md#windowmuxy) API as panels and tabs — theme (`muxy.theme`, `muxy.onThemeChange`), data (`muxy.data`, `muxy.onDataChange`), focus (`muxy.onFocus`, `muxy.focused`), and the workspace surfaces (`projects`, `git`, `files`, `events`, …) gated by their permissions. Because the sidebar replaces the built-in project list, `muxy.projects` (`list` / `switchTo`) is the usual way to render and switch projects.
+
+## Reacting to workspace changes
+
+A sidebar is created once and persists across the session — it does **not** reload when the active project, worktree, or tab changes. `muxy.projects.list()` reads live state at call time, so to keep the active highlight correct you must re-fetch on the relevant [event](events.md) instead of relying on the initial load:
+
+```js
+muxy.events.subscribe('project.switched', async () => {
+  render(await muxy.projects.list());
+});
+```
+
+Workspace events (`project.switched`, `worktree.switched`, `tab.focused`, …) must be **declared in your manifest `events` array** before you can subscribe — subscribing to an undeclared event is rejected and your handler silently never fires. See [Events](events.md) for the full list.
+
+```json
+"muxy": {
+  "events": ["project.switched", "worktree.switched", "tab.focused"]
+}
+```
+
+## Minimal example
+
+```
+workspace-nav/
+  package.json
+  vite.config.js
+  src/sidebar/index.html
+```
+
+```json
+{
+  "name": "workspace-nav",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": { "dev": "vite", "build": "vite build" },
+  "devDependencies": { "vite": "^5.0.0" },
+  "muxy": {
+    "permissions": ["projects:read", "projects:write"],
+    "events": ["project.switched"],
+    "sidebar": {
+      "id": "main",
+      "title": "Workspace",
+      "icon": "sidebar.left",
+      "entry": "sidebar/index.html"
+    }
+  }
+}
+```
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        margin: 0;
+        height: 100vh;
+        font: 12px -apple-system, system-ui, sans-serif;
+        background: var(--muxy-background);
+        color: var(--muxy-foreground);
+      }
+      .row {
+        padding: 8px 10px;
+        cursor: pointer;
+      }
+      .row:hover {
+        background: var(--muxy-hover);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="projects"></div>
+    <script type="module">
+      const list = document.getElementById('projects');
+      const render = (projects) => {
+        list.replaceChildren(
+          ...projects.map((project) => {
+            const row = document.createElement('div');
+            row.className = 'row';
+            row.textContent = project.isActive ? `• ${project.name}` : project.name;
+            row.onclick = () => muxy.projects.switchTo(project.id);
+            return row;
+          }),
+        );
+      };
+      const refresh = async () => render(await muxy.projects.list());
+      muxy.events.subscribe('project.switched', refresh);
+      refresh();
+    </script>
+  </body>
+</html>
+```


### PR DESCRIPTION
Moves sidebar options into a new Settings → Sidebar menu and lets an
  extension register a single webview sidebar that replaces the built-in one
  (picked via an Active Sidebar dropdown). Toggle shortcut and resize keep
  working on the whole region.