### PR TITLE
add workspace switcher to terminal omnibox

### DIFF
--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -56,6 +56,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case terminalOmnibox
     case terminalOmniboxProjects
     case terminalOmniboxWorktrees
+    case terminalOmniboxWorkspaces
     case terminalOmniboxCommands
     case toggleSidebar
     case navigateBack
@@ -113,6 +114,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .terminalOmnibox,
         .terminalOmniboxProjects,
         .terminalOmniboxWorktrees,
+        .terminalOmniboxWorkspaces,
         .terminalOmniboxCommands,
         .toggleSidebar,
         .navigateBack,
@@ -187,6 +189,11 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
             )
         case .terminalOmniboxWorktrees: ShortcutMetadata(
                 displayName: "Terminal Omnibox Worktrees",
+                category: "Terminal",
+                scope: .mainWindow
+            )
+        case .terminalOmniboxWorkspaces: ShortcutMetadata(
+                displayName: "Terminal Omnibox Workspaces",
                 category: "Terminal",
                 scope: .mainWindow
             )
@@ -329,6 +336,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .terminalOmnibox, combo: KeyCombo(key: "o", command: true, option: true)),
         Self(action: .terminalOmniboxProjects, combo: KeyCombo(key: "p", command: true, option: true)),
         Self(action: .terminalOmniboxWorktrees, combo: KeyCombo(key: "w", command: true, option: true)),
+        Self(action: .terminalOmniboxWorkspaces, combo: KeyCombo(key: "s", command: true, shift: true)),
         Self(action: .terminalOmniboxCommands, combo: KeyCombo(key: "p", command: true, shift: true)),
         Self(action: .toggleSidebar, combo: KeyCombo(key: "b", command: true)),
         Self(action: .navigateBack, combo: KeyCombo(key: KeyCombo.leftArrowKey, command: true, control: true)),

--- a/Muxy/Models/KeyBinding.swift
+++ b/Muxy/Models/KeyBinding.swift
@@ -336,7 +336,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .terminalOmnibox, combo: KeyCombo(key: "o", command: true, option: true)),
         Self(action: .terminalOmniboxProjects, combo: KeyCombo(key: "p", command: true, option: true)),
         Self(action: .terminalOmniboxWorktrees, combo: KeyCombo(key: "w", command: true, option: true)),
-        Self(action: .terminalOmniboxWorkspaces, combo: KeyCombo(key: "s", command: true, shift: true)),
+        Self(action: .terminalOmniboxWorkspaces, combo: KeyCombo(key: "s", command: true, option: true)),
         Self(action: .terminalOmniboxCommands, combo: KeyCombo(key: "p", command: true, shift: true)),
         Self(action: .toggleSidebar, combo: KeyCombo(key: "b", command: true)),
         Self(action: .navigateBack, combo: KeyCombo(key: KeyCombo.leftArrowKey, command: true, control: true)),

--- a/Muxy/Models/TerminalOmniboxItem.swift
+++ b/Muxy/Models/TerminalOmniboxItem.swift
@@ -3,6 +3,7 @@ import Foundation
 enum TerminalOmniboxLaunchScope: String {
     case projects
     case worktrees
+    case workspaces
     case openTabs
     case commandShortcuts
 }
@@ -50,6 +51,18 @@ struct TerminalOmniboxWorktreeItem: Identifiable, Equatable {
     }
 }
 
+struct TerminalOmniboxWorkspaceItem: Identifiable, Equatable {
+    let groupID: UUID?
+    let name: String
+    let projectCount: Int
+
+    var id: String { "workspace-\(groupID?.uuidString ?? "all")" }
+
+    var searchKey: String {
+        [name, "workspace"].joined(separator: " ")
+    }
+}
+
 struct ExtensionPaletteItem: Identifiable, Equatable {
     let extensionID: String
     let extensionName: String
@@ -65,6 +78,7 @@ struct ExtensionPaletteItem: Identifiable, Equatable {
 enum TerminalOmniboxItem: Identifiable, Equatable {
     case project(TerminalOmniboxProjectItem)
     case worktree(TerminalOmniboxWorktreeItem)
+    case workspace(TerminalOmniboxWorkspaceItem)
     case openTab(OpenTerminalTabItem)
     case commandShortcut(CommandShortcut)
     case extensionCommand(ExtensionPaletteItem)
@@ -75,6 +89,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
             project.id
         case let .worktree(wt):
             wt.id
+        case let .workspace(workspace):
+            workspace.id
         case let .openTab(tab):
             tab.id
         case let .commandShortcut(shortcut):
@@ -90,6 +106,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
             project.name
         case let .worktree(wt):
             wt.name
+        case let .workspace(workspace):
+            workspace.name
         case let .openTab(tab):
             tab.title
         case let .commandShortcut(shortcut):
@@ -105,6 +123,10 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
             project.path
         case let .worktree(wt):
             wt.branch.map { "(\($0)) \(wt.path)" } ?? wt.path
+        case let .workspace(workspace):
+            workspace.groupID == nil
+                ? "All projects"
+                : "\(workspace.projectCount) project\(workspace.projectCount == 1 ? "" : "s")"
         case let .openTab(tab):
             tab.command ?? tab.workingDirectory
         case let .commandShortcut(shortcut):
@@ -120,6 +142,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
             "Projects"
         case .worktree:
             "Worktrees"
+        case .workspace:
+            "Workspaces"
         case .openTab:
             "Open Tabs"
         case .commandShortcut:
@@ -135,6 +159,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
             "folder"
         case let .worktree(wt):
             wt.isPrimary ? "folder.badge.gearshape" : "arrow.triangle.branch"
+        case let .workspace(workspace):
+            workspace.groupID == nil ? "square.grid.2x2" : "square.stack.3d.up"
         case .openTab:
             "terminal"
         case .commandShortcut:
@@ -150,6 +176,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
             project.searchKey
         case let .worktree(wt):
             wt.searchKey
+        case let .workspace(workspace):
+            workspace.searchKey
         case let .openTab(tab):
             tab.searchKey
         case let .commandShortcut(shortcut):
@@ -163,6 +191,7 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
 struct TerminalOmniboxItemContext {
     let projects: [TerminalOmniboxProjectItem]
     let worktrees: [TerminalOmniboxWorktreeItem]
+    let workspaces: [TerminalOmniboxWorkspaceItem]
     let openTabs: [OpenTerminalTabItem]
     let commandShortcuts: [CommandShortcut]
     let extensionCommands: [ExtensionPaletteItem]
@@ -173,6 +202,7 @@ struct TerminalOmniboxItemContext {
     init(
         projects: [TerminalOmniboxProjectItem],
         worktrees: [TerminalOmniboxWorktreeItem],
+        workspaces: [TerminalOmniboxWorkspaceItem] = [],
         openTabs: [OpenTerminalTabItem],
         commandShortcuts: [CommandShortcut],
         extensionCommands: [ExtensionPaletteItem] = [],
@@ -182,6 +212,7 @@ struct TerminalOmniboxItemContext {
     ) {
         self.projects = projects
         self.worktrees = worktrees
+        self.workspaces = workspaces
         self.openTabs = openTabs
         self.commandShortcuts = commandShortcuts
         self.extensionCommands = extensionCommands
@@ -204,6 +235,8 @@ enum TerminalOmniboxItemResolver {
             return context.worktrees
                 .filter { $0.projectID == activeProjectID }
                 .map(TerminalOmniboxItem.worktree)
+        case .workspaces:
+            return context.workspaces.map(TerminalOmniboxItem.workspace)
         case .openTabs:
             guard let activeProjectID = context.activeProjectID,
                   let activeWorktreeID = context.activeWorktreeID

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -169,6 +169,9 @@ struct ShortcutActionDispatcher {
         case .terminalOmniboxWorktrees:
             postTerminalOmnibox(scope: .worktrees)
             return true
+        case .terminalOmniboxWorkspaces:
+            postTerminalOmnibox(scope: .workspaces)
+            return true
         case .terminalOmniboxCommands:
             postTerminalOmnibox(scope: .commandShortcuts)
             return true

--- a/Muxy/Views/Components/TerminalOmniboxOverlay.swift
+++ b/Muxy/Views/Components/TerminalOmniboxOverlay.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TerminalOmniboxOverlay: View {
     let projects: [TerminalOmniboxProjectItem]
     let worktrees: [TerminalOmniboxWorktreeItem]
+    let workspaces: [TerminalOmniboxWorkspaceItem]
     let openTabs: [OpenTerminalTabItem]
     let commandShortcuts: [CommandShortcut]
     let extensionCommands: [ExtensionPaletteItem]
@@ -31,6 +32,7 @@ struct TerminalOmniboxOverlay: View {
             in: TerminalOmniboxItemContext(
                 projects: projects,
                 worktrees: worktrees,
+                workspaces: workspaces,
                 openTabs: openTabs,
                 commandShortcuts: commandShortcuts,
                 extensionCommands: extensionCommands,
@@ -101,6 +103,8 @@ struct TerminalOmniboxOverlay: View {
             "Search project..."
         case .worktrees:
             "Search worktree..."
+        case .workspaces:
+            "Search workspace..."
         case .openTabs:
             "Search open tabs..."
         case .commandShortcuts:
@@ -163,6 +167,8 @@ struct TerminalOmniboxOverlay: View {
             "No projects found"
         case .worktrees:
             "No worktrees found"
+        case .workspaces:
+            "No workspaces found"
         case .openTabs:
             "No open tabs found"
         case .commandShortcuts:
@@ -173,7 +179,8 @@ struct TerminalOmniboxOverlay: View {
     private var returnHintLabel: String {
         switch launchScope {
         case .projects,
-             .worktrees:
+             .worktrees,
+             .workspaces:
             "Switch"
         default:
             "Open"
@@ -228,7 +235,8 @@ struct TerminalOmniboxOverlay: View {
     private func dispatchSelection(_ item: TerminalOmniboxItem) {
         switch item {
         case .project,
-             .worktree:
+             .worktree,
+             .workspace:
             onSelect(item, nil, nil)
         case .commandShortcut:
             onSelect(item, activeProjectID, activeWorktreeID)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -653,16 +653,17 @@ struct MainWindow: View {
     }
 
     private var terminalOmniboxWorkspaces: [TerminalOmniboxWorkspaceItem] {
+        let storedProjects = projectStore.storedProjects
         let allProjects = TerminalOmniboxWorkspaceItem(
             groupID: nil,
             name: "All Projects",
-            projectCount: projectStore.storedProjects.count
+            projectCount: storedProjects.count
         )
         let groups = projectGroupStore.groups.map { group in
             TerminalOmniboxWorkspaceItem(
                 groupID: group.id,
                 name: group.name,
-                projectCount: group.projectIDs.count
+                projectCount: storedProjects.count { group.projectIDs.contains($0.id) }
             )
         }
         return [allProjects] + groups

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -529,6 +529,7 @@ struct MainWindow: View {
             TerminalOmniboxOverlay(
                 projects: terminalOmniboxProjects,
                 worktrees: terminalOmniboxWorktrees,
+                workspaces: terminalOmniboxWorkspaces,
                 openTabs: terminalOmniboxOpenTabs,
                 commandShortcuts: CommandShortcutStore.shared.shortcuts,
                 extensionCommands: terminalOmniboxExtensionCommands,
@@ -589,6 +590,8 @@ struct MainWindow: View {
             _ = selectOmniboxProject(project.projectID)
         case let .worktree(worktree):
             _ = selectOmniboxProject(worktree.projectID, worktreeID: worktree.worktreeID)
+        case let .workspace(workspace):
+            selectOmniboxWorkspace(workspace)
         case let .openTab(tab):
             _ = selectOmniboxProject(tab.projectID, worktreeID: tab.worktreeID)
             appState.dispatch(.selectTab(projectID: tab.projectID, areaID: tab.areaID, tabID: tab.tabID))
@@ -649,6 +652,22 @@ struct MainWindow: View {
         }
     }
 
+    private var terminalOmniboxWorkspaces: [TerminalOmniboxWorkspaceItem] {
+        let allProjects = TerminalOmniboxWorkspaceItem(
+            groupID: nil,
+            name: "All Projects",
+            projectCount: projectStore.storedProjects.count
+        )
+        let groups = projectGroupStore.groups.map { group in
+            TerminalOmniboxWorkspaceItem(
+                groupID: group.id,
+                name: group.name,
+                projectCount: group.projectIDs.count
+            )
+        }
+        return [allProjects] + groups
+    }
+
     private var terminalOmniboxOpenTabs: [OpenTerminalTabItem] {
         omniboxProjects.flatMap { appState.allOpenTerminalTabItems(for: $0.id) }
     }
@@ -672,6 +691,14 @@ struct MainWindow: View {
         guard let worktree else { return false }
         appState.selectProject(project, worktree: worktree)
         return true
+    }
+
+    private func selectOmniboxWorkspace(_ workspace: TerminalOmniboxWorkspaceItem) {
+        guard let groupID = workspace.groupID else {
+            projectGroupStore.clearGroupSelection()
+            return
+        }
+        projectGroupStore.selectGroup(id: groupID)
     }
 
     private var toastPosition: ToastPosition {

--- a/Tests/MuxyTests/Models/TerminalOmniboxItemTests.swift
+++ b/Tests/MuxyTests/Models/TerminalOmniboxItemTests.swift
@@ -64,6 +64,18 @@ struct TerminalOmniboxItemResolverTests {
         #expect(TerminalOmniboxItem.openTab(openTab).sectionTitle == "Open Tabs")
         #expect(TerminalOmniboxItem.openTab(openTab).symbol == "terminal")
 
+        let namedWorkspace = TerminalOmniboxWorkspaceItem(groupID: UUID(), name: "Backend", projectCount: 3)
+        let allWorkspaces = TerminalOmniboxWorkspaceItem(groupID: nil, name: "All Projects", projectCount: 7)
+        #expect(TerminalOmniboxItem.workspace(namedWorkspace).title == "Backend")
+        #expect(TerminalOmniboxItem.workspace(namedWorkspace).subtitle == "3 projects")
+        #expect(TerminalOmniboxItem.workspace(namedWorkspace).symbol == "square.stack.3d.up")
+        #expect(TerminalOmniboxItem.workspace(namedWorkspace).sectionTitle == "Workspaces")
+        #expect(TerminalOmniboxItem.workspace(allWorkspaces).id == "workspace-all")
+        #expect(TerminalOmniboxItem.workspace(allWorkspaces).subtitle == "All projects")
+        #expect(TerminalOmniboxItem.workspace(allWorkspaces).symbol == "square.grid.2x2")
+        #expect(TerminalOmniboxItem
+            .workspace(TerminalOmniboxWorkspaceItem(groupID: UUID(), name: "Solo", projectCount: 1)).subtitle == "1 project")
+
         #expect(TerminalOmniboxItem.commandShortcut(shortcut).id == "shortcut-\(shortcutID.uuidString)")
         #expect(TerminalOmniboxItem.commandShortcut(shortcut).title == "Run Tests")
         #expect(TerminalOmniboxItem.commandShortcut(shortcut).subtitle == "swift test")
@@ -193,6 +205,25 @@ struct TerminalOmniboxItemResolverTests {
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .worktrees).isEmpty)
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .openTabs).isEmpty)
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .commandShortcuts).isEmpty)
+    }
+
+    @Test("Workspaces scope returns every workspace item")
+    func workspacesScopeReturnsAllWorkspaces() {
+        let allProjects = TerminalOmniboxWorkspaceItem(groupID: nil, name: "All Projects", projectCount: 5)
+        let backend = TerminalOmniboxWorkspaceItem(groupID: UUID(), name: "Backend", projectCount: 2)
+        let context = TerminalOmniboxItemContext(
+            projects: [],
+            worktrees: [],
+            workspaces: [allProjects, backend],
+            openTabs: [],
+            commandShortcuts: [],
+            activeProjectID: nil,
+            activeWorktreeID: nil,
+            commandProjectIDs: []
+        )
+
+        let items = TerminalOmniboxItemResolver.items(in: context, launchScope: .workspaces)
+        #expect(items == [.workspace(allProjects), .workspace(backend)])
     }
 
     @Test("commandShortcuts scope includes extension commands")

--- a/docs/features/project-workspaces.md
+++ b/docs/features/project-workspaces.md
@@ -11,6 +11,7 @@ Open the workspace menu at the top of the sidebar.
 | Action | How |
 | --- | --- |
 | Show everything | Pick **All Projects** |
+| Switch from the keyboard | Press **⌘⌥S** to open the workspace switcher in the terminal omnibox |
 | Create a workspace | Pick **New Workspace** |
 | Rename / delete | Use the workspace row actions |
 | Move a project | Right-click a project -> **Move to Workspace** |


### PR DESCRIPTION
Adds a workspace opener to the terminal omnibox (⌘⌥S), matching the existing project and worktree switchers.
Lists "All Projects" plus named workspaces; selecting one switches the active workspace filter.
Closes #603