### PR TITLE
resume claude code sessions when restoring workspaces

### DIFF
--- a/Muxy/Models/TerminalPaneState.swift
+++ b/Muxy/Models/TerminalPaneState.swift
@@ -19,7 +19,12 @@ final class TerminalPaneState: Identifiable {
     let externalEditorFilePath: String?
     var isOffline = false
     let searchState = TerminalSearchState()
+    @ObservationIgnored var foregroundProcessNameProvider: (() -> String?)?
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
+
+    var foregroundProcessName: String? {
+        foregroundProcessNameProvider?()
+    }
 
     init(
         id: UUID = UUID(),

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -82,7 +82,10 @@ final class TerminalTab: Identifiable {
                 id: snapshot.paneID ?? UUID(),
                 projectPath: snapshot.projectPath,
                 title: snapshot.paneTitle,
-                initialWorkingDirectory: restoredWorkingDirectory
+                initialWorkingDirectory: restoredWorkingDirectory,
+                startupCommand: snapshot.agentResumeCommand,
+                startupCommandInteractive: snapshot.agentResumeCommand != nil,
+                closesOnStartupCommandExit: false
             ))
         case .extensionWebView:
             if let extensionID = snapshot.extensionID,
@@ -112,6 +115,7 @@ final class TerminalTab: Identifiable {
             paneTitle: extensionTabDefaultTitle ?? content.pane?.title,
             paneID: content.pane?.id,
             currentWorkingDirectory: content.pane?.currentWorkingDirectory,
+            agentResumeCommand: agentResumeCommand(),
             extensionID: content.extensionState?.extensionID,
             extensionTabTypeID: content.extensionState?.tabTypeID,
             extensionTabData: content.extensionState?.data
@@ -120,6 +124,11 @@ final class TerminalTab: Identifiable {
 
     private var extensionTabDefaultTitle: String? {
         content.extensionState?.defaultTitle
+    }
+
+    private func agentResumeCommand() -> String? {
+        guard let pane = content.pane else { return nil }
+        return AIProviderRegistry.shared.resumeCommand(forProcessName: pane.foregroundProcessName)
     }
 
     private static func restoredWorkingDirectory(_ path: String?, projectPath: String) -> String? {

--- a/Muxy/Models/WorkspaceSnapshot.swift
+++ b/Muxy/Models/WorkspaceSnapshot.swift
@@ -108,6 +108,7 @@ struct TerminalTabSnapshot: Codable {
     let paneID: UUID?
     let filePath: String?
     let currentWorkingDirectory: String?
+    let agentResumeCommand: String?
     let extensionID: String?
     let extensionTabTypeID: String?
     let extensionTabData: ExtensionJSON?
@@ -123,6 +124,7 @@ struct TerminalTabSnapshot: Codable {
         paneID: UUID? = nil,
         filePath: String? = nil,
         currentWorkingDirectory: String? = nil,
+        agentResumeCommand: String? = nil,
         extensionID: String? = nil,
         extensionTabTypeID: String? = nil,
         extensionTabData: ExtensionJSON? = nil
@@ -137,6 +139,7 @@ struct TerminalTabSnapshot: Codable {
         self.paneID = paneID
         self.filePath = filePath
         self.currentWorkingDirectory = currentWorkingDirectory
+        self.agentResumeCommand = agentResumeCommand
         self.extensionID = extensionID
         self.extensionTabTypeID = extensionTabTypeID
         self.extensionTabData = extensionTabData
@@ -153,6 +156,7 @@ struct TerminalTabSnapshot: Codable {
         case paneID
         case filePath
         case currentWorkingDirectory
+        case agentResumeCommand
         case extensionID
         case extensionTabTypeID
         case extensionTabData
@@ -171,6 +175,7 @@ struct TerminalTabSnapshot: Codable {
         paneID = try container.decodeIfPresent(UUID.self, forKey: .paneID)
         filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
         currentWorkingDirectory = try container.decodeIfPresent(String.self, forKey: .currentWorkingDirectory)
+        agentResumeCommand = try container.decodeIfPresent(String.self, forKey: .agentResumeCommand)
         extensionID = try container.decodeIfPresent(String.self, forKey: .extensionID)
         extensionTabTypeID = try container.decodeIfPresent(String.self, forKey: .extensionTabTypeID)
         extensionTabData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .extensionTabData)

--- a/Muxy/Services/AIProviderIntegration.swift
+++ b/Muxy/Services/AIProviderIntegration.swift
@@ -11,6 +11,7 @@ protocol AIProviderIntegration {
     var executableNames: [String] { get }
     var hookScriptName: String { get }
     var hookScriptExtension: String { get }
+    var sessionResumeCommand: String? { get }
 
     func isToolInstalled() -> Bool
     func install(hookScriptPath: String) throws
@@ -20,6 +21,7 @@ protocol AIProviderIntegration {
 extension AIProviderIntegration {
     var hookScriptName: String { "muxy-claude-hook" }
     var hookScriptExtension: String { "sh" }
+    var sessionResumeCommand: String? { nil }
 }
 
 extension AIProviderIntegration {
@@ -130,6 +132,11 @@ final class AIProviderRegistry {
                 logger.error("Failed to uninstall \(provider.displayName): \(error.localizedDescription)")
             }
         }
+    }
+
+    func resumeCommand(forProcessName name: String?) -> String? {
+        guard let name = name?.lowercased(), !name.isEmpty else { return nil }
+        return providers.first { $0.executableNames.contains(name) }?.sessionResumeCommand
     }
 
     func notificationSource(for socketType: String) -> MuxyNotification.Source {

--- a/Muxy/Services/Providers/ClaudeCodeProvider.swift
+++ b/Muxy/Services/Providers/ClaudeCodeProvider.swift
@@ -6,6 +6,7 @@ struct ClaudeCodeProvider: AIProviderIntegration {
     let socketTypeKey = "claude_hook"
     let iconName = "claude"
     let executableNames = ["claude"]
+    let sessionResumeCommand: String? = "claude --continue"
 
     private static let settingsPath = NSHomeDirectory() + "/.claude/settings.json"
     private static let muxyMarker = "muxy-notification-hook"

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1386,6 +1386,11 @@ final class GhosttyTerminalNSView: NSView {
         return cells.alt_screen
     }
 
+    func foregroundProcessName() -> String? {
+        guard let surface else { return nil }
+        return Self.processName(pid: ghostty_surface_foreground_pid(surface))
+    }
+
     private static func processName(pid: UInt64) -> String? {
         guard pid > 0, pid <= UInt64(Int32.max) else { return nil }
         var buffer = [CChar](repeating: 0, count: 1024)

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -229,6 +229,9 @@ struct TerminalBridge: NSViewRepresentable {
         view.onOfflineChange = { [weak state] offline in
             state?.isOffline = offline
         }
+        state.foregroundProcessNameProvider = { [weak view] in
+            view?.foregroundProcessName()
+        }
         view.updateResumeWorkingDirectory(state.currentWorkingDirectory ?? state.projectPath)
         configureSearchCallbacks(view)
         configureFileOpenCallback(view)

--- a/Tests/MuxyTests/Models/WorkspaceSnapshotTests.swift
+++ b/Tests/MuxyTests/Models/WorkspaceSnapshotTests.swift
@@ -65,6 +65,100 @@ struct WorkspaceSnapshotTests {
         #expect(decoded.projectPath == testPath)
     }
 
+    @Test("TerminalTabSnapshot round-trip preserves agentResumeCommand")
+    func terminalTabSnapshotPreservesAgentResumeCommand() throws {
+        let snapshot = TerminalTabSnapshot(
+            kind: .terminal,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: testPath,
+            paneTitle: "claude",
+            agentResumeCommand: "claude --continue"
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(TerminalTabSnapshot.self, from: data)
+
+        #expect(decoded.agentResumeCommand == "claude --continue")
+    }
+
+    @Test("TerminalTabSnapshot decoding without agentResumeCommand defaults to nil")
+    func terminalTabSnapshotAgentResumeBackwardCompatibility() throws {
+        let json = """
+        {
+            "kind": "terminal",
+            "isPinned": false,
+            "projectPath": "\(testPath)",
+            "paneTitle": "Shell"
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(TerminalTabSnapshot.self, from: json)
+
+        #expect(decoded.agentResumeCommand == nil)
+    }
+
+    @Test("TerminalTab.snapshot captures resume command when an agent is foreground")
+    func tabSnapshotCapturesAgentResumeCommand() {
+        let pane = TerminalPaneState(projectPath: testPath)
+        pane.foregroundProcessNameProvider = { "Claude" }
+        let tab = TerminalTab(pane: pane)
+
+        #expect(tab.snapshot().agentResumeCommand == "claude --continue")
+    }
+
+    @Test("TerminalTab.snapshot leaves resume command nil when a shell is foreground")
+    func tabSnapshotSkipsResumeCommandForShell() {
+        let pane = TerminalPaneState(projectPath: testPath)
+        pane.foregroundProcessNameProvider = { "zsh" }
+        let tab = TerminalTab(pane: pane)
+
+        #expect(tab.snapshot().agentResumeCommand == nil)
+    }
+
+    @Test("TerminalTab.snapshot leaves resume command nil without a foreground provider")
+    func tabSnapshotSkipsResumeCommandWithoutProvider() {
+        let tab = TerminalTab(pane: TerminalPaneState(projectPath: testPath))
+
+        #expect(tab.snapshot().agentResumeCommand == nil)
+    }
+
+    @Test("TerminalTab restore relaunches the agent resume command")
+    func tabRestoreRelaunchesAgentResumeCommand() {
+        let snapshot = TerminalTabSnapshot(
+            kind: .terminal,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: testPath,
+            paneTitle: "claude",
+            currentWorkingDirectory: testPath,
+            agentResumeCommand: "claude --continue"
+        )
+        let tab = TerminalTab(restoring: snapshot)
+        let pane = tab.content.pane
+
+        #expect(pane?.startupCommand == "claude --continue")
+        #expect(pane?.startupCommandInteractive == true)
+        #expect(pane?.closesOnStartupCommandExit == false)
+    }
+
+    @Test("TerminalTab restore without resume command launches a plain shell")
+    func tabRestoreWithoutResumeCommandLaunchesShell() {
+        let snapshot = TerminalTabSnapshot(
+            kind: .terminal,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: testPath,
+            paneTitle: "Shell"
+        )
+        let tab = TerminalTab(restoring: snapshot)
+        let pane = tab.content.pane
+
+        #expect(pane?.startupCommand == nil)
+        #expect(pane?.startupCommandInteractive == false)
+    }
+
     @Test("TerminalTabSnapshot decoding with removed editor kind falls back to terminal")
     func terminalTabSnapshotRemovedEditorKind() throws {
         let json = """


### PR DESCRIPTION
Restored tabs always relaunched as bare shells, so Claude Code sessions running at quit were lost on restart.
Snapshots now record a resume command when a known agent is the pane's foreground process, and restore replays it (`claude --continue`) in the saved working directory.
No UI change; covered by new snapshot/restore tests, and degrades to a plain shell when there is nothing to resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)