### PR TITLE
Add multi-select device deletion to Mobile settings

### DIFF
--- a/Muxy/Services/ApprovedDevicesStore.swift
+++ b/Muxy/Services/ApprovedDevicesStore.swift
@@ -77,9 +77,15 @@ final class ApprovedDevicesStore {
     }
 
     func revoke(deviceID: UUID) {
-        devices.removeAll { $0.id == deviceID }
+        revoke(deviceIDs: [deviceID])
+    }
+
+    func revoke(deviceIDs: Set<UUID>) {
+        let removed = devices.filter { deviceIDs.contains($0.id) }
+        guard !removed.isEmpty else { return }
+        devices.removeAll { deviceIDs.contains($0.id) }
         save()
-        onRevoke?(deviceID)
+        removed.forEach { onRevoke?($0.id) }
     }
 
     func replaceDevices(_ newDevices: [ApprovedDevice]) {

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -11,6 +11,9 @@ struct MobileSettingsView: View {
     @Bindable private var service = MobileServerService.shared
     @Bindable private var devices = ApprovedDevicesStore.shared
     @State private var deviceToRevoke: ApprovedDevice?
+    @State private var isSelecting = false
+    @State private var selectedDeviceIDs: Set<UUID> = []
+    @State private var showBatchRevokeConfirmation = false
     @State private var portText: String = ""
     @State private var portValidationError: String?
     @State private var showFreePortConfirmation = false
@@ -92,6 +95,7 @@ struct MobileSettingsView: View {
                         .padding(.horizontal, SettingsMetrics.horizontalPadding)
                         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
                 } else {
+                    deviceSelectionActions
                     ForEach(devices.devices) { device in
                         deviceRow(device)
                     }
@@ -110,6 +114,13 @@ struct MobileSettingsView: View {
         }
         .onChange(of: service.isEnabled) { _, _ in
             refreshPairingHosts()
+        }
+        .onChange(of: devices.devices) { _, newValue in
+            let availableIDs = Set(newValue.map(\.id))
+            selectedDeviceIDs.formIntersection(availableIDs)
+            if newValue.isEmpty {
+                exitSelection()
+            }
         }
         .alert(
             "Free port \(String(service.port))?",
@@ -136,6 +147,18 @@ struct MobileSettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: { _ in
             Text("The device will be disconnected immediately and must request approval again to reconnect.")
+        }
+        .alert(
+            "Revoke \(selectedDeviceIDs.count) \(selectedDeviceIDs.count == 1 ? "device" : "devices")?",
+            isPresented: $showBatchRevokeConfirmation
+        ) {
+            Button("Revoke", role: .destructive) {
+                devices.revoke(deviceIDs: selectedDeviceIDs)
+                exitSelection()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("The selected devices will be disconnected immediately and must request approval again to reconnect.")
         }
     }
 
@@ -259,8 +282,81 @@ struct MobileSettingsView: View {
         }
     }
 
+    private var deviceSelectionActions: some View {
+        HStack(spacing: 12) {
+            if isSelecting {
+                Button(allDevicesSelected ? "Deselect All" : "Select All") {
+                    toggleSelectAll()
+                }
+                .buttonStyle(.borderless)
+                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                .foregroundStyle(MuxyTheme.accent)
+
+                if !selectedDeviceIDs.isEmpty {
+                    Button("Revoke Selected (\(selectedDeviceIDs.count))", role: .destructive) {
+                        showBatchRevokeConfirmation = true
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                    .foregroundStyle(SettingsStyle.destructive)
+                }
+
+                Spacer()
+
+                Button("Done") {
+                    exitSelection()
+                }
+                .buttonStyle(.borderless)
+                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                .foregroundStyle(MuxyTheme.accent)
+            } else {
+                Spacer()
+                Button("Select") {
+                    isSelecting = true
+                }
+                .buttonStyle(.borderless)
+                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                .foregroundStyle(MuxyTheme.accent)
+            }
+        }
+        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+    }
+
+    private var allDevicesSelected: Bool {
+        !devices.devices.isEmpty && selectedDeviceIDs.count == devices.devices.count
+    }
+
+    private func toggleSelectAll() {
+        if allDevicesSelected {
+            selectedDeviceIDs.removeAll()
+        } else {
+            selectedDeviceIDs = Set(devices.devices.map(\.id))
+        }
+    }
+
+    private func exitSelection() {
+        isSelecting = false
+        selectedDeviceIDs.removeAll()
+    }
+
+    private func toggleSelection(_ device: ApprovedDevice) {
+        if selectedDeviceIDs.contains(device.id) {
+            selectedDeviceIDs.remove(device.id)
+        } else {
+            selectedDeviceIDs.insert(device.id)
+        }
+    }
+
     private func deviceRow(_ device: ApprovedDevice) -> some View {
         HStack {
+            if isSelecting {
+                Image(systemName: selectedDeviceIDs.contains(device.id) ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .foregroundStyle(
+                        selectedDeviceIDs.contains(device.id) ? MuxyTheme.accent : SettingsStyle.mutedForeground
+                    )
+            }
             VStack(alignment: .leading, spacing: 2) {
                 Text(device.name)
                     .font(.system(size: SettingsMetrics.labelFontSize))
@@ -269,15 +365,22 @@ struct MobileSettingsView: View {
                     .foregroundStyle(SettingsStyle.mutedForeground)
             }
             Spacer()
-            Button("Revoke", role: .destructive) {
-                deviceToRevoke = device
+            if !isSelecting {
+                Button("Revoke", role: .destructive) {
+                    deviceToRevoke = device
+                }
+                .buttonStyle(.borderless)
+                .font(.system(size: SettingsMetrics.footnoteFontSize))
+                .foregroundStyle(SettingsStyle.destructive)
             }
-            .buttonStyle(.borderless)
-            .font(.system(size: SettingsMetrics.footnoteFontSize))
-            .foregroundStyle(SettingsStyle.destructive)
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard isSelecting else { return }
+            toggleSelection(device)
+        }
     }
 
     private func lastSeenText(_ device: ApprovedDevice) -> String {

--- a/Tests/MuxyTests/Services/ApprovedDevicesStoreTests.swift
+++ b/Tests/MuxyTests/Services/ApprovedDevicesStoreTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ApprovedDevicesStore", .serialized)
+@MainActor
+struct ApprovedDevicesStoreTests {
+    private let store = ApprovedDevicesStore.shared
+
+    private final class RevokedRecorder {
+        private(set) var ids: [UUID] = []
+        func record(_ id: UUID) { ids.append(id) }
+    }
+
+    private func withSeededDevices(
+        _ count: Int,
+        _ body: ([ApprovedDevice], RevokedRecorder) -> Void
+    ) {
+        let original = store.devices
+        let onRevoke = store.onRevoke
+        defer {
+            store.replaceDevices(original)
+            store.onRevoke = onRevoke
+        }
+
+        store.replaceDevices([])
+        let ids = (0 ..< count).map { _ in UUID() }
+        for (index, id) in ids.enumerated() {
+            store.approve(deviceID: id, name: "Device \(index)", token: "token-\(index)")
+        }
+
+        let recorder = RevokedRecorder()
+        store.onRevoke = { recorder.record($0) }
+        body(store.devices, recorder)
+    }
+
+    @Test("batch revoke removes only the selected devices")
+    func batchRevokeRemovesSelected() {
+        withSeededDevices(3) { seeded, _ in
+            let toRemove: Set<UUID> = [seeded[0].id, seeded[2].id]
+            store.revoke(deviceIDs: toRemove)
+
+            #expect(store.devices.map(\.id) == [seeded[1].id])
+        }
+    }
+
+    @Test("batch revoke fires onRevoke once per removed device")
+    func batchRevokeFiresCallbackPerDevice() {
+        withSeededDevices(3) { seeded, recorder in
+            let toRemove: Set<UUID> = [seeded[0].id, seeded[1].id]
+            store.revoke(deviceIDs: toRemove)
+
+            #expect(Set(recorder.ids) == toRemove)
+            #expect(recorder.ids.count == 2)
+        }
+    }
+
+    @Test("batch revoke with empty set is a no-op")
+    func batchRevokeEmptySetNoOp() {
+        withSeededDevices(2) { seeded, recorder in
+            store.revoke(deviceIDs: [])
+
+            #expect(store.devices.map(\.id) == seeded.map(\.id))
+            #expect(recorder.ids.isEmpty)
+        }
+    }
+
+    @Test("batch revoke ignores unknown ids")
+    func batchRevokeUnknownIDsNoOp() {
+        withSeededDevices(2) { seeded, recorder in
+            store.revoke(deviceIDs: [UUID()])
+
+            #expect(store.devices.map(\.id) == seeded.map(\.id))
+            #expect(recorder.ids.isEmpty)
+        }
+    }
+
+    @Test("single revoke removes exactly one device and fires once")
+    func singleRevokeDelegates() {
+        withSeededDevices(3) { seeded, recorder in
+            store.revoke(deviceID: seeded[1].id)
+
+            #expect(store.devices.map(\.id) == [seeded[0].id, seeded[2].id])
+            #expect(recorder.ids == [seeded[1].id])
+        }
+    }
+}


### PR DESCRIPTION
Adds a selection mode to the Approved Devices list with per-row checkmarks and Select All, so multiple devices can be revoked in one action.
Single-device revoke is unchanged; batch revoke disconnects each device immediately.