### PR TITLE
Fix icon corner radius to match macOS squircle style

### DIFF
--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -266,7 +266,7 @@ struct ExpandedProjectRow: View {
         let unread = NotificationStore.shared.unreadCount(for: project.id)
         let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
-            RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous)
                 .fill(iconBackground(hasLogo: logo != nil))
 
             if project.isHome {
@@ -278,7 +278,7 @@ struct ExpandedProjectRow: View {
                     .resizable()
                     .scaledToFill()
                     .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
-                    .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                    .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous))
             } else if let iconName = project.icon {
                 Image(systemName: iconName)
                     .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -214,7 +214,7 @@ struct ProjectRow: View {
         let unread = NotificationStore.shared.unreadCount(for: project.id)
         let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
-            RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous)
                 .fill(iconBackground(hasLogo: logo != nil))
 
             if project.isHome {
@@ -226,7 +226,7 @@ struct ProjectRow: View {
                     .resizable()
                     .scaledToFill()
                     .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
-                    .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+                    .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous))
             } else if let iconName = project.icon {
                 Image(systemName: iconName)
                     .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))
@@ -251,7 +251,7 @@ struct ProjectRow: View {
             }
         }
         .overlay {
-            RoundedRectangle(cornerRadius: UIMetrics.scaled(11))
+            RoundedRectangle(cornerRadius: UIMetrics.radiusMD + UIMetrics.scaled(3), style: .continuous)
                 .strokeBorder(isActive ? MuxyTheme.accent : .clear, lineWidth: 1.5)
                 .animation(.easeInOut(duration: 0.15), value: isActive)
         }


### PR DESCRIPTION
Use `style: .continuous` on project icon `RoundedRectangle` shapes so corners match the macOS app icon squircle curve. Also corrects the active selection border radius from `scaled(11)` to `radiusMD + scaled(3)` so it sits proportionally parallel to the icon it wraps.

<!-- screenshot -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)