### PR TITLE
Fix: allow removing stale dev-extension load errors

### DIFF
--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -43,6 +43,7 @@ final class ExtensionStore {
         let id = UUID()
         let directory: URL
         let message: String
+        var devSourcePath: String?
     }
 
     private(set) var statuses: [ExtensionStatus] = []
@@ -751,7 +752,8 @@ final class ExtensionStore {
             guard !seenIDs.contains(ext.id) else {
                 loadFailures.append(LoadFailure(
                     directory: url,
-                    message: ExtensionLoadError.duplicateName(ext.id).localizedDescription
+                    message: ExtensionLoadError.duplicateName(ext.id).localizedDescription,
+                    devSourcePath: devSourcePath
                 ))
                 return
             }
@@ -769,7 +771,8 @@ final class ExtensionStore {
         } catch {
             loadFailures.append(LoadFailure(
                 directory: url,
-                message: error.localizedDescription
+                message: error.localizedDescription,
+                devSourcePath: devSourcePath
             ))
             logger.error("Failed to load extension at \(url.path): \(error.localizedDescription)")
         }

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -265,7 +265,10 @@ private struct ExtensionsListPage: View {
             VStack(alignment: .leading, spacing: 14) {
                 developmentBanner
                 if !store.loadFailures.isEmpty {
-                    LoadFailuresBlock(failures: store.loadFailures)
+                    LoadFailuresBlock(
+                        failures: store.loadFailures,
+                        onRemoveDevPath: { store.removeDevPath($0) }
+                    )
                 }
                 if store.statuses.isEmpty {
                     emptyState
@@ -340,6 +343,7 @@ private struct ExtensionsListPage: View {
 
 private struct LoadFailuresBlock: View {
     let failures: [ExtensionStore.LoadFailure]
+    let onRemoveDevPath: (String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -351,13 +355,27 @@ private struct LoadFailuresBlock: View {
                     .foregroundStyle(MuxyTheme.fg)
             }
             ForEach(failures) { failure in
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(failure.directory.lastPathComponent)
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(MuxyTheme.diffRemoveFg)
-                    Text(failure.message)
-                        .font(.system(size: 11))
-                        .foregroundStyle(MuxyTheme.fgMuted)
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(failure.directory.lastPathComponent)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(MuxyTheme.diffRemoveFg)
+                        Text(failure.message)
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuxyTheme.fgMuted)
+                    }
+                    Spacer(minLength: 0)
+                    if let devSourcePath = failure.devSourcePath {
+                        Button {
+                            onRemoveDevPath(devSourcePath)
+                        } label: {
+                            Text("Remove")
+                                .font(.system(size: 11))
+                                .foregroundStyle(MuxyTheme.diffRemoveFg)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Stop loading this dev extension. Your folder is left untouched.")
+                    }
                 }
             }
         }

--- a/Tests/MuxyTests/Services/ExtensionStoreDevPathTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreDevPathTests.swift
@@ -62,6 +62,37 @@ struct ExtensionStoreDevPathTests {
         #expect(!store.loadFailures.isEmpty)
     }
 
+    @Test("a failed dev path load carries its source path so it can be removed")
+    func failedDevPathLoadCarriesSourcePath() throws {
+        let root = try makeRoot()
+        let devParent = try makeRoot()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: devParent)
+        }
+        let missing = devParent.appendingPathComponent("does-not-exist")
+
+        let store = makeStore(root: root, devPaths: [missing.path])
+        store.startAll()
+
+        let failure = try #require(store.loadFailures.first)
+        #expect(failure.devSourcePath == missing.path)
+    }
+
+    @Test("a failed root extension load is not removable as a dev path")
+    func failedRootLoadHasNoDevSourcePath() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let broken = root.appendingPathComponent("broken")
+        try FileManager.default.createDirectory(at: broken, withIntermediateDirectories: true)
+
+        let store = makeStore(root: root, devPaths: [])
+        store.startAll()
+
+        let failure = try #require(store.loadFailures.first)
+        #expect(failure.devSourcePath == nil)
+    }
+
     private func makeRoot() throws -> URL {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("exts-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)


### PR DESCRIPTION
Failed dev-path loads stayed registered, so their errors persisted on every reload with no way to dismiss them.
  The Load Errors block now shows a Remove button on dev-path failures that drops the path from the store (folder
  untouched).