### PR TITLE
Add optional checks flag to git.pr.list (lighter query for extensions, avoids 504)

### DIFF
--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -504,20 +504,29 @@ struct GitRepositoryService {
         case all
     }
 
+    static func pullRequestListJSONFields(includeChecks: Bool) -> String {
+        var fields = [
+            "number", "title", "author",
+            "headRefName", "headRefOid", "baseRefName",
+            "state", "isDraft", "url", "updatedAt",
+            "mergeable", "mergeStateStatus",
+        ]
+        if includeChecks {
+            fields.append("statusCheckRollup")
+        }
+        return fields.joined(separator: ",")
+    }
+
     func listPullRequests(
         repoPath: String,
         filter: PRListFilter = .open,
-        limit: Int = 100
+        limit: Int = 100,
+        includeChecks: Bool = true
     ) async throws -> [PRListItem] {
         guard let ghPath = GitProcessRunner.resolveExecutable("gh") else {
             throw PRCreateError.ghNotInstalled
         }
-        let jsonFields = [
-            "number", "title", "author",
-            "headRefName", "headRefOid", "baseRefName",
-            "state", "isDraft", "url", "updatedAt",
-            "statusCheckRollup", "mergeable", "mergeStateStatus",
-        ].joined(separator: ",")
+        let jsonFields = Self.pullRequestListJSONFields(includeChecks: includeChecks)
         let arguments = [
             "pr", "list",
             "--state", filter.rawValue,

--- a/Muxy/Services/MuxyAPIDispatcher.swift
+++ b/Muxy/Services/MuxyAPIDispatcher.swift
@@ -428,6 +428,7 @@ enum MuxyAPIDispatcher {
                 projectIdentifier: project,
                 filter: prListFilter(args["filter"] as? String),
                 limit: intArg(args, "limit") ?? 100,
+                includeChecks: boolArg(args, "checks") ?? true,
                 context: git
             )).map(GitDTO.prListItem)
         case "git.worktrees":
@@ -737,6 +738,12 @@ enum MuxyAPIDispatcher {
     private static func intArg(_ args: [String: Any], _ key: String) -> Int? {
         if let value = args[key] as? Int { return value }
         if let value = args[key] as? NSNumber { return value.intValue }
+        return nil
+    }
+
+    private static func boolArg(_ args: [String: Any], _ key: String) -> Bool? {
+        if let value = args[key] as? Bool { return value }
+        if let value = args[key] as? NSNumber { return value.boolValue }
         return nil
     }
 

--- a/Muxy/Services/MuxyAPIGit.swift
+++ b/Muxy/Services/MuxyAPIGit.swift
@@ -204,13 +204,15 @@ extension MuxyAPI {
             projectIdentifier: String?,
             filter: GitRepositoryService.PRListFilter,
             limit: Int,
+            includeChecks: Bool,
             context: Context
         ) async -> Result<[GitRepositoryService.PRListItem], APIError> {
             await read(projectIdentifier, context) { repoPath, git in
                 try await git.listPullRequests(
                     repoPath: repoPath,
                     filter: filter,
-                    limit: min(max(limit, 1), maxPRListLimit)
+                    limit: min(max(limit, 1), maxPRListLimit),
+                    includeChecks: includeChecks
                 )
             }
         }

--- a/Muxy/Views/Extensions/ExtensionWebBridge.swift
+++ b/Muxy/Views/Extensions/ExtensionWebBridge.swift
@@ -383,6 +383,7 @@ enum ExtensionWebBridge {
                             project: gitProject(o),
                             filter: (o || {}).filter == null ? null : String(o.filter),
                             limit: (o || {}).limit == null ? null : Number(o.limit),
+                            checks: (o || {}).checks == null ? null : Boolean(o.checks),
                         }); },
                         create(o) { return send('git.pr.create', {
                             project: gitProject(o),

--- a/MuxyShared/ExtensionBridgeJS.swift
+++ b/MuxyShared/ExtensionBridgeJS.swift
@@ -297,6 +297,7 @@ public enum ExtensionBridgeJS {
                         project: gitProject(o),
                         filter: (o || {}).filter == null ? null : String(o.filter),
                         limit: (o || {}).limit == null ? null : Number(o.limit),
+                        checks: (o || {}).checks == null ? null : Boolean(o.checks),
                     }),
                     create: (o) => dispatch('git.pr.create', {
                         project: gitProject(o),

--- a/Tests/MuxyTests/Git/PullRequestListFieldsTests.swift
+++ b/Tests/MuxyTests/Git/PullRequestListFieldsTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("PullRequestList JSON fields")
+struct PullRequestListFieldsTests {
+    @Test("excludes statusCheckRollup when checks are disabled")
+    func excludesChecks() {
+        let fields = GitRepositoryService.pullRequestListJSONFields(includeChecks: false)
+        #expect(!fields.contains("statusCheckRollup"))
+        #expect(fields.contains("number"))
+        #expect(fields.contains("headRefName"))
+    }
+
+    @Test("includes statusCheckRollup when checks are enabled")
+    func includesChecks() {
+        let fields = GitRepositoryService.pullRequestListJSONFields(includeChecks: true)
+        #expect(fields.contains("statusCheckRollup"))
+    }
+}

--- a/docs/extensions/git.md
+++ b/docs/extensions/git.md
@@ -106,9 +106,10 @@ await muxy.git.pr.info();                                  // PR for the current
 await muxy.git.pr.number();                                // just the PR number for the current branch, or null
 await muxy.git.pr.diff({ number: 42 });                    // { diff: "<unified diff text>", truncated }
 await muxy.git.pr.list({ filter: "open", limit: 50 });     // filter: open | closed | merged | all
+await muxy.git.pr.list({ checks: false });                 // skip CI checks for a lighter, faster query
 ```
 
-`pr.number` is a cheap way to learn whether the current branch has a PR without fetching its full status. `pr.diff` fetches the PR head and returns the raw diff against its merge base. All require the GitHub CLI (`gh`) to be installed and authenticated.
+`pr.number` is a cheap way to learn whether the current branch has a PR without fetching its full status. `pr.diff` fetches the PR head and returns the raw diff against its merge base. `pr.list` includes each PR's CI `checks` by default; pass `checks: false` to drop the `statusCheckRollup` field, which makes the underlying query much lighter and avoids GitHub timeouts (504) on large repositories. All require the GitHub CLI (`gh`) to be installed and authenticated.
 
 ### `muxy.git.worktrees(opts?)`
 


### PR DESCRIPTION
## Summary

`muxy.git.pr.list` always requested the `statusCheckRollup` field from `gh`, which makes the
GraphQL query heavy enough that GitHub returns HTTP 504 on large repositories. This adds an
optional `checks` flag so callers can request a lighter, faster list when they don't need CI
status. Default behavior is unchanged.

This is needed by an extension that builds a custom sidebar listing each worktree's PRs: it calls
`git.pr.list` per project, and the 504s currently break that use case.

## Changes

- Add a `checks` option to `git.pr.list` (default `true`).
- When `checks: false`, drop `statusCheckRollup` from the `gh pr list` fields → lighter query, no 504.
- Extract the field list into `GitRepositoryService.pullRequestListJSONFields(includeChecks:)`.
- Thread the flag through `MuxyAPIGit`, `MuxyAPIDispatcher`, and both JS bridges.
- Document `pr.list({ checks })` in `docs/extensions/git.md`.
- Add a unit test for the field selection.

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS