### PR TITLE
fix: terminate opencode notification payload with newline

### DIFF
--- a/Muxy/Resources/scripts/opencode-muxy-plugin.js
+++ b/Muxy/Resources/scripts/opencode-muxy-plugin.js
@@ -66,7 +66,7 @@ function consumeRecentReply(sessionID) {
 }
 
 async function sendNotification(socketPath, paneID, body) {
-  const payload = `opencode|${paneID}|OpenCode|${sanitize(body)}`
+  const payload = `opencode|${paneID}|OpenCode|${sanitize(body)}\n`
   try {
     const { createConnection } = await import("net")
     const conn = createConnection({ path: socketPath })


### PR DESCRIPTION
## Summary

The notification socket server reads newline-delimited messages and drops any trailing partial line when the client disconnects.

Append a trailing newline so the server processes the message instead of dropping it on close.


## Changes

Append a trailing newline so the server processes the message instead of dropping it on close.

## Testing

Tested by updating the plugin and testing that it works

- [X] `scripts/checks.sh` passes
- [X] Tested manually on macOS