### PR TITLE
Add configurable project sorting and running indicator

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -176,11 +176,13 @@ final class AppState {
     }
 
     func selectProject(_ project: Project, worktree: Worktree) {
+        let wasActive = activeProjectID == project.id
         dispatch(.selectProject(
             projectID: project.id,
             worktreeID: worktree.id,
             worktreePath: worktree.path
         ))
+        guard !wasActive else { return }
         onProjectSelected?(project.id)
     }
 

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -62,6 +62,7 @@ final class AppState {
     private let terminalViews: any TerminalViewRemoving
     private let workspacePersistence: any WorkspacePersisting
     var onProjectsEmptied: (([UUID]) -> Void)?
+    var onProjectSelected: ((UUID) -> Void)?
 
     var activeProjectID: UUID?
 
@@ -180,6 +181,7 @@ final class AppState {
             worktreeID: worktree.id,
             worktreePath: worktree.path
         ))
+        onProjectSelected?(project.id)
     }
 
     func selectWorktree(projectID: UUID, worktree: Worktree) {

--- a/Muxy/Models/Project.swift
+++ b/Muxy/Models/Project.swift
@@ -6,6 +6,7 @@ struct Project: Identifiable, Codable, Hashable {
     var path: String
     var sortOrder: Int
     var createdAt: Date
+    var lastActiveAt: Date?
     var icon: String?
     var logo: String?
     var iconColor: String?
@@ -27,6 +28,7 @@ struct Project: Identifiable, Codable, Hashable {
         self.path = path
         self.sortOrder = sortOrder
         self.createdAt = Date()
+        self.lastActiveAt = nil
         self.icon = nil
         self.logo = nil
         self.iconColor = nil
@@ -45,6 +47,7 @@ struct Project: Identifiable, Codable, Hashable {
         path = try container.decode(String.self, forKey: .path)
         sortOrder = try container.decode(Int.self, forKey: .sortOrder)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
+        lastActiveAt = try container.decodeIfPresent(Date.self, forKey: .lastActiveAt)
         icon = try container.decodeIfPresent(String.self, forKey: .icon)
         logo = try container.decodeIfPresent(String.self, forKey: .logo)
         iconColor = try container.decodeIfPresent(String.self, forKey: .iconColor)

--- a/Muxy/Models/ProjectSortMode.swift
+++ b/Muxy/Models/ProjectSortMode.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+enum ProjectSortMode: String, CaseIterable, Identifiable {
+    case manual
+    case nameAscending
+    case nameDescending
+    case recentlyActive
+    case dateCreated
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .manual: "Manual"
+        case .nameAscending: "Name (A–Z)"
+        case .nameDescending: "Name (Z–A)"
+        case .recentlyActive: "Recently Active"
+        case .dateCreated: "Date Added"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .manual: "hand.draw"
+        case .nameAscending: "textformat.abc"
+        case .nameDescending: "textformat.abc.dottedunderline"
+        case .recentlyActive: "clock.arrow.circlepath"
+        case .dateCreated: "calendar"
+        }
+    }
+
+    static let storageKey = "muxy.projectSortMode"
+    static let defaultValue: ProjectSortMode = .manual
+
+    static var current: ProjectSortMode {
+        guard let raw = UserDefaults.standard.string(forKey: storageKey),
+              let mode = ProjectSortMode(rawValue: raw)
+        else { return defaultValue }
+        return mode
+    }
+
+    func sorted(_ projects: [Project]) -> [Project] {
+        switch self {
+        case .manual:
+            projects
+        case .nameAscending:
+            projects.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+        case .nameDescending:
+            projects.sorted { $0.name.localizedStandardCompare($1.name) == .orderedDescending }
+        case .recentlyActive:
+            projects.sorted { lhs, rhs in
+                switch (lhs.lastActiveAt, rhs.lastActiveAt) {
+                case let (l?, r?): l > r
+                case (_?, nil): true
+                case (nil, _?): false
+                case (nil, nil): lhs.sortOrder < rhs.sortOrder
+                }
+            }
+        case .dateCreated:
+            projects.sorted { $0.createdAt < $1.createdAt }
+        }
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -145,6 +145,9 @@ struct MuxyApp: App {
                     projectStore.onProjectRemoved = { [projectGroupStore] projectID in
                         projectGroupStore.removeProjectFromAllGroups(projectID: projectID)
                     }
+                    appState.onProjectSelected = { [projectStore] projectID in
+                        projectStore.markActive(id: projectID)
+                    }
                 }
         }
         .windowStyle(HiddenTitleBarWindowStyle())

--- a/Muxy/Services/ProjectGroupStore.swift
+++ b/Muxy/Services/ProjectGroupStore.swift
@@ -74,9 +74,9 @@ final class ProjectGroupStore {
         activeGroup?.type == .ssh
     }
 
-    func displayProjects(localProjects: [Project]) -> [Project] {
+    func displayProjects(localProjects: [Project], sortMode: ProjectSortMode = .current) -> [Project] {
         guard let group = activeGroup, group.type == .ssh else {
-            return filteredProjects(from: localProjects)
+            return sortMode.sorted(filteredProjects(from: localProjects))
         }
         return group.remoteProjects.enumerated().map { index, remote in
             remote.asProject(workspaceID: group.id, sortOrder: index)

--- a/Muxy/Services/ProjectStore.swift
+++ b/Muxy/Services/ProjectStore.swift
@@ -70,6 +70,21 @@ final class ProjectStore {
         save()
     }
 
+    func markActive(id: UUID) {
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
+        storedProjects[index].lastActiveAt = Date()
+        save()
+    }
+
+    func persistOrder(_ orderedIDs: [UUID]) {
+        let positions = Dictionary(uniqueKeysWithValues: orderedIDs.enumerated().map { ($1, $0) })
+        storedProjects.sort { positions[$0.id, default: Int.max] < positions[$1.id, default: Int.max] }
+        for index in storedProjects.indices {
+            storedProjects[index].sortOrder = index
+        }
+        save()
+    }
+
     func reorder(fromOffsets source: IndexSet, toOffset destination: Int) {
         storedProjects.move(fromOffsets: source, toOffset: destination)
         for index in storedProjects.indices {

--- a/Muxy/Services/TerminalProgressStore.swift
+++ b/Muxy/Services/TerminalProgressStore.swift
@@ -76,4 +76,8 @@ final class TerminalProgressStore {
     func hasCompletionPending(for projectID: UUID) -> Bool {
         completionPending.contains { paneToProject[$0] == projectID }
     }
+
+    func hasActiveProgress(for projectID: UUID) -> Bool {
+        progresses.keys.contains { paneToProject[$0] == projectID }
+    }
 }

--- a/Muxy/Views/Settings/ProjectsSettingsView.swift
+++ b/Muxy/Views/Settings/ProjectsSettingsView.swift
@@ -8,6 +8,8 @@ struct ProjectsSettingsView: View {
     private var keepProjectsOpenWhenNoTabs = false
     @AppStorage(ProjectPickerPreferences.storageKey)
     private var projectPickerModeRaw = ProjectPickerMode.custom.rawValue
+    @AppStorage(ProjectSortMode.storageKey)
+    private var projectSortModeRaw = ProjectSortMode.defaultValue.rawValue
     @State private var projectPickerDefaultLocationSettings = ProjectPickerDefaultLocationSettingsModel()
 
     var body: some View {
@@ -31,6 +33,16 @@ struct ProjectsSettingsView: View {
                         model: projectPickerDefaultLocationSettings,
                         pickerModeRaw: projectPickerModeRaw
                     )
+                }
+
+                SettingsRow("Sort Projects By") {
+                    Picker("", selection: $projectSortModeRaw) {
+                        ForEach(ProjectSortMode.allCases) { mode in
+                            Text(mode.title).tag(mode.rawValue)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
                 }
 
                 SettingsToggleRow(

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -232,17 +232,12 @@ struct Sidebar: View {
                 }
             }
         } else {
-            VStack(spacing: UIMetrics.spacing3) {
-                WorkspaceSwitcher(isWide: isWide)
-                if showSortMenu {
-                    sortMenu
-                }
-            }
+            WorkspaceSwitcher(isWide: isWide)
         }
     }
 
     private var showSortMenu: Bool {
-        !projectGroupStore.isRemoteWorkspaceActive && !displayedProjects.isEmpty
+        isWide && !projectGroupStore.isRemoteWorkspaceActive && !displayedProjects.isEmpty
     }
 
     private var projectList: some View {
@@ -570,10 +565,10 @@ private enum SortMenuButton {
             Image(systemName: "arrow.up.arrow.down")
                 .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
-                .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .background(
                     hovered ? MuxyTheme.hover : MuxyTheme.surface,
-                    in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
+                    in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                 )
                 .onHover { hovered = $0 }
                 .accessibilityLabel("Sort Projects")

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -54,6 +54,7 @@ struct Sidebar: View {
     @AppStorage(SidebarExpandedStyle.storageKey) private var expandedStyleRaw = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
     @AppStorage(SidebarSelection.storageKey) private var activeSidebarRaw = SidebarSelection.builtinValue
+    @AppStorage(ProjectSortMode.storageKey) private var sortModeRaw = ProjectSortMode.defaultValue.rawValue
 
     private var activeExtensionSidebarID: String? {
         SidebarSelection.resolvedExtensionID(from: activeSidebarRaw, store: extensionStore)
@@ -149,6 +150,23 @@ struct Sidebar: View {
         }
     }
 
+    private var sortMenu: some View {
+        Menu {
+            Picker("Sort Projects By", selection: $sortModeRaw) {
+                ForEach(ProjectSortMode.allCases) { mode in
+                    Label(mode.title, systemImage: mode.systemImage).tag(mode.rawValue)
+                }
+            }
+            .pickerStyle(.inline)
+        } label: {
+            SortMenuButton.Label(mode: sortMode)
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .help("Sort Projects: \(sortMode.title)")
+    }
+
     private var remoteProjectMenu: some View {
         Menu {
             let devices = remoteDeviceStore.sshDevices()
@@ -197,15 +215,49 @@ struct Sidebar: View {
         return Project.home
     }
 
+    private var sortMode: ProjectSortMode {
+        ProjectSortMode(rawValue: sortModeRaw) ?? .defaultValue
+    }
+
     private var displayedProjects: [Project] {
-        projectGroupStore.displayProjects(localProjects: projectStore.storedProjects)
+        projectGroupStore.displayProjects(localProjects: projectStore.storedProjects, sortMode: sortMode)
+    }
+
+    @ViewBuilder private var listHeader: some View {
+        if isWide {
+            HStack(spacing: UIMetrics.spacing2) {
+                WorkspaceSwitcher(isWide: isWide)
+                if showSortMenu {
+                    sortMenu
+                }
+            }
+        } else {
+            VStack(spacing: UIMetrics.spacing3) {
+                WorkspaceSwitcher(isWide: isWide)
+                if showSortMenu {
+                    sortMenu
+                }
+            }
+        }
+    }
+
+    private var showSortMenu: Bool {
+        !projectGroupStore.isRemoteWorkspaceActive && !displayedProjects.isEmpty
     }
 
     private var projectList: some View {
+        VStack(spacing: UIMetrics.spacing3) {
+            listHeader
+                .padding(.horizontal, isWide ? UIMetrics.spacing3 : UIMetrics.spacing4)
+                .padding(.top, UIMetrics.spacing2)
+
+            scrollableProjects
+        }
+    }
+
+    private var scrollableProjects: some View {
         ScrollView(.vertical, showsIndicators: false) {
             LazyVStack(spacing: UIMetrics.spacing3) {
-                WorkspaceSwitcher(isWide: isWide)
-
                 if let homeProject {
                     projectRow(for: homeProject, shortcutIndex: 1)
                 }
@@ -228,7 +280,7 @@ struct Sidebar: View {
                 addButton
             }
             .padding(.horizontal, isWide ? UIMetrics.spacing3 : UIMetrics.spacing4)
-            .padding(.vertical, UIMetrics.spacing2)
+            .padding(.bottom, UIMetrics.spacing2)
             .onPreferenceChange(UUIDFramePreferenceKey<SidebarFrameTag>.self) { frames in
                 guard dragState.draggedID != nil else { return }
                 dragState.frames = frames
@@ -314,6 +366,7 @@ struct Sidebar: View {
         DragGesture(minimumDistance: 6, coordinateSpace: .named("sidebar"))
             .onChanged { value in
                 if dragState.draggedID == nil {
+                    switchToManualSortIfNeeded()
                     dragState.draggedID = project.id
                     dragState.lastReorderTargetID = nil
                 }
@@ -387,6 +440,13 @@ struct Sidebar: View {
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "OK")
         alert.runModal()
+    }
+
+    private func switchToManualSortIfNeeded() {
+        guard sortMode != .manual else { return }
+        guard !projectGroupStore.isRemoteWorkspaceActive else { return }
+        projectStore.persistOrder(displayedProjects.map(\.id))
+        sortModeRaw = ProjectSortMode.manual.rawValue
     }
 
     private func reorderIfNeeded(at location: CGPoint) {
@@ -497,6 +557,26 @@ private struct AddProjectButton: View {
             }
             .padding(UIMetrics.spacing2)
             .background(hovered ? MuxyTheme.hover : Color.clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
+        }
+    }
+}
+
+private enum SortMenuButton {
+    struct Label: View {
+        let mode: ProjectSortMode
+        @State private var hovered = false
+
+        var body: some View {
+            Image(systemName: "arrow.up.arrow.down")
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
+                .background(
+                    hovered ? MuxyTheme.hover : MuxyTheme.surface,
+                    in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
+                )
+                .onHover { hovered = $0 }
+                .accessibilityLabel("Sort Projects")
         }
     }
 }

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -289,6 +289,7 @@ struct ExpandedProjectRow: View {
     private var projectIcon: some View {
         let logo = resolvedLogo
         let unread = NotificationStore.shared.unreadCount(for: project.id)
+        let isRunning = TerminalProgressStore.shared.hasActiveProgress(for: project.id)
         let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
             RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous)
@@ -319,6 +320,10 @@ struct ExpandedProjectRow: View {
             if unread > 0 {
                 NotificationBadge(count: unread)
                     .offset(x: UIMetrics.spacing2, y: -UIMetrics.spacing2)
+            } else if isRunning {
+                ProgressView()
+                    .controlSize(.mini)
+                    .offset(x: UIMetrics.spacing1, y: -UIMetrics.spacing1)
             } else if hasCompletion {
                 Circle()
                     .fill(MuxyTheme.accent)

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -215,6 +215,7 @@ struct ProjectRow: View {
     private var projectIcon: some View {
         let logo = resolvedLogo
         let unread = NotificationStore.shared.unreadCount(for: project.id)
+        let isRunning = TerminalProgressStore.shared.hasActiveProgress(for: project.id)
         let hasCompletion = TerminalProgressStore.shared.hasCompletionPending(for: project.id)
         return ZStack {
             RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous)
@@ -246,6 +247,10 @@ struct ProjectRow: View {
             if unread > 0 {
                 NotificationBadge(count: unread)
                     .offset(x: UIMetrics.spacing2, y: -UIMetrics.spacing2)
+            } else if isRunning {
+                ProgressView()
+                    .controlSize(.mini)
+                    .offset(x: UIMetrics.spacing1, y: -UIMetrics.spacing1)
             } else if hasCompletion {
                 Circle()
                     .fill(MuxyTheme.accent)

--- a/Muxy/Views/Sidebar/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Sidebar/WorkspaceSwitcher.swift
@@ -92,7 +92,7 @@ struct WorkspaceSwitcher: View {
                     .foregroundStyle(MuxyTheme.fgMuted)
             }
             .padding(.horizontal, UIMetrics.spacing4)
-            .padding(.vertical, UIMetrics.spacing3)
+            .frame(height: UIMetrics.controlMedium)
             .background(
                 isTriggerHovered ? MuxyTheme.hover : MuxyTheme.surface,
                 in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)

--- a/Tests/MuxyTests/Models/AppStateSelectProjectTests.swift
+++ b/Tests/MuxyTests/Models/AppStateSelectProjectTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("AppState.selectProject")
+@MainActor
+struct AppStateSelectProjectTests {
+    @Test("selecting a new project notifies onProjectSelected")
+    func notifiesOnNewSelection() {
+        let project = Project(name: "api", path: "/tmp/api")
+        let worktree = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let appState = makeAppState()
+        var selected: [UUID] = []
+        appState.onProjectSelected = { selected.append($0) }
+
+        appState.selectProject(project, worktree: worktree)
+
+        #expect(selected == [project.id])
+    }
+
+    @Test("reselecting the active project does not notify again")
+    func skipsNotificationWhenAlreadyActive() {
+        let project = Project(name: "api", path: "/tmp/api")
+        let worktree = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let appState = makeAppState()
+        var selected: [UUID] = []
+        appState.onProjectSelected = { selected.append($0) }
+
+        appState.selectProject(project, worktree: worktree)
+        appState.selectProject(project, worktree: worktree)
+
+        #expect(selected == [project.id])
+    }
+
+    private func makeAppState() -> AppState {
+        AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for paneID: UUID) {}
+    func needsConfirmQuit(for paneID: UUID) -> Bool { false }
+}

--- a/Tests/MuxyTests/Models/ProjectSortModeTests.swift
+++ b/Tests/MuxyTests/Models/ProjectSortModeTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProjectSortMode")
+struct ProjectSortModeTests {
+    private func project(_ name: String, sortOrder: Int = 0, createdAt: Date = Date(), lastActiveAt: Date? = nil) -> Project {
+        var project = Project(name: name, path: "/tmp/\(name)", sortOrder: sortOrder)
+        project.createdAt = createdAt
+        project.lastActiveAt = lastActiveAt
+        return project
+    }
+
+    @Test("manual preserves the given order")
+    func manualPreservesOrder() {
+        let input = [project("B", sortOrder: 0), project("A", sortOrder: 1)]
+        #expect(ProjectSortMode.manual.sorted(input).map(\.name) == ["B", "A"])
+    }
+
+    @Test("name ascending uses natural ordering")
+    func nameAscendingNaturalOrder() {
+        let input = [project("repo10"), project("repo2"), project("Repo1")]
+        #expect(ProjectSortMode.nameAscending.sorted(input).map(\.name) == ["Repo1", "repo2", "repo10"])
+    }
+
+    @Test("name descending reverses natural ordering")
+    func nameDescendingNaturalOrder() {
+        let input = [project("Repo1"), project("repo10"), project("repo2")]
+        #expect(ProjectSortMode.nameDescending.sorted(input).map(\.name) == ["repo10", "repo2", "Repo1"])
+    }
+
+    @Test("recently active orders newest first with nils last")
+    func recentlyActiveOrdersByTimestamp() {
+        let old = Date(timeIntervalSince1970: 1000)
+        let recent = Date(timeIntervalSince1970: 2000)
+        let input = [
+            project("Never", sortOrder: 0, lastActiveAt: nil),
+            project("Old", sortOrder: 1, lastActiveAt: old),
+            project("Recent", sortOrder: 2, lastActiveAt: recent),
+        ]
+        #expect(ProjectSortMode.recentlyActive.sorted(input).map(\.name) == ["Recent", "Old", "Never"])
+    }
+
+    @Test("recently active breaks ties by sortOrder when both nil")
+    func recentlyActiveBreaksNilTies() {
+        let input = [project("Second", sortOrder: 1), project("First", sortOrder: 0)]
+        #expect(ProjectSortMode.recentlyActive.sorted(input).map(\.name) == ["First", "Second"])
+    }
+
+    @Test("date created orders oldest first")
+    func dateCreatedOrdersByCreation() {
+        let older = Date(timeIntervalSince1970: 1000)
+        let newer = Date(timeIntervalSince1970: 2000)
+        let input = [project("Newer", createdAt: newer), project("Older", createdAt: older)]
+        #expect(ProjectSortMode.dateCreated.sorted(input).map(\.name) == ["Older", "Newer"])
+    }
+}

--- a/Tests/MuxyTests/Services/ProjectSidebarDropHandlerTests.swift
+++ b/Tests/MuxyTests/Services/ProjectSidebarDropHandlerTests.swift
@@ -26,7 +26,7 @@ struct ProjectSidebarDropHandlerTests {
             )
         }
 
-        await Task.yield()
+        await waitUntil { projectStore.storedProjects.count == 1 }
 
         #expect(consumed)
         #expect(projectStore.storedProjects.count == 1)
@@ -43,11 +43,13 @@ struct ProjectSidebarDropHandlerTests {
         defer { try? FileManager.default.removeItem(at: directory) }
         let project = Project(name: directory.lastPathComponent, path: directory.standardizedFileURL.path)
         projectStore.add(project)
+        var handled = false
 
         let consumed = ProjectSidebarDropHandler.handle(
             providers: [FileURLItemProviderStub(item: directory as NSURL)]
         ) { path in
-            ProjectOpenService.confirmProjectPathResult(
+            handled = true
+            return ProjectOpenService.confirmProjectPathResult(
                 path,
                 appState: appState,
                 projectStore: projectStore,
@@ -56,7 +58,7 @@ struct ProjectSidebarDropHandlerTests {
             )
         }
 
-        await Task.yield()
+        await waitUntil { handled }
 
         #expect(consumed)
         #expect(projectStore.storedProjects.count == 1)
@@ -71,10 +73,12 @@ struct ProjectSidebarDropHandlerTests {
         try Data().write(to: file)
         defer { try? FileManager.default.removeItem(at: file) }
 
+        var handled = false
         let consumed = ProjectSidebarDropHandler.handle(
             providers: [FileURLItemProviderStub(item: file as NSURL)]
         ) { path in
-            ProjectOpenService.confirmProjectPathResult(
+            handled = true
+            return ProjectOpenService.confirmProjectPathResult(
                 path,
                 appState: appState,
                 projectStore: projectStore,
@@ -83,7 +87,7 @@ struct ProjectSidebarDropHandlerTests {
             )
         }
 
-        await Task.yield()
+        await waitUntil { handled }
 
         #expect(consumed)
         #expect(projectStore.storedProjects.isEmpty)
@@ -102,7 +106,7 @@ struct ProjectSidebarDropHandlerTests {
             return .success
         }
 
-        await Task.yield()
+        await waitUntil { receivedPath != nil }
 
         #expect(consumed)
         #expect(receivedPath == directory.path(percentEncoded: false))
@@ -123,8 +127,7 @@ struct ProjectSidebarDropHandlerTests {
             return .success
         }
 
-        await Task.yield()
-        await Task.yield()
+        await waitUntil { paths.count == 2 }
 
         #expect(consumed)
         #expect(paths == [
@@ -133,6 +136,13 @@ struct ProjectSidebarDropHandlerTests {
         ])
         #expect(first.loadCount == 1)
         #expect(second.loadCount == 1)
+    }
+
+    private func waitUntil(_ condition: () -> Bool, attempts: Int = 100) async {
+        for _ in 0 ..< attempts {
+            if condition() { return }
+            await Task.yield()
+        }
     }
 }
 

--- a/Tests/MuxyTests/Services/ProjectStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectStoreTests.swift
@@ -75,6 +75,45 @@ struct ProjectStoreTests {
 
         #expect(store.projects.contains { $0.isHome })
     }
+
+    @Test("markActive stamps lastActiveAt and persists")
+    func markActiveStampsTimestamp() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let store = ProjectStore(persistence: persistence)
+
+        #expect(store.storedProjects.first?.lastActiveAt == nil)
+
+        store.markActive(id: project.id)
+
+        #expect(store.storedProjects.first?.lastActiveAt != nil)
+        #expect(persistence.projects.first?.lastActiveAt != nil)
+    }
+
+    @Test("markActive ignores unknown ids")
+    func markActiveIgnoresUnknown() {
+        let persistence = ProjectPersistenceStub(initial: [Project(name: "Repo", path: "/tmp/repo")])
+        let store = ProjectStore(persistence: persistence)
+
+        store.markActive(id: UUID())
+
+        #expect(store.storedProjects.first?.lastActiveAt == nil)
+    }
+
+    @Test("persistOrder rewrites sortOrder to match the given order")
+    func persistOrderRewritesSortOrder() {
+        let first = Project(name: "A", path: "/tmp/a", sortOrder: 0)
+        let second = Project(name: "B", path: "/tmp/b", sortOrder: 1)
+        let third = Project(name: "C", path: "/tmp/c", sortOrder: 2)
+        let persistence = ProjectPersistenceStub(initial: [first, second, third])
+        let store = ProjectStore(persistence: persistence)
+
+        store.persistOrder([third.id, first.id, second.id])
+
+        #expect(store.storedProjects.map(\.id) == [third.id, first.id, second.id])
+        #expect(store.storedProjects.map(\.sortOrder) == [0, 1, 2])
+        #expect(persistence.projects.map(\.id) == [third.id, first.id, second.id])
+    }
 }
 
 private final class ProjectPersistenceStub: ProjectPersisting {

--- a/Tests/MuxyTests/Services/TerminalProgressStoreTests.swift
+++ b/Tests/MuxyTests/Services/TerminalProgressStoreTests.swift
@@ -86,6 +86,40 @@ struct TerminalProgressStoreTests {
         #expect(!store.hasCompletionPending(for: project))
     }
 
+    @Test("hasActiveProgress reflects running then finished state")
+    func tracksActiveProgress() {
+        let store = TerminalProgressStore()
+        let pane = UUID()
+        let project = UUID()
+
+        #expect(!store.hasActiveProgress(for: project))
+
+        store.setProgress(.clamping(kind: .set, percent: 60), for: pane, projectID: project)
+        #expect(store.hasActiveProgress(for: project))
+        #expect(!store.hasCompletionPending(for: project))
+
+        store.setProgress(nil, for: pane, projectID: project)
+        #expect(!store.hasActiveProgress(for: project))
+        #expect(store.hasCompletionPending(for: project))
+
+        store.resetPane(pane)
+        #expect(!store.hasActiveProgress(for: project))
+        #expect(!store.hasCompletionPending(for: project))
+    }
+
+    @Test("hasActiveProgress scopes by project")
+    func activeProgressScopesByProject() {
+        let store = TerminalProgressStore()
+        let pane = UUID()
+        let projectA = UUID()
+        let projectB = UUID()
+
+        store.setProgress(.clamping(kind: .set, percent: 10), for: pane, projectID: projectA)
+
+        #expect(store.hasActiveProgress(for: projectA))
+        #expect(!store.hasActiveProgress(for: projectB))
+    }
+
     @Test("hasCompletionPending scopes by project")
     func scopesByProject() {
         let store = TerminalProgressStore()


### PR DESCRIPTION
Add sort modes (manual, name A–Z/Z–A, recently active, date added), switchable from the sidebar menu and Projects settings.
Dragging in a non-manual mode persists the order and switches back to manual.
Project icons now show a spinner while a terminal reports progress, then the existing completion dot.