### PR TITLE
fix: worktree removal no longer deletes its git branch

### DIFF
--- a/Muxy/Models/Worktree.swift
+++ b/Muxy/Models/Worktree.swift
@@ -10,7 +10,6 @@ struct Worktree: Identifiable, Codable, Hashable {
     var name: String
     var path: String
     var branch: String?
-    var ownsBranch: Bool
     var source: WorktreeSource
     var isPrimary: Bool
     var createdAt: Date
@@ -20,7 +19,6 @@ struct Worktree: Identifiable, Codable, Hashable {
         name: String,
         path: String,
         branch: String? = nil,
-        ownsBranch: Bool = false,
         source: WorktreeSource = .muxy,
         isPrimary: Bool,
         createdAt: Date = Date()
@@ -29,7 +27,6 @@ struct Worktree: Identifiable, Codable, Hashable {
         self.name = name
         self.path = path
         self.branch = branch
-        self.ownsBranch = ownsBranch
         self.source = source
         self.isPrimary = isPrimary
         self.createdAt = createdAt
@@ -48,7 +45,6 @@ struct Worktree: Identifiable, Codable, Hashable {
         case name
         case path
         case branch
-        case ownsBranch
         case source
         case isPrimary
         case createdAt
@@ -60,7 +56,6 @@ struct Worktree: Identifiable, Codable, Hashable {
         name = try container.decode(String.self, forKey: .name)
         path = try container.decode(String.self, forKey: .path)
         branch = try container.decodeIfPresent(String.self, forKey: .branch)
-        ownsBranch = try container.decodeIfPresent(Bool.self, forKey: .ownsBranch) ?? false
         source = try container.decodeIfPresent(WorktreeSource.self, forKey: .source) ?? .muxy
         isPrimary = try container.decode(Bool.self, forKey: .isPrimary)
         createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -187,22 +187,6 @@ actor GitWorktreeService: GitWorktreeListing {
         return toplevel.isEmpty ? nil : toplevel
     }
 
-    func deleteBranch(
-        repoPath: String,
-        branch: String,
-        force: Bool = true,
-        context: WorkspaceContext = .local
-    ) async throws {
-        try Self.validateBranchName(branch)
-        let args = ["branch", force ? "-D" : "-d", "--", branch]
-        let result = try await GitProcessRunner.runGit(repoPath: repoPath, arguments: args, context: context)
-        guard result.status == 0 else {
-            throw GitWorktreeError.commandFailed(
-                result.stderr.isEmpty ? "Failed to delete branch \(branch)." : result.stderr
-            )
-        }
-    }
-
     private func parsePorcelain(_ raw: String) -> [GitWorktreeRecord] {
         var records: [GitWorktreeRecord] = []
         var currentPath: String?

--- a/Muxy/Services/WorktreeStore.swift
+++ b/Muxy/Services/WorktreeStore.swift
@@ -111,7 +111,6 @@ final class WorktreeStore {
             name: request.name,
             path: request.path,
             branch: request.branch,
-            ownsBranch: request.createBranch,
             isPrimary: false
         )
         add(worktree, to: project.id)
@@ -265,17 +264,6 @@ final class WorktreeStore {
             force: true,
             context: context
         )
-
-        if worktree.ownsBranch,
-           let branch = worktree.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !branch.isEmpty
-        {
-            do {
-                try await GitWorktreeService.shared.deleteBranch(repoPath: repoPath, branch: branch, context: context)
-            } catch {
-                logger.error("Failed to delete branch \(branch) for worktree \(worktree.path): \(error)")
-            }
-        }
 
         try? await context.fileOps.removeItem(at: worktree.path)
         guard !context.isRemote, !worktree.isExternallyManaged else { return }

--- a/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
+++ b/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
@@ -49,6 +49,29 @@ struct GitWorktreeServiceRemoveTests {
         #expect(!records.contains { $0.path == worktreePath })
     }
 
+    @Test("cleanupOnDisk removes the worktree but keeps its branch")
+    func cleanupKeepsBranch() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("keep-branch-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        let worktree = Worktree(name: "keep-branch-wt", path: worktreePath, branch: "feature", isPrimary: false)
+        try await WorktreeStore.cleanupOnDisk(worktree: worktree, repoPath: repo.path)
+
+        let records = try await GitWorktreeService.shared.listWorktrees(repoPath: repo.path)
+        #expect(!records.contains { $0.path == worktreePath })
+        #expect(repo.branchExists("feature"))
+    }
+
     @Test("heals an orphaned worktree referenced through a symlinked parent")
     func healsOrphanThroughSymlinkedParent() async throws {
         let repo = try TempGitRepo()
@@ -111,6 +134,20 @@ private struct TempGitRepo {
         let aliasParent = realParent.appendingPathComponent("alias-\(UUID().uuidString)")
         try FileManager.default.createSymbolicLink(at: aliasParent, withDestinationURL: realParent)
         return aliasParent.appendingPathComponent(name).path
+    }
+
+    func branchExists(_ branch: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", path, "branch", "--list", "--format=%(refname:short)"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        guard (try? process.run()) != nil else { return false }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        return output.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }.contains(branch)
     }
 
     func orphanWorktreeAdmin(named name: String) throws {

--- a/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/SocketCommandHandlerTests.swift
@@ -245,7 +245,6 @@ struct SocketCommandHandlerTests {
         let worktree = try #require(stores.worktreeStore.list(for: project.id).first { $0.name == "Feature" })
         #expect(worktree.branch == "feature")
         #expect(worktree.path == createdPath)
-        #expect(worktree.ownsBranch)
         #expect(appState.activeWorktreeID[project.id] == worktree.id)
     }
 


### PR DESCRIPTION
Removing a worktree force-deleted its branch (git branch -D) via the ownsBranch flag.
  Dropped that behavior so branches always survive worktree removal; removed the now-dead ownsBranch flag and
  GitWorktreeService.deleteBranch.