### PR TITLE
fix: ESC closes Omnibox in fullscreen instead of exiting fullscreen

### DIFF
--- a/Muxy/Views/Components/PaletteOverlay.swift
+++ b/Muxy/Views/Components/PaletteOverlay.swift
@@ -280,6 +280,10 @@ struct PaletteSearchField: NSViewRepresentable {
             textView _: NSTextView,
             doCommandBy commandSelector: Selector
         ) -> Bool {
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                parent.onEscape()
+                return true
+            }
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 syncText(from: control, skipsMarkedText: false)
                 parent.onSubmit()

--- a/Tests/MuxyTests/Views/PaletteSearchFieldTests.swift
+++ b/Tests/MuxyTests/Views/PaletteSearchFieldTests.swift
@@ -44,6 +44,34 @@ struct PaletteSearchFieldTests {
         window.orderOut(nil)
     }
 
+    @Test("invokes onEscape when field editor cancels")
+    func invokesOnEscapeWhenFieldEditorCancels() {
+        let escaped = PaletteSearchFieldFlag()
+        let text = PaletteSearchFieldTextBox()
+        let field = PaletteSearchField(
+            text: Binding(
+                get: { text.value },
+                set: { text.value = $0 }
+            ),
+            placeholder: "Search",
+            onSubmit: {},
+            onEscape: { escaped.value = true },
+            onArrowUp: {},
+            onArrowDown: {}
+        )
+        let coordinator = field.makeCoordinator()
+        let control = NSTextField()
+
+        let handled = coordinator.control(
+            control,
+            textView: NSTextView(),
+            doCommandBy: #selector(NSResponder.cancelOperation(_:))
+        )
+
+        #expect(handled)
+        #expect(escaped.value)
+    }
+
     private func waitForFocus(_ field: NSTextField) async throws {
         for _ in 0..<40 {
             if field.currentEditor() != nil {
@@ -70,4 +98,9 @@ struct PaletteSearchFieldTests {
 @MainActor
 private final class PaletteSearchFieldTextBox {
     var value = ""
+}
+
+@MainActor
+private final class PaletteSearchFieldFlag {
+    var value = false
 }


### PR DESCRIPTION
Handle ESC via the field editor's cancelOperation: selector so it closes the palette deterministically regardless
  of focus timing or fullscreen state.