### PR TITLE
fix: denying an extension consent prompt no longer crashes the app

### DIFF
--- a/Muxy/Views/Extensions/ExtensionConsentDialog.swift
+++ b/Muxy/Views/Extensions/ExtensionConsentDialog.swift
@@ -83,7 +83,6 @@ private struct ExtensionConsentSheetHost: NSViewRepresentable {
             let sheet = ExtensionConsentSheetWindow(request: request) { [weak self] choice in
                 guard let self else { return }
                 let request = self.sheet?.currentRequest ?? request
-                self.dismiss()
                 self.onChoice(request, choice)
             }
             self.sheet = sheet


### PR DESCRIPTION
The deny/allow button tore down its own sheet synchronously from inside the
  button's event dispatch, causing a use-after-free crash. The closure now only
  reports the choice; the sheet dismisses reactively when pendingPrompt changes.