### PR TITLE
fix: switching projects via omnibox now switches the active workspace

### DIFF
--- a/Muxy/Services/ProjectGroupStore.swift
+++ b/Muxy/Services/ProjectGroupStore.swift
@@ -33,6 +33,23 @@ final class ProjectGroupStore {
         syncActiveWorkspaceContext()
     }
 
+    func groupID(containing project: Project) -> UUID? {
+        if let workspaceID = project.remoteWorkspaceID {
+            return workspaceID
+        }
+        return groups.first { $0.projectIDs.contains(project.id) }?.id
+    }
+
+    func activateWorkspace(containing project: Project) {
+        let groupID = groupID(containing: project)
+        guard groupID != activeGroupID else { return }
+        guard let groupID else {
+            clearGroupSelection()
+            return
+        }
+        selectGroup(id: groupID)
+    }
+
     func clearGroupSelection() {
         activeGroupID = nil
         persistence.saveActiveGroupID(nil)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -742,6 +742,11 @@ struct MainWindow: View {
             worktreeStore.preferred(for: project.id, matching: appState.activeWorktreeID[project.id])
         }
         guard let worktree else { return false }
+        guard project.id != Project.homeID else {
+            appState.selectProject(project, worktree: worktree)
+            return true
+        }
+        projectGroupStore.activateWorkspace(containing: project)
         appState.selectProject(project, worktree: worktree)
         return true
     }

--- a/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
@@ -475,6 +475,83 @@ struct ProjectGroupStoreTests {
         #expect(store.workspaceContext(for: project) == .ssh(device.destination))
     }
 
+    @Test("groupID(containing:) returns the local group holding the project")
+    func groupIDContainingLocalProject() {
+        let project = Project(name: "A", path: "/a")
+        let group = ProjectGroup(name: "Work", projectIDs: [project.id])
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [group]))
+
+        #expect(store.groupID(containing: project) == group.id)
+    }
+
+    @Test("groupID(containing:) returns nil for a project in no group")
+    func groupIDContainingUngroupedProject() {
+        let group = ProjectGroup(name: "Work")
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [group]))
+
+        #expect(store.groupID(containing: Project(name: "A", path: "/a")) == nil)
+    }
+
+    @Test("groupID(containing:) resolves a remote project to its workspace")
+    func groupIDContainingRemoteProject() {
+        let workspaceID = UUID()
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: []))
+        let project = Project(name: "api", path: "~/code/api", remoteWorkspaceID: workspaceID)
+
+        #expect(store.groupID(containing: project) == workspaceID)
+    }
+
+    @Test("groupID(containing:) resolves a remote home project to its workspace")
+    func groupIDContainingRemoteHomeProject() {
+        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~/code"))
+        let group = ProjectGroup(name: "Remote", type: .ssh, remoteDeviceID: device.id)
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [group]), devices: [device])
+        let home = store.remoteHomeProject(for: group)
+
+        #expect(home?.isHome == true)
+        #expect(store.groupID(containing: home!) == group.id)
+    }
+
+    @Test("activateWorkspace selects the group containing the project")
+    func activateWorkspaceSelectsGroup() {
+        let project = Project(name: "A", path: "/a")
+        let group = ProjectGroup(name: "Work", projectIDs: [project.id])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+
+        store.activateWorkspace(containing: project)
+
+        #expect(store.activeGroupID == group.id)
+        #expect(persistence.storedActiveGroupID == group.id)
+    }
+
+    @Test("activateWorkspace clears selection for a project in no group")
+    func activateWorkspaceClearsForUngroupedProject() {
+        let group = ProjectGroup(name: "Work")
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+        store.selectGroup(id: group.id)
+
+        store.activateWorkspace(containing: Project(name: "A", path: "/a"))
+
+        #expect(store.activeGroupID == nil)
+        #expect(persistence.storedActiveGroupID == nil)
+    }
+
+    @Test("activateWorkspace is a no-op when the project's group is already active")
+    func activateWorkspaceNoOpWhenAlreadyActive() {
+        let project = Project(name: "A", path: "/a")
+        let group = ProjectGroup(name: "Work", projectIDs: [project.id])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+        store.selectGroup(id: group.id)
+        persistence.savedGroups = nil
+
+        store.activateWorkspace(containing: project)
+
+        #expect(store.activeGroupID == group.id)
+    }
+
     @Test("RemoteProject.asProject preserves the worktrees flag and workspace id")
     func remoteProjectAsProjectRoundTrip() {
         let workspaceID = UUID()


### PR DESCRIPTION
Selecting a project (or its worktree/tab/command) in the omnibox left the
  active workspace stale, so the sidebar kept showing the old workspace.
  The omnibox now activates the project's owning workspace on selection