### PR TITLE
export and import Muxy data

### DIFF
--- a/Muxy/Info.plist
+++ b/Muxy/Info.plist
@@ -71,5 +71,40 @@
 			</array>
 		</dict>
 	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.muxy.app.backup</string>
+			<key>UTTypeDescription</key>
+			<string>Muxy Backup</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.zip-archive</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>muxy</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Muxy Backup</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.muxy.app.backup</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Muxy/Models/BackupManifest.swift
+++ b/Muxy/Models/BackupManifest.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct BackupManifest: Codable, Equatable {
+    static let currentSchemaVersion = 1
+    static let filename = "manifest.json"
+
+    var schemaVersion: Int
+    var appVersion: String
+    var createdAt: Date
+    var files: [String]
+
+    var isSupported: Bool {
+        schemaVersion >= 1 && schemaVersion <= Self.currentSchemaVersion
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -466,14 +466,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             NotificationCenter.default.removeObserver(modalThemeObserver)
             self.modalThemeObserver = nil
         }
-        onTerminate?()
+        persistUserStateForTermination()
         NotificationStore.shared.saveToDisk()
         NotificationSocketServer.shared.stop()
         MainActor.assumeIsolated {
             MobileServerService.shared.stopForTermination()
-            RichInputDraftStore.shared.flush()
             ExtensionStore.shared.stopAll()
         }
+    }
+
+    func persistUserStateForTermination() {
+        guard !AppRelaunch.isRelaunching else { return }
+        onTerminate?()
+        RichInputDraftStore.shared.flush()
     }
 
     @MainActor

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -417,7 +417,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        confirmQuitIfNeeded()
+        guard !AppRelaunch.isRelaunching else { return .terminateNow }
+        return confirmQuitIfNeeded()
     }
 
     @MainActor

--- a/Muxy/Services/AppRelaunch.swift
+++ b/Muxy/Services/AppRelaunch.swift
@@ -5,10 +5,16 @@ enum AppRelaunch {
     @MainActor private(set) static var isRelaunching = false
 
     @MainActor
+    static func prepareForRelaunch() {
+        isRelaunching = true
+    }
+
+    @MainActor
     static func relaunch() {
+        prepareForRelaunch()
+
         let bundleURL = Bundle.main.bundleURL
         guard bundleURL.pathExtension == "app" else {
-            isRelaunching = true
             NSApp.terminate(nil)
             return
         }
@@ -22,7 +28,11 @@ enum AppRelaunch {
         process.arguments = ["-c", waitAndReopen]
         try? process.run()
 
-        isRelaunching = true
         NSApp.terminate(nil)
+    }
+
+    @MainActor
+    static func resetForTesting() {
+        isRelaunching = false
     }
 }

--- a/Muxy/Services/AppRelaunch.swift
+++ b/Muxy/Services/AppRelaunch.swift
@@ -1,8 +1,26 @@
 import AppKit
 import Foundation
 
+enum AppRelaunchError: LocalizedError {
+    case launchFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .launchFailed(message):
+            "Failed to restart Muxy: \(message)"
+        }
+    }
+}
+
+struct AppRelaunchRequest: Equatable {
+    let executableURL: URL
+    let arguments: [String]
+}
+
 enum AppRelaunch {
     @MainActor private(set) static var isRelaunching = false
+    private static let waitAndOpenScript = "while /bin/kill -0 \"$1\" 2>/dev/null; do /bin/sleep 0.1; done; /usr/bin/open \"$2\""
+    private static let waitAndRunScript = "while /bin/kill -0 \"$1\" 2>/dev/null; do /bin/sleep 0.1; done; \"$2\""
 
     @MainActor
     static func prepareForRelaunch() {
@@ -10,25 +28,66 @@ enum AppRelaunch {
     }
 
     @MainActor
-    static func relaunch() {
+    static func relaunch() throws {
         prepareForRelaunch()
 
         let bundleURL = Bundle.main.bundleURL
-        guard bundleURL.pathExtension == "app" else {
-            NSApp.terminate(nil)
-            return
+        let request = launchRequest(
+            bundleURL: bundleURL,
+            executableURL: Bundle.main.executableURL,
+            processID: ProcessInfo.processInfo.processIdentifier
+        )
+        do {
+            try launch(request)
+        } catch {
+            throw error
         }
 
-        let pid = ProcessInfo.processInfo.processIdentifier
-        let quotedPath = ShellEscaper.escape(bundleURL.path)
-        let waitAndReopen = "while /bin/kill -0 \(pid) 2>/dev/null; do /bin/sleep 0.1; done; /usr/bin/open \(quotedPath)"
+        dismissAttachedSheets()
+        DispatchQueue.main.async {
+            NSApp.terminate(nil)
+        }
+    }
 
+    @MainActor
+    static func dismissAttachedSheets(in windows: [NSWindow]) {
+        for window in windows {
+            guard let sheet = window.attachedSheet else { continue }
+            window.endSheet(sheet)
+        }
+    }
+
+    @MainActor
+    private static func dismissAttachedSheets() {
+        dismissAttachedSheets(in: NSApp.windows)
+    }
+
+    nonisolated static func launchRequest(bundleURL: URL, executableURL: URL?, processID: Int32) -> AppRelaunchRequest {
+        if bundleURL.pathExtension == "app" {
+            return request(script: waitAndOpenScript, targetPath: bundleURL.path, processID: processID)
+        }
+        return request(script: waitAndRunScript, targetPath: executableURL?.path ?? bundleURL.path, processID: processID)
+    }
+
+    private static func launch(_ request: AppRelaunchRequest) throws {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", waitAndReopen]
-        try? process.run()
+        process.executableURL = request.executableURL
+        process.arguments = request.arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            throw AppRelaunchError.launchFailed(error.localizedDescription)
+        }
+    }
 
-        NSApp.terminate(nil)
+    private static func request(script: String, targetPath: String, processID: Int32) -> AppRelaunchRequest {
+        AppRelaunchRequest(
+            executableURL: URL(fileURLWithPath: "/usr/bin/nohup"),
+            arguments: ["/bin/sh", "-c", script, "muxy-relaunch", "\(processID)", targetPath]
+        )
     }
 
     @MainActor

--- a/Muxy/Services/AppRelaunch.swift
+++ b/Muxy/Services/AppRelaunch.swift
@@ -2,20 +2,27 @@ import AppKit
 import Foundation
 
 enum AppRelaunch {
+    @MainActor private(set) static var isRelaunching = false
+
     @MainActor
     static func relaunch() {
-        let process = Process()
         let bundleURL = Bundle.main.bundleURL
-        if bundleURL.pathExtension == "app" {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-            process.arguments = ["-n", bundleURL.path]
-        } else if let executableURL = Bundle.main.executableURL {
-            process.executableURL = executableURL
-        } else {
+        guard bundleURL.pathExtension == "app" else {
+            isRelaunching = true
             NSApp.terminate(nil)
             return
         }
+
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let quotedPath = ShellEscaper.escape(bundleURL.path)
+        let waitAndReopen = "while /bin/kill -0 \(pid) 2>/dev/null; do /bin/sleep 0.1; done; /usr/bin/open \(quotedPath)"
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", waitAndReopen]
         try? process.run()
+
+        isRelaunching = true
         NSApp.terminate(nil)
     }
 }

--- a/Muxy/Services/AppRelaunch.swift
+++ b/Muxy/Services/AppRelaunch.swift
@@ -1,0 +1,21 @@
+import AppKit
+import Foundation
+
+enum AppRelaunch {
+    @MainActor
+    static func relaunch() {
+        let process = Process()
+        let bundleURL = Bundle.main.bundleURL
+        if bundleURL.pathExtension == "app" {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            process.arguments = ["-n", bundleURL.path]
+        } else if let executableURL = Bundle.main.executableURL {
+            process.executableURL = executableURL
+        } else {
+            NSApp.terminate(nil)
+            return
+        }
+        try? process.run()
+        NSApp.terminate(nil)
+    }
+}

--- a/Muxy/Services/BackupArchive.swift
+++ b/Muxy/Services/BackupArchive.swift
@@ -1,9 +1,12 @@
+import Darwin
 import Foundation
 import UniformTypeIdentifiers
 
 enum BackupArchiveError: LocalizedError {
     case archiveFailed(Int32)
+    case archiveTimedOut
     case extractionFailed(Int32)
+    case extractionTimedOut
     case manifestMissing
     case manifestUnsupported
 
@@ -11,8 +14,12 @@ enum BackupArchiveError: LocalizedError {
         switch self {
         case let .archiveFailed(status):
             "Failed to create backup archive (ditto exited with status \(status))."
+        case .archiveTimedOut:
+            "Failed to create backup archive because the operation took too long."
         case let .extractionFailed(status):
             "Failed to read backup archive (ditto exited with status \(status))."
+        case .extractionTimedOut:
+            "Failed to read backup archive because the operation took too long."
         case .manifestMissing:
             "The selected file is not a valid Muxy backup."
         case .manifestUnsupported:
@@ -25,6 +32,7 @@ enum BackupArchive {
     static let fileExtension = "muxy"
 
     static let contentType = UTType(filenameExtension: fileExtension) ?? .data
+    private static let processTimeout: TimeInterval = 600
 
     static let exportableFiles = [
         "settings.json",
@@ -47,27 +55,55 @@ enum BackupArchive {
     ]
 
     static func zip(directory: URL, to archiveURL: URL) throws {
-        let status = runDitto(["-c", "-k", "--sequesterRsrc", directory.path, archiveURL.path])
-        guard status == 0 else { throw BackupArchiveError.archiveFailed(status) }
+        switch runDitto(["-c", "-k", "--sequesterRsrc", directory.path, archiveURL.path]) {
+        case .success:
+            return
+        case let .failed(status):
+            throw BackupArchiveError.archiveFailed(status)
+        case .timedOut:
+            throw BackupArchiveError.archiveTimedOut
+        }
     }
 
     static func unzip(archiveURL: URL, to directory: URL) throws {
-        let status = runDitto(["-x", "-k", archiveURL.path, directory.path])
-        guard status == 0 else { throw BackupArchiveError.extractionFailed(status) }
+        switch runDitto(["-x", "-k", archiveURL.path, directory.path]) {
+        case .success:
+            return
+        case let .failed(status):
+            throw BackupArchiveError.extractionFailed(status)
+        case .timedOut:
+            throw BackupArchiveError.extractionTimedOut
+        }
     }
 
-    private static func runDitto(_ arguments: [String]) -> Int32 {
+    private static func runDitto(_ arguments: [String]) -> DittoResult {
         let process = Process()
+        let didExit = DispatchSemaphore(value: 0)
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
         process.arguments = arguments
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
+        process.terminationHandler = { _ in didExit.signal() }
         do {
             try process.run()
         } catch {
-            return -1
+            return .failed(-1)
         }
-        process.waitUntilExit()
-        return process.terminationStatus
+        guard didExit.wait(timeout: .now() + processTimeout) == .success else {
+            process.terminate()
+            if didExit.wait(timeout: .now() + 2) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                process.waitUntilExit()
+            }
+            return .timedOut
+        }
+        guard process.terminationStatus == 0 else { return .failed(process.terminationStatus) }
+        return .success
     }
+}
+
+private enum DittoResult {
+    case success
+    case failed(Int32)
+    case timedOut
 }

--- a/Muxy/Services/BackupArchive.swift
+++ b/Muxy/Services/BackupArchive.swift
@@ -1,0 +1,72 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum BackupArchiveError: LocalizedError {
+    case archiveFailed(Int32)
+    case extractionFailed(Int32)
+    case manifestMissing
+    case manifestUnsupported
+
+    var errorDescription: String? {
+        switch self {
+        case let .archiveFailed(status):
+            "Failed to create backup archive (ditto exited with status \(status))."
+        case let .extractionFailed(status):
+            "Failed to read backup archive (ditto exited with status \(status))."
+        case .manifestMissing:
+            "The selected file is not a valid Muxy backup."
+        case .manifestUnsupported:
+            "This backup was created by a newer version of Muxy and cannot be imported."
+        }
+    }
+}
+
+enum BackupArchive {
+    static let fileExtension = "muxy"
+
+    static let contentType = UTType(filenameExtension: fileExtension) ?? .data
+
+    static let exportableFiles = [
+        "settings.json",
+        "projects.json",
+        "project-groups.json",
+        "remote-devices.json",
+        "workspaces.json",
+        "extension-shortcuts.json",
+        "keybindings.json",
+        "command-shortcuts.json",
+        "editor-settings.json",
+        "rich-input-drafts.json",
+    ]
+
+    static let exportableDirectories = [
+        "worktrees",
+        "logos",
+        "RichInputImages",
+    ]
+
+    static func zip(directory: URL, to archiveURL: URL) throws {
+        let status = runDitto(["-c", "-k", "--sequesterRsrc", directory.path, archiveURL.path])
+        guard status == 0 else { throw BackupArchiveError.archiveFailed(status) }
+    }
+
+    static func unzip(archiveURL: URL, to directory: URL) throws {
+        let status = runDitto(["-x", "-k", archiveURL.path, directory.path])
+        guard status == 0 else { throw BackupArchiveError.extractionFailed(status) }
+    }
+
+    private static func runDitto(_ arguments: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return -1
+        }
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+}

--- a/Muxy/Services/BackupArchive.swift
+++ b/Muxy/Services/BackupArchive.swift
@@ -37,6 +37,7 @@ enum BackupArchive {
         "command-shortcuts.json",
         "editor-settings.json",
         "rich-input-drafts.json",
+        "ghostty.conf",
     ]
 
     static let exportableDirectories = [

--- a/Muxy/Services/BackupSanitizer.swift
+++ b/Muxy/Services/BackupSanitizer.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum BackupSanitizer {
+    static func sanitizedRemoteDevices(at url: URL) throws -> Data {
+        let devices = try JSONDecoder().decode([RemoteDevice].self, from: Data(contentsOf: url))
+        let sanitized = devices.map { device -> RemoteDevice in
+            var copy = device
+            copy.ssh.environment = SSHEnvironmentVariables.default
+            return copy
+        }
+        return try JSONEncoder().encode(sanitized)
+    }
+
+    static func sanitizedSettings(at url: URL) throws -> Data {
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        guard var dictionary = object as? [String: Any] else { return try Data(contentsOf: url) }
+        dictionary["mobile.approvedDevices"] = []
+        return try JSONSerialization.data(
+            withJSONObject: dictionary,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+    }
+}

--- a/Muxy/Services/BackupService.swift
+++ b/Muxy/Services/BackupService.swift
@@ -53,11 +53,11 @@ struct BackupService {
         let manifest = try readManifest(from: staging)
         guard manifest.isSupported else { throw BackupArchiveError.manifestUnsupported }
 
-        let backupDirectory = try backUpCurrentData(stamp: backupStamp)
+        let backupDirectory = try createCurrentDataBackupAndClearActiveData(stamp: backupStamp)
         do {
             try restoreContents(from: staging, manifest: manifest)
         } catch {
-            try? rollBack(from: backupDirectory)
+            try? restoreCurrentData(from: backupDirectory)
             throw error
         }
         return backupDirectory
@@ -102,23 +102,60 @@ struct BackupService {
         }
     }
 
-    private func backUpCurrentData(stamp: String) throws -> URL {
-        let fileManager = FileManager.default
-        let backupDirectory = baseDirectory
-            .appendingPathComponent("Backups", isDirectory: true)
-            .appendingPathComponent("pre-import-\(stamp)", isDirectory: true)
-        try fileManager.createDirectory(at: backupDirectory, withIntermediateDirectories: true)
+    private func createCurrentDataBackupAndClearActiveData(stamp: String) throws -> URL {
+        let backupDirectory = try makePreImportBackupDirectory(stamp: stamp)
 
-        for name in BackupArchive.exportableFiles + BackupArchive.exportableDirectories {
-            let source = baseDirectory.appendingPathComponent(name)
-            guard fileManager.fileExists(atPath: source.path) else { continue }
-            try fileManager.moveItem(at: source, to: backupDirectory.appendingPathComponent(name))
+        do {
+            try copyCurrentData(to: backupDirectory)
+        } catch {
+            try? FileManager.default.removeItem(at: backupDirectory)
+            throw error
+        }
+
+        do {
+            try removeCurrentData()
+        } catch {
+            try? restoreCurrentData(from: backupDirectory)
+            throw error
         }
 
         return backupDirectory
     }
 
-    private func rollBack(from backupDirectory: URL) throws {
+    private func makePreImportBackupDirectory(stamp: String) throws -> URL {
+        let fileManager = FileManager.default
+        let backupsDirectory = baseDirectory.appendingPathComponent("Backups", isDirectory: true)
+        try fileManager.createDirectory(at: backupsDirectory, withIntermediateDirectories: true)
+
+        var backupDirectory = backupsDirectory.appendingPathComponent("pre-import-\(stamp)", isDirectory: true)
+        var suffix = 1
+        while fileManager.fileExists(atPath: backupDirectory.path) {
+            backupDirectory = backupsDirectory.appendingPathComponent("pre-import-\(stamp)-\(suffix)", isDirectory: true)
+            suffix += 1
+        }
+        try fileManager.createDirectory(at: backupDirectory, withIntermediateDirectories: true)
+        return backupDirectory
+    }
+
+    private func copyCurrentData(to backupDirectory: URL) throws {
+        let fileManager = FileManager.default
+        for name in BackupArchive.exportableFiles + BackupArchive.exportableDirectories {
+            let source = baseDirectory.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            try fileManager.copyItem(at: source, to: backupDirectory.appendingPathComponent(name))
+        }
+    }
+
+    private func removeCurrentData() throws {
+        let fileManager = FileManager.default
+        for name in BackupArchive.exportableFiles + BackupArchive.exportableDirectories {
+            let url = baseDirectory.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: url.path) else { continue }
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    private func restoreCurrentData(from backupDirectory: URL) throws {
         let fileManager = FileManager.default
 
         for name in BackupArchive.exportableFiles + BackupArchive.exportableDirectories {
@@ -128,7 +165,7 @@ struct BackupService {
             if fileManager.fileExists(atPath: destination.path) {
                 try fileManager.removeItem(at: destination)
             }
-            try fileManager.moveItem(at: source, to: destination)
+            try fileManager.copyItem(at: source, to: destination)
         }
     }
 

--- a/Muxy/Services/BackupService.swift
+++ b/Muxy/Services/BackupService.swift
@@ -1,0 +1,148 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "BackupService")
+
+struct BackupService {
+    let baseDirectory: URL
+
+    init(baseDirectory: URL = MuxyFileStorage.appSupportDirectory()) {
+        self.baseDirectory = baseDirectory
+    }
+
+    func export(to archiveURL: URL, appVersion: String, createdAt: Date) throws {
+        let staging = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: staging) }
+
+        let copiedFiles = try stageExportContents(into: staging)
+        let manifest = BackupManifest(
+            schemaVersion: BackupManifest.currentSchemaVersion,
+            appVersion: appVersion,
+            createdAt: createdAt,
+            files: copiedFiles
+        )
+        try writeManifest(manifest, into: staging)
+
+        try? FileManager.default.removeItem(at: archiveURL)
+        try BackupArchive.zip(directory: staging, to: archiveURL)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.privateFile],
+            ofItemAtPath: archiveURL.path
+        )
+    }
+
+    @discardableResult
+    func importBackup(from archiveURL: URL, backupStamp: String) throws -> URL {
+        let staging = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: staging) }
+
+        try BackupArchive.unzip(archiveURL: archiveURL, to: staging)
+        let manifest = try readManifest(from: staging)
+        guard manifest.isSupported else { throw BackupArchiveError.manifestUnsupported }
+
+        let backupDirectory = try backUpCurrentData(stamp: backupStamp)
+        try restoreContents(from: staging, manifest: manifest)
+        return backupDirectory
+    }
+
+    private func stageExportContents(into staging: URL) throws -> [String] {
+        let fileManager = FileManager.default
+        var copied: [String] = []
+
+        for name in BackupArchive.exportableFiles {
+            let source = baseDirectory.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            let destination = staging.appendingPathComponent(name)
+
+            if let sanitized = try sanitizedData(for: name, at: source) {
+                try sanitized.write(to: destination, options: .atomic)
+            } else {
+                try fileManager.copyItem(at: source, to: destination)
+            }
+            copied.append(name)
+        }
+
+        for name in BackupArchive.exportableDirectories {
+            let source = baseDirectory.appendingPathComponent(name, isDirectory: true)
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: source.path, isDirectory: &isDirectory), isDirectory.boolValue else { continue }
+            try fileManager.copyItem(at: source, to: staging.appendingPathComponent(name, isDirectory: true))
+            copied.append(name)
+        }
+
+        return copied
+    }
+
+    private func sanitizedData(for name: String, at url: URL) throws -> Data? {
+        switch name {
+        case "remote-devices.json":
+            try BackupSanitizer.sanitizedRemoteDevices(at: url)
+        case "settings.json":
+            try BackupSanitizer.sanitizedSettings(at: url)
+        default:
+            nil
+        }
+    }
+
+    private func backUpCurrentData(stamp: String) throws -> URL {
+        let fileManager = FileManager.default
+        let backupDirectory = baseDirectory
+            .appendingPathComponent("Backups", isDirectory: true)
+            .appendingPathComponent("pre-import-\(stamp)", isDirectory: true)
+        try fileManager.createDirectory(at: backupDirectory, withIntermediateDirectories: true)
+
+        for name in BackupArchive.exportableFiles + BackupArchive.exportableDirectories {
+            let source = baseDirectory.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            try fileManager.moveItem(at: source, to: backupDirectory.appendingPathComponent(name))
+        }
+
+        return backupDirectory
+    }
+
+    private func restoreContents(from staging: URL, manifest: BackupManifest) throws {
+        let fileManager = FileManager.default
+        let allowed = Set(BackupArchive.exportableFiles + BackupArchive.exportableDirectories)
+
+        for name in manifest.files {
+            guard allowed.contains(name) else {
+                logger.error("Skipping unexpected backup entry: \(name)")
+                continue
+            }
+            let source = staging.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            let destination = baseDirectory.appendingPathComponent(name)
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.copyItem(at: source, to: destination)
+        }
+    }
+
+    private func writeManifest(_ manifest: BackupManifest, into directory: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(manifest)
+        try data.write(to: directory.appendingPathComponent(BackupManifest.filename), options: .atomic)
+    }
+
+    private func readManifest(from directory: URL) throws -> BackupManifest {
+        let url = directory.appendingPathComponent(BackupManifest.filename)
+        guard FileManager.default.fileExists(atPath: url.path) else { throw BackupArchiveError.manifestMissing }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode(BackupManifest.self, from: Data(contentsOf: url))
+        } catch {
+            throw BackupArchiveError.manifestMissing
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-backup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/Muxy/Services/BackupService.swift
+++ b/Muxy/Services/BackupService.swift
@@ -10,7 +10,13 @@ struct BackupService {
         self.baseDirectory = baseDirectory
     }
 
-    func export(to archiveURL: URL, appVersion: String, createdAt: Date) throws {
+    func export(to archiveURL: URL, appVersion: String, createdAt: Date) async throws {
+        try await GitProcessRunner.offMainThrowing {
+            try performExport(to: archiveURL, appVersion: appVersion, createdAt: createdAt)
+        }
+    }
+
+    private func performExport(to archiveURL: URL, appVersion: String, createdAt: Date) throws {
         let staging = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: staging) }
 
@@ -32,7 +38,14 @@ struct BackupService {
     }
 
     @discardableResult
-    func importBackup(from archiveURL: URL, backupStamp: String) throws -> URL {
+    func importBackup(from archiveURL: URL, backupStamp: String) async throws -> URL {
+        try await GitProcessRunner.offMainThrowing {
+            try performImport(from: archiveURL, backupStamp: backupStamp)
+        }
+    }
+
+    @discardableResult
+    private func performImport(from archiveURL: URL, backupStamp: String) throws -> URL {
         let staging = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: staging) }
 
@@ -41,7 +54,12 @@ struct BackupService {
         guard manifest.isSupported else { throw BackupArchiveError.manifestUnsupported }
 
         let backupDirectory = try backUpCurrentData(stamp: backupStamp)
-        try restoreContents(from: staging, manifest: manifest)
+        do {
+            try restoreContents(from: staging, manifest: manifest)
+        } catch {
+            try? rollBack(from: backupDirectory)
+            throw error
+        }
         return backupDirectory
     }
 
@@ -98,6 +116,20 @@ struct BackupService {
         }
 
         return backupDirectory
+    }
+
+    private func rollBack(from backupDirectory: URL) throws {
+        let fileManager = FileManager.default
+
+        for name in BackupArchive.exportableFiles + BackupArchive.exportableDirectories {
+            let source = backupDirectory.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            let destination = baseDirectory.appendingPathComponent(name)
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.moveItem(at: source, to: destination)
+        }
     }
 
     private func restoreContents(from staging: URL, manifest: BackupManifest) throws {

--- a/Muxy/Services/SettingsJSONStore.swift
+++ b/Muxy/Services/SettingsJSONStore.swift
@@ -38,6 +38,11 @@ enum SettingsJSONStore {
         syncUserSettingsFileWithCurrentSettings()
     }
 
+    static func applyUserSettingsFile() throws {
+        let text = try String(contentsOf: userSettingsURL, encoding: .utf8)
+        try saveUserSettingsText(text)
+    }
+
     static func prettifiedSettingsText(_ text: String) throws -> String {
         let data = Data(text.utf8)
         let object = try JSONSerialization.jsonObject(with: data)

--- a/Muxy/Views/Settings/BackupSettingsView.swift
+++ b/Muxy/Views/Settings/BackupSettingsView.swift
@@ -16,7 +16,6 @@ struct BackupSettingsView: View {
     @State private var isWorking = false
     @State private var errorMessage: String?
     @State private var pendingImportURL: URL?
-    @State private var showRestartPrompt = false
 
     private var importConfirmationBinding: Binding<Bool> {
         Binding(
@@ -68,11 +67,6 @@ struct BackupSettingsView: View {
         } message: {
             Text("This replaces all current Muxy data and restarts the app. Your current data is backed up first.")
         }
-        .alert("Import complete", isPresented: $showRestartPrompt) {
-            Button("Restart Muxy") { AppRelaunch.relaunch() }
-        } message: {
-            Text("Muxy needs to restart to load the imported data.")
-        }
     }
 
     private func actionRow(
@@ -100,6 +94,7 @@ struct BackupSettingsView: View {
         errorMessage = nil
         isWorking = true
         let version = appVersion
+        SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         Task {
             do {
                 try await BackupService().export(to: url, appVersion: version, createdAt: Date())
@@ -135,8 +130,9 @@ struct BackupSettingsView: View {
         Task {
             do {
                 try await BackupService().importBackup(from: url, backupStamp: stamp)
+                try SettingsJSONStore.applyUserSettingsFile()
                 isWorking = false
-                showRestartPrompt = true
+                AppRelaunch.relaunch()
             } catch {
                 errorMessage = error.localizedDescription
                 isWorking = false

--- a/Muxy/Views/Settings/BackupSettingsView.swift
+++ b/Muxy/Views/Settings/BackupSettingsView.swift
@@ -1,0 +1,168 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BackupSettingsView: View {
+    private static let exportFooter = """
+    Saves your settings, projects, remote devices, shortcuts and customizations to a single .muxy file. \
+    Credentials such as SSH keys, passwords and paired mobile devices are never included.
+    """
+
+    private static let importFooter = """
+    Replaces all current Muxy data with the contents of a backup and restarts the app. \
+    Your current data is backed up first so it can be recovered.
+    """
+
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+    @State private var pendingImportURL: URL?
+    @State private var showRestartPrompt = false
+
+    private var importConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { pendingImportURL != nil },
+            set: { if !$0 { pendingImportURL = nil } }
+        )
+    }
+
+    var body: some View {
+        SettingsContainer {
+            SettingsSection(
+                "Export",
+                footer: Self.exportFooter
+            ) {
+                actionRow(
+                    title: "Export Muxy",
+                    description: "Create a backup you can import on another Mac.",
+                    buttonTitle: "Export…",
+                    action: performExport
+                )
+            }
+
+            SettingsSection(
+                "Import",
+                footer: Self.importFooter,
+                showsDivider: false
+            ) {
+                actionRow(
+                    title: "Import Muxy",
+                    description: "Restore a backup created on this or another Mac.",
+                    buttonTitle: "Import…",
+                    action: chooseImportFile
+                )
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(SettingsStyle.destructive)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                        .padding(.bottom, SettingsMetrics.rowVerticalPadding)
+                }
+            }
+        }
+        .disabled(isWorking)
+        .alert("Import backup?", isPresented: importConfirmationBinding) {
+            Button("Import & Restart", role: .destructive, action: performImport)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This replaces all current Muxy data and restarts the app. Your current data is backed up first.")
+        }
+        .alert("Import complete", isPresented: $showRestartPrompt) {
+            Button("Restart Muxy") { AppRelaunch.relaunch() }
+        } message: {
+            Text("Muxy needs to restart to load the imported data.")
+        }
+    }
+
+    private func actionRow(
+        title: String,
+        description: String,
+        buttonTitle: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        SettingsRow(title) {
+            Button(buttonTitle, action: action)
+                .buttonStyle(.plain)
+                .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
+                .foregroundStyle(SettingsStyle.accent)
+        }
+        .help(description)
+    }
+
+    private func performExport() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [BackupArchive.contentType]
+        panel.nameFieldStringValue = defaultExportName()
+        panel.message = "Choose where to save the Muxy backup"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        errorMessage = nil
+        isWorking = true
+        do {
+            try BackupService().export(to: url, appVersion: appVersion, createdAt: Date())
+            ToastState.shared.show(title: "Export complete", body: url.lastPathComponent)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isWorking = false
+    }
+
+    private func chooseImportFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        let delegate = BackupOpenPanelDelegate()
+        panel.delegate = delegate
+        panel.message = "Select a Muxy backup to import"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        errorMessage = nil
+        DispatchQueue.main.async {
+            pendingImportURL = url
+        }
+    }
+
+    private func performImport() {
+        guard let url = pendingImportURL else { return }
+        pendingImportURL = nil
+        isWorking = true
+        do {
+            try BackupService().importBackup(from: url, backupStamp: backupStamp())
+            isWorking = false
+            showRestartPrompt = true
+        } catch {
+            errorMessage = error.localizedDescription
+            isWorking = false
+        }
+    }
+
+    private func defaultExportName() -> String {
+        let host = Host.current().localizedName ?? "Mac"
+        let sanitizedHost = host.components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        return "Muxy-Backup-\(sanitizedHost).\(BackupArchive.fileExtension)"
+    }
+
+    private func backupStamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        return formatter.string(from: Date())
+    }
+
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    }
+}
+
+private final class BackupOpenPanelDelegate: NSObject, NSOpenSavePanelDelegate {
+    func panel(_ sender: Any, shouldEnable url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue {
+            return true
+        }
+        return url.pathExtension.lowercased() == BackupArchive.fileExtension
+    }
+}

--- a/Muxy/Views/Settings/BackupSettingsView.swift
+++ b/Muxy/Views/Settings/BackupSettingsView.swift
@@ -132,7 +132,7 @@ struct BackupSettingsView: View {
                 try await BackupService().importBackup(from: url, backupStamp: stamp)
                 try SettingsJSONStore.applyUserSettingsFile()
                 isWorking = false
-                AppRelaunch.relaunch()
+                try AppRelaunch.relaunch()
             } catch {
                 errorMessage = error.localizedDescription
                 isWorking = false

--- a/Muxy/Views/Settings/BackupSettingsView.swift
+++ b/Muxy/Views/Settings/BackupSettingsView.swift
@@ -99,13 +99,16 @@ struct BackupSettingsView: View {
 
         errorMessage = nil
         isWorking = true
-        do {
-            try BackupService().export(to: url, appVersion: appVersion, createdAt: Date())
-            ToastState.shared.show(title: "Export complete", body: url.lastPathComponent)
-        } catch {
-            errorMessage = error.localizedDescription
+        let version = appVersion
+        Task {
+            do {
+                try await BackupService().export(to: url, appVersion: version, createdAt: Date())
+                ToastState.shared.show(title: "Export complete", body: url.lastPathComponent)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isWorking = false
         }
-        isWorking = false
     }
 
     private func chooseImportFile() {
@@ -128,13 +131,16 @@ struct BackupSettingsView: View {
         guard let url = pendingImportURL else { return }
         pendingImportURL = nil
         isWorking = true
-        do {
-            try BackupService().importBackup(from: url, backupStamp: backupStamp())
-            isWorking = false
-            showRestartPrompt = true
-        } catch {
-            errorMessage = error.localizedDescription
-            isWorking = false
+        let stamp = backupStamp()
+        Task {
+            do {
+                try await BackupService().importBackup(from: url, backupStamp: stamp)
+                isWorking = false
+                showRestartPrompt = true
+            } catch {
+                errorMessage = error.localizedDescription
+                isWorking = false
+            }
         }
     }
 

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -14,6 +14,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case voice
     case notifications
     case mobile
+    case backup
     case json
 
     var id: String { rawValue }
@@ -32,6 +33,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .voice: "Voice"
         case .notifications: "Notifications"
         case .mobile: "Mobile"
+        case .backup: "Backup"
         case .json: "JSON"
         }
     }
@@ -50,6 +52,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .voice: "mic"
         case .notifications: "bell"
         case .mobile: "iphone"
+        case .backup: "externaldrive"
         case .json: "curlybraces"
         }
     }
@@ -492,6 +495,22 @@ enum SettingsCatalog {
             description: "Manages mobile devices that can connect.",
             category: .mobile,
             section: "Approved Devices"
+        ),
+        SettingsCatalogItem(
+            key: "backup.export",
+            title: "Export Muxy",
+            description: "Saves settings, projects, remote devices and customizations to a file.",
+            category: .backup,
+            section: "Export",
+            aliases: ["backup", "migrate", "transfer"]
+        ),
+        SettingsCatalogItem(
+            key: "backup.import",
+            title: "Import Muxy",
+            description: "Restores a backup and replaces all current Muxy data.",
+            category: .backup,
+            section: "Import",
+            aliases: ["backup", "restore", "migrate"]
         ),
     ]
 

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -139,6 +139,8 @@ struct SettingsView: View {
             NotificationSettingsView()
         case .mobile:
             MobileSettingsView()
+        case .backup:
+            BackupSettingsView()
         case .json:
             SettingsJSONEditorView()
         }

--- a/Tests/MuxyTests/Services/AppRelaunchTests.swift
+++ b/Tests/MuxyTests/Services/AppRelaunchTests.swift
@@ -1,0 +1,24 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("AppRelaunch")
+@MainActor
+struct AppRelaunchTests {
+    @Test("relaunch suppresses termination user-state persistence")
+    func relaunchSuppressesTerminationUserStatePersistence() {
+        AppRelaunch.resetForTesting()
+        defer { AppRelaunch.resetForTesting() }
+
+        let delegate = AppDelegate()
+        var didPersist = false
+        delegate.onTerminate = {
+            didPersist = true
+        }
+
+        AppRelaunch.prepareForRelaunch()
+        delegate.persistUserStateForTermination()
+
+        #expect(!didPersist)
+    }
+}

--- a/Tests/MuxyTests/Services/AppRelaunchTests.swift
+++ b/Tests/MuxyTests/Services/AppRelaunchTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Foundation
 import Testing
 
 @testable import Muxy
@@ -5,6 +7,39 @@ import Testing
 @Suite("AppRelaunch")
 @MainActor
 struct AppRelaunchTests {
+    @Test("app bundles relaunch through nohup and open")
+    func appBundleRelaunchUsesDetachedOpenRequest() {
+        let bundleURL = URL(fileURLWithPath: "/Applications/Muxy Beta.app")
+        let request = AppRelaunch.launchRequest(bundleURL: bundleURL, executableURL: nil, processID: 42)
+
+        #expect(request.executableURL.path == "/usr/bin/nohup")
+        #expect(request.arguments == [
+            "/bin/sh",
+            "-c",
+            "while /bin/kill -0 \"$1\" 2>/dev/null; do /bin/sleep 0.1; done; /usr/bin/open \"$2\"",
+            "muxy-relaunch",
+            "42",
+            "/Applications/Muxy Beta.app",
+        ])
+    }
+
+    @Test("non app bundles relaunch the executable")
+    func nonAppBundleRelaunchUsesExecutableRequest() {
+        let bundleURL = URL(fileURLWithPath: "/tmp/MuxyPackageTests.xctest")
+        let executableURL = URL(fileURLWithPath: "/tmp/Muxy")
+        let request = AppRelaunch.launchRequest(bundleURL: bundleURL, executableURL: executableURL, processID: 7)
+
+        #expect(request.executableURL.path == "/usr/bin/nohup")
+        #expect(request.arguments == [
+            "/bin/sh",
+            "-c",
+            "while /bin/kill -0 \"$1\" 2>/dev/null; do /bin/sleep 0.1; done; \"$2\"",
+            "muxy-relaunch",
+            "7",
+            "/tmp/Muxy",
+        ])
+    }
+
     @Test("relaunch suppresses termination user-state persistence")
     func relaunchSuppressesTerminationUserStatePersistence() {
         AppRelaunch.resetForTesting()
@@ -20,5 +55,36 @@ struct AppRelaunchTests {
         delegate.persistUserStateForTermination()
 
         #expect(!didPersist)
+    }
+
+    @Test("dismisses attached sheets so termination is not blocked")
+    func dismissesAttachedSheetsBeforeTermination() {
+        let parent = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let sheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        parent.beginSheet(sheet)
+        pumpRunLoop(until: { parent.attachedSheet === sheet })
+        #expect(parent.attachedSheet === sheet)
+
+        AppRelaunch.dismissAttachedSheets(in: [parent])
+        pumpRunLoop(until: { parent.attachedSheet == nil })
+
+        #expect(parent.attachedSheet == nil)
+    }
+
+    private func pumpRunLoop(until condition: () -> Bool) {
+        let deadline = Date().addingTimeInterval(2)
+        while !condition(), Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
     }
 }

--- a/Tests/MuxyTests/Services/BackupServiceTests.swift
+++ b/Tests/MuxyTests/Services/BackupServiceTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("BackupService")
+struct BackupServiceTests {
+    private func tempDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BackupServiceTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func write(_ data: Data, named name: String, in directory: URL) throws {
+        try data.write(to: directory.appendingPathComponent(name), options: .atomic)
+    }
+
+    private func seedSource() throws -> URL {
+        let source = tempDirectory()
+        try write(Data("[]".utf8), named: "projects.json", in: source)
+        try write(Data(#"{"muxy.showStatusBar":true,"mobile.approvedDevices":[{"id":"x","tokenHash":"secret"}]}"#.utf8), named: "settings.json", in: source)
+
+        let device = RemoteDevice(
+            name: "Box",
+            ssh: SSHWorkspaceData(host: "example.com", environment: ["SECRET_TOKEN": "abc", "TERM": "xterm-256color"])
+        )
+        try write(try JSONEncoder().encode([device]), named: "remote-devices.json", in: source)
+
+        let logos = source.appendingPathComponent("logos", isDirectory: true)
+        try FileManager.default.createDirectory(at: logos, withIntermediateDirectories: true)
+        try write(Data("png".utf8), named: "logo.png", in: logos)
+        return source
+    }
+
+    @Test("export then import round-trips files into a clean target")
+    func roundTrip() throws {
+        let source = try seedSource()
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+        #expect(FileManager.default.fileExists(atPath: archive.path))
+
+        let target = tempDirectory()
+        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+
+        #expect(FileManager.default.fileExists(atPath: target.appendingPathComponent("projects.json").path))
+        let logo = target.appendingPathComponent("logos/logo.png")
+        #expect(try Data(contentsOf: logo) == Data("png".utf8))
+    }
+
+    @Test("export strips SSH environment secrets")
+    func stripsSSHEnvironment() throws {
+        let source = try seedSource()
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+
+        let target = tempDirectory()
+        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+
+        let data = try Data(contentsOf: target.appendingPathComponent("remote-devices.json"))
+        let devices = try JSONDecoder().decode([RemoteDevice].self, from: data)
+        #expect(devices.first?.ssh.environment == SSHEnvironmentVariables.default)
+    }
+
+    @Test("export empties approved devices from settings")
+    func stripsApprovedDevices() throws {
+        let source = try seedSource()
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+
+        let target = tempDirectory()
+        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+
+        let data = try Data(contentsOf: target.appendingPathComponent("settings.json"))
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let approved = object?["mobile.approvedDevices"] as? [Any]
+        #expect(approved?.isEmpty == true)
+    }
+
+    @Test("approved-devices file is never included in the archive")
+    func excludesApprovedDevicesFile() throws {
+        let source = try seedSource()
+        try write(Data("[]".utf8), named: "approved-devices.json", in: source)
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+
+        let target = tempDirectory()
+        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("approved-devices.json").path))
+    }
+
+    @Test("import backs up existing data before replacing")
+    func backsUpExistingData() throws {
+        let source = try seedSource()
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+
+        let target = tempDirectory()
+        try write(Data(#"["old"]"#.utf8), named: "projects.json", in: target)
+        let backupDirectory = try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+
+        let preserved = backupDirectory.appendingPathComponent("projects.json")
+        #expect(try Data(contentsOf: preserved) == Data(#"["old"]"#.utf8))
+    }
+
+    @Test("import rejects an archive without a manifest")
+    func rejectsMissingManifest() throws {
+        let staging = tempDirectory()
+        try write(Data("[]".utf8), named: "projects.json", in: staging)
+        let archive = tempDirectory().appendingPathComponent("invalid.muxy")
+        try BackupArchive.zip(directory: staging, to: archive)
+
+        let target = tempDirectory()
+        #expect(throws: BackupArchiveError.self) {
+            try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        }
+    }
+
+    @Test("import ignores entries not in the allowlist")
+    func ignoresUnexpectedEntries() throws {
+        let source = try seedSource()
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+
+        let staging = tempDirectory()
+        try BackupArchive.unzip(archiveURL: archive, to: staging)
+        try write(Data("evil".utf8), named: "passwd", in: staging)
+
+        let manifestURL = staging.appendingPathComponent(BackupManifest.filename)
+        var manifest = try JSONDecoder.iso8601.decode(BackupManifest.self, from: Data(contentsOf: manifestURL))
+        manifest.files.append("../passwd")
+        try JSONEncoder.iso8601.encode(manifest).write(to: manifestURL, options: .atomic)
+
+        let repacked = tempDirectory().appendingPathComponent("repacked.muxy")
+        try BackupArchive.zip(directory: staging, to: repacked)
+
+        let target = tempDirectory()
+        try BackupService(baseDirectory: target).importBackup(from: repacked, backupStamp: "stamp")
+        #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("passwd").path))
+    }
+}
+
+private extension JSONDecoder {
+    static var iso8601: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+private extension JSONEncoder {
+    static var iso8601: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/Tests/MuxyTests/Services/BackupServiceTests.swift
+++ b/Tests/MuxyTests/Services/BackupServiceTests.swift
@@ -27,6 +27,8 @@ struct BackupServiceTests {
         )
         try write(try JSONEncoder().encode([device]), named: "remote-devices.json", in: source)
 
+        try write(Data("font-family = Menlo".utf8), named: "ghostty.conf", in: source)
+
         let logos = source.appendingPathComponent("logos", isDirectory: true)
         try FileManager.default.createDirectory(at: logos, withIntermediateDirectories: true)
         try write(Data("png".utf8), named: "logo.png", in: logos)
@@ -34,28 +36,30 @@ struct BackupServiceTests {
     }
 
     @Test("export then import round-trips files into a clean target")
-    func roundTrip() throws {
+    func roundTrip() async throws {
         let source = try seedSource()
         let archive = tempDirectory().appendingPathComponent("backup.muxy")
-        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
         #expect(FileManager.default.fileExists(atPath: archive.path))
 
         let target = tempDirectory()
-        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
 
         #expect(FileManager.default.fileExists(atPath: target.appendingPathComponent("projects.json").path))
         let logo = target.appendingPathComponent("logos/logo.png")
         #expect(try Data(contentsOf: logo) == Data("png".utf8))
+        let ghostty = target.appendingPathComponent("ghostty.conf")
+        #expect(try Data(contentsOf: ghostty) == Data("font-family = Menlo".utf8))
     }
 
     @Test("export strips SSH environment secrets")
-    func stripsSSHEnvironment() throws {
+    func stripsSSHEnvironment() async throws {
         let source = try seedSource()
         let archive = tempDirectory().appendingPathComponent("backup.muxy")
-        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
 
         let target = tempDirectory()
-        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
 
         let data = try Data(contentsOf: target.appendingPathComponent("remote-devices.json"))
         let devices = try JSONDecoder().decode([RemoteDevice].self, from: data)
@@ -63,13 +67,13 @@ struct BackupServiceTests {
     }
 
     @Test("export empties approved devices from settings")
-    func stripsApprovedDevices() throws {
+    func stripsApprovedDevices() async throws {
         let source = try seedSource()
         let archive = tempDirectory().appendingPathComponent("backup.muxy")
-        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
 
         let target = tempDirectory()
-        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
 
         let data = try Data(contentsOf: target.appendingPathComponent("settings.json"))
         let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -78,49 +82,49 @@ struct BackupServiceTests {
     }
 
     @Test("approved-devices file is never included in the archive")
-    func excludesApprovedDevicesFile() throws {
+    func excludesApprovedDevicesFile() async throws {
         let source = try seedSource()
         try write(Data("[]".utf8), named: "approved-devices.json", in: source)
         let archive = tempDirectory().appendingPathComponent("backup.muxy")
-        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
 
         let target = tempDirectory()
-        try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
         #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("approved-devices.json").path))
     }
 
     @Test("import backs up existing data before replacing")
-    func backsUpExistingData() throws {
+    func backsUpExistingData() async throws {
         let source = try seedSource()
         let archive = tempDirectory().appendingPathComponent("backup.muxy")
-        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
 
         let target = tempDirectory()
         try write(Data(#"["old"]"#.utf8), named: "projects.json", in: target)
-        let backupDirectory = try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        let backupDirectory = try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
 
         let preserved = backupDirectory.appendingPathComponent("projects.json")
         #expect(try Data(contentsOf: preserved) == Data(#"["old"]"#.utf8))
     }
 
     @Test("import rejects an archive without a manifest")
-    func rejectsMissingManifest() throws {
+    func rejectsMissingManifest() async throws {
         let staging = tempDirectory()
         try write(Data("[]".utf8), named: "projects.json", in: staging)
         let archive = tempDirectory().appendingPathComponent("invalid.muxy")
         try BackupArchive.zip(directory: staging, to: archive)
 
         let target = tempDirectory()
-        #expect(throws: BackupArchiveError.self) {
-            try BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        await #expect(throws: BackupArchiveError.self) {
+            try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
         }
     }
 
     @Test("import ignores entries not in the allowlist")
-    func ignoresUnexpectedEntries() throws {
+    func ignoresUnexpectedEntries() async throws {
         let source = try seedSource()
         let archive = tempDirectory().appendingPathComponent("backup.muxy")
-        try BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
 
         let staging = tempDirectory()
         try BackupArchive.unzip(archiveURL: archive, to: staging)
@@ -135,7 +139,7 @@ struct BackupServiceTests {
         try BackupArchive.zip(directory: staging, to: repacked)
 
         let target = tempDirectory()
-        try BackupService(baseDirectory: target).importBackup(from: repacked, backupStamp: "stamp")
+        try await BackupService(baseDirectory: target).importBackup(from: repacked, backupStamp: "stamp")
         #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("passwd").path))
     }
 }

--- a/Tests/MuxyTests/Services/BackupServiceTests.swift
+++ b/Tests/MuxyTests/Services/BackupServiceTests.swift
@@ -107,6 +107,43 @@ struct BackupServiceTests {
         #expect(try Data(contentsOf: preserved) == Data(#"["old"]"#.utf8))
     }
 
+    @Test("import leaves active data in place when backup preparation fails")
+    func leavesActiveDataWhenBackupPreparationFails() async throws {
+        let source = try seedSource()
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+
+        let target = tempDirectory()
+        try write(Data(#"["old"]"#.utf8), named: "projects.json", in: target)
+        try write(Data("not a directory".utf8), named: "Backups", in: target)
+
+        await #expect(throws: Error.self) {
+            try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+        }
+
+        let active = target.appendingPathComponent("projects.json")
+        #expect(try Data(contentsOf: active) == Data(#"["old"]"#.utf8))
+    }
+
+    @Test("import creates a unique pre-import backup directory")
+    func createsUniquePreImportBackupDirectory() async throws {
+        let source = try seedSource()
+        let archive = tempDirectory().appendingPathComponent("backup.muxy")
+        try await BackupService(baseDirectory: source).export(to: archive, appVersion: "1.0", createdAt: Date())
+
+        let target = tempDirectory()
+        try write(Data(#"["old"]"#.utf8), named: "projects.json", in: target)
+        let existing = target.appendingPathComponent("Backups/pre-import-stamp", isDirectory: true)
+        try FileManager.default.createDirectory(at: existing, withIntermediateDirectories: true)
+        try write(Data(#"["previous"]"#.utf8), named: "projects.json", in: existing)
+
+        let backupDirectory = try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
+
+        #expect(backupDirectory.lastPathComponent == "pre-import-stamp-1")
+        #expect(try Data(contentsOf: backupDirectory.appendingPathComponent("projects.json")) == Data(#"["old"]"#.utf8))
+        #expect(try Data(contentsOf: existing.appendingPathComponent("projects.json")) == Data(#"["previous"]"#.utf8))
+    }
+
     @Test("import rejects an archive without a manifest")
     func rejectsMissingManifest() async throws {
         let staging = tempDirectory()

--- a/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/SettingsJSONStoreTests.swift
@@ -23,6 +23,19 @@ struct SettingsJSONStoreTests {
     }
 
     @Test
+    func applyUserSettingsFileAppliesImportedSettings() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
+        defer { snapshot.restore() }
+
+        UserDefaults.standard.set(1234, forKey: MobileServerService.portKey)
+        try Data("{\"\(MobileServerService.portKey)\":4242}".utf8).write(to: SettingsJSONStore.userSettingsURL, options: .atomic)
+
+        try SettingsJSONStore.applyUserSettingsFile()
+
+        #expect(UserDefaults.standard.integer(forKey: MobileServerService.portKey) == 4242)
+    }
+
+    @Test
     func invalidKnownValueDoesNotWriteOrApplySettings() throws {
         let snapshot = SettingsJSONStoreSnapshot.capture(keys: [MobileServerService.portKey])
         defer { snapshot.restore() }


### PR DESCRIPTION
Adds a Backup settings section to export all configs, projects, remote devices and
  customizations to a .muxy file and import them on another Mac. Credentials (SSH keys,
  passwords, paired mobile tokens) are excluded; import replaces all data after backing
  up the current state, then restarts.