### PR TITLE
Add workspaces API to the remote server

### DIFF
--- a/Muxy/Services/RemoteServerDelegate.swift
+++ b/Muxy/Services/RemoteServerDelegate.swift
@@ -9,6 +9,7 @@ private let logger = Logger(subsystem: "app.muxy", category: "RemoteServerDelega
 @MainActor
 final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     static let diffPreviewLineLimit = 20000
+    static let defaultLocalWorkspaceName = "Local"
     private let appState: AppState
     private let projectStore: ProjectStore
     private let worktreeStore: WorktreeStore
@@ -122,10 +123,77 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     }
 
     private func projectSnapshots() -> [ProjectDTO] {
-        let localProjects = projectStore.projects.map { $0.toDTO(workspaceKind: .local) }
-        let remoteProjects = projectGroupStore.groups
+        let groupByProjectID = localGroupByProjectID()
+        let localProjects = projectStore.projects.map { project in
+            guard let group = groupByProjectID[project.id] else {
+                return project.toDTO(
+                    workspaceID: WorkspaceInfoDTO.defaultLocalID,
+                    workspaceName: Self.defaultLocalWorkspaceName,
+                    workspaceKind: .local
+                )
+            }
+            return project.toDTO(workspaceID: group.id, workspaceName: group.name, workspaceKind: .local)
+        }
+        return localProjects + remoteGroupSnapshots().flatMap(\.projects)
+    }
+
+    private func localGroupByProjectID() -> [UUID: ProjectGroup] {
+        var map: [UUID: ProjectGroup] = [:]
+        for group in projectGroupStore.groups where group.type == .local {
+            for projectID in group.projectIDs where map[projectID] == nil {
+                map[projectID] = group
+            }
+        }
+        return map
+    }
+
+    private func workspaceProjectSnapshots() -> [(workspace: WorkspaceInfoDTO, projects: [ProjectDTO])] {
+        defaultLocalSnapshot() + localGroupSnapshots() + remoteGroupSnapshots()
+    }
+
+    private func defaultLocalSnapshot() -> [(workspace: WorkspaceInfoDTO, projects: [ProjectDTO])] {
+        let groupedIDs = Set(projectGroupStore.groups.filter { $0.type == .local }.flatMap(\.projectIDs))
+        let projects = projectStore.projects
+            .filter { !groupedIDs.contains($0.id) }
+            .map {
+                $0.toDTO(
+                    workspaceID: WorkspaceInfoDTO.defaultLocalID,
+                    workspaceName: Self.defaultLocalWorkspaceName,
+                    workspaceKind: .local
+                )
+            }
+        let workspace = WorkspaceInfoDTO(
+            id: WorkspaceInfoDTO.defaultLocalID,
+            name: Self.defaultLocalWorkspaceName,
+            kind: .local,
+            isDefault: true,
+            projectCount: projects.count
+        )
+        return [(workspace, projects)]
+    }
+
+    private func localGroupSnapshots() -> [(workspace: WorkspaceInfoDTO, projects: [ProjectDTO])] {
+        let projectsByID = Dictionary(projectStore.projects.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return projectGroupStore.groups
+            .filter { $0.type == .local }
+            .map { group in
+                let projects = group.projectIDs
+                    .compactMap { projectsByID[$0] }
+                    .map { $0.toDTO(workspaceID: group.id, workspaceName: group.name, workspaceKind: .local) }
+                let workspace = WorkspaceInfoDTO(
+                    id: group.id,
+                    name: group.name,
+                    kind: .local,
+                    projectCount: projects.count
+                )
+                return (workspace, projects)
+            }
+    }
+
+    private func remoteGroupSnapshots() -> [(workspace: WorkspaceInfoDTO, projects: [ProjectDTO])] {
+        projectGroupStore.groups
             .filter { $0.type == .ssh }
-            .flatMap { group -> [ProjectDTO] in
+            .map { group in
                 let home = projectGroupStore.remoteHomeProject(for: group).map {
                     $0.toDTO(workspaceID: group.id, workspaceName: group.name, workspaceKind: .ssh)
                 }
@@ -133,9 +201,15 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
                     remote.asProject(workspaceID: group.id, sortOrder: index)
                         .toDTO(workspaceID: group.id, workspaceName: group.name, workspaceKind: .ssh)
                 }
-                return (home.map { [$0] } ?? []) + projects
+                let all = (home.map { [$0] } ?? []) + projects
+                let workspace = WorkspaceInfoDTO(
+                    id: group.id,
+                    name: group.name,
+                    kind: .ssh,
+                    projectCount: all.count
+                )
+                return (workspace, all)
             }
-        return localProjects + remoteProjects
     }
 
     private func resolveRemoteProject(_ projectID: UUID) -> (project: Project, group: ProjectGroup)? {
@@ -162,6 +236,14 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
 
     func listProjects() -> [ProjectDTO] {
         projectSnapshots()
+    }
+
+    func listWorkspaces() -> [WorkspaceInfoDTO] {
+        workspaceProjectSnapshots().map(\.workspace)
+    }
+
+    func listProjectsByWorkspace(workspaceID: UUID) -> [ProjectDTO] {
+        workspaceProjectSnapshots().first { $0.workspace.id == workspaceID }?.projects ?? []
     }
 
     func selectProject(_ projectID: UUID) {

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -28,6 +28,8 @@ public enum MuxyRemoteServerError: LocalizedError {
 @MainActor
 public protocol MuxyRemoteServerDelegate: AnyObject {
     func listProjects() -> [ProjectDTO]
+    func listWorkspaces() -> [WorkspaceInfoDTO]
+    func listProjectsByWorkspace(workspaceID: UUID) -> [ProjectDTO]
     func selectProject(_ projectID: UUID)
     func listWorktrees(projectID: UUID) -> [WorktreeDTO]
     func selectWorktree(projectID: UUID, worktreeID: UUID)
@@ -331,6 +333,17 @@ public final class MuxyRemoteServer: @unchecked Sendable {
 
         case .listProjects:
             let projects = delegate.listProjects()
+            return MuxyResponse(id: request.id, result: .projects(projects))
+
+        case .listWorkspaces:
+            let workspaces = delegate.listWorkspaces()
+            return MuxyResponse(id: request.id, result: .workspaces(workspaces))
+
+        case .listProjectsByWorkspace:
+            guard case let .listProjectsByWorkspace(params) = request.params else {
+                return MuxyResponse(id: request.id, error: .invalidParams)
+            }
+            let projects = delegate.listProjectsByWorkspace(workspaceID: params.workspaceID)
             return MuxyResponse(id: request.id, result: .projects(projects))
 
         case .selectProject:

--- a/MuxyShared/MuxyProtocol.swift
+++ b/MuxyShared/MuxyProtocol.swift
@@ -66,6 +66,8 @@ public struct MuxyError: Codable, Sendable, Error {
 
 public enum MuxyMethod: String, Codable, Sendable {
     case listProjects
+    case listWorkspaces
+    case listProjectsByWorkspace
     case selectProject
     case listWorktrees
     case selectWorktree
@@ -111,6 +113,7 @@ public enum MuxyMethod: String, Codable, Sendable {
 }
 
 public enum MuxyParams: Codable, Sendable {
+    case listProjectsByWorkspace(ListProjectsByWorkspaceParams)
     case selectProject(SelectProjectParams)
     case listWorktrees(ListWorktreesParams)
     case selectWorktree(SelectWorktreeParams)
@@ -162,6 +165,10 @@ public enum MuxyParams: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(String.self, forKey: .type)
         switch type {
+        case "listProjectsByWorkspace": self = try .listProjectsByWorkspace(container.decode(
+                ListProjectsByWorkspaceParams.self,
+                forKey: .value
+            ))
         case "selectProject": self = try .selectProject(container.decode(SelectProjectParams.self, forKey: .value))
         case "listWorktrees": self = try .listWorktrees(container.decode(ListWorktreesParams.self, forKey: .value))
         case "selectWorktree": self = try .selectWorktree(container.decode(SelectWorktreeParams.self, forKey: .value))
@@ -210,6 +217,8 @@ public enum MuxyParams: Codable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
+        case let .listProjectsByWorkspace(v): try container.encode("listProjectsByWorkspace", forKey: .type)
+            try container.encode(v, forKey: .value)
         case let .selectProject(v): try container.encode("selectProject", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .listWorktrees(v): try container.encode("listWorktrees", forKey: .type)
@@ -298,6 +307,7 @@ public enum MuxyParams: Codable, Sendable {
 
 public enum MuxyResult: Codable, Sendable {
     case projects([ProjectDTO])
+    case workspaces([WorkspaceInfoDTO])
     case worktrees([WorktreeDTO])
     case workspace(WorkspaceDTO)
     case tab(TabDTO)
@@ -325,6 +335,7 @@ public enum MuxyResult: Codable, Sendable {
         let type = try container.decode(String.self, forKey: .type)
         switch type {
         case "projects": self = try .projects(container.decode([ProjectDTO].self, forKey: .value))
+        case "workspaces": self = try .workspaces(container.decode([WorkspaceInfoDTO].self, forKey: .value))
         case "worktrees": self = try .worktrees(container.decode([WorktreeDTO].self, forKey: .value))
         case "workspace": self = try .workspace(container.decode(WorkspaceDTO.self, forKey: .value))
         case "tab": self = try .tab(container.decode(TabDTO.self, forKey: .value))
@@ -349,6 +360,8 @@ public enum MuxyResult: Codable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case let .projects(v): try container.encode("projects", forKey: .type)
+            try container.encode(v, forKey: .value)
+        case let .workspaces(v): try container.encode("workspaces", forKey: .type)
             try container.encode(v, forKey: .value)
         case let .worktrees(v): try container.encode("worktrees", forKey: .type)
             try container.encode(v, forKey: .value)

--- a/MuxyShared/ProjectDTO.swift
+++ b/MuxyShared/ProjectDTO.swift
@@ -5,6 +5,30 @@ public enum WorkspaceKindDTO: String, Codable, Hashable, Sendable {
     case ssh
 }
 
+public struct WorkspaceInfoDTO: Identifiable, Codable, Hashable, Sendable {
+    public static let defaultLocalID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2))
+
+    public let id: UUID
+    public var name: String
+    public var kind: WorkspaceKindDTO
+    public var isDefault: Bool
+    public var projectCount: Int
+
+    public init(
+        id: UUID,
+        name: String,
+        kind: WorkspaceKindDTO,
+        isDefault: Bool = false,
+        projectCount: Int = 0
+    ) {
+        self.id = id
+        self.name = name
+        self.kind = kind
+        self.isDefault = isDefault
+        self.projectCount = projectCount
+    }
+}
+
 public struct ProjectDTO: Identifiable, Codable, Hashable, Sendable {
     public let id: UUID
     public var name: String

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -27,6 +27,13 @@ public struct ExtensionResultDTO: Codable, Sendable {
     }
 }
 
+public struct ListProjectsByWorkspaceParams: Codable, Sendable {
+    public let workspaceID: UUID
+    public init(workspaceID: UUID) {
+        self.workspaceID = workspaceID
+    }
+}
+
 public struct ListWorktreesParams: Codable, Sendable {
     public let projectID: UUID
     public init(projectID: UUID) {

--- a/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
@@ -88,6 +88,7 @@ struct MuxyProtocolVariantTests {
     private static func paramSamples() -> [ProtocolSample<MuxyParams>] {
         let ids = IDs()
         return [
+            ProtocolSample(.listProjectsByWorkspace(ListProjectsByWorkspaceParams(workspaceID: ids.projectID)), caseName: ".listProjectsByWorkspace"),
             ProtocolSample(.selectProject(SelectProjectParams(projectID: ids.projectID)), caseName: ".selectProject"),
             ProtocolSample(.listWorktrees(ListWorktreesParams(projectID: ids.projectID)), caseName: ".listWorktrees"),
             ProtocolSample(.selectWorktree(SelectWorktreeParams(projectID: ids.projectID, worktreeID: ids.worktreeID)), caseName: ".selectWorktree"),
@@ -136,6 +137,7 @@ struct MuxyProtocolVariantTests {
         let ids = IDs()
         return [
             ProtocolSample(.projects([project(ids)]), caseName: ".projects"),
+            ProtocolSample(.workspaces([WorkspaceInfoDTO(id: WorkspaceInfoDTO.defaultLocalID, name: "Local", kind: .local, isDefault: true, projectCount: 1)]), caseName: ".workspaces"),
             ProtocolSample(.worktrees([WorktreeDTO(id: ids.worktreeID, name: "Main", path: "/repo", branch: "main", isPrimary: true, createdAt: Date(timeIntervalSince1970: 3))]), caseName: ".worktrees"),
             ProtocolSample(.workspace(workspace(ids)), caseName: ".workspace"),
             ProtocolSample(.tab(tab(ids)), caseName: ".tab"),

--- a/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
@@ -29,6 +29,9 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
     var vcsRemoveWorktreeCalls: [(projectID: UUID, worktreeID: UUID)] = []
 
     var stubProjects: [ProjectDTO] = []
+    var stubWorkspaces: [WorkspaceInfoDTO] = []
+    var listProjectsByWorkspaceCalls: [UUID] = []
+    var stubProjectsByWorkspace: [UUID: [ProjectDTO]] = [:]
     var stubWorkspace: WorkspaceDTO?
     var stubTab: TabDTO?
     var stubTerminalContent: TerminalCellsDTO?
@@ -42,6 +45,15 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
     func listProjects() -> [ProjectDTO] {
         listProjectsCalled += 1
         return stubProjects
+    }
+
+    func listWorkspaces() -> [WorkspaceInfoDTO] {
+        stubWorkspaces
+    }
+
+    func listProjectsByWorkspace(workspaceID: UUID) -> [ProjectDTO] {
+        listProjectsByWorkspaceCalls.append(workspaceID)
+        return stubProjectsByWorkspace[workspaceID] ?? []
     }
 
     func selectProject(_ projectID: UUID) {
@@ -239,6 +251,105 @@ struct MuxyRemoteServerRoutingTests {
         #expect(projects.count == 1)
         #expect(projects.first?.id == project.id)
         #expect(response.error == nil)
+    }
+
+    @Test("listWorkspaces routes to delegate and returns workspaces")
+    func listWorkspacesRoutes() async {
+        let (server, delegate) = makeServer()
+        let workspace = WorkspaceInfoDTO(
+            id: WorkspaceInfoDTO.defaultLocalID,
+            name: "Local",
+            kind: .local,
+            isDefault: true,
+            projectCount: 2
+        )
+        delegate.stubWorkspaces = [workspace]
+
+        let response = await server.processRequest(
+            MuxyRequest(id: "ws-1", method: .listWorkspaces),
+            clientID: authedClient(on: server)
+        )
+
+        guard case let .workspaces(workspaces) = response.result else {
+            Issue.record("expected workspaces result")
+            return
+        }
+        #expect(workspaces.count == 1)
+        #expect(workspaces.first?.id == WorkspaceInfoDTO.defaultLocalID)
+        #expect(workspaces.first?.isDefault == true)
+        #expect(workspaces.first?.projectCount == 2)
+        #expect(response.error == nil)
+    }
+
+    @Test("listProjectsByWorkspace forwards workspaceID and returns its projects")
+    func listProjectsByWorkspaceRoutes() async {
+        let (server, delegate) = makeServer()
+        let workspaceID = UUID()
+        let project = ProjectDTO(
+            id: UUID(),
+            name: "Muxy",
+            path: "/tmp/muxy",
+            sortOrder: 0,
+            createdAt: Date(timeIntervalSince1970: 0),
+            workspaceID: workspaceID,
+            workspaceName: "Frontend",
+            workspaceKind: .local
+        )
+        delegate.stubProjectsByWorkspace = [workspaceID: [project]]
+
+        let response = await server.processRequest(
+            MuxyRequest(
+                id: "ws-2",
+                method: .listProjectsByWorkspace,
+                params: .listProjectsByWorkspace(ListProjectsByWorkspaceParams(workspaceID: workspaceID))
+            ),
+            clientID: authedClient(on: server)
+        )
+
+        #expect(delegate.listProjectsByWorkspaceCalls == [workspaceID])
+        guard case let .projects(projects) = response.result else {
+            Issue.record("expected projects result")
+            return
+        }
+        #expect(projects.count == 1)
+        #expect(projects.first?.workspaceID == workspaceID)
+        #expect(response.error == nil)
+    }
+
+    @Test("workspace methods require authentication")
+    func workspaceMethodsRequireAuth() async {
+        let (server, delegate) = makeServer()
+
+        let listResponse = await server.processRequest(
+            MuxyRequest(id: "ws-auth-1", method: .listWorkspaces),
+            clientID: UUID()
+        )
+        let byWorkspaceResponse = await server.processRequest(
+            MuxyRequest(
+                id: "ws-auth-2",
+                method: .listProjectsByWorkspace,
+                params: .listProjectsByWorkspace(ListProjectsByWorkspaceParams(workspaceID: UUID()))
+            ),
+            clientID: UUID()
+        )
+
+        #expect(listResponse.error?.code == 401)
+        #expect(byWorkspaceResponse.error?.code == 401)
+        #expect(delegate.listProjectsByWorkspaceCalls.isEmpty)
+    }
+
+    @Test("listProjectsByWorkspace rejects missing params as invalidParams")
+    func listProjectsByWorkspaceInvalidParams() async {
+        let (server, delegate) = makeServer()
+
+        let response = await server.processRequest(
+            MuxyRequest(id: "ws-3", method: .listProjectsByWorkspace, params: nil),
+            clientID: authedClient(on: server)
+        )
+
+        #expect(delegate.listProjectsByWorkspaceCalls.isEmpty)
+        #expect(response.error?.code == 400)
+        #expect(response.result == nil)
     }
 
     @Test("selectProject forwards projectID")

--- a/Tests/MuxyTests/Remote/RemoteServerDelegateWorkspacesTests.swift
+++ b/Tests/MuxyTests/Remote/RemoteServerDelegateWorkspacesTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import MuxyShared
+import Testing
+
+@testable import Muxy
+
+@Suite("RemoteServerDelegate workspaces")
+@MainActor
+struct RemoteServerDelegateWorkspacesTests {
+    @Test("listWorkspaces always exposes the default Local workspace")
+    func defaultLocalWorkspaceExists() {
+        let delegate = makeDelegate(projects: [], groups: [])
+
+        let workspaces = delegate.listWorkspaces()
+
+        #expect(workspaces.count == 1)
+        let local = workspaces.first
+        #expect(local?.id == WorkspaceInfoDTO.defaultLocalID)
+        #expect(local?.isDefault == true)
+        #expect(local?.kind == .local)
+    }
+
+    @Test("ungrouped local projects and Home land in the default Local workspace")
+    func ungroupedProjectsInDefaultWorkspace() {
+        let project = localProject(name: "Alpha")
+        let delegate = makeDelegate(projects: [project], groups: [])
+
+        let local = delegate.listProjectsByWorkspace(workspaceID: WorkspaceInfoDTO.defaultLocalID)
+
+        #expect(local.contains { $0.id == project.id })
+        #expect(local.contains { $0.id == Project.homeID })
+        #expect(local.allSatisfy { $0.workspaceID == WorkspaceInfoDTO.defaultLocalID })
+    }
+
+    @Test("a local group exposes only its members and excludes them from default")
+    func localGroupScopesProjects() {
+        let grouped = localProject(name: "Grouped")
+        let loose = localProject(name: "Loose")
+        let group = ProjectGroup(name: "Frontend", projectIDs: [grouped.id])
+        let delegate = makeDelegate(projects: [grouped, loose], groups: [group])
+
+        let workspaces = delegate.listWorkspaces()
+        let groupInfo = workspaces.first { $0.id == group.id }
+        #expect(groupInfo?.name == "Frontend")
+        #expect(groupInfo?.kind == .local)
+        #expect(groupInfo?.projectCount == 1)
+
+        let groupProjects = delegate.listProjectsByWorkspace(workspaceID: group.id)
+        #expect(groupProjects.map(\.id) == [grouped.id])
+        #expect(groupProjects.first?.workspaceID == group.id)
+        #expect(groupProjects.first?.workspaceName == "Frontend")
+
+        let defaultProjects = delegate.listProjectsByWorkspace(workspaceID: WorkspaceInfoDTO.defaultLocalID)
+        #expect(defaultProjects.contains { $0.id == loose.id })
+        #expect(!defaultProjects.contains { $0.id == grouped.id })
+    }
+
+    @Test("listProjects equals the union of every workspace's projects")
+    func listProjectsMatchesWorkspaceUnion() {
+        let grouped = localProject(name: "Grouped")
+        let loose = localProject(name: "Loose")
+        let group = ProjectGroup(name: "Frontend", projectIDs: [grouped.id])
+        let delegate = makeDelegate(projects: [grouped, loose], groups: [group])
+
+        let flat = Set(delegate.listProjects().map(\.id))
+        let perWorkspace = Set(delegate.listWorkspaces().flatMap {
+            delegate.listProjectsByWorkspace(workspaceID: $0.id).map(\.id)
+        })
+
+        #expect(flat == perWorkspace)
+        #expect(flat.contains(grouped.id))
+        #expect(flat.contains(loose.id))
+        #expect(flat.contains(Project.homeID))
+    }
+
+    @Test("listProjects keeps the stored local project order regardless of grouping")
+    func listProjectsPreservesLocalOrder() {
+        let first = localProject(name: "First")
+        let second = localProject(name: "Second")
+        let third = localProject(name: "Third")
+        let group = ProjectGroup(name: "Frontend", projectIDs: [second.id])
+        let delegate = makeDelegate(projects: [first, second, third], groups: [group])
+
+        let localIDs = delegate.listProjects()
+            .filter { $0.workspaceKind == .local }
+            .map(\.id)
+
+        #expect(localIDs == [Project.homeID, first.id, second.id, third.id])
+    }
+
+    @Test("unknown workspace id returns no projects")
+    func unknownWorkspaceIsEmpty() {
+        let delegate = makeDelegate(projects: [localProject(name: "Alpha")], groups: [])
+
+        #expect(delegate.listProjectsByWorkspace(workspaceID: UUID()).isEmpty)
+    }
+
+    private func localProject(name: String) -> Project {
+        Project(id: UUID(), name: name, path: "/tmp/\(name)", sortOrder: 0)
+    }
+
+    private func makeDelegate(projects: [Project], groups: [ProjectGroup]) -> RemoteServerDelegate {
+        let projectStore = ProjectStore(persistence: InMemoryProjectPersistence(initial: projects))
+        let worktreeStore = WorktreeStore(
+            persistence: InMemoryWorktreePersistence(),
+            projects: projectStore.projects
+        )
+        let appState = AppState(
+            selectionStore: InMemorySelectionStore(),
+            terminalViews: NoopTerminalViewRemoving(),
+            workspacePersistence: InMemoryWorkspacePersistence()
+        )
+        let projectGroupStore = ProjectGroupStore(
+            persistence: InMemoryGroupPersistence(initial: groups),
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        return RemoteServerDelegate(
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+    }
+}
+
+private final class InMemoryProjectPersistence: ProjectPersisting {
+    private var projects: [Project]
+    init(initial: [Project]) { projects = initial }
+    func loadProjects() throws -> [Project] { projects }
+    func saveProjects(_ projects: [Project]) throws { self.projects = projects }
+}
+
+private final class InMemoryWorktreePersistence: WorktreePersisting {
+    private var storage: [UUID: [Worktree]] = [:]
+    func loadWorktrees(projectID: UUID) throws -> [Worktree] { storage[projectID] ?? [] }
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws { storage[projectID] = worktrees }
+    func removeWorktrees(projectID: UUID) throws { storage.removeValue(forKey: projectID) }
+}
+
+private final class InMemoryGroupPersistence: ProjectGroupPersisting {
+    private var groups: [ProjectGroup]
+    private var activeGroupID: UUID?
+    init(initial: [ProjectGroup]) { groups = initial }
+    func loadProjectGroups() throws -> [ProjectGroup] { groups }
+    func saveProjectGroups(_ groups: [ProjectGroup]) throws { self.groups = groups }
+    func loadActiveGroupID() -> UUID? { activeGroupID }
+    func saveActiveGroupID(_ id: UUID?) { activeGroupID = id }
+}
+
+private final class InMemoryWorkspacePersistence: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws { snapshots = workspaces }
+}
+
+@MainActor
+private final class InMemorySelectionStore: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class NoopTerminalViewRemoving: TerminalViewRemoving {
+    func removeView(for paneID: UUID) {}
+    func needsConfirmQuit(for paneID: UUID) -> Bool { false }
+}

--- a/docs/remote-server/data-objects.md
+++ b/docs/remote-server/data-objects.md
@@ -24,7 +24,23 @@ Every object below is the exact wire shape produced by the desktop. All dates ar
 
 `icon`, `logo`, `iconColor`, and `preferredWorktreeParentPath` are optional and omitted when unset. `icon` is an SF Symbol name. `logo` is an opaque storage identifier — fetch the image with [`getProjectLogo`](methods.md). `iconColor` is a hex string or a palette id (`red`, `blue`, `violet`, …). `worktreesEnabled` indicates whether the project exposes its worktrees in the sidebar; it defaults to `false`.
 
-`listProjects` returns projects from **all** workspaces — local projects plus every remote (SSH) workspace's projects. `workspaceKind` is `"local"` or `"ssh"`; `workspaceID`/`workspaceName` identify the owning workspace (omitted for plain local projects). Selecting an `ssh` project via [`selectProject`](methods.md) makes the Mac activate that workspace and connect over SSH, so the mobile client drives the remote server transparently — terminals, git, and exec all run on the remote host while the Mac brokers the connection. `path` for an `ssh` project is a remote path.
+`listProjects` returns projects from **all** workspaces — local projects plus every remote (SSH) workspace's projects. `workspaceKind` is `"local"` or `"ssh"`; `workspaceID`/`workspaceName` identify the owning workspace. Ungrouped local projects and Home belong to the implicit **Local** workspace and carry its `workspaceID`. Selecting an `ssh` project via [`selectProject`](methods.md) makes the Mac activate that workspace and connect over SSH, so the mobile client drives the remote server transparently — terminals, git, and exec all run on the remote host while the Mac brokers the connection. `path` for an `ssh` project is a remote path.
+
+## Workspace info
+
+`listWorkspaces` returns one of these per workspace. A workspace groups projects; it is **not** the split/tab layout (that is [Workspace](#workspace), returned by `getWorkspace`).
+
+```json
+{
+  "id": "uuid",
+  "name": "Local",
+  "kind": "local",
+  "isDefault": true,
+  "projectCount": 3
+}
+```
+
+`kind` is `"local"` or `"ssh"`. Exactly one workspace has `isDefault: true` — the implicit **Local** workspace that holds every ungrouped local project plus Home; its `id` is the stable constant `00000000-0000-0000-0000-000000000002`. `projectCount` is the number of projects the workspace owns. Fetch those projects with [`listProjectsByWorkspace`](methods.md).
 
 ## Worktree
 

--- a/docs/remote-server/methods.md
+++ b/docs/remote-server/methods.md
@@ -7,6 +7,8 @@ Each method name doubles as the `params.type` discriminator. The **Result** colu
 | Method | Parameters | Result |
 | --- | --- | --- |
 | `listProjects` | none | `projects` |
+| `listWorkspaces` | none | `workspaces` |
+| `listProjectsByWorkspace` | `workspaceID` | `projects` |
 | `selectProject` | `projectID` | `ok` |
 | `listWorktrees` | `projectID` | `worktrees` |
 | `selectWorktree` | `projectID`, `worktreeID` | `ok` |
@@ -23,6 +25,8 @@ Enums:
 - `kind`: `terminal`, `vcs` (default `terminal`). `extensionWebView` is rejected — only terminal and VCS tabs can be created remotely.
 - `direction`: `horizontal`, `vertical`
 - `position`: `first`, `second`
+
+`listWorkspaces` returns every workspace as a [workspace info](data-objects.md) object — the implicit **Local** workspace (`isDefault: true`) that owns all ungrouped local projects plus Home, each user-defined local group, and each remote (SSH) workspace. `listProjectsByWorkspace` returns just the projects in one workspace (same shape as `listProjects`) and is empty for an unknown `workspaceID`. `listProjects` still returns every project across all workspaces in one call.
 
 `getWorkspace` returns the workspace for the project's **active** worktree; select the worktree first with `selectWorktree`. It returns `404` when the project has no active workspace. `createTab` returns `tab` (the newly active tab) or `500` if creation fails.
 


### PR DESCRIPTION
Adds `listWorkspaces` and `listProjectsByWorkspace` to the remote-server API so the mobile app can browse projects by workspace.

Ungrouped local projects and Home fall under an implicit default "Local" workspace; `listProjects` now also tags local projects with their group.