### PR TITLE
feat: browser profiles & Chrome import (v2)

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
     static let openExtensionDirectoryAsProject = Notification.Name("MuxyOpenExtensionDirectoryAsProject")
     static let focusProjectPickerDefaultLocation = Notification.Name("MuxyFocusProjectPickerDefaultLocation")
     static let focusRemoteDevicesSettings = Notification.Name("MuxyFocusRemoteDevicesSettings")
+    static let focusBrowserSettings = Notification.Name("MuxyFocusBrowserSettings")
     static let windowFullScreenDidChange = Notification.Name("MuxyWindowFullScreenDidChange")
     static let toggleSidebar = Notification.Name("MuxyToggleSidebar")
     static let toggleNotificationPanel = Notification.Name("MuxyToggleNotificationPanel")

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -311,7 +311,7 @@ final class AppState {
     func openInBuiltInBrowser(_ url: URL?, profileID: UUID? = nil) -> Bool {
         guard let projectID = activeProjectID else { return false }
         let areaID = focusedArea(for: projectID)?.id
-        let resolvedProfileID = profileID ?? BrowserProfileStore.defaultProfileIDOrFallback
+        let resolvedProfileID = profileID ?? BrowserPreferences.defaultProfileID
         dispatch(.createBrowserTab(projectID: projectID, areaID: areaID, url: url, profileID: resolvedProfileID))
         return true
     }

--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -37,7 +37,7 @@ final class AppState {
         case createTabInDirectory(projectID: UUID, areaID: UUID?, directory: String)
         case createCommandTab(CommandTabRequest)
         case createExtensionTab(projectID: UUID, areaID: UUID?, request: CreateExtensionTabRequest)
-        case createBrowserTab(projectID: UUID, areaID: UUID?, url: URL?)
+        case createBrowserTab(projectID: UUID, areaID: UUID?, url: URL?, profileID: UUID)
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTabByIndex(projectID: UUID, index: Int)
@@ -308,10 +308,11 @@ final class AppState {
     }
 
     @discardableResult
-    func openInBuiltInBrowser(_ url: URL?) -> Bool {
+    func openInBuiltInBrowser(_ url: URL?, profileID: UUID? = nil) -> Bool {
         guard let projectID = activeProjectID else { return false }
         let areaID = focusedArea(for: projectID)?.id
-        dispatch(.createBrowserTab(projectID: projectID, areaID: areaID, url: url))
+        let resolvedProfileID = profileID ?? BrowserProfileStore.defaultProfileIDOrFallback
+        dispatch(.createBrowserTab(projectID: projectID, areaID: areaID, url: url, profileID: resolvedProfileID))
         return true
     }
 

--- a/Muxy/Models/BrowserPreferences.swift
+++ b/Muxy/Models/BrowserPreferences.swift
@@ -2,9 +2,20 @@ import Foundation
 
 enum BrowserPreferences {
     static let openLinksInBuiltInBrowserKey = "muxy.browser.openLinksInBuiltIn"
+    static let defaultProfileIDKey = "muxy.browser.defaultProfileID"
 
     static var openLinksInBuiltInBrowser: Bool {
         get { UserDefaults.standard.bool(forKey: openLinksInBuiltInBrowserKey) }
         set { UserDefaults.standard.set(newValue, forKey: openLinksInBuiltInBrowserKey) }
+    }
+
+    static var defaultProfileID: UUID {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: defaultProfileIDKey),
+                  let id = UUID(uuidString: raw)
+            else { return BrowserProfile.defaultID }
+            return id
+        }
+        set { UserDefaults.standard.set(newValue.uuidString, forKey: defaultProfileIDKey) }
     }
 }

--- a/Muxy/Models/BrowserProfile.swift
+++ b/Muxy/Models/BrowserProfile.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct BrowserProfile: Identifiable, Codable, Hashable {
+    static let defaultID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xB0))
+    static let defaultName = "Default"
+
+    let id: UUID
+    var name: String
+
+    var isDefault: Bool { id == Self.defaultID }
+
+    init(id: UUID = UUID(), name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    static let `default` = Self(id: defaultID, name: defaultName)
+}

--- a/Muxy/Models/BrowserTabState.swift
+++ b/Muxy/Models/BrowserTabState.swift
@@ -12,6 +12,7 @@ final class BrowserTabState: Identifiable {
 
     let id = UUID()
     let projectPath: String
+    var profileID: UUID
 
     var url: URL?
     var pendingURL: URL?
@@ -30,9 +31,10 @@ final class BrowserTabState: Identifiable {
         return "New Tab"
     }
 
-    init(projectPath: String, url: URL? = nil) {
+    init(projectPath: String, url: URL? = nil, profileID: UUID = BrowserProfile.defaultID) {
         self.projectPath = projectPath
         self.url = url
+        self.profileID = profileID
         pendingURL = url
     }
 

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -115,8 +115,8 @@ final class TabArea: Identifiable {
         insertTab(TerminalTab(extensionState: state))
     }
 
-    func createBrowserTab(url: URL?) {
-        let state = BrowserTabState(projectPath: projectPath, url: url)
+    func createBrowserTab(url: URL?, profileID: UUID = BrowserProfile.defaultID) {
+        let state = BrowserTabState(projectPath: projectPath, url: url, profileID: profileID)
         insertTab(TerminalTab(browserState: state))
     }
 

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -117,7 +117,8 @@ final class TerminalTab: Identifiable {
         case .browser:
             content = .browser(BrowserTabState(
                 projectPath: snapshot.projectPath,
-                url: snapshot.browserURL.flatMap(URL.init(string:))
+                url: snapshot.browserURL.flatMap(URL.init(string:)),
+                profileID: snapshot.browserProfileID.flatMap(UUID.init(uuidString:)) ?? BrowserProfile.defaultID
             ))
         }
     }
@@ -136,7 +137,8 @@ final class TerminalTab: Identifiable {
             extensionID: content.extensionState?.extensionID,
             extensionTabTypeID: content.extensionState?.tabTypeID,
             extensionTabData: content.extensionState?.data,
-            browserURL: content.browserState?.url?.absoluteString
+            browserURL: content.browserState?.url?.absoluteString,
+            browserProfileID: content.browserState?.profileID.uuidString
         )
     }
 

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -99,11 +99,12 @@ enum WorkspaceReducer {
                 state: &state
             )
 
-        case let .createBrowserTab(projectID, areaID, url):
+        case let .createBrowserTab(projectID, areaID, url, profileID):
             TabReducer.createBrowserTab(
                 projectID: projectID,
                 areaID: areaID,
                 url: url,
+                profileID: profileID,
                 state: &state
             )
 

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -68,12 +68,18 @@ enum TabReducer {
         )
     }
 
-    static func createBrowserTab(projectID: UUID, areaID: UUID?, url: URL?, state: inout WorkspaceState) {
+    static func createBrowserTab(
+        projectID: UUID,
+        areaID: UUID?,
+        url: URL?,
+        profileID: UUID,
+        state: inout WorkspaceState
+    ) {
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
               let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
         else { return }
         FocusReducer.focusArea(area.id, key: key, state: &state)
-        area.createBrowserTab(url: url)
+        area.createBrowserTab(url: url, profileID: profileID)
     }
 
     static func selectTab(projectID: UUID, areaID: UUID?, tabID: UUID, state: inout WorkspaceState) {

--- a/Muxy/Models/WorkspaceSnapshot.swift
+++ b/Muxy/Models/WorkspaceSnapshot.swift
@@ -112,6 +112,7 @@ struct TerminalTabSnapshot: Codable {
     let extensionTabTypeID: String?
     let extensionTabData: ExtensionJSON?
     let browserURL: String?
+    let browserProfileID: String?
 
     init(
         kind: TerminalTab.Kind,
@@ -127,7 +128,8 @@ struct TerminalTabSnapshot: Codable {
         extensionID: String? = nil,
         extensionTabTypeID: String? = nil,
         extensionTabData: ExtensionJSON? = nil,
-        browserURL: String? = nil
+        browserURL: String? = nil,
+        browserProfileID: String? = nil
     ) {
         self.kind = kind
         self.id = id
@@ -143,6 +145,7 @@ struct TerminalTabSnapshot: Codable {
         self.extensionTabTypeID = extensionTabTypeID
         self.extensionTabData = extensionTabData
         self.browserURL = browserURL
+        self.browserProfileID = browserProfileID
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -160,6 +163,7 @@ struct TerminalTabSnapshot: Codable {
         case extensionTabTypeID
         case extensionTabData
         case browserURL
+        case browserProfileID
     }
 
     init(from decoder: Decoder) throws {
@@ -179,6 +183,7 @@ struct TerminalTabSnapshot: Codable {
         extensionTabTypeID = try container.decodeIfPresent(String.self, forKey: .extensionTabTypeID)
         extensionTabData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .extensionTabData)
         browserURL = try container.decodeIfPresent(String.self, forKey: .browserURL)
+        browserProfileID = try container.decodeIfPresent(String.self, forKey: .browserProfileID)
     }
 }
 

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -14,6 +14,7 @@ struct MuxyApp: App {
     @State private var worktreeStore: WorktreeStore
     @State private var projectGroupStore: ProjectGroupStore
     @State private var remoteDeviceStore: RemoteDeviceStore
+    @State private var browserProfileStore: BrowserProfileStore
     @State private var worktreeAutoRefresher: VCSWorktreeAutoRefresher?
     @State private var didStartDeferredServices = false
 
@@ -35,6 +36,9 @@ struct MuxyApp: App {
         let remoteDeviceStore = RemoteDeviceStore(
             persistence: environment.remoteDevicePersistence
         )
+        let browserProfileStore = BrowserProfileStore(
+            persistence: environment.browserProfilePersistence
+        )
         let projectGroupStore = ProjectGroupStore(
             persistence: environment.projectGroupPersistence,
             remoteDeviceStore: remoteDeviceStore
@@ -49,6 +53,7 @@ struct MuxyApp: App {
         _worktreeStore = State(initialValue: worktreeStore)
         _projectGroupStore = State(initialValue: projectGroupStore)
         _remoteDeviceStore = State(initialValue: remoteDeviceStore)
+        _browserProfileStore = State(initialValue: browserProfileStore)
     }
 
     var body: some Scene {
@@ -59,6 +64,7 @@ struct MuxyApp: App {
                 .environment(worktreeStore)
                 .environment(projectGroupStore)
                 .environment(remoteDeviceStore)
+                .environment(browserProfileStore)
                 .environment(SSHConnectionService.shared)
                 .environment(GhosttyService.shared)
                 .environment(MuxyConfig.shared)
@@ -78,11 +84,12 @@ struct MuxyApp: App {
                     appDelegate.onTerminate = { [appState] in
                         appState.saveWorkspaces()
                     }
-                    appDelegate.settingsContent = { [projectGroupStore, remoteDeviceStore] in
+                    appDelegate.settingsContent = { [projectGroupStore, remoteDeviceStore, browserProfileStore] in
                         AnyView(
                             SettingsView()
                                 .environment(projectGroupStore)
                                 .environment(remoteDeviceStore)
+                                .environment(browserProfileStore)
                                 .environment(SSHConnectionService.shared)
                         )
                     }

--- a/Muxy/Services/AppEnvironment.swift
+++ b/Muxy/Services/AppEnvironment.swift
@@ -17,6 +17,7 @@ struct AppEnvironment {
     let worktreePersistence: any WorktreePersisting
     let projectGroupPersistence: any ProjectGroupPersisting
     let remoteDevicePersistence: any RemoteDevicePersisting
+    let browserProfilePersistence: any BrowserProfilePersisting
 
     static let live = Self(
         selectionStore: UserDefaultsActiveProjectSelectionStore(),
@@ -25,6 +26,7 @@ struct AppEnvironment {
         workspacePersistence: FileWorkspacePersistence(),
         worktreePersistence: FileWorktreePersistence(),
         projectGroupPersistence: FileProjectGroupPersistence(),
-        remoteDevicePersistence: FileRemoteDevicePersistence()
+        remoteDevicePersistence: FileRemoteDevicePersistence(),
+        browserProfilePersistence: FileBrowserProfilePersistence()
     )
 }

--- a/Muxy/Services/BrowserDataStoreCache.swift
+++ b/Muxy/Services/BrowserDataStoreCache.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WebKit
+
+@MainActor
+final class BrowserDataStoreCache {
+    static let shared = BrowserDataStoreCache()
+
+    private var stores: [UUID: WKWebsiteDataStore] = [:]
+
+    func store(for profileID: UUID) -> WKWebsiteDataStore {
+        if let existing = stores[profileID] {
+            return existing
+        }
+        let store = profileID == BrowserProfile.defaultID
+            ? WKWebsiteDataStore.default()
+            : WKWebsiteDataStore(forIdentifier: profileID)
+        stores[profileID] = store
+        return store
+    }
+}

--- a/Muxy/Services/BrowserDataStoreCache.swift
+++ b/Muxy/Services/BrowserDataStoreCache.swift
@@ -17,4 +17,8 @@ final class BrowserDataStoreCache {
         stores[profileID] = store
         return store
     }
+
+    func evict(_ profileID: UUID) {
+        stores[profileID] = nil
+    }
 }

--- a/Muxy/Services/BrowserImport/BrowserImporter.swift
+++ b/Muxy/Services/BrowserImport/BrowserImporter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum BrowserImportSource: String, CaseIterable, Identifiable {
+    case chrome
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .chrome: "Google Chrome"
+        }
+    }
+}
+
+struct ImportableProfile: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let directory: URL
+}
+
+enum BrowserImportError: LocalizedError {
+    case sourceNotInstalled
+    case profileUnavailable
+    case keyUnavailable
+    case unsupportedEncryption
+    case readFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .sourceNotInstalled: "The selected browser is not installed."
+        case .profileUnavailable: "The selected browser profile could not be found."
+        case .keyUnavailable: "Could not read the browser's encryption key from the Keychain."
+        case .unsupportedEncryption:
+            "This browser version stores its key in Apple Passwords and cannot be imported."
+        case let .readFailed(reason): "Could not read browser cookies: \(reason)"
+        }
+    }
+}
+
+protocol BrowserImporter {
+    var source: BrowserImportSource { get }
+    func isInstalled() -> Bool
+    func availableProfiles() throws -> [ImportableProfile]
+    func importCookies(from profile: ImportableProfile) throws -> [HTTPCookie]
+}

--- a/Muxy/Services/BrowserImport/ChromeCookieDatabase.swift
+++ b/Muxy/Services/BrowserImport/ChromeCookieDatabase.swift
@@ -12,8 +12,6 @@ struct ChromeCookieRow {
 }
 
 enum ChromeCookieDatabase {
-    private static let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-
     static func readRows(at fileURL: URL) throws -> [ChromeCookieRow] {
         let copyURL = try copyToTemporary(fileURL)
         defer { try? FileManager.default.removeItem(at: copyURL) }

--- a/Muxy/Services/BrowserImport/ChromeCookieDatabase.swift
+++ b/Muxy/Services/BrowserImport/ChromeCookieDatabase.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SQLite3
+
+struct ChromeCookieRow {
+    let name: String
+    let encryptedValue: Data
+    let host: String
+    let path: String
+    let isSecure: Bool
+    let isHTTPOnly: Bool
+    let expiresUTC: Int64
+}
+
+enum ChromeCookieDatabase {
+    private static let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    static func readRows(at fileURL: URL) throws -> [ChromeCookieRow] {
+        let copyURL = try copyToTemporary(fileURL)
+        defer { try? FileManager.default.removeItem(at: copyURL) }
+
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(copyURL.path, &database, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let database
+        else {
+            sqlite3_close(database)
+            throw BrowserImportError.readFailed("could not open cookie database")
+        }
+        defer { sqlite3_close(database) }
+
+        let sql = """
+        SELECT name, encrypted_value, host_key, path, is_secure, is_httponly, expires_utc
+        FROM cookies
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw BrowserImportError.readFailed("could not query cookies table")
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var rows: [ChromeCookieRow] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let row = parseRow(statement) else { continue }
+            rows.append(row)
+        }
+        return rows
+    }
+
+    private static func parseRow(_ statement: OpaquePointer?) -> ChromeCookieRow? {
+        guard let nameCString = sqlite3_column_text(statement, 0),
+              let hostCString = sqlite3_column_text(statement, 2),
+              let pathCString = sqlite3_column_text(statement, 3)
+        else { return nil }
+
+        let blobLength = Int(sqlite3_column_bytes(statement, 1))
+        let encryptedValue = if blobLength > 0, let blob = sqlite3_column_blob(statement, 1) {
+            Data(bytes: blob, count: blobLength)
+        } else {
+            Data()
+        }
+
+        return ChromeCookieRow(
+            name: String(cString: nameCString),
+            encryptedValue: encryptedValue,
+            host: String(cString: hostCString),
+            path: String(cString: pathCString),
+            isSecure: sqlite3_column_int(statement, 4) != 0,
+            isHTTPOnly: sqlite3_column_int(statement, 5) != 0,
+            expiresUTC: sqlite3_column_int64(statement, 6)
+        )
+    }
+
+    private static func copyToTemporary(_ fileURL: URL) throws -> URL {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw BrowserImportError.profileUnavailable
+        }
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-chrome-cookies-\(UUID().uuidString).sqlite")
+        try FileManager.default.copyItem(at: fileURL, to: destination)
+        return destination
+    }
+}

--- a/Muxy/Services/BrowserImport/ChromeCookieDecryptor.swift
+++ b/Muxy/Services/BrowserImport/ChromeCookieDecryptor.swift
@@ -1,0 +1,89 @@
+import CommonCrypto
+import Foundation
+
+enum ChromeCookieDecryptor {
+    private static let salt = "saltysalt"
+    private static let iterations = 1003
+    private static let keyLength = kCCKeySizeAES128
+    private static let iv = Data(repeating: 0x20, count: kCCBlockSizeAES128)
+    private static let domainHashLength = 32
+
+    static func deriveKey(fromSafeStoragePassword password: String) -> Data? {
+        guard let passwordData = password.data(using: .utf8),
+              let saltData = salt.data(using: .utf8)
+        else { return nil }
+
+        var derived = Data(count: keyLength)
+        let status = derived.withUnsafeMutableBytes { derivedBytes in
+            saltData.withUnsafeBytes { saltBytes in
+                passwordData.withUnsafeBytes { passwordBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.bindMemory(to: Int8.self).baseAddress,
+                        passwordData.count,
+                        saltBytes.bindMemory(to: UInt8.self).baseAddress,
+                        saltData.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA1),
+                        UInt32(iterations),
+                        derivedBytes.bindMemory(to: UInt8.self).baseAddress,
+                        keyLength
+                    )
+                }
+            }
+        }
+        return status == kCCSuccess ? derived : nil
+    }
+
+    static func decrypt(encryptedValue: Data, key: Data) -> String? {
+        guard encryptedValue.count > 3 else { return nil }
+        let prefix = encryptedValue.prefix(3)
+        guard prefix == Data("v10".utf8) || prefix == Data("v11".utf8) else {
+            return String(data: encryptedValue, encoding: .utf8)
+        }
+
+        let ciphertext = encryptedValue.dropFirst(3)
+        guard !ciphertext.isEmpty, ciphertext.count.isMultiple(of: kCCBlockSizeAES128) else { return nil }
+
+        guard let decrypted = aesCBCDecrypt(ciphertext: Data(ciphertext), key: key, iv: iv) else {
+            return nil
+        }
+
+        let payload = decrypted.count > domainHashLength ? decrypted.dropFirst(domainHashLength) : decrypted
+        if let value = String(data: payload, encoding: .utf8) {
+            return value
+        }
+        return String(data: decrypted, encoding: .utf8)
+    }
+
+    private static func aesCBCDecrypt(ciphertext: Data, key: Data, iv: Data) -> Data? {
+        let outputCapacity = ciphertext.count + kCCBlockSizeAES128
+        var output = Data(count: outputCapacity)
+        var decryptedCount = 0
+
+        let status = output.withUnsafeMutableBytes { outputBytes in
+            ciphertext.withUnsafeBytes { ciphertextBytes in
+                key.withUnsafeBytes { keyBytes in
+                    iv.withUnsafeBytes { ivBytes in
+                        CCCrypt(
+                            CCOperation(kCCDecrypt),
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            keyBytes.baseAddress,
+                            key.count,
+                            ivBytes.baseAddress,
+                            ciphertextBytes.baseAddress,
+                            ciphertext.count,
+                            outputBytes.baseAddress,
+                            outputCapacity,
+                            &decryptedCount
+                        )
+                    }
+                }
+            }
+        }
+
+        guard status == kCCSuccess else { return nil }
+        output.removeSubrange(decryptedCount ..< output.count)
+        return output
+    }
+}

--- a/Muxy/Services/BrowserImport/ChromeCookieDecryptor.swift
+++ b/Muxy/Services/BrowserImport/ChromeCookieDecryptor.swift
@@ -34,7 +34,7 @@ enum ChromeCookieDecryptor {
         return status == kCCSuccess ? derived : nil
     }
 
-    static func decrypt(encryptedValue: Data, key: Data) -> String? {
+    static func decrypt(encryptedValue: Data, host: String, key: Data) -> String? {
         guard encryptedValue.count > 3 else { return nil }
         let prefix = encryptedValue.prefix(3)
         guard prefix == Data("v10".utf8) || prefix == Data("v11".utf8) else {
@@ -48,11 +48,26 @@ enum ChromeCookieDecryptor {
             return nil
         }
 
-        let payload = decrypted.count > domainHashLength ? decrypted.dropFirst(domainHashLength) : decrypted
-        if let value = String(data: payload, encoding: .utf8) {
-            return value
+        let payload = stripDomainHash(from: decrypted, host: host)
+        return String(data: payload, encoding: .utf8)
+    }
+
+    private static func stripDomainHash(from decrypted: Data, host: String) -> Data {
+        guard decrypted.count >= domainHashLength,
+              decrypted.prefix(domainHashLength) == sha256(host)
+        else { return decrypted }
+        return decrypted.dropFirst(domainHashLength)
+    }
+
+    private static func sha256(_ value: String) -> Data {
+        let bytes = Data(value.utf8)
+        var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
+        digest.withUnsafeMutableBytes { digestBytes in
+            bytes.withUnsafeBytes { valueBytes in
+                _ = CC_SHA256(valueBytes.baseAddress, CC_LONG(bytes.count), digestBytes.bindMemory(to: UInt8.self).baseAddress)
+            }
         }
-        return String(data: decrypted, encoding: .utf8)
+        return digest
     }
 
     private static func aesCBCDecrypt(ciphertext: Data, key: Data, iv: Data) -> Data? {

--- a/Muxy/Services/BrowserImport/ChromeImporter.swift
+++ b/Muxy/Services/BrowserImport/ChromeImporter.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+final class ChromeImporter: BrowserImporter, Sendable {
+    let source: BrowserImportSource = .chrome
+
+    private let keychainService = "Chrome Safe Storage"
+    private let keychainAccount = "Chrome"
+    private let chromeEpochOffset: TimeInterval = 11_644_473_600
+
+    private var rootDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Google/Chrome", isDirectory: true)
+    }
+
+    func isInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: rootDirectory.path)
+    }
+
+    func availableProfiles() throws -> [ImportableProfile] {
+        guard isInstalled() else { throw BrowserImportError.sourceNotInstalled }
+        let names = profileDisplayNames()
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: rootDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        )) ?? []
+
+        let profiles = contents.compactMap { url -> ImportableProfile? in
+            let dirName = url.lastPathComponent
+            guard dirName == "Default" || dirName.hasPrefix("Profile ") else { return nil }
+            guard FileManager.default.fileExists(atPath: url.appendingPathComponent("Cookies").path)
+            else { return nil }
+            return ImportableProfile(id: dirName, name: names[dirName] ?? dirName, directory: url)
+        }
+        return profiles.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    func importCookies(from profile: ImportableProfile) throws -> [HTTPCookie] {
+        guard let password = ChromeSafeStorageKeychain.password(
+            service: keychainService,
+            account: keychainAccount
+        )
+        else {
+            throw BrowserImportError.keyUnavailable
+        }
+        guard let key = ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: password) else {
+            throw BrowserImportError.keyUnavailable
+        }
+
+        let rows = try ChromeCookieDatabase.readRows(at: profile.directory.appendingPathComponent("Cookies"))
+        return rows.compactMap { cookie(from: $0, key: key) }
+    }
+
+    private func cookie(from row: ChromeCookieRow, key: Data) -> HTTPCookie? {
+        guard !row.encryptedValue.isEmpty,
+              let value = ChromeCookieDecryptor.decrypt(encryptedValue: row.encryptedValue, key: key)
+        else { return nil }
+
+        var properties: [HTTPCookiePropertyKey: Any] = [
+            .name: row.name,
+            .value: value,
+            .domain: row.host,
+            .path: row.path.isEmpty ? "/" : row.path,
+        ]
+        if row.isSecure { properties[.secure] = "TRUE" }
+        if let expiry = expiryDate(from: row.expiresUTC) { properties[.expires] = expiry }
+
+        return HTTPCookie(properties: properties)
+    }
+
+    private func expiryDate(from chromeExpiresUTC: Int64) -> Date? {
+        guard chromeExpiresUTC > 0 else { return nil }
+        let secondsSince1601 = TimeInterval(chromeExpiresUTC) / 1_000_000
+        return Date(timeIntervalSince1970: secondsSince1601 - chromeEpochOffset)
+    }
+
+    private func profileDisplayNames() -> [String: String] {
+        let localStateURL = rootDirectory.appendingPathComponent("Local State")
+        guard let data = try? Data(contentsOf: localStateURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let profile = json["profile"] as? [String: Any],
+              let infoCache = profile["info_cache"] as? [String: Any]
+        else { return [:] }
+
+        var names: [String: String] = [:]
+        for (dirName, info) in infoCache {
+            if let info = info as? [String: Any], let name = info["name"] as? String {
+                names[dirName] = name
+            }
+        }
+        return names
+    }
+}

--- a/Muxy/Services/BrowserImport/ChromeImporter.swift
+++ b/Muxy/Services/BrowserImport/ChromeImporter.swift
@@ -52,7 +52,7 @@ final class ChromeImporter: BrowserImporter, Sendable {
 
     private func cookie(from row: ChromeCookieRow, key: Data) -> HTTPCookie? {
         guard !row.encryptedValue.isEmpty,
-              let value = ChromeCookieDecryptor.decrypt(encryptedValue: row.encryptedValue, key: key)
+              let value = ChromeCookieDecryptor.decrypt(encryptedValue: row.encryptedValue, host: row.host, key: key)
         else { return nil }
 
         var properties: [HTTPCookiePropertyKey: Any] = [
@@ -62,6 +62,7 @@ final class ChromeImporter: BrowserImporter, Sendable {
             .path: row.path.isEmpty ? "/" : row.path,
         ]
         if row.isSecure { properties[.secure] = "TRUE" }
+        if row.isHTTPOnly { properties[HTTPCookiePropertyKey("HttpOnly")] = "TRUE" }
         if let expiry = expiryDate(from: row.expiresUTC) { properties[.expires] = expiry }
 
         return HTTPCookie(properties: properties)

--- a/Muxy/Services/BrowserImport/ChromeSafeStorageKeychain.swift
+++ b/Muxy/Services/BrowserImport/ChromeSafeStorageKeychain.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Security
+
+enum ChromeSafeStorageKeychain {
+    static func password(service: String, account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/Muxy/Services/BrowserImport/CookieImportService.swift
+++ b/Muxy/Services/BrowserImport/CookieImportService.swift
@@ -1,0 +1,31 @@
+import Foundation
+import WebKit
+
+@MainActor
+enum CookieImportService {
+    struct Result {
+        let imported: Int
+    }
+
+    nonisolated static func importer(for source: BrowserImportSource) -> BrowserImporter {
+        switch source {
+        case .chrome: ChromeImporter()
+        }
+    }
+
+    static func importCookies(
+        from source: BrowserImportSource,
+        profile: ImportableProfile,
+        into targetProfileID: UUID
+    ) async throws -> Result {
+        let cookies = try await Task.detached(priority: .userInitiated) {
+            try importer(for: source).importCookies(from: profile)
+        }.value
+
+        let cookieStore = BrowserDataStoreCache.shared.store(for: targetProfileID).httpCookieStore
+        for cookie in cookies {
+            await cookieStore.setCookie(cookie)
+        }
+        return Result(imported: cookies.count)
+    }
+}

--- a/Muxy/Services/BrowserProfilePersistence.swift
+++ b/Muxy/Services/BrowserProfilePersistence.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+protocol BrowserProfilePersisting {
+    func loadProfiles() throws -> [BrowserProfile]
+    func saveProfiles(_ profiles: [BrowserProfile]) throws
+}
+
+final class FileBrowserProfilePersistence: BrowserProfilePersisting {
+    private let store: CodableFileStore<[BrowserProfile]>
+
+    init(fileURL: URL = MuxyFileStorage.fileURL(filename: "browser-profiles.json")) {
+        store = CodableFileStore(
+            fileURL: fileURL,
+            options: CodableFileStoreOptions(filePermissions: FilePermissions.privateFile)
+        )
+    }
+
+    func loadProfiles() throws -> [BrowserProfile] {
+        try store.load() ?? []
+    }
+
+    func saveProfiles(_ profiles: [BrowserProfile]) throws {
+        try store.save(profiles)
+    }
+}
+
+final class InMemoryBrowserProfilePersistence: BrowserProfilePersisting {
+    private var profiles: [BrowserProfile]
+
+    init(initial: [BrowserProfile] = []) {
+        profiles = initial
+    }
+
+    func loadProfiles() throws -> [BrowserProfile] {
+        profiles
+    }
+
+    func saveProfiles(_ profiles: [BrowserProfile]) throws {
+        self.profiles = profiles
+    }
+}

--- a/Muxy/Services/BrowserProfileStore.swift
+++ b/Muxy/Services/BrowserProfileStore.swift
@@ -7,8 +7,6 @@ private let logger = Logger(subsystem: "app.muxy", category: "BrowserProfileStor
 @MainActor
 @Observable
 final class BrowserProfileStore {
-    private(set) static var shared: BrowserProfileStore?
-
     private(set) var profiles: [BrowserProfile] = []
     private(set) var defaultProfileID: UUID = BrowserProfile.defaultID
     private let persistence: any BrowserProfilePersisting
@@ -16,11 +14,6 @@ final class BrowserProfileStore {
     init(persistence: any BrowserProfilePersisting) {
         self.persistence = persistence
         load()
-        Self.shared = self
-    }
-
-    static var defaultProfileIDOrFallback: UUID {
-        shared?.defaultProfileID ?? BrowserProfile.defaultID
     }
 
     func profile(id: UUID?) -> BrowserProfile? {
@@ -68,6 +61,7 @@ final class BrowserProfileStore {
     }
 
     private func purgeData(for id: UUID) {
+        BrowserDataStoreCache.shared.evict(id)
         WKWebsiteDataStore.remove(forIdentifier: id) { error in
             if let error {
                 logger.error("Failed to purge browser profile data: \(error)")

--- a/Muxy/Services/BrowserProfileStore.swift
+++ b/Muxy/Services/BrowserProfileStore.swift
@@ -61,6 +61,12 @@ final class BrowserProfileStore {
         purgeData(for: id)
     }
 
+    func clearData(for id: UUID) async {
+        let dataStore = BrowserDataStoreCache.shared.store(for: id)
+        let types = WKWebsiteDataStore.allWebsiteDataTypes()
+        await dataStore.removeData(ofTypes: types, modifiedSince: .distantPast)
+    }
+
     private func purgeData(for id: UUID) {
         WKWebsiteDataStore.remove(forIdentifier: id) { error in
             if let error {

--- a/Muxy/Services/BrowserProfileStore.swift
+++ b/Muxy/Services/BrowserProfileStore.swift
@@ -1,0 +1,99 @@
+import Foundation
+import os
+import WebKit
+
+private let logger = Logger(subsystem: "app.muxy", category: "BrowserProfileStore")
+
+@MainActor
+@Observable
+final class BrowserProfileStore {
+    private(set) static var shared: BrowserProfileStore?
+
+    private(set) var profiles: [BrowserProfile] = []
+    private let persistence: any BrowserProfilePersisting
+
+    init(persistence: any BrowserProfilePersisting) {
+        self.persistence = persistence
+        load()
+        Self.shared = self
+    }
+
+    static var defaultProfileIDOrFallback: UUID {
+        shared?.defaultProfileID ?? BrowserProfile.defaultID
+    }
+
+    var defaultProfileID: UUID {
+        let id = BrowserPreferences.defaultProfileID
+        return profiles.contains(where: { $0.id == id }) ? id : BrowserProfile.defaultID
+    }
+
+    func profile(id: UUID?) -> BrowserProfile? {
+        guard let id else { return nil }
+        return profiles.first(where: { $0.id == id })
+    }
+
+    @discardableResult
+    func add(name: String) -> BrowserProfile {
+        let profile = BrowserProfile(name: trimmedName(name, fallback: "Profile"))
+        profiles.append(profile)
+        save()
+        return profile
+    }
+
+    func rename(id: UUID, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let index = profiles.firstIndex(where: { $0.id == id })
+        else { return }
+        profiles[index].name = trimmed
+        save()
+    }
+
+    func setDefault(id: UUID) {
+        guard profiles.contains(where: { $0.id == id }) else { return }
+        BrowserPreferences.defaultProfileID = id
+    }
+
+    func remove(id: UUID) {
+        guard id != BrowserProfile.defaultID else { return }
+        profiles.removeAll { $0.id == id }
+        if BrowserPreferences.defaultProfileID == id {
+            BrowserPreferences.defaultProfileID = BrowserProfile.defaultID
+        }
+        save()
+        purgeData(for: id)
+    }
+
+    private func purgeData(for id: UUID) {
+        WKWebsiteDataStore.remove(forIdentifier: id) { error in
+            if let error {
+                logger.error("Failed to purge browser profile data: \(error)")
+            }
+        }
+    }
+
+    private func trimmedName(_ name: String, fallback: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+
+    private func save() {
+        do {
+            try persistence.saveProfiles(profiles)
+        } catch {
+            logger.error("Failed to save browser profiles: \(error)")
+        }
+    }
+
+    private func load() {
+        do {
+            profiles = try persistence.loadProfiles()
+        } catch {
+            logger.error("Failed to load browser profiles: \(error)")
+        }
+        if !profiles.contains(where: { $0.id == BrowserProfile.defaultID }) {
+            profiles.insert(.default, at: 0)
+            save()
+        }
+    }
+}

--- a/Muxy/Services/BrowserProfileStore.swift
+++ b/Muxy/Services/BrowserProfileStore.swift
@@ -10,6 +10,7 @@ final class BrowserProfileStore {
     private(set) static var shared: BrowserProfileStore?
 
     private(set) var profiles: [BrowserProfile] = []
+    private(set) var defaultProfileID: UUID = BrowserProfile.defaultID
     private let persistence: any BrowserProfilePersisting
 
     init(persistence: any BrowserProfilePersisting) {
@@ -20,11 +21,6 @@ final class BrowserProfileStore {
 
     static var defaultProfileIDOrFallback: UUID {
         shared?.defaultProfileID ?? BrowserProfile.defaultID
-    }
-
-    var defaultProfileID: UUID {
-        let id = BrowserPreferences.defaultProfileID
-        return profiles.contains(where: { $0.id == id }) ? id : BrowserProfile.defaultID
     }
 
     func profile(id: UUID?) -> BrowserProfile? {
@@ -51,14 +47,15 @@ final class BrowserProfileStore {
 
     func setDefault(id: UUID) {
         guard profiles.contains(where: { $0.id == id }) else { return }
+        defaultProfileID = id
         BrowserPreferences.defaultProfileID = id
     }
 
     func remove(id: UUID) {
         guard id != BrowserProfile.defaultID else { return }
         profiles.removeAll { $0.id == id }
-        if BrowserPreferences.defaultProfileID == id {
-            BrowserPreferences.defaultProfileID = BrowserProfile.defaultID
+        if defaultProfileID == id {
+            setDefault(id: BrowserProfile.defaultID)
         }
         save()
         purgeData(for: id)
@@ -95,5 +92,9 @@ final class BrowserProfileStore {
             profiles.insert(.default, at: 0)
             save()
         }
+        let storedDefault = BrowserPreferences.defaultProfileID
+        defaultProfileID = profiles.contains(where: { $0.id == storedDefault })
+            ? storedDefault
+            : BrowserProfile.defaultID
     }
 }

--- a/Muxy/Services/InstalledBrowsers.swift
+++ b/Muxy/Services/InstalledBrowsers.swift
@@ -1,0 +1,45 @@
+import AppKit
+import Foundation
+
+struct InstalledBrowser: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let appURL: URL
+
+    var icon: NSImage {
+        NSWorkspace.shared.icon(forFile: appURL.path)
+    }
+}
+
+enum InstalledBrowsers {
+    private static let probeURL = URL(string: "https://example.com") ?? URL(filePath: "/")
+
+    static func all() -> [InstalledBrowser] {
+        let urls = NSWorkspace.shared.urlsForApplications(toOpen: probeURL)
+        let browsers = urls.compactMap(browser(from:))
+        var seen = Set<String>()
+        return browsers
+            .filter { seen.insert($0.id).inserted }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    static func defaultBrowser() -> InstalledBrowser? {
+        guard let url = NSWorkspace.shared.urlForApplication(toOpen: probeURL) else { return nil }
+        return browser(from: url)
+    }
+
+    static func open(_ url: URL, in browser: InstalledBrowser) {
+        let configuration = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.open([url], withApplicationAt: browser.appURL, configuration: configuration)
+    }
+
+    private static func browser(from appURL: URL) -> InstalledBrowser? {
+        guard let bundle = Bundle(url: appURL),
+              let bundleID = bundle.bundleIdentifier
+        else { return nil }
+        let name = (bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+            ?? (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? appURL.deletingPathExtension().lastPathComponent
+        return InstalledBrowser(id: bundleID, name: name, appURL: appURL)
+    }
+}

--- a/Muxy/Services/SettingsFocusCoordinator.swift
+++ b/Muxy/Services/SettingsFocusCoordinator.swift
@@ -24,6 +24,7 @@ final class SettingsFocusCoordinator {
 enum SettingsFocusRequest: Hashable {
     case projectPickerDefaultLocation
     case remoteDevices
+    case browser
 
     var notificationName: Notification.Name {
         switch self {
@@ -31,6 +32,8 @@ enum SettingsFocusRequest: Hashable {
             .focusProjectPickerDefaultLocation
         case .remoteDevices:
             .focusRemoteDevicesSettings
+        case .browser:
+            .focusBrowserSettings
         }
     }
 }

--- a/Muxy/Views/Browser/BrowserPane.swift
+++ b/Muxy/Views/Browser/BrowserPane.swift
@@ -12,6 +12,7 @@ struct BrowserPane: View {
         VStack(spacing: 0) {
             BrowserToolbar(state: state, addressFieldFocused: $addressFieldFocused)
             BrowserWebView(state: state, focused: focused && !addressFieldFocused, appState: appState)
+                .id(state.profileID)
                 .contentShape(Rectangle())
                 .onTapGesture { onFocus() }
         }

--- a/Muxy/Views/Browser/BrowserToolbar.swift
+++ b/Muxy/Views/Browser/BrowserToolbar.swift
@@ -72,6 +72,7 @@ struct BrowserToolbar: View {
             }
             Divider()
             Button("Manage Profiles…") {
+                SettingsFocusCoordinator.shared.request(.browser)
                 NotificationCenter.default.post(name: .openSettingsModal, object: nil)
             }
         } label: {

--- a/Muxy/Views/Browser/BrowserToolbar.swift
+++ b/Muxy/Views/Browser/BrowserToolbar.swift
@@ -6,6 +6,7 @@ struct BrowserToolbar: View {
 
     @Environment(BrowserProfileStore.self) private var profileStore
     @State private var addressText: String = ""
+    @State private var installedBrowsers: [InstalledBrowser] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -31,6 +32,8 @@ struct BrowserToolbar: View {
 
                 addressField
 
+                openInBrowserMenu
+
                 profilePicker
             }
             .padding(.horizontal, UIMetrics.spacing3)
@@ -55,6 +58,42 @@ struct BrowserToolbar: View {
         .onAppear {
             addressText = state.url?.absoluteString ?? ""
         }
+    }
+
+    private var openInBrowserMenu: some View {
+        Menu {
+            Button("Open in Default Browser") { openInDefaultBrowser() }
+            if !installedBrowsers.isEmpty {
+                Divider()
+                ForEach(installedBrowsers) { browser in
+                    Button(browser.name) { openURL(in: browser) }
+                }
+            }
+        } label: {
+            Image(systemName: "arrow.up.forward.app")
+                .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .disabled(state.url == nil)
+        .help("Open in External Browser")
+        .onAppear {
+            if installedBrowsers.isEmpty { installedBrowsers = InstalledBrowsers.all() }
+        }
+    }
+
+    private func openInDefaultBrowser() {
+        guard let url = state.url else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func openURL(in browser: InstalledBrowser) {
+        guard let url = state.url else { return }
+        InstalledBrowsers.open(url, in: browser)
     }
 
     private var profilePicker: some View {

--- a/Muxy/Views/Browser/BrowserToolbar.swift
+++ b/Muxy/Views/Browser/BrowserToolbar.swift
@@ -4,6 +4,7 @@ struct BrowserToolbar: View {
     let state: BrowserTabState
     @FocusState.Binding var addressFieldFocused: Bool
 
+    @Environment(BrowserProfileStore.self) private var profileStore
     @State private var addressText: String = ""
 
     var body: some View {
@@ -29,6 +30,8 @@ struct BrowserToolbar: View {
                 }
 
                 addressField
+
+                profilePicker
             }
             .padding(.horizontal, UIMetrics.spacing3)
             .frame(height: UIMetrics.titleBarHeight)
@@ -51,6 +54,51 @@ struct BrowserToolbar: View {
         }
         .onAppear {
             addressText = state.url?.absoluteString ?? ""
+        }
+    }
+
+    private var profilePicker: some View {
+        Menu {
+            ForEach(profileStore.profiles) { profile in
+                Button {
+                    selectProfile(profile.id)
+                } label: {
+                    if profile.id == state.profileID {
+                        Label(profile.name, systemImage: "checkmark")
+                    } else {
+                        Text(profile.name)
+                    }
+                }
+            }
+            Divider()
+            Button("Manage Profiles…") {
+                NotificationCenter.default.post(name: .openSettingsModal, object: nil)
+            }
+        } label: {
+            HStack(spacing: UIMetrics.spacing1) {
+                Image(systemName: "person.crop.circle")
+                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                Text(currentProfileName)
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(MuxyTheme.fgMuted)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Browser Profile")
+    }
+
+    private var currentProfileName: String {
+        profileStore.profile(id: state.profileID)?.name ?? BrowserProfile.defaultName
+    }
+
+    private func selectProfile(_ id: UUID) {
+        guard id != state.profileID else { return }
+        state.profileID = id
+        if let url = state.url {
+            state.pendingURL = url
         }
     }
 

--- a/Muxy/Views/Browser/BrowserWebView.swift
+++ b/Muxy/Views/Browser/BrowserWebView.swift
@@ -13,6 +13,7 @@ struct BrowserWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.defaultWebpagePreferences.allowsContentJavaScript = true
+        config.websiteDataStore = BrowserDataStoreCache.shared.store(for: state.profileID)
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
@@ -138,7 +139,7 @@ extension BrowserWebView.Coordinator: WKNavigationDelegate, WKUIDelegate {
         windowFeatures _: WKWindowFeatures
     ) -> WKWebView? {
         if let url = navigationAction.request.url, BrowserURL.isAllowed(url) {
-            appState.openInBuiltInBrowser(url)
+            appState.openInBuiltInBrowser(url, profileID: state.profileID)
         }
         return nil
     }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -31,6 +31,7 @@ struct MainWindow: View {
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @Environment(RemoteDeviceStore.self) private var remoteDeviceStore
+    @Environment(BrowserProfileStore.self) private var browserProfileStore
     @Environment(GhosttyService.self) private var ghostty
     @State private var dragCoordinator = TabDragCoordinator()
     private enum CloseConfirmationKind {
@@ -440,7 +441,8 @@ struct MainWindow: View {
                     appState.dispatch(.createBrowserTab(
                         projectID: project.id,
                         areaID: area.id,
-                        url: BrowserURL.resolve(from: BrowserURL.defaultURLString)
+                        url: BrowserURL.resolve(from: BrowserURL.defaultURLString),
+                        profileID: browserProfileStore.defaultProfileID
                     ))
                 },
                 onCloseTab: { tabID in

--- a/Muxy/Views/Settings/BrowserImportSheet.swift
+++ b/Muxy/Views/Settings/BrowserImportSheet.swift
@@ -11,49 +11,55 @@ struct BrowserImportSheet: View {
     private let source: BrowserImportSource = .chrome
 
     var body: some View {
-        VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing6) {
+            header
+            content
+            footer
+        }
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(440))
+        .task { load() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
             Text("Import to “\(targetProfile.name)”")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
-
-            Text("Choose a \(source.displayName) profile. macOS may ask for Keychain permission to read its cookies.")
+            Text("Choose a \(source.displayName) profile to copy cookies from. macOS may ask for Keychain permission.")
                 .font(.system(size: SettingsMetrics.footnoteFontSize))
                 .foregroundStyle(SettingsStyle.mutedForeground)
                 .fixedSize(horizontal: false, vertical: true)
-
-            content
-
-            HStack(spacing: UIMetrics.spacing3) {
-                Spacer()
-                Button("Close", action: onDismiss)
-                    .keyboardShortcut(.cancelAction)
-            }
         }
-        .padding(UIMetrics.spacing8)
-        .frame(width: UIMetrics.scaled(420))
-        .task { load() }
     }
 
     @ViewBuilder
     private var content: some View {
         if let loadError {
-            Text(loadError)
-                .font(.system(size: SettingsMetrics.labelFontSize))
-                .foregroundStyle(SettingsStyle.mutedForeground)
+            messageBox(loadError)
         } else if profiles.isEmpty {
-            Text("No \(source.displayName) profiles with cookies were found.")
-                .font(.system(size: SettingsMetrics.labelFontSize))
-                .foregroundStyle(SettingsStyle.mutedForeground)
+            messageBox("No \(source.displayName) profiles with cookies were found.")
         } else {
-            VStack(spacing: 4) {
+            VStack(spacing: 0) {
                 ForEach(profiles) { profile in
                     importRow(profile)
+                    if profile.id != profiles.last?.id {
+                        Divider()
+                    }
                 }
             }
+            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .overlay(
+                RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
+                    .stroke(SettingsStyle.border, lineWidth: 1)
+            )
         }
     }
 
     private func importRow(_ profile: ImportableProfile) -> some View {
-        HStack(spacing: 10) {
+        HStack(spacing: UIMetrics.spacing3) {
+            Image(systemName: "person.crop.circle")
+                .font(.system(size: SettingsMetrics.labelFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
             Text(profile.name)
                 .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
                 .foregroundStyle(SettingsStyle.foreground)
@@ -62,7 +68,27 @@ struct BrowserImportSheet: View {
                 .disabled(isImporting)
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
-        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+        .padding(.vertical, UIMetrics.spacing3)
+    }
+
+    private func messageBox(_ message: String) -> some View {
+        Text(message)
+            .font(.system(size: SettingsMetrics.labelFontSize))
+            .foregroundStyle(SettingsStyle.mutedForeground)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(SettingsMetrics.horizontalPadding)
+            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+    }
+
+    private var footer: some View {
+        HStack {
+            if isImporting {
+                ProgressView().controlSize(.small)
+            }
+            Spacer()
+            Button("Close", action: onDismiss)
+                .keyboardShortcut(.cancelAction)
+        }
     }
 
     private func load() {

--- a/Muxy/Views/Settings/BrowserImportSheet.swift
+++ b/Muxy/Views/Settings/BrowserImportSheet.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct BrowserImportSheet: View {
+    let targetProfile: BrowserProfile
+    let onDismiss: () -> Void
+
+    @State private var profiles: [ImportableProfile] = []
+    @State private var loadError: String?
+    @State private var isImporting = false
+
+    private let source: BrowserImportSource = .chrome
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
+            Text("Import to “\(targetProfile.name)”")
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+
+            Text("Choose a \(source.displayName) profile. macOS may ask for Keychain permission to read its cookies.")
+                .font(.system(size: SettingsMetrics.footnoteFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+                .fixedSize(horizontal: false, vertical: true)
+
+            content
+
+            HStack(spacing: UIMetrics.spacing3) {
+                Spacer()
+                Button("Close", action: onDismiss)
+                    .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(420))
+        .task { load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let loadError {
+            Text(loadError)
+                .font(.system(size: SettingsMetrics.labelFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+        } else if profiles.isEmpty {
+            Text("No \(source.displayName) profiles with cookies were found.")
+                .font(.system(size: SettingsMetrics.labelFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+        } else {
+            VStack(spacing: 4) {
+                ForEach(profiles) { profile in
+                    importRow(profile)
+                }
+            }
+        }
+    }
+
+    private func importRow(_ profile: ImportableProfile) -> some View {
+        HStack(spacing: 10) {
+            Text(profile.name)
+                .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
+                .foregroundStyle(SettingsStyle.foreground)
+            Spacer()
+            Button("Import") { runImport(profile) }
+                .disabled(isImporting)
+        }
+        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+    }
+
+    private func load() {
+        let importer = CookieImportService.importer(for: source)
+        guard importer.isInstalled() else {
+            loadError = "\(source.displayName) is not installed."
+            return
+        }
+        do {
+            profiles = try importer.availableProfiles()
+        } catch {
+            loadError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func runImport(_ profile: ImportableProfile) {
+        isImporting = true
+        Task {
+            do {
+                let result = try await CookieImportService.importCookies(
+                    from: source,
+                    profile: profile,
+                    into: targetProfile.id
+                )
+                ToastState.shared.show("Imported \(result.imported) cookies into “\(targetProfile.name)”")
+                onDismiss()
+            } catch {
+                let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                ToastState.shared.show(message)
+            }
+            isImporting = false
+        }
+    }
+}

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -22,27 +22,13 @@ struct BrowserSettingsView: View {
                     isOn: $openLinksInBuiltInBrowser
                 )
                 SettingsRow("Default Profile") {
-                    HStack(spacing: UIMetrics.spacing2) {
-                        if profileStore.defaultProfileID != BrowserProfile.defaultID {
-                            Button {
-                                profileStore.setDefault(id: BrowserProfile.defaultID)
-                            } label: {
-                                Image(systemName: "arrow.counterclockwise")
-                                    .font(.system(size: 10))
-                                    .foregroundStyle(SettingsStyle.mutedForeground)
-                            }
-                            .buttonStyle(.plain)
-                            .help("Reset to Default")
-                            .accessibilityLabel("Reset Default Profile")
+                    Picker("", selection: defaultProfileBinding) {
+                        ForEach(profileStore.profiles) { profile in
+                            Text(profile.name).tag(profile.id)
                         }
-                        Picker("", selection: defaultProfileBinding) {
-                            ForEach(profileStore.profiles) { profile in
-                                Text(profile.name).tag(profile.id)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
                     }
+                    .labelsHidden()
+                    .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
                 }
             }
 

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -21,13 +21,27 @@ struct BrowserSettingsView: View {
                     isOn: $openLinksInBuiltInBrowser
                 )
                 SettingsRow("Default Profile") {
-                    Picker("", selection: defaultProfileBinding) {
-                        ForEach(profileStore.profiles) { profile in
-                            Text(profile.name).tag(profile.id)
+                    HStack(spacing: UIMetrics.spacing2) {
+                        if profileStore.defaultProfileID != BrowserProfile.defaultID {
+                            Button {
+                                profileStore.setDefault(id: BrowserProfile.defaultID)
+                            } label: {
+                                Image(systemName: "arrow.counterclockwise")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(SettingsStyle.mutedForeground)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Reset to Default")
+                            .accessibilityLabel("Reset Default Profile")
                         }
+                        Picker("", selection: defaultProfileBinding) {
+                            ForEach(profileStore.profiles) { profile in
+                                Text(profile.name).tag(profile.id)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: SettingsMetrics.controlWidth, alignment: .trailing)
                     }
-                    .labelsHidden()
-                    .frame(width: SettingsMetrics.controlWidth)
                 }
             }
 
@@ -170,7 +184,7 @@ private struct BrowserProfileRow: View {
             Image(systemName: "ellipsis")
                 .font(.system(size: SettingsMetrics.labelFontSize, weight: .semibold))
                 .foregroundStyle(SettingsStyle.mutedForeground)
-                .frame(width: 24, height: 20)
+                .frame(height: 20)
                 .contentShape(Rectangle())
         }
         .menuStyle(.borderlessButton)

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -6,6 +6,7 @@ struct BrowserSettingsView: View {
 
     @State private var editorMode: BrowserProfileEditorMode?
     @State private var profilePendingDelete: BrowserProfile?
+    @State private var profilePendingClear: BrowserProfile?
     @State private var importTarget: BrowserProfile?
 
     private static let profilesFooter = """
@@ -51,6 +52,7 @@ struct BrowserSettingsView: View {
                         profile: profile,
                         onRename: { editorMode = .edit(profile) },
                         onImport: { importTarget = profile },
+                        onClearData: { profilePendingClear = profile },
                         onDelete: { profilePendingDelete = profile }
                     )
                 }
@@ -87,6 +89,22 @@ struct BrowserSettingsView: View {
         } message: { _ in
             Text("This permanently deletes the profile's cookies and browsing data.")
         }
+        .alert(
+            "Clear data for “\(profilePendingClear?.name ?? "")”?",
+            isPresented: clearAlertBinding,
+            presenting: profilePendingClear
+        ) { profile in
+            Button("Clear Data", role: .destructive) {
+                let id = profile.id
+                Task { await profileStore.clearData(for: id) }
+                ToastState.shared.show("Cleared browsing data for “\(profile.name)”")
+                profilePendingClear = nil
+            }
+            .keyboardShortcut(.defaultAction)
+            Button("Cancel", role: .cancel) { profilePendingClear = nil }
+        } message: { _ in
+            Text("This signs out and removes all cookies, cache, and logins for this profile, including imported ones.")
+        }
     }
 
     private var addButton: some View {
@@ -121,6 +139,13 @@ struct BrowserSettingsView: View {
         )
     }
 
+    private var clearAlertBinding: Binding<Bool> {
+        Binding(
+            get: { profilePendingClear != nil },
+            set: { if !$0 { profilePendingClear = nil } }
+        )
+    }
+
     private func save(mode: BrowserProfileEditorMode, name: String) {
         switch mode {
         case .create:
@@ -135,6 +160,7 @@ private struct BrowserProfileRow: View {
     let profile: BrowserProfile
     let onRename: () -> Void
     let onImport: () -> Void
+    let onClearData: () -> Void
     let onDelete: () -> Void
 
     @State private var isHovered = false
@@ -177,7 +203,10 @@ private struct BrowserProfileRow: View {
             Button("Import from Chrome…", action: onImport)
             if !profile.isDefault {
                 Button("Rename…", action: onRename)
-                Divider()
+            }
+            Divider()
+            Button("Clear Data", role: .destructive, action: onClearData)
+            if !profile.isDefault {
                 Button("Delete", role: .destructive, action: onDelete)
             }
         } label: {

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+
+struct BrowserSettingsView: View {
+    @Environment(BrowserProfileStore.self) private var profileStore
+    @AppStorage(BrowserPreferences.openLinksInBuiltInBrowserKey) private var openLinksInBuiltInBrowser = false
+    @AppStorage(BrowserPreferences.defaultProfileIDKey) private var defaultProfileIDRaw = BrowserProfile.defaultID.uuidString
+
+    @State private var editorMode: BrowserProfileEditorMode?
+    @State private var profilePendingDelete: BrowserProfile?
+    @State private var importTarget: BrowserProfile?
+
+    private static let profilesFooter = """
+    Each profile keeps its own cookies, cache, and logins. Pick a profile per tab from the browser \
+    toolbar. Import brings an existing browser's cookies so tabs start signed in.
+    """
+
+    var body: some View {
+        SettingsContainer {
+            SettingsSection("General") {
+                SettingsToggleRow(
+                    label: "Open terminal links in built-in browser",
+                    isOn: $openLinksInBuiltInBrowser
+                )
+                SettingsRow("Default Profile") {
+                    Picker("", selection: defaultProfileBinding) {
+                        ForEach(profileStore.profiles) { profile in
+                            Text(profile.name).tag(profile.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: SettingsMetrics.controlWidth)
+                }
+            }
+
+            SettingsSection("Profiles", footer: Self.profilesFooter, showsDivider: false) {
+                ForEach(profileStore.profiles) { profile in
+                    BrowserProfileRow(
+                        profile: profile,
+                        onRename: { editorMode = .edit(profile) },
+                        onImport: { importTarget = profile },
+                        onDelete: { profilePendingDelete = profile }
+                    )
+                }
+                addButton
+            }
+        }
+        .sheet(item: $editorMode) { mode in
+            BrowserProfileEditorSheet(
+                mode: mode,
+                onSave: { name in
+                    save(mode: mode, name: name)
+                    editorMode = nil
+                },
+                onCancel: { editorMode = nil }
+            )
+        }
+        .sheet(item: $importTarget) { profile in
+            BrowserImportSheet(
+                targetProfile: profile,
+                onDismiss: { importTarget = nil }
+            )
+        }
+        .alert(
+            "Delete “\(profilePendingDelete?.name ?? "")”?",
+            isPresented: deleteAlertBinding,
+            presenting: profilePendingDelete
+        ) { profile in
+            Button("Delete", role: .destructive) {
+                profileStore.remove(id: profile.id)
+                profilePendingDelete = nil
+            }
+            .keyboardShortcut(.defaultAction)
+            Button("Cancel", role: .cancel) { profilePendingDelete = nil }
+        } message: { _ in
+            Text("This permanently deletes the profile's cookies and browsing data.")
+        }
+    }
+
+    private var addButton: some View {
+        Button {
+            editorMode = .create
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("Add Profile")
+                    .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
+            }
+            .foregroundStyle(SettingsStyle.accent)
+            .padding(.horizontal, SettingsMetrics.horizontalPadding)
+            .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var defaultProfileBinding: Binding<UUID> {
+        Binding(
+            get: { profileStore.defaultProfileID },
+            set: { newValue in
+                profileStore.setDefault(id: newValue)
+                defaultProfileIDRaw = newValue.uuidString
+            }
+        )
+    }
+
+    private var deleteAlertBinding: Binding<Bool> {
+        Binding(
+            get: { profilePendingDelete != nil },
+            set: { if !$0 { profilePendingDelete = nil } }
+        )
+    }
+
+    private func save(mode: BrowserProfileEditorMode, name: String) {
+        switch mode {
+        case .create:
+            profileStore.add(name: name)
+        case let .edit(profile):
+            profileStore.rename(id: profile.id, to: name)
+        }
+    }
+}
+
+private struct BrowserProfileRow: View {
+    let profile: BrowserProfile
+    let onRename: () -> Void
+    let onImport: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "person.crop.circle")
+                .font(.system(size: SettingsMetrics.labelFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+            Text(profile.name)
+                .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
+                .foregroundStyle(SettingsStyle.foreground)
+            if profile.isDefault {
+                Text("Default")
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                    .foregroundStyle(SettingsStyle.mutedForeground)
+            }
+            Spacer()
+            Button("Import from Chrome", action: onImport)
+                .buttonStyle(.plain)
+                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                .foregroundStyle(SettingsStyle.accent)
+            if !profile.isDefault {
+                Button("Rename", action: onRename)
+                    .buttonStyle(.plain)
+                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+                    .foregroundStyle(SettingsStyle.accent)
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(SettingsStyle.destructive)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+        .background(
+            isHovered ? SettingsStyle.hover : .clear,
+            in: RoundedRectangle(cornerRadius: 6)
+        )
+        .onHover { isHovered = $0 }
+    }
+}
+
+enum BrowserProfileEditorMode: Identifiable {
+    case create
+    case edit(BrowserProfile)
+
+    var id: String {
+        switch self {
+        case .create: "profile-create"
+        case let .edit(profile): "profile-edit-\(profile.id.uuidString)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .create: "Add Profile"
+        case .edit: "Rename Profile"
+        }
+    }
+
+    var initialName: String {
+        switch self {
+        case .create: ""
+        case let .edit(profile): profile.name
+        }
+    }
+}
+
+private struct BrowserProfileEditorSheet: View {
+    let mode: BrowserProfileEditorMode
+    let onSave: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var name = ""
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
+            Text(mode.title)
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+
+            TextField("Profile name", text: $name)
+                .settingsTextInput(maxWidth: .infinity)
+
+            HStack(spacing: UIMetrics.spacing3) {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") { onSave(name) }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canSave)
+            }
+        }
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(360))
+        .onAppear { name = mode.initialName }
+    }
+}

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct BrowserSettingsView: View {
     @Environment(BrowserProfileStore.self) private var profileStore
     @AppStorage(BrowserPreferences.openLinksInBuiltInBrowserKey) private var openLinksInBuiltInBrowser = false
-    @AppStorage(BrowserPreferences.defaultProfileIDKey) private var defaultProfileIDRaw = BrowserProfile.defaultID.uuidString
 
     @State private var editorMode: BrowserProfileEditorMode?
     @State private var profilePendingDelete: BrowserProfile?
@@ -97,10 +96,7 @@ struct BrowserSettingsView: View {
     private var defaultProfileBinding: Binding<UUID> {
         Binding(
             get: { profileStore.defaultProfileID },
-            set: { newValue in
-                profileStore.setDefault(id: newValue)
-                defaultProfileIDRaw = newValue.uuidString
-            }
+            set: { profileStore.setDefault(id: $0) }
         )
     }
 
@@ -130,35 +126,19 @@ private struct BrowserProfileRow: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 8) {
             Image(systemName: "person.crop.circle")
                 .font(.system(size: SettingsMetrics.labelFontSize))
                 .foregroundStyle(SettingsStyle.mutedForeground)
+                .frame(width: 16)
             Text(profile.name)
                 .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
                 .foregroundStyle(SettingsStyle.foreground)
             if profile.isDefault {
-                Text("Default")
-                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                    .foregroundStyle(SettingsStyle.mutedForeground)
+                defaultBadge
             }
             Spacer()
-            Button("Import from Chrome", action: onImport)
-                .buttonStyle(.plain)
-                .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                .foregroundStyle(SettingsStyle.accent)
-            if !profile.isDefault {
-                Button("Rename", action: onRename)
-                    .buttonStyle(.plain)
-                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
-                    .foregroundStyle(SettingsStyle.accent)
-                Button(action: onDelete) {
-                    Image(systemName: "trash")
-                        .font(.system(size: SettingsMetrics.footnoteFontSize))
-                        .foregroundStyle(SettingsStyle.destructive)
-                }
-                .buttonStyle(.plain)
-            }
+            actionsMenu
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
@@ -167,6 +147,35 @@ private struct BrowserProfileRow: View {
             in: RoundedRectangle(cornerRadius: 6)
         )
         .onHover { isHovered = $0 }
+    }
+
+    private var defaultBadge: some View {
+        Text("Default")
+            .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .medium))
+            .foregroundStyle(SettingsStyle.mutedForeground)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(SettingsStyle.hover, in: Capsule())
+    }
+
+    private var actionsMenu: some View {
+        Menu {
+            Button("Import from Chrome…", action: onImport)
+            if !profile.isDefault {
+                Button("Rename…", action: onRename)
+                Divider()
+                Button("Delete", role: .destructive, action: onDelete)
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: SettingsMetrics.labelFontSize, weight: .semibold))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+                .frame(width: 24, height: 20)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
     }
 }
 

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -82,9 +82,12 @@ struct BrowserSettingsView: View {
         ) { profile in
             Button("Clear Data", role: .destructive) {
                 let id = profile.id
-                Task { await profileStore.clearData(for: id) }
-                ToastState.shared.show("Cleared browsing data for “\(profile.name)”")
+                let name = profile.name
                 profilePendingClear = nil
+                Task {
+                    await profileStore.clearData(for: id)
+                    ToastState.shared.show("Cleared browsing data for “\(name)”")
+                }
             }
             .keyboardShortcut(.defaultAction)
             Button("Cancel", role: .cancel) { profilePendingClear = nil }

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -9,7 +9,6 @@ struct InterfaceSettingsView: View {
     @State private var currentDarkTheme: String?
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
     @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
-    @AppStorage(BrowserPreferences.openLinksInBuiltInBrowserKey) private var openLinksInBuiltInBrowser = false
 
     var body: some View {
         SettingsContainer {
@@ -30,7 +29,7 @@ struct InterfaceSettingsView: View {
                 }
             }
 
-            SettingsSection("Interface") {
+            SettingsSection("Interface", showsDivider: false) {
                 SettingsRow("Size") {
                     Picker("", selection: $uiScale.preset) {
                         ForEach(UIScale.Preset.allCases) { preset in
@@ -47,13 +46,6 @@ struct InterfaceSettingsView: View {
                 SettingsToggleRow(label: "Show Status Bar", isOn: $showStatusBar)
 
                 SettingsToggleRow(label: "Show Resource Usage in Status Bar", isOn: $showResourceUsage)
-            }
-
-            SettingsSection("Browser", showsDivider: false) {
-                SettingsToggleRow(
-                    label: "Open terminal links in built-in browser",
-                    isOn: $openLinksInBuiltInBrowser
-                )
             }
         }
         .task {

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -8,6 +8,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case appearance
     case sidebar
     case terminal
+    case browser
     case richInput
     case shortcuts
     case commands
@@ -27,6 +28,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .appearance: "Interface"
         case .sidebar: "Sidebar"
         case .terminal: "Terminal"
+        case .browser: "Browser"
         case .richInput: "Rich Input"
         case .shortcuts: "Shortcuts"
         case .commands: "Commands"
@@ -46,6 +48,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .appearance: "macwindow"
         case .sidebar: "sidebar.left"
         case .terminal: "terminal"
+        case .browser: "globe"
         case .richInput: "text.cursor"
         case .shortcuts: "keyboard"
         case .commands: "command"

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -71,6 +71,10 @@ struct SettingsView: View {
             searchText = ""
             selectedRoute = .builtin(.remoteDevices)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .focusBrowserSettings)) { _ in
+            searchText = ""
+            selectedRoute = .builtin(.browser)
+        }
     }
 
     private var selectedBuiltinCategory: SettingsCategory? {

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -127,6 +127,8 @@ struct SettingsView: View {
             SidebarSettingsView()
         case .terminal:
             TerminalSettingsView()
+        case .browser:
+            BrowserSettingsView()
         case .richInput:
             RichInputSettingsView()
         case .shortcuts:

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -42,6 +42,14 @@ struct TabAreaView: View {
                     shortcutIndexOffset: shortcutIndexOffset,
                     onSelectTab: onSelectTab,
                     onCreateTab: onCreateTab,
+                    onOpenBrowser: {
+                        appState.dispatch(.createBrowserTab(
+                            projectID: projectID,
+                            areaID: area.id,
+                            url: BrowserURL.resolve(from: BrowserURL.defaultURLString),
+                            profileID: BrowserProfileStore.defaultProfileIDOrFallback
+                        ))
+                    },
                     onCloseTab: onCloseTab,
                     onCloseOtherTabs: { tabID in
                         closeTabs(area.tabs.filter { $0.id != tabID && !$0.isPinned }.map(\.id))

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -47,7 +47,7 @@ struct TabAreaView: View {
                             projectID: projectID,
                             areaID: area.id,
                             url: BrowserURL.resolve(from: BrowserURL.defaultURLString),
-                            profileID: BrowserProfileStore.defaultProfileIDOrFallback
+                            profileID: BrowserPreferences.defaultProfileID
                         ))
                     },
                     onCloseTab: onCloseTab,

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -91,10 +91,6 @@ struct PaneTabStrip: View {
                     if let openInIDEProjectPath {
                         OpenInIDEControl(projectPath: openInIDEProjectPath)
                     }
-                    if let onOpenBrowser {
-                        IconButton(symbol: "globe", accessibilityLabel: "Open Browser Tab", action: onOpenBrowser)
-                            .help("Open Browser Tab")
-                    }
                     LayoutPickerMenu(projectID: projectID)
                     ExtensionTopbarItems()
                 }
@@ -112,6 +108,10 @@ struct PaneTabStrip: View {
                     .help(shortcutTooltip("Split Down", for: .splitDown))
                 IconButton(symbol: "plus", accessibilityLabel: "New Tab") { onCreateTab() }
                     .help(shortcutTooltip("New Tab", for: .newTab))
+                if let onOpenBrowser {
+                    IconButton(symbol: "globe", accessibilityLabel: "Open Browser Tab", action: onOpenBrowser)
+                        .help("Open Browser Tab")
+                }
             }
             .padding(.leading, UIMetrics.spacing4)
             .padding(.trailing, UIMetrics.spacing2)

--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,7 @@ let package = Package(
                 .linkedFramework("Speech"),
                 .linkedFramework("UserNotifications"),
                 .linkedLibrary("c++"),
+                .linkedLibrary("sqlite3"),
             ]
         ),
         .testTarget(
@@ -111,6 +112,7 @@ let package = Package(
                 .linkedFramework("Speech"),
                 .linkedFramework("UserNotifications"),
                 .linkedLibrary("c++"),
+                .linkedLibrary("sqlite3"),
             ]
         ),
     ]

--- a/Tests/MuxyTests/Models/BrowserProfileStoreTests.swift
+++ b/Tests/MuxyTests/Models/BrowserProfileStoreTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("BrowserProfileStore")
+@MainActor
+struct BrowserProfileStoreTests {
+    private func makeStore(initial: [BrowserProfile] = []) -> BrowserProfileStore {
+        BrowserProfileStore(persistence: InMemoryBrowserProfilePersistence(initial: initial))
+    }
+
+    @Test("seeds a default profile when empty")
+    func seedsDefault() {
+        let store = makeStore()
+        #expect(store.profiles.contains { $0.id == BrowserProfile.defaultID })
+        #expect(store.profiles.first { $0.isDefault }?.name == BrowserProfile.defaultName)
+    }
+
+    @Test("does not duplicate default profile when already present")
+    func keepsExistingDefault() {
+        let store = makeStore(initial: [.default])
+        #expect(store.profiles.filter { $0.id == BrowserProfile.defaultID }.count == 1)
+    }
+
+    @Test("add appends a profile")
+    func addProfile() {
+        let store = makeStore()
+        let count = store.profiles.count
+        store.add(name: "Work")
+        #expect(store.profiles.count == count + 1)
+        #expect(store.profiles.contains { $0.name == "Work" })
+    }
+
+    @Test("rename updates the name")
+    func renameProfile() {
+        let store = makeStore()
+        let profile = store.add(name: "Work")
+        store.rename(id: profile.id, to: "Personal")
+        #expect(store.profiles.first { $0.id == profile.id }?.name == "Personal")
+    }
+
+    @Test("delete removes a non-default profile")
+    func deleteProfile() {
+        let store = makeStore()
+        let profile = store.add(name: "Work")
+        store.remove(id: profile.id)
+        #expect(!store.profiles.contains { $0.id == profile.id })
+    }
+
+    @Test("default profile cannot be deleted")
+    func cannotDeleteDefault() {
+        let store = makeStore()
+        store.remove(id: BrowserProfile.defaultID)
+        #expect(store.profiles.contains { $0.id == BrowserProfile.defaultID })
+    }
+}

--- a/Tests/MuxyTests/Models/BrowserProfileStoreTests.swift
+++ b/Tests/MuxyTests/Models/BrowserProfileStoreTests.swift
@@ -3,11 +3,12 @@ import Testing
 
 @testable import Muxy
 
-@Suite("BrowserProfileStore")
+@Suite("BrowserProfileStore", .serialized)
 @MainActor
 struct BrowserProfileStoreTests {
     private func makeStore(initial: [BrowserProfile] = []) -> BrowserProfileStore {
-        BrowserProfileStore(persistence: InMemoryBrowserProfilePersistence(initial: initial))
+        UserDefaults.standard.removeObject(forKey: BrowserPreferences.defaultProfileIDKey)
+        return BrowserProfileStore(persistence: InMemoryBrowserProfilePersistence(initial: initial))
     }
 
     @Test("seeds a default profile when empty")
@@ -53,5 +54,24 @@ struct BrowserProfileStoreTests {
         let store = makeStore()
         store.remove(id: BrowserProfile.defaultID)
         #expect(store.profiles.contains { $0.id == BrowserProfile.defaultID })
+    }
+
+    @Test("setDefault can be changed and reset back to Default")
+    func defaultCanBeReset() {
+        let store = makeStore()
+        let profile = store.add(name: "Work")
+        store.setDefault(id: profile.id)
+        #expect(store.defaultProfileID == profile.id)
+        store.setDefault(id: BrowserProfile.defaultID)
+        #expect(store.defaultProfileID == BrowserProfile.defaultID)
+    }
+
+    @Test("deleting the default-selected profile resets to Default")
+    func deletingDefaultSelectionResets() {
+        let store = makeStore()
+        let profile = store.add(name: "Work")
+        store.setDefault(id: profile.id)
+        store.remove(id: profile.id)
+        #expect(store.defaultProfileID == BrowserProfile.defaultID)
     }
 }

--- a/Tests/MuxyTests/Models/BrowserProfileTabTests.swift
+++ b/Tests/MuxyTests/Models/BrowserProfileTabTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("BrowserProfileTab")
+@MainActor
+struct BrowserProfileTabTests {
+    private let testPath = "/tmp/test"
+
+    private func makeState(projectID: UUID, worktreeID: UUID) -> WorkspaceState {
+        var state = WorkspaceState(
+            activeProjectID: projectID,
+            activeWorktreeID: [projectID: worktreeID],
+            workspaceRoots: [:],
+            focusedAreaID: [:],
+            focusHistory: [:]
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: testPath)
+        state.workspaceRoots[key] = .tabArea(area)
+        state.focusedAreaID[key] = area.id
+        return state
+    }
+
+    private func focusedArea(in state: WorkspaceState, projectID: UUID) -> TabArea? {
+        guard let worktreeID = state.activeWorktreeID[projectID] else { return nil }
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        guard let focusedID = state.focusedAreaID[key],
+              let root = state.workspaceRoots[key]
+        else { return nil }
+        return root.findArea(id: focusedID)
+    }
+
+    @Test("createBrowserTab honors the profile id")
+    func createBrowserTabWithProfile() {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let profileID = UUID()
+        var state = makeState(projectID: projectID, worktreeID: worktreeID)
+
+        let action = AppState.Action.createBrowserTab(
+            projectID: projectID,
+            areaID: nil,
+            url: URL(string: "https://muxy.app"),
+            profileID: profileID
+        )
+        _ = WorkspaceReducer.reduce(action: action, state: &state)
+
+        let tab = focusedArea(in: state, projectID: projectID)?.activeTab
+        #expect(tab?.content.browserState?.profileID == profileID)
+    }
+
+    @Test("browser profile survives snapshot round-trip")
+    func snapshotRoundTrip() {
+        let profileID = UUID()
+        let state = BrowserTabState(
+            projectPath: testPath,
+            url: URL(string: "https://muxy.app"),
+            profileID: profileID
+        )
+        let snapshot = TerminalTab(browserState: state).snapshot()
+        #expect(snapshot.browserProfileID == profileID.uuidString)
+
+        let restored = TerminalTab(restoring: snapshot)
+        #expect(restored.content.browserState?.profileID == profileID)
+    }
+
+    @Test("restoring a snapshot without a profile id falls back to default")
+    func restoreFallsBackToDefault() {
+        let snapshot = TerminalTabSnapshot(
+            kind: .browser,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: testPath,
+            paneTitle: "Browser",
+            browserURL: "https://muxy.app",
+            browserProfileID: nil
+        )
+        let restored = TerminalTab(restoring: snapshot)
+        #expect(restored.content.browserState?.profileID == BrowserProfile.defaultID)
+    }
+}

--- a/Tests/MuxyTests/Models/BrowserTabReducerTests.swift
+++ b/Tests/MuxyTests/Models/BrowserTabReducerTests.swift
@@ -39,7 +39,12 @@ struct BrowserTabReducerTests {
         var state = makeState(projectID: projectID, worktreeID: worktreeID)
         let url = URL(string: "https://muxy.app")
 
-        let action = AppState.Action.createBrowserTab(projectID: projectID, areaID: nil, url: url)
+        let action = AppState.Action.createBrowserTab(
+            projectID: projectID,
+            areaID: nil,
+            url: url,
+            profileID: BrowserProfile.defaultID
+        )
         _ = WorkspaceReducer.reduce(action: action, state: &state)
 
         let area = focusedArea(in: state, projectID: projectID)
@@ -55,7 +60,12 @@ struct BrowserTabReducerTests {
         let worktreeID = UUID()
         var state = makeState(projectID: projectID, worktreeID: worktreeID)
 
-        let action = AppState.Action.createBrowserTab(projectID: projectID, areaID: nil, url: nil)
+        let action = AppState.Action.createBrowserTab(
+            projectID: projectID,
+            areaID: nil,
+            url: nil,
+            profileID: BrowserProfile.defaultID
+        )
         _ = WorkspaceReducer.reduce(action: action, state: &state)
 
         let tab = focusedArea(in: state, projectID: projectID)?.activeTab

--- a/Tests/MuxyTests/Services/ChromeCookieDecryptorTests.swift
+++ b/Tests/MuxyTests/Services/ChromeCookieDecryptorTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ChromeCookieDecryptor")
+struct ChromeCookieDecryptorTests {
+    private let safeStoragePassword = "peanuts"
+    private let encryptedV10Base64 = "djEwqHqEox1Z+dFydWNsALd51aiMflZL7UMmHHSinuykTHl81u//o1a/VlICPdMRWPl2"
+    private let expectedValue = "secret-value"
+
+    @Test("derives a 16-byte AES-128 key")
+    func derivesKey() {
+        let key = ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword)
+        #expect(key?.count == 16)
+    }
+
+    @Test("decrypts a v10 cookie and strips the domain hash prefix")
+    func decryptsV10() throws {
+        let key = try #require(ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword))
+        let blob = try #require(Data(base64Encoded: encryptedV10Base64))
+        let value = ChromeCookieDecryptor.decrypt(encryptedValue: blob, key: key)
+        #expect(value == expectedValue)
+    }
+
+    @Test("returns nil for an empty payload")
+    func emptyPayload() {
+        let key = ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword)!
+        #expect(ChromeCookieDecryptor.decrypt(encryptedValue: Data(), key: key) == nil)
+    }
+}

--- a/Tests/MuxyTests/Services/ChromeCookieDecryptorTests.swift
+++ b/Tests/MuxyTests/Services/ChromeCookieDecryptorTests.swift
@@ -7,7 +7,10 @@ import Testing
 struct ChromeCookieDecryptorTests {
     private let safeStoragePassword = "peanuts"
     private let encryptedV10Base64 = "djEwqHqEox1Z+dFydWNsALd51aiMflZL7UMmHHSinuykTHl81u//o1a/VlICPdMRWPl2"
+    private let host = "example.com"
     private let expectedValue = "secret-value"
+    private let legacyV10Base64 = "djEwb0a3I7dlcdlKdz3FlzZceUHW24fWNfUZhThUM8H7JteE9NYNFFOz0PhWnZMaufp4"
+    private let legacyValue = "long-session-token-value-exceeding-32"
 
     @Test("derives a 16-byte AES-128 key")
     func derivesKey() {
@@ -19,13 +22,28 @@ struct ChromeCookieDecryptorTests {
     func decryptsV10() throws {
         let key = try #require(ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword))
         let blob = try #require(Data(base64Encoded: encryptedV10Base64))
-        let value = ChromeCookieDecryptor.decrypt(encryptedValue: blob, key: key)
+        let value = ChromeCookieDecryptor.decrypt(encryptedValue: blob, host: host, key: key)
         #expect(value == expectedValue)
     }
 
+    @Test("keeps the full value for a legacy cookie without a domain hash prefix")
+    func keepsValueForOldFormat() throws {
+        let key = try #require(ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword))
+        let blob = try #require(Data(base64Encoded: legacyV10Base64))
+        let value = ChromeCookieDecryptor.decrypt(encryptedValue: blob, host: host, key: key)
+        #expect(value == legacyValue)
+    }
+
+    @Test("returns the raw value for a non-versioned payload")
+    func passesThroughPlaintext() throws {
+        let key = try #require(ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword))
+        let plain = Data("plain-value".utf8)
+        #expect(ChromeCookieDecryptor.decrypt(encryptedValue: plain, host: host, key: key) == "plain-value")
+    }
+
     @Test("returns nil for an empty payload")
-    func emptyPayload() {
-        let key = ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword)!
-        #expect(ChromeCookieDecryptor.decrypt(encryptedValue: Data(), key: key) == nil)
+    func emptyPayload() throws {
+        let key = try #require(ChromeCookieDecryptor.deriveKey(fromSafeStoragePassword: safeStoragePassword))
+        #expect(ChromeCookieDecryptor.decrypt(encryptedValue: Data(), host: host, key: key) == nil)
     }
 }


### PR DESCRIPTION
Adds isolated browser profiles (per-tab picker + default), opt-in Chrome cookie import behind an extensible importer, and Clear Data per profile.
Toolbar gains an open-in-external-browser menu; the new-browser-tab globe sits at the end of every tab strip.
New Settings → Browser tab manages profiles, default, and the open-links toggle.