### PR TITLE
Fix Swift 6 data race in FaviconStore favicon loading

### DIFF
--- a/Muxy/Services/FaviconStore.swift
+++ b/Muxy/Services/FaviconStore.swift
@@ -23,7 +23,7 @@ final class FaviconStore {
         cache[Self.cacheKey(for: pageURL)]
     }
 
-    func load(for pageURL: URL, iconURL: URL, completion: @escaping (NSImage?) -> Void) {
+    func load(for pageURL: URL, iconURL: URL, completion: @escaping @MainActor (NSImage?) -> Void) {
         let key = Self.cacheKey(for: pageURL)
         if let cached = cache[key] {
             completion(cached)
@@ -31,15 +31,19 @@ final class FaviconStore {
         }
         guard !inFlight.contains(key) else { return }
         inFlight.insert(key)
-        session.dataTask(with: iconURL) { [weak self] data, _, _ in
-            let image = data.flatMap(NSImage.init(data:))
-            Task { @MainActor in
-                self?.finishLoad(key: key, image: image, completion: completion)
-            }
-        }.resume()
+        Task { [weak self] in
+            let image = await Self.fetchImage(from: iconURL, session: self?.session)
+            self?.finishLoad(key: key, image: image, completion: completion)
+        }
     }
 
-    private func finishLoad(key: String, image: NSImage?, completion: (NSImage?) -> Void) {
+    nonisolated private static func fetchImage(from iconURL: URL, session: URLSession?) async -> NSImage? {
+        guard let session else { return nil }
+        guard let data = try? await session.data(from: iconURL).0 else { return nil }
+        return NSImage(data: data)
+    }
+
+    private func finishLoad(key: String, image: NSImage?, completion: @MainActor (NSImage?) -> Void) {
         inFlight.remove(key)
         guard let image, image.isValid else {
             completion(nil)

--- a/Muxy/Services/FaviconStore.swift
+++ b/Muxy/Services/FaviconStore.swift
@@ -32,20 +32,14 @@ final class FaviconStore {
         guard !inFlight.contains(key) else { return }
         inFlight.insert(key)
         Task { [weak self] in
-            let image = await Self.fetchImage(from: iconURL, session: self?.session)
-            self?.finishLoad(key: key, image: image, completion: completion)
+            let data = try? await self?.session.data(from: iconURL).0
+            self?.finishLoad(key: key, data: data, completion: completion)
         }
     }
 
-    nonisolated private static func fetchImage(from iconURL: URL, session: URLSession?) async -> NSImage? {
-        guard let session else { return nil }
-        guard let data = try? await session.data(from: iconURL).0 else { return nil }
-        return NSImage(data: data)
-    }
-
-    private func finishLoad(key: String, image: NSImage?, completion: @MainActor (NSImage?) -> Void) {
+    private func finishLoad(key: String, data: Data?, completion: @MainActor (NSImage?) -> Void) {
         inFlight.remove(key)
-        guard let image, image.isValid else {
+        guard let data, let image = NSImage(data: data), image.isValid else {
             completion(nil)
             return
         }


### PR DESCRIPTION
PR #799 merged a `FaviconStore.load` that sent a non-Sendable `completion` across an isolation boundary, which the Swift 6 compiler intermittently rejects with `sending 'completion' risks causing data races`.
This keeps `completion` `@MainActor`-isolated and moves the network fetch into a `nonisolated` async helper, so it compiles deterministically.
Verified locally with `scripts/checks.sh` (format, lint, build, test all pass).