### PR TITLE
Fix browser inspector on profile switch

### DIFF
--- a/Muxy/Models/BrowserTabState.swift
+++ b/Muxy/Models/BrowserTabState.swift
@@ -68,6 +68,13 @@ final class BrowserTabState: Identifiable {
         pendingURL = resolved
     }
 
+    func switchProfile(to id: UUID) {
+        guard id != profileID else { return }
+        profileID = id
+        guard let url else { return }
+        pendingURL = url
+    }
+
     func navigationURLForWebViewMount() -> URL? {
         if let pendingURL {
             self.pendingURL = nil

--- a/Muxy/Services/BrowserWebViewRegistry.swift
+++ b/Muxy/Services/BrowserWebViewRegistry.swift
@@ -24,7 +24,8 @@ final class BrowserWebViewRegistry {
         entries[tabID] = WeakBox(webView)
     }
 
-    func unregister(_ tabID: UUID) {
+    func unregister(_ tabID: UUID, ifMatches webView: WKWebView? = nil) {
+        if let webView, entries[tabID]?.webView !== webView { return }
         entries[tabID] = nil
     }
 

--- a/Muxy/Services/BrowserWebViewRegistry.swift
+++ b/Muxy/Services/BrowserWebViewRegistry.swift
@@ -4,6 +4,7 @@ import WebKit
 @MainActor
 protocol BrowserElementInspecting: AnyObject {
     func inspectElement() -> Bool
+    func closeInspector() -> Bool
 }
 
 @MainActor

--- a/Muxy/Views/Browser/BrowserInspectableWebView.swift
+++ b/Muxy/Views/Browser/BrowserInspectableWebView.swift
@@ -58,6 +58,15 @@ final class BrowserInspectableWebView: WKWebView, BrowserElementInspecting {
         return true
     }
 
+    @discardableResult
+    func closeInspector() -> Bool {
+        guard let inspector,
+              inspector.responds(to: Self.hideInspectorSelector)
+        else { return false }
+        hideInspector(inspector)
+        return true
+    }
+
     func addInspectElementItem(to menu: NSMenu) {
         guard canOpenInspector else { return }
         guard Self.inspectorMenuItem(in: menu) == nil else { return }

--- a/Muxy/Views/Browser/BrowserToolbar.swift
+++ b/Muxy/Views/Browser/BrowserToolbar.swift
@@ -146,11 +146,7 @@ struct BrowserToolbar: View {
     }
 
     private func selectProfile(_ id: UUID) {
-        guard id != state.profileID else { return }
-        state.profileID = id
-        if let url = state.url {
-            state.pendingURL = url
-        }
+        state.switchProfile(to: id)
     }
 
     private var addressField: some View {

--- a/Muxy/Views/Browser/BrowserWebView.swift
+++ b/Muxy/Views/Browser/BrowserWebView.swift
@@ -14,7 +14,8 @@ struct BrowserWebView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> WKWebView {
-        if let webView = state.webView {
+        let dataStore = BrowserDataStoreCache.shared.store(for: state.profileID)
+        if let webView = Self.reusableWebView(for: state, dataStore: dataStore) {
             webView.navigationDelegate = context.coordinator
             webView.uiDelegate = context.coordinator
             context.coordinator.attach(to: webView)
@@ -25,7 +26,7 @@ struct BrowserWebView: NSViewRepresentable {
 
         let config = WKWebViewConfiguration()
         config.defaultWebpagePreferences.allowsContentJavaScript = true
-        config.websiteDataStore = BrowserDataStoreCache.shared.store(for: state.profileID)
+        config.websiteDataStore = dataStore
         BrowserInspectableWebView.enableInspection(in: config)
 
         let webView = BrowserInspectableWebView(frame: .zero, configuration: config)
@@ -53,8 +54,27 @@ struct BrowserWebView: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        _ = (webView as? any BrowserElementInspecting)?.closeInspector()
         BrowserWebViewRegistry.shared.unregister(coordinator.tabID)
         coordinator.detach(from: webView)
+    }
+
+    static func reusableWebView(for state: BrowserTabState, dataStore: WKWebsiteDataStore) -> WKWebView? {
+        guard let webView = state.webView else { return nil }
+        guard webView.configuration.websiteDataStore === dataStore else {
+            retireCachedWebView(webView, state: state)
+            return nil
+        }
+        return webView
+    }
+
+    private static func retireCachedWebView(_ webView: WKWebView, state: BrowserTabState) {
+        _ = (webView as? any BrowserElementInspecting)?.closeInspector()
+        webView.stopLoading()
+        BrowserWebViewRegistry.shared.unregister(state.id)
+        if state.webView === webView {
+            state.webView = nil
+        }
     }
 
     @MainActor

--- a/Muxy/Views/Browser/BrowserWebView.swift
+++ b/Muxy/Views/Browser/BrowserWebView.swift
@@ -55,7 +55,7 @@ struct BrowserWebView: NSViewRepresentable {
 
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
         _ = (webView as? any BrowserElementInspecting)?.closeInspector()
-        BrowserWebViewRegistry.shared.unregister(coordinator.tabID)
+        BrowserWebViewRegistry.shared.unregister(coordinator.tabID, ifMatches: webView)
         coordinator.detach(from: webView)
     }
 
@@ -71,7 +71,7 @@ struct BrowserWebView: NSViewRepresentable {
     private static func retireCachedWebView(_ webView: WKWebView, state: BrowserTabState) {
         _ = (webView as? any BrowserElementInspecting)?.closeInspector()
         webView.stopLoading()
-        BrowserWebViewRegistry.shared.unregister(state.id)
+        BrowserWebViewRegistry.shared.unregister(state.id, ifMatches: webView)
         if state.webView === webView {
             state.webView = nil
         }

--- a/Tests/MuxyTests/Models/BrowserProfileTabTests.swift
+++ b/Tests/MuxyTests/Models/BrowserProfileTabTests.swift
@@ -111,6 +111,32 @@ struct BrowserProfileTabTests {
         #expect(restored.content.browserState?.profileID == BrowserProfile.defaultID)
     }
 
+    @Test("switching browser profile reloads the current page")
+    func switchProfileReloadsCurrentPage() throws {
+        let url = try #require(URL(string: "https://muxy.app"))
+        let profileID = UUID()
+        let state = BrowserTabState(projectPath: testPath, url: url)
+        _ = state.navigationURLForWebViewMount()
+
+        state.switchProfile(to: profileID)
+
+        #expect(state.profileID == profileID)
+        #expect(state.pendingURL == url)
+    }
+
+    @Test("switching to the same browser profile is a no-op")
+    func switchProfileSameProfileDoesNothing() throws {
+        let url = try #require(URL(string: "https://muxy.app"))
+        let profileID = UUID()
+        let state = BrowserTabState(projectPath: testPath, url: url, profileID: profileID)
+        _ = state.navigationURLForWebViewMount()
+
+        state.switchProfile(to: profileID)
+
+        #expect(state.profileID == profileID)
+        #expect(state.pendingURL == nil)
+    }
+
     @Test("active browser inspect request uses registered web view")
     func inspectActiveBrowserElementUsesRegisteredWebView() {
         let projectID = UUID()
@@ -189,9 +215,15 @@ private final class WorkspacePersistenceStub: WorkspacePersisting {
 @MainActor
 private final class InspectingWebViewStub: WKWebView, BrowserElementInspecting {
     var inspectCount = 0
+    var closeCount = 0
 
     func inspectElement() -> Bool {
         inspectCount += 1
+        return true
+    }
+
+    func closeInspector() -> Bool {
+        closeCount += 1
         return true
     }
 }

--- a/Tests/MuxyTests/Views/BrowserInspectableWebViewTests.swift
+++ b/Tests/MuxyTests/Views/BrowserInspectableWebViewTests.swift
@@ -40,4 +40,43 @@ struct BrowserInspectableWebViewTests {
 
         #expect(menu.items.isEmpty)
     }
+
+    @Test("cached web view is not reused after profile changes")
+    func cachedWebViewIsNotReusedAfterProfileChanges() {
+        let firstProfileID = UUID()
+        let secondProfileID = UUID()
+        defer {
+            BrowserDataStoreCache.shared.evict(firstProfileID)
+            BrowserDataStoreCache.shared.evict(secondProfileID)
+        }
+        let state = BrowserTabState(projectPath: "/tmp/test", profileID: firstProfileID)
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = BrowserDataStoreCache.shared.store(for: firstProfileID)
+        let webView = InspectorClosingWebViewStub(frame: .zero, configuration: configuration)
+        state.webView = webView
+        state.profileID = secondProfileID
+
+        let reused = BrowserWebView.reusableWebView(
+            for: state,
+            dataStore: BrowserDataStoreCache.shared.store(for: secondProfileID)
+        )
+
+        #expect(reused == nil)
+        #expect(state.webView == nil)
+        #expect(webView.closeCount == 1)
+    }
+}
+
+@MainActor
+private final class InspectorClosingWebViewStub: WKWebView, BrowserElementInspecting {
+    var closeCount = 0
+
+    func inspectElement() -> Bool {
+        true
+    }
+
+    func closeInspector() -> Bool {
+        closeCount += 1
+        return true
+    }
 }

--- a/Tests/MuxyTests/Views/BrowserInspectableWebViewTests.swift
+++ b/Tests/MuxyTests/Views/BrowserInspectableWebViewTests.swift
@@ -65,6 +65,24 @@ struct BrowserInspectableWebViewTests {
         #expect(state.webView == nil)
         #expect(webView.closeCount == 1)
     }
+
+    @Test("cached web view is reused when the profile data store matches")
+    func cachedWebViewIsReusedWhenDataStoreMatches() {
+        let profileID = UUID()
+        defer { BrowserDataStoreCache.shared.evict(profileID) }
+        let dataStore = BrowserDataStoreCache.shared.store(for: profileID)
+        let state = BrowserTabState(projectPath: "/tmp/test", profileID: profileID)
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = dataStore
+        let webView = InspectorClosingWebViewStub(frame: .zero, configuration: configuration)
+        state.webView = webView
+
+        let reused = BrowserWebView.reusableWebView(for: state, dataStore: dataStore)
+
+        #expect(reused === webView)
+        #expect(state.webView === webView)
+        #expect(webView.closeCount == 0)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
Closes browser inspector before profile remount.
  Reloads the current page with the selected profile.
  Adds regression coverage for profile switching.