### PR TITLE
Fix All Projects project selection

### DIFF
--- a/Muxy/Services/ProjectGroupStore.swift
+++ b/Muxy/Services/ProjectGroupStore.swift
@@ -50,6 +50,11 @@ final class ProjectGroupStore {
         selectGroup(id: groupID)
     }
 
+    func activateWorkspaceForProjectSelection(containing project: Project) {
+        guard activeGroupID != nil else { return }
+        activateWorkspace(containing: project)
+    }
+
     func clearGroupSelection() {
         activeGroupID = nil
         persistence.saveActiveGroupID(nil)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -766,7 +766,7 @@ struct MainWindow: View {
         guard let projectID = appState.activeProjectID, projectID != Project.homeID else { return }
         let candidates = projectStore.projects + projectGroupStore.remoteProjects
         guard let project = candidates.first(where: { $0.id == projectID }) else { return }
-        projectGroupStore.activateWorkspace(containing: project)
+        projectGroupStore.activateWorkspaceForProjectSelection(containing: project)
     }
 
     private func resolveOmniboxProject(_ projectID: UUID) -> Project? {

--- a/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/ProjectGroupStoreTests.swift
@@ -552,6 +552,34 @@ struct ProjectGroupStoreTests {
         #expect(store.activeGroupID == group.id)
     }
 
+    @Test("project selection preserves All Projects")
+    func projectSelectionPreservesAllProjects() {
+        let project = Project(name: "A", path: "/a")
+        let group = ProjectGroup(name: "Work", projectIDs: [project.id])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+
+        store.activateWorkspaceForProjectSelection(containing: project)
+
+        #expect(store.activeGroupID == nil)
+        #expect(persistence.storedActiveGroupID == nil)
+    }
+
+    @Test("project selection still switches between named workspaces")
+    func projectSelectionSwitchesBetweenNamedWorkspaces() {
+        let project = Project(name: "A", path: "/a")
+        let target = ProjectGroup(name: "Work", projectIDs: [project.id])
+        let source = ProjectGroup(name: "Personal")
+        let persistence = ProjectGroupPersistenceStub(initial: [target, source])
+        let store = makeStore(persistence: persistence)
+        store.selectGroup(id: source.id)
+
+        store.activateWorkspaceForProjectSelection(containing: project)
+
+        #expect(store.activeGroupID == target.id)
+        #expect(persistence.storedActiveGroupID == target.id)
+    }
+
     @Test("RemoteProject.asProject preserves the worktrees flag and workspace id")
     func remoteProjectAsProjectRoundTrip() {
         let workspaceID = UUID()


### PR DESCRIPTION
Preserves All Projects when selecting a grouped project.
Keeps named workspace switching behavior covered by regression tests.
Verified: `scripts/checks.sh --fix`; visual behavior confirmed by reporter.