### PR TITLE
Fix Checks runner Xcode pin

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   checks:
     name: Checks
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Pins Checks to macos-15 so the Xcode 16.4 path exists on GitHub-hosted runners.
Fixes fork PR CI failures caused by macos-latest resolving to macos-26.
Verification: scripts/checks.sh --fix.