### PR TITLE
Fix stale CLI install with a self-updating wrapper

### DIFF
--- a/Muxy/Services/CLIAccessor.swift
+++ b/Muxy/Services/CLIAccessor.swift
@@ -46,66 +46,44 @@ enum CLIAccessor {
     }
 
     static func installCLI() {
-        guard let resourceURL = cliResourceURL()
-        else {
-            alert(title: "CLI Not Found", body: "The CLI script was not found in the app bundle.")
-            return
-        }
+        let appPath = Bundle.main.bundleURL.path
+        let wrapper = CLIWrapperScript.contents(installedAppPath: appPath)
 
         guard confirmInstall() else { return }
 
-        if copyScript(from: resourceURL, to: "/usr/local/bin", label: "/usr/local/bin/muxy") {
+        if writeWrapper(wrapper, to: "/usr/local/bin") {
             showInstalledAlert(label: "/usr/local/bin/muxy", pathNote: "")
             return
         }
 
         Task.detached(priority: .userInitiated) {
-            let success = runAdminInstall(resourceURL: resourceURL)
+            let success = runAdminInstall(wrapper: wrapper)
             await MainActor.run {
                 if success {
                     showInstalledAlert(label: "/usr/local/bin/muxy", pathNote: "")
                     return
                 }
-                if tryFallbackInstalls(resourceURL: resourceURL) { return }
+                if tryFallbackInstalls(wrapper: wrapper) { return }
                 alert(
                     title: "CLI Installation Failed",
                     body: """
                     Could not install muxy to /usr/local/bin or any fallback directory.
 
-                    Try manually:
-                      sudo cp "\(resourceURL.path)" /usr/local/bin/muxy
-                      sudo chmod +x /usr/local/bin/muxy
+                    Make sure /usr/local/bin exists and is writable, then try again.
                     """
                 )
             }
         }
     }
 
-    private static func cliResourceURL() -> URL? {
-        if let url = Bundle.appResources.resourceURL?
-            .appendingPathComponent("scripts/muxy-cli"),
-            FileManager.default.fileExists(atPath: url.path)
-        {
-            return url
-        }
-
-        return Bundle.appResources.url(
-            forResource: "muxy-cli",
-            withExtension: ""
-        )
-    }
-
-    private static func copyScript(from resourceURL: URL, to binPath: String, label: String) -> Bool {
+    private static func writeWrapper(_ wrapper: String, to binPath: String) -> Bool {
         let target = URL(fileURLWithPath: "\(binPath)/muxy")
         let dir = URL(fileURLWithPath: binPath)
         if !FileManager.default.fileExists(atPath: binPath) {
             try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         }
-        if FileManager.default.fileExists(atPath: target.path) {
-            try? FileManager.default.removeItem(at: target)
-        }
         do {
-            try FileManager.default.copyItem(at: resourceURL, to: target)
+            try wrapper.write(to: target, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes(
                 [.posixPermissions: FilePermissions.executable],
                 ofItemAtPath: target.path
@@ -116,9 +94,9 @@ enum CLIAccessor {
         }
     }
 
-    nonisolated private static func runAdminInstall(resourceURL: URL) -> Bool {
-        let quotedSource = ShellEscaper.escape(resourceURL.path)
-        let shellCommand = "mkdir -p /usr/local/bin && cp \(quotedSource) /usr/local/bin/muxy && chmod +x /usr/local/bin/muxy"
+    nonisolated private static func runAdminInstall(wrapper: String) -> Bool {
+        let quotedWrapper = ShellEscaper.escape(wrapper)
+        let shellCommand = "mkdir -p /usr/local/bin && printf '%s' \(quotedWrapper) > /usr/local/bin/muxy && chmod +x /usr/local/bin/muxy"
         let escapedForAppleScript = shellCommand
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
@@ -129,14 +107,14 @@ enum CLIAccessor {
         return error == nil
     }
 
-    private static func tryFallbackInstalls(resourceURL: URL) -> Bool {
+    private static func tryFallbackInstalls(wrapper: String) -> Bool {
         let home = NSHomeDirectory()
         let fallbacks = [
             (path: "\(home)/bin", label: "~/bin/muxy"),
             (path: "\(home)/.local/bin", label: "~/.local/bin/muxy"),
         ]
         for fallback in fallbacks {
-            guard copyScript(from: resourceURL, to: fallback.path, label: fallback.label) else {
+            guard writeWrapper(wrapper, to: fallback.path) else {
                 continue
             }
             let pathNote = "\n\nAdd to PATH:\n  export PATH=\"$PATH:\(fallback.path)\""

--- a/Muxy/Services/CLIWrapperScript.swift
+++ b/Muxy/Services/CLIWrapperScript.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum CLIWrapperScript {
+    static let bundleIdentifier = "com.muxy.app"
+    static let bundledScriptRelativePath = "Contents/Resources/Muxy_Muxy.bundle/scripts/muxy-cli"
+
+    static func contents(installedAppPath: String) -> String {
+        let escapedAppPath = ShellEscaper.escape(installedAppPath)
+        let escapedRelativePath = ShellEscaper.escape(bundledScriptRelativePath)
+        let escapedBundleID = ShellEscaper.escape(bundleIdentifier)
+        return """
+        #!/bin/bash
+        # Muxy CLI wrapper. Resolves the bundled muxy-cli at runtime so it never
+        # goes stale across app updates and survives the app being moved.
+        REL=\(escapedRelativePath)
+
+        resolve_script() {
+            local app="$1"
+            [ -n "$app" ] && [ -x "$app/$REL" ] && printf '%s' "$app/$REL"
+        }
+
+        for candidate in \\
+            "${MUXY_APP_PATH:-}" \\
+            \(escapedAppPath) \\
+            "/Applications/Muxy.app" \\
+            "$HOME/Applications/Muxy.app"; do
+            SCRIPT="$(resolve_script "$candidate")"
+            [ -n "$SCRIPT" ] && exec "$SCRIPT" "$@"
+        done
+
+        APP="$(mdfind "kMDItemCFBundleIdentifier == \(escapedBundleID)" 2>/dev/null | head -n 1)"
+        SCRIPT="$(resolve_script "$APP")"
+        [ -n "$SCRIPT" ] && exec "$SCRIPT" "$@"
+
+        echo "Error: Muxy.app not found. Reinstall the CLI from Muxy → Install CLI." >&2
+        exit 1
+        """
+    }
+}

--- a/Tests/MuxyTests/Services/CLIWrapperScriptTests.swift
+++ b/Tests/MuxyTests/Services/CLIWrapperScriptTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("CLIWrapperScript")
+struct CLIWrapperScriptTests {
+    @Test("wrapper execs the bundled script rather than embedding the CLI body")
+    func wrapperExecsBundledScript() {
+        let wrapper = CLIWrapperScript.contents(installedAppPath: "/Applications/Muxy.app")
+        #expect(wrapper.hasPrefix("#!/bin/bash"))
+        #expect(wrapper.contains("exec \"$SCRIPT\" \"$@\""))
+        #expect(wrapper.contains(CLIWrapperScript.bundledScriptRelativePath))
+        #expect(!wrapper.contains("send_command"))
+    }
+
+    @Test("wrapper resolves the app by bundle id so it survives moves")
+    func wrapperResolvesByBundleID() {
+        let wrapper = CLIWrapperScript.contents(installedAppPath: "/Applications/Muxy.app")
+        #expect(wrapper.contains("kMDItemCFBundleIdentifier == \(CLIWrapperScript.bundleIdentifier)"))
+        #expect(wrapper.contains("mdfind"))
+    }
+
+    @Test("wrapper honors MUXY_APP_PATH and falls back to standard locations")
+    func wrapperHonorsOverrideAndFallbacks() {
+        let wrapper = CLIWrapperScript.contents(installedAppPath: "/Applications/Muxy.app")
+        #expect(wrapper.contains("${MUXY_APP_PATH:-}"))
+        #expect(wrapper.contains("/Applications/Muxy.app"))
+        #expect(wrapper.contains("$HOME/Applications/Muxy.app"))
+    }
+
+    @Test("captured app path with spaces is shell-quoted")
+    func capturedAppPathIsQuoted() {
+        let wrapper = CLIWrapperScript.contents(installedAppPath: "/Users/a/My Apps/Muxy.app")
+        #expect(wrapper.contains("'/Users/a/My Apps/Muxy.app'"))
+    }
+}

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -105,14 +105,15 @@ struct MuxyCLILaunchResourceTests {
         #expect(script.contains("nc -w \"$NC_TIMEOUT\" -U \"$SOCKET\""))
     }
 
-    @Test("CLI installer prefers copied scripts resource directory")
-    func cliInstallerUsesScriptsResourceDirectory() throws {
+    @Test("CLI installer installs a self-updating wrapper, not a copied snapshot")
+    func cliInstallerInstallsWrapper() throws {
         let accessor = try String(
             contentsOf: Self.repositoryRoot
                 .appendingPathComponent("Muxy/Services/CLIAccessor.swift"),
             encoding: .utf8
         )
-        #expect(accessor.contains("scripts/muxy-cli"))
+        #expect(accessor.contains("CLIWrapperScript.contents"))
+        #expect(!accessor.contains("copyItem"))
     }
 
     @Test("app bundle prohibits multiple running instances")


### PR DESCRIPTION
Install CLI now writes a wrapper that resolves Muxy.app at runtime and execs the bundled muxy-cli, instead of copying it. The shim no longer goes stale across app updates and survives the app being moved.

Closes #779