### PR TITLE
Fix infinite SwiftUI layout cycle in lazy sidebar/omnibox lists

### DIFF
--- a/Muxy/Views/Components/TerminalOmniboxOverlay.swift
+++ b/Muxy/Views/Components/TerminalOmniboxOverlay.swift
@@ -127,13 +127,15 @@ struct TerminalOmniboxOverlay: View {
                     ScrollView(.vertical, showsIndicators: true) {
                         LazyVStack(spacing: 0) {
                             ForEach(Array(displayList.enumerated()), id: \.element.id) { index, item in
-                                if shouldShowSectionHeader(at: index) {
-                                    TerminalOmniboxSectionHeader(title: item.sectionTitle)
+                                VStack(spacing: 0) {
+                                    if shouldShowSectionHeader(at: index) {
+                                        TerminalOmniboxSectionHeader(title: item.sectionTitle)
+                                    }
+                                    TerminalOmniboxRow(item: item, isHighlighted: index == highlightedIndex)
+                                        .contentShape(Rectangle())
+                                        .onTapGesture { handleTap(item) }
                                 }
-                                TerminalOmniboxRow(item: item, isHighlighted: index == highlightedIndex)
-                                    .contentShape(Rectangle())
-                                    .onTapGesture { handleTap(item) }
-                                    .id(item.id)
+                                .id(item.id)
                             }
                         }
                     }

--- a/Muxy/Views/Sidebar.swift
+++ b/Muxy/Views/Sidebar.swift
@@ -230,6 +230,10 @@ struct Sidebar: View {
         return lastPinned
     }
 
+    private var pinnedDividerOffset: CGFloat {
+        UIMetrics.spacing3 / 2
+    }
+
     @ViewBuilder private var listHeader: some View {
         if isWide {
             HStack(spacing: UIMetrics.spacing2) {
@@ -277,10 +281,12 @@ struct Sidebar: View {
                             }
                         }
                         .gesture(projectDragGesture(for: project))
-
-                    if offset == pinnedBoundaryIndex {
-                        PinnedProjectsDivider()
-                    }
+                        .overlay(alignment: .bottom) {
+                            PinnedProjectsDivider()
+                                .offset(y: pinnedDividerOffset)
+                                .opacity(offset == pinnedBoundaryIndex ? 1 : 0)
+                                .allowsHitTesting(false)
+                        }
                 }
 
                 addButton


### PR DESCRIPTION
Each `ForEach` element in the lazy sidebar and omnibox lists emitted a variable number of sibling views (conditional divider/section header), building an unstable `DynamicViewList` that could spin the layout engine forever.

Each element now emits exactly one structurally-stable view, eliminating the cycle.

Closes #775