### PR TITLE
Fix extension consent prompt sizing

### DIFF
--- a/Muxy/Views/Extensions/ExtensionConsentDialog.swift
+++ b/Muxy/Views/Extensions/ExtensionConsentDialog.swift
@@ -80,7 +80,10 @@ private struct ExtensionConsentSheetHost: NSViewRepresentable {
 
         private func present(request: ExtensionConsentRequest) {
             guard let window = parentWindow() else { return }
-            let sheet = ExtensionConsentSheetWindow(request: request) { [weak self] choice in
+            let sheet = ExtensionConsentSheetWindow(
+                request: request,
+                visibleFrame: window.screen?.visibleFrame
+            ) { [weak self] choice in
                 guard let self else { return }
                 let request = self.sheet?.currentRequest ?? request
                 self.onChoice(request, choice)
@@ -106,6 +109,7 @@ private final class ExtensionConsentSheetWindow: NSPanel {
 
     init(
         request: ExtensionConsentRequest,
+        visibleFrame: NSRect?,
         onChoice: @escaping (ExtensionConsentChoice) -> Void
     ) {
         currentRequest = request
@@ -115,11 +119,12 @@ private final class ExtensionConsentSheetWindow: NSPanel {
         host.translatesAutoresizingMaskIntoConstraints = true
         hostingView = host
 
-        let intrinsic = host.fittingSize
-        let width: CGFloat = max(520, intrinsic.width)
-        let height: CGFloat = intrinsic.height
+        let size = ExtensionConsentSheetLayout.contentSize(
+            for: host.fittingSize,
+            visibleFrame: visibleFrame ?? NSScreen.main?.visibleFrame
+        )
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: width, height: height),
+            contentRect: NSRect(x: 0, y: 0, width: size.width, height: size.height),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -132,15 +137,18 @@ private final class ExtensionConsentSheetWindow: NSPanel {
         isOpaque = false
         backgroundColor = .clear
         contentView = host
-        host.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        host.frame = NSRect(origin: .zero, size: size)
     }
 
     func updateRequest(_ request: ExtensionConsentRequest) {
         currentRequest = request
         hostingView.rootView = ExtensionConsentDialog(request: request, onChoice: onChoice)
-        let fitting = hostingView.fittingSize
-        let newSize = NSSize(width: max(520, fitting.width), height: fitting.height)
+        let newSize = ExtensionConsentSheetLayout.contentSize(
+            for: hostingView.fittingSize,
+            visibleFrame: screen?.visibleFrame ?? NSScreen.main?.visibleFrame
+        )
         setContentSize(newSize)
+        hostingView.frame = NSRect(origin: .zero, size: newSize)
     }
 
     override var canBecomeKey: Bool { true }
@@ -148,6 +156,25 @@ private final class ExtensionConsentSheetWindow: NSPanel {
 
     override func cancelOperation(_: Any?) {
         onChoice(.denyOnce)
+    }
+}
+
+enum ExtensionConsentSheetLayout {
+    static let width: CGFloat = 520
+    static let minimumHeight: CGFloat = 220
+    static let screenMargin: CGFloat = 80
+
+    @MainActor
+    static var payloadMaxHeight: CGFloat { UIMetrics.scaled(260) }
+
+    @MainActor
+    static var rememberRulePreviewHeight: CGFloat { UIMetrics.scaled(14) }
+
+    static func contentSize(for fittingSize: NSSize, visibleFrame: NSRect?) -> NSSize {
+        let height = visibleFrame.map { frame in
+            min(fittingSize.height, max(minimumHeight, frame.height - screenMargin))
+        } ?? fittingSize.height
+        return NSSize(width: max(width, fittingSize.width), height: height)
     }
 }
 
@@ -165,7 +192,7 @@ struct ExtensionConsentDialog: View {
             buttons
         }
         .padding(20)
-        .frame(maxWidth: 520, alignment: .leading)
+        .frame(width: ExtensionConsentSheetLayout.width, alignment: .leading)
         .background(MuxyTheme.bg)
         .overlay(
             RoundedRectangle(cornerRadius: 10)
@@ -192,16 +219,19 @@ struct ExtensionConsentDialog: View {
     }
 
     private var payloadBox: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            ForEach(Array(request.payloadDetails.enumerated()), id: \.offset) { _, detail in
-                Text(detail)
-                    .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
-                    .foregroundStyle(MuxyTheme.fg)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+        ScrollView(.vertical, showsIndicators: true) {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(request.payloadDetails.enumerated()), id: \.offset) { _, detail in
+                    Text(detail)
+                        .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
+            .padding(12)
         }
-        .padding(12)
+        .frame(maxHeight: ExtensionConsentSheetLayout.payloadMaxHeight)
         .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
     }
 
@@ -217,12 +247,23 @@ struct ExtensionConsentDialog: View {
                 Image(systemName: "info.circle")
                     .font(.system(size: UIMetrics.fontCaption))
                     .foregroundStyle(MuxyTheme.fgMuted)
-                Text("\"Remember\" saves rule: ")
-                    .font(.system(size: UIMetrics.fontCaption))
-                    .foregroundStyle(MuxyTheme.fgMuted)
-                    + Text(rememberRuleDescription)
-                    .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
-                    .foregroundStyle(MuxyTheme.fg)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\"Remember\" saves rule")
+                        .font(.system(size: UIMetrics.fontCaption))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                    Text(rememberRuleDescription)
+                        .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
+                        .foregroundStyle(MuxyTheme.fg)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(
+                            maxWidth: .infinity,
+                            minHeight: ExtensionConsentSheetLayout.rememberRulePreviewHeight,
+                            maxHeight: ExtensionConsentSheetLayout.rememberRulePreviewHeight,
+                            alignment: .leading
+                        )
+                        .clipped()
+                }
                 Spacer()
             }
         }

--- a/Muxy/Views/Extensions/ExtensionConsentDialog.swift
+++ b/Muxy/Views/Extensions/ExtensionConsentDialog.swift
@@ -114,14 +114,19 @@ private final class ExtensionConsentSheetWindow: NSPanel {
     ) {
         currentRequest = request
         self.onChoice = onChoice
-        let dialog = ExtensionConsentDialog(request: request, onChoice: onChoice)
+        let frame = visibleFrame ?? NSScreen.main?.visibleFrame
+        let dialog = ExtensionConsentDialog(
+            request: request,
+            payloadMaxHeight: ExtensionConsentSheetLayout.payloadMaxHeight(for: frame),
+            onChoice: onChoice
+        )
         let host = NSHostingView(rootView: dialog)
         host.translatesAutoresizingMaskIntoConstraints = true
         hostingView = host
 
         let size = ExtensionConsentSheetLayout.contentSize(
             for: host.fittingSize,
-            visibleFrame: visibleFrame ?? NSScreen.main?.visibleFrame
+            visibleFrame: frame
         )
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: size.width, height: size.height),
@@ -142,10 +147,15 @@ private final class ExtensionConsentSheetWindow: NSPanel {
 
     func updateRequest(_ request: ExtensionConsentRequest) {
         currentRequest = request
-        hostingView.rootView = ExtensionConsentDialog(request: request, onChoice: onChoice)
+        let frame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame
+        hostingView.rootView = ExtensionConsentDialog(
+            request: request,
+            payloadMaxHeight: ExtensionConsentSheetLayout.payloadMaxHeight(for: frame),
+            onChoice: onChoice
+        )
         let newSize = ExtensionConsentSheetLayout.contentSize(
             for: hostingView.fittingSize,
-            visibleFrame: screen?.visibleFrame ?? NSScreen.main?.visibleFrame
+            visibleFrame: frame
         )
         setContentSize(newSize)
         hostingView.frame = NSRect(origin: .zero, size: newSize)
@@ -163,23 +173,32 @@ enum ExtensionConsentSheetLayout {
     static let width: CGFloat = 520
     static let minimumHeight: CGFloat = 220
     static let screenMargin: CGFloat = 80
+    static let payloadFallbackHeight: CGFloat = 260
+    static let payloadMinimumHeight: CGFloat = 80
+
+    static func availableHeight(for visibleFrame: NSRect?) -> CGFloat {
+        visibleFrame.map { max(minimumHeight, $0.height - screenMargin) } ?? .greatestFiniteMagnitude
+    }
 
     @MainActor
-    static var payloadMaxHeight: CGFloat { UIMetrics.scaled(260) }
-
-    @MainActor
-    static var rememberRulePreviewHeight: CGFloat { UIMetrics.scaled(14) }
+    static func payloadMaxHeight(for visibleFrame: NSRect?) -> CGFloat {
+        guard let visibleFrame else { return payloadFallbackHeight }
+        let available = availableHeight(for: visibleFrame) - chromeHeight
+        return max(payloadMinimumHeight, min(payloadFallbackHeight, available))
+    }
 
     static func contentSize(for fittingSize: NSSize, visibleFrame: NSRect?) -> NSSize {
-        let height = visibleFrame.map { frame in
-            min(fittingSize.height, max(minimumHeight, frame.height - screenMargin))
-        } ?? fittingSize.height
+        let height = min(fittingSize.height, availableHeight(for: visibleFrame))
         return NSSize(width: max(width, fittingSize.width), height: height)
     }
+
+    @MainActor
+    private static var chromeHeight: CGFloat { UIMetrics.scaled(200) }
 }
 
 struct ExtensionConsentDialog: View {
     let request: ExtensionConsentRequest
+    var payloadMaxHeight: CGFloat = ExtensionConsentSheetLayout.payloadFallbackHeight
     let onChoice: (ExtensionConsentChoice) -> Void
 
     @State private var blockKind = false
@@ -231,7 +250,7 @@ struct ExtensionConsentDialog: View {
             }
             .padding(12)
         }
-        .frame(maxHeight: ExtensionConsentSheetLayout.payloadMaxHeight)
+        .frame(maxHeight: payloadMaxHeight)
         .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: 6))
     }
 
@@ -256,13 +275,8 @@ struct ExtensionConsentDialog: View {
                         .foregroundStyle(MuxyTheme.fg)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                        .frame(
-                            maxWidth: .infinity,
-                            minHeight: ExtensionConsentSheetLayout.rememberRulePreviewHeight,
-                            maxHeight: ExtensionConsentSheetLayout.rememberRulePreviewHeight,
-                            alignment: .leading
-                        )
-                        .clipped()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .help(rememberRuleDescription)
                 }
                 Spacer()
             }

--- a/Tests/MuxyTests/Views/ExtensionConsentDialogTests.swift
+++ b/Tests/MuxyTests/Views/ExtensionConsentDialogTests.swift
@@ -1,0 +1,60 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("ExtensionConsentDialog")
+struct ExtensionConsentDialogTests {
+    @Test("sheet height is capped to the visible screen")
+    func sheetHeightIsCappedToVisibleScreen() {
+        let fitting = NSSize(width: 520, height: 1_200)
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1_200, height: 640)
+
+        let size = ExtensionConsentSheetLayout.contentSize(for: fitting, visibleFrame: visibleFrame)
+
+        #expect(size.width == 520)
+        #expect(size.height == 560)
+    }
+
+    @Test("long shell command keeps dialog fitting height bounded")
+    func longShellCommandKeepsDialogFittingHeightBounded() {
+        let command = String(repeating: "printf '%s' very-long-extension-command && ", count: 300)
+        let request = ExtensionConsentRequest(
+            extensionID: "demo-long-command",
+            extensionDisplayName: "Long Command Demo",
+            verb: .exec,
+            payload: .exec(argv: nil, shell: command),
+            payloadSummary: "sh -c …",
+            payloadDetails: ["shell: \(command)"],
+            suggestedMatch: .shellExact(command),
+            source: "test"
+        )
+        let view = ExtensionConsentDialog(request: request, onChoice: { _ in })
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.layoutSubtreeIfNeeded()
+
+        #expect(hostingView.fittingSize.height <= 620)
+    }
+
+    @Test("long remember rule keeps dialog fitting height bounded")
+    func longRememberRuleKeepsDialogFittingHeightBounded() {
+        let command = String(repeating: "remember-rule-segment-", count: 300)
+        let request = ExtensionConsentRequest(
+            extensionID: "demo-long-command",
+            extensionDisplayName: "Long Command Demo",
+            verb: .exec,
+            payload: .exec(argv: nil, shell: command),
+            payloadSummary: "sh -c …",
+            payloadDetails: ["shell: short"],
+            suggestedMatch: .shellExact(command),
+            source: "test"
+        )
+        let view = ExtensionConsentDialog(request: request, onChoice: { _ in })
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.layoutSubtreeIfNeeded()
+
+        #expect(hostingView.fittingSize.height <= 260)
+    }
+}

--- a/Tests/MuxyTests/Views/ExtensionConsentDialogTests.swift
+++ b/Tests/MuxyTests/Views/ExtensionConsentDialogTests.swift
@@ -7,6 +7,10 @@ import Testing
 @MainActor
 @Suite("ExtensionConsentDialog")
 struct ExtensionConsentDialogTests {
+    init() {
+        UIScale.shared.preset = .regular
+    }
+
     @Test("sheet height is capped to the visible screen")
     func sheetHeightIsCappedToVisibleScreen() {
         let fitting = NSSize(width: 520, height: 1_200)
@@ -18,20 +22,22 @@ struct ExtensionConsentDialogTests {
         #expect(size.height == 560)
     }
 
+    @Test("payload max height shrinks on short screens to keep buttons reachable")
+    func payloadMaxHeightShrinksOnShortScreens() {
+        let tall = NSRect(x: 0, y: 0, width: 1_200, height: 1_080)
+        let short = NSRect(x: 0, y: 0, width: 1_200, height: 480)
+
+        let fallback = ExtensionConsentSheetLayout.payloadFallbackHeight
+        #expect(ExtensionConsentSheetLayout.payloadMaxHeight(for: tall) == fallback)
+        #expect(ExtensionConsentSheetLayout.payloadMaxHeight(for: short) < fallback)
+        #expect(ExtensionConsentSheetLayout.payloadMaxHeight(for: short) >= ExtensionConsentSheetLayout.payloadMinimumHeight)
+    }
+
     @Test("long shell command keeps dialog fitting height bounded")
     func longShellCommandKeepsDialogFittingHeightBounded() {
         let command = String(repeating: "printf '%s' very-long-extension-command && ", count: 300)
-        let request = ExtensionConsentRequest(
-            extensionID: "demo-long-command",
-            extensionDisplayName: "Long Command Demo",
-            verb: .exec,
-            payload: .exec(argv: nil, shell: command),
-            payloadSummary: "sh -c …",
-            payloadDetails: ["shell: \(command)"],
-            suggestedMatch: .shellExact(command),
-            source: "test"
-        )
-        let view = ExtensionConsentDialog(request: request, onChoice: { _ in })
+        let request = makeRequest(payloadDetails: ["shell: \(command)"], match: .shellExact(command))
+        let view = ExtensionConsentDialog(request: request, payloadMaxHeight: 260, onChoice: { _ in })
         let hostingView = NSHostingView(rootView: view)
         hostingView.layoutSubtreeIfNeeded()
 
@@ -41,20 +47,24 @@ struct ExtensionConsentDialogTests {
     @Test("long remember rule keeps dialog fitting height bounded")
     func longRememberRuleKeepsDialogFittingHeightBounded() {
         let command = String(repeating: "remember-rule-segment-", count: 300)
-        let request = ExtensionConsentRequest(
-            extensionID: "demo-long-command",
-            extensionDisplayName: "Long Command Demo",
-            verb: .exec,
-            payload: .exec(argv: nil, shell: command),
-            payloadSummary: "sh -c …",
-            payloadDetails: ["shell: short"],
-            suggestedMatch: .shellExact(command),
-            source: "test"
-        )
-        let view = ExtensionConsentDialog(request: request, onChoice: { _ in })
+        let request = makeRequest(payloadDetails: ["shell: short"], match: .shellExact(command))
+        let view = ExtensionConsentDialog(request: request, payloadMaxHeight: 260, onChoice: { _ in })
         let hostingView = NSHostingView(rootView: view)
         hostingView.layoutSubtreeIfNeeded()
 
         #expect(hostingView.fittingSize.height <= 260)
+    }
+
+    private func makeRequest(payloadDetails: [String], match: ExtensionGrantMatch) -> ExtensionConsentRequest {
+        ExtensionConsentRequest(
+            extensionID: "demo-long-command",
+            extensionDisplayName: "Long Command Demo",
+            verb: .exec,
+            payload: .exec(argv: nil, shell: payloadDetails.first),
+            payloadSummary: "sh -c …",
+            payloadDetails: payloadDetails,
+            suggestedMatch: match,
+            source: "test"
+        )
     }
 }


### PR DESCRIPTION
Fixes #756.

Caps the extension consent sheet and scrolls long payloads so action buttons stay reachable.

Tests: scripts/checks.sh --fix