### PR TITLE
Add extension file opener registry

### DIFF
--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -560,6 +560,58 @@ struct ExtensionRemoteMethod: Codable, Equatable, Identifiable {
     let description: String?
 }
 
+struct ExtensionFileOpener: Codable, Equatable, Identifiable {
+    let id: String
+    let title: String?
+    let tabType: String
+    let patterns: [String]
+    let singleton: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case tabType
+        case patterns
+        case singleton
+    }
+
+    init(
+        id: String,
+        title: String? = nil,
+        tabType: String,
+        patterns: [String] = ["*"],
+        singleton: Bool = true
+    ) {
+        self.id = id
+        self.title = title
+        self.tabType = tabType
+        self.patterns = patterns
+        self.singleton = singleton
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        tabType = try container.decode(String.self, forKey: .tabType)
+        patterns = try container.decodeIfPresent([String].self, forKey: .patterns) ?? ["*"]
+        singleton = try container.decodeIfPresent(Bool.self, forKey: .singleton) ?? true
+    }
+
+    func matches(relativePath: String) -> Bool {
+        let activePatterns = patterns.isEmpty ? ["*"] : patterns
+        return activePatterns.contains { Self.pattern($0, matches: relativePath) }
+    }
+
+    private static func pattern(_ pattern: String, matches relativePath: String) -> Bool {
+        let escaped = NSRegularExpression.escapedPattern(for: pattern)
+            .replacingOccurrences(of: "\\*", with: ".*")
+            .replacingOccurrences(of: "\\?", with: ".")
+        let regex = "^\(escaped)$"
+        return relativePath.range(of: regex, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+}
+
 struct ExtensionManifest: Codable, Equatable {
     let name: String
     let version: String
@@ -571,6 +623,7 @@ struct ExtensionManifest: Codable, Equatable {
     let panels: [ExtensionPanel]
     let popovers: [ExtensionPopover]
     let sidebar: ExtensionSidebar?
+    let fileOpeners: [ExtensionFileOpener]
     let permissions: [ExtensionPermission]
     let topbarItems: [ExtensionTopbarItem]
     let statusBarItems: [ExtensionStatusBarItem]
@@ -588,6 +641,7 @@ struct ExtensionManifest: Codable, Equatable {
         case panels
         case popovers
         case sidebar
+        case fileOpeners
         case permissions
         case topbarItems
         case statusBarItems
@@ -606,6 +660,7 @@ struct ExtensionManifest: Codable, Equatable {
         panels: [ExtensionPanel] = [],
         popovers: [ExtensionPopover] = [],
         sidebar: ExtensionSidebar? = nil,
+        fileOpeners: [ExtensionFileOpener] = [],
         permissions: [ExtensionPermission] = [],
         topbarItems: [ExtensionTopbarItem] = [],
         statusBarItems: [ExtensionStatusBarItem] = [],
@@ -622,6 +677,7 @@ struct ExtensionManifest: Codable, Equatable {
         self.panels = panels
         self.popovers = popovers
         self.sidebar = sidebar
+        self.fileOpeners = fileOpeners
         self.permissions = permissions
         self.topbarItems = topbarItems
         self.statusBarItems = statusBarItems
@@ -641,6 +697,7 @@ struct ExtensionManifest: Codable, Equatable {
         panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
         popovers = try container.decodeIfPresent([ExtensionPopover].self, forKey: .popovers) ?? []
         sidebar = try container.decodeIfPresent(ExtensionSidebar.self, forKey: .sidebar)
+        fileOpeners = try container.decodeIfPresent([ExtensionFileOpener].self, forKey: .fileOpeners) ?? []
         permissions = try container.decodeIfPresent([ExtensionPermission].self, forKey: .permissions) ?? []
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
@@ -660,6 +717,7 @@ struct ExtensionManifest: Codable, Equatable {
         panels = muxy.panels
         popovers = muxy.popovers
         sidebar = muxy.sidebar
+        fileOpeners = muxy.fileOpeners
         permissions = muxy.permissions
         topbarItems = muxy.topbarItems
         statusBarItems = muxy.statusBarItems
@@ -677,6 +735,10 @@ struct ExtensionManifest: Codable, Equatable {
 
     func popover(id: String) -> ExtensionPopover? {
         popovers.first { $0.id == id }
+    }
+
+    func fileOpener(id: String) -> ExtensionFileOpener? {
+        fileOpeners.first { $0.id == id }
     }
 
     func setting(key: String) -> ExtensionSettingEntry? {
@@ -717,6 +779,7 @@ struct MuxyManifestBody: Codable, Equatable {
     let panels: [ExtensionPanel]
     let popovers: [ExtensionPopover]
     let sidebar: ExtensionSidebar?
+    let fileOpeners: [ExtensionFileOpener]
     let permissions: [ExtensionPermission]
     let topbarItems: [ExtensionTopbarItem]
     let statusBarItems: [ExtensionStatusBarItem]
@@ -732,6 +795,7 @@ struct MuxyManifestBody: Codable, Equatable {
         case panels
         case popovers
         case sidebar
+        case fileOpeners
         case permissions
         case topbarItems
         case statusBarItems
@@ -749,6 +813,7 @@ struct MuxyManifestBody: Codable, Equatable {
         panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
         popovers = try container.decodeIfPresent([ExtensionPopover].self, forKey: .popovers) ?? []
         sidebar = try container.decodeIfPresent(ExtensionSidebar.self, forKey: .sidebar)
+        fileOpeners = try container.decodeIfPresent([ExtensionFileOpener].self, forKey: .fileOpeners) ?? []
         permissions = try container.decodeIfPresent([ExtensionPermission].self, forKey: .permissions) ?? []
         topbarItems = try container.decodeIfPresent([ExtensionTopbarItem].self, forKey: .topbarItems) ?? []
         statusBarItems = try container.decodeIfPresent([ExtensionStatusBarItem].self, forKey: .statusBarItems) ?? []
@@ -804,6 +869,10 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case statusBarItemSVGOutsideDirectory(itemID: String, url: URL)
     case settingEmptyKey
     case duplicateSettingKey(String)
+    case fileOpenerEmptyID
+    case duplicateFileOpener(String)
+    case fileOpenerReferencesUnknownTabType(openerID: String, tabType: String)
+    case fileOpenerEmptyPattern(openerID: String)
     case remoteMethodEmptyID
     case remoteMethodInvalidID(String)
     case duplicateRemoteMethod(String)
@@ -902,6 +971,14 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Setting key must not be empty"
         case let .duplicateSettingKey(key):
             "Duplicate setting key '\(key)'"
+        case .fileOpenerEmptyID:
+            "File opener id must not be empty"
+        case let .duplicateFileOpener(id):
+            "Duplicate file opener '\(id)'"
+        case let .fileOpenerReferencesUnknownTabType(openerID, tabType):
+            "File opener '\(openerID)' references unknown tab type '\(tabType)'"
+        case let .fileOpenerEmptyPattern(openerID):
+            "File opener '\(openerID)' has an empty pattern"
         case .remoteMethodEmptyID:
             "Remote method id must not be empty"
         case let .remoteMethodInvalidID(id):
@@ -985,6 +1062,7 @@ enum ExtensionManifestLoader {
         }
 
         try validateTabTypes(manifest: manifest, in: muxyExtension)
+        try validateFileOpeners(manifest: manifest)
         try validatePanels(manifest: manifest, in: muxyExtension)
         try validatePopovers(manifest: manifest, in: muxyExtension)
         try validateSidebar(manifest: manifest, in: muxyExtension)
@@ -1048,6 +1126,26 @@ enum ExtensionManifestLoader {
             }
             guard FileManager.default.fileExists(atPath: url.path) else {
                 throw ExtensionLoadError.tabTypeEntryMissing(tabTypeID: tabType.id, url: url)
+            }
+        }
+    }
+
+    private static func validateFileOpeners(manifest: ExtensionManifest) throws {
+        let tabTypeIDs = Set(manifest.tabTypes.map(\.id))
+        var seen = Set<String>()
+        for opener in manifest.fileOpeners {
+            guard !opener.id.isEmpty else { throw ExtensionLoadError.fileOpenerEmptyID }
+            guard seen.insert(opener.id).inserted else {
+                throw ExtensionLoadError.duplicateFileOpener(opener.id)
+            }
+            guard tabTypeIDs.contains(opener.tabType) else {
+                throw ExtensionLoadError.fileOpenerReferencesUnknownTabType(
+                    openerID: opener.id,
+                    tabType: opener.tabType
+                )
+            }
+            if opener.patterns.contains(where: { $0.isEmpty }) {
+                throw ExtensionLoadError.fileOpenerEmptyPattern(openerID: opener.id)
             }
         }
     }

--- a/Muxy/Models/Extension.swift
+++ b/Muxy/Models/Extension.swift
@@ -1144,7 +1144,7 @@ enum ExtensionManifestLoader {
                     tabType: opener.tabType
                 )
             }
-            if opener.patterns.contains(where: { $0.isEmpty }) {
+            if opener.patterns.contains(where: \.isEmpty) {
                 throw ExtensionLoadError.fileOpenerEmptyPattern(openerID: opener.id)
             }
         }

--- a/Muxy/Models/FileOpenerSelection.swift
+++ b/Muxy/Models/FileOpenerSelection.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum FileOpenerSelection {
+    static let storageKey = "muxy.defaultFileOpener"
+    static let builtinValue = ""
+
+    @MainActor
+    static func resolvedBinding(
+        from storedValue: String,
+        relativePath: String? = nil,
+        store: ExtensionStore = .shared
+    ) -> ExtensionStore.FileOpenerBinding? {
+        guard let identifier = parse(storedValue) else { return nil }
+        return store.fileOpener(
+            extensionID: identifier.extensionID,
+            openerID: identifier.openerID,
+            relativePath: relativePath
+        )
+    }
+
+    @MainActor
+    static func availableOpeners(store: ExtensionStore = .shared) -> [ExtensionStore.FileOpenerBinding] {
+        store.fileOpeners()
+    }
+
+    static func value(extensionID: String, openerID: String) -> String {
+        "\(extensionID):\(openerID)"
+    }
+
+    static func parse(_ storedValue: String) -> (extensionID: String, openerID: String)? {
+        guard !storedValue.isEmpty else { return nil }
+        let parts = storedValue.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+        return (String(parts[0]), String(parts[1]))
+    }
+}

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -484,16 +484,15 @@ final class ExtensionStore {
     }
 
     func preferredFileOpener(for relativePath: String) -> FileOpenerBinding? {
-        if let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
-            IDEIntegrationService.shared.selectedBundleIdentifier
-        ) {
-            return fileOpener(
-                extensionID: selected.extensionID,
-                openerID: selected.openerID,
-                relativePath: relativePath
-            )
-        }
-        return nil
+        guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
+            IDEIntegrationService.shared.selectedFileOpenerIdentifier
+        )
+        else { return nil }
+        return fileOpener(
+            extensionID: selected.extensionID,
+            openerID: selected.openerID,
+            relativePath: relativePath
+        )
     }
 
     func statusBarItems(side: ExtensionStatusBarItem.Side) -> [StatusBarItemBinding] {

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -484,14 +484,10 @@ final class ExtensionStore {
     }
 
     func preferredFileOpener(for relativePath: String) -> FileOpenerBinding? {
-        guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
-            IDEIntegrationService.shared.selectedFileOpenerIdentifier
-        )
-        else { return nil }
-        return fileOpener(
-            extensionID: selected.extensionID,
-            openerID: selected.openerID,
-            relativePath: relativePath
+        FileOpenerSelection.resolvedBinding(
+            from: IDEIntegrationService.shared.selectedFileOpenerValue,
+            relativePath: relativePath,
+            store: self
         )
     }
 

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -399,6 +399,16 @@ final class ExtensionStore {
         let command: ExtensionPaletteCommand
     }
 
+    struct FileOpenerBinding: Equatable, Identifiable {
+        let muxyExtension: MuxyExtension
+        let opener: ExtensionFileOpener
+        let tabType: ExtensionTabType
+
+        var id: String {
+            "\(muxyExtension.id):\(opener.id)"
+        }
+    }
+
     struct ItemOverride: Equatable {
         var icon: ExtensionIcon?
         var text: String?
@@ -443,6 +453,47 @@ final class ExtensionStore {
                     .filter { !$0.action.isAnchored }
                     .map { PaletteCommandBinding(muxyExtension: status.muxyExtension, command: $0) }
             }
+    }
+
+    func fileOpeners(for relativePath: String) -> [FileOpenerBinding] {
+        fileOpeners().filter { $0.opener.matches(relativePath: relativePath) }
+    }
+
+    func fileOpeners() -> [FileOpenerBinding] {
+        statuses
+            .filter(\.isEnabled)
+            .flatMap { status in
+                let ext = status.muxyExtension
+                return ext.manifest.fileOpeners.compactMap { opener -> FileOpenerBinding? in
+                    guard let tabType = ext.manifest.tabType(id: opener.tabType)
+                    else {
+                        return nil
+                    }
+                    return FileOpenerBinding(muxyExtension: ext, opener: opener, tabType: tabType)
+                }
+            }
+    }
+
+    func fileOpener(extensionID: String, openerID: String, relativePath: String? = nil) -> FileOpenerBinding? {
+        fileOpeners().first { binding in
+            let matchesPath = relativePath.map { binding.opener.matches(relativePath: $0) } ?? true
+            return binding.muxyExtension.id == extensionID &&
+                binding.opener.id == openerID &&
+                matchesPath
+        }
+    }
+
+    func preferredFileOpener(for relativePath: String) -> FileOpenerBinding? {
+        if let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
+            IDEIntegrationService.shared.selectedBundleIdentifier
+        ) {
+            return fileOpener(
+                extensionID: selected.extensionID,
+                openerID: selected.openerID,
+                relativePath: relativePath
+            )
+        }
+        return nil
     }
 
     func statusBarItems(side: ExtensionStatusBarItem.Side) -> [StatusBarItemBinding] {

--- a/Muxy/Services/IDEIntegrationService.swift
+++ b/Muxy/Services/IDEIntegrationService.swift
@@ -56,6 +56,7 @@ final class IDEIntegrationService: ObservableObject {
     }
 
     static let selectedBundleIdentifierKey = "muxy.ide.selectedBundleIdentifier"
+    static let extensionFileOpenerIdentifierPrefix = "muxy.extensionFileOpener:"
     static let finderBundleIdentifier = "com.apple.finder"
     static let finderAppURL = URL(fileURLWithPath: "/System/Library/CoreServices/Finder.app")
     static let finderApplication = IDEApplication(
@@ -91,6 +92,24 @@ final class IDEIntegrationService: ObservableObject {
         if selectedBundleIdentifier != identifier {
             selectedBundleIdentifier = identifier
         }
+    }
+
+    func selectFileOpener(extensionID: String, openerID: String) {
+        setSelectedBundleIdentifier(Self.fileOpenerSelectionIdentifier(extensionID: extensionID, openerID: openerID))
+    }
+
+    static func fileOpenerSelectionIdentifier(extensionID: String, openerID: String) -> String {
+        "\(extensionFileOpenerIdentifierPrefix)\(extensionID):\(openerID)"
+    }
+
+    static func parseFileOpenerSelectionIdentifier(_ identifier: String?) -> (extensionID: String, openerID: String)? {
+        guard let identifier,
+              identifier.hasPrefix(extensionFileOpenerIdentifierPrefix)
+        else { return nil }
+        let raw = String(identifier.dropFirst(extensionFileOpenerIdentifierPrefix.count))
+        let parts = raw.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+        return (String(parts[0]), String(parts[1]))
     }
 
     var defaultIDE: IDEApplication? {

--- a/Muxy/Services/IDEIntegrationService.swift
+++ b/Muxy/Services/IDEIntegrationService.swift
@@ -56,6 +56,7 @@ final class IDEIntegrationService: ObservableObject {
     }
 
     static let selectedBundleIdentifierKey = "muxy.ide.selectedBundleIdentifier"
+    static let selectedFileOpenerIdentifierKey = "muxy.ide.selectedFileOpenerIdentifier"
     static let extensionFileOpenerIdentifierPrefix = "muxy.extensionFileOpener:"
     static let finderBundleIdentifier = "com.apple.finder"
     static let finderAppURL = URL(fileURLWithPath: "/System/Library/CoreServices/Finder.app")
@@ -70,6 +71,7 @@ final class IDEIntegrationService: ObservableObject {
 
     @Published private(set) var installedApps: [IDEApplication] = []
     @Published private(set) var selectedBundleIdentifier: String?
+    @Published private(set) var selectedFileOpenerIdentifier: String?
 
     private let workspace: NSWorkspace
     private let defaults: UserDefaults
@@ -84,6 +86,7 @@ final class IDEIntegrationService: ObservableObject {
         self.defaults = defaults
         self.fileManager = fileManager
         self.selectedBundleIdentifier = defaults.string(forKey: Self.selectedBundleIdentifierKey)
+        self.selectedFileOpenerIdentifier = defaults.string(forKey: Self.selectedFileOpenerIdentifierKey)
         refreshInstalledApps()
     }
 
@@ -92,10 +95,21 @@ final class IDEIntegrationService: ObservableObject {
         if selectedBundleIdentifier != identifier {
             selectedBundleIdentifier = identifier
         }
+        clearSelectedFileOpener()
     }
 
     func selectFileOpener(extensionID: String, openerID: String) {
-        setSelectedBundleIdentifier(Self.fileOpenerSelectionIdentifier(extensionID: extensionID, openerID: openerID))
+        let identifier = Self.fileOpenerSelectionIdentifier(extensionID: extensionID, openerID: openerID)
+        defaults.set(identifier, forKey: Self.selectedFileOpenerIdentifierKey)
+        if selectedFileOpenerIdentifier != identifier {
+            selectedFileOpenerIdentifier = identifier
+        }
+    }
+
+    private func clearSelectedFileOpener() {
+        guard selectedFileOpenerIdentifier != nil else { return }
+        defaults.removeObject(forKey: Self.selectedFileOpenerIdentifierKey)
+        selectedFileOpenerIdentifier = nil
     }
 
     static func fileOpenerSelectionIdentifier(extensionID: String, openerID: String) -> String {

--- a/Muxy/Services/IDEIntegrationService.swift
+++ b/Muxy/Services/IDEIntegrationService.swift
@@ -56,8 +56,6 @@ final class IDEIntegrationService: ObservableObject {
     }
 
     static let selectedBundleIdentifierKey = "muxy.ide.selectedBundleIdentifier"
-    static let selectedFileOpenerIdentifierKey = "muxy.ide.selectedFileOpenerIdentifier"
-    static let extensionFileOpenerIdentifierPrefix = "muxy.extensionFileOpener:"
     static let finderBundleIdentifier = "com.apple.finder"
     static let finderAppURL = URL(fileURLWithPath: "/System/Library/CoreServices/Finder.app")
     static let finderApplication = IDEApplication(
@@ -71,7 +69,10 @@ final class IDEIntegrationService: ObservableObject {
 
     @Published private(set) var installedApps: [IDEApplication] = []
     @Published private(set) var selectedBundleIdentifier: String?
-    @Published private(set) var selectedFileOpenerIdentifier: String?
+
+    var selectedFileOpenerValue: String {
+        defaults.string(forKey: FileOpenerSelection.storageKey) ?? FileOpenerSelection.builtinValue
+    }
 
     private let workspace: NSWorkspace
     private let defaults: UserDefaults
@@ -86,7 +87,6 @@ final class IDEIntegrationService: ObservableObject {
         self.defaults = defaults
         self.fileManager = fileManager
         self.selectedBundleIdentifier = defaults.string(forKey: Self.selectedBundleIdentifierKey)
-        self.selectedFileOpenerIdentifier = defaults.string(forKey: Self.selectedFileOpenerIdentifierKey)
         refreshInstalledApps()
     }
 
@@ -95,35 +95,16 @@ final class IDEIntegrationService: ObservableObject {
         if selectedBundleIdentifier != identifier {
             selectedBundleIdentifier = identifier
         }
-        clearSelectedFileOpener()
+        setSelectedFileOpenerValue(FileOpenerSelection.builtinValue)
     }
 
     func selectFileOpener(extensionID: String, openerID: String) {
-        let identifier = Self.fileOpenerSelectionIdentifier(extensionID: extensionID, openerID: openerID)
-        defaults.set(identifier, forKey: Self.selectedFileOpenerIdentifierKey)
-        if selectedFileOpenerIdentifier != identifier {
-            selectedFileOpenerIdentifier = identifier
-        }
+        setSelectedFileOpenerValue(FileOpenerSelection.value(extensionID: extensionID, openerID: openerID))
     }
 
-    private func clearSelectedFileOpener() {
-        guard selectedFileOpenerIdentifier != nil else { return }
-        defaults.removeObject(forKey: Self.selectedFileOpenerIdentifierKey)
-        selectedFileOpenerIdentifier = nil
-    }
-
-    static func fileOpenerSelectionIdentifier(extensionID: String, openerID: String) -> String {
-        "\(extensionFileOpenerIdentifierPrefix)\(extensionID):\(openerID)"
-    }
-
-    static func parseFileOpenerSelectionIdentifier(_ identifier: String?) -> (extensionID: String, openerID: String)? {
-        guard let identifier,
-              identifier.hasPrefix(extensionFileOpenerIdentifierPrefix)
-        else { return nil }
-        let raw = String(identifier.dropFirst(extensionFileOpenerIdentifierPrefix.count))
-        let parts = raw.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
-        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
-        return (String(parts[0]), String(parts[1]))
+    func setSelectedFileOpenerValue(_ value: String) {
+        objectWillChange.send()
+        defaults.set(value, forKey: FileOpenerSelection.storageKey)
     }
 
     var defaultIDE: IDEApplication? {

--- a/Muxy/Views/Components/OpenInIDEControl.swift
+++ b/Muxy/Views/Components/OpenInIDEControl.swift
@@ -10,6 +10,7 @@ struct OpenInIDEControl: View {
     @Environment(AppState.self) private var appState
     @ObservedObject private var ideService = IDEIntegrationService.shared
     @State private var extensionStore = ExtensionStore.shared
+    @AppStorage(FileOpenerSelection.storageKey) private var selectedFileOpenerValue = FileOpenerSelection.builtinValue
     @State private var hoveredPrimary = false
     @State private var hoveredMenu = false
     @State private var showingMenu = false
@@ -203,11 +204,7 @@ struct OpenInIDEControl: View {
     }
 
     private var defaultFileOpener: ExtensionStore.FileOpenerBinding? {
-        guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
-            ideService.selectedFileOpenerIdentifier
-        )
-        else { return nil }
-        return extensionStore.fileOpener(extensionID: selected.extensionID, openerID: selected.openerID)
+        FileOpenerSelection.resolvedBinding(from: selectedFileOpenerValue, store: extensionStore)
     }
 
     private var defaultTargetIDE: IDEIntegrationService.IDEApplication? {
@@ -348,11 +345,7 @@ struct OpenInIDEControl: View {
     }
 
     private func isSelected(_ binding: ExtensionStore.FileOpenerBinding) -> Bool {
-        guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
-            ideService.selectedFileOpenerIdentifier
-        )
-        else { return false }
-        return selected.extensionID == binding.muxyExtension.id && selected.openerID == binding.opener.id
+        selectedFileOpenerValue == binding.id
     }
 }
 

--- a/Muxy/Views/Components/OpenInIDEControl.swift
+++ b/Muxy/Views/Components/OpenInIDEControl.swift
@@ -3,12 +3,21 @@ import SwiftUI
 @MainActor
 struct OpenInIDEControl: View {
     let projectPath: String?
+    var projectID: UUID?
+    var areaID: UUID?
     var compact = true
 
+    @Environment(AppState.self) private var appState
     @ObservedObject private var ideService = IDEIntegrationService.shared
+    @State private var extensionStore = ExtensionStore.shared
     @State private var hoveredPrimary = false
     @State private var hoveredMenu = false
     @State private var showingMenu = false
+
+    private enum OpenTarget {
+        case ide(IDEIntegrationService.IDEApplication)
+        case fileOpener(ExtensionStore.FileOpenerBinding)
+    }
 
     var body: some View {
         if compact {
@@ -22,8 +31,12 @@ struct OpenInIDEControl: View {
         HStack(spacing: 0) {
             Button(action: openDefaultIDE) {
                 Group {
-                    if let defaultIDE {
+                    if let defaultIDE = defaultTargetIDE {
                         AppBundleIconView(appURL: defaultIDE.appURL, fallbackSystemName: defaultIDE.symbolName, size: UIMetrics.iconLG)
+                    } else if defaultFileOpener != nil {
+                        Image(systemName: "doc.text")
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                            .foregroundStyle(primaryForeground)
                     } else {
                         Image(systemName: "chevron.left.forwardslash.chevron.right")
                             .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
@@ -35,7 +48,7 @@ struct OpenInIDEControl: View {
                 .background(hoveredPrimary ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             }
             .buttonStyle(.plain)
-            .disabled(projectPath == nil || defaultIDE == nil)
+            .disabled(projectPath == nil || defaultOpenTarget == nil)
             .onHover { hoveredPrimary = $0 }
             .help(helpText)
             .accessibilityLabel(helpText)
@@ -51,12 +64,14 @@ struct OpenInIDEControl: View {
         HStack(spacing: 0) {
             Button(action: openDefaultIDE) {
                 HStack(spacing: UIMetrics.spacing3) {
-                    if let defaultIDE {
+                    if let defaultIDE = defaultTargetIDE {
                         AppBundleIconView(appURL: defaultIDE.appURL, fallbackSystemName: defaultIDE.symbolName, size: UIMetrics.iconLG)
+                    } else if defaultFileOpener != nil {
+                        Image(systemName: "doc.text")
                     } else {
                         Image(systemName: "chevron.left.forwardslash.chevron.right")
                     }
-                    Text(defaultIDE.map { "Open in \($0.displayName)" } ?? "Open in IDE")
+                    Text(defaultOpenTarget.map { "Open in \(displayName(for: $0))" } ?? "Open in IDE")
                 }
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .foregroundStyle(primaryForeground)
@@ -66,7 +81,7 @@ struct OpenInIDEControl: View {
                 .background(hoveredPrimary ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
             }
             .buttonStyle(.plain)
-            .disabled(projectPath == nil || defaultIDE == nil)
+            .disabled(projectPath == nil || defaultOpenTarget == nil)
             .onHover { hoveredPrimary = $0 }
             .help(helpText)
             .accessibilityLabel(helpText)
@@ -106,20 +121,23 @@ struct OpenInIDEControl: View {
                     showingMenu = false
                     _ = ideService.openProject(at: projectPath, in: IDEIntegrationService.finderApplication)
                 }
-                if !installedApps.isEmpty {
+                if hasTargets {
                     Divider()
                         .padding(.vertical, UIMetrics.spacing2)
                 }
             }
 
-            if installedApps.isEmpty {
-                Text("No supported IDEs found")
+            if !hasTargets {
+                Text("No supported editors found")
                     .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .padding(.leading, UIMetrics.spacing5)
                     .padding(.trailing, UIMetrics.spacing6)
                     .padding(.vertical, UIMetrics.spacing4)
             } else {
+                if !fileOpeners.isEmpty {
+                    fileOpenerSection(title: "Muxy Editors", openers: fileOpeners)
+                }
                 if !editorApps.isEmpty {
                     menuSection(title: "Editors & IDEs", apps: editorApps)
                 }
@@ -131,6 +149,22 @@ struct OpenInIDEControl: View {
         .padding(UIMetrics.spacing4)
         .fixedSize(horizontal: true, vertical: true)
         .background(MuxyTheme.bg)
+    }
+
+    private func fileOpenerSection(title: String, openers: [ExtensionStore.FileOpenerBinding]) -> some View {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
+            Text(title)
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .padding(.leading, UIMetrics.scaled(9))
+                .padding(.trailing, UIMetrics.spacing6)
+                .padding(.top, UIMetrics.spacing2)
+                .padding(.bottom, UIMetrics.scaled(1))
+
+            ForEach(openers, id: \.id) { binding in
+                fileOpenerButton(for: binding)
+            }
+        }
     }
 
     private func menuSection(title: String, apps: [IDEIntegrationService.IDEApplication]) -> some View {
@@ -153,8 +187,41 @@ struct OpenInIDEControl: View {
         ideService.installedApps
     }
 
+    private var fileOpeners: [ExtensionStore.FileOpenerBinding] {
+        extensionStore.fileOpeners()
+            .sorted {
+                displayName(for: .fileOpener($0)).localizedCaseInsensitiveCompare(displayName(for: .fileOpener($1))) == .orderedAscending
+            }
+    }
+
+    private var hasTargets: Bool {
+        !installedApps.isEmpty || !fileOpeners.isEmpty
+    }
+
     private var defaultIDE: IDEIntegrationService.IDEApplication? {
         ideService.defaultIDE
+    }
+
+    private var defaultFileOpener: ExtensionStore.FileOpenerBinding? {
+        guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
+            ideService.selectedBundleIdentifier
+        ) else { return nil }
+        return extensionStore.fileOpener(extensionID: selected.extensionID, openerID: selected.openerID)
+    }
+
+    private var defaultTargetIDE: IDEIntegrationService.IDEApplication? {
+        if defaultFileOpener != nil { return nil }
+        return defaultIDE
+    }
+
+    private var defaultOpenTarget: OpenTarget? {
+        if let defaultFileOpener {
+            return .fileOpener(defaultFileOpener)
+        }
+        if let defaultIDE {
+            return .ide(defaultIDE)
+        }
+        return nil
     }
 
     private var editorApps: [IDEIntegrationService.IDEApplication] {
@@ -177,6 +244,17 @@ struct OpenInIDEControl: View {
         )
     }
 
+    private func fileOpenerButton(for binding: ExtensionStore.FileOpenerBinding) -> some View {
+        FileOpenerMenuRow(
+            title: displayName(for: .fileOpener(binding)),
+            isSelected: isSelected(binding),
+            action: {
+                showingMenu = false
+                open(.fileOpener(binding))
+            }
+        )
+    }
+
     private func menuActionRow(
         appURL: URL,
         fallbackSystemName: String,
@@ -188,19 +266,19 @@ struct OpenInIDEControl: View {
 
     private var helpText: String {
         guard projectPath != nil else { return "Open a project to enable IDE launching" }
-        if let defaultIDE {
-            return "Open in \(defaultIDE.displayName)"
+        if let defaultOpenTarget {
+            return "Open in \(displayName(for: defaultOpenTarget))"
         }
-        return installedApps.isEmpty ? "No supported IDEs found" : "No default IDE available"
+        return hasTargets ? "No default editor available" : "No supported editors found"
     }
 
     private var menuHelpText: String {
-        guard projectPath != nil else { return "Open a project to choose an IDE" }
-        return "Choose IDE"
+        guard projectPath != nil else { return "Open a project to choose an editor" }
+        return "Choose editor"
     }
 
     private var primaryForeground: Color {
-        if projectPath == nil || defaultIDE == nil {
+        if projectPath == nil || defaultOpenTarget == nil {
             return MuxyTheme.fgMuted.opacity(0.45)
         }
         return hoveredPrimary ? MuxyTheme.fg : MuxyTheme.fgMuted
@@ -214,13 +292,65 @@ struct OpenInIDEControl: View {
     }
 
     private func openDefaultIDE() {
-        guard let defaultIDE else { return }
-        open(defaultIDE)
+        guard let defaultOpenTarget else { return }
+        open(defaultOpenTarget)
     }
 
     private func open(_ ide: IDEIntegrationService.IDEApplication) {
         guard let projectPath else { return }
         _ = ideService.openProject(at: projectPath, in: ide)
+    }
+
+    private func open(_ target: OpenTarget) {
+        switch target {
+        case let .ide(ide):
+            open(ide)
+        case let .fileOpener(binding):
+            openFileOpener(binding)
+        }
+    }
+
+    private func openFileOpener(_ binding: ExtensionStore.FileOpenerBinding) {
+        ideService.selectFileOpener(extensionID: binding.muxyExtension.id, openerID: binding.opener.id)
+        guard let projectID = projectID ?? appState.activeProjectID else { return }
+        appState.dispatch(.createExtensionTab(
+            projectID: projectID,
+            areaID: areaID,
+            request: AppState.CreateExtensionTabRequest(
+                extensionID: binding.muxyExtension.id,
+                tabTypeID: binding.opener.tabType,
+                title: binding.opener.title ?? binding.tabType.title,
+                data: .object(["source": .string("open-control")]),
+                singleton: binding.opener.singleton
+            )
+        ))
+    }
+
+    private func displayName(for target: OpenTarget) -> String {
+        switch target {
+        case let .ide(ide):
+            return ide.displayName
+        case let .fileOpener(binding):
+            let extensionName = formattedExtensionName(binding.muxyExtension.displayName)
+            if let title = binding.opener.title, !title.isEmpty {
+                return "\(extensionName) (\(title))"
+            }
+            return extensionName
+        }
+    }
+
+    private func formattedExtensionName(_ name: String) -> String {
+        if name == name.lowercased() {
+            return name.capitalized
+        }
+        return name
+    }
+
+    private func isSelected(_ binding: ExtensionStore.FileOpenerBinding) -> Bool {
+        guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
+            ideService.selectedBundleIdentifier
+        ) else { return false }
+        return selected.extensionID == binding.muxyExtension.id && selected.openerID == binding.opener.id
     }
 }
 
@@ -237,6 +367,41 @@ private struct IDEMenuRow: View {
                 AppBundleIconView(appURL: ide.appURL, fallbackSystemName: ide.symbolName, size: UIMetrics.iconMD)
                 Text(ide.displayName)
                     .font(.system(size: UIMetrics.fontBody))
+            }
+            .foregroundStyle(MuxyTheme.fg)
+            .padding(.leading, UIMetrics.scaled(9))
+            .padding(.trailing, UIMetrics.spacing6)
+            .padding(.vertical, UIMetrics.spacing2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(hovered ? MuxyTheme.hover : .clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+    }
+}
+
+@MainActor
+private struct FileOpenerMenuRow: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: UIMetrics.scaled(7)) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                    .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
+                Text(title)
+                    .font(.system(size: UIMetrics.fontBody))
+                Spacer(minLength: UIMetrics.spacing4)
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: UIMetrics.fontMicro, weight: .semibold))
+                }
             }
             .foregroundStyle(MuxyTheme.fg)
             .padding(.leading, UIMetrics.scaled(9))

--- a/Muxy/Views/Components/OpenInIDEControl.swift
+++ b/Muxy/Views/Components/OpenInIDEControl.swift
@@ -204,8 +204,9 @@ struct OpenInIDEControl: View {
 
     private var defaultFileOpener: ExtensionStore.FileOpenerBinding? {
         guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
-            ideService.selectedBundleIdentifier
-        ) else { return nil }
+            ideService.selectedFileOpenerIdentifier
+        )
+        else { return nil }
         return extensionStore.fileOpener(extensionID: selected.extensionID, openerID: selected.openerID)
     }
 
@@ -348,8 +349,9 @@ struct OpenInIDEControl: View {
 
     private func isSelected(_ binding: ExtensionStore.FileOpenerBinding) -> Bool {
         guard let selected = IDEIntegrationService.parseFileOpenerSelectionIdentifier(
-            ideService.selectedBundleIdentifier
-        ) else { return false }
+            ideService.selectedFileOpenerIdentifier
+        )
+        else { return false }
         return selected.extensionID == binding.muxyExtension.id && selected.openerID == binding.opener.id
     }
 }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -522,7 +522,7 @@ struct MainWindow: View {
                         }
                         if let project = activeProject {
                             if !project.isRemote {
-                                OpenInIDEControl(projectPath: activeWorktreePath(for: project))
+                                OpenInIDEControl(projectPath: activeWorktreePath(for: project), projectID: project.id)
                             }
                             LayoutPickerMenu(projectID: project.id)
                         }

--- a/Muxy/Views/Settings/ProjectsSettingsView.swift
+++ b/Muxy/Views/Settings/ProjectsSettingsView.swift
@@ -10,7 +10,10 @@ struct ProjectsSettingsView: View {
     private var projectPickerModeRaw = ProjectPickerMode.custom.rawValue
     @AppStorage(ProjectSortMode.storageKey)
     private var projectSortModeRaw = ProjectSortMode.defaultValue.rawValue
+    @AppStorage(FileOpenerSelection.storageKey)
+    private var defaultFileOpener = FileOpenerSelection.builtinValue
     @State private var projectPickerDefaultLocationSettings = ProjectPickerDefaultLocationSettingsModel()
+    @State private var extensionStore = ExtensionStore.shared
 
     var body: some View {
         SettingsContainer {
@@ -51,6 +54,29 @@ struct ProjectsSettingsView: View {
                 )
             }
 
+            if !fileOpeners.isEmpty {
+                SettingsSection(
+                    "Open Files With",
+                    footer: "Files opened from the terminal or the Open in IDE control go to this opener. "
+                        + "Falls back to the IDE when its patterns don't match."
+                ) {
+                    SettingsRow("Default Opener") {
+                        HStack {
+                            Spacer()
+                            Picker("", selection: $defaultFileOpener) {
+                                Text("Built-in (IDE)").tag(FileOpenerSelection.builtinValue)
+                                ForEach(fileOpeners) { binding in
+                                    Text(label(for: binding)).tag(binding.id)
+                                }
+                            }
+                            .labelsHidden()
+                            .fixedSize()
+                        }
+                        .frame(width: SettingsMetrics.controlWidth)
+                    }
+                }
+            }
+
             SettingsSection(
                 "Worktrees",
                 footer: "Muxy creates a project-named subfolder inside this folder. "
@@ -60,6 +86,17 @@ struct ProjectsSettingsView: View {
                 worktreeLocationControl
             }
         }
+    }
+
+    private var fileOpeners: [ExtensionStore.FileOpenerBinding] {
+        FileOpenerSelection.availableOpeners(store: extensionStore)
+    }
+
+    private func label(for binding: ExtensionStore.FileOpenerBinding) -> String {
+        guard let title = binding.opener.title, !title.isEmpty else {
+            return binding.muxyExtension.displayName
+        }
+        return "\(binding.muxyExtension.displayName) (\(title))"
     }
 
     private var projectPickerMode: ProjectPickerMode {

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -233,6 +233,15 @@ enum SettingsCatalog {
             defaultValue: false
         ),
         SettingsCatalogItem(
+            key: FileOpenerSelection.storageKey,
+            title: "Default Opener",
+            description: "Chooses the IDE or an extension opener for files opened from native surfaces.",
+            category: .projects,
+            section: "Open Files With",
+            defaultValue: FileOpenerSelection.builtinValue,
+            aliases: ["file opener", "open in ide", "editor", "extension opener"]
+        ),
+        SettingsCatalogItem(
             key: GeneralSettingsKeys.defaultWorktreeParentPath,
             title: "Default Worktree Path",
             description: "Sets the parent folder for new worktrees.",

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -882,6 +882,7 @@ final class GhosttyTerminalNSView: NSView {
     private struct CmdFileToken {
         let text: String
         let underlineSegments: [FileUnderlineSegment]
+        let cols: Int
     }
 
     private struct FileUnderlineSegment {
@@ -916,29 +917,24 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     private func resolvedCmdFileToken(for word: QuicklookWord) -> CmdFileToken? {
-        for candidate in cmdFileTokenCandidates(for: word) {
-            if resolveCmdHoverFile?(candidate.text) == true {
-                return candidate
-            }
+        if resolveCmdHoverFile?(word.text) == true {
+            return CmdFileToken(text: word.text, underlineSegments: [], cols: 0)
         }
-        return nil
+        return wrappedCmdFileTokenCandidates(for: word).first { resolveCmdHoverFile?($0.text) == true }
     }
 
-    private func cmdFileTokenCandidates(for word: QuicklookWord) -> [CmdFileToken] {
-        let base = CmdFileToken(text: word.text, underlineSegments: [])
-        var candidates = [base]
+    private func wrappedCmdFileTokenCandidates(for word: QuicklookWord) -> [CmdFileToken] {
         guard let snapshot = readScreenSnapshot(),
               let row = screenRow(for: word, lines: snapshot.lines)
         else {
-            return candidates
+            return []
         }
-
-        for candidate in Self.wrappedFileTokenCandidatesWithFragments(word: word.text, row: row, lines: snapshot.lines) {
-            if !candidates.contains(where: { $0.text == candidate.text }) {
-                candidates.append(candidate)
-            }
-        }
-        return candidates
+        return Self.wrappedFileTokenCandidatesWithFragments(
+            word: word.text,
+            row: row,
+            lines: snapshot.lines,
+            cols: snapshot.cols
+        )
     }
 
     private func readScreenSnapshot() -> ScreenSnapshot? {
@@ -980,10 +976,15 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     static func wrappedFileTokenCandidates(word: String, row: Int, lines: [String]) -> [String] {
-        wrappedFileTokenCandidatesWithFragments(word: word, row: row, lines: lines).map(\.text)
+        wrappedFileTokenCandidatesWithFragments(word: word, row: row, lines: lines, cols: 0).map(\.text)
     }
 
-    private static func wrappedFileTokenCandidatesWithFragments(word: String, row: Int, lines: [String]) -> [CmdFileToken] {
+    private static func wrappedFileTokenCandidatesWithFragments(
+        word: String,
+        row: Int,
+        lines: [String],
+        cols: Int
+    ) -> [CmdFileToken] {
         guard row >= 0, row < lines.count,
               let anchor = matchingPathFragment(word: word, line: lines[row])
         else { return [] }
@@ -1010,19 +1011,18 @@ final class GhosttyTerminalNSView: NSView {
 
         let text = joinedPathText(fragments)
         guard text != word else { return [] }
-        return [CmdFileToken(
-            text: text,
-            underlineSegments: fragments.map {
-                FileUnderlineSegment(
-                    row: $0.row,
-                    startColumn: $0.fragment.startColumn,
-                    endColumn: $0.fragment.endColumn
-                )
-            }
-        )]
+        let segments = fragments.map {
+            FileUnderlineSegment(
+                row: $0.row,
+                startColumn: $0.fragment.startColumn,
+                endColumn: $0.fragment.endColumn
+            )
+        }
+        return [CmdFileToken(text: text, underlineSegments: segments, cols: cols)]
     }
 
-    private static let wrappedPathScalars = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/._-+@~:$%#=&")
+    private static let wrappedPathScalars =
+        CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/._-+@~:$%#=&")
     private static let maxWrappedFileTokenRows = 6
 
     private static func matchingPathFragment(word: String, line: String) -> PathFragment? {
@@ -1089,11 +1089,8 @@ final class GhosttyTerminalNSView: NSView {
         let thickness = max(font.underlineThickness, 1 / scale)
 
         let path = CGMutablePath()
-        if !token.underlineSegments.isEmpty,
-           let snapshot = readScreenSnapshot(),
-           snapshot.cols > 0
-        {
-            let cellWidth = bounds.width / CGFloat(snapshot.cols)
+        if !token.underlineSegments.isEmpty, token.cols > 0 {
+            let cellWidth = bounds.width / CGFloat(token.cols)
             for segment in token.underlineSegments {
                 let x = CGFloat(segment.startColumn) * cellWidth
                 let y = CGFloat(segment.row) * rowHeight + rowHeight - max(2, font.underlineThickness)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -787,21 +787,11 @@ final class GhosttyTerminalNSView: NSView {
         }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
-        if event.modifierFlags.contains(.command), !hasOSC8LinkUnderCursor, let word = readWordUnderMouse() {
-            onCmdClickFile?(word)
+        if event.modifierFlags.contains(.command), !hasOSC8LinkUnderCursor, let word = readQuicklookWordUnderMouse() {
+            onCmdClickFile?(resolvedCmdFileToken(for: word)?.text ?? word.text)
             return
         }
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
-    }
-
-    private func readWordUnderMouse() -> String? {
-        guard let surface else { return nil }
-        var text = ghostty_text_s()
-        guard ghostty_surface_quicklook_word(surface, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
-        guard let value = extractString(from: text) else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -859,12 +849,14 @@ final class GhosttyTerminalNSView: NSView {
             hideFileHoverUnderline()
             return
         }
-        guard let word = readQuicklookWordUnderMouse(), resolveCmdHoverFile?(word.text) == true else {
+        guard let word = readQuicklookWordUnderMouse(),
+              let token = resolvedCmdFileToken(for: word)
+        else {
             setHandCursor(false)
             hideFileHoverUnderline()
             return
         }
-        showFileHoverUnderline(for: word)
+        showFileHoverUnderline(for: word, token: token)
         setHandCursor(true)
     }
 
@@ -887,6 +879,28 @@ final class GhosttyTerminalNSView: NSView {
         let topLeftPoints: CGPoint
     }
 
+    private struct CmdFileToken {
+        let text: String
+        let underlineSegments: [FileUnderlineSegment]
+    }
+
+    private struct FileUnderlineSegment {
+        let row: Int
+        let startColumn: Int
+        let endColumn: Int
+    }
+
+    private struct ScreenSnapshot {
+        let lines: [String]
+        let cols: Int
+    }
+
+    private struct PathFragment {
+        let text: String
+        let startColumn: Int
+        let endColumn: Int
+    }
+
     private func readQuicklookWordUnderMouse() -> QuicklookWord? {
         guard let surface else { return nil }
         var text = ghostty_text_s()
@@ -901,7 +915,164 @@ final class GhosttyTerminalNSView: NSView {
         )
     }
 
-    private func showFileHoverUnderline(for word: QuicklookWord) {
+    private func resolvedCmdFileToken(for word: QuicklookWord) -> CmdFileToken? {
+        for candidate in cmdFileTokenCandidates(for: word) {
+            if resolveCmdHoverFile?(candidate.text) == true {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private func cmdFileTokenCandidates(for word: QuicklookWord) -> [CmdFileToken] {
+        let base = CmdFileToken(text: word.text, underlineSegments: [])
+        var candidates = [base]
+        guard let snapshot = readScreenSnapshot(),
+              let row = screenRow(for: word, lines: snapshot.lines)
+        else {
+            return candidates
+        }
+
+        for candidate in Self.wrappedFileTokenCandidatesWithFragments(word: word.text, row: row, lines: snapshot.lines) {
+            if !candidates.contains(where: { $0.text == candidate.text }) {
+                candidates.append(candidate)
+            }
+        }
+        return candidates
+    }
+
+    private func readScreenSnapshot() -> ScreenSnapshot? {
+        guard let surface else { return nil }
+        var out = ghostty_cells_s()
+        guard ghostty_surface_read_cells(surface, &out) else { return nil }
+        defer { ghostty_surface_free_cells(surface, &out) }
+
+        let cols = Int(out.cols)
+        let rows = Int(out.rows)
+        guard cols > 0, rows > 0, let cells = out.cells else { return nil }
+
+        var lines: [String] = []
+        lines.reserveCapacity(rows)
+        for row in 0 ..< rows {
+            var line = ""
+            for col in 0 ..< cols {
+                let cell = cells[row * cols + col]
+                let cp = cell.codepoint
+                if cp == 0 {
+                    line.append(" ")
+                } else if let scalar = Unicode.Scalar(cp) {
+                    line.append(Character(scalar))
+                } else {
+                    line.append(" ")
+                }
+            }
+            lines.append(line)
+        }
+        return ScreenSnapshot(lines: lines, cols: cols)
+    }
+
+    private func screenRow(for word: QuicklookWord, lines: [String]) -> Int? {
+        guard let rowHeight = terminalRowHeight(), rowHeight > 0 else { return nil }
+        let y = lastMouseTopDownPoint?.y ?? word.topLeftPoints.y
+        let row = Int(floor(y / rowHeight))
+        guard row >= 0, row < lines.count else { return nil }
+        return row
+    }
+
+    static func wrappedFileTokenCandidates(word: String, row: Int, lines: [String]) -> [String] {
+        wrappedFileTokenCandidatesWithFragments(word: word, row: row, lines: lines).map(\.text)
+    }
+
+    private static func wrappedFileTokenCandidatesWithFragments(word: String, row: Int, lines: [String]) -> [CmdFileToken] {
+        guard row >= 0, row < lines.count,
+              let anchor = matchingPathFragment(word: word, line: lines[row])
+        else { return [] }
+
+        var fragments: [(row: Int, fragment: PathFragment)] = [(row, anchor)]
+
+        while fragments.count < maxWrappedFileTokenRows,
+              let first = fragments.first,
+              first.row > 0,
+              let previous = trailingPathFragment(from: lines[first.row - 1]),
+              shouldPrepend(previous.text, before: joinedPathText(fragments))
+        {
+            fragments.insert((first.row - 1, previous), at: 0)
+        }
+
+        while fragments.count < maxWrappedFileTokenRows,
+              let last = fragments.last,
+              last.row + 1 < lines.count,
+              let next = leadingPathFragment(from: lines[last.row + 1]),
+              shouldAppend(next.text, after: joinedPathText(fragments))
+        {
+            fragments.append((last.row + 1, next))
+        }
+
+        let text = joinedPathText(fragments)
+        guard text != word else { return [] }
+        return [CmdFileToken(
+            text: text,
+            underlineSegments: fragments.map {
+                FileUnderlineSegment(
+                    row: $0.row,
+                    startColumn: $0.fragment.startColumn,
+                    endColumn: $0.fragment.endColumn
+                )
+            }
+        )]
+    }
+
+    private static let wrappedPathScalars = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/._-+@~:$%#=&")
+    private static let maxWrappedFileTokenRows = 6
+
+    private static func matchingPathFragment(word: String, line: String) -> PathFragment? {
+        [leadingPathFragment(from: line), trailingPathFragment(from: line)]
+            .compactMap(\.self)
+            .first { fragment in
+                fragment.text == word
+                    || fragment.text == ":\(word)"
+                    || ((fragment.text.contains("/") || fragment.text.hasPrefix(":")) && fragment.text.contains(word))
+            }
+    }
+
+    private static func joinedPathText(_ fragments: [(row: Int, fragment: PathFragment)]) -> String {
+        fragments.map(\.fragment.text).joined()
+    }
+
+    private static func shouldPrepend(_ previous: String, before current: String) -> Bool {
+        previous.contains("/") || previous.hasPrefix("~") || current.hasPrefix(":")
+    }
+
+    private static func shouldAppend(_ next: String, after current: String) -> Bool {
+        current.contains("/") || current.hasPrefix("~") || next.hasPrefix(":")
+    }
+
+    private static func leadingPathFragment(from line: String) -> PathFragment? {
+        let scalars = Array(line.unicodeScalars)
+        guard let start = scalars.firstIndex(where: { !CharacterSet.whitespaces.contains($0) }) else { return nil }
+        var end = start
+        while end < scalars.count, wrappedPathScalars.contains(scalars[end]) {
+            end += 1
+        }
+        guard end > start else { return nil }
+        let fragment = String(String.UnicodeScalarView(scalars[start ..< end]))
+        return PathFragment(text: fragment, startColumn: start, endColumn: end)
+    }
+
+    private static func trailingPathFragment(from line: String) -> PathFragment? {
+        let scalars = Array(line.unicodeScalars)
+        guard let last = scalars.lastIndex(where: { !CharacterSet.whitespaces.contains($0) }) else { return nil }
+        var start = last
+        while start > 0, wrappedPathScalars.contains(scalars[start - 1]) {
+            start -= 1
+        }
+        guard wrappedPathScalars.contains(scalars[last]) else { return nil }
+        let end = last + 1
+        let fragment = String(String.UnicodeScalarView(scalars[start ..< end]))
+        return PathFragment(text: fragment, startColumn: start, endColumn: end)
+    }
+
+    private func showFileHoverUnderline(for word: QuicklookWord, token: CmdFileToken) {
         guard let layer else { return }
         let underlineLayer = fileHoverUnderlineLayer ?? CAShapeLayer()
         if fileHoverUnderlineLayer == nil {
@@ -914,17 +1085,31 @@ final class GhosttyTerminalNSView: NSView {
         let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
         let font = quicklookFont()
         let textSize = (word.text as NSString).size(withAttributes: [.font: font])
-        let x = word.topLeftPoints.x
         let rowHeight = terminalRowHeight() ?? max(textSize.height, font.ascender - font.descender + font.leading)
-        let mouseY = lastMouseTopDownPoint?.y ?? word.topLeftPoints.y
-        let rowTopY = floor(mouseY / rowHeight) * rowHeight
-        let y = rowTopY + rowHeight - max(2, font.underlineThickness)
-        let width = max(textSize.width, 1)
         let thickness = max(font.underlineThickness, 1 / scale)
 
         let path = CGMutablePath()
-        path.move(to: CGPoint(x: x, y: y))
-        path.addLine(to: CGPoint(x: x + width, y: y))
+        if !token.underlineSegments.isEmpty,
+           let snapshot = readScreenSnapshot(),
+           snapshot.cols > 0
+        {
+            let cellWidth = bounds.width / CGFloat(snapshot.cols)
+            for segment in token.underlineSegments {
+                let x = CGFloat(segment.startColumn) * cellWidth
+                let y = CGFloat(segment.row) * rowHeight + rowHeight - max(2, font.underlineThickness)
+                let width = max(CGFloat(segment.endColumn - segment.startColumn) * cellWidth, 1)
+                path.move(to: CGPoint(x: x, y: y))
+                path.addLine(to: CGPoint(x: x + width, y: y))
+            }
+        } else {
+            let x = word.topLeftPoints.x
+            let mouseY = lastMouseTopDownPoint?.y ?? word.topLeftPoints.y
+            let rowTopY = floor(mouseY / rowHeight) * rowHeight
+            let y = rowTopY + rowHeight - max(2, font.underlineThickness)
+            let width = max(textSize.width, 1)
+            path.move(to: CGPoint(x: x, y: y))
+            path.addLine(to: CGPoint(x: x + width, y: y))
+        }
 
         CATransaction.begin()
         CATransaction.setDisableActions(true)

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -321,6 +321,8 @@ struct TerminalBridge: NSViewRepresentable {
     private func configureFileOpenCallback(_ view: GhosttyTerminalNSView) {
         let projectPath = state.projectPath
         let appState = appState
+        let projectID = worktreeKey?.projectID
+        let areaID = areaID
         guard !workspaceContext.isRemote else {
             view.resolveCmdHoverFile = { _ in false }
             view.onCmdClickFile = { _ in }
@@ -331,14 +333,37 @@ struct TerminalBridge: NSViewRepresentable {
             return
         }
         view.resolveCmdHoverFile = { token in
-            Self.resolveFilePath(token, projectPath: projectPath) != nil
+            Self.resolveFileLocation(from: token, projectPath: projectPath) != nil
         }
         view.onCmdClickFile = { token in
-            guard let resolved = Self.resolveFilePath(token, projectPath: projectPath) else { return }
-            _ = IDEIntegrationService.shared.openProject(at: projectPath, highlightingFileAt: resolved)
+            guard let location = Self.resolveFileLocation(from: token, projectPath: projectPath) else { return }
+            if Self.openWithRegisteredFileOpener(
+                location,
+                projectPath: projectPath,
+                projectID: projectID,
+                areaID: areaID,
+                appState: appState
+            ) {
+                return
+            }
+            _ = IDEIntegrationService.shared.openProject(
+                at: projectPath,
+                highlightingFileAt: location.path,
+                line: location.line,
+                column: location.column
+            )
         }
         view.onOpenURL = { url in
             if let location = Self.resolveFileLocation(from: url, projectPath: projectPath) {
+                if Self.openWithRegisteredFileOpener(
+                    location,
+                    projectPath: projectPath,
+                    projectID: projectID,
+                    areaID: areaID,
+                    appState: appState
+                ) {
+                    return true
+                }
                 return IDEIntegrationService.shared.openProject(
                     at: projectPath,
                     highlightingFileAt: location.path,
@@ -352,6 +377,56 @@ struct TerminalBridge: NSViewRepresentable {
             }
             return Self.openExternalLink(url, appState: appState)
         }
+    }
+
+    @MainActor
+    private static func openWithRegisteredFileOpener(
+        _ location: ResolvedFileLocation,
+        projectPath: String,
+        projectID: UUID?,
+        areaID: UUID,
+        appState: AppState
+    ) -> Bool {
+        guard let projectID,
+              let relativePath = relativePath(location.path, inside: projectPath),
+              let binding = ExtensionStore.shared.preferredFileOpener(for: relativePath)
+        else {
+            return false
+        }
+
+        var data: [String: ExtensionJSON] = [
+            "filePath": .string(relativePath),
+            "source": .string("terminal"),
+        ]
+        if let line = location.line {
+            data["line"] = .number(Double(line))
+        }
+        if let column = location.column {
+            data["column"] = .number(Double(column))
+        }
+
+        appState.dispatch(.createExtensionTab(
+            projectID: projectID,
+            areaID: areaID,
+            request: AppState.CreateExtensionTabRequest(
+                extensionID: binding.muxyExtension.id,
+                tabTypeID: binding.opener.tabType,
+                title: binding.opener.title ?? binding.tabType.title,
+                data: .object(data),
+                singleton: binding.opener.singleton
+            )
+        ))
+        return true
+    }
+
+    static func relativePath(_ filePath: String, inside projectPath: String) -> String? {
+        let fileURL = URL(fileURLWithPath: filePath).standardizedFileURL
+        let projectURL = URL(fileURLWithPath: projectPath).standardizedFileURL
+        let file = fileURL.path
+        let project = projectURL.path
+        guard file == project || file.hasPrefix(project + "/") else { return nil }
+        let relative = String(file.dropFirst(project.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return relative.isEmpty ? nil : relative
     }
 
     private static func openExternalLink(_ url: URL, appState: AppState) -> Bool {
@@ -406,6 +481,16 @@ struct TerminalBridge: NSViewRepresentable {
         guard isLocalPathCandidate(url) else { return nil }
         let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
         return resolveFilePath(raw, projectPath: projectPath)
+    }
+
+    static func resolveFileLocation(from token: String, projectPath: String) -> ResolvedFileLocation? {
+        if let path = resolveFilePath(token, projectPath: projectPath) {
+            return ResolvedFileLocation(path: path, line: nil, column: nil)
+        }
+        let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: "\"' \t\n\r()[]<>"))
+        guard let stripped = stripLineColumnSuffix(from: cleaned) else { return nil }
+        guard let path = resolveFilePath(stripped.path, projectPath: projectPath) else { return nil }
+        return ResolvedFileLocation(path: path, line: stripped.line, column: stripped.column)
     }
 
     static func resolveFileLocation(from url: URL, projectPath: String) -> ResolvedFileLocation? {

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -91,7 +91,7 @@ struct PaneTabStrip: View {
                 }
                 if isWindowTitleBar {
                     if let openInIDEProjectPath {
-                        OpenInIDEControl(projectPath: openInIDEProjectPath)
+                        OpenInIDEControl(projectPath: openInIDEProjectPath, projectID: projectID, areaID: areaID)
                     }
                     LayoutPickerMenu(projectID: projectID)
                     ExtensionTopbarItems()

--- a/Tests/MuxyTests/Models/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/ExtensionManifestTests.swift
@@ -47,6 +47,50 @@ struct ExtensionManifestTests {
         #expect(manifest.permissions == [.panesRead, .tabsWrite, .notificationsWrite])
     }
 
+    @Test("decodes file openers with defaults")
+    func decodesFileOpeners() throws {
+        let json = #"""
+        {
+            "name": "demo",
+            "version": "2.1",
+            "tabTypes": [
+                { "id": "editor", "title": "Editor", "entry": "editor.html" }
+            ],
+            "fileOpeners": [
+                { "id": "default", "tabType": "editor" },
+                {
+                    "id": "swift",
+                    "title": "Swift Editor",
+                    "tabType": "editor",
+                    "patterns": ["*.swift"],
+                    "singleton": false
+                }
+            ]
+        }
+        """#
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+
+        #expect(manifest.fileOpeners == [
+            ExtensionFileOpener(id: "default", tabType: "editor"),
+            ExtensionFileOpener(
+                id: "swift",
+                title: "Swift Editor",
+                tabType: "editor",
+                patterns: ["*.swift"],
+                singleton: false
+            ),
+        ])
+    }
+
+    @Test("file opener patterns support wildcards")
+    func fileOpenerPatternsSupportWildcards() {
+        let opener = ExtensionFileOpener(id: "swift", tabType: "editor", patterns: ["Sources/*.swift", "Package.*"])
+
+        #expect(opener.matches(relativePath: "Sources/main.swift"))
+        #expect(opener.matches(relativePath: "Package.swift"))
+        #expect(!opener.matches(relativePath: "README.md"))
+    }
+
     @Test("loads from directory and resolves background script")
     func loadsFromDirectory() throws {
         let directory = try makeTemporaryExtension(
@@ -67,6 +111,75 @@ struct ExtensionManifestTests {
         #expect(ext.id == "tmp-ext")
         #expect(ext.manifest.permissions == [.panesRead])
         #expect(ext.backgroundScriptURL != nil)
+    }
+
+    @Test("loads file openers that reference local tab types")
+    func loadsFileOpeners() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "openers",
+                "version": "1.0.0",
+                "tabTypes": [
+                    { "id": "editor", "title": "Editor", "entry": "editor.html" }
+                ],
+                "fileOpeners": [
+                    { "id": "default", "tabType": "editor", "patterns": ["*"] }
+                ]
+            }
+            """,
+            files: ["editor.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let ext = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(ext.manifest.fileOpener(id: "default")?.tabType == "editor")
+    }
+
+    @Test("rejects file opener that references an unknown tab type")
+    func rejectsFileOpenerUnknownTabType() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "bad-openers",
+                "version": "1.0.0",
+                "fileOpeners": [
+                    { "id": "default", "tabType": "missing" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.fileOpenerReferencesUnknownTabType(openerID: "default", tabType: "missing")) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects duplicate file opener ids")
+    func rejectsDuplicateFileOpeners() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "duplicate-openers",
+                "version": "1.0.0",
+                "tabTypes": [
+                    { "id": "editor", "title": "Editor", "entry": "editor.html" }
+                ],
+                "fileOpeners": [
+                    { "id": "default", "tabType": "editor" },
+                    { "id": "default", "tabType": "editor" }
+                ]
+            }
+            """,
+            files: ["editor.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.duplicateFileOpener("default")) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
     }
 
     @Test("loads from the dist build output when present")

--- a/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
+++ b/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
@@ -66,6 +66,22 @@ struct IDEIntegrationServiceTests {
         #expect(IDEIntegrationService.parseFileOpenerSelectionIdentifier("com.microsoft.VSCode") == nil)
     }
 
+    @Test("file opener selection persists independently of the selected IDE")
+    func fileOpenerSelectionPersistsIndependentlyOfIDE() throws {
+        let defaults = try #require(UserDefaults(suiteName: "muxy.tests.\(UUID().uuidString)"))
+        defaults.set("com.microsoft.VSCode", forKey: IDEIntegrationService.selectedBundleIdentifierKey)
+        let service = IDEIntegrationService(defaults: defaults)
+
+        service.selectFileOpener(extensionID: "files", openerID: "editor")
+
+        #expect(service.selectedFileOpenerIdentifier == IDEIntegrationService.fileOpenerSelectionIdentifier(
+            extensionID: "files",
+            openerID: "editor"
+        ))
+        #expect(service.selectedBundleIdentifier == "com.microsoft.VSCode")
+        #expect(IDEIntegrationService(defaults: defaults).selectedFileOpenerIdentifier == service.selectedFileOpenerIdentifier)
+    }
+
     @Test("launchCommands uses vscode CLI goto strategy when available")
     func launchCommandsUsesVSCodeCLIGotoStrategyWhenAvailable() {
         let ide = IDEIntegrationService.IDEApplication(

--- a/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
+++ b/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
@@ -53,33 +53,26 @@ struct IDEIntegrationServiceTests {
         #expect(resolved?.bundleIdentifier == zed.bundleIdentifier)
     }
 
-    @Test("file opener selection identifiers round trip")
-    func fileOpenerSelectionIdentifiersRoundTrip() throws {
-        let identifier = IDEIntegrationService.fileOpenerSelectionIdentifier(
-            extensionID: "files",
-            openerID: "editor"
-        )
-        let parsed = try #require(IDEIntegrationService.parseFileOpenerSelectionIdentifier(identifier))
+    @Test("file opener selection values round trip")
+    func fileOpenerSelectionValuesRoundTrip() throws {
+        let value = FileOpenerSelection.value(extensionID: "files", openerID: "editor")
+        let parsed = try #require(FileOpenerSelection.parse(value))
 
         #expect(parsed.extensionID == "files")
         #expect(parsed.openerID == "editor")
-        #expect(IDEIntegrationService.parseFileOpenerSelectionIdentifier("com.microsoft.VSCode") == nil)
+        #expect(FileOpenerSelection.parse(FileOpenerSelection.builtinValue) == nil)
+        #expect(FileOpenerSelection.parse("files") == nil)
     }
 
-    @Test("file opener selection persists independently of the selected IDE")
-    func fileOpenerSelectionPersistsIndependentlyOfIDE() throws {
+    @Test("file opener selection persists and survives relaunch")
+    func fileOpenerSelectionPersists() throws {
         let defaults = try #require(UserDefaults(suiteName: "muxy.tests.\(UUID().uuidString)"))
-        defaults.set("com.microsoft.VSCode", forKey: IDEIntegrationService.selectedBundleIdentifierKey)
         let service = IDEIntegrationService(defaults: defaults)
 
         service.selectFileOpener(extensionID: "files", openerID: "editor")
 
-        #expect(service.selectedFileOpenerIdentifier == IDEIntegrationService.fileOpenerSelectionIdentifier(
-            extensionID: "files",
-            openerID: "editor"
-        ))
-        #expect(service.selectedBundleIdentifier == "com.microsoft.VSCode")
-        #expect(IDEIntegrationService(defaults: defaults).selectedFileOpenerIdentifier == service.selectedFileOpenerIdentifier)
+        #expect(service.selectedFileOpenerValue == FileOpenerSelection.value(extensionID: "files", openerID: "editor"))
+        #expect(IDEIntegrationService(defaults: defaults).selectedFileOpenerValue == service.selectedFileOpenerValue)
     }
 
     @Test("launchCommands uses vscode CLI goto strategy when available")

--- a/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
+++ b/Tests/MuxyTests/Services/IDEIntegrationServiceTests.swift
@@ -53,6 +53,19 @@ struct IDEIntegrationServiceTests {
         #expect(resolved?.bundleIdentifier == zed.bundleIdentifier)
     }
 
+    @Test("file opener selection identifiers round trip")
+    func fileOpenerSelectionIdentifiersRoundTrip() throws {
+        let identifier = IDEIntegrationService.fileOpenerSelectionIdentifier(
+            extensionID: "files",
+            openerID: "editor"
+        )
+        let parsed = try #require(IDEIntegrationService.parseFileOpenerSelectionIdentifier(identifier))
+
+        #expect(parsed.extensionID == "files")
+        #expect(parsed.openerID == "editor")
+        #expect(IDEIntegrationService.parseFileOpenerSelectionIdentifier("com.microsoft.VSCode") == nil)
+    }
+
     @Test("launchCommands uses vscode CLI goto strategy when available")
     func launchCommandsUsesVSCodeCLIGotoStrategyWhenAvailable() {
         let ide = IDEIntegrationService.IDEApplication(

--- a/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
+++ b/Tests/MuxyTests/Services/TerminalBridgeResolveFilePathTests.swift
@@ -179,6 +179,176 @@ struct TerminalBridgeResolveFilePathTests {
         #expect(location == .init(path: file, line: nil, column: nil))
     }
 
+    @Test func resolvesTokenFileLocationWithLineSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sub = dir.appendingPathComponent("Sources")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        let file = writeFile(sub, name: "main.swift")
+        let location = TerminalBridge.resolveFileLocation(from: "Sources/main.swift:42", projectPath: dir.path)
+        #expect(location == .init(path: file, line: 42, column: nil))
+    }
+
+    @Test func resolvesTokenFileLocationWithLineAndColumnSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sub = dir.appendingPathComponent("Sources")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        let file = writeFile(sub, name: "main.swift")
+        let location = TerminalBridge.resolveFileLocation(from: "Sources/main.swift:42:7", projectPath: dir.path)
+        #expect(location == .init(path: file, line: 42, column: 7))
+    }
+
+    @Test func resolvesTokenFileLocationPrefersRealFileWithColonInName() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = writeFile(dir, name: "foo:12")
+        let location = TerminalBridge.resolveFileLocation(from: "foo:12", projectPath: dir.path)
+        #expect(location == .init(path: file, line: nil, column: nil))
+    }
+
+    @Test func resolvesWrappedTokenFileLocationFromPreviousLineSuffix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let services = dir.appendingPathComponent("muxy/Tests/MuxyTests/Services")
+        try FileManager.default.createDirectory(at: services, withIntermediateDirectories: true)
+        let file = writeFile(services, name: "TerminalBridgeResolveFilePathTests.swift")
+        let lines = [
+            "test file: muxy/Tests/MuxyTests/Services/",
+            "  TerminalBridgeResolveFilePathTests.swift:179",
+        ]
+        let candidate = try #require(GhosttyTerminalNSView.wrappedFileTokenCandidates(
+            word: "TerminalBridgeResolveFilePathTests.swift:179",
+            row: 1,
+            lines: lines
+        ).first)
+        let location = TerminalBridge.resolveFileLocation(from: candidate, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 179, column: nil))
+    }
+
+    @Test func resolvesWrappedTokenFileLocationFromNextLinePrefix() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let services = dir.appendingPathComponent("muxy/Tests/MuxyTests/Services")
+        try FileManager.default.createDirectory(at: services, withIntermediateDirectories: true)
+        let file = writeFile(services, name: "TerminalBridgeResolveFilePathTests.swift")
+        let lines = [
+            "test file: muxy/Tests/MuxyTests/Services/",
+            "  TerminalBridgeResolveFilePathTests.swift:179",
+        ]
+        let candidate = try #require(GhosttyTerminalNSView.wrappedFileTokenCandidates(
+            word: "muxy/Tests/MuxyTests/Services/",
+            row: 0,
+            lines: lines
+        ).first)
+        let location = TerminalBridge.resolveFileLocation(from: candidate, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 179, column: nil))
+    }
+
+    @Test func resolvesMultiLineWrappedTokenFileLocationFromFirstSegment() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let services = dir.appendingPathComponent("Tests/MuxyTests/Services")
+        try FileManager.default.createDirectory(at: services, withIntermediateDirectories: true)
+        let file = writeFile(services, name: "TerminalBridgeResolveFilePathTests.swift")
+        let lines = [
+            "test file: Tests/",
+            "    MuxyTests/Services/",
+            "    TerminalBridgeResolveFilePathTests.swift",
+            "    :210",
+        ]
+        let candidate = try #require(GhosttyTerminalNSView.wrappedFileTokenCandidates(
+            word: "Tests",
+            row: 0,
+            lines: lines
+        ).first)
+        let location = TerminalBridge.resolveFileLocation(from: candidate, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 210, column: nil))
+    }
+
+    @Test func resolvesMultiLineWrappedTokenFileLocationFromMiddleDirectoryWord() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let services = dir.appendingPathComponent("Tests/MuxyTests/Services")
+        try FileManager.default.createDirectory(at: services, withIntermediateDirectories: true)
+        let file = writeFile(services, name: "TerminalBridgeResolveFilePathTests.swift")
+        let lines = [
+            "test file: Tests/",
+            "    MuxyTests/Services/",
+            "    TerminalBridgeResolveFilePathTests.swift",
+            "    :210",
+        ]
+        let candidate = try #require(GhosttyTerminalNSView.wrappedFileTokenCandidates(
+            word: "Services",
+            row: 1,
+            lines: lines
+        ).first)
+        let location = TerminalBridge.resolveFileLocation(from: candidate, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 210, column: nil))
+    }
+
+    @Test func resolvesMultiLineWrappedTokenFileLocationFromFileNameSegment() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let services = dir.appendingPathComponent("Tests/MuxyTests/Services")
+        try FileManager.default.createDirectory(at: services, withIntermediateDirectories: true)
+        let file = writeFile(services, name: "TerminalBridgeResolveFilePathTests.swift")
+        let lines = [
+            "test file: Tests/",
+            "    MuxyTests/Services/",
+            "    TerminalBridgeResolveFilePathTests.swift",
+            "    :210",
+        ]
+        let candidate = try #require(GhosttyTerminalNSView.wrappedFileTokenCandidates(
+            word: "TerminalBridgeResolveFilePathTests.swift",
+            row: 2,
+            lines: lines
+        ).first)
+        let location = TerminalBridge.resolveFileLocation(from: candidate, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 210, column: nil))
+    }
+
+    @Test func resolvesMultiLineWrappedTokenFileLocationFromLineSuffixSegment() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let services = dir.appendingPathComponent("Tests/MuxyTests/Services")
+        try FileManager.default.createDirectory(at: services, withIntermediateDirectories: true)
+        let file = writeFile(services, name: "TerminalBridgeResolveFilePathTests.swift")
+        let lines = [
+            "test file: Tests/",
+            "    MuxyTests/Services/",
+            "    TerminalBridgeResolveFilePathTests.swift",
+            "    :210",
+        ]
+        let candidate = try #require(GhosttyTerminalNSView.wrappedFileTokenCandidates(
+            word: "210",
+            row: 3,
+            lines: lines
+        ).first)
+        let location = TerminalBridge.resolveFileLocation(from: candidate, projectPath: dir.path)
+        #expect(location == .init(path: file, line: 210, column: nil))
+    }
+
+    @Test func resolvesWrappedAbsolutePathSplitInsideName() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let parent = dir.appendingPathComponent("dev/_references")
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        let file = writeFile(parent, name: "muxy-extensions.broken-20260625110716")
+        let lines = [
+            "moved to:",
+            "    \(parent.path)/muxy-",
+            "    extensions.broken-20260625110716",
+        ]
+        let candidate = try #require(GhosttyTerminalNSView.wrappedFileTokenCandidates(
+            word: "extensions.broken-20260625110716",
+            row: 2,
+            lines: lines
+        ).first)
+        let location = TerminalBridge.resolveFileLocation(from: candidate, projectPath: "/unused")
+        #expect(location == .init(path: file, line: nil, column: nil))
+    }
+
     @Test func resolvesFileLocationRejectsUnresolvableSchemeless() throws {
         let url = try #require(URL(string: "/tmp/does-not-exist-\(UUID().uuidString).md:12"))
         #expect(TerminalBridge.resolveFileLocation(from: url, projectPath: "/unused") == nil)
@@ -187,6 +357,26 @@ struct TerminalBridgeResolveFilePathTests {
     @Test func resolvesFileLocationRejectsHttpURL() throws {
         let url = try #require(URL(string: "https://example.com/readme.md:12"))
         #expect(TerminalBridge.resolveFileLocation(from: url, projectPath: "/tmp") == nil)
+    }
+
+    @Test func relativePathInsideProject() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sub = dir.appendingPathComponent("Sources")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        let file = writeFile(sub, name: "main.swift")
+
+        #expect(TerminalBridge.relativePath(file, inside: dir.path) == "Sources/main.swift")
+    }
+
+    @Test func relativePathRejectsProjectRootAndOutsideProject() throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let outside = writeFile(URL(fileURLWithPath: NSTemporaryDirectory()), name: "outside-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(atPath: outside) }
+
+        #expect(TerminalBridge.relativePath(dir.path, inside: dir.path) == nil)
+        #expect(TerminalBridge.relativePath(outside, inside: dir.path) == nil)
     }
 
     @Test func stripsLineSuffixOnlyWhenTrailingNumeric() {

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -53,7 +53,7 @@ All Muxy-specific manifest fields live under the `muxy` object.
 | `events` | string[] | no | Workspace events the extension may subscribe to. Local `extension.*` events are not declared here. See [Events](events.md). Defaults to empty. |
 | `commands` | object[] | no | Palette commands to register. See [Palette Commands](palette-commands.md). |
 | `tabTypes` | object[] | no | Webview tab types the extension exposes. See [Tabs](tabs.md). |
-| `fileOpeners` | object[] | no | Project-file openers the extension contributes. Each opener references one of the extension's `tabTypes`; Muxy opens it with `{ filePath, line?, column?, source }` when a native surface opens a file. |
+| `fileOpeners` | object[] | no | Project-file openers the extension contributes. Each opener references one of the extension's `tabTypes`; Muxy opens it with `{ filePath, line?, column?, source }` when a native surface opens a file. See [File openers](tabs.md#file-openers). |
 | `panels` | object[] | no | Dockable/floating webview panels. See [Panels](panels.md). |
 | `popovers` | object[] | no | Transient webview popovers anchored to a topbar/status-bar item. See [Popovers](popovers.md). |
 | `sidebar` | object | no | A single full-height webview that replaces the built-in left sidebar when the user selects it. See [Sidebars](sidebars.md). |

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -2,7 +2,7 @@
 
 Every extension is an npm + [Vite](https://vitejs.dev) project. Its manifest is the `muxy` object inside the `package.json` at the root of its directory.
 
-Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `panels`, `popovers`, `sidebar`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
+Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `fileOpeners`, `panels`, `popovers`, `sidebar`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
 
 `package.json` must also declare a `build` script. The publishing pipeline runs `npm run build` (Vite) and ships **only** the build output directory, `dist/`. The app installs and reads from `dist/`, so every entry/asset path inside `muxy` (popover/tab `entry`, `background`, marketplace `icon`/`screenshots`) resolves against the build output, not your source tree.
 
@@ -53,6 +53,7 @@ All Muxy-specific manifest fields live under the `muxy` object.
 | `events` | string[] | no | Workspace events the extension may subscribe to. Local `extension.*` events are not declared here. See [Events](events.md). Defaults to empty. |
 | `commands` | object[] | no | Palette commands to register. See [Palette Commands](palette-commands.md). |
 | `tabTypes` | object[] | no | Webview tab types the extension exposes. See [Tabs](tabs.md). |
+| `fileOpeners` | object[] | no | Project-file openers the extension contributes. Each opener references one of the extension's `tabTypes`; Muxy opens it with `{ filePath, line?, column?, source }` when a native surface opens a file. |
 | `panels` | object[] | no | Dockable/floating webview panels. See [Panels](panels.md). |
 | `popovers` | object[] | no | Transient webview popovers anchored to a topbar/status-bar item. See [Popovers](popovers.md). |
 | `sidebar` | object | no | A single full-height webview that replaces the built-in left sidebar when the user selects it. See [Sidebars](sidebars.md). |

--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -62,6 +62,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/tabType" }
         },
+        "fileOpeners": {
+          "type": "array",
+          "description": "File openers this extension contributes. Muxy passes filePath plus optional line/column data to the referenced tabType when a native surface opens a project file.",
+          "items": { "$ref": "#/$defs/fileOpener" }
+        },
         "panels": {
           "type": "array",
           "items": { "$ref": "#/$defs/panel" }
@@ -181,6 +186,22 @@
         "title": { "type": "string" },
         "entry": { "type": "string", "minLength": 1 },
         "defaultData": {}
+      }
+    },
+    "fileOpener": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "tabType"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "tabType": { "type": "string", "minLength": 1 },
+        "patterns": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "default": ["*"]
+        },
+        "singleton": { "type": "boolean", "default": true }
       }
     },
     "panel": {

--- a/docs/extensions/tabs.md
+++ b/docs/extensions/tabs.md
@@ -34,6 +34,39 @@ A tab type lets an extension render its own HTML/CSS/JS as a full tab inside Mux
 
 The page loads at `muxy-ext://<extensionID>/<entry>` and references its own files with relative paths; the scheme is scoped to that one extension's directory.
 
+## File openers
+
+A tab type can register as a **file opener** so the user can pick it as their "Open in IDE" target. When selected, Muxy routes native file opens — terminal file links and the Open in IDE control — into a tab of that type instead of an external editor. Declare openers under the `fileOpeners` manifest array:
+
+```jsonc
+"fileOpeners": [
+  { "id": "editor", "tabType": "editor", "patterns": ["*"], "singleton": true }
+]
+```
+
+### Fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Stable per extension. |
+| `tabType` | string | yes | A `tabTypes` id this opener opens. |
+| `title` | string | no | Overrides the tab title; shown alongside the extension name in the menu. |
+| `patterns` | string[] | no | Glob patterns (`*`, `?`) matched against the project-relative path. Defaults to `["*"]`. A file opens through the opener only when one pattern matches. |
+| `singleton` | boolean | no | Reuse one tab per type instead of opening a new one. Defaults to `true`. |
+
+The opened tab receives `window.muxy.data` with the file location:
+
+```ts
+{
+  filePath: string,   // path relative to the project root
+  line?: number,      // 1-based, when the source had a line suffix
+  column?: number,    // 1-based, when the source had a column suffix
+  source: string,     // "terminal" or "open-control"
+}
+```
+
+Only files inside the active project are routed; anything else falls back to the native IDE. With `singleton: true`, reopening pushes the new location through [`muxy.onDataChange`](#opening-another-tab).
+
 ## Topbar (recommended)
 
 A tab fills its whole region with one webview, so the page renders all of its own chrome. Extension tabs open with a thin **topbar** at the top — a horizontal bar holding the title on the left and controls on the right. **Render a matching topbar at the top of your page so your tab feels native; split panes line up only when every tab uses the same bar.**


### PR DESCRIPTION
## Background
Terminal file links currently open through the native IDE integration, so a local file link still falls through to the selected external editor, such as VS Code. Extensions also did not have a manifest-level way to declare that they can handle file opens. This PR adds that host-side contract and routes terminal file links plus the Open in IDE control through registered extension file openers when one is selected.

Companion plugin PR: muxy-app/extensions#60 registers the Files extension as the first file opener and consumes line/column payloads.

## Summary
- add `fileOpeners` to the extension manifest/schema and validate opener tab type references
- expose enabled extension file openers through `ExtensionStore` and let the Open in IDE menu select extension-backed file openers
- route terminal file links through the selected registered opener, including wrapped path and line/column handling

## Notes
- if no matching extension opener is selected, the existing native IDE fallback remains unchanged
- this path handles file links, not directory links

## Tests
- `swift test --filter 'IDEIntegrationServiceTests|ExtensionManifestTests|TerminalBridgeResolveFilePathTests'`\n