### PR TITLE
Fix slow sidebar content load on launch

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -52,6 +52,7 @@ struct MuxyApp: App {
             worktrees: worktreeStore.worktrees,
             skippingProjectIDs: projectGroupStore.activeRemoteProjectIDs
         )
+        ExtensionStore.shared.loadManifestsIfNeeded()
         _appState = State(initialValue: appState)
         _projectStore = State(initialValue: projectStore)
         _worktreeStore = State(initialValue: worktreeStore)

--- a/Muxy/Services/ExtensionStore.swift
+++ b/Muxy/Services/ExtensionStore.swift
@@ -117,8 +117,13 @@ final class ExtensionStore {
 
     var rootDirectory: URL { rootDirectoryURL }
 
-    func startAll() {
+    func loadManifestsIfNeeded() {
+        guard !hasLoadedFromDisk else { return }
         loadFromDisk()
+    }
+
+    func startAll() {
+        loadManifestsIfNeeded()
         for index in statuses.indices where statuses[index].isEnabled {
             startExtension(at: index)
         }
@@ -138,6 +143,7 @@ final class ExtensionStore {
             ExtensionPanelRegistry.shared.closeAll(extensionID: status.id)
             PopoverHost.shared.close(extensionID: status.id)
         }
+        hasLoadedFromDisk = false
         rebuildExtensionUICache()
         publishSnapshot()
     }

--- a/Muxy/Services/GitRepoStatusCache.swift
+++ b/Muxy/Services/GitRepoStatusCache.swift
@@ -5,7 +5,7 @@ import Foundation
 final class GitRepoStatusCache {
     static let shared = GitRepoStatusCache()
 
-    private var statusByPath: [String: Bool]
+    private var statusByKey: [String: Bool]
     private let store: CodableFileStore<[String: Bool]>
 
     init(
@@ -14,16 +14,26 @@ final class GitRepoStatusCache {
         )
     ) {
         self.store = store
-        statusByPath = (try? store.load()) ?? [:]
+        statusByKey = (try? store.load()) ?? [:]
     }
 
-    func cachedStatus(for path: String) -> Bool? {
-        statusByPath[path]
+    func cachedStatus(for path: String, context: WorkspaceContext) -> Bool? {
+        statusByKey[key(path: path, context: context)]
     }
 
-    func update(path: String, isGitRepo: Bool) {
-        guard statusByPath[path] != isGitRepo else { return }
-        statusByPath[path] = isGitRepo
-        try? store.save(statusByPath)
+    func update(path: String, context: WorkspaceContext, isGitRepo: Bool) {
+        let key = key(path: path, context: context)
+        guard statusByKey[key] != isGitRepo else { return }
+        statusByKey[key] = isGitRepo
+        try? store.save(statusByKey)
+    }
+
+    func remove(path: String, context: WorkspaceContext) {
+        guard statusByKey.removeValue(forKey: key(path: path, context: context)) != nil else { return }
+        try? store.save(statusByKey)
+    }
+
+    private func key(path: String, context: WorkspaceContext) -> String {
+        "\(context.cacheKeyPrefix)|\(path)"
     }
 }

--- a/Muxy/Services/GitRepoStatusCache.swift
+++ b/Muxy/Services/GitRepoStatusCache.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@MainActor
+@Observable
+final class GitRepoStatusCache {
+    static let shared = GitRepoStatusCache()
+
+    private var statusByPath: [String: Bool]
+    private let store: CodableFileStore<[String: Bool]>
+
+    init(
+        store: CodableFileStore<[String: Bool]> = CodableFileStore(
+            fileURL: MuxyFileStorage.fileURL(filename: "git-repo-status.json")
+        )
+    ) {
+        self.store = store
+        statusByPath = (try? store.load()) ?? [:]
+    }
+
+    func cachedStatus(for path: String) -> Bool? {
+        statusByPath[path]
+    }
+
+    func update(path: String, isGitRepo: Bool) {
+        guard statusByPath[path] != isGitRepo else { return }
+        statusByPath[path] = isGitRepo
+        try? store.save(statusByPath)
+    }
+}

--- a/Muxy/Services/ProjectRemovalService.swift
+++ b/Muxy/Services/ProjectRemovalService.swift
@@ -9,6 +9,11 @@ enum ProjectRemovalService {
         worktreeStore: WorktreeStore,
         projectGroupStore: ProjectGroupStore
     ) async throws {
+        GitRepoStatusCache.shared.remove(
+            path: project.path,
+            context: projectGroupStore.workspaceContext(for: project)
+        )
+
         guard !project.isRemote else {
             if let workspaceID = project.remoteWorkspaceID {
                 projectGroupStore.removeRemoteProject(id: project.id, fromGroup: workspaceID)

--- a/Muxy/Services/Remote/WorkspaceContext.swift
+++ b/Muxy/Services/Remote/WorkspaceContext.swift
@@ -13,4 +13,13 @@ enum WorkspaceContext: Hashable {
         if case let .ssh(destination) = self { return destination }
         return nil
     }
+
+    var cacheKeyPrefix: String {
+        switch self {
+        case .local:
+            "local"
+        case let .ssh(destination):
+            "ssh:\(destination.target):\(destination.port ?? 22)"
+        }
+    }
 }

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -86,7 +86,13 @@ struct ExpandedProjectRow: View {
                 isCheckingGitRepo = false
                 return
             }
-            isCheckingGitRepo = true
+            if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path) {
+                isGitRepo = cached
+                isCheckingGitRepo = false
+                if autoExpandWorktrees, isActive, hasWorktreeUI {
+                    worktreesExpanded = true
+                }
+            }
             try? await Task.sleep(for: .seconds(2))
             guard !Task.isCancelled else { return }
             isGitRepo = await GitWorktreeService.shared.isGitRepository(
@@ -94,6 +100,7 @@ struct ExpandedProjectRow: View {
                 context: projectGroupStore.workspaceContext(for: project)
             )
             isCheckingGitRepo = false
+            GitRepoStatusCache.shared.update(path: project.path, isGitRepo: isGitRepo)
             if autoExpandWorktrees, isActive, hasWorktreeUI {
                 worktreesExpanded = true
             }

--- a/Muxy/Views/Sidebar/ExpandedProjectRow.swift
+++ b/Muxy/Views/Sidebar/ExpandedProjectRow.swift
@@ -86,7 +86,8 @@ struct ExpandedProjectRow: View {
                 isCheckingGitRepo = false
                 return
             }
-            if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path) {
+            let context = projectGroupStore.workspaceContext(for: project)
+            if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) {
                 isGitRepo = cached
                 isCheckingGitRepo = false
                 if autoExpandWorktrees, isActive, hasWorktreeUI {
@@ -97,10 +98,10 @@ struct ExpandedProjectRow: View {
             guard !Task.isCancelled else { return }
             isGitRepo = await GitWorktreeService.shared.isGitRepository(
                 project.path,
-                context: projectGroupStore.workspaceContext(for: project)
+                context: context
             )
             isCheckingGitRepo = false
-            GitRepoStatusCache.shared.update(path: project.path, isGitRepo: isGitRepo)
+            GitRepoStatusCache.shared.update(path: project.path, context: context, isGitRepo: isGitRepo)
             if autoExpandWorktrees, isActive, hasWorktreeUI {
                 worktreesExpanded = true
             }

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -84,7 +84,10 @@ struct ProjectRow: View {
                     isCheckingGitRepo = false
                     return
                 }
-                isCheckingGitRepo = true
+                if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path) {
+                    isGitRepo = cached
+                    isCheckingGitRepo = false
+                }
                 try? await Task.sleep(for: .seconds(2))
                 guard !Task.isCancelled else { return }
                 isGitRepo = await GitWorktreeService.shared.isGitRepository(
@@ -92,6 +95,7 @@ struct ProjectRow: View {
                     context: projectGroupStore.workspaceContext(for: project)
                 )
                 isCheckingGitRepo = false
+                GitRepoStatusCache.shared.update(path: project.path, isGitRepo: isGitRepo)
             }
             .contextMenu {
                 if project.isHome {

--- a/Muxy/Views/Sidebar/ProjectRow.swift
+++ b/Muxy/Views/Sidebar/ProjectRow.swift
@@ -84,7 +84,8 @@ struct ProjectRow: View {
                     isCheckingGitRepo = false
                     return
                 }
-                if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path) {
+                let context = projectGroupStore.workspaceContext(for: project)
+                if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) {
                     isGitRepo = cached
                     isCheckingGitRepo = false
                 }
@@ -92,10 +93,10 @@ struct ProjectRow: View {
                 guard !Task.isCancelled else { return }
                 isGitRepo = await GitWorktreeService.shared.isGitRepository(
                     project.path,
-                    context: projectGroupStore.workspaceContext(for: project)
+                    context: context
                 )
                 isCheckingGitRepo = false
-                GitRepoStatusCache.shared.update(path: project.path, isGitRepo: isGitRepo)
+                GitRepoStatusCache.shared.update(path: project.path, context: context, isGitRepo: isGitRepo)
             }
             .contextMenu {
                 if project.isHome {

--- a/Tests/MuxyTests/Services/ExtensionStoreManifestLoadingTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionStoreManifestLoadingTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ExtensionStore manifest loading")
+@MainActor
+struct ExtensionStoreManifestLoadingTests {
+    @Test("loadManifestsIfNeeded populates statuses from disk")
+    func loadsManifestsEagerly() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeExtension(name: "alpha", in: root)
+
+        let store = makeStore(root: root)
+        store.loadManifestsIfNeeded()
+
+        #expect(store.hasLoadedFromDisk)
+        #expect(store.statuses.contains { $0.id == "alpha" })
+    }
+
+    @Test("loadManifestsIfNeeded does not rescan once loaded")
+    func skipsRescanWhenAlreadyLoaded() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeExtension(name: "alpha", in: root)
+
+        let store = makeStore(root: root)
+        store.loadManifestsIfNeeded()
+        try makeExtension(name: "beta", in: root)
+        store.loadManifestsIfNeeded()
+
+        #expect(!store.statuses.contains { $0.id == "beta" })
+    }
+
+    @Test("reload rescans disk after eager load")
+    func reloadRescansAfterEagerLoad() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeExtension(name: "alpha", in: root)
+
+        let store = makeStore(root: root)
+        store.loadManifestsIfNeeded()
+        try makeExtension(name: "beta", in: root)
+        store.reload()
+
+        #expect(store.statuses.contains { $0.id == "beta" })
+    }
+
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("exts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func makeExtension(name: String, in root: URL) throws {
+        let directory = root.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let manifest = """
+        {
+            "name": "\(name)",
+            "version": "1.0.0"
+        }
+        """
+        try ExtensionManifestFixture.write(flatManifest: manifest, to: directory)
+    }
+
+    private func makeStore(root: URL) -> ExtensionStore {
+        ExtensionStore.makeForTesting(
+            rootDirectory: root,
+            snapshotSink: NoopManifestSnapshotSink(),
+            resolveHostURL: { nil }
+        )
+    }
+}
+
+@MainActor
+private final class NoopManifestSnapshotSink: ExtensionSnapshotSink {
+    nonisolated func applyExtensionSnapshot(_: NotificationSocketServer.ExtensionSnapshot) {}
+}

--- a/Tests/MuxyTests/Services/GitRepoStatusCacheTests.swift
+++ b/Tests/MuxyTests/Services/GitRepoStatusCacheTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GitRepoStatusCache")
+@MainActor
+struct GitRepoStatusCacheTests {
+    private func makeCache() -> GitRepoStatusCache {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("git-repo-status-\(UUID().uuidString).json")
+        return GitRepoStatusCache(store: CodableFileStore(fileURL: url))
+    }
+
+    private var remote: WorkspaceContext {
+        .ssh(SSHDestination(host: "server"))
+    }
+
+    @Test("returns nil before any update")
+    func missingReturnsNil() {
+        let cache = makeCache()
+        #expect(cache.cachedStatus(for: "/repo", context: .local) == nil)
+    }
+
+    @Test("stores and reads status per context")
+    func storesPerContext() {
+        let cache = makeCache()
+        cache.update(path: "/repo", context: .local, isGitRepo: true)
+        #expect(cache.cachedStatus(for: "/repo", context: .local) == true)
+    }
+
+    @Test("same path on different contexts does not collide")
+    func contextsDoNotCollide() {
+        let cache = makeCache()
+        cache.update(path: "/repo", context: .local, isGitRepo: true)
+        cache.update(path: "/repo", context: remote, isGitRepo: false)
+        #expect(cache.cachedStatus(for: "/repo", context: .local) == true)
+        #expect(cache.cachedStatus(for: "/repo", context: remote) == false)
+    }
+
+    @Test("remove clears only the matching entry")
+    func removeClearsEntry() {
+        let cache = makeCache()
+        cache.update(path: "/repo", context: .local, isGitRepo: true)
+        cache.update(path: "/repo", context: remote, isGitRepo: true)
+        cache.remove(path: "/repo", context: .local)
+        #expect(cache.cachedStatus(for: "/repo", context: .local) == nil)
+        #expect(cache.cachedStatus(for: "/repo", context: remote) == true)
+    }
+
+    @Test("status persists across cache instances")
+    func persistsAcrossInstances() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("git-repo-status-\(UUID().uuidString).json")
+        let first = GitRepoStatusCache(store: CodableFileStore(fileURL: url))
+        first.update(path: "/repo", context: .local, isGitRepo: true)
+
+        let second = GitRepoStatusCache(store: CodableFileStore(fileURL: url))
+        #expect(second.cachedStatus(for: "/repo", context: .local) == true)
+    }
+}


### PR DESCRIPTION
Render the extension sidebar from eagerly-loaded manifests and seed each project's worktree UI from a persisted git-repo cache, so sidebar content appears immediately instead of after the deferred-services delay.

Heavy work (extension host spawning, git checks) still runs deferred in the background.