### PR TITLE
Add draggable terminal scrollbar

### DIFF
--- a/Muxy/Services/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/GhosttyRuntimeEventAdapter.swift
@@ -59,6 +59,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         case GHOSTTY_ACTION_PROGRESS_REPORT:
             handleProgressReport(target: target, report: action.action.progress_report)
             return true
+        case GHOSTTY_ACTION_SCROLLBAR:
+            handleScrollbar(target: target, scrollbar: action.action.scrollbar)
+            return true
         default:
             return false
         }
@@ -199,6 +202,16 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         let value = total.total >= 0 ? Int(total.total) : nil
         DispatchQueue.main.async {
             view.onSearchTotal?(value)
+        }
+    }
+
+    private func handleScrollbar(target: ghostty_target_s, scrollbar: ghostty_action_scrollbar_s) {
+        guard let view = surfaceView(from: target) else { return }
+        let total = Int(scrollbar.total)
+        let offset = Int(scrollbar.offset)
+        let len = Int(scrollbar.len)
+        DispatchQueue.main.async {
+            view.updateScrollbar(total: total, offset: offset, len: len)
         }
     }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -24,6 +24,7 @@ final class GhosttyTerminalNSView: NSView {
     var onSearchTotal: ((Int?) -> Void)?
     var onSearchSelected: ((Int?) -> Void)?
     var onProgressReport: ((TerminalProgress?) -> Void)?
+    private let scrollbarOverlay = TerminalScrollbarOverlay()
     var onCmdClickFile: ((String) -> Void)?
     var resolveCmdHoverFile: ((String) -> Bool)?
     var onOpenURL: ((URL) -> Bool)?
@@ -80,6 +81,7 @@ final class GhosttyTerminalNSView: NSView {
         super.init(frame: .zero)
         wantsLayer = true
         setupTrackingArea()
+        installScrollbarOverlay()
         registerForDraggedTypes([.fileURL, .string])
         setAccessibilityRole(.textArea)
         setAccessibilityRoleDescription("Terminal")
@@ -346,6 +348,11 @@ final class GhosttyTerminalNSView: NSView {
     override func viewDidChangeBackingProperties() {
         super.viewDidChangeBackingProperties()
         updateMetalLayerSize(deferred: true)
+    }
+
+    override func layout() {
+        super.layout()
+        scrollbarOverlay.frame = bounds
     }
 
     func setVisible(_ visible: Bool) {
@@ -830,6 +837,7 @@ final class GhosttyTerminalNSView: NSView {
         lastMouseTopDownPoint = pt
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
         updateCmdHoverCursor(modifierFlags: event.modifierFlags)
+        scrollbarOverlay.flashIfNearScroller(point: convert(event.locationInWindow, from: nil))
     }
 
     override func mouseExited(with event: NSEvent) {
@@ -1219,6 +1227,31 @@ final class GhosttyTerminalNSView: NSView {
         var mods: ghostty_input_scroll_mods_t = 0
         if event.hasPreciseScrollingDeltas { mods |= 1 }
         ghostty_surface_mouse_scroll(surface, event.scrollingDeltaX, event.scrollingDeltaY, mods)
+        scrollbarOverlay.flash()
+    }
+
+    private func installScrollbarOverlay() {
+        scrollbarOverlay.onScrollToRow = { [weak self] row in
+            self?.scrollToRow(row)
+        }
+        addSubview(scrollbarOverlay, positioned: .above, relativeTo: nil)
+    }
+
+    func updateScrollbar(total: Int, offset: Int, len: Int) {
+        scrollbarOverlay.update(total: total, offset: offset, len: len, cellHeight: cellHeightPoints())
+    }
+
+    private func cellHeightPoints() -> CGFloat {
+        guard let surface else { return 0 }
+        let size = ghostty_surface_size(surface)
+        guard size.cell_height_px > 0, let window else { return 0 }
+        return CGFloat(size.cell_height_px) / window.backingScaleFactor
+    }
+
+    private func scrollToRow(_ row: Int) {
+        guard let surface else { return }
+        let action = "scroll_to_row:\(row)"
+        ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
     }
 
     private func buildKeyEvent(from event: NSEvent, action: ghostty_input_action_e) -> ghostty_input_key_s {

--- a/Muxy/Views/Terminal/TerminalScrollbarOverlay.swift
+++ b/Muxy/Views/Terminal/TerminalScrollbarOverlay.swift
@@ -75,8 +75,8 @@ final class TerminalScrollbarOverlay: NSView {
 
     func update(total: Int, offset: Int, len: Int, cellHeight: CGFloat) {
         self.total = total
-        self.offset = offset
         self.len = len
+        self.offset = min(max(offset, 0), max(total - len, 0))
         self.cellHeight = cellHeight
         synchronizeScrollView()
     }
@@ -88,7 +88,7 @@ final class TerminalScrollbarOverlay: NSView {
 
     func flashIfNearScroller(point: NSPoint) {
         guard hasScrollableContent else { return }
-        let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: .overlay)
+        let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollView.scrollerStyle)
         guard point.x >= bounds.maxX - scrollerWidth * 2 else { return }
         scrollView.flashScrollers()
     }
@@ -138,5 +138,9 @@ private final class TerminalScrollbarScrollView: NSScrollView {
         let scrollerPoint = scroller.convert(point, from: superview)
         guard scroller.bounds.contains(scrollerPoint) else { return nil }
         return super.hitTest(point)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        superview?.superview?.scrollWheel(with: event)
     }
 }

--- a/Muxy/Views/Terminal/TerminalScrollbarOverlay.swift
+++ b/Muxy/Views/Terminal/TerminalScrollbarOverlay.swift
@@ -1,0 +1,142 @@
+import AppKit
+
+final class TerminalScrollbarOverlay: NSView {
+    var onScrollToRow: ((Int) -> Void)?
+
+    private let scrollView = TerminalScrollbarScrollView()
+    private let documentView = NSView()
+
+    private var total = 0
+    private var len = 0
+    private var offset = 0
+    private var cellHeight: CGFloat = 0
+    private var isLiveScrolling = false
+    private var lastSentRow: Int?
+    nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
+
+    private var hasScrollableContent: Bool { cellHeight > 0 && total > len && total > 0 }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        configureScrollView()
+        registerScrollObservers()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    deinit {
+        observers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+
+    private func configureScrollView() {
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.drawsBackground = false
+        scrollView.contentView.clipsToBounds = false
+        scrollView.documentView = documentView
+        addSubview(scrollView)
+    }
+
+    private func registerScrollObservers() {
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isLiveScrolling = true }
+        })
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSScrollView.didEndLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isLiveScrolling = false }
+        })
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSScrollView.didLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.handleLiveScroll() }
+        })
+    }
+
+    override func layout() {
+        super.layout()
+        scrollView.frame = bounds
+        documentView.frame.size.width = bounds.width
+        synchronizeScrollView()
+    }
+
+    func update(total: Int, offset: Int, len: Int, cellHeight: CGFloat) {
+        self.total = total
+        self.offset = offset
+        self.len = len
+        self.cellHeight = cellHeight
+        synchronizeScrollView()
+    }
+
+    func flash() {
+        guard hasScrollableContent else { return }
+        scrollView.flashScrollers()
+    }
+
+    func flashIfNearScroller(point: NSPoint) {
+        guard hasScrollableContent else { return }
+        let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: .overlay)
+        guard point.x >= bounds.maxX - scrollerWidth * 2 else { return }
+        scrollView.flashScrollers()
+    }
+
+    private func synchronizeScrollView() {
+        guard hasScrollableContent else {
+            documentView.frame.size.height = scrollView.contentSize.height
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            return
+        }
+
+        documentView.frame.size.height = documentHeight()
+
+        guard !isLiveScrolling else {
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            return
+        }
+
+        let offsetY = CGFloat(total - offset - len) * cellHeight
+        scrollView.contentView.scroll(to: CGPoint(x: 0, y: offsetY))
+        lastSentRow = offset
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    private func documentHeight() -> CGFloat {
+        let contentHeight = scrollView.contentSize.height
+        let gridHeight = CGFloat(total) * cellHeight
+        let padding = contentHeight - (CGFloat(len) * cellHeight)
+        return gridHeight + padding
+    }
+
+    private func handleLiveScroll() {
+        guard hasScrollableContent else { return }
+        let visibleRect = scrollView.contentView.documentVisibleRect
+        let scrollOffset = documentView.frame.height - visibleRect.origin.y - visibleRect.height
+        let row = Int((scrollOffset / cellHeight).rounded())
+        let clamped = min(max(row, 0), total - len)
+        guard clamped != lastSentRow else { return }
+        lastSentRow = clamped
+        onScrollToRow?(clamped)
+    }
+}
+
+private final class TerminalScrollbarScrollView: NSScrollView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let scroller = verticalScroller, !scroller.isHidden else { return nil }
+        let scrollerPoint = scroller.convert(point, from: superview)
+        guard scroller.bounds.contains(scrollerPoint) else { return nil }
+        return super.hitTest(point)
+    }
+}


### PR DESCRIPTION
Wraps the terminal surface in a native NSScrollView so a real, draggable scrollbar appears, driven by Ghostty's scrollbar action and scroll_to_row.

Closes #714