### PR TITLE
Fix files/git API failing in runScript from palette and shortcut

### DIFF
--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -657,7 +657,9 @@ struct MainWindow: View {
                 commandID: item.command.id,
                 appState: appState,
                 projectStore: projectStore,
-                worktreeStore: worktreeStore
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore,
+                browserProfileStore: browserProfileStore
             ))
         }
     }
@@ -1041,7 +1043,9 @@ struct MainWindow: View {
             commandID: shortcut.commandID,
             appState: appState,
             projectStore: projectStore,
-            worktreeStore: worktreeStore
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
+            browserProfileStore: browserProfileStore
         ))
         return true
     }


### PR DESCRIPTION
Command palette and keyboard shortcut built `CommandInvocation` without `projectGroupStore`/`browserProfileStore`, so `muxy.files` (and git) threw `worktreeStoreUnavailable` in runScript.

Now passes all stores at both sites, matching the topbar/panel paths.

Verified via a demo extension across palette, shortcut, and topbar triggers.