### PR TITLE
Fix deadlock when extension dialogs block the in-process script runner

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -448,6 +448,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @MainActor
     private func confirmQuitIfNeeded() -> NSApplication.TerminateReply {
+        ExtensionDialogService.cancelAll()
         guard QuitConfirmationPreferences.confirmQuit else { return .terminateNow }
 
         let alert = NSAlert()
@@ -497,6 +498,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         MainActor.assumeIsolated {
             MobileServerService.shared.stopForTermination()
             ExtensionStore.shared.stopAll()
+            ExtensionScriptRunner.shared.evictAll()
         }
     }
 

--- a/Muxy/Services/ExtensionDialogService.swift
+++ b/Muxy/Services/ExtensionDialogService.swift
@@ -39,7 +39,7 @@ enum ExtensionDialogService {
     static let maxTextLength = 2000
     static let maxButtonCount = 3
 
-    private static var busyExtensionIDs: Set<String> = []
+    private static var activeSheets: [String: () -> Void] = [:]
 
     static func confirm(_ request: ConfirmRequest) async throws -> String? {
         try claim(request.extensionID)
@@ -50,7 +50,7 @@ enum ExtensionDialogService {
         for (button, equivalent) in zip(buttons, equivalents) {
             button.keyEquivalent = equivalent
         }
-        let result = try await runModal(alert)
+        let result = try await runModal(alert, extensionID: request.extensionID)
         guard let index = buttonIndex(for: result, buttonCount: request.buttons.count) else {
             return nil
         }
@@ -66,7 +66,7 @@ enum ExtensionDialogService {
         defer { release(request.extensionID) }
         let alert = makeAlert(title: request.title, message: request.message, style: request.style)
         alert.addButton(withTitle: "OK")
-        _ = try await runModal(alert)
+        _ = try await runModal(alert, extensionID: request.extensionID)
     }
 
     static func prompt(_ request: PromptRequest) async throws -> String? {
@@ -82,7 +82,7 @@ enum ExtensionDialogService {
         field.placeholderString = request.placeholder
         alert.accessoryView = field
         alert.window.initialFirstResponder = field
-        let result = try await runModal(alert)
+        let result = try await runModal(alert, extensionID: request.extensionID)
         guard result == .alertFirstButtonReturn else { return nil }
         return clamped(field.stringValue)
     }
@@ -100,9 +100,21 @@ enum ExtensionDialogService {
         if let defaultPath = request.defaultPath {
             panel.directoryURL = URL(fileURLWithPath: defaultPath, isDirectory: true)
         }
-        let response = try await runPanel(panel)
+        let response = try await runPanel(panel, extensionID: request.extensionID)
         guard response == .OK else { return nil }
         return panel.url?.path
+    }
+
+    static func cancel(extensionID: String) {
+        activeSheets.removeValue(forKey: extensionID)?()
+    }
+
+    static func cancelAll() {
+        let dismissals = activeSheets.values
+        activeSheets.removeAll()
+        for dismiss in dismissals {
+            dismiss()
+        }
     }
 
     static func makePromptRequest(extensionID: String, args: [String: Any]) throws -> PromptRequest {
@@ -186,14 +198,18 @@ enum ExtensionDialogService {
     }
 
     private static func claim(_ extensionID: String) throws {
-        guard !busyExtensionIDs.contains(extensionID) else {
+        guard activeSheets[extensionID] == nil else {
             throw APIError.invalidArguments("a dialog is already open for this extension")
         }
-        busyExtensionIDs.insert(extensionID)
+        activeSheets[extensionID] = {}
     }
 
     private static func release(_ extensionID: String) {
-        busyExtensionIDs.remove(extensionID)
+        activeSheets.removeValue(forKey: extensionID)
+    }
+
+    private static func isClaimed(_ extensionID: String) -> Bool {
+        activeSheets[extensionID] != nil
     }
 
     private static func clamped(_ value: String) -> String {
@@ -216,24 +232,50 @@ enum ExtensionDialogService {
         return index
     }
 
-    private static func runModal(_ alert: NSAlert) async throws -> NSApplication.ModalResponse {
+    private static func runModal(_ alert: NSAlert, extensionID: String) async throws -> NSApplication.ModalResponse {
         guard let parent = parentWindow() else {
             throw APIError.invalidArguments("no window available to present the dialog")
         }
         return await withCheckedContinuation { continuation in
+            let resolver = SheetResolver(continuation)
+            guard isClaimed(extensionID) else {
+                resolver.resolve(with: .cancel)
+                return
+            }
+            activeSheets[extensionID] = { [weak parent, weak alert] in
+                guard let parent, let alert else {
+                    resolver.resolve(with: .cancel)
+                    return
+                }
+                parent.endSheet(alert.window, returnCode: .cancel)
+            }
             alert.beginSheetModal(for: parent) { response in
-                continuation.resume(returning: response)
+                activeSheets.removeValue(forKey: extensionID)
+                resolver.resolve(with: response)
             }
         }
     }
 
-    private static func runPanel(_ panel: NSOpenPanel) async throws -> NSApplication.ModalResponse {
+    private static func runPanel(_ panel: NSOpenPanel, extensionID: String) async throws -> NSApplication.ModalResponse {
         guard let parent = parentWindow() else {
             throw APIError.invalidArguments("no window available to present the dialog")
         }
         return await withCheckedContinuation { continuation in
+            let resolver = SheetResolver(continuation)
+            guard isClaimed(extensionID) else {
+                resolver.resolve(with: .cancel)
+                return
+            }
+            activeSheets[extensionID] = { [weak panel] in
+                guard let panel else {
+                    resolver.resolve(with: .cancel)
+                    return
+                }
+                panel.cancel(nil)
+            }
             panel.beginSheetModal(for: parent) { response in
-                continuation.resume(returning: response)
+                activeSheets.removeValue(forKey: extensionID)
+                resolver.resolve(with: response)
             }
         }
     }
@@ -252,5 +294,20 @@ enum ExtensionDialogService {
 
     private static func string(_ args: [String: Any], _ key: String) -> String? {
         args[key] as? String
+    }
+}
+
+@MainActor
+private final class SheetResolver {
+    private var continuation: CheckedContinuation<NSApplication.ModalResponse, Never>?
+
+    init(_ continuation: CheckedContinuation<NSApplication.ModalResponse, Never>) {
+        self.continuation = continuation
+    }
+
+    func resolve(with response: NSApplication.ModalResponse) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(returning: response)
     }
 }

--- a/Muxy/Services/ExtensionScriptRunner.swift
+++ b/Muxy/Services/ExtensionScriptRunner.swift
@@ -47,6 +47,14 @@ final class ExtensionScriptRunner {
             handle.cancelFlag.cancel()
         }
         ExtensionModalService.shared.dismiss(extensionID: extensionID)
+        ExtensionDialogService.cancel(extensionID: extensionID)
+    }
+
+    func evictAll() {
+        for extensionID in Array(contexts.keys) {
+            evict(extensionID: extensionID)
+        }
+        ExtensionDialogService.cancelAll()
     }
 
     func runScript(
@@ -110,6 +118,7 @@ final class ExtensionScriptRunner {
     }
 
     private func makeContextHandle(for extensionID: String) throws -> ContextHandle {
+        evict(extensionID: extensionID)
         let queue = DispatchQueue(label: "app.muxy.extension.\(extensionID)")
         guard let context = JSContext() else {
             throw RunError.evaluationFailed("Failed to create JSContext")
@@ -123,6 +132,7 @@ final class ExtensionScriptRunner {
 final class ScriptCancelFlag: @unchecked Sendable {
     private let lock = NSLock()
     private var cancelled = false
+    private var waiters: [DispatchSemaphore] = []
 
     var isCancelled: Bool {
         lock.lock()
@@ -133,7 +143,26 @@ final class ScriptCancelFlag: @unchecked Sendable {
     func cancel() {
         lock.lock()
         cancelled = true
+        let pending = waiters
+        waiters.removeAll()
         lock.unlock()
+        for waiter in pending {
+            waiter.signal()
+        }
+    }
+
+    func register(_ waiter: DispatchSemaphore) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled else { return false }
+        waiters.append(waiter)
+        return true
+    }
+
+    func unregister(_ waiter: DispatchSemaphore) {
+        lock.lock()
+        defer { lock.unlock() }
+        waiters.removeAll { $0 === waiter }
     }
 }
 
@@ -183,7 +212,7 @@ private final class ScriptBridge: @unchecked Sendable {
         let bridge = self
         let argsBox = AnyBox(args)
         do {
-            let encoded = try syncAwait { @MainActor in
+            let encoded = try syncAwait(cancelFlag: cancelFlag) { @MainActor in
                 let raw = try await bridge.handle(verb: verb, args: argsBox.value)
                 if verb == "modal.open", let dict = raw as? [String: Any], let requestID = dict["requestID"] as? String {
                     bridge.registerModalDelivery(requestID: requestID)
@@ -279,7 +308,21 @@ private final class ScriptBridge: @unchecked Sendable {
 }
 
 private final class ResultBox<T>: @unchecked Sendable {
-    var value: Result<T, Error>?
+    private let lock = NSLock()
+    private var stored: Result<T, Error>?
+
+    var value: Result<T, Error>? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return stored
+        }
+        set {
+            lock.lock()
+            stored = newValue
+            lock.unlock()
+        }
+    }
 }
 
 private struct AnyBox<T>: @unchecked Sendable {
@@ -347,10 +390,13 @@ private struct BridgeValue: @unchecked Sendable {
     }
 }
 
-private func syncAwait<T: Sendable>(_ operation: @MainActor @Sendable @escaping () async throws -> T) throws -> T {
+private func syncAwait<T: Sendable>(
+    cancelFlag: ScriptCancelFlag,
+    _ operation: @MainActor @Sendable @escaping () async throws -> T
+) throws -> T {
     let semaphore = DispatchSemaphore(value: 0)
     let box = ResultBox<T>()
-    Task { @MainActor in
+    let task = Task { @MainActor in
         do {
             box.value = try await .success(operation())
         } catch {
@@ -358,9 +404,15 @@ private func syncAwait<T: Sendable>(_ operation: @MainActor @Sendable @escaping 
         }
         semaphore.signal()
     }
+    guard cancelFlag.register(semaphore) else {
+        task.cancel()
+        throw APIError.underlying("extension stopped")
+    }
     semaphore.wait()
+    cancelFlag.unregister(semaphore)
     guard let result = box.value else {
-        throw APIError.underlying("script bridge produced no result")
+        task.cancel()
+        throw APIError.underlying("extension stopped")
     }
     switch result {
     case let .success(value): return value

--- a/Tests/MuxyTests/Services/ExtensionScriptRunnerTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionScriptRunnerTests.swift
@@ -102,6 +102,40 @@ struct ExtensionScriptRunnerTests {
         ExtensionScriptRunner.shared.evict(extensionID: "test-ext-evict")
     }
 
+    @Test("cancel flag signals registered waiters so blocked threads wake")
+    func cancelFlagWakesRegisteredWaiters() async {
+        let flag = ScriptCancelFlag()
+        let semaphore = DispatchSemaphore(value: 0)
+        #expect(flag.register(semaphore))
+
+        let woke = SendableBox(false)
+        DispatchQueue.global().async {
+            semaphore.wait()
+            woke.value = true
+        }
+
+        flag.cancel()
+
+        for _ in 0..<50 where !woke.value {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(woke.value)
+        #expect(flag.isCancelled)
+    }
+
+    @Test("registering on an already cancelled flag is refused")
+    func cancelFlagRefusesRegistrationAfterCancel() {
+        let flag = ScriptCancelFlag()
+        flag.cancel()
+        #expect(!flag.register(DispatchSemaphore(value: 0)))
+    }
+
+    @Test("dialog cancel is a safe no-op without an active sheet")
+    func dialogCancelWithoutActiveSheetIsSafe() {
+        ExtensionDialogService.cancel(extensionID: "no-such-ext")
+        ExtensionDialogService.cancelAll()
+    }
+
     @Test("modal onSelect keeps the script bridge alive through delivery")
     func modalOnSelectKeepsBridgeAliveThroughDelivery() async throws {
         let extensionID = "test-ext-modal-\(UUID().uuidString)"
@@ -188,6 +222,28 @@ struct ExtensionScriptRunnerTests {
         appState.workspaceRoots[key] = .tabArea(area)
         appState.focusedAreaID[key] = area.id
         return appState
+    }
+}
+
+private final class SendableBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: T
+
+    init(_ value: T) {
+        stored = value
+    }
+
+    var value: T {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return stored
+        }
+        set {
+            lock.lock()
+            stored = newValue
+            lock.unlock()
+        }
     }
 }
 


### PR DESCRIPTION
In-process `runScript` extensions that opened a native dialog could park the JS thread forever (force-quit required), since the bridge blocked on a semaphore awaiting main-actor work with no cancellation.

Native dialogs are now cancellable, the blocked thread wakes on eviction, and dialogs are dismissed before the quit-confirmation modal.

Note: not confirmed to fix the omnibox/switcher hang or #731 (100% CPU spin) — different signature.