### PR TITLE
Fire tab.focused/tab.created when creating an adjacent tab

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -34,6 +34,7 @@ final class AppState {
             replacementWorktreePath: String?
         )
         case createTab(projectID: UUID, areaID: UUID?)
+        case createTabAdjacent(projectID: UUID, areaID: UUID, tabID: UUID, side: TabArea.InsertSide)
         case createTabInDirectory(projectID: UUID, areaID: UUID?, directory: String)
         case createCommandTab(CommandTabRequest)
         case createExtensionTab(projectID: UUID, areaID: UUID?, request: CreateExtensionTabRequest)

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -82,6 +82,15 @@ enum WorkspaceReducer {
         case let .createTab(projectID, areaID):
             effects.createdTabID = TabReducer.createTab(projectID: projectID, areaID: areaID, state: &state)
 
+        case let .createTabAdjacent(projectID, areaID, tabID, side):
+            TabReducer.createTabAdjacent(
+                projectID: projectID,
+                areaID: areaID,
+                tabID: tabID,
+                side: side,
+                state: &state
+            )
+
         case let .createTabInDirectory(projectID, areaID, directory):
             effects.createdTabID = TabReducer.createTabInDirectory(
                 projectID: projectID,

--- a/Muxy/Models/WorkspaceReducer/TabReducer.swift
+++ b/Muxy/Models/WorkspaceReducer/TabReducer.swift
@@ -10,6 +10,20 @@ enum TabReducer {
         return area.createTab()
     }
 
+    static func createTabAdjacent(
+        projectID: UUID,
+        areaID: UUID,
+        tabID: UUID,
+        side: TabArea.InsertSide,
+        state: inout WorkspaceState
+    ) {
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
+              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
+        else { return }
+        FocusReducer.focusArea(area.id, key: key, state: &state)
+        area.createTabAdjacent(to: tabID, side: side)
+    }
+
     static func createTabInDirectory(
         projectID: UUID,
         areaID: UUID?,

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -477,7 +477,12 @@ struct MainWindow: View {
                     appState.dispatch(result.action(projectID: project.id))
                 },
                 onCreateTabAdjacent: { tabID, side in
-                    area.createTabAdjacent(to: tabID, side: side)
+                    appState.dispatch(.createTabAdjacent(
+                        projectID: project.id,
+                        areaID: area.id,
+                        tabID: tabID,
+                        side: side
+                    ))
                 },
                 onTogglePin: { tabID in
                     area.togglePin(tabID)

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -69,7 +69,12 @@ struct TabAreaView: View {
                     isMaximized: isMaximized,
                     onToggleMaximize: onToggleMaximize,
                     onCreateTabAdjacent: { tabID, side in
-                        area.createTabAdjacent(to: tabID, side: side)
+                        appState.dispatch(.createTabAdjacent(
+                            projectID: projectID,
+                            areaID: area.id,
+                            tabID: tabID,
+                            side: side
+                        ))
                     },
                     onTogglePin: { tabID in
                         area.togglePin(tabID)

--- a/Tests/MuxyTests/Services/ExtensionEventEmitterTests.swift
+++ b/Tests/MuxyTests/Services/ExtensionEventEmitterTests.swift
@@ -43,6 +43,28 @@ struct ExtensionEventEmitterTests {
         #expect(afterContext.cwd == "/tmp/project/sub")
     }
 
+    @Test("creating an adjacent tab focuses it in the snapshot diff")
+    func adjacentTabFocusedInSnapshotDiff() {
+        let appState = makeAppState()
+        let area = firstArea(in: appState)
+        let originalTabID = area.activeTabID!
+
+        let before = ExtensionEventEmitter.snapshot(from: appState)
+        appState.dispatch(.createTabAdjacent(
+            projectID: projectID,
+            areaID: area.id,
+            tabID: originalTabID,
+            side: .right
+        ))
+        let after = ExtensionEventEmitter.snapshot(from: appState)
+
+        let newTabID = area.activeTabID!
+        #expect(newTabID != originalTabID)
+        #expect(before.activeTabIDPerArea[area.id] == originalTabID)
+        #expect(after.activeTabIDPerArea[area.id] == newTabID)
+        #expect(after.tabs.subtracting(before.tabs) == [newTabID])
+    }
+
     @Test("closed tab context resolves from the before snapshot")
     func closedTabContextFromBeforeSnapshot() {
         let appState = makeAppState()


### PR DESCRIPTION
Creating a tab via the tab context menu (New Tab Left/Right) bypassed dispatch, so extensions never received tab.created or tab.focused for it.

Route it through a new createTabAdjacent action so the snapshot diff emits both events like every other tab path.