### PR TITLE
Tab-focused parity: cross-project tabs, tab nav, ctrl badges, add workspace

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -435,31 +435,16 @@ final class AppState {
         pendingLastTabClose = nil
     }
 
-    func openTerminalTabItems(for projectID: UUID) -> [OpenTerminalTabItem] {
-        guard let key = activeWorktreeKey(for: projectID) else { return [] }
-        return allAreas(for: projectID).flatMap { area in
-            area.tabs.compactMap { tab in
-                guard let pane = tab.content.pane else { return nil }
-                let command = TerminalCommandTracker.shared.lastSubmittedCommand(for: pane.id)
-                    ?? pane.startupCommand
-                return OpenTerminalTabItem(
-                    projectID: projectID,
-                    worktreeID: key.worktreeID,
-                    areaID: area.id,
-                    tabID: tab.id,
-                    title: tab.title,
-                    workingDirectory: pane.currentWorkingDirectory ?? pane.projectPath,
-                    command: command
-                )
-            }
-        }
-    }
-
-    func allOpenTerminalTabItems(for projectID: UUID) -> [OpenTerminalTabItem] {
+    func allOpenTerminalTabItems(
+        for projectID: UUID,
+        projectName: String,
+        worktreeLabel: (UUID) -> (name: String?, branch: String?)
+    ) -> [OpenTerminalTabItem] {
         workspaceRoots
             .filter { $0.key.projectID == projectID }
             .flatMap { key, root in
-                root.allAreas().flatMap { area in
+                let label = worktreeLabel(key.worktreeID)
+                return root.allAreas().flatMap { area in
                     area.tabs.compactMap { tab -> OpenTerminalTabItem? in
                         guard let pane = tab.content.pane else { return nil }
                         let command = TerminalCommandTracker.shared.lastSubmittedCommand(for: pane.id)
@@ -471,7 +456,10 @@ final class AppState {
                             tabID: tab.id,
                             title: tab.title,
                             workingDirectory: pane.currentWorkingDirectory ?? pane.projectPath,
-                            command: command
+                            command: command,
+                            projectName: projectName,
+                            worktreeName: label.name,
+                            worktreeBranch: label.branch
                         )
                     }
                 }

--- a/Muxy/Models/TerminalOmniboxItem.swift
+++ b/Muxy/Models/TerminalOmniboxItem.swift
@@ -16,11 +16,22 @@ struct OpenTerminalTabItem: Identifiable, Equatable {
     let title: String
     let workingDirectory: String?
     let command: String?
+    let projectName: String
+    let worktreeName: String?
+    let worktreeBranch: String?
 
     var id: String { "open-\(areaID.uuidString)-\(tabID.uuidString)" }
 
+    var sectionTitle: String {
+        let context = worktreeBranch ?? worktreeName
+        guard let context, !context.isEmpty else { return "Open Tabs — \(projectName)" }
+        return "Open Tabs — \(projectName) (\(context))"
+    }
+
     var searchKey: String {
-        [title, workingDirectory, command].compactMap(\.self).joined(separator: " ")
+        [title, workingDirectory, command, projectName, worktreeName, worktreeBranch]
+            .compactMap(\.self)
+            .joined(separator: " ")
     }
 }
 
@@ -144,8 +155,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
             "Worktrees"
         case .workspace:
             "Workspaces"
-        case .openTab:
-            "Open Tabs"
+        case let .openTab(tab):
+            tab.sectionTitle
         case .commandShortcut:
             "Custom Commands"
         case .extensionCommand:
@@ -220,6 +231,10 @@ struct TerminalOmniboxItemContext {
         self.activeWorktreeID = activeWorktreeID
         self.commandProjectIDs = commandProjectIDs
     }
+
+    func isActiveWorktree(_ tab: OpenTerminalTabItem) -> Bool {
+        tab.projectID == activeProjectID && tab.worktreeID == activeWorktreeID
+    }
 }
 
 enum TerminalOmniboxItemResolver {
@@ -238,12 +253,15 @@ enum TerminalOmniboxItemResolver {
         case .workspaces:
             return context.workspaces.map(TerminalOmniboxItem.workspace)
         case .openTabs:
-            guard let activeProjectID = context.activeProjectID,
-                  let activeWorktreeID = context.activeWorktreeID
-            else { return [] }
             return context.openTabs
-                .filter { $0.projectID == activeProjectID && $0.worktreeID == activeWorktreeID }
-                .map(TerminalOmniboxItem.openTab)
+                .enumerated()
+                .sorted { lhs, rhs in
+                    let lhsActive = context.isActiveWorktree(lhs.element)
+                    let rhsActive = context.isActiveWorktree(rhs.element)
+                    if lhsActive != rhsActive { return lhsActive }
+                    return lhs.offset < rhs.offset
+                }
+                .map { TerminalOmniboxItem.openTab($0.element) }
         case .commandShortcuts:
             let extensionItems = context.extensionCommands.map(TerminalOmniboxItem.extensionCommand)
             guard context.activeProjectID.map(context.commandProjectIDs.contains) == true else {

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -168,15 +168,15 @@ struct ShortcutActionDispatcher {
             appState.cyclePreviousTabAcrossPanes(projectID: projectID)
             return true
         case .nextTab:
-            if AppLayoutStore.shared.layout == .tabFocused {
-                return selectGlobalTabRelative(offset: 1)
+            if AppLayoutStore.shared.layout == .tabFocused, selectGlobalTabRelative(offset: 1) {
+                return true
             }
             guard let projectID = appState.activeProjectID else { return false }
             appState.selectNextTab(projectID: projectID)
             return true
         case .previousTab:
-            if AppLayoutStore.shared.layout == .tabFocused {
-                return selectGlobalTabRelative(offset: -1)
+            if AppLayoutStore.shared.layout == .tabFocused, selectGlobalTabRelative(offset: -1) {
+                return true
             }
             guard let projectID = appState.activeProjectID else { return false }
             appState.selectPreviousTab(projectID: projectID)

--- a/Muxy/Services/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/ShortcutActionDispatcher.swift
@@ -36,15 +36,34 @@ struct ShortcutActionDispatcher {
         return [Project.home] + filtered
     }
 
-    private func selectGlobalTab(index: Int) -> Bool {
-        let entries = TabFocusedTabOrder.entries(
+    private var tabFocusedEntries: [TabFocusedTabOrder.Entry] {
+        TabFocusedTabOrder.entries(
             appState: appState,
             projectStore: projectStore,
             projectGroupStore: projectGroupStore,
             worktreeStore: worktreeStore
         )
+    }
+
+    private func selectGlobalTab(index: Int) -> Bool {
+        let entries = tabFocusedEntries
         guard index >= 0, index < entries.count else { return false }
-        let entry = entries[index]
+        return selectGlobalTab(entries[index])
+    }
+
+    private func selectGlobalTabRelative(offset: Int) -> Bool {
+        let entries = tabFocusedEntries
+        guard entries.count > 1 else { return false }
+        guard let projectID = appState.activeProjectID,
+              let area = appState.focusedArea(for: projectID),
+              let activeTabID = area.activeTabID,
+              let current = entries.firstIndex(where: { $0.areaID == area.id && $0.tabID == activeTabID })
+        else { return false }
+        let next = (current + offset + entries.count) % entries.count
+        return selectGlobalTab(entries[next])
+    }
+
+    private func selectGlobalTab(_ entry: TabFocusedTabOrder.Entry) -> Bool {
         if appState.activeProjectID != entry.projectID,
            let project = navigableProjects.first(where: { $0.id == entry.projectID })
         {
@@ -149,10 +168,16 @@ struct ShortcutActionDispatcher {
             appState.cyclePreviousTabAcrossPanes(projectID: projectID)
             return true
         case .nextTab:
+            if AppLayoutStore.shared.layout == .tabFocused {
+                return selectGlobalTabRelative(offset: 1)
+            }
             guard let projectID = appState.activeProjectID else { return false }
             appState.selectNextTab(projectID: projectID)
             return true
         case .previousTab:
+            if AppLayoutStore.shared.layout == .tabFocused {
+                return selectGlobalTabRelative(offset: -1)
+            }
             guard let projectID = appState.activeProjectID else { return false }
             appState.selectPreviousTab(projectID: projectID)
             return true

--- a/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
@@ -471,7 +471,7 @@ private struct WorkspaceRow: View {
     }
 }
 
-private struct RemoteWorkspaceEditorSheet: View {
+struct RemoteWorkspaceEditorSheet: View {
     let mode: RemoteWorkspaceEditorMode
     let onSubmit: (_ name: String, _ deviceID: UUID) -> Void
     let onCancel: () -> Void
@@ -593,7 +593,7 @@ private struct RemoteWorkspaceEditorSheet: View {
     }
 }
 
-private struct WorkspaceEditorSheet: View {
+struct WorkspaceEditorSheet: View {
     let mode: WorkspaceEditorMode
     let onSubmit: (String) -> Void
     let onCancel: () -> Void

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedBreadcrumb.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedBreadcrumb.swift
@@ -5,6 +5,8 @@ struct TabFocusedBreadcrumb: View {
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
+    @Environment(RemoteDeviceStore.self) private var deviceStore
+    @Environment(SSHConnectionService.self) private var sshConnections
 
     private static let originKey = "muxy.breadcrumb.origin"
     private static let originID = "tabFocusedBreadcrumb"
@@ -17,6 +19,8 @@ struct TabFocusedBreadcrumb: View {
     @State private var showWorktreePopover = false
     @State private var showCreateSheet = false
     @State private var isSwitching = false
+    @State private var workspaceEditorMode: WorkspaceEditorMode?
+    @State private var remoteWorkspaceEditor: RemoteWorkspaceEditorMode?
 
     private var activeProject: Project? {
         guard let id = appState.activeProjectID else { return nil }
@@ -84,7 +88,31 @@ struct TabFocusedBreadcrumb: View {
             action: { showWorkspacePopover = true }
         )
         .popover(isPresented: $showWorkspacePopover, arrowEdge: .bottom) {
-            TabFocusedWorkspacePopover(onDismiss: { showWorkspacePopover = false })
+            TabFocusedWorkspacePopover(
+                onDismiss: { showWorkspacePopover = false },
+                onCreateLocal: { workspaceEditorMode = .create },
+                onCreateRemote: { remoteWorkspaceEditor = .create }
+            )
+        }
+        .sheet(item: $workspaceEditorMode) { mode in
+            WorkspaceEditorSheet(
+                mode: mode,
+                onSubmit: { name in
+                    applyWorkspace(mode: mode, name: name)
+                    workspaceEditorMode = nil
+                },
+                onCancel: { workspaceEditorMode = nil }
+            )
+        }
+        .sheet(item: $remoteWorkspaceEditor) { mode in
+            RemoteWorkspaceEditorSheet(
+                mode: mode,
+                onSubmit: { name, deviceID in
+                    applyRemoteWorkspace(mode: mode, name: name, deviceID: deviceID)
+                    remoteWorkspaceEditor = nil
+                },
+                onCancel: { remoteWorkspaceEditor = nil }
+            )
         }
     }
 
@@ -226,6 +254,43 @@ struct TabFocusedBreadcrumb: View {
             ?? remaining.first
         appState.removeWorktree(projectID: project.id, worktree: worktree, replacement: replacement)
         worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+    }
+
+    private func applyWorkspace(mode: WorkspaceEditorMode, name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, case .create = mode else { return }
+        projectGroupStore.addGroup(name: trimmed)
+    }
+
+    private func applyRemoteWorkspace(mode: RemoteWorkspaceEditorMode, name: String, deviceID: UUID) {
+        guard case .create = mode else { return }
+        let group = projectGroupStore.addRemoteWorkspace(name: name, deviceID: deviceID)
+        selectWorkspace(group)
+    }
+
+    private func selectWorkspace(_ group: ProjectGroup) {
+        guard group.type == .ssh, let destination = deviceStore.device(id: group.remoteDeviceID)?.destination else {
+            projectGroupStore.selectGroup(id: group.id)
+            selectFirstProject()
+            return
+        }
+        Task {
+            guard await sshConnections.connect(destination: destination) else {
+                ToastState.shared.show("Could not connect to \(group.name)")
+                return
+            }
+            projectGroupStore.selectGroup(id: group.id)
+            selectFirstProject()
+        }
+    }
+
+    private func selectFirstProject() {
+        WorkspaceSelectionService.selectFirstProject(
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
     }
 }
 

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct TabFocusedProjectRow: View {
     let project: Project
     let shortcutNumbers: [UUID: Int]
+    var projectShortcutIndex: Int?
 
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
@@ -13,6 +14,7 @@ struct TabFocusedProjectRow: View {
     @State private var expansionStore = TabFocusedSidebarState.shared
     @State private var notificationStore = NotificationStore.shared
     @State private var progressStore = TerminalProgressStore.shared
+    @State private var modifierMonitor = ModifierKeyMonitor.shared
 
     @State private var hovered = false
     @State private var isGitRepo = false
@@ -32,6 +34,13 @@ struct TabFocusedProjectRow: View {
 
     private var isExpanded: Bool {
         expansionStore.isExpanded(project.id, default: false)
+    }
+
+    private var shortcutHint: KeyCombo? {
+        guard let projectShortcutIndex,
+              let action = ShortcutAction.projectAction(for: projectShortcutIndex)
+        else { return nil }
+        return modifierMonitor.hint(for: action)
     }
 
     var body: some View {
@@ -261,7 +270,16 @@ struct TabFocusedProjectRow: View {
         String(project.name.prefix(1)).uppercased()
     }
 
+    @ViewBuilder
     private var icon: some View {
+        if let projectShortcutIndex, let hint = shortcutHint {
+            ShortcutIconBadge(number: projectShortcutIndex, size: UIMetrics.iconXL, combo: hint)
+        } else {
+            projectIcon
+        }
+    }
+
+    private var projectIcon: some View {
         let logo = resolvedLogo
         return ZStack {
             RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous)

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -45,8 +45,12 @@ struct TabFocusedSidebar: View {
         return VStack(spacing: 0) {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(projects) { project in
-                        TabFocusedProjectRow(project: project, shortcutNumbers: numbers)
+                    ForEach(Array(projects.enumerated()), id: \.element.id) { offset, project in
+                        TabFocusedProjectRow(
+                            project: project,
+                            shortcutNumbers: numbers,
+                            projectShortcutIndex: projectShortcutIndex(forRowAt: offset)
+                        )
                     }
                     TabFocusedAddProjectRow(action: openProjectPicker)
                 }
@@ -58,6 +62,11 @@ struct TabFocusedSidebar: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(MuxyTheme.bg)
+    }
+
+    private func projectShortcutIndex(forRowAt offset: Int) -> Int? {
+        let index = offset + 1
+        return index <= 9 ? index : nil
     }
 
     private func openProjectPicker() {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedWorkspacePopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedWorkspacePopover.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct TabFocusedWorkspacePopover: View {
     let onDismiss: () -> Void
+    let onCreateLocal: () -> Void
+    let onCreateRemote: () -> Void
 
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @Environment(RemoteDeviceStore.self) private var deviceStore
@@ -31,11 +33,25 @@ struct TabFocusedWorkspacePopover: View {
             filterKey: { $0.name },
             searchPlaceholder: "Search workspaces…",
             emptyLabel: "No workspaces",
+            footerActions: footerActions,
             onSelect: { select($0) },
             row: { item, isHighlighted in
                 row(item, isHighlighted: isHighlighted)
             }
         )
+    }
+
+    private var footerActions: [PopoverFooterAction] {
+        [
+            PopoverFooterAction(title: "New Local Workspace", icon: "square.stack.3d.up") {
+                onDismiss()
+                onCreateLocal()
+            },
+            PopoverFooterAction(title: "New Remote Workspace", icon: "network") {
+                onDismiss()
+                onCreateRemote()
+            },
+        ]
     }
 
     private func row(_ item: Item, isHighlighted: Bool) -> some View {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -807,7 +807,14 @@ struct MainWindow: View {
     }
 
     private var terminalOmniboxOpenTabs: [OpenTerminalTabItem] {
-        omniboxProjects.flatMap { appState.allOpenTerminalTabItems(for: $0.id) }
+        omniboxProjects.flatMap { project in
+            appState.allOpenTerminalTabItems(for: project.id, projectName: project.name) { worktreeID in
+                guard let worktree = worktreeStore.worktree(projectID: project.id, worktreeID: worktreeID) else {
+                    return (nil, nil)
+                }
+                return (worktree.name, worktree.branch)
+            }
+        }
     }
 
     private var terminalOmniboxCommandProjectIDs: Set<UUID> {

--- a/Tests/MuxyTests/Models/TerminalOmniboxItemTests.swift
+++ b/Tests/MuxyTests/Models/TerminalOmniboxItemTests.swift
@@ -37,7 +37,10 @@ struct TerminalOmniboxItemResolverTests {
             tabID: tabID,
             title: "Server",
             workingDirectory: "/repo/muxy",
-            command: "npm run dev"
+            command: "npm run dev",
+            projectName: "Muxy",
+            worktreeName: "main",
+            worktreeBranch: "main"
         )
         let shortcut = CommandShortcut(
             id: shortcutID,
@@ -61,7 +64,7 @@ struct TerminalOmniboxItemResolverTests {
 
         #expect(TerminalOmniboxItem.openTab(openTab).id == "open-\(areaID.uuidString)-\(tabID.uuidString)")
         #expect(TerminalOmniboxItem.openTab(openTab).subtitle == "npm run dev")
-        #expect(TerminalOmniboxItem.openTab(openTab).sectionTitle == "Open Tabs")
+        #expect(TerminalOmniboxItem.openTab(openTab).sectionTitle == "Open Tabs — Muxy (main)")
         #expect(TerminalOmniboxItem.openTab(openTab).symbol == "terminal")
 
         let namedWorkspace = TerminalOmniboxWorkspaceItem(groupID: UUID(), name: "Backend", projectCount: 3)
@@ -154,7 +157,10 @@ struct TerminalOmniboxItemResolverTests {
             tabID: UUID(),
             title: "Active",
             workingDirectory: "/repo/muxy",
-            command: nil
+            command: nil,
+            projectName: "Muxy",
+            worktreeName: "main",
+            worktreeBranch: "main"
         )
         let otherOpenTab = OpenTerminalTabItem(
             projectID: activeProjectID,
@@ -163,7 +169,10 @@ struct TerminalOmniboxItemResolverTests {
             tabID: UUID(),
             title: "Other",
             workingDirectory: "/repo/muxy-other",
-            command: nil
+            command: nil,
+            projectName: "Muxy",
+            worktreeName: "other",
+            worktreeBranch: nil
         )
         let shortcut = CommandShortcut(name: "Build", command: "swift build")
         let emptyShortcut = CommandShortcut(name: "Empty", command: "   ")
@@ -189,7 +198,8 @@ struct TerminalOmniboxItemResolverTests {
 
         #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .projects) == [.project(project)])
         #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .worktrees) == [.worktree(activeWorktree)])
-        #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .openTabs) == [.openTab(activeOpenTab)])
+        #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .openTabs) ==
+            [.openTab(activeOpenTab), .openTab(otherOpenTab)])
         #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .commandShortcuts) == [.commandShortcut(shortcut)])
 
         let inactiveContext = TerminalOmniboxItemContext(
@@ -203,8 +213,51 @@ struct TerminalOmniboxItemResolverTests {
         )
 
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .worktrees).isEmpty)
-        #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .openTabs).isEmpty)
+        #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .openTabs) == [.openTab(activeOpenTab)])
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .commandShortcuts).isEmpty)
+    }
+
+    @Test("Open tabs scope includes every project and worktree with the active one first")
+    func openTabsScopeIncludesAllProjectsActiveFirst() {
+        let activeProjectID = UUID()
+        let otherProjectID = UUID()
+        let activeWorktreeID = UUID()
+        let otherWorktreeID = UUID()
+
+        func tab(project: UUID, worktree: UUID, name: String) -> OpenTerminalTabItem {
+            OpenTerminalTabItem(
+                projectID: project,
+                worktreeID: worktree,
+                areaID: UUID(),
+                tabID: UUID(),
+                title: name,
+                workingDirectory: nil,
+                command: nil,
+                projectName: name,
+                worktreeName: name,
+                worktreeBranch: name
+            )
+        }
+
+        let otherProjectTab = tab(project: otherProjectID, worktree: otherWorktreeID, name: "other")
+        let activeWorktreeTab = tab(project: activeProjectID, worktree: activeWorktreeID, name: "active")
+        let otherWorktreeTab = tab(project: activeProjectID, worktree: otherWorktreeID, name: "secondary")
+
+        let context = TerminalOmniboxItemContext(
+            projects: [],
+            worktrees: [],
+            openTabs: [otherProjectTab, otherWorktreeTab, activeWorktreeTab],
+            commandShortcuts: [],
+            activeProjectID: activeProjectID,
+            activeWorktreeID: activeWorktreeID,
+            commandProjectIDs: []
+        )
+
+        let items = TerminalOmniboxItemResolver.items(in: context, launchScope: .openTabs)
+        #expect(items.first == .openTab(activeWorktreeTab))
+        #expect(items.count == 3)
+        #expect(items.contains(.openTab(otherProjectTab)))
+        #expect(items.contains(.openTab(otherWorktreeTab)))
     }
 
     @Test("Workspaces scope returns every workspace item")


### PR DESCRIPTION
- Omnibox (cmd+option+o) now lists tabs from every project/worktree, active first, grouped by project.
- Fixes tab-focused mode: cmd+[ / cmd+] cycle tabs, Ctrl-hold shows project shortcut badges.
- Adds create-workspace actions to the tab-focused workspace dropdown.