### PR TITLE
Add tab control commands to the CLI

### DIFF
--- a/Muxy/Models/AppState.swift
+++ b/Muxy/Models/AppState.swift
@@ -40,6 +40,7 @@ final class AppState {
         case createExtensionTab(projectID: UUID, areaID: UUID?, request: CreateExtensionTabRequest)
         case createBrowserTab(projectID: UUID, areaID: UUID?, url: URL?, profileID: UUID)
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
+        case closeTabInWorktree(key: WorktreeKey, areaID: UUID, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTabByIndex(projectID: UUID, index: Int)
         case selectNextTab(projectID: UUID)
@@ -73,7 +74,7 @@ final class AppState {
     private(set) var worktreeMRU: [WorktreeKey] = []
 
     struct PendingTabClose: Equatable {
-        let projectID: UUID
+        let key: WorktreeKey
         let areaID: UUID
         let tabID: UUID
     }
@@ -348,19 +349,28 @@ final class AppState {
     }
 
     func closeTab(_ tabID: UUID, projectID: UUID) {
-        guard let area = focusedArea(for: projectID) else { return }
-        closeTab(tabID, areaID: area.id, projectID: projectID)
+        guard let key = activeWorktreeKey(for: projectID),
+              let root = workspaceRoots[key],
+              let areaID = focusedAreaID[key],
+              let area = root.findArea(id: areaID)
+        else { return }
+        closeTab(tabID, areaID: area.id, key: key)
     }
 
     func closeTab(_ tabID: UUID, areaID: UUID, projectID: UUID) {
-        guard let surfaceKey = lifecycleSurfaceKey(tabID: tabID, areaID: areaID, projectID: projectID) else {
-            proceedCloseAfterVeto(tabID, areaID: areaID, projectID: projectID)
+        guard let key = activeWorktreeKey(for: projectID) else { return }
+        closeTab(tabID, areaID: areaID, key: key)
+    }
+
+    func closeTab(_ tabID: UUID, areaID: UUID, key: WorktreeKey) {
+        guard let surfaceKey = lifecycleSurfaceKey(tabID: tabID, areaID: areaID, key: key) else {
+            proceedCloseAfterVeto(tabID, areaID: areaID, key: key)
             return
         }
         Task { @MainActor in
             let verdict = await ExtensionSurfaceBridgeRegistry.shared.requestBeforeClose(surfaceKey)
             guard verdict == .allow else { return }
-            proceedCloseAfterVeto(tabID, areaID: areaID, projectID: projectID)
+            proceedCloseAfterVeto(tabID, areaID: areaID, key: key)
         }
     }
 
@@ -370,34 +380,38 @@ final class AppState {
         }
     }
 
-    private func proceedCloseAfterVeto(_ tabID: UUID, areaID: UUID, projectID: UUID) {
-        if needsProcessConfirmation(tabID: tabID, areaID: areaID, projectID: projectID) {
-            pendingProcessTabClose = PendingTabClose(projectID: projectID, areaID: areaID, tabID: tabID)
+    private func proceedCloseAfterVeto(_ tabID: UUID, areaID: UUID, key: WorktreeKey) {
+        if needsProcessConfirmation(tabID: tabID, areaID: areaID, key: key) {
+            pendingProcessTabClose = PendingTabClose(key: key, areaID: areaID, tabID: tabID)
             return
         }
-        closeTabWithLastCheck(tabID, areaID: areaID, projectID: projectID)
+        closeTabWithLastCheck(tabID, areaID: areaID, key: key)
     }
 
     func forceCloseTab(_ tabID: UUID, areaID: UUID, projectID: UUID) {
-        clearPendingProcessCloseIfMatching(tabID: tabID, areaID: areaID, projectID: projectID)
-        unpinTabIfNeeded(tabID, areaID: areaID, projectID: projectID)
-        dispatch(.closeTab(projectID: projectID, areaID: areaID, tabID: tabID))
+        guard let key = activeWorktreeKey(for: projectID) else { return }
+        forceCloseTab(tabID, areaID: areaID, key: key)
+    }
+
+    func forceCloseTab(_ tabID: UUID, areaID: UUID, key: WorktreeKey) {
+        clearPendingProcessCloseIfMatching(tabID: tabID, areaID: areaID, key: key)
+        unpinTabIfNeeded(tabID, areaID: areaID, key: key)
+        dispatch(.closeTabInWorktree(key: key, areaID: areaID, tabID: tabID))
     }
 
     func forceCloseTab(instanceID: String) {
         for (key, root) in workspaceRoots {
             for area in root.allAreas() {
                 for tab in area.tabs where tab.content.extensionState?.id.uuidString == instanceID {
-                    forceCloseTab(tab.id, areaID: area.id, projectID: key.projectID)
+                    forceCloseTab(tab.id, areaID: area.id, key: key)
                     return
                 }
             }
         }
     }
 
-    private func lifecycleSurfaceKey(tabID: UUID, areaID: UUID, projectID: UUID) -> LifecycleSurfaceKey? {
-        guard let key = activeWorktreeKey(for: projectID),
-              let root = workspaceRoots[key],
+    private func lifecycleSurfaceKey(tabID: UUID, areaID: UUID, key: WorktreeKey) -> LifecycleSurfaceKey? {
+        guard let root = workspaceRoots[key],
               let area = root.findArea(id: areaID),
               let tab = area.tabs.first(where: { $0.id == tabID }),
               let state = tab.content.extensionState
@@ -408,27 +422,27 @@ final class AppState {
     func confirmCloseRunningTab() {
         guard let pending = pendingProcessTabClose else { return }
         pendingProcessTabClose = nil
-        closeTabWithLastCheck(pending.tabID, areaID: pending.areaID, projectID: pending.projectID)
+        closeTabWithLastCheck(pending.tabID, areaID: pending.areaID, key: pending.key)
     }
 
     func cancelCloseRunningTab() {
         pendingProcessTabClose = nil
     }
 
-    private func closeTabWithLastCheck(_ tabID: UUID, areaID: UUID, projectID: UUID) {
+    private func closeTabWithLastCheck(_ tabID: UUID, areaID: UUID, key: WorktreeKey) {
         if !ProjectLifecyclePreferences.keepOpenWhenNoTabs,
-           isLastTabInProject(tabID, areaID: areaID, projectID: projectID)
+           isLastTabInWorktree(tabID, areaID: areaID, key: key)
         {
-            pendingLastTabClose = PendingTabClose(projectID: projectID, areaID: areaID, tabID: tabID)
+            pendingLastTabClose = PendingTabClose(key: key, areaID: areaID, tabID: tabID)
             return
         }
-        dispatch(.closeTab(projectID: projectID, areaID: areaID, tabID: tabID))
+        dispatch(.closeTabInWorktree(key: key, areaID: areaID, tabID: tabID))
     }
 
     func confirmCloseLastTab() {
         guard let pending = pendingLastTabClose else { return }
         pendingLastTabClose = nil
-        dispatch(.closeTab(projectID: pending.projectID, areaID: pending.areaID, tabID: pending.tabID))
+        dispatch(.closeTabInWorktree(key: pending.key, areaID: pending.areaID, tabID: pending.tabID))
     }
 
     func cancelCloseLastTab() {
@@ -505,9 +519,8 @@ final class AppState {
         return root.allAreas().first?.projectPath
     }
 
-    private func unpinTabIfNeeded(_ tabID: UUID, areaID: UUID, projectID: UUID) {
-        guard let key = activeWorktreeKey(for: projectID),
-              let root = workspaceRoots[key],
+    private func unpinTabIfNeeded(_ tabID: UUID, areaID: UUID, key: WorktreeKey) {
+        guard let root = workspaceRoots[key],
               let area = root.findArea(id: areaID),
               let tab = area.tabs.first(where: { $0.id == tabID }),
               tab.isPinned
@@ -515,19 +528,16 @@ final class AppState {
         area.togglePin(tabID)
     }
 
-    private func isLastTabInProject(_ tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
-        guard let key = activeWorktreeKey(for: projectID),
-              let root = workspaceRoots[key]
-        else { return false }
+    private func isLastTabInWorktree(_ tabID: UUID, areaID: UUID, key: WorktreeKey) -> Bool {
+        guard let root = workspaceRoots[key] else { return false }
         let allAreas = root.allAreas()
         let totalTabs = allAreas.reduce(0) { $0 + $1.tabs.count }
         return totalTabs <= 1
     }
 
-    private func needsProcessConfirmation(tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
+    private func needsProcessConfirmation(tabID: UUID, areaID: UUID, key: WorktreeKey) -> Bool {
         guard TabCloseConfirmationPreferences.confirmRunningProcess else { return false }
-        guard let key = activeWorktreeKey(for: projectID),
-              let root = workspaceRoots[key],
+        guard let root = workspaceRoots[key],
               let area = root.findArea(id: areaID),
               let tab = area.tabs.first(where: { $0.id == tabID }),
               let paneID = tab.content.pane?.id
@@ -772,9 +782,9 @@ final class AppState {
         roots.mapValues(\.id)
     }
 
-    private func clearPendingProcessCloseIfMatching(tabID: UUID, areaID: UUID, projectID: UUID) {
+    private func clearPendingProcessCloseIfMatching(tabID: UUID, areaID: UUID, key: WorktreeKey) {
         guard let pending = pendingProcessTabClose else { return }
-        guard pending.projectID == projectID,
+        guard pending.key == key,
               pending.areaID == areaID,
               pending.tabID == tabID
         else { return }
@@ -783,21 +793,20 @@ final class AppState {
 
     private func reconcilePendingClosures() {
         if let pending = pendingLastTabClose,
-           !tabExists(tabID: pending.tabID, areaID: pending.areaID, projectID: pending.projectID)
+           !tabExists(tabID: pending.tabID, areaID: pending.areaID, key: pending.key)
         {
             pendingLastTabClose = nil
         }
 
         if let pending = pendingProcessTabClose,
-           !tabExists(tabID: pending.tabID, areaID: pending.areaID, projectID: pending.projectID)
+           !tabExists(tabID: pending.tabID, areaID: pending.areaID, key: pending.key)
         {
             pendingProcessTabClose = nil
         }
     }
 
-    private func tabExists(tabID: UUID, areaID: UUID, projectID: UUID) -> Bool {
-        guard let key = activeWorktreeKey(for: projectID),
-              let root = workspaceRoots[key],
+    private func tabExists(tabID: UUID, areaID: UUID, key: WorktreeKey) -> Bool {
+        guard let root = workspaceRoots[key],
               let area = root.findArea(id: areaID)
         else { return false }
         return area.tabs.contains(where: { $0.id == tabID })

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -197,7 +197,12 @@ final class TabArea: Identifiable {
     }
 
     func reorderTab(fromOffsets source: IndexSet, toOffset destination: Int) {
-        tabs.move(fromOffsets: source, toOffset: destination)
+        guard let from = source.first, from < tabs.count else { return }
+        let boundary = firstUnpinnedIndex
+        let lowerBound = tabs[from].isPinned ? 0 : boundary
+        let upperBound = tabs[from].isPinned ? boundary : tabs.count
+        let clamped = min(max(destination, lowerBound), upperBound)
+        tabs.move(fromOffsets: source, toOffset: clamped)
     }
 
     func removeTab(_ tabID: UUID) -> TerminalTab? {

--- a/Muxy/Models/TabArea.swift
+++ b/Muxy/Models/TabArea.swift
@@ -237,6 +237,11 @@ final class TabArea: Identifiable {
         tab.colorID = colorID
     }
 
+    func setCustomIcon(_ tabID: UUID, icon: String?) {
+        guard let tab = tabs.first(where: { $0.id == tabID }) else { return }
+        tab.customIcon = icon
+    }
+
     func togglePin(_ tabID: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         let tab = tabs[index]

--- a/Muxy/Models/TerminalTab.swift
+++ b/Muxy/Models/TerminalTab.swift
@@ -49,6 +49,7 @@ final class TerminalTab: Identifiable {
     let id: UUID
     var customTitle: String?
     var colorID: String?
+    var customIcon: String?
     var isPinned: Bool = false
     let content: Content
 
@@ -87,6 +88,7 @@ final class TerminalTab: Identifiable {
         id = snapshot.id
         customTitle = snapshot.customTitle
         colorID = snapshot.colorID
+        customIcon = snapshot.customIcon
         isPinned = snapshot.isPinned
         switch snapshot.kind {
         case .terminal:
@@ -131,6 +133,7 @@ final class TerminalTab: Identifiable {
             id: id,
             customTitle: customTitle,
             colorID: colorID,
+            customIcon: customIcon,
             isPinned: isPinned,
             projectPath: content.projectPath,
             paneTitle: extensionTabDefaultTitle ?? content.pane?.title,

--- a/Muxy/Models/WorkspaceReducer.swift
+++ b/Muxy/Models/WorkspaceReducer.swift
@@ -123,6 +123,10 @@ enum WorkspaceReducer {
             guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { break }
             TabReducer.closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)
 
+        case let .closeTabInWorktree(key, areaID, tabID):
+            guard state.workspaceRoots[key] != nil else { break }
+            TabReducer.closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)
+
         case let .selectTab(projectID, areaID, tabID):
             TabReducer.selectTab(projectID: projectID, areaID: areaID, tabID: tabID, state: &state)
 

--- a/Muxy/Models/WorkspaceSnapshot.swift
+++ b/Muxy/Models/WorkspaceSnapshot.swift
@@ -102,6 +102,7 @@ struct TerminalTabSnapshot: Codable {
     let id: UUID
     let customTitle: String?
     let colorID: String?
+    let customIcon: String?
     let isPinned: Bool
     let projectPath: String
     let paneTitle: String
@@ -119,6 +120,7 @@ struct TerminalTabSnapshot: Codable {
         id: UUID = UUID(),
         customTitle: String?,
         colorID: String?,
+        customIcon: String? = nil,
         isPinned: Bool,
         projectPath: String,
         paneTitle: String?,
@@ -135,6 +137,7 @@ struct TerminalTabSnapshot: Codable {
         self.id = id
         self.customTitle = customTitle
         self.colorID = colorID
+        self.customIcon = customIcon
         self.isPinned = isPinned
         self.projectPath = projectPath
         self.paneTitle = paneTitle ?? "Terminal"
@@ -153,6 +156,7 @@ struct TerminalTabSnapshot: Codable {
         case id
         case customTitle
         case colorID
+        case customIcon
         case isPinned
         case projectPath
         case paneTitle
@@ -173,6 +177,7 @@ struct TerminalTabSnapshot: Codable {
         id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
         customTitle = try container.decodeIfPresent(String.self, forKey: .customTitle)
         colorID = try container.decodeIfPresent(String.self, forKey: .colorID)
+        customIcon = try container.decodeIfPresent(String.self, forKey: .customIcon)
         isPinned = try container.decode(Bool.self, forKey: .isPinned)
         projectPath = try container.decode(String.self, forKey: .projectPath)
         paneTitle = try container.decodeIfPresent(String.self, forKey: .paneTitle) ?? "Terminal"

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -20,6 +20,13 @@
 #   muxy switch-tab <index|id|title>           Switch active tab
 #   muxy new-tab                               Create a terminal tab
 #   muxy next-tab|previous-tab                 Switch tabs
+#   muxy tab rename <tab> [title]              Rename a tab (omit title to reset)
+#   muxy tab set-color <tab> [color]           Set a tab color (omit to reset)
+#       colors: red orange amber yellow lime green teal cyan blue indigo violet pink
+#   muxy tab set-icon <tab> [sf-symbol]        Set a tab icon (SF Symbol; omit to reset)
+#   muxy tab pin|unpin <tab>                   Pin or unpin a tab
+#   muxy tab close <tab>                       Close a tab
+#   muxy tab move <tab> <to-index>             Reorder a tab within its area
 #   muxy install-skills [skills args...]       Install Muxy agent skills into detected AI harnesses
 #
 # Run "muxy <command> --help" for the options of a single command.
@@ -49,6 +56,7 @@ usage_for() {
         new-tab)           echo "muxy new-tab" ;;
         next-tab)          echo "muxy next-tab" ;;
         previous-tab)      echo "muxy previous-tab" ;;
+        tab)               echo "muxy tab <rename|set-color|set-icon|pin|unpin|close|move> <index|id|title> [args...]" ;;
         browser)           echo "muxy browser <open|navigate|list|read|close|eval|click|type|fill|press|select|hover|check|uncheck|scroll-into-view|wait|wait-for|wait-for-navigation|get-text|get-html|get-value|get-attribute|get-count|is|find|snapshot|reload|back|forward|screenshot|storage|cookies> [args...]" ;;
         install-skills)    echo "muxy install-skills [skills args...]" ;;
     esac
@@ -90,6 +98,13 @@ usage() {
     echo "  muxy new-tab                             Create a terminal tab"
     echo "  muxy next-tab                            Switch to next tab"
     echo "  muxy previous-tab                        Switch to previous tab"
+    echo "  muxy tab rename <tab> [title]            Rename a tab (omit title to reset)"
+    echo "  muxy tab set-color <tab> [color]         Set a tab color (omit to reset); colors:"
+    echo "                                           red orange amber yellow lime green teal cyan blue indigo violet pink"
+    echo "  muxy tab set-icon <tab> [sf-symbol]      Set a tab icon (SF Symbol; omit to reset)"
+    echo "  muxy tab pin|unpin <tab>                 Pin or unpin a tab"
+    echo "  muxy tab close <tab>                     Close a tab"
+    echo "  muxy tab move <tab> <to-index>           Reorder a tab within its area"
     echo "  muxy browser open <url> [--split]        Open a URL in a built-in browser tab (returns tab ID)"
     echo "  muxy browser navigate <tab-id> <url>     Navigate a browser tab to a URL"
     echo "  muxy browser list                        List built-in browser tabs"
@@ -460,6 +475,58 @@ case "$COMMAND" in
         wants_help "$2" && print_command_help previous-tab
         send_command "previous-tab"
         ;;
+    tab)
+        shift
+        wants_help "$1" && print_command_help tab
+        SUB="${1:-}"
+        shift || true
+        case "$SUB" in
+            rename)
+                [ $# -lt 1 ] && die_usage tab
+                if [ $# -ge 2 ]; then
+                    send_command "tab-rename|$1|$2"
+                else
+                    send_command "tab-rename|$1"
+                fi
+                ;;
+            set-color)
+                [ $# -lt 1 ] && die_usage tab
+                if [ $# -ge 2 ]; then
+                    send_command "tab-set-color|$1|$2"
+                else
+                    send_command "tab-set-color|$1"
+                fi
+                ;;
+            set-icon)
+                [ $# -lt 1 ] && die_usage tab
+                if [ $# -ge 2 ]; then
+                    send_command "tab-set-icon|$1|$2"
+                else
+                    send_command "tab-set-icon|$1"
+                fi
+                ;;
+            pin)
+                [ $# -lt 1 ] && die_usage tab
+                send_command "tab-pin|$1"
+                ;;
+            unpin)
+                [ $# -lt 1 ] && die_usage tab
+                send_command "tab-unpin|$1"
+                ;;
+            close)
+                [ $# -lt 1 ] && die_usage tab
+                send_command "tab-close|$1"
+                ;;
+            move)
+                [ $# -lt 2 ] && die_usage tab
+                send_command "tab-move|$1|$2"
+                ;;
+            *)
+                die_usage tab
+                ;;
+        esac
+        exit 0
+        ;;
     install-skills)
         shift
         wants_help "$1" && print_command_help install-skills
@@ -736,6 +803,7 @@ if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "spli
    [ "$COMMAND" != "refresh-worktrees" ] && [ "$COMMAND" != "list-tabs" ] && \
    [ "$COMMAND" != "switch-tab" ] && [ "$COMMAND" != "new-tab" ] && \
    [ "$COMMAND" != "next-tab" ] && [ "$COMMAND" != "previous-tab" ] && \
+   [ "$COMMAND" != "tab" ] && \
    [ "$COMMAND" != "install-skills" ]; then
     TARGET_DIR="$COMMAND"
 

--- a/Muxy/Resources/skills/muxy-cli/SKILL.md
+++ b/Muxy/Resources/skills/muxy-cli/SKILL.md
@@ -108,6 +108,20 @@ muxy previous-tab            # cycle backward
 
 Use `switch-tab` (resolves index/ID/title) when you know the target; reach for `next-tab`/`previous-tab` only for relative cycling. List first with `muxy list-tabs` when you need the index or ID.
 
+Customize and manage a tab with `muxy tab <op> <index|id|title>`. The target resolves the same way as `switch-tab` — by index or title within the active worktree, or by tab ID anywhere across open workspaces:
+
+```bash
+muxy tab rename 0 "Server"          # omit the title to reset to the default
+muxy tab set-color 0 blue           # palette name; omit to reset
+muxy tab set-icon 0 "flame.fill"    # any SF Symbol name; omit to reset
+muxy tab pin 0                       # pin / unpin (pinned tabs can't be closed)
+muxy tab unpin 0
+muxy tab move 0 2                    # reorder within the tab's area
+muxy tab close "Server"             # close by index/id/title
+```
+
+The color must be one of Muxy's palette names: `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `teal`, `cyan`, `blue`, `indigo`, `violet`, `pink`. `set-icon` takes an SF Symbol name. Pin a tab to protect it from `tab close` / `close-pane`; `tab close` is a no-op on a pinned tab, so `unpin` first.
+
 ## Browser
 
 The built-in browser opens web pages in a tab and can be fully automated for workflows — navigation, DOM interaction, JavaScript, cookies, storage, and screenshots:

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -735,7 +735,7 @@ enum MuxyAPI {
             guard let loc = locateTab(paneID: paneID, appState: appState) else {
                 return .failure(.paneNotFound(paneIDString))
             }
-            appState.closeTab(loc.tabID, areaID: loc.areaID, projectID: loc.key.projectID)
+            appState.closeTab(loc.tabID, areaID: loc.areaID, key: loc.key)
             return .success(())
         }
 
@@ -1155,7 +1155,7 @@ enum MuxyAPI {
         struct LocatedTab {
             let tab: TerminalTab
             let area: TabArea
-            let projectID: UUID
+            let key: WorktreeKey
         }
 
         static func locate(identifier: String, appState: AppState) -> LocatedTab? {
@@ -1163,7 +1163,7 @@ enum MuxyAPI {
                 for (key, root) in appState.workspaceRoots {
                     for area in root.allAreas() {
                         guard let tab = area.tabs.first(where: { tabMatches($0, identifier: identifier) }) else { continue }
-                        return LocatedTab(tab: tab, area: area, projectID: key.projectID)
+                        return LocatedTab(tab: tab, area: area, key: key)
                     }
                 }
                 return nil
@@ -1177,7 +1177,7 @@ enum MuxyAPI {
                 for area in root.allAreas() {
                     for tab in area.tabs {
                         if current == index {
-                            return LocatedTab(tab: tab, area: area, projectID: projectID)
+                            return LocatedTab(tab: tab, area: area, key: key)
                         }
                         current += 1
                     }
@@ -1186,7 +1186,7 @@ enum MuxyAPI {
             }
             for area in root.allAreas() {
                 guard let tab = area.tabs.first(where: { tabMatches($0, identifier: identifier) }) else { continue }
-                return LocatedTab(tab: tab, area: area, projectID: projectID)
+                return LocatedTab(tab: tab, area: area, key: key)
             }
             return nil
         }
@@ -1243,7 +1243,7 @@ enum MuxyAPI {
             guard let located = locate(identifier: identifier, appState: appState) else {
                 return .failure(.tabNotFound(identifier))
             }
-            appState.closeTab(located.tab.id, areaID: located.area.id, projectID: located.projectID)
+            appState.closeTab(located.tab.id, areaID: located.area.id, key: located.key)
             return .success(())
         }
 
@@ -1621,7 +1621,7 @@ enum MuxyAPI {
             guard let located = locate(tabIDString: tabIDString, appState: appState) else {
                 return .failure(.browserTabNotFound(tabIDString))
             }
-            appState.closeTab(located.tabID, areaID: located.areaID, projectID: located.projectID)
+            appState.closeTab(located.tabID, areaID: located.areaID, key: located.key)
             return .success(())
         }
 
@@ -1647,7 +1647,7 @@ enum MuxyAPI {
             let state: BrowserTabState
             let tabID: UUID
             let areaID: UUID
-            let projectID: UUID
+            let key: WorktreeKey
         }
 
         private static func locate(tabIDString: String, appState: AppState) -> Located? {
@@ -1656,7 +1656,7 @@ enum MuxyAPI {
                 for area in root.allAreas() {
                     for tab in area.tabs where tab.id == id {
                         guard let state = tab.content.browserState else { return nil }
-                        return Located(state: state, tabID: tab.id, areaID: area.id, projectID: key.projectID)
+                        return Located(state: state, tabID: tab.id, areaID: area.id, key: key)
                     }
                 }
             }

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MuxyShared
 import WebKit
 
 enum APIError: Error, Equatable {
@@ -369,6 +370,13 @@ enum MuxyAPI {
             "next-tab": "tabs.next",
             "previous-tab": "tabs.previous",
             "open-tab": "tabs.open",
+            "tab-rename": "tabs.rename",
+            "tab-set-color": "tabs.setColor",
+            "tab-set-icon": "tabs.setIcon",
+            "tab-pin": "tabs.setPin",
+            "tab-unpin": "tabs.setPin",
+            "tab-close": "tabs.close",
+            "tab-move": "tabs.move",
         ]
 
         private static let verbPermissions: [String: ExtensionPermission] = [
@@ -387,6 +395,11 @@ enum MuxyAPI {
             "tabs.open": .tabsWrite,
             "tabs.setTitle": .tabsWrite,
             "tabs.setIcon": .tabsWrite,
+            "tabs.rename": .tabsWrite,
+            "tabs.setColor": .tabsWrite,
+            "tabs.setPin": .tabsWrite,
+            "tabs.close": .tabsWrite,
+            "tabs.move": .tabsWrite,
             "browser.open": .browserWrite,
             "browser.navigate": .browserWrite,
             "browser.list": .browserRead,
@@ -1136,6 +1149,120 @@ enum MuxyAPI {
         static func previous(appState: AppState) -> Result<Void, APIError> {
             guard let projectID = appState.activeProjectID else { return .failure(.noActiveProject) }
             appState.selectPreviousTab(projectID: projectID)
+            return .success(())
+        }
+
+        struct LocatedTab {
+            let tab: TerminalTab
+            let area: TabArea
+            let projectID: UUID
+        }
+
+        static func locate(identifier: String, appState: AppState) -> LocatedTab? {
+            if let id = UUID(uuidString: identifier) {
+                for (key, root) in appState.workspaceRoots {
+                    for area in root.allAreas() where area.tabs.contains(where: { $0.id == id }) {
+                        guard let tab = area.tabs.first(where: { $0.id == id }) else { continue }
+                        return LocatedTab(tab: tab, area: area, projectID: key.projectID)
+                    }
+                }
+            }
+            guard let projectID = appState.activeProjectID,
+                  let key = appState.activeWorktreeKey(for: projectID),
+                  let root = appState.workspaceRoots[key]
+            else { return nil }
+            if let index = Int(identifier) {
+                var current = 0
+                for area in root.allAreas() {
+                    for tab in area.tabs {
+                        if current == index {
+                            return LocatedTab(tab: tab, area: area, projectID: projectID)
+                        }
+                        current += 1
+                    }
+                }
+                return nil
+            }
+            for area in root.allAreas() {
+                guard let tab = area.tabs.first(where: {
+                    $0.title.localizedCaseInsensitiveCompare(identifier) == .orderedSame
+                })
+                else { continue }
+                return LocatedTab(tab: tab, area: area, projectID: projectID)
+            }
+            return nil
+        }
+
+        static func rename(identifier: String, title: String?, appState: AppState) -> Result<Void, APIError> {
+            guard let located = locate(identifier: identifier, appState: appState) else {
+                return .failure(.tabNotFound(identifier))
+            }
+            let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+            located.area.setCustomTitle(located.tab.id, title: (trimmed?.isEmpty ?? true) ? nil : trimmed)
+            appState.saveWorkspaces()
+            return .success(())
+        }
+
+        static func setColor(identifier: String, color: String?, appState: AppState) -> Result<Void, APIError> {
+            guard let located = locate(identifier: identifier, appState: appState) else {
+                return .failure(.tabNotFound(identifier))
+            }
+            let resolved: String?
+            if let color, !color.isEmpty {
+                guard let swatch = ProjectIconColor.swatch(for: color) else {
+                    return .failure(.invalidArguments("unknown color '\(color)'"))
+                }
+                resolved = swatch.id
+            } else {
+                resolved = nil
+            }
+            located.area.setColorID(located.tab.id, colorID: resolved)
+            appState.saveWorkspaces()
+            return .success(())
+        }
+
+        static func setIcon(identifier: String, icon: String?, appState: AppState) -> Result<Void, APIError> {
+            guard let located = locate(identifier: identifier, appState: appState) else {
+                return .failure(.tabNotFound(identifier))
+            }
+            let trimmed = icon?.trimmingCharacters(in: .whitespacesAndNewlines)
+            located.area.setCustomIcon(located.tab.id, icon: (trimmed?.isEmpty ?? true) ? nil : trimmed)
+            appState.saveWorkspaces()
+            return .success(())
+        }
+
+        static func setPinned(identifier: String, pinned: Bool, appState: AppState) -> Result<Void, APIError> {
+            guard let located = locate(identifier: identifier, appState: appState) else {
+                return .failure(.tabNotFound(identifier))
+            }
+            guard located.tab.isPinned != pinned else { return .success(()) }
+            located.area.togglePin(located.tab.id)
+            appState.saveWorkspaces()
+            return .success(())
+        }
+
+        static func close(identifier: String, appState: AppState) -> Result<Void, APIError> {
+            guard let located = locate(identifier: identifier, appState: appState) else {
+                return .failure(.tabNotFound(identifier))
+            }
+            appState.closeTab(located.tab.id, areaID: located.area.id, projectID: located.projectID)
+            return .success(())
+        }
+
+        static func move(identifier: String, toIndex: Int, appState: AppState) -> Result<Void, APIError> {
+            guard let located = locate(identifier: identifier, appState: appState) else {
+                return .failure(.tabNotFound(identifier))
+            }
+            let area = located.area
+            guard let from = area.tabs.firstIndex(where: { $0.id == located.tab.id }) else {
+                return .failure(.tabNotFound(identifier))
+            }
+            guard toIndex >= 0, toIndex < area.tabs.count else {
+                return .failure(.invalidArguments("index out of range"))
+            }
+            let destination = toIndex > from ? toIndex + 1 : toIndex
+            area.reorderTab(fromOffsets: IndexSet(integer: from), toOffset: destination)
+            appState.saveWorkspaces()
             return .success(())
         }
 

--- a/Muxy/Services/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI.swift
@@ -1159,13 +1159,14 @@ enum MuxyAPI {
         }
 
         static func locate(identifier: String, appState: AppState) -> LocatedTab? {
-            if let id = UUID(uuidString: identifier) {
+            if UUID(uuidString: identifier) != nil {
                 for (key, root) in appState.workspaceRoots {
-                    for area in root.allAreas() where area.tabs.contains(where: { $0.id == id }) {
-                        guard let tab = area.tabs.first(where: { $0.id == id }) else { continue }
+                    for area in root.allAreas() {
+                        guard let tab = area.tabs.first(where: { tabMatches($0, identifier: identifier) }) else { continue }
                         return LocatedTab(tab: tab, area: area, projectID: key.projectID)
                     }
                 }
+                return nil
             }
             guard let projectID = appState.activeProjectID,
                   let key = appState.activeWorktreeKey(for: projectID),
@@ -1184,10 +1185,7 @@ enum MuxyAPI {
                 return nil
             }
             for area in root.allAreas() {
-                guard let tab = area.tabs.first(where: {
-                    $0.title.localizedCaseInsensitiveCompare(identifier) == .orderedSame
-                })
-                else { continue }
+                guard let tab = area.tabs.first(where: { tabMatches($0, identifier: identifier) }) else { continue }
                 return LocatedTab(tab: tab, area: area, projectID: projectID)
             }
             return nil
@@ -1257,7 +1255,10 @@ enum MuxyAPI {
             guard let from = area.tabs.firstIndex(where: { $0.id == located.tab.id }) else {
                 return .failure(.tabNotFound(identifier))
             }
-            guard toIndex >= 0, toIndex < area.tabs.count else {
+            let boundary = area.tabs.firstIndex(where: { !$0.isPinned }) ?? area.tabs.count
+            let lowerBound = located.tab.isPinned ? 0 : boundary
+            let upperBound = located.tab.isPinned ? boundary : area.tabs.count
+            guard toIndex >= lowerBound, toIndex < upperBound else {
                 return .failure(.invalidArguments("index out of range"))
             }
             let destination = toIndex > from ? toIndex + 1 : toIndex

--- a/Muxy/Services/SocketCommandHandler.swift
+++ b/Muxy/Services/SocketCommandHandler.swift
@@ -177,6 +177,50 @@ enum SocketCommandHandler {
             return serialize(MuxyAPI.Tabs.next(appState: appState), ok: "ok")
         case "previous-tab":
             return serialize(MuxyAPI.Tabs.previous(appState: appState), ok: "ok")
+        case "tab-rename":
+            guard parts.count >= 2 else { return "error:usage tab-rename|<index-or-id-or-title>[|title]" }
+            let title = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
+            return serialize(
+                MuxyAPI.Tabs.rename(identifier: parts[1], title: title, appState: appState),
+                ok: "ok"
+            )
+        case "tab-set-color":
+            guard parts.count >= 2 else { return "error:usage tab-set-color|<index-or-id-or-title>[|color]" }
+            let color = parts.count >= 3 ? parts[2] : nil
+            return serialize(
+                MuxyAPI.Tabs.setColor(identifier: parts[1], color: color, appState: appState),
+                ok: "ok"
+            )
+        case "tab-set-icon":
+            guard parts.count >= 2 else { return "error:usage tab-set-icon|<index-or-id-or-title>[|sf-symbol]" }
+            let icon = parts.count >= 3 ? parts[2] : nil
+            return serialize(
+                MuxyAPI.Tabs.setIcon(identifier: parts[1], icon: icon, appState: appState),
+                ok: "ok"
+            )
+        case "tab-pin":
+            guard parts.count >= 2 else { return "error:usage tab-pin|<index-or-id-or-title>" }
+            return serialize(
+                MuxyAPI.Tabs.setPinned(identifier: parts[1], pinned: true, appState: appState),
+                ok: "ok"
+            )
+        case "tab-unpin":
+            guard parts.count >= 2 else { return "error:usage tab-unpin|<index-or-id-or-title>" }
+            return serialize(
+                MuxyAPI.Tabs.setPinned(identifier: parts[1], pinned: false, appState: appState),
+                ok: "ok"
+            )
+        case "tab-close":
+            guard parts.count >= 2 else { return "error:usage tab-close|<index-or-id-or-title>" }
+            return serialize(MuxyAPI.Tabs.close(identifier: parts[1], appState: appState), ok: "ok")
+        case "tab-move":
+            guard parts.count >= 3, let index = Int(parts[2]) else {
+                return "error:usage tab-move|<index-or-id-or-title>|<to-index>"
+            }
+            return serialize(
+                MuxyAPI.Tabs.move(identifier: parts[1], toIndex: index, appState: appState),
+                ok: "ok"
+            )
         case "open-tab":
             guard parts.count >= 2 else { return "error:usage open-tab|<json>" }
             let payload = parts.dropFirst().joined(separator: "|")

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -11,6 +11,7 @@ struct PaneTabStrip: View {
         let isPinned: Bool
         let hasCustomTitle: Bool
         let colorID: String?
+        let customIconSymbol: String?
         let extensionID: String?
         let customIcon: ExtensionIcon?
         let isOffline: Bool
@@ -59,6 +60,7 @@ struct PaneTabStrip: View {
                 isPinned: tab.isPinned,
                 hasCustomTitle: tab.customTitle != nil,
                 colorID: tab.colorID,
+                customIconSymbol: tab.customIcon,
                 extensionID: tab.content.extensionState?.extensionID,
                 customIcon: tab.content.extensionState?.customIcon,
                 isOffline: tab.content.pane?.isOffline ?? false,
@@ -673,6 +675,9 @@ private struct TabCell: View {
             Image(systemName: "moon.zzz")
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                 .help("Idle — terminal freed to save memory. Reopens when selected.")
+        } else if let customIconSymbol = tab.customIconSymbol {
+            Image(systemName: customIconSymbol)
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
         } else {
             switch tab.kind {
             case .terminal:

--- a/Tests/MuxyTests/Services/MuxyAPITabsControlTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPITabsControlTests.swift
@@ -101,6 +101,44 @@ struct MuxyAPITabsControlTests {
         #expect(area.tabs[0].title == "First")
     }
 
+    @Test("move keeps an unpinned tab out of the pinned region")
+    func moveRejectsCrossingPinnedBoundary() {
+        let (appState, area) = makeAppState(tabTitles: ["Pinned", "First", "Second"])
+        area.togglePin(area.tabs[0].id)
+        let unpinned = area.tabs[2]
+
+        let result = MuxyAPI.Tabs.move(identifier: unpinned.id.uuidString, toIndex: 0, appState: appState)
+        guard case let .failure(error) = result else { Issue.record("expected failure"); return }
+        #expect(error == .invalidArguments("index out of range"))
+        #expect(area.tabs[0].isPinned)
+        #expect(area.tabs.firstIndex(where: { !$0.isPinned }) == 1)
+    }
+
+    @Test("move reorders within the unpinned region while a pinned tab is present")
+    func moveReordersWithinUnpinnedRegion() {
+        let (appState, area) = makeAppState(tabTitles: ["Pinned", "First", "Second"])
+        area.togglePin(area.tabs[0].id)
+        let second = area.tabs[2]
+
+        let result = MuxyAPI.Tabs.move(identifier: second.id.uuidString, toIndex: 1, appState: appState)
+        guard case .success = result else { Issue.record("expected success"); return }
+        #expect(area.tabs[0].isPinned)
+        #expect(area.tabs[1].id == second.id)
+    }
+
+    @Test("a tab resolves by ID across a non-active workspace")
+    func resolvesTabAcrossWorkspaces() {
+        let (appState, _) = makeAppState(tabTitles: ["First"])
+        let otherProjectID = UUID()
+        let otherKey = WorktreeKey(projectID: otherProjectID, worktreeID: UUID())
+        let otherArea = TabArea(projectPath: testPath)
+        appState.workspaceRoots[otherKey] = .tabArea(otherArea)
+        let target = otherArea.tabs[0]
+
+        _ = MuxyAPI.Tabs.rename(identifier: target.id.uuidString, title: "Remote", appState: appState)
+        #expect(target.customTitle == "Remote")
+    }
+
     @Test("an unknown identifier fails with tabNotFound")
     func unknownIdentifierFails() {
         let (appState, _) = makeAppState(tabTitles: ["First"])

--- a/Tests/MuxyTests/Services/MuxyAPITabsControlTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPITabsControlTests.swift
@@ -139,6 +139,22 @@ struct MuxyAPITabsControlTests {
         #expect(target.customTitle == "Remote")
     }
 
+    @Test("close resolves a tab by ID in a non-active worktree")
+    func closeResolvesTabByIDInNonActiveWorktree() {
+        let (appState, _) = makeAppState(tabTitles: ["First"])
+        let projectID = appState.activeProjectID!
+        let otherKey = WorktreeKey(projectID: projectID, worktreeID: UUID())
+        let otherArea = TabArea(projectPath: testPath)
+        let secondTabID = otherArea.createTab()
+        appState.workspaceRoots[otherKey] = .tabArea(otherArea)
+        appState.focusedAreaID[otherKey] = otherArea.id
+
+        let result = MuxyAPI.Tabs.close(identifier: secondTabID.uuidString, appState: appState)
+
+        guard case .success = result else { Issue.record("expected success"); return }
+        #expect(!otherArea.tabs.contains { $0.id == secondTabID })
+    }
+
     @Test("an unknown identifier fails with tabNotFound")
     func unknownIdentifierFails() {
         let (appState, _) = makeAppState(tabTitles: ["First"])

--- a/Tests/MuxyTests/Services/MuxyAPITabsControlTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPITabsControlTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("MuxyAPI.Tabs control commands")
+@MainActor
+struct MuxyAPITabsControlTests {
+    private let testPath = "/tmp/test"
+
+    @Test("rename sets and resets the tab title")
+    func renameSetsAndResets() {
+        let (appState, area) = makeAppState(tabTitles: ["First", "Second"])
+        let tab = area.tabs[1]
+
+        _ = MuxyAPI.Tabs.rename(identifier: tab.id.uuidString, title: "Renamed", appState: appState)
+        #expect(tab.customTitle == "Renamed")
+
+        _ = MuxyAPI.Tabs.rename(identifier: tab.id.uuidString, title: "  ", appState: appState)
+        #expect(tab.customTitle == nil)
+    }
+
+    @Test("rename resolves a tab by index")
+    func renameResolvesByIndex() {
+        let (appState, area) = makeAppState(tabTitles: ["First", "Second"])
+
+        _ = MuxyAPI.Tabs.rename(identifier: "1", title: "ByIndex", appState: appState)
+        #expect(area.tabs[1].customTitle == "ByIndex")
+    }
+
+    @Test("setColor validates against the palette and resets")
+    func setColorValidatesAndResets() {
+        let (appState, area) = makeAppState(tabTitles: ["First"])
+        let tab = area.tabs[0]
+
+        let ok = MuxyAPI.Tabs.setColor(identifier: "0", color: "blue", appState: appState)
+        guard case .success = ok else { Issue.record("expected success"); return }
+        #expect(tab.colorID == "blue")
+
+        let bad = MuxyAPI.Tabs.setColor(identifier: "0", color: "not-a-color", appState: appState)
+        guard case let .failure(error) = bad else { Issue.record("expected failure"); return }
+        #expect(error == .invalidArguments("unknown color 'not-a-color'"))
+        #expect(tab.colorID == "blue")
+
+        _ = MuxyAPI.Tabs.setColor(identifier: "0", color: nil, appState: appState)
+        #expect(tab.colorID == nil)
+    }
+
+    @Test("setIcon stores and resets the SF Symbol")
+    func setIconStoresAndResets() {
+        let (appState, area) = makeAppState(tabTitles: ["First"])
+        let tab = area.tabs[0]
+
+        _ = MuxyAPI.Tabs.setIcon(identifier: "0", icon: "flame.fill", appState: appState)
+        #expect(tab.customIcon == "flame.fill")
+
+        _ = MuxyAPI.Tabs.setIcon(identifier: "0", icon: " ", appState: appState)
+        #expect(tab.customIcon == nil)
+    }
+
+    @Test("setPinned pins and unpins idempotently")
+    func setPinnedTogglesIdempotently() {
+        let (appState, area) = makeAppState(tabTitles: ["First", "Second"])
+        let tab = area.tabs[1]
+
+        _ = MuxyAPI.Tabs.setPinned(identifier: tab.id.uuidString, pinned: true, appState: appState)
+        #expect(tab.isPinned)
+
+        _ = MuxyAPI.Tabs.setPinned(identifier: tab.id.uuidString, pinned: true, appState: appState)
+        #expect(tab.isPinned)
+
+        _ = MuxyAPI.Tabs.setPinned(identifier: tab.id.uuidString, pinned: false, appState: appState)
+        #expect(!tab.isPinned)
+    }
+
+    @Test("close removes an unpinned tab")
+    func closeRemovesTab() {
+        let (appState, area) = makeAppState(tabTitles: ["First", "Second"])
+        let tab = area.tabs[1]
+
+        _ = MuxyAPI.Tabs.close(identifier: tab.id.uuidString, appState: appState)
+        #expect(!area.tabs.contains { $0.id == tab.id })
+    }
+
+    @Test("move reorders a tab within its area")
+    func moveReordersTab() {
+        let (appState, area) = makeAppState(tabTitles: ["First", "Second", "Third"])
+        let third = area.tabs[2]
+
+        _ = MuxyAPI.Tabs.move(identifier: third.id.uuidString, toIndex: 0, appState: appState)
+        #expect(area.tabs.first?.id == third.id)
+    }
+
+    @Test("move rejects an out-of-range index")
+    func moveRejectsOutOfRange() {
+        let (appState, area) = makeAppState(tabTitles: ["First", "Second"])
+
+        let result = MuxyAPI.Tabs.move(identifier: "0", toIndex: 5, appState: appState)
+        guard case let .failure(error) = result else { Issue.record("expected failure"); return }
+        #expect(error == .invalidArguments("index out of range"))
+        #expect(area.tabs[0].title == "First")
+    }
+
+    @Test("an unknown identifier fails with tabNotFound")
+    func unknownIdentifierFails() {
+        let (appState, _) = makeAppState(tabTitles: ["First"])
+        let missing = UUID().uuidString
+
+        let result = MuxyAPI.Tabs.rename(identifier: missing, title: "x", appState: appState)
+        guard case let .failure(error) = result else { Issue.record("expected failure"); return }
+        #expect(error == .tabNotFound(missing))
+    }
+
+    private func makeAppState(tabTitles: [String]) -> (AppState, TabArea) {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: testPath)
+        area.tabs[0].customTitle = tabTitles[0]
+        for title in tabTitles.dropFirst() {
+            let id = area.createTab()
+            area.setCustomTitle(id, title: title)
+        }
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        return (appState, area)
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}


### PR DESCRIPTION
Adds `muxy tab <rename|set-color|set-icon|pin|unpin|close|move>`, resolving a tab by index/title in the active worktree or by ID across workspaces.

Adds a persisted `customIcon` (SF Symbol) on terminal/browser tabs so `set-icon` works for all tab kinds.