### PR TITLE
Make terminal cmd-click file open behavior configurable

### DIFF
--- a/Muxy/Models/GeneralSettingsKeys.swift
+++ b/Muxy/Models/GeneralSettingsKeys.swift
@@ -6,8 +6,8 @@ enum GeneralSettingsKeys {
 }
 
 enum TerminalFileOpenBehavior: String, CaseIterable, Identifiable {
-    case externalEditor = "External editor"
-    case inAppOpener = "In-app opener"
+    case externalEditor = "Open in external editor"
+    case inAppOpener = "Open with in-app opener only"
 
     static let defaultBehavior: TerminalFileOpenBehavior = .externalEditor
 

--- a/Muxy/Models/GeneralSettingsKeys.swift
+++ b/Muxy/Models/GeneralSettingsKeys.swift
@@ -2,4 +2,22 @@ enum GeneralSettingsKeys {
     static let autoExpandWorktreesOnProjectSwitch = "muxy.general.autoExpandWorktreesOnProjectSwitch"
     static let defaultWorktreeParentPath = "muxy.general.defaultWorktreeParentPath"
     static let autoCopyTerminalSelection = "muxy.general.autoCopyTerminalSelection"
+    static let terminalFileOpenBehavior = "muxy.general.terminalFileOpenBehavior"
+}
+
+enum TerminalFileOpenBehavior: String, CaseIterable, Identifiable {
+    case externalEditor = "External editor"
+    case inAppOpener = "In-app opener"
+
+    static let defaultBehavior: TerminalFileOpenBehavior = .externalEditor
+
+    var id: String { rawValue }
+
+    var allowsExternalEditorFallback: Bool {
+        self == .externalEditor
+    }
+
+    static func resolve(from storedValue: String?) -> TerminalFileOpenBehavior {
+        storedValue.flatMap(TerminalFileOpenBehavior.init(rawValue:)) ?? defaultBehavior
+    }
 }

--- a/Muxy/Services/SettingsJSONStore.swift
+++ b/Muxy/Services/SettingsJSONStore.swift
@@ -209,6 +209,7 @@ enum SettingsJSONStore {
             "editor.richInputImageStrategy": Set(RichInputImageStrategy.allCases.map(\.rawValue)),
             NotificationSettings.Key.sound: Set(NotificationSound.allCases.map(\.rawValue)),
             NotificationSettings.Key.toastPosition: Set(ToastPosition.allCases.map(\.rawValue)),
+            GeneralSettingsKeys.terminalFileOpenBehavior: Set(TerminalFileOpenBehavior.allCases.map(\.rawValue)),
         ]
         guard let allowed = allowedValues[key] else { return }
         guard allowed.contains(value) else { throw SettingsJSONError.invalidValue(key) }

--- a/Muxy/Views/Settings/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/SettingsCatalog.swift
@@ -256,6 +256,15 @@ enum SettingsCatalog {
             defaultValue: false
         ),
         SettingsCatalogItem(
+            key: GeneralSettingsKeys.terminalFileOpenBehavior,
+            title: "Terminal File Open Behavior",
+            description: "Chooses whether cmd-clicking a terminal file path uses an in-app opener or launches an external editor.",
+            category: .terminal,
+            section: "Files",
+            defaultValue: TerminalFileOpenBehavior.defaultBehavior.rawValue,
+            aliases: ["cmd click", "open file", "external editor", "in app opener"]
+        ),
+        SettingsCatalogItem(
             key: TabCloseConfirmationPreferences.confirmRunningProcessKey,
             title: "Confirm Running Process Tab Close",
             description: "Asks before closing a terminal tab with a running process.",

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -38,13 +38,14 @@ struct TerminalSettingsView: View {
             SettingsSection(
                 "Files",
                 footer: "Choose what happens when you cmd-click a file path in the terminal. "
-                    + "In-app opener uses a registered extension opener and never launches an external editor; "
-                    + "if no opener is registered, Muxy shows a notice instead."
+                    + "Open in external editor keeps the current behavior, trying a registered opener first "
+                    + "and then launching your external editor. Open with in-app opener only uses a registered "
+                    + "extension opener and shows a notice instead of launching an external editor when none is registered."
             ) {
                 SettingsPickerRow<TerminalFileOpenBehavior>(
-                    label: "Cmd-click opens files with",
+                    label: "Cmd-click a file path",
                     selection: $terminalFileOpenBehavior,
-                    width: 160
+                    width: 220
                 )
             }
 

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct TerminalSettingsView: View {
     @AppStorage(GeneralSettingsKeys.autoCopyTerminalSelection)
     private var autoCopyTerminalSelection = false
+    @AppStorage(GeneralSettingsKeys.terminalFileOpenBehavior)
+    private var terminalFileOpenBehavior = TerminalFileOpenBehavior.defaultBehavior.rawValue
     @AppStorage(TabCloseConfirmationPreferences.confirmRunningProcessKey)
     private var confirmRunningProcess = true
     @AppStorage(TerminalOfflinePreferences.enabledKey)
@@ -30,6 +32,19 @@ struct TerminalSettingsView: View {
                 SettingsToggleRow(
                     label: "Auto-copy selected text",
                     isOn: $autoCopyTerminalSelection
+                )
+            }
+
+            SettingsSection(
+                "Files",
+                footer: "Choose what happens when you cmd-click a file path in the terminal. "
+                    + "In-app opener uses a registered extension opener and never launches an external editor; "
+                    + "if no opener is registered, Muxy shows a notice instead."
+            ) {
+                SettingsPickerRow<TerminalFileOpenBehavior>(
+                    label: "Cmd-click opens files with",
+                    selection: $terminalFileOpenBehavior,
+                    width: 160
                 )
             }
 

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -384,7 +384,7 @@ struct TerminalBridge: NSViewRepresentable {
                 }
                 guard Self.terminalFileOpenBehavior().allowsExternalEditorFallback else {
                     ToastState.shared.show("No in-app opener is registered for this file")
-                    return false
+                    return true
                 }
                 return IDEIntegrationService.shared.openProject(
                     at: projectPath,

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -360,6 +360,10 @@ struct TerminalBridge: NSViewRepresentable {
             ) {
                 return
             }
+            guard Self.terminalFileOpenBehavior().allowsExternalEditorFallback else {
+                ToastState.shared.show("No in-app opener is registered for this file")
+                return
+            }
             _ = IDEIntegrationService.shared.openProject(
                 at: projectPath,
                 highlightingFileAt: location.path,
@@ -378,6 +382,10 @@ struct TerminalBridge: NSViewRepresentable {
                 ) {
                     return true
                 }
+                guard Self.terminalFileOpenBehavior().allowsExternalEditorFallback else {
+                    ToastState.shared.show("No in-app opener is registered for this file")
+                    return false
+                }
                 return IDEIntegrationService.shared.openProject(
                     at: projectPath,
                     highlightingFileAt: location.path,
@@ -391,6 +399,12 @@ struct TerminalBridge: NSViewRepresentable {
             }
             return Self.openExternalLink(url, appState: appState)
         }
+    }
+
+    private static func terminalFileOpenBehavior() -> TerminalFileOpenBehavior {
+        TerminalFileOpenBehavior.resolve(
+            from: UserDefaults.standard.string(forKey: GeneralSettingsKeys.terminalFileOpenBehavior)
+        )
     }
 
     @MainActor

--- a/Tests/MuxyTests/Models/FileOpenBehaviorTests.swift
+++ b/Tests/MuxyTests/Models/FileOpenBehaviorTests.swift
@@ -18,8 +18,8 @@ struct TerminalFileOpenBehaviorTests {
 
     @Test("resolve maps stored labels to behavior cases")
     func resolveMapsStoredLabels() {
-        #expect(TerminalFileOpenBehavior.resolve(from: "In-app opener") == .inAppOpener)
-        #expect(TerminalFileOpenBehavior.resolve(from: "External editor") == .externalEditor)
+        #expect(TerminalFileOpenBehavior.resolve(from: "Open with in-app opener only") == .inAppOpener)
+        #expect(TerminalFileOpenBehavior.resolve(from: "Open in external editor") == .externalEditor)
     }
 
     @Test("external editor fallback is only enabled for external editor behavior")
@@ -31,6 +31,6 @@ struct TerminalFileOpenBehaviorTests {
     @Test("all cases contains the expected picker values")
     func allCasesContainExpectedValues() {
         #expect(TerminalFileOpenBehavior.allCases == [.externalEditor, .inAppOpener])
-        #expect(TerminalFileOpenBehavior.allCases.map(\.rawValue) == ["External editor", "In-app opener"])
+        #expect(TerminalFileOpenBehavior.allCases.map(\.rawValue) == ["Open in external editor", "Open with in-app opener only"])
     }
 }

--- a/Tests/MuxyTests/Models/FileOpenBehaviorTests.swift
+++ b/Tests/MuxyTests/Models/FileOpenBehaviorTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalFileOpenBehavior")
+struct TerminalFileOpenBehaviorTests {
+    @Test("default behavior opens with external editor")
+    func defaultBehaviorUsesExternalEditor() {
+        #expect(TerminalFileOpenBehavior.defaultBehavior == .externalEditor)
+    }
+
+    @Test("resolve falls back to default behavior for missing or invalid stored values")
+    func resolveFallsBackToDefaultBehavior() {
+        #expect(TerminalFileOpenBehavior.resolve(from: nil) == .externalEditor)
+        #expect(TerminalFileOpenBehavior.resolve(from: "garbage") == .externalEditor)
+    }
+
+    @Test("resolve maps stored labels to behavior cases")
+    func resolveMapsStoredLabels() {
+        #expect(TerminalFileOpenBehavior.resolve(from: "In-app opener") == .inAppOpener)
+        #expect(TerminalFileOpenBehavior.resolve(from: "External editor") == .externalEditor)
+    }
+
+    @Test("external editor fallback is only enabled for external editor behavior")
+    func externalEditorFallbackAvailability() {
+        #expect(TerminalFileOpenBehavior.externalEditor.allowsExternalEditorFallback)
+        #expect(!TerminalFileOpenBehavior.inAppOpener.allowsExternalEditorFallback)
+    }
+
+    @Test("all cases contains the expected picker values")
+    func allCasesContainExpectedValues() {
+        #expect(TerminalFileOpenBehavior.allCases == [.externalEditor, .inAppOpener])
+        #expect(TerminalFileOpenBehavior.allCases.map(\.rawValue) == ["External editor", "In-app opener"])
+    }
+}


### PR DESCRIPTION
## Summary

Closes #732. Cmd-clicking a file path in the terminal always falls back to launching an external editor, with no way to keep files inside Muxy. This adds a Terminal setting to pick between that behavior and using a registered in-app opener only.

## Changes

- New "Files" picker in Terminal settings: "Open in external editor" (the current default) or "Open with in-app opener only".
- `TerminalPane` now reads the setting on cmd-click and OSC8 file links. When in-app-only is chosen and no opener is registered, it shows a notice and skips the external editor instead of launching it.
- Registered the key for settings search and JSON validation, and added unit tests for the behavior model.

## Testing

- [x] `swiftformat --lint` and `swiftlint --strict` clean on the changed files
- [x] Added `FileOpenBehaviorTests` covering the setting model and its default

I have not run the full `scripts/checks.sh` build or a manual macOS pass yet, so please confirm those before merging. The default keeps today's behavior, so existing users see no change.

## Screenshots

New Terminal settings row "Cmd-click a file path" with the two options.
