### PR TITLE
Add focus mode to tab-focused sidebar and refine spacing

### DIFF
--- a/Muxy/Models/Layout/TabFocusedSidebarMetrics.swift
+++ b/Muxy/Models/Layout/TabFocusedSidebarMetrics.swift
@@ -14,4 +14,6 @@ enum TabFocusedSidebarPreferences {
     static func groupByWorktreeKey(_ projectID: UUID) -> String {
         "muxy.tabFocused.groupByWorktree.\(projectID.uuidString)"
     }
+
+    static let focusModeKey = "muxy.tabFocused.focusMode"
 }

--- a/Muxy/Models/Layout/TabFocusedSidebarState.swift
+++ b/Muxy/Models/Layout/TabFocusedSidebarState.swift
@@ -9,6 +9,7 @@ final class TabFocusedSidebarState {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        focusMode = defaults.bool(forKey: TabFocusedSidebarPreferences.focusModeKey)
     }
 
     private var expanded: [UUID: Bool] = [:]
@@ -31,6 +32,13 @@ final class TabFocusedSidebarState {
     func isExpandedPersisted(_ projectID: UUID) -> Bool {
         if let value = expanded[projectID] { return value }
         return defaults.bool(forKey: TabFocusedSidebarPreferences.projectExpandedKey(projectID))
+    }
+
+    var focusMode: Bool {
+        didSet {
+            guard focusMode != oldValue else { return }
+            defaults.set(focusMode, forKey: TabFocusedSidebarPreferences.focusModeKey)
+        }
     }
 
     private var groupByWorktree: [UUID: Bool] = [:]

--- a/Muxy/Models/Layout/TabFocusedTabOrder.swift
+++ b/Muxy/Models/Layout/TabFocusedTabOrder.swift
@@ -30,6 +30,12 @@ enum TabFocusedTabOrder {
         expansionStore: TabFocusedSidebarState = .shared
     ) -> [Entry] {
         orderedProjects(projectStore: projectStore, projectGroupStore: projectGroupStore)
+            .filter { project in
+                if expansionStore.focusMode, let activeID = appState.activeProjectID {
+                    return project.id == activeID
+                }
+                return true
+            }
             .filter { expansionStore.isExpandedPersisted($0.id) }
             .flatMap { project -> [Entry] in
                 guard expansionStore.isGroupedByWorktree(project.id) else {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -51,6 +51,12 @@ struct TabFocusedProjectRow: View {
             }
         }
         .onAppear { applyDefaultExpansion() }
+        .onChange(of: isActive) { _, active in
+            guard active, !isExpanded else { return }
+            withAnimation(.easeInOut(duration: 0.15)) {
+                expansionStore.set(project.id, expanded: true)
+            }
+        }
         .task(id: project.path) { await checkGitRepo() }
     }
 
@@ -71,6 +77,11 @@ struct TabFocusedProjectRow: View {
                 HStack(spacing: 0) {
                     actions
                     chevron
+                }
+            } else if isFocused {
+                HStack(spacing: 0) {
+                    statusIndicator
+                    focusModeButton
                 }
             } else {
                 statusIndicator
@@ -246,6 +257,42 @@ struct TabFocusedProjectRow: View {
                 expansionStore.setGroupedByWorktree(project.id, grouped: !isGroupedByWorktree)
             }
         }
+        if !project.isHome {
+            focusModeButton
+        }
+    }
+
+    private var isFocused: Bool {
+        expansionStore.focusMode && isActive
+    }
+
+    private var focusModeButton: some View {
+        SidebarActionButton(
+            symbol: "scope",
+            label: isFocused ? "Exit Focus Mode" : "Focus This Project",
+            isActive: isFocused,
+            action: toggleFocusMode
+        )
+    }
+
+    private func toggleFocusMode() {
+        if isFocused {
+            expansionStore.focusMode = false
+            return
+        }
+        activateProjectIfNeeded()
+        expansionStore.focusMode = true
+    }
+
+    private func activateProjectIfNeeded() {
+        guard !isActive else { return }
+        worktreeStore.ensurePrimary(for: project)
+        guard let target = worktreeStore.preferred(
+            for: project.id,
+            matching: appState.activeWorktreeID[project.id]
+        )
+        else { return }
+        appState.selectProject(project, worktree: target)
     }
 
     private var chevron: some View {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -231,7 +231,6 @@ struct TabFocusedProjectRow: View {
         expansionStore.isGroupedByWorktree(project.id)
     }
 
-    @ViewBuilder
     private var trailingControls: some View {
         HStack(spacing: 0) {
             if hovered {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -73,19 +73,7 @@ struct TabFocusedProjectRow: View {
                     .truncationMode(.tail)
             }
             Spacer(minLength: UIMetrics.spacing2)
-            if hovered {
-                HStack(spacing: 0) {
-                    actions
-                    chevron
-                }
-            } else if isFocused {
-                HStack(spacing: 0) {
-                    statusIndicator
-                    focusModeButton
-                }
-            } else {
-                statusIndicator
-            }
+            trailingControls
             if project.isPinned {
                 Image(systemName: "pin.fill")
                     .font(.system(size: UIMetrics.fontXS, weight: .semibold))
@@ -244,6 +232,21 @@ struct TabFocusedProjectRow: View {
     }
 
     @ViewBuilder
+    private var trailingControls: some View {
+        HStack(spacing: 0) {
+            if hovered {
+                actions
+                chevron
+            } else if !isFocused {
+                statusIndicator
+            }
+            if isFocused {
+                focusModeButton
+            }
+        }
+    }
+
+    @ViewBuilder
     private var actions: some View {
         if !isGroupedByWorktree {
             TabFocusedTabActions(project: project, worktree: nil)
@@ -257,7 +260,7 @@ struct TabFocusedProjectRow: View {
                 expansionStore.setGroupedByWorktree(project.id, grouped: !isGroupedByWorktree)
             }
         }
-        if !project.isHome {
+        if !project.isHome, !isFocused {
             focusModeButton
         }
     }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -5,6 +5,7 @@ struct TabFocusedSidebar: View {
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
+    @State private var expansionStore = TabFocusedSidebarState.shared
     @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
     @AppStorage(ProjectSortMode.storageKey) private var sortModeRaw = ProjectSortMode.defaultValue.rawValue
 
@@ -22,8 +23,12 @@ struct TabFocusedSidebar: View {
 
     private var projects: [Project] {
         let stored = projectGroupStore.displayProjects(localProjects: projectStore.storedProjects, sortMode: sortMode)
-        guard let homeProject else { return stored }
-        return [homeProject] + stored
+        let all = homeProject.map { [$0] + stored } ?? stored
+        guard expansionStore.focusMode,
+              let activeID = appState.activeProjectID,
+              let focused = all.first(where: { $0.id == activeID })
+        else { return all }
+        return [focused]
     }
 
     private var shortcutNumbers: [UUID: Int] {
@@ -52,9 +57,11 @@ struct TabFocusedSidebar: View {
                             projectShortcutIndex: projectShortcutIndex(forRowAt: offset)
                         )
                     }
-                    TabFocusedAddProjectRow(action: openProjectPicker)
+                    if !expansionStore.focusMode {
+                        TabFocusedAddProjectRow(action: openProjectPicker)
+                    }
                 }
-                .padding(.vertical, UIMetrics.spacing3)
+                .padding(.bottom, UIMetrics.spacing3)
             }
             .scrollIndicators(.never)
 

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -89,7 +89,6 @@ struct TabFocusedTabsList: View {
                 tabRows(activeAreaTabs, numbers: shortcutNumbers, emptyOnNoTabs: true)
             }
         }
-        .padding(.bottom, UIMetrics.spacing3)
         .coordinateSpace(name: TabFocusedDragCoordinateSpace.list)
         .onPreferenceChange(TabFocusedRowFramePreferenceKey.self) { frames in
             guard dragState.draggedID != nil else { return }
@@ -114,14 +113,16 @@ struct TabFocusedTabsList: View {
                 Text("No open tabs")
                     .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
-                    .padding(.horizontal, TabFocusedSidebarMetrics.rowHorizontalInset)
-                    .padding(.bottom, UIMetrics.spacing3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, TabFocusedSidebarMetrics.rowHorizontalInset + UIMetrics.spacing4)
+                    .padding(.vertical, UIMetrics.spacing3)
             } else {
                 Text("No tabs")
                     .font(.system(size: UIMetrics.fontFootnote))
                     .foregroundStyle(MuxyTheme.fgDim)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, TabFocusedSidebarMetrics.rowHorizontalInset + UIMetrics.spacing4)
-                    .padding(.bottom, UIMetrics.spacing2)
+                    .padding(.vertical, UIMetrics.spacing3)
             }
         } else {
             ForEach(tabs) { item in
@@ -243,7 +244,8 @@ private struct WorktreeGroupHeader: View {
         }
         .padding(.leading, TabFocusedSidebarMetrics.rowHorizontalInset + UIMetrics.spacing4)
         .padding(.trailing, TabFocusedSidebarMetrics.rowHorizontalInset)
-        .padding(.vertical, UIMetrics.spacing4)
+        .padding(.top, UIMetrics.spacing3)
+        .padding(.bottom, UIMetrics.spacing1)
         .contentShape(Rectangle())
         .onHover { hovered = $0 }
     }
@@ -407,7 +409,7 @@ private struct TabFocusedTabRow: View {
             if let tabColor {
                 Rectangle()
                     .fill(tabColor)
-                    .frame(width: UIMetrics.scaled(2))
+                    .frame(width: UIMetrics.scaled(3))
                     .accessibilityHidden(true)
             }
         }


### PR DESCRIPTION
Adds a per-project focus mode (scope icon) that collapses the tab-focused sidebar to only the active project, with cmd+1-9 and cmd+[/] scoped to it.
Auto-expands a project when it becomes active and tightens worktree-group, empty-state, and top/bottom spacing.

Screenshots: _to add_