### PR TITLE
Add --project/--worktree targeting to the muxy CLI

### DIFF
--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -39,13 +39,19 @@ final class AppState {
         case createCommandTab(CommandTabRequest)
         case createExtensionTab(projectID: UUID, areaID: UUID?, request: CreateExtensionTabRequest)
         case createBrowserTab(projectID: UUID, areaID: UUID?, url: URL?, profileID: UUID)
+        case createTabInWorktree(key: WorktreeKey, areaID: UUID?)
+        case createBrowserTabInWorktree(key: WorktreeKey, areaID: UUID?, url: URL?, profileID: UUID)
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case closeTabInWorktree(key: WorktreeKey, areaID: UUID, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
+        case selectTabInWorktree(key: WorktreeKey, areaID: UUID, tabID: UUID)
         case selectTabByIndex(projectID: UUID, index: Int)
         case selectNextTab(projectID: UUID)
         case selectPreviousTab(projectID: UUID)
+        case selectNextTabInWorktree(key: WorktreeKey)
+        case selectPreviousTabInWorktree(key: WorktreeKey)
         case splitArea(SplitAreaRequest)
+        case splitAreaInWorktree(key: WorktreeKey, request: SplitAreaRequest)
         case closeArea(projectID: UUID, areaID: UUID)
         case focusArea(projectID: UUID, areaID: UUID)
         case focusPaneLeft(projectID: UUID)
@@ -225,6 +231,17 @@ final class AppState {
     func allAreas(for projectID: UUID) -> [TabArea] {
         guard let key = activeWorktreeKey(for: projectID) else { return [] }
         return workspaceRoots[key]?.allAreas() ?? []
+    }
+
+    @discardableResult
+    func ensureWorkspace(projectID: UUID, worktreeID: UUID, worktreePath: String) -> WorktreeKey {
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        guard workspaceRoots[key] == nil else { return key }
+        let area = TabArea(projectPath: worktreePath)
+        workspaceRoots[key] = .tabArea(area)
+        focusedAreaID[key] = area.id
+        saveWorkspaces()
+        return key
     }
 
     func areas(for key: WorktreeKey) -> [TabArea] {

--- a/Muxy/Models/Workspace/Reducer/SplitReducer.swift
+++ b/Muxy/Models/Workspace/Reducer/SplitReducer.swift
@@ -4,9 +4,17 @@ import Foundation
 enum SplitReducer {
     @discardableResult
     static func splitArea(_ request: AppState.SplitAreaRequest, state: inout WorkspaceState) -> UUID? {
-        guard let key = WorkspaceReducerShared.activeKey(projectID: request.projectID, state: state),
-              let root = state.workspaceRoots[key]
-        else { return nil }
+        guard let key = WorkspaceReducerShared.activeKey(projectID: request.projectID, state: state) else { return nil }
+        return splitArea(request, key: key, state: &state)
+    }
+
+    @discardableResult
+    static func splitArea(
+        _ request: AppState.SplitAreaRequest,
+        key: WorktreeKey,
+        state: inout WorkspaceState
+    ) -> UUID? {
+        guard let root = state.workspaceRoots[key] else { return nil }
         let (newRoot, newAreaID) = root.splitting(
             areaID: request.areaID,
             direction: request.direction,

--- a/Muxy/Models/Workspace/Reducer/TabReducer.swift
+++ b/Muxy/Models/Workspace/Reducer/TabReducer.swift
@@ -3,9 +3,12 @@ import Foundation
 @MainActor
 enum TabReducer {
     static func createTab(projectID: UUID, areaID: UUID?, state: inout WorkspaceState) -> UUID? {
-        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
-              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
-        else { return nil }
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { return nil }
+        return createTab(key: key, areaID: areaID, state: &state)
+    }
+
+    static func createTab(key: WorktreeKey, areaID: UUID?, state: inout WorkspaceState) -> UUID? {
+        guard let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state) else { return nil }
         FocusReducer.focusArea(area.id, key: key, state: &state)
         return area.createTab()
     }
@@ -89,8 +92,18 @@ enum TabReducer {
         profileID: UUID,
         state: inout WorkspaceState
     ) -> UUID? {
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { return nil }
+        return createBrowserTab(key: key, areaID: areaID, url: url, profileID: profileID, state: &state)
+    }
+
+    static func createBrowserTab(
+        key: WorktreeKey,
+        areaID: UUID?,
+        url: URL?,
+        profileID: UUID,
+        state: inout WorkspaceState
+    ) -> UUID? {
         guard BrowserPreferences.isEnabled,
-              let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
               let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
         else { return nil }
         FocusReducer.focusArea(area.id, key: key, state: &state)
@@ -98,9 +111,12 @@ enum TabReducer {
     }
 
     static func selectTab(projectID: UUID, areaID: UUID?, tabID: UUID, state: inout WorkspaceState) {
-        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
-              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state)
-        else { return }
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { return }
+        selectTab(key: key, areaID: areaID, tabID: tabID, state: &state)
+    }
+
+    static func selectTab(key: WorktreeKey, areaID: UUID?, tabID: UUID, state: inout WorkspaceState) {
+        guard let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state) else { return }
         FocusReducer.focusArea(area.id, key: key, state: &state)
         area.selectTab(tabID)
     }
@@ -124,16 +140,22 @@ enum TabReducer {
     }
 
     static func selectNextTab(projectID: UUID, state: WorkspaceState) {
-        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
-              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: nil, state: state)
-        else { return }
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { return }
+        selectNextTab(key: key, state: state)
+    }
+
+    static func selectNextTab(key: WorktreeKey, state: WorkspaceState) {
+        guard let area = WorkspaceReducerShared.resolveArea(key: key, areaID: nil, state: state) else { return }
         area.selectNextTab()
     }
 
     static func selectPreviousTab(projectID: UUID, state: WorkspaceState) {
-        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state),
-              let area = WorkspaceReducerShared.resolveArea(key: key, areaID: nil, state: state)
-        else { return }
+        guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { return }
+        selectPreviousTab(key: key, state: state)
+    }
+
+    static func selectPreviousTab(key: WorktreeKey, state: WorkspaceState) {
+        guard let area = WorkspaceReducerShared.resolveArea(key: key, areaID: nil, state: state) else { return }
         area.selectPreviousTab()
     }
 

--- a/Muxy/Models/Workspace/WorkspaceReducer.swift
+++ b/Muxy/Models/Workspace/WorkspaceReducer.swift
@@ -119,6 +119,20 @@ enum WorkspaceReducer {
                 state: &state
             )
 
+        case let .createTabInWorktree(key, areaID):
+            guard state.workspaceRoots[key] != nil else { break }
+            effects.createdTabID = TabReducer.createTab(key: key, areaID: areaID, state: &state)
+
+        case let .createBrowserTabInWorktree(key, areaID, url, profileID):
+            guard state.workspaceRoots[key] != nil else { break }
+            effects.createdTabID = TabReducer.createBrowserTab(
+                key: key,
+                areaID: areaID,
+                url: url,
+                profileID: profileID,
+                state: &state
+            )
+
         case let .closeTab(projectID, areaID, tabID):
             guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { break }
             TabReducer.closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)
@@ -130,6 +144,10 @@ enum WorkspaceReducer {
         case let .selectTab(projectID, areaID, tabID):
             TabReducer.selectTab(projectID: projectID, areaID: areaID, tabID: tabID, state: &state)
 
+        case let .selectTabInWorktree(key, areaID, tabID):
+            guard state.workspaceRoots[key] != nil else { break }
+            TabReducer.selectTab(key: key, areaID: areaID, tabID: tabID, state: &state)
+
         case let .selectTabByIndex(projectID, index):
             TabReducer.selectTabByIndex(projectID: projectID, index: index, state: &state)
 
@@ -139,8 +157,20 @@ enum WorkspaceReducer {
         case let .selectPreviousTab(projectID):
             TabReducer.selectPreviousTab(projectID: projectID, state: state)
 
+        case let .selectNextTabInWorktree(key):
+            guard state.workspaceRoots[key] != nil else { break }
+            TabReducer.selectNextTab(key: key, state: state)
+
+        case let .selectPreviousTabInWorktree(key):
+            guard state.workspaceRoots[key] != nil else { break }
+            TabReducer.selectPreviousTab(key: key, state: state)
+
         case let .splitArea(request):
             effects.createdPaneID = SplitReducer.splitArea(request, state: &state)
+
+        case let .splitAreaInWorktree(key, request):
+            guard state.workspaceRoots[key] != nil else { break }
+            effects.createdPaneID = SplitReducer.splitArea(request, key: key, state: &state)
 
         case let .closeArea(projectID, areaID):
             guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { break }

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -42,8 +42,8 @@ NC_TIMEOUT="${MUXY_CLI_TIMEOUT:-10}"
 
 usage_for() {
     case "$1" in
-        split-right)       echo "muxy split-right [--from <id>] [--project <p>] [--worktree <w>] [cmd...]" ;;
-        split-down)        echo "muxy split-down [--from <id>] [--project <p>] [--worktree <w>] [cmd...]" ;;
+        split-right)       echo "muxy split-right [--from <id>] [cmd...] [--project <p>] [--worktree <w>]" ;;
+        split-down)        echo "muxy split-down [--from <id>] [cmd...] [--project <p>] [--worktree <w>]" ;;
         send)              echo "muxy send --pane <id> <text>" ;;
         send-keys)         echo "muxy send-keys --pane <id> <key>" ;;
         read-screen)       echo "muxy read-screen --pane <id> [--lines N]" ;;
@@ -238,22 +238,22 @@ api_timeout_for_ms() {
 extract_target_flags() {
     TARGET_PROJECT=""
     TARGET_WORKTREE=""
-    TARGET_REST=()
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
+    TARGET_REST=("$@")
+    while [[ ${#TARGET_REST[@]} -ge 2 ]]; do
+        local count=${#TARGET_REST[@]}
+        local flag="${TARGET_REST[$((count - 2))]}"
+        local value="${TARGET_REST[$((count - 1))]}"
+        case "$flag" in
             --project)
-                [ $# -lt 2 ] && return 1
-                TARGET_PROJECT="$2"
-                shift 2
+                TARGET_PROJECT="$value"
+                TARGET_REST=("${TARGET_REST[@]:0:$((count - 2))}")
                 ;;
             --worktree)
-                [ $# -lt 2 ] && return 1
-                TARGET_WORKTREE="$2"
-                shift 2
+                TARGET_WORKTREE="$value"
+                TARGET_REST=("${TARGET_REST[@]:0:$((count - 2))}")
                 ;;
             *)
-                TARGET_REST+=("$1")
-                shift
+                break
                 ;;
         esac
     done
@@ -272,7 +272,8 @@ case "$COMMAND" in
         shift
         extract_target_flags "$@" || die_usage split-right
         set -- "${TARGET_REST[@]}"
-        FROM="${MUXY_PANE_ID:-}"
+        FROM=""
+        [ -z "$(target_suffix)" ] && FROM="${MUXY_PANE_ID:-}"
         CMD_ARGS=()
         while [[ $# -gt 0 ]]; do
             case $1 in
@@ -296,7 +297,8 @@ case "$COMMAND" in
         shift
         extract_target_flags "$@" || die_usage split-down
         set -- "${TARGET_REST[@]}"
-        FROM="${MUXY_PANE_ID:-}"
+        FROM=""
+        [ -z "$(target_suffix)" ] && FROM="${MUXY_PANE_ID:-}"
         CMD_ARGS=()
         while [[ $# -gt 0 ]]; do
             case $1 in

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -29,6 +29,11 @@
 #   muxy tab move <tab> <to-index>             Reorder a tab within its area
 #   muxy install-skills [skills args...]       Install Muxy agent skills into detected AI harnesses
 #
+# Worktree targeting:
+#   new-tab, list-tabs, switch-tab, next-tab, previous-tab, split-right, split-down,
+#   browser open and browser list accept [--project <name|id|path>] and
+#   [--worktree <name|id|branch>] to act on a specific worktree without moving your view.
+#
 # Run "muxy <command> --help" for the options of a single command.
 
 COMMAND="$1"
@@ -37,8 +42,8 @@ NC_TIMEOUT="${MUXY_CLI_TIMEOUT:-10}"
 
 usage_for() {
     case "$1" in
-        split-right)       echo "muxy split-right [--from <id>] [cmd...]" ;;
-        split-down)        echo "muxy split-down [--from <id>] [cmd...]" ;;
+        split-right)       echo "muxy split-right [--from <id>] [--project <p>] [--worktree <w>] [cmd...]" ;;
+        split-down)        echo "muxy split-down [--from <id>] [--project <p>] [--worktree <w>] [cmd...]" ;;
         send)              echo "muxy send --pane <id> <text>" ;;
         send-keys)         echo "muxy send-keys --pane <id> <key>" ;;
         read-screen)       echo "muxy read-screen --pane <id> [--lines N]" ;;
@@ -51,11 +56,11 @@ usage_for() {
         create-worktree)   echo "muxy create-worktree <name> [--branch <branch>] [--base <branch>] [--project <project>] [--path <path>] [--existing]" ;;
         switch-worktree)   echo "muxy switch-worktree <name|id|path> [--project <name|id|path>]" ;;
         refresh-worktrees) echo "muxy refresh-worktrees [project]" ;;
-        list-tabs)         echo "muxy list-tabs" ;;
-        switch-tab)        echo "muxy switch-tab <index|id|title>" ;;
-        new-tab)           echo "muxy new-tab" ;;
-        next-tab)          echo "muxy next-tab" ;;
-        previous-tab)      echo "muxy previous-tab" ;;
+        list-tabs)         echo "muxy list-tabs [--project <p>] [--worktree <w>]" ;;
+        switch-tab)        echo "muxy switch-tab <index|id|title> [--project <p>] [--worktree <w>]" ;;
+        new-tab)           echo "muxy new-tab [--project <p>] [--worktree <w>]" ;;
+        next-tab)          echo "muxy next-tab [--project <p>] [--worktree <w>]" ;;
+        previous-tab)      echo "muxy previous-tab [--project <p>] [--worktree <w>]" ;;
         tab)               echo "muxy tab <rename|set-color|set-icon|pin|unpin|close|move> <index|id|title> [args...]" ;;
         browser)           echo "muxy browser <open|navigate|list|read|close|eval|click|type|fill|press|select|hover|check|uncheck|scroll-into-view|wait|wait-for|wait-for-navigation|get-text|get-html|get-value|get-attribute|get-count|is|find|snapshot|reload|back|forward|screenshot|storage|cookies> [args...]" ;;
         install-skills)    echo "muxy install-skills [skills args...]" ;;
@@ -98,6 +103,8 @@ usage() {
     echo "  muxy new-tab                             Create a terminal tab"
     echo "  muxy next-tab                            Switch to next tab"
     echo "  muxy previous-tab                        Switch to previous tab"
+    echo "                                           tab/split/browser commands accept [--project <p>] [--worktree <w>]"
+    echo "                                           to target another worktree without moving your view"
     echo "  muxy tab rename <tab> [title]            Rename a tab (omit title to reset)"
     echo "  muxy tab set-color <tab> [color]         Set a tab color (omit to reset); colors:"
     echo "                                           red orange amber yellow lime green teal cyan blue indigo violet pink"
@@ -228,9 +235,43 @@ api_timeout_for_ms() {
     echo $(( ms / 1000 + NC_TIMEOUT ))
 }
 
+extract_target_flags() {
+    TARGET_PROJECT=""
+    TARGET_WORKTREE=""
+    TARGET_REST=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --project)
+                [ $# -lt 2 ] && return 1
+                TARGET_PROJECT="$2"
+                shift 2
+                ;;
+            --worktree)
+                [ $# -lt 2 ] && return 1
+                TARGET_WORKTREE="$2"
+                shift 2
+                ;;
+            *)
+                TARGET_REST+=("$1")
+                shift
+                ;;
+        esac
+    done
+    return 0
+}
+
+target_suffix() {
+    local suffix=""
+    [ -n "$TARGET_PROJECT" ] && suffix="$suffix|--project|$TARGET_PROJECT"
+    [ -n "$TARGET_WORKTREE" ] && suffix="$suffix|--worktree|$TARGET_WORKTREE"
+    printf '%s' "$suffix"
+}
+
 case "$COMMAND" in
     split-right)
         shift
+        extract_target_flags "$@" || die_usage split-right
+        set -- "${TARGET_REST[@]}"
         FROM="${MUXY_PANE_ID:-}"
         CMD_ARGS=()
         while [[ $# -gt 0 ]]; do
@@ -245,14 +286,16 @@ case "$COMMAND" in
             esac
         done
         CMD="${CMD_ARGS[*]}"
-        if [ -n "$CMD" ] || [ -n "$FROM" ]; then
-            send_command "split-right|$FROM|$CMD"
+        if [ -n "$CMD" ] || [ -n "$FROM" ] || [ -n "$(target_suffix)" ]; then
+            send_command "split-right|$FROM|$CMD$(target_suffix)"
         else
             send_command "split-right"
         fi
         ;;
     split-down)
         shift
+        extract_target_flags "$@" || die_usage split-down
+        set -- "${TARGET_REST[@]}"
         FROM="${MUXY_PANE_ID:-}"
         CMD_ARGS=()
         while [[ $# -gt 0 ]]; do
@@ -267,8 +310,8 @@ case "$COMMAND" in
             esac
         done
         CMD="${CMD_ARGS[*]}"
-        if [ -n "$CMD" ] || [ -n "$FROM" ]; then
-            send_command "split-down|$FROM|$CMD"
+        if [ -n "$CMD" ] || [ -n "$FROM" ] || [ -n "$(target_suffix)" ]; then
+            send_command "split-down|$FROM|$CMD$(target_suffix)"
         else
             send_command "split-down"
         fi
@@ -467,28 +510,37 @@ case "$COMMAND" in
         fi
         ;;
     list-tabs)
-        wants_help "$2" && print_command_help list-tabs
-        send_command "list-tabs"
+        shift
+        wants_help "$1" && print_command_help list-tabs
+        extract_target_flags "$@" || die_usage list-tabs
+        send_command "list-tabs$(target_suffix)"
         ;;
     switch-tab)
         shift
         wants_help "$1" && print_command_help switch-tab
-        if [ $# -lt 1 ]; then
+        extract_target_flags "$@" || die_usage switch-tab
+        if [ ${#TARGET_REST[@]} -lt 1 ]; then
             die_usage switch-tab
         fi
-        send_command "switch-tab|$*"
+        send_command "switch-tab|${TARGET_REST[*]}$(target_suffix)"
         ;;
     new-tab)
-        wants_help "$2" && print_command_help new-tab
-        send_command "new-tab"
+        shift
+        wants_help "$1" && print_command_help new-tab
+        extract_target_flags "$@" || die_usage new-tab
+        send_command "new-tab$(target_suffix)"
         ;;
     next-tab)
-        wants_help "$2" && print_command_help next-tab
-        send_command "next-tab"
+        shift
+        wants_help "$1" && print_command_help next-tab
+        extract_target_flags "$@" || die_usage next-tab
+        send_command "next-tab$(target_suffix)"
         ;;
     previous-tab)
-        wants_help "$2" && print_command_help previous-tab
-        send_command "previous-tab"
+        shift
+        wants_help "$1" && print_command_help previous-tab
+        extract_target_flags "$@" || die_usage previous-tab
+        send_command "previous-tab$(target_suffix)"
         ;;
     tab)
         shift
@@ -562,6 +614,8 @@ case "$COMMAND" in
         shift || true
         case "$SUB" in
             open)
+                extract_target_flags "$@" || die_usage browser
+                set -- "${TARGET_REST[@]}"
                 URL=""
                 SPLIT=""
                 HAS_URL=""
@@ -576,14 +630,14 @@ case "$COMMAND" in
                 done
                 if [ -n "$SPLIT" ]; then
                     if [ -n "$HAS_URL" ]; then
-                        send_command "browser.open|$URL|$SPLIT"
+                        send_command "browser.open|$URL|$SPLIT$(target_suffix)"
                     else
-                        send_command "browser.open|$SPLIT"
+                        send_command "browser.open|$SPLIT$(target_suffix)"
                     fi
                 elif [ -n "$HAS_URL" ]; then
-                    send_command "browser.open|$URL"
+                    send_command "browser.open|$URL$(target_suffix)"
                 else
-                    send_command "browser.open"
+                    send_command "browser.open$(target_suffix)"
                 fi
                 ;;
             navigate)
@@ -591,7 +645,8 @@ case "$COMMAND" in
                 send_command "browser.navigate|$1|$2"
                 ;;
             list)
-                send_command "browser.list"
+                extract_target_flags "$@" || die_usage browser
+                send_command "browser.list$(target_suffix)"
                 ;;
             read)
                 [ $# -lt 1 ] && die_usage browser

--- a/Muxy/Resources/skills/muxy-cli/SKILL.md
+++ b/Muxy/Resources/skills/muxy-cli/SKILL.md
@@ -108,6 +108,14 @@ muxy previous-tab            # cycle backward
 
 Use `switch-tab` (resolves index/ID/title) when you know the target; reach for `next-tab`/`previous-tab` only for relative cycling. List first with `muxy list-tabs` when you need the index or ID.
 
+`new-tab`, `list-tabs`, `switch-tab`, `next-tab`, `previous-tab`, and `split-right`/`split-down` accept `--project <name|id|path>` and `--worktree <name|id|branch>` to target a specific worktree. Both are optional: with neither they act on the active worktree; `--worktree` alone resolves in the active project, then searches all projects for a unique match (ambiguous — pass `--project`); `--project` alone uses that project's active/preferred worktree; both are explicit. Targeting acts in the target worktree's background workspace — your visible view stays put. Use `switch-project`/`switch-worktree` to actually move focus.
+
+```bash
+muxy new-tab --worktree feature/login        # tab created in that worktree, your view stays put
+muxy list-tabs --project "My App" --worktree main
+muxy switch-tab 2 --worktree feature/login
+```
+
 Customize and manage a tab with `muxy tab <op> <index|id|title>`. The target resolves the same way as `switch-tab` — by index or title within the active worktree, or by tab ID anywhere across open workspaces:
 
 ```bash
@@ -164,6 +172,13 @@ muxy browser cookies delete "$TAB" session
 
 **Headless by default.** Every browser command — including `screenshot`, `eval`, DOM reads, clicks, and navigation — works on any open tab in the active project **without that tab being visible or focused**. You can drive a browser tab from a terminal tab and never leave your view; there is no need to `switch-tab` to it first. `screenshot` renders the page off-screen, so it captures real content even for a backgrounded tab.
 
+`browser open` and `browser list` accept `--project <name|id|path>` and `--worktree <name|id|branch>` to target a specific worktree (same resolution as Tabs; both optional). The tab opens in the target worktree's background workspace — your visible view stays put. Use `switch-project`/`switch-worktree` to actually move focus.
+
+```bash
+muxy browser open localhost:3000 --worktree feature/login
+muxy browser list --worktree feature/login
+```
+
 Run `browser open` with no URL to open the configured home page (blank by default). Capture the tab ID from `browser open` (or `browser list`) and reuse it; never guess it. After navigating, give the page a moment to load (`wait-for`, `wait-for-navigation`, or a `wait` condition) before reading. Cookies are shared by all tabs on the same profile. If the built-in browser is disabled in Settings, browser actions return an error and `browser list` returns no tabs.
 
 ## Install the skills into your AI harnesses
@@ -177,6 +192,7 @@ Run `browser open` with no URL to open the configured home page (blank by defaul
 - **The socket is local to your macOS user.** It grants no extra privileges, but any process running as your user can drive the workspace while Muxy is open. Don't pipe untrusted input into `muxy send`, and be mindful that `read-screen` can surface sensitive output. See the **Security model** section of the docs.
 - **Prefer switching to creating.** `switch-project` / `switch-worktree` select an existing entry; opening a path that is already open selects it rather than duplicating it. Reach for `create-worktree` / `new-tab` only when nothing suitable exists.
 - **Leave the user's focus where they expect it.** You share the visible workspace — name panes you create (`rename-pane`) so the user can tell what is yours, and close them (`close-pane`) when the work is done.
+- **Targeting a worktree (`--project`/`--worktree`) never moves the user's visible workspace** — the action runs in the target's background workspace; use `switch-*` to actually change focus.
 
 ## Checklist
 
@@ -185,3 +201,4 @@ Run `browser open` with no URL to open the configured home page (blank by defaul
 - [ ] Parsed list output by the first (ID) column, not by a possibly-duplicate title.
 - [ ] Used `send` for text and `send-keys` for one supported key; quoted commands with spaces/operators.
 - [ ] Named panes you create and closed them when finished, so the shared workspace stays legible.
+- [ ] Remembered that targeting a worktree (`--project`/`--worktree`) never moves the user's visible workspace; used `switch-*` to actually change focus.

--- a/Muxy/Resources/skills/muxy-cli/SKILL.md
+++ b/Muxy/Resources/skills/muxy-cli/SKILL.md
@@ -114,6 +114,7 @@ Use `switch-tab` (resolves index/ID/title) when you know the target; reach for `
 muxy new-tab --worktree feature/login        # tab created in that worktree, your view stays put
 muxy list-tabs --project "My App" --worktree main
 muxy switch-tab 2 --worktree feature/login
+muxy split-right npm test --worktree feature/login
 ```
 
 Customize and manage a tab with `muxy tab <op> <index|id|title>`. The target resolves the same way as `switch-tab` — by index or title within the active worktree, or by tab ID anywhere across open workspaces:

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -576,14 +576,22 @@ enum MuxyAPI {
             let key: WorktreeKey
             let areaID: UUID
 
-            if let fromPane, let paneID = UUID(uuidString: fromPane),
-               let loc = locateTab(paneID: paneID, appState: appState)
+            if let target {
+                key = target.key
+                if let fromPane,
+                   let paneID = UUID(uuidString: fromPane),
+                   let loc = locateTab(paneID: paneID, appState: appState),
+                   loc.key == target.key
+                {
+                    areaID = loc.areaID
+                } else {
+                    areaID = target.areaID
+                }
+            } else if let fromPane, let paneID = UUID(uuidString: fromPane),
+                      let loc = locateTab(paneID: paneID, appState: appState)
             {
                 key = loc.key
                 areaID = loc.areaID
-            } else if let target {
-                key = target.key
-                areaID = target.areaID
             } else {
                 guard let activeID = appState.activeProjectID else {
                     return .failure(.noActiveProject)
@@ -1629,6 +1637,7 @@ enum MuxyAPI {
             target: WorktreeTarget,
             appState: AppState
         ) -> Result<UUID, APIError> {
+            var areaID = target.areaID
             if split {
                 appState.dispatch(.splitAreaInWorktree(
                     key: target.key,
@@ -1639,10 +1648,11 @@ enum MuxyAPI {
                         position: .second
                     )
                 ))
+                areaID = appState.focusedAreaID[target.key] ?? target.areaID
             }
             let effects = appState.dispatchReturningEffects(.createBrowserTabInWorktree(
                 key: target.key,
-                areaID: target.areaID,
+                areaID: areaID,
                 url: url,
                 profileID: profileID
             ))

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -1110,7 +1110,9 @@ enum MuxyAPI {
             } else {
                 return .failure(.noActiveProject)
             }
-            guard let root = appState.workspaceRoots[key] else { return .failure(.noActiveProject) }
+            guard let root = appState.workspaceRoots[key] else {
+                return .failure(target == nil ? .noActiveProject : .noActiveWorkspace)
+            }
 
             let focusedAreaID = appState.focusedAreaID[key]
             var index = 0
@@ -1627,9 +1629,8 @@ enum MuxyAPI {
             target: WorktreeTarget,
             appState: AppState
         ) -> Result<UUID, APIError> {
-            var areaID = target.areaID
             if split {
-                let paneID = appState.dispatchReturningEffects(.splitAreaInWorktree(
+                appState.dispatch(.splitAreaInWorktree(
                     key: target.key,
                     request: .init(
                         projectID: target.key.projectID,
@@ -1637,17 +1638,11 @@ enum MuxyAPI {
                         direction: .horizontal,
                         position: .second
                     )
-                )).createdPaneID
-                if let paneID,
-                   let newArea = appState.areas(for: target.key)
-                   .first(where: { $0.tabs.contains(where: { $0.content.pane?.id == paneID }) })
-                {
-                    areaID = newArea.id
-                }
+                ))
             }
             let effects = appState.dispatchReturningEffects(.createBrowserTabInWorktree(
                 key: target.key,
-                areaID: areaID,
+                areaID: target.areaID,
                 url: url,
                 profileID: profileID
             ))

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -570,37 +570,46 @@ enum MuxyAPI {
             direction: SplitDirection,
             command: String?,
             fromPane: String?,
-            appState: AppState
+            appState: AppState,
+            target: WorktreeTarget? = nil
         ) -> Result<UUID, APIError> {
-            let projectID: UUID
+            let key: WorktreeKey
             let areaID: UUID
 
             if let fromPane, let paneID = UUID(uuidString: fromPane),
                let loc = locateTab(paneID: paneID, appState: appState)
             {
-                projectID = loc.key.projectID
+                key = loc.key
                 areaID = loc.areaID
+            } else if let target {
+                key = target.key
+                areaID = target.areaID
             } else {
                 guard let activeID = appState.activeProjectID else {
                     return .failure(.noActiveProject)
                 }
-                guard let area = appState.focusedArea(for: activeID) else {
+                guard let activeKey = appState.activeWorktreeKey(for: activeID),
+                      let area = appState.focusedArea(for: activeID)
+                else {
                     return .failure(.noFocusedArea)
                 }
-                projectID = activeID
+                key = activeKey
                 areaID = area.id
             }
 
             let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
             let finalCommand = (trimmed?.isEmpty ?? true) ? nil : trimmed
 
-            let effects = appState.dispatchReturningEffects(.splitArea(.init(
-                projectID: projectID,
-                areaID: areaID,
-                direction: direction,
-                position: .second,
-                command: finalCommand
-            )))
+            let effects = appState.dispatchReturningEffects(.splitAreaInWorktree(
+                key: key,
+                request: .init(
+                    projectID: key.projectID,
+                    areaID: areaID,
+                    direction: direction,
+                    position: .second,
+                    command: finalCommand
+                )
+            ))
 
             guard let newPaneID = effects.createdPaneID else {
                 return .failure(.splitFailed)
@@ -1090,11 +1099,18 @@ enum MuxyAPI {
 
     @MainActor
     enum Tabs {
-        static func list(appState: AppState) -> Result<[TabInfo], APIError> {
-            guard let projectID = appState.activeProjectID,
-                  let key = appState.activeWorktreeKey(for: projectID),
-                  let root = appState.workspaceRoots[key]
-            else { return .failure(.noActiveProject) }
+        static func list(appState: AppState, target: WorktreeTarget? = nil) -> Result<[TabInfo], APIError> {
+            let key: WorktreeKey
+            if let target {
+                key = target.key
+            } else if let projectID = appState.activeProjectID,
+                      let activeKey = appState.activeWorktreeKey(for: projectID)
+            {
+                key = activeKey
+            } else {
+                return .failure(.noActiveProject)
+            }
+            guard let root = appState.workspaceRoots[key] else { return .failure(.noActiveProject) }
 
             let focusedAreaID = appState.focusedAreaID[key]
             var index = 0
@@ -1115,7 +1131,10 @@ enum MuxyAPI {
             return .success(infos)
         }
 
-        static func switchTo(identifier: String, appState: AppState) -> Result<Void, APIError> {
+        static func switchTo(identifier: String, appState: AppState, target: WorktreeTarget? = nil) -> Result<Void, APIError> {
+            if let target {
+                return switchInWorktree(identifier: identifier, key: target.key, appState: appState)
+            }
             guard let projectID = appState.activeProjectID,
                   let key = appState.activeWorktreeKey(for: projectID),
                   let root = appState.workspaceRoots[key]
@@ -1134,19 +1153,54 @@ enum MuxyAPI {
             return .failure(.tabNotFound(identifier))
         }
 
-        static func new(appState: AppState) -> Result<UUID?, APIError> {
+        private static func switchInWorktree(
+            identifier: String,
+            key: WorktreeKey,
+            appState: AppState
+        ) -> Result<Void, APIError> {
+            guard let root = appState.workspaceRoots[key] else { return .failure(.noActiveWorkspace) }
+            if let index = Int(identifier) {
+                guard let tab = tab(at: index, in: root),
+                      let area = root.allAreas().first(where: { $0.tabs.contains(where: { $0.id == tab.id }) })
+                else { return .failure(.tabNotFound(identifier)) }
+                appState.dispatch(.selectTabInWorktree(key: key, areaID: area.id, tabID: tab.id))
+                return .success(())
+            }
+            for area in root.allAreas() {
+                guard let tab = area.tabs.first(where: { tabMatches($0, identifier: identifier) }) else { continue }
+                appState.dispatch(.selectTabInWorktree(key: key, areaID: area.id, tabID: tab.id))
+                return .success(())
+            }
+            return .failure(.tabNotFound(identifier))
+        }
+
+        static func new(appState: AppState, target: WorktreeTarget? = nil) -> Result<UUID?, APIError> {
+            if let target {
+                let effects = appState.dispatchReturningEffects(
+                    .createTabInWorktree(key: target.key, areaID: target.areaID)
+                )
+                return .success(effects.createdTabID)
+            }
             guard let projectID = appState.activeProjectID else { return .failure(.noActiveProject) }
             let effects = appState.dispatchReturningEffects(.createTab(projectID: projectID, areaID: nil))
             return .success(effects.createdTabID)
         }
 
-        static func next(appState: AppState) -> Result<Void, APIError> {
+        static func next(appState: AppState, target: WorktreeTarget? = nil) -> Result<Void, APIError> {
+            if let target {
+                appState.dispatch(.selectNextTabInWorktree(key: target.key))
+                return .success(())
+            }
             guard let projectID = appState.activeProjectID else { return .failure(.noActiveProject) }
             appState.selectNextTab(projectID: projectID)
             return .success(())
         }
 
-        static func previous(appState: AppState) -> Result<Void, APIError> {
+        static func previous(appState: AppState, target: WorktreeTarget? = nil) -> Result<Void, APIError> {
+            if let target {
+                appState.dispatch(.selectPreviousTabInWorktree(key: target.key))
+                return .success(())
+            }
             guard let projectID = appState.activeProjectID else { return .failure(.noActiveProject) }
             appState.selectPreviousTab(projectID: projectID)
             return .success(())
@@ -1526,12 +1580,24 @@ enum MuxyAPI {
             url: String?,
             profileID: UUID? = nil,
             split: Bool = false,
-            appState: AppState
+            appState: AppState,
+            target: WorktreeTarget? = nil
         ) -> Result<UUID, APIError> {
             guard BrowserPreferences.isEnabled else { return .failure(.browserDisabled) }
-            guard let projectID = appState.activeProjectID else { return .failure(.noActiveProject) }
             let resolvedURL = url.flatMap(BrowserURL.resolve(from:)) ?? BrowserURL.homeURL
             let resolvedProfileID = profileID ?? BrowserPreferences.defaultProfileID
+
+            if let target {
+                return openInWorktree(
+                    url: resolvedURL,
+                    profileID: resolvedProfileID,
+                    split: split,
+                    target: target,
+                    appState: appState
+                )
+            }
+
+            guard let projectID = appState.activeProjectID else { return .failure(.noActiveProject) }
 
             if split, let areaID = appState.focusedAreaID(for: projectID) {
                 appState.dispatch(.splitArea(.init(
@@ -1554,6 +1620,43 @@ enum MuxyAPI {
             return .success(newID)
         }
 
+        private static func openInWorktree(
+            url: URL?,
+            profileID: UUID,
+            split: Bool,
+            target: WorktreeTarget,
+            appState: AppState
+        ) -> Result<UUID, APIError> {
+            var areaID = target.areaID
+            if split {
+                let paneID = appState.dispatchReturningEffects(.splitAreaInWorktree(
+                    key: target.key,
+                    request: .init(
+                        projectID: target.key.projectID,
+                        areaID: target.areaID,
+                        direction: .horizontal,
+                        position: .second
+                    )
+                )).createdPaneID
+                if let paneID,
+                   let newArea = appState.areas(for: target.key)
+                   .first(where: { $0.tabs.contains(where: { $0.content.pane?.id == paneID }) })
+                {
+                    areaID = newArea.id
+                }
+            }
+            let effects = appState.dispatchReturningEffects(.createBrowserTabInWorktree(
+                key: target.key,
+                areaID: areaID,
+                url: url,
+                profileID: profileID
+            ))
+            guard let newID = effects.createdTabID else {
+                return .failure(.browserTabCreateFailed)
+            }
+            return .success(newID)
+        }
+
         static func navigate(tabIDString: String, url: String, appState: AppState) -> Result<Void, APIError> {
             guard BrowserPreferences.isEnabled else { return .failure(.browserDisabled) }
             guard let state = locate(tabIDString: tabIDString, appState: appState)?.state else {
@@ -1566,10 +1669,14 @@ enum MuxyAPI {
             return .success(())
         }
 
-        static func list(appState: AppState, profileStore: BrowserProfileStore?) -> [BrowserTabInfo] {
+        static func list(
+            appState: AppState,
+            profileStore: BrowserProfileStore?,
+            target: WorktreeTarget? = nil
+        ) -> [BrowserTabInfo] {
             guard BrowserPreferences.isEnabled else { return [] }
             var infos: [BrowserTabInfo] = []
-            for (key, root) in appState.workspaceRoots {
+            for (key, root) in appState.workspaceRoots where target == nil || key == target?.key {
                 let focusedAreaID = appState.focusedAreaID[key]
                 for area in root.allAreas() {
                     for tab in area.tabs {
@@ -1815,6 +1922,115 @@ private func findWorktree(_ identifier: String, in worktrees: [Worktree]) -> Wor
             || worktree.name.localizedCaseInsensitiveCompare(identifier) == .orderedSame
             || worktree.branch?.localizedCaseInsensitiveCompare(identifier) == .orderedSame
             || URL(fileURLWithPath: worktree.path).standardizedFileURL.path == standardizedPath
+    }
+}
+
+extension MuxyAPI {
+    struct WorktreeTarget: Equatable {
+        let key: WorktreeKey
+        let areaID: UUID
+    }
+
+    @MainActor
+    static func resolveWorktreeTarget(
+        project projectIdentifier: String?,
+        worktree worktreeIdentifier: String?,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) -> Result<WorktreeTarget?, APIError> {
+        let hasProject = projectIdentifier?.isEmpty == false
+        let hasWorktree = worktreeIdentifier?.isEmpty == false
+        guard hasProject || hasWorktree else { return .success(nil) }
+
+        let resolved: (project: Project, worktree: Worktree)
+        switch resolveProjectAndWorktree(
+            project: projectIdentifier,
+            worktree: worktreeIdentifier,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        ) {
+        case let .success(pair): resolved = pair
+        case let .failure(error): return .failure(error)
+        }
+
+        let key = appState.ensureWorkspace(
+            projectID: resolved.project.id,
+            worktreeID: resolved.worktree.id,
+            worktreePath: resolved.worktree.path
+        )
+        guard let areaID = appState.focusedAreaID[key] ?? appState.areas(for: key).first?.id else {
+            return .failure(.noActiveWorkspace)
+        }
+        return .success(WorktreeTarget(key: key, areaID: areaID))
+    }
+
+    @MainActor
+    private static func resolveProjectAndWorktree(
+        project projectIdentifier: String?,
+        worktree worktreeIdentifier: String?,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) -> Result<(project: Project, worktree: Worktree), APIError> {
+        if let worktreeIdentifier, !worktreeIdentifier.isEmpty,
+           projectIdentifier?.isEmpty != false
+        {
+            return resolveWorktreeAcrossProjects(
+                worktreeIdentifier,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
+        }
+
+        guard let project = resolveProject(projectIdentifier, appState: appState, projectStore: projectStore) else {
+            return .failure(.projectNotFound(projectIdentifier ?? ""))
+        }
+        let worktrees = worktreeStore.list(for: project.id)
+        guard let worktreeIdentifier, !worktreeIdentifier.isEmpty else {
+            guard let worktree = worktreeStore.preferred(
+                for: project.id,
+                matching: appState.activeWorktreeID[project.id]
+            )
+            else {
+                return .failure(.worktreeNotFound(""))
+            }
+            return .success((project, worktree))
+        }
+        guard let worktree = findWorktree(worktreeIdentifier, in: worktrees) else {
+            return .failure(.worktreeNotFound(worktreeIdentifier))
+        }
+        return .success((project, worktree))
+    }
+
+    @MainActor
+    private static func resolveWorktreeAcrossProjects(
+        _ identifier: String,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore
+    ) -> Result<(project: Project, worktree: Worktree), APIError> {
+        if let activeProjectID = appState.activeProjectID,
+           let project = projectStore.projects.first(where: { $0.id == activeProjectID }),
+           let worktree = findWorktree(identifier, in: worktreeStore.list(for: project.id))
+        {
+            return .success((project, worktree))
+        }
+        let matches = projectStore.projects.compactMap { project -> (Project, Worktree)? in
+            guard let worktree = findWorktree(identifier, in: worktreeStore.list(for: project.id)) else { return nil }
+            return (project, worktree)
+        }
+        guard let match = matches.first else {
+            return .failure(.worktreeNotFound(identifier))
+        }
+        guard matches.count == 1 else {
+            return .failure(.invalidArguments(
+                "worktree '\(identifier)' is ambiguous across projects; pass --project to disambiguate"
+            ))
+        }
+        return .success(match)
     }
 }
 

--- a/Muxy/Services/Socket/SocketCommandHandler.swift
+++ b/Muxy/Services/Socket/SocketCommandHandler.swift
@@ -26,21 +26,21 @@ enum SocketCommandHandler {
 
         switch cmd {
         case "split-right":
-            let request = parseSplitRequest(parts: parts)
-            return serialize(MuxyAPI.Panes.split(
+            return handleSplit(
                 direction: .horizontal,
-                command: request.command,
-                fromPane: request.fromPane,
-                appState: appState
-            )) { $0.uuidString }
+                parts: parts,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
         case "split-down":
-            let request = parseSplitRequest(parts: parts)
-            return serialize(MuxyAPI.Panes.split(
+            return handleSplit(
                 direction: .vertical,
-                command: request.command,
-                fromPane: request.fromPane,
-                appState: appState
-            )) { $0.uuidString }
+                parts: parts,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore
+            )
         case "send":
             guard parts.count >= 3 else { return "error:usage send|paneID|text" }
             return await serialize(
@@ -155,28 +155,59 @@ enum SocketCommandHandler {
                 "ok\t\(result.count)"
             }
         case "list-tabs":
-            return serialize(MuxyAPI.Tabs.list(appState: appState)) { tabs in
-                tabs.map { tab in
-                    "\(tab.index)\t\(tab.id.uuidString)\t\(tab.kind.rawValue)\t\(tab.title)\t\(tab.isActive)"
-                }.joined(separator: "\n")
+            let parsed = parseTargetFlags(Array(parts.dropFirst()))
+            switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+            case let .failure(error):
+                return "error:\(error.message)"
+            case let .success(target):
+                return serialize(MuxyAPI.Tabs.list(appState: appState, target: target)) { tabs in
+                    tabs.map { tab in
+                        "\(tab.index)\t\(tab.id.uuidString)\t\(tab.kind.rawValue)\t\(tab.title)\t\(tab.isActive)"
+                    }.joined(separator: "\n")
+                }
             }
         case "switch-tab":
-            guard parts.count >= 2 else { return "error:usage switch-tab|index-or-id-or-title" }
-            return serialize(
-                MuxyAPI.Tabs.switchTo(
-                    identifier: parts.dropFirst().joined(separator: "|"),
-                    appState: appState
-                ),
-                ok: "ok"
-            )
+            let parsed = parseTargetFlags(Array(parts.dropFirst()))
+            guard !parsed.remaining.isEmpty else { return "error:usage switch-tab|index-or-id-or-title" }
+            switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+            case let .failure(error):
+                return "error:\(error.message)"
+            case let .success(target):
+                return serialize(
+                    MuxyAPI.Tabs.switchTo(
+                        identifier: parsed.remaining.joined(separator: "|"),
+                        appState: appState,
+                        target: target
+                    ),
+                    ok: "ok"
+                )
+            }
         case "new-tab":
-            return serialize(MuxyAPI.Tabs.new(appState: appState)) { newTabID in
-                newTabID?.uuidString ?? "ok"
+            let parsed = parseTargetFlags(Array(parts.dropFirst()))
+            switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+            case let .failure(error):
+                return "error:\(error.message)"
+            case let .success(target):
+                return serialize(MuxyAPI.Tabs.new(appState: appState, target: target)) { newTabID in
+                    newTabID?.uuidString ?? "ok"
+                }
             }
         case "next-tab":
-            return serialize(MuxyAPI.Tabs.next(appState: appState), ok: "ok")
+            let parsed = parseTargetFlags(Array(parts.dropFirst()))
+            switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+            case let .failure(error):
+                return "error:\(error.message)"
+            case let .success(target):
+                return serialize(MuxyAPI.Tabs.next(appState: appState, target: target), ok: "ok")
+            }
         case "previous-tab":
-            return serialize(MuxyAPI.Tabs.previous(appState: appState), ok: "ok")
+            let parsed = parseTargetFlags(Array(parts.dropFirst()))
+            switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+            case let .failure(error):
+                return "error:\(error.message)"
+            case let .success(target):
+                return serialize(MuxyAPI.Tabs.previous(appState: appState, target: target), ok: "ok")
+            }
         case "tab-rename":
             guard parts.count >= 2 else { return "error:usage tab-rename|<index-or-id-or-title>[|title]" }
             let title = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "|") : nil
@@ -255,11 +286,19 @@ enum SocketCommandHandler {
                 )
             )
         case "browser.open":
-            let split = parts.contains("--split")
-            let urlParts = trimTrailingEmptyFields(parts.dropFirst().filter { $0 != "--split" })
+            let parsed = parseTargetFlags(Array(parts.dropFirst()))
+            let split = parsed.remaining.contains("--split")
+            let urlParts = trimTrailingEmptyFields(parsed.remaining.filter { $0 != "--split" })
             let url = urlParts.isEmpty ? nil : urlParts.joined(separator: "|")
-            return serialize(MuxyAPI.Browser.open(url: url, split: split, appState: appState)) { tabID in
-                tabID.uuidString
+            switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+            case let .failure(error):
+                return "error:\(error.message)"
+            case let .success(target):
+                return serialize(
+                    MuxyAPI.Browser.open(url: url, split: split, appState: appState, target: target)
+                ) { tabID in
+                    tabID.uuidString
+                }
             }
         case "browser.navigate":
             guard parts.count >= 3 else { return "error:usage browser.navigate|<tab-id>|<url>" }
@@ -272,10 +311,20 @@ enum SocketCommandHandler {
                 ok: "ok"
             )
         case "browser.list":
-            let browserTabs = MuxyAPI.Browser.list(appState: appState, profileStore: browserProfileStore)
-            return browserTabs.map { tab in
-                "\(tab.id.uuidString)\t\(tab.title)\t\(tab.url ?? "")\t\(tab.profile)\t\(tab.isActive)"
-            }.joined(separator: "\n")
+            let parsed = parseTargetFlags(Array(parts.dropFirst()))
+            switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+            case let .failure(error):
+                return "error:\(error.message)"
+            case let .success(target):
+                let browserTabs = MuxyAPI.Browser.list(
+                    appState: appState,
+                    profileStore: browserProfileStore,
+                    target: target
+                )
+                return browserTabs.map { tab in
+                    "\(tab.id.uuidString)\t\(tab.title)\t\(tab.url ?? "")\t\(tab.profile)\t\(tab.isActive)"
+                }.joined(separator: "\n")
+            }
         case "browser.read":
             guard parts.count >= 2 else { return "error:usage browser.read|<tab-id>" }
             return await serialize(MuxyAPI.Browser.read(tabIDString: parts[1], appState: appState)) { content in
@@ -757,6 +806,78 @@ enum SocketCommandHandler {
             trimmed.removeLast()
         }
         return trimmed
+    }
+
+    @MainActor
+    private static func handleSplit(
+        direction: SplitDirection,
+        parts: [String],
+        appState: AppState,
+        projectStore: ProjectStore?,
+        worktreeStore: WorktreeStore?
+    ) -> String {
+        let parsed = parseTargetFlags(Array(parts.dropFirst()))
+        switch resolveTarget(parsed, appState: appState, projectStore: projectStore, worktreeStore: worktreeStore) {
+        case let .failure(error):
+            return "error:\(error.message)"
+        case let .success(target):
+            let request = parseSplitRequest(parts: [parts[0]] + parsed.remaining)
+            return serialize(MuxyAPI.Panes.split(
+                direction: direction,
+                command: request.command,
+                fromPane: request.fromPane,
+                appState: appState,
+                target: target
+            )) { $0.uuidString }
+        }
+    }
+
+    struct ParsedTarget {
+        let project: String?
+        let worktree: String?
+        let remaining: [String]
+    }
+
+    static func parseTargetFlags(_ parts: [String]) -> ParsedTarget {
+        var project: String?
+        var worktree: String?
+        var remaining: [String] = []
+        var index = 0
+        while index < parts.count {
+            switch parts[index] {
+            case "--project" where index + 1 < parts.count:
+                project = parts[index + 1]
+                index += 2
+            case "--worktree" where index + 1 < parts.count:
+                worktree = parts[index + 1]
+                index += 2
+            default:
+                remaining.append(parts[index])
+                index += 1
+            }
+        }
+        return ParsedTarget(project: project, worktree: worktree, remaining: remaining)
+    }
+
+    @MainActor
+    private static func resolveTarget(
+        _ parsed: ParsedTarget,
+        appState: AppState,
+        projectStore: ProjectStore?,
+        worktreeStore: WorktreeStore?
+    ) -> Result<MuxyAPI.WorktreeTarget?, APIError> {
+        let hasFlags = parsed.project?.isEmpty == false || parsed.worktree?.isEmpty == false
+        guard hasFlags else { return .success(nil) }
+        guard let projectStore, let worktreeStore else {
+            return .failure(.worktreeStoreUnavailable)
+        }
+        return MuxyAPI.resolveWorktreeTarget(
+            project: parsed.project,
+            worktree: parsed.worktree,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        )
     }
 
     static func requiredPermissions(command: String, parts: [String]) -> [ExtensionPermission] {

--- a/Muxy/Services/Socket/SocketCommandHandler.swift
+++ b/Muxy/Services/Socket/SocketCommandHandler.swift
@@ -884,7 +884,8 @@ enum SocketCommandHandler {
         }
         var permissions = MuxyAPI.Permissions.required(for: command).map { [$0] } ?? []
         guard command == "split-right" || command == "split-down" else { return permissions }
-        let splitRequest = parseSplitRequest(parts: parts)
+        let parsed = parseTargetFlags(Array(parts.dropFirst()))
+        let splitRequest = parseSplitRequest(parts: [command] + parsed.remaining)
         let trimmedCommand = splitRequest.command?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmedCommand?.isEmpty == false else { return permissions }
         permissions.append(.commandsExec)

--- a/Muxy/Services/Socket/SocketCommandHandler.swift
+++ b/Muxy/Services/Socket/SocketCommandHandler.swift
@@ -841,22 +841,19 @@ enum SocketCommandHandler {
     static func parseTargetFlags(_ parts: [String]) -> ParsedTarget {
         var project: String?
         var worktree: String?
-        var remaining: [String] = []
-        var index = 0
-        while index < parts.count {
-            switch parts[index] {
-            case "--project" where index + 1 < parts.count:
-                project = parts[index + 1]
-                index += 2
-            case "--worktree" where index + 1 < parts.count:
-                worktree = parts[index + 1]
-                index += 2
+        var end = parts.count
+        while end >= 2 {
+            switch parts[end - 2] {
+            case "--project":
+                project = parts[end - 1]
+            case "--worktree":
+                worktree = parts[end - 1]
             default:
-                remaining.append(parts[index])
-                index += 1
+                return ParsedTarget(project: project, worktree: worktree, remaining: Array(parts[0 ..< end]))
             }
+            end -= 2
         }
-        return ParsedTarget(project: project, worktree: worktree, remaining: remaining)
+        return ParsedTarget(project: project, worktree: worktree, remaining: Array(parts[0 ..< end]))
     }
 
     @MainActor

--- a/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
@@ -335,6 +335,14 @@ struct SocketCommandHandlerTests {
         #expect(parsed.remaining == ["2"])
     }
 
+    @Test("parseTargetFlags only consumes trailing flags, preserving flag-like values")
+    func parseTargetFlagsPreservesFlagLikeValues() {
+        let parsed = SocketCommandHandler.parseTargetFlags(["https://x.com/--project/p", "--worktree", "feature"])
+        #expect(parsed.project == nil)
+        #expect(parsed.worktree == "feature")
+        #expect(parsed.remaining == ["https://x.com/--project/p"])
+    }
+
     @Test("new-tab --worktree creates tab in target without switching active worktree")
     func newTabTargetsWorktree() async {
         let project = Project(name: "Test Project", path: testPath)
@@ -427,6 +435,31 @@ struct SocketCommandHandlerTests {
         #expect(appState.activeWorktreeID[project.id] == primary.id)
         let featureKey = WorktreeKey(projectID: project.id, worktreeID: feature.id)
         #expect(appState.areas(for: featureKey).first?.tabs.contains { $0.id == tabID } == true)
+    }
+
+    @Test("browser open --split --worktree opens the tab in the focused area, not the new split pane")
+    func browserOpenSplitTargetsFocusedArea() async throws {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+
+        let result = await SocketCommandHandler.handleRequest(
+            "browser.open|https://example.com|--split|--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        let tabID = try #require(UUID(uuidString: result))
+        let featureKey = WorktreeKey(projectID: project.id, worktreeID: feature.id)
+        let areas = appState.areas(for: featureKey)
+        #expect(areas.count == 2)
+        let hostingArea = try #require(areas.first { $0.tabs.contains { $0.id == tabID } })
+        #expect(hostingArea.tabs.contains { $0.content.pane != nil })
+        let splitArea = try #require(areas.first { $0.id != hostingArea.id })
+        #expect(splitArea.tabs.allSatisfy { $0.content.browserState == nil })
     }
 
     @Test("split-right --worktree splits the target worktree")

--- a/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
@@ -327,6 +327,171 @@ struct SocketCommandHandlerTests {
         #expect(browserState(tabID: tabID, appState: appState)?.url?.absoluteString == BrowserHomePage.blankURLString)
     }
 
+    @Test("parseTargetFlags extracts project and worktree from remaining args")
+    func parseTargetFlagsExtractsFlags() {
+        let parsed = SocketCommandHandler.parseTargetFlags(["2", "--worktree", "feature", "--project", "App"])
+        #expect(parsed.project == "App")
+        #expect(parsed.worktree == "feature")
+        #expect(parsed.remaining == ["2"])
+    }
+
+    @Test("new-tab --worktree creates tab in target without switching active worktree")
+    func newTabTargetsWorktree() async {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+
+        let result = await SocketCommandHandler.handleRequest(
+            "new-tab|--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(UUID(uuidString: result) != nil)
+        #expect(appState.activeWorktreeID[project.id] == primary.id)
+        let featureKey = WorktreeKey(projectID: project.id, worktreeID: feature.id)
+        #expect(appState.areas(for: featureKey).first?.tabs.contains { $0.id.uuidString == result } == true)
+    }
+
+    @Test("list-tabs --worktree lists only the target worktree's tabs")
+    func listTabsTargetsWorktree() async {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+
+        _ = await SocketCommandHandler.handleRequest(
+            "new-tab|--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+        let featureResult = await SocketCommandHandler.handleRequest(
+            "list-tabs|--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+        let activeResult = await SocketCommandHandler.handleRequest("list-tabs", appState: appState)
+
+        let featureKey = WorktreeKey(projectID: project.id, worktreeID: feature.id)
+        #expect(featureResult.split(separator: "\n").count == appState.areas(for: featureKey).flatMap(\.tabs).count)
+        #expect(activeResult.split(separator: "\n").count == 1)
+    }
+
+    @Test("switch-tab --worktree selects within target without switching active worktree")
+    func switchTabTargetsWorktree() async {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+
+        _ = await SocketCommandHandler.handleRequest(
+            "new-tab|--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+        let result = await SocketCommandHandler.handleRequest(
+            "switch-tab|0|--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(result == "ok")
+        #expect(appState.activeWorktreeID[project.id] == primary.id)
+    }
+
+    @Test("browser open --worktree creates browser tab in target without switching active worktree")
+    func browserOpenTargetsWorktree() async throws {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+
+        let result = await SocketCommandHandler.handleRequest(
+            "browser.open|https://example.com|--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        let tabID = try #require(UUID(uuidString: result))
+        #expect(appState.activeWorktreeID[project.id] == primary.id)
+        let featureKey = WorktreeKey(projectID: project.id, worktreeID: feature.id)
+        #expect(appState.areas(for: featureKey).first?.tabs.contains { $0.id == tabID } == true)
+    }
+
+    @Test("split-right --worktree splits the target worktree")
+    func splitTargetsWorktree() async {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+
+        let result = await SocketCommandHandler.handleRequest(
+            "split-right|||--worktree|feature",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(UUID(uuidString: result) != nil)
+        #expect(appState.activeWorktreeID[project.id] == primary.id)
+        let featureKey = WorktreeKey(projectID: project.id, worktreeID: feature.id)
+        #expect(appState.areas(for: featureKey).count == 2)
+    }
+
+    @Test("new-tab --worktree reports unknown worktree")
+    func newTabUnknownWorktree() async {
+        let project = Project(name: "Test Project", path: testPath)
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
+        let stores = makeStores(projects: [project], worktrees: [project.id: [primary]])
+
+        let result = await SocketCommandHandler.handleRequest(
+            "new-tab|--worktree|missing",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(result.hasPrefix("error:worktree not found"))
+    }
+
+    @Test("new-tab --project targets the project's preferred worktree")
+    func newTabTargetsProject() async {
+        let project = Project(name: "Other", path: "/tmp/other")
+        let other = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let active = Project(name: "Active", path: testPath)
+        let activeWorktree = Worktree(name: active.name, path: active.path, isPrimary: true)
+        let appState = makeAppState(projectID: active.id, worktreeID: activeWorktree.id)
+        let stores = makeStores(
+            projects: [active, project],
+            worktrees: [active.id: [activeWorktree], project.id: [other]]
+        )
+
+        let result = await SocketCommandHandler.handleRequest(
+            "new-tab|--project|Other",
+            appState: appState,
+            projectStore: stores.projectStore,
+            worktreeStore: stores.worktreeStore
+        )
+
+        #expect(UUID(uuidString: result) != nil)
+        #expect(appState.activeProjectID == active.id)
+        let otherKey = WorktreeKey(projectID: project.id, worktreeID: other.id)
+        #expect(appState.areas(for: otherKey).first?.tabs.contains { $0.id.uuidString == result } == true)
+    }
+
     @Test("direct tabs.open requires an identified extension")
     func directTabsOpenRequiresIdentify() async {
         let appState = makeAppState()

--- a/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
@@ -62,10 +62,15 @@ struct SocketCommandHandlerTests {
             command: "split-down",
             parts: ["split-down", "", "   "]
         )
+        let targetedSplit = SocketCommandHandler.requiredPermissions(
+            command: "split-right",
+            parts: ["split-right", "", "", "--worktree", "feature"]
+        )
 
         #expect(plainSplit == [.panesWrite])
         #expect(commandSplit == [.panesWrite, .commandsExec])
         #expect(whitespaceCommandSplit == [.panesWrite])
+        #expect(targetedSplit == [.panesWrite])
     }
 
     @Test("split fails without active project")
@@ -437,8 +442,8 @@ struct SocketCommandHandlerTests {
         #expect(appState.areas(for: featureKey).first?.tabs.contains { $0.id == tabID } == true)
     }
 
-    @Test("browser open --split --worktree opens the tab in the focused area, not the new split pane")
-    func browserOpenSplitTargetsFocusedArea() async throws {
+    @Test("browser open --split --worktree opens the tab in the new split area")
+    func browserOpenSplitTargetsNewArea() async throws {
         let project = Project(name: "Test Project", path: testPath)
         let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
         let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
@@ -457,21 +462,22 @@ struct SocketCommandHandlerTests {
         let areas = appState.areas(for: featureKey)
         #expect(areas.count == 2)
         let hostingArea = try #require(areas.first { $0.tabs.contains { $0.id == tabID } })
+        #expect(hostingArea.id == appState.focusedAreaID[featureKey])
         #expect(hostingArea.tabs.contains { $0.content.pane != nil })
-        let splitArea = try #require(areas.first { $0.id != hostingArea.id })
-        #expect(splitArea.tabs.allSatisfy { $0.content.browserState == nil })
     }
 
     @Test("split-right --worktree splits the target worktree")
-    func splitTargetsWorktree() async {
+    func splitTargetsWorktreeInsteadOfCallingPane() async throws {
         let project = Project(name: "Test Project", path: testPath)
         let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
         let feature = Worktree(name: "Feature", path: "/tmp/feature", branch: "feature", isPrimary: false)
         let appState = makeAppState(projectID: project.id, worktreeID: primary.id)
         let stores = makeStores(projects: [project], worktrees: [project.id: [primary, feature]])
+        let primaryKey = WorktreeKey(projectID: project.id, worktreeID: primary.id)
+        let primaryPaneID = try #require(appState.areas(for: primaryKey).first?.tabs.first?.content.pane?.id)
 
         let result = await SocketCommandHandler.handleRequest(
-            "split-right|||--worktree|feature",
+            "split-right|\(primaryPaneID.uuidString)||--worktree|feature",
             appState: appState,
             projectStore: stores.projectStore,
             worktreeStore: stores.worktreeStore
@@ -480,6 +486,7 @@ struct SocketCommandHandlerTests {
         #expect(UUID(uuidString: result) != nil)
         #expect(appState.activeWorktreeID[project.id] == primary.id)
         let featureKey = WorktreeKey(projectID: project.id, worktreeID: feature.id)
+        #expect(appState.areas(for: primaryKey).count == 1)
         #expect(appState.areas(for: featureKey).count == 2)
     }
 

--- a/docs/features/muxy-cli.md
+++ b/docs/features/muxy-cli.md
@@ -166,6 +166,8 @@ Split from a different pane with `--from`:
 muxy split-right --from "$PANE" "npm test"
 ```
 
+`split-right` and `split-down` also accept `--project` and `--worktree` to split a pane in another worktree's workspace without leaving your current view. See [Targeting a project or worktree](#targeting-a-project-or-worktree).
+
 ### List panes
 
 ```bash
@@ -255,6 +257,8 @@ Output is tab-separated:
 <index>  <tab-id>  <kind>  <title>  <active>
 ```
 
+Add `--project` or `--worktree` to list the tabs of another worktree. See [Targeting a project or worktree](#targeting-a-project-or-worktree).
+
 ### Switch and create tabs
 
 Switch tabs by index, ID, or title:
@@ -270,11 +274,36 @@ Create a new terminal tab:
 muxy new-tab
 ```
 
+`new-tab`, `switch-tab`, and the navigation commands take `--project` and `--worktree` to act on another worktree; `new-tab` returns the new tab's ID so you can address it later. See [Targeting a project or worktree](#targeting-a-project-or-worktree).
+
 Move through tabs:
 
 ```bash
 muxy next-tab
 muxy previous-tab
+```
+
+### Targeting a project or worktree
+
+`new-tab`, `list-tabs`, `switch-tab`, `next-tab`, `previous-tab`, `split-right`, `split-down`, `browser open`, and `browser list` accept two optional flags to choose where the action runs:
+
+- `--project <name|id|path>` — target a specific project
+- `--worktree <name|id|branch>` — target a specific worktree
+
+Resolution rules (both flags are optional):
+
+- Neither flag: acts on the active worktree, exactly as before.
+- `--worktree` only: resolves the worktree in the active project; if it is not there, Muxy searches all projects for a unique match by name, branch, or ID. If the match is ambiguous across projects, the command errors — pass `--project` to disambiguate.
+- `--project` only: targets that project's active worktree.
+- Both: targets the worktree in the given project explicitly.
+
+Targeting a worktree does not move or switch your visible workspace. The action runs in the target worktree's workspace in the background, even when it belongs to a different project than the one you are looking at, and the created tab or browser tab is addressable by its returned ID. To actually move your view, run `switch-project` or `switch-worktree`. This keeps your focus where you expect it.
+
+```bash
+muxy new-tab --worktree feature/login
+muxy list-tabs --project "My App" --worktree main
+muxy browser open localhost:3000 --worktree feature/login
+muxy split-right --worktree feature/login npm test
 ```
 
 ## Browser control
@@ -290,6 +319,8 @@ muxy browser read "$TAB"
 muxy browser navigate "$TAB" "https://muxy.app"
 muxy browser close "$TAB"
 ```
+
+`browser open` and `browser list` accept `--project` and `--worktree` to open or list browser tabs in another worktree's workspace. The opened tab's ID still comes back, so you can read or automate it without switching views. See [Targeting a project or worktree](#targeting-a-project-or-worktree).
 
 Automate the page:
 

--- a/docs/features/muxy-cli.md
+++ b/docs/features/muxy-cli.md
@@ -303,7 +303,7 @@ Targeting a worktree does not move or switch your visible workspace. The action 
 muxy new-tab --worktree feature/login
 muxy list-tabs --project "My App" --worktree main
 muxy browser open localhost:3000 --worktree feature/login
-muxy split-right --worktree feature/login npm test
+muxy split-right npm test --worktree feature/login
 ```
 
 ## Browser control


### PR DESCRIPTION
Adds optional `--project`/`--worktree` flags to `new-tab`, `list-tabs`, `switch-tab`, `next-tab`, `previous-tab`, `split-right`, `split-down`, `browser open` and `browser list` so actions can run against a specific worktree.
Targeting never moves the user's visible workspace — the action happens in the target's background workspace; omitting the flags keeps today's active-worktree behavior.
Verified on a live build across worktrees/projects; docs, skill and tests updated (all 1880 pass).