### PR TITLE
Add shortcut to toggle app layout

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -318,6 +318,12 @@ struct MuxyCommands: Commands {
             }
             .shortcut(for: .toggleSidebar, store: keyBindings)
 
+            Button("Toggle App Layout") {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.toggleAppLayout)
+            }
+            .shortcut(for: .toggleAppLayout, store: keyBindings)
+
             Button("Toggle Rich Input") {
                 guard isMainWindowFocused else { return }
                 performShortcutAction(.toggleRichInput)

--- a/Muxy/Models/Keyboard/KeyBinding.swift
+++ b/Muxy/Models/Keyboard/KeyBinding.swift
@@ -60,6 +60,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case terminalOmniboxWorkspaces
     case terminalOmniboxCommands
     case toggleSidebar
+    case toggleAppLayout
     case navigateBack
     case navigateForward
     case toggleMaximizePane
@@ -120,6 +121,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .terminalOmniboxWorkspaces,
         .terminalOmniboxCommands,
         .toggleSidebar,
+        .toggleAppLayout,
         .navigateBack,
         .navigateForward,
         .toggleMaximizePane,
@@ -208,6 +210,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
                 scope: .mainWindow
             )
         case .toggleSidebar: ShortcutMetadata(displayName: "Toggle Sidebar", category: "App", scope: .mainWindow)
+        case .toggleAppLayout: ShortcutMetadata(displayName: "Toggle App Layout", category: "App", scope: .mainWindow)
         case .navigateBack: ShortcutMetadata(displayName: "Navigate Back", category: "Navigation", scope: .mainWindow)
         case .navigateForward: ShortcutMetadata(displayName: "Navigate Forward", category: "Navigation", scope: .mainWindow)
         case .toggleVoiceRecording: ShortcutMetadata(
@@ -357,6 +360,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .terminalOmniboxWorkspaces, combo: KeyCombo(key: "s", command: true, option: true)),
         Self(action: .terminalOmniboxCommands, combo: KeyCombo(key: "p", command: true, shift: true)),
         Self(action: .toggleSidebar, combo: KeyCombo(key: "b", command: true)),
+        Self(action: .toggleAppLayout, combo: KeyCombo(key: "l", command: true, shift: true)),
         Self(action: .navigateBack, combo: KeyCombo(key: KeyCombo.leftArrowKey, command: true, control: true)),
         Self(action: .navigateForward, combo: KeyCombo(key: KeyCombo.rightArrowKey, command: true, control: true)),
         Self(action: .toggleMaximizePane, combo: KeyCombo(key: KeyCombo.returnKey, command: true, option: true)),

--- a/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
@@ -241,6 +241,9 @@ struct ShortcutActionDispatcher {
         case .toggleSidebar:
             notificationCenter.post(name: .toggleSidebar, object: nil)
             return true
+        case .toggleAppLayout:
+            AppLayoutStore.shared.toggle()
+            return true
         case .toggleExtensionConsole:
             notificationCenter.post(name: .toggleExtensionConsole, object: nil)
             return true

--- a/Tests/MuxyTests/Models/Keyboard/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/Keyboard/KeyBindingTests.swift
@@ -133,6 +133,12 @@ struct KeyBindingTests {
         #expect(combos[.refreshWorktrees] == KeyCombo(key: "r", command: true, option: true))
     }
 
+    @Test("Toggle App Layout uses Cmd+Shift+L by default")
+    func defaultsIncludesToggleAppLayoutShortcut() {
+        let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
+        #expect(combos[.toggleAppLayout] == KeyCombo(key: "l", command: true, shift: true))
+    }
+
     @Test("KeyBinding Codable round-trip")
     func codableRoundTrip() throws {
         let binding = KeyBinding(

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -60,6 +60,7 @@ Mouse side buttons (3 / 4) and three‑finger horizontal trackpad swipes also na
 | --- | --- |
 | Open Project… | `Cmd+O` |
 | Toggle Sidebar | `Cmd+B` |
+| Toggle App Layout | `Cmd+Shift+L` |
 | Theme Picker | `Cmd+Shift+K` |
 | Reload Configuration | `Cmd+Shift+R` |
 | Toggle Full Screen | `Cmd+Ctrl+F` |


### PR DESCRIPTION
Adds a rebindable keyboard shortcut (`Cmd+Shift+L`) to toggle between tab-focused and project-focused layouts.

Wired through the existing keybinding system, menu bar, and Settings; documented and tested.