### PR TITLE
Fix stuck AI completion indicator on tabs

### DIFF
--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -629,6 +629,7 @@ final class AppState {
             if let key = activeWorktreeKey(for: projectID),
                maximizedAreaID[key] != nil
             {
+                clearActivePaneIndicators()
                 return WorkspaceSideEffects()
             }
         default:
@@ -639,6 +640,7 @@ final class AppState {
            let key = activeWorktreeKey(for: projectID),
            focusedAreaID[key] == areaID
         {
+            clearActivePaneIndicators()
             return WorkspaceSideEffects()
         }
 
@@ -649,6 +651,7 @@ final class AppState {
            area.activeTabID == tabID,
            focusedAreaID[key] == areaID
         {
+            clearActivePaneIndicators()
             return WorkspaceSideEffects()
         }
 
@@ -705,6 +708,14 @@ final class AppState {
         recordCurrentNavigationEntry()
         recordActiveWorktreeUsage()
 
+        clearActivePaneIndicators()
+
+        saveWorkspaces()
+        saveSelection()
+        return effects
+    }
+
+    private func clearActivePaneIndicators() {
         if let activeTabID = NotificationNavigator.activeTabID(appState: self) {
             NotificationStore.shared.markAsRead(tabID: activeTabID)
         }
@@ -712,10 +723,6 @@ final class AppState {
         if let activePaneID = NotificationNavigator.activePaneID(appState: self) {
             TerminalProgressStore.shared.clearCompletion(for: activePaneID)
         }
-
-        saveWorkspaces()
-        saveSelection()
-        return effects
     }
 
     func goBack() {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -301,13 +301,8 @@ private struct TabFocusedTabRow: View {
         if agentStatus == .waiting {
             return MuxyTheme.warning
         }
-        if !active {
-            if hasUnread || hasCompletionPending {
-                return MuxyTheme.accent
-            }
-            if agentStatus == .idle {
-                return MuxyTheme.diffAddFg
-            }
+        if !active, hasUnread || hasCompletionPending {
+            return MuxyTheme.accent
         }
         return nil
     }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -405,13 +405,8 @@ private struct TabCell: View {
         if tab.agentStatus == .waiting {
             return MuxyTheme.warning
         }
-        if !active {
-            if hasUnread || hasCompletionPending {
-                return MuxyTheme.accent
-            }
-            if tab.agentStatus == .idle {
-                return MuxyTheme.diffAddFg
-            }
+        if !active, hasUnread || hasCompletionPending {
+            return MuxyTheme.accent
         }
         return nil
     }


### PR DESCRIPTION
The completion dot now clears whenever you visit the active pane, including already-focused/selected paths that previously skipped the cleanup.

Drops the persistent green idle-agent dot that kept reappearing on inactive tabs; keeps the accent completion dot and amber waiting dot.

Verified manually: completion dot clears on visit and no longer returns when switching away.