### PR TITLE
Add sidebar to extension manifest schema

### DIFF
--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -75,6 +75,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/popover" }
         },
+        "sidebar": { "$ref": "#/$defs/sidebar" },
         "commands": {
           "type": "array",
           "items": { "$ref": "#/$defs/command" }
@@ -258,6 +259,19 @@
         "entry": { "type": "string", "minLength": 1 },
         "width": { "type": "number", "exclusiveMinimum": 0 },
         "height": { "type": "number", "exclusiveMinimum": 0 },
+        "defaultData": {}
+      }
+    },
+    "sidebar": {
+      "description": "A single full-height webview that replaces Muxy's built-in left sidebar when the user selects it in Settings → Sidebar. At most one per extension.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "entry"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "icon": { "$ref": "#/$defs/icon" },
+        "entry": { "type": "string", "minLength": 1 },
         "defaultData": {}
       }
     },


### PR DESCRIPTION
## Summary

The app and docs ship the `muxy.sidebar` field, but the schema mirror omitted it — so the marketplace validator (`validate.mjs`) rejected every sidebar extension with `manifest/muxy must NOT have additional properties`. This adds the missing key so sidebar extensions can pass validation and be published.

## Changes

- Add `sidebar` to `muxy.properties` and a `$defs/sidebar` definition in `docs/extensions/schema/manifest.schema.json` — `id`/`entry` required, `title`/`icon`/`defaultData` optional — mirroring `ExtensionSidebar` in `Extension.swift` and the field table in `docs/extensions/sidebars.md`.

## Testing

Schema-only (JSON) change; no Swift touched. Verified with the extensions repo's `ajv` and the real `validate.mjs`: the old schema fails with `/muxy must NOT have additional properties`; the new schema accepts every documented sidebar variant (minimal, full, `icon` as string / `{symbol}` / `{svg}`) and still rejects malformed ones (missing/empty `entry`, empty `id`, unknown fields, array-instead-of-object) — matching the app's load-time validation.

- [ ] `scripts/checks.sh` passes — N/A, no Swift changed
- [ ] Tested manually on macOS — N/A; validated via `ajv` + `validate.mjs`

## Screenshots

N/A — manifest schema (JSON) change, no UI.
