### PR TITLE
Fix extension modal freeze from in-process JS lock deadlock

### DIFF
--- a/Muxy/Services/Extensions/ExtensionScriptRunner.swift
+++ b/Muxy/Services/Extensions/ExtensionScriptRunner.swift
@@ -5,6 +5,84 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "ExtensionScriptRunner")
 
+final class JSExecutor: @unchecked Sendable {
+    private let thread: Thread
+    private let ready = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var runLoop: CFRunLoop?
+    private var stopped = false
+
+    init(label: String) {
+        let box = ThreadStartBox()
+        thread = Thread {
+            guard let runLoop = CFRunLoopGetCurrent() else { return }
+            box.publish(runLoop)
+            var sourceContext = CFRunLoopSourceContext()
+            let source = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &sourceContext)
+            CFRunLoopAddSource(runLoop, source, .commonModes)
+            while !box.shouldStop() {
+                CFRunLoopRunInMode(.defaultMode, 1_000_000_000, false)
+            }
+        }
+        thread.name = label
+        thread.stackSize = 4 << 20
+        box.configure(executor: self)
+        thread.start()
+        ready.wait()
+    }
+
+    fileprivate func markReady(_ loop: CFRunLoop) {
+        lock.lock()
+        runLoop = loop
+        lock.unlock()
+        ready.signal()
+    }
+
+    fileprivate func isStopped() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+
+    func stop() {
+        lock.lock()
+        stopped = true
+        let loop = runLoop
+        lock.unlock()
+        if let loop {
+            CFRunLoopWakeUp(loop)
+        }
+    }
+
+    func async(_ work: @escaping @Sendable () -> Void) {
+        lock.lock()
+        let loop = runLoop
+        let alreadyStopped = stopped
+        lock.unlock()
+        guard let loop, !alreadyStopped else { return }
+        CFRunLoopPerformBlock(loop, CFRunLoopMode.defaultMode.rawValue, work)
+        CFRunLoopWakeUp(loop)
+    }
+}
+
+private final class ThreadStartBox: @unchecked Sendable {
+    private weak var executor: JSExecutor?
+
+    func configure(executor: JSExecutor) {
+        self.executor = executor
+    }
+
+    func onStart() {}
+
+    func publish(_ loop: CFRunLoop) {
+        executor?.markReady(loop)
+    }
+
+    func shouldStop() -> Bool {
+        executor?.isStopped() ?? true
+    }
+}
+
 @MainActor
 final class ExtensionScriptRunner {
     static let shared = ExtensionScriptRunner()
@@ -23,15 +101,15 @@ final class ExtensionScriptRunner {
 
     private final class ContextHandle {
         let context: JSContext
-        let queue: DispatchQueue
+        let executor: JSExecutor
         let cancelFlag: ScriptCancelFlag
         var bridge: AnyObject?
         var pendingModals = 0
         var scriptFinished = false
 
-        init(context: JSContext, queue: DispatchQueue, cancelFlag: ScriptCancelFlag) {
+        init(context: JSContext, executor: JSExecutor, cancelFlag: ScriptCancelFlag) {
             self.context = context
-            self.queue = queue
+            self.executor = executor
             self.cancelFlag = cancelFlag
         }
 
@@ -45,6 +123,7 @@ final class ExtensionScriptRunner {
     func evict(extensionID: String) {
         if let handle = contexts.removeValue(forKey: extensionID) {
             handle.cancelFlag.cancel()
+            handle.executor.stop()
         }
         ExtensionModalService.shared.dismiss(extensionID: extensionID)
         ExtensionDialogService.cancel(extensionID: extensionID)
@@ -75,13 +154,12 @@ final class ExtensionScriptRunner {
             cancelFlag: handle.cancelFlag
         )
         handle.bridge = bridge
-        bridge.deliveryQueue = handle.queue
+        bridge.executor = handle.executor
         bridge.modalPendingChanged = { [weak self, weak handle] delta in
             guard let self, let handle else { return }
             handle.pendingModals += delta
             self.evictIfIdle(extensionID: extensionID, handle: handle)
         }
-        bridge.install(into: handle.context)
 
         defer {
             handle.scriptFinished = true
@@ -89,15 +167,20 @@ final class ExtensionScriptRunner {
         }
 
         let contextBox = JSContextBox(handle.context)
+        let bridgeBox = ScriptBridgeBox(bridge)
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            handle.queue.async {
+            handle.executor.async {
                 let context = contextBox.context
+                bridgeBox.bridge.install(into: context)
                 let capture = ExceptionCapture()
                 context.exceptionHandler = { _, exception in
                     capture.message = exception?.toString() ?? "unknown error"
                 }
                 _ = context.evaluateScript(source, withSourceURL: scriptURL)
-                context.exceptionHandler = nil
+                context.exceptionHandler = { _, exception in
+                    let message = exception?.toString() ?? "unknown error"
+                    ExtensionLogStore.shared.append(extensionID: extensionID, line: "[err] \(message)")
+                }
                 if let message = capture.message {
                     logger.error("Extension \(extensionID) script error: \(message)")
                     continuation.resume(throwing: RunError.evaluationFailed(message))
@@ -119,13 +202,32 @@ final class ExtensionScriptRunner {
 
     private func makeContextHandle(for extensionID: String) throws -> ContextHandle {
         evict(extensionID: extensionID)
-        let queue = DispatchQueue(label: "app.muxy.extension.\(extensionID)")
-        guard let context = JSContext() else {
+        let executor = JSExecutor(label: "app.muxy.extension.\(extensionID)")
+        let contextBox = MakeContextBox()
+        let ready = DispatchSemaphore(value: 0)
+        executor.async {
+            contextBox.context = JSContext()
+            ready.signal()
+        }
+        ready.wait()
+        guard let context = contextBox.context else {
+            executor.stop()
             throw RunError.evaluationFailed("Failed to create JSContext")
         }
-        let handle = ContextHandle(context: context, queue: queue, cancelFlag: ScriptCancelFlag())
+        let handle = ContextHandle(context: context, executor: executor, cancelFlag: ScriptCancelFlag())
         contexts[extensionID] = handle
         return handle
+    }
+}
+
+private final class MakeContextBox: @unchecked Sendable {
+    var context: JSContext?
+}
+
+private struct ScriptBridgeBox: @unchecked Sendable {
+    let bridge: ScriptBridge
+    init(_ bridge: ScriptBridge) {
+        self.bridge = bridge
     }
 }
 
@@ -187,7 +289,6 @@ private final class ScriptBridge: @unchecked Sendable {
 
     private weak var context: JSContext?
 
-    @MainActor
     func install(into context: JSContext) {
         self.context = context
         let dispatcher: @convention(block) (String, JSValue?) -> Any = { [weak self] verb, args in
@@ -248,7 +349,7 @@ private final class ScriptBridge: @unchecked Sendable {
         item: ExtensionModalService.Item?,
         completion: ModalDeliveryCompletion
     ) {
-        guard let queue = deliveryQueue, let context else {
+        guard let executor, let context else {
             completion.finish()
             return
         }
@@ -261,7 +362,7 @@ private final class ScriptBridge: @unchecked Sendable {
             payload = NSNull()
         }
         let delivery = ModalDeliveryBox(context: context, requestID: requestID, payload: payload)
-        queue.async {
+        executor.async {
             let deliver = delivery.context.objectForKeyedSubscript("__muxiDeliverModalResult")
             deliver?.call(withArguments: [delivery.requestID, delivery.payload])
             completion.finish()
@@ -282,7 +383,9 @@ private final class ScriptBridge: @unchecked Sendable {
         query: String,
         options: ExtensionModalSearchOptions
     ) {
-        guard let queue = deliveryQueue, let context else { return }
+        guard let executor, let context else { return }
+        modalQueryStamp.advance(requestID: requestID, queryID: queryID)
+        let stamp = modalQueryStamp
         let delivery = ModalQueryDeliveryBox(
             context: context,
             requestID: requestID,
@@ -290,14 +393,16 @@ private final class ScriptBridge: @unchecked Sendable {
             query: query,
             options: options.payload
         )
-        queue.async {
+        executor.async {
+            guard stamp.isCurrent(requestID: delivery.requestID, queryID: delivery.queryID) else { return }
             let deliver = delivery.context.objectForKeyedSubscript("__muxyDeliverModalQuery")
             deliver?.call(withArguments: [delivery.requestID, delivery.queryID, delivery.query, delivery.options])
         }
     }
 
-    var deliveryQueue: DispatchQueue?
+    var executor: JSExecutor?
     var modalPendingChanged: ((Int) -> Void)?
+    private let modalQueryStamp = ModalQueryStamp()
 
     private static func errorObject(_ message: String) -> [String: Any] {
         ["ok": false, "error": message]
@@ -315,6 +420,25 @@ private final class ScriptBridge: @unchecked Sendable {
                 stores: stores
             )
         )
+    }
+}
+
+private final class ModalQueryStamp: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requestID: String?
+    private var queryID = 0
+
+    func advance(requestID: String, queryID: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.requestID = requestID
+        self.queryID = queryID
+    }
+
+    func isCurrent(requestID: String, queryID: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestID == self.requestID && queryID == self.queryID
     }
 }
 

--- a/Muxy/Services/Extensions/ExtensionScriptRunner.swift
+++ b/Muxy/Services/Extensions/ExtensionScriptRunner.swift
@@ -15,7 +15,10 @@ final class JSExecutor: @unchecked Sendable {
     init(label: String) {
         let box = ThreadStartBox()
         thread = Thread {
-            guard let runLoop = CFRunLoopGetCurrent() else { return }
+            guard let runLoop = CFRunLoopGetCurrent() else {
+                box.abandon()
+                return
+            }
             box.publish(runLoop)
             var sourceContext = CFRunLoopSourceContext()
             let source = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &sourceContext)
@@ -31,7 +34,7 @@ final class JSExecutor: @unchecked Sendable {
         ready.wait()
     }
 
-    fileprivate func markReady(_ loop: CFRunLoop) {
+    fileprivate func markReady(_ loop: CFRunLoop?) {
         lock.lock()
         runLoop = loop
         lock.unlock()
@@ -50,18 +53,21 @@ final class JSExecutor: @unchecked Sendable {
         let loop = runLoop
         lock.unlock()
         if let loop {
+            CFRunLoopStop(loop)
             CFRunLoopWakeUp(loop)
         }
     }
 
-    func async(_ work: @escaping @Sendable () -> Void) {
+    @discardableResult
+    func async(_ work: @escaping @Sendable () -> Void) -> Bool {
         lock.lock()
         let loop = runLoop
         let alreadyStopped = stopped
         lock.unlock()
-        guard let loop, !alreadyStopped else { return }
+        guard let loop, !alreadyStopped else { return false }
         CFRunLoopPerformBlock(loop, CFRunLoopMode.defaultMode.rawValue, work)
         CFRunLoopWakeUp(loop)
+        return true
     }
 }
 
@@ -72,10 +78,12 @@ private final class ThreadStartBox: @unchecked Sendable {
         self.executor = executor
     }
 
-    func onStart() {}
-
     func publish(_ loop: CFRunLoop) {
         executor?.markReady(loop)
+    }
+
+    func abandon() {
+        executor?.markReady(nil)
     }
 
     func shouldStop() -> Bool {
@@ -362,9 +370,12 @@ private final class ScriptBridge: @unchecked Sendable {
             payload = NSNull()
         }
         let delivery = ModalDeliveryBox(context: context, requestID: requestID, payload: payload)
-        executor.async {
+        let enqueued = executor.async {
             let deliver = delivery.context.objectForKeyedSubscript("__muxiDeliverModalResult")
             deliver?.call(withArguments: [delivery.requestID, delivery.payload])
+            completion.finish()
+        }
+        if !enqueued {
             completion.finish()
         }
     }

--- a/Muxy/Views/Components/Overlays/PaletteOverlay.swift
+++ b/Muxy/Views/Components/Overlays/PaletteOverlay.swift
@@ -36,6 +36,7 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
     @State private var isSearchFieldFocused = false
     @State private var keyMonitor: Any?
     @State private var paletteWindow: NSWindow?
+    @State private var loadMoreGate = LoadMoreGate()
 
     var body: some View {
         ZStack {
@@ -170,7 +171,7 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
                                     .onTapGesture { onSelect(item) }
                                     .id(item.id)
                                     .onAppear {
-                                        if index >= results.count - 1 { loadMore() }
+                                        if index >= results.count - 1 { scheduleLoadMore() }
                                     }
                             }
                         }
@@ -249,6 +250,15 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
             highlightedIndex = result.items.isEmpty ? nil : 0
         } else if let index = highlightedIndex {
             highlightedIndex = min(index, max(0, result.items.count - 1))
+        }
+    }
+
+    private func scheduleLoadMore() {
+        guard hasMore, !isSearching, !loadMoreGate.isScheduled else { return }
+        loadMoreGate.isScheduled = true
+        Task { @MainActor in
+            loadMoreGate.isScheduled = false
+            loadMore()
         }
     }
 
@@ -353,6 +363,10 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
             return false
         }
     }
+}
+
+private final class LoadMoreGate {
+    var isScheduled = false
 }
 
 enum PaletteOverlayKeyAction: Equatable {
@@ -474,15 +488,25 @@ struct PaletteSearchField: NSViewRepresentable {
             field.onEscape = onEscape
             field.onControlKey = onControlKey
         }
-        onWindowChange(nsView.window)
+        context.coordinator.notifyWindowChange(nsView.window)
     }
 
     @MainActor
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: PaletteSearchField
+        private weak var lastNotifiedWindow: NSWindow?
 
         init(parent: PaletteSearchField) {
             self.parent = parent
+        }
+
+        func notifyWindowChange(_ window: NSWindow?) {
+            guard window !== lastNotifiedWindow else { return }
+            lastNotifiedWindow = window
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.parent.onWindowChange(window)
+            }
         }
 
         func controlTextDidChange(_ obj: Notification) {
@@ -501,7 +525,7 @@ struct PaletteSearchField: NSViewRepresentable {
 
         func controlTextDidBeginEditing(_ obj: Notification) {
             parent.onFocusChange(true)
-            parent.onWindowChange((obj.object as? NSControl)?.window)
+            notifyWindowChange((obj.object as? NSControl)?.window)
         }
 
         func controlTextDidEndEditing(_: Notification) {

--- a/MuxyShared/ExtensionBridgeJS.swift
+++ b/MuxyShared/ExtensionBridgeJS.swift
@@ -53,24 +53,28 @@ public enum ExtensionBridgeJS {
                 }
             };
             this.__muxyDeliverModalQuery = (requestID, queryID, query, options) => {
-                const handler = modalQueryHandlers[requestID];
-                const emit = (batch) => dispatch('modal.feed', { items: normalizeModalItems(batch), queryID });
-                const finish = () => dispatch('modal.finish', { queryID });
-                if (typeof handler !== 'function') { finish(); return; }
-                let produced;
-                const previousModalQueryID = activeModalQueryID;
-                activeModalQueryID = queryID;
                 try {
-                    produced = handler(query, emit, options || {});
-                } catch (error) {
-                    console.error(error);
+                    const handler = modalQueryHandlers[requestID];
+                    const emit = (batch) => dispatch('modal.feed', { items: normalizeModalItems(batch), queryID });
+                    const finish = () => dispatch('modal.finish', { queryID });
+                    if (typeof handler !== 'function') { finish(); return; }
+                    let produced;
+                    const previousModalQueryID = activeModalQueryID;
+                    activeModalQueryID = queryID;
+                    try {
+                        produced = handler(query, emit, options || {});
+                    } catch (error) {
+                        console.error(error);
+                        finish();
+                        return;
+                    } finally {
+                        activeModalQueryID = previousModalQueryID;
+                    }
+                    if (produced != null) emit(produced);
                     finish();
-                    return;
-                } finally {
-                    activeModalQueryID = previousModalQueryID;
+                } catch (error) {
+                    try { console.error(error); } catch (ignored) {}
                 }
-                if (produced != null) emit(produced);
-                finish();
             };
             const muxy = {
                 extensionID: \(extLiteral),

--- a/Tests/MuxyTests/Services/Extensions/ExtensionScriptRunnerTests.swift
+++ b/Tests/MuxyTests/Services/Extensions/ExtensionScriptRunnerTests.swift
@@ -222,6 +222,173 @@ struct ExtensionScriptRunnerTests {
         #expect(page.items.map(\.title) == ["한글"])
     }
 
+    @Test("sync muxy API called from onQuery under rapid queries does not deadlock the main thread")
+    func syncApiFromModalQueryDoesNotDeadlock() async throws {
+        let extensionID = "test-ext-lockstorm"
+        let logDirectory = try makeExtensionDirectory()
+        ExtensionLogStore.shared.register(extensionID: extensionID, directory: logDirectory)
+        defer {
+            ExtensionScriptRunner.shared.evict(extensionID: extensionID)
+            ExtensionModalService.shared.dismiss()
+            ExtensionLogStore.shared.unregister(extensionID: extensionID)
+            ExtensionLogStore.shared.flush()
+            try? FileManager.default.removeItem(at: logDirectory)
+        }
+
+        let appState = makeAppState()
+        let scriptURL = try writeScript("""
+        muxy.modal.open({
+          items: [],
+          onQuery(query, emit) {
+            try { muxy.storage.set('last', query); } catch (e) {}
+            emit([{ id: query || 'empty', title: query || 'empty' }]);
+            return [{ id: query || 'empty', title: query || 'empty' }];
+          },
+        });
+        """)
+        defer { try? FileManager.default.removeItem(at: scriptURL.deletingLastPathComponent()) }
+
+        try await ExtensionScriptRunner.shared.runScript(
+            extensionID: extensionID,
+            scriptURL: scriptURL,
+            appState: appState,
+            stores: ExtensionAPIStores()
+        )
+
+        for round in 0 ..< 40 {
+            ExtensionModalService.shared.queryChanged("q-\(round)")
+            ExtensionModalService.shared.queryChanged("")
+        }
+
+        ExtensionModalService.shared.queryChanged("done")
+        let page = try await waitForModalPage(query: "done")
+        #expect(page.items.map(\.title).contains("done"))
+    }
+
+    @Test("rapid modal queries, clears, feeds, and reruns do not crash or deadlock")
+    func rapidModalStormDoesNotCrashOrDeadlock() async throws {
+        let extensionID = "test-ext-storm"
+        let logDirectory = try makeExtensionDirectory()
+        ExtensionLogStore.shared.register(extensionID: extensionID, directory: logDirectory)
+        defer {
+            ExtensionScriptRunner.shared.evict(extensionID: extensionID)
+            ExtensionModalService.shared.dismiss()
+            ExtensionLogStore.shared.unregister(extensionID: extensionID)
+            ExtensionLogStore.shared.flush()
+            try? FileManager.default.removeItem(at: logDirectory)
+        }
+
+        let appState = makeAppState()
+        let scriptURL = try writeScript("""
+        const rows = [];
+        for (let i = 0; i < 1000; i++) {
+          rows.push({ id: 'row-' + i, title: 'title '.repeat(20) + i, subtitle: 'sub '.repeat(40) + i });
+        }
+        muxy.modal.open({
+          placeholder: 'storm',
+          items(emit) {
+            for (let b = 0; b < 5; b++) emit(rows.slice(b * 200, (b + 1) * 200));
+          },
+          onQuery(query, emit) {
+            const until = Date.now() + 20;
+            while (Date.now() < until) {}
+            for (let b = 0; b < 5; b++) emit(rows.slice(b * 200, (b + 1) * 200));
+            return rows.slice(0, 200);
+          },
+          onSelect(choice) {
+            console.log('storm-select:' + (choice ? choice.id : 'null'));
+          },
+        });
+        """)
+        defer { try? FileManager.default.removeItem(at: scriptURL.deletingLastPathComponent()) }
+
+        let stores = ExtensionAPIStores()
+        try await ExtensionScriptRunner.shared.runScript(
+            extensionID: extensionID,
+            scriptURL: scriptURL,
+            appState: appState,
+            stores: stores
+        )
+
+        for round in 0 ..< 30 {
+            ExtensionModalService.shared.queryChanged("query-\(round)")
+            try await Task.sleep(for: .milliseconds(8))
+            ExtensionModalService.shared.queryChanged("")
+            try await Task.sleep(for: .milliseconds(8))
+
+            if round % 5 == 4 {
+                try await ExtensionScriptRunner.shared.runScript(
+                    extensionID: extensionID,
+                    scriptURL: scriptURL,
+                    appState: appState,
+                    stores: stores
+                )
+            }
+            if round % 7 == 6 {
+                ExtensionModalService.shared.select(
+                    ExtensionModalService.Item(id: "row-1", title: "t", subtitle: nil)
+                )
+                try await ExtensionScriptRunner.shared.runScript(
+                    extensionID: extensionID,
+                    scriptURL: scriptURL,
+                    appState: appState,
+                    stores: stores
+                )
+            }
+        }
+
+        ExtensionModalService.shared.queryChanged("final")
+        let page = try await waitForModalPage(query: "final")
+        #expect(!page.items.isEmpty)
+    }
+
+    @Test("superseded modal queries are skipped before invoking the handler")
+    func supersededModalQueriesAreSkipped() async throws {
+        let extensionID = "test-ext-stale-\(UUID().uuidString)"
+        let logDirectory = try makeExtensionDirectory()
+        ExtensionLogStore.shared.register(extensionID: extensionID, directory: logDirectory)
+        defer {
+            ExtensionScriptRunner.shared.evict(extensionID: extensionID)
+            ExtensionModalService.shared.dismiss()
+            ExtensionLogStore.shared.unregister(extensionID: extensionID)
+            ExtensionLogStore.shared.flush()
+            try? FileManager.default.removeItem(at: logDirectory)
+        }
+
+        let appState = makeAppState()
+        let scriptURL = try writeScript("""
+        muxy.modal.open({
+          items: [],
+          onQuery(query) {
+            console.log('query-start:' + query);
+            const until = Date.now() + 300;
+            while (Date.now() < until) {}
+            console.log('query-end:' + query);
+            return [{ id: query, title: query }];
+          },
+        });
+        """)
+        defer { try? FileManager.default.removeItem(at: scriptURL.deletingLastPathComponent()) }
+
+        try await ExtensionScriptRunner.shared.runScript(
+            extensionID: extensionID,
+            scriptURL: scriptURL,
+            appState: appState,
+            stores: ExtensionAPIStores()
+        )
+
+        ExtensionModalService.shared.queryChanged("warm")
+        _ = try await waitForLog(extensionID: extensionID, directory: logDirectory, contains: "query-start:warm")
+        ExtensionModalService.shared.queryChanged("q1")
+        ExtensionModalService.shared.queryChanged("q2")
+        ExtensionModalService.shared.queryChanged("q3")
+
+        let log = try await waitForLog(extensionID: extensionID, directory: logDirectory, contains: "query-end:q3")
+        #expect(log.contains("query-end:q3"))
+        #expect(!log.contains("query-start:q1"))
+        #expect(!log.contains("query-start:q2"))
+    }
+
     private func writeScript(_ source: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("script-\(UUID().uuidString)")

--- a/docs/extensions/modal.md
+++ b/docs/extensions/modal.md
@@ -128,7 +128,9 @@ async onQuery(query) {
   prefer `onQuery` because it also receives `emit` and uses the stale-query protection built into the
   dynamic modal pipeline.
 - Each call replaces the list for that query. Muxy tags every call with a revision and drops responses
-  for superseded queries, so a slow request that resolves late never overwrites a newer one.
+  for superseded queries, so a slow request that resolves late never overwrites a newer one. On
+  `runScript` scripts, queued queries that are already superseded are skipped before your handler runs,
+  so a slow synchronous search (e.g. `muxy.exec` over a large repo) never piles up once per keystroke.
 - The initial `items` (array or producer) still supplies the list shown before the user types; `onQuery`
   takes over once the query changes, including when it is cleared back to empty.
 - On webview pages `onQuery` may be `async` (do `await muxy.http.fetch(...)`); in `runScript` and


### PR DESCRIPTION
The in-process runScript JSContext ran on the main run loop, so a synchronous `muxy.*` call from a modal `onQuery` (e.g. the files extension's search) parked the JS thread while holding the JS lock and the main thread deadlocked acquiring it. Each extension VM now runs on its own thread/run loop, superseded queries are dropped, and modal delivery is guarded against crashes.

Verified live: Cmd+Shift+F / Cmd+P rapid type-and-clear in the files extension no longer hangs.