### PR TITLE
Sync Homebrew tap after stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,3 +342,11 @@ jobs:
             -X POST -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"; then
             echo "Discord notification failed; release succeeded regardless"
           fi
+
+  update-homebrew-tap:
+    needs: [validate, release]
+    if: ${{ !inputs.draft }}
+    uses: ./.github/workflows/update-homebrew-tap.yml
+    with:
+      tag: v${{ needs.validate.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,8 +1,12 @@
 name: Update Homebrew Tap
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Stable release tag to publish to the tap (e.g. v1.0.0)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -18,7 +22,7 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+          TAG: ${{ inputs.tag }}
         run: |
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Tag $TAG is not a stable vX.Y.Z release, skipping"


### PR DESCRIPTION
Releases published with `GITHUB_TOKEN` never fired the `release: published` event, so the tap was never updated automatically.

Chains the tap update deterministically as the final step of `release.yml` (skipped for drafts).

Closes #851