### PR TITLE
Fix extension action buttons wrapping during updates

### DIFF
--- a/Muxy/Views/Extensions/ExtensionInstallPage.swift
+++ b/Muxy/Views/Extensions/ExtensionInstallPage.swift
@@ -185,6 +185,8 @@ struct ExtensionInstallPage: View {
                     }
                     Text(installButtonTitle)
                         .font(.system(size: 13, weight: .semibold))
+                        .lineLimit(1)
+                        .fixedSize()
                 }
                 .foregroundStyle(.white)
                 .padding(.horizontal, 16)

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -143,6 +143,8 @@ struct ExtensionsView: View {
                             }
                             Text(isUpdatingAll ? "Updating…" : "Update All (\(store.updateCount))")
                                 .font(.system(size: 12, weight: .semibold))
+                                .lineLimit(1)
+                                .fixedSize()
                         }
                         .foregroundStyle(.white)
                         .padding(.horizontal, 10)
@@ -477,6 +479,8 @@ private struct ExtensionUpdateButton: View {
                 }
                 Text(isUpdating ? "Updating…" : "Update v\(version)")
                     .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                    .fixedSize()
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 10)


### PR DESCRIPTION
Extension action buttons (Update, Update All, Install) wrapped to two lines when swapping to the loading state, because their labels lacked a single-line constraint under the row's greedy `maxWidth: .infinity` layout.

Pin each button label to `.lineLimit(1).fixedSize()` so it stays one line at intrinsic width.