### PR TITLE
Default terminal free-idle off; make it opt-in

### DIFF
--- a/Muxy/Models/Preferences/TerminalOfflinePreferences.swift
+++ b/Muxy/Models/Preferences/TerminalOfflinePreferences.swift
@@ -4,7 +4,7 @@ enum TerminalOfflinePreferences {
     static let enabledKey = "muxy.terminalOffline.enabled"
     static let idleThresholdKey = "muxy.terminalOffline.idleThresholdSeconds"
 
-    static let defaultIsEnabled = true
+    static let defaultIsEnabled = false
     static let defaultIdleThreshold: TimeInterval = 300
 
     static var isEnabled: Bool {


### PR DESCRIPTION
Makes the "free idle inactive terminals" memory saver disabled by default; users opt in from Settings → Terminal → Memory.

Flips `TerminalOfflinePreferences.defaultIsEnabled`, the single source of truth for the runtime accessor, the settings toggle, and the settings catalog. Existing users who enabled it keep their setting.

Related to #757.