### PR TITLE
Add keyboard shortcuts to create and remove worktrees

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -97,6 +97,24 @@ struct MuxyCommands: Commands {
             .shortcut(for: .refreshWorktrees, store: keyBindings)
             .disabled(activeProject == nil)
 
+            Button {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.createWorktree)
+            } label: {
+                Label("New Worktree", systemImage: "plus")
+            }
+            .shortcut(for: .createWorktree, store: keyBindings)
+            .disabled(activeProject == nil)
+
+            Button {
+                guard isMainWindowFocused else { return }
+                performShortcutAction(.removeCurrentWorktree)
+            } label: {
+                Label("Remove Current Worktree", systemImage: "trash")
+            }
+            .shortcut(for: .removeCurrentWorktree, store: keyBindings)
+            .disabled(activeProject == nil)
+
             Divider()
 
             Button {

--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -30,6 +30,23 @@ struct MuxyCommands: Commands {
             ?? project.path
     }
 
+    private var canCreateWorktreeForActiveProject: Bool {
+        WorktreeActionEligibility.canCreateWorktree(
+            project: activeProject,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
+            allowUnknownGitStatus: true
+        )
+    }
+
+    private var canRemoveCurrentWorktree: Bool {
+        WorktreeActionEligibility.removableCurrentWorktree(
+            project: activeProject,
+            appState: appState,
+            worktreeStore: worktreeStore
+        ) != nil
+    }
+
     private var shortcutDispatcher: ShortcutActionDispatcher {
         ShortcutActionDispatcher(
             appState: appState,
@@ -104,7 +121,7 @@ struct MuxyCommands: Commands {
                 Label("New Worktree", systemImage: "plus")
             }
             .shortcut(for: .createWorktree, store: keyBindings)
-            .disabled(activeProject == nil)
+            .disabled(!canCreateWorktreeForActiveProject)
 
             Button {
                 guard isMainWindowFocused else { return }
@@ -113,7 +130,7 @@ struct MuxyCommands: Commands {
                 Label("Remove Current Worktree", systemImage: "trash")
             }
             .shortcut(for: .removeCurrentWorktree, store: keyBindings)
-            .disabled(activeProject == nil)
+            .disabled(!canRemoveCurrentWorktree)
 
             Divider()
 

--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -21,6 +21,8 @@ extension Notification.Name {
     static let toggleSidebar = Notification.Name("MuxyToggleSidebar")
     static let toggleAppLayout = Notification.Name("MuxyToggleAppLayout")
     static let toggleNotificationPanel = Notification.Name("MuxyToggleNotificationPanel")
+    static let createWorktreeRequested = Notification.Name("MuxyCreateWorktreeRequested")
+    static let removeCurrentWorktreeRequested = Notification.Name("MuxyRemoveCurrentWorktreeRequested")
     static let vcsRepoDidChange = Notification.Name("MuxyVCSRepoDidChange")
     static let vcsDidRefresh = Notification.Name("MuxyVCSDidRefresh")
     static let externalDragHoverChanged = Notification.Name("MuxyExternalDragHoverChanged")

--- a/Muxy/Models/Keyboard/KeyBinding.swift
+++ b/Muxy/Models/Keyboard/KeyBinding.swift
@@ -30,6 +30,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case openProject
     case reloadConfig
     case refreshWorktrees
+    case createWorktree
+    case removeCurrentWorktree
     case selectTab1
     case selectTab2
     case selectTab3
@@ -91,6 +93,8 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .openProject,
         .reloadConfig,
         .refreshWorktrees,
+        .createWorktree,
+        .removeCurrentWorktree,
         .selectTab1,
         .selectTab2,
         .selectTab3,
@@ -223,6 +227,12 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .openProject: ShortcutMetadata(displayName: "Open Project", category: "App", scope: .mainWindow)
         case .reloadConfig: ShortcutMetadata(displayName: "Reload Configuration", category: "App", scope: .global)
         case .refreshWorktrees: ShortcutMetadata(displayName: "Refresh Worktrees", category: "App", scope: .mainWindow)
+        case .createWorktree: ShortcutMetadata(displayName: "New Worktree", category: "App", scope: .mainWindow)
+        case .removeCurrentWorktree: ShortcutMetadata(
+                displayName: "Remove Current Worktree",
+                category: "App",
+                scope: .mainWindow
+            )
         case .toggleMaximizePane: ShortcutMetadata(displayName: "Toggle Maximize Pane", category: "Panes", scope: .mainWindow)
         case .toggleFullScreen: ShortcutMetadata(displayName: "Toggle Full Screen", category: "App", scope: .mainWindow)
         case .toggleExtensionConsole: ShortcutMetadata(
@@ -328,6 +338,8 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),
         Self(action: .reloadConfig, combo: KeyCombo(key: "r", command: true, shift: true)),
         Self(action: .refreshWorktrees, combo: KeyCombo(key: "r", command: true, option: true)),
+        Self(action: .createWorktree, combo: KeyCombo(key: "n", command: true, option: true)),
+        Self(action: .removeCurrentWorktree, combo: KeyCombo(key: "", modifiers: 0)),
         Self(action: .nextTab, combo: KeyCombo(key: "]", command: true)),
         Self(action: .previousTab, combo: KeyCombo(key: "[", command: true)),
         Self(action: .selectTab1, combo: KeyCombo(key: "1", command: true)),

--- a/Muxy/Services/Keyboard/KeyBindingPersistence.swift
+++ b/Muxy/Services/Keyboard/KeyBindingPersistence.swift
@@ -31,9 +31,21 @@ final class FileKeyBindingPersistence: KeyBindingPersisting {
     }
 
     private static func mergeWithDefaults(_ saved: [KeyBinding]) -> [KeyBinding] {
-        let savedByAction = Dictionary(uniqueKeysWithValues: saved.map { ($0.action, $0) })
+        var savedByAction: [ShortcutAction: KeyBinding] = [:]
+        var claimedCombos = Set(saved.map(\.combo).filter(\.isAssigned))
+        for binding in saved {
+            savedByAction[binding.action] = binding
+        }
         return KeyBinding.defaults.map { defaultBinding in
-            savedByAction[defaultBinding.action] ?? defaultBinding
+            if let savedBinding = savedByAction[defaultBinding.action] {
+                return savedBinding
+            }
+            guard defaultBinding.combo.isAssigned else { return defaultBinding }
+            guard !claimedCombos.contains(defaultBinding.combo) else {
+                return KeyBinding(action: defaultBinding.action, combo: KeyCombo(key: "", modifiers: 0))
+            }
+            claimedCombos.insert(defaultBinding.combo)
+            return defaultBinding
         }
     }
 

--- a/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
@@ -208,6 +208,14 @@ struct ShortcutActionDispatcher {
                 )
             }
             return true
+        case .createWorktree:
+            guard activeProject != nil else { return false }
+            notificationCenter.post(name: .createWorktreeRequested, object: nil)
+            return true
+        case .removeCurrentWorktree:
+            guard activeProject != nil else { return false }
+            notificationCenter.post(name: .removeCurrentWorktreeRequested, object: nil)
+            return true
         case .nextProject:
             appState.selectNextProject(projects: navigableProjects, worktrees: worktreeStore.worktrees)
             return true

--- a/Muxy/Services/Project/WorktreeActionEligibility.swift
+++ b/Muxy/Services/Project/WorktreeActionEligibility.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+@MainActor
+enum WorktreeActionEligibility {
+    static func canCreateWorktree(
+        project: Project?,
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore,
+        allowUnknownGitStatus: Bool
+    ) -> Bool {
+        guard let project, !project.isHome, project.worktreesEnabled else { return false }
+        if worktreeStore.list(for: project.id).count > 1 { return true }
+        let context = projectGroupStore.workspaceContext(for: project)
+        return GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) ?? allowUnknownGitStatus
+    }
+
+    static func canCreateWorktreeResolvingGitStatus(
+        project: Project,
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore
+    ) async -> Bool {
+        guard !project.isHome, project.worktreesEnabled else { return false }
+        if worktreeStore.list(for: project.id).count > 1 { return true }
+        let context = projectGroupStore.workspaceContext(for: project)
+        if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) {
+            return cached
+        }
+        let isGitRepo = await GitWorktreeService.shared.isGitRepository(project.path, context: context)
+        GitRepoStatusCache.shared.update(path: project.path, context: context, isGitRepo: isGitRepo)
+        return isGitRepo
+    }
+
+    static func removableCurrentWorktree(
+        project: Project?,
+        appState: AppState,
+        worktreeStore: WorktreeStore
+    ) -> Worktree? {
+        guard let project else { return nil }
+        guard let worktree = worktreeStore.preferred(for: project.id, matching: appState.activeWorktreeID[project.id]) else { return nil }
+        return worktree.canBeRemoved ? worktree : nil
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1050,15 +1050,20 @@ struct MainWindow: View {
         worktreeStore.preferred(for: project.id, matching: appState.activeWorktreeID[project.id])
     }
 
-    private var canCreateWorktreeForActiveProject: Bool {
-        guard let project = activeProject, !project.isHome, project.worktreesEnabled else { return false }
-        let context = projectGroupStore.workspaceContext(for: project)
-        let isGitRepo = GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) ?? false
-        return isGitRepo || worktreeStore.list(for: project.id).count > 1
+    private func beginCreateWorktree() {
+        guard let project = activeProject else { return }
+        Task { await beginCreateWorktree(project: project) }
     }
 
-    private func beginCreateWorktree() {
-        guard canCreateWorktreeForActiveProject, let project = activeProject else { return }
+    @MainActor
+    private func beginCreateWorktree(project: Project) async {
+        guard await WorktreeActionEligibility.canCreateWorktreeResolvingGitStatus(
+            project: project,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+        else { return }
+        guard activeProject?.id == project.id else { return }
         worktreeCreationProject = project
     }
 
@@ -1076,8 +1081,11 @@ struct MainWindow: View {
 
     private func requestRemoveCurrentWorktree() {
         guard let project = activeProject,
-              let worktree = resolvedActiveWorktree(for: project),
-              worktree.canBeRemoved
+              let worktree = WorktreeActionEligibility.removableCurrentWorktree(
+                  project: project,
+                  appState: appState,
+                  worktreeStore: worktreeStore
+              )
         else { return }
         Task { await requestRemoveWorktree(worktree, in: project) }
     }

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -75,6 +75,8 @@ struct MainWindow: View {
     private var orderWorktreesByMRU = WorktreeListPreferences.defaultOrderByMRU
     @State private var showTerminalOmnibox = false
     @State private var terminalOmniboxLaunchScope = TerminalOmniboxLaunchScope.openTabs
+    @State private var worktreeCreationProject: Project?
+    @State private var pendingWorktreeRemoval: PendingWorktreeRemoval?
     @State private var showProjectPicker = false
     @State private var remoteProjectDevice: RemoteDevice?
     @State private var overlayAnimatingOut = false
@@ -159,6 +161,14 @@ struct MainWindow: View {
         }
         .overlay { modalOverlayLayer }
         .overlay { ExtensionConsentOverlay() }
+        .modifier(WorktreeActionsModifier(
+            creationProject: $worktreeCreationProject,
+            pendingRemoval: $pendingWorktreeRemoval,
+            onCreateRequested: beginCreateWorktree,
+            onRemoveCurrentRequested: requestRemoveCurrentWorktree,
+            onCreateResult: handleCreateWorktreeResult,
+            onPerformRemove: performRemoveWorktree
+        ))
         .animation(.easeInOut(duration: 0.15), value: showTerminalOmnibox)
         .animation(.easeInOut(duration: 0.15), value: showProjectPicker)
         .animation(.easeInOut(duration: 0.15), value: ExtensionModalService.shared.active)
@@ -1040,6 +1050,68 @@ struct MainWindow: View {
         worktreeStore.preferred(for: project.id, matching: appState.activeWorktreeID[project.id])
     }
 
+    private var canCreateWorktreeForActiveProject: Bool {
+        guard let project = activeProject, !project.isHome, project.worktreesEnabled else { return false }
+        let context = projectGroupStore.workspaceContext(for: project)
+        let isGitRepo = GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) ?? false
+        return isGitRepo || worktreeStore.list(for: project.id).count > 1
+    }
+
+    private func beginCreateWorktree() {
+        guard canCreateWorktreeForActiveProject, let project = activeProject else { return }
+        worktreeCreationProject = project
+    }
+
+    private func handleCreateWorktreeResult(_ result: CreateWorktreeResult, project: Project) {
+        worktreeCreationProject = nil
+        guard case let .created(worktree, runSetup) = result else { return }
+        appState.selectWorktree(projectID: project.id, worktree: worktree)
+        guard runSetup,
+              let paneID = appState.focusedArea(for: project.id)?.activeTab?.content.pane?.id
+        else { return }
+        Task {
+            await WorktreeSetupRunner.run(sourceProjectPath: project.path, paneID: paneID)
+        }
+    }
+
+    private func requestRemoveCurrentWorktree() {
+        guard let project = activeProject,
+              let worktree = resolvedActiveWorktree(for: project),
+              worktree.canBeRemoved
+        else { return }
+        Task { await requestRemoveWorktree(worktree, in: project) }
+    }
+
+    @MainActor
+    private func requestRemoveWorktree(_ worktree: Worktree, in project: Project) async {
+        let hasChanges = await GitWorktreeService.shared.hasUncommittedChanges(
+            worktreePath: worktree.path,
+            context: projectGroupStore.workspaceContext(for: project)
+        )
+        pendingWorktreeRemoval = PendingWorktreeRemoval(
+            project: project,
+            confirmation: WorktreeRemovalConfirmation(worktree: worktree, hasUncommittedChanges: hasChanges)
+        )
+    }
+
+    private func performRemoveWorktree(_ pending: PendingWorktreeRemoval) {
+        let project = pending.project
+        let worktree = pending.confirmation.worktree
+        let remaining = worktreeStore.list(for: project.id).filter { $0.id != worktree.id }
+        let replacement = remaining.first(where: { $0.id == appState.activeWorktreeID[project.id] })
+            ?? remaining.first(where: { $0.isPrimary })
+            ?? remaining.first
+        worktreeStore.beginRemoval(
+            worktree: worktree,
+            repoPath: project.path,
+            context: projectGroupStore.workspaceContext(for: project),
+            onSuccess: {
+                appState.removeWorktree(projectID: project.id, worktree: worktree, replacement: replacement)
+                worktreeStore.remove(worktreeID: worktree.id, from: project.id)
+            }
+        )
+    }
+
     private var shortcutDispatcher: ShortcutActionDispatcher {
         ShortcutActionDispatcher(
             appState: appState,
@@ -1827,5 +1899,60 @@ private struct OverlayExitTracker: ViewModifier {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             onAnimatingOut(false)
         }
+    }
+}
+
+struct PendingWorktreeRemoval {
+    let project: Project
+    let confirmation: WorktreeRemovalConfirmation
+}
+
+private struct WorktreeActionsModifier: ViewModifier {
+    @Binding var creationProject: Project?
+    @Binding var pendingRemoval: PendingWorktreeRemoval?
+    let onCreateRequested: () -> Void
+    let onRemoveCurrentRequested: () -> Void
+    let onCreateResult: (CreateWorktreeResult, Project) -> Void
+    let onPerformRemove: (PendingWorktreeRemoval) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .createWorktreeRequested)) { _ in
+                onCreateRequested()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .removeCurrentWorktreeRequested)) { _ in
+                onRemoveCurrentRequested()
+            }
+            .sheet(item: $creationProject) { project in
+                CreateWorktreeSheet(project: project) { result in
+                    onCreateResult(result, project)
+                }
+            }
+            .alert(
+                pendingRemoval?.confirmation.title ?? "",
+                isPresented: alertBinding,
+                presenting: pendingRemoval
+            ) { pending in
+                Button("Remove", role: .destructive) {
+                    onPerformRemove(pending)
+                    pendingRemoval = nil
+                }
+                .keyboardShortcut(.defaultAction)
+                Button("Cancel", role: .cancel) {
+                    pendingRemoval = nil
+                }
+                .keyboardShortcut(.cancelAction)
+            } message: { pending in
+                Text(pending.confirmation.message)
+            }
+    }
+
+    private var alertBinding: Binding<Bool> {
+        Binding(
+            get: { pendingRemoval != nil },
+            set: { newValue in
+                if !newValue { pendingRemoval = nil }
+            }
+        )
     }
 }

--- a/Tests/MuxyTests/Models/Keyboard/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/Keyboard/KeyBindingTests.swift
@@ -133,6 +133,13 @@ struct KeyBindingTests {
         #expect(combos[.refreshWorktrees] == KeyCombo(key: "r", command: true, option: true))
     }
 
+    @Test("Worktree actions use expected default shortcuts")
+    func defaultsIncludeWorktreeActionShortcuts() {
+        let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
+        #expect(combos[.createWorktree] == KeyCombo(key: "n", command: true, option: true))
+        #expect(combos[.removeCurrentWorktree]?.isAssigned == false)
+    }
+
     @Test("Toggle App Layout uses Cmd+Shift+L by default")
     func defaultsIncludesToggleAppLayoutShortcut() {
         let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })

--- a/Tests/MuxyTests/Services/Keyboard/KeyBindingStoreTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/KeyBindingStoreTests.swift
@@ -110,6 +110,29 @@ struct KeyBindingStoreTests {
         #expect(store.combo(for: .refreshWorktrees) == KeyCombo(key: "r", command: true, option: true))
     }
 
+    @Test("new default shortcuts do not shadow saved custom bindings")
+    func newDefaultShortcutsDoNotShadowSavedCustomBindings() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("keybindings-\(UUID().uuidString).json")
+        let savedCombo = KeyCombo(key: "n", command: true, option: true)
+        let savedBinding = KeyBinding(action: .terminalOmniboxCommands, combo: savedCombo)
+        let data = try JSONEncoder().encode([savedBinding])
+        try data.write(to: url, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = KeyBindingStore(persistence: FileKeyBindingPersistence(fileURL: url))
+        let keyCode = try #require(KeyCombo.keyCode(for: "n"))
+        let event = try keyEvent(
+            characters: "n",
+            charactersIgnoringModifiers: "n",
+            keyCode: keyCode,
+            modifiers: [.command, .option]
+        )
+
+        #expect(store.combo(for: .terminalOmniboxCommands) == savedCombo)
+        #expect(store.combo(for: .createWorktree).isAssigned == false)
+        #expect(store.action(for: event, scopes: [.mainWindow]) == .terminalOmniboxCommands)
+    }
+
     private func keyEvent(
         characters: String,
         charactersIgnoringModifiers: String,

--- a/Tests/MuxyTests/Services/Keyboard/ShortcutActionDispatcherTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/ShortcutActionDispatcherTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ShortcutActionDispatcher")
+@MainActor
+struct ShortcutActionDispatcherTests {
+    @Test("create worktree posts request notification")
+    func createWorktreePostsRequestNotification() {
+        let project = Project(name: "App", path: "/tmp/app")
+        let center = NotificationCenter()
+        let capture = NotificationCapture()
+        let token = center.addObserver(forName: .createWorktreeRequested, object: nil, queue: nil) { notification in
+            capture.record(notification.name)
+        }
+        defer { center.removeObserver(token) }
+
+        let performed = makeDispatcher(notificationCenter: center).perform(.createWorktree, activeProject: project)
+
+        #expect(performed)
+        #expect(capture.contains(.createWorktreeRequested))
+    }
+
+    @Test("remove current worktree posts request notification")
+    func removeCurrentWorktreePostsRequestNotification() {
+        let project = Project(name: "App", path: "/tmp/app")
+        let center = NotificationCenter()
+        let capture = NotificationCapture()
+        let token = center.addObserver(forName: .removeCurrentWorktreeRequested, object: nil, queue: nil) { notification in
+            capture.record(notification.name)
+        }
+        defer { center.removeObserver(token) }
+
+        let performed = makeDispatcher(notificationCenter: center).perform(.removeCurrentWorktree, activeProject: project)
+
+        #expect(performed)
+        #expect(capture.contains(.removeCurrentWorktreeRequested))
+    }
+
+    @Test("worktree requests return false without an active project")
+    func worktreeRequestsReturnFalseWithoutActiveProject() {
+        let dispatcher = makeDispatcher(notificationCenter: NotificationCenter())
+
+        #expect(!dispatcher.perform(.createWorktree, activeProject: nil))
+        #expect(!dispatcher.perform(.removeCurrentWorktree, activeProject: nil))
+    }
+
+    private func makeDispatcher(notificationCenter: NotificationCenter) -> ShortcutActionDispatcher {
+        let projectStore = ProjectStore(persistence: DispatcherProjectPersistenceStub())
+        let worktreeStore = WorktreeStore(persistence: DispatcherWorktreePersistenceStub(), projects: [])
+        let appState = AppState(
+            selectionStore: DispatcherSelectionStoreStub(),
+            terminalViews: DispatcherTerminalViewRemovingStub(),
+            workspacePersistence: DispatcherWorkspacePersistenceStub()
+        )
+        let projectGroupStore = ProjectGroupStore(
+            persistence: DispatcherProjectGroupPersistenceStub(),
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        return ShortcutActionDispatcher(
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
+            ghostty: GhosttyService.shared,
+            notificationCenter: notificationCenter
+        )
+    }
+}
+
+private final class NotificationCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var names: [Notification.Name] = []
+
+    func record(_ name: Notification.Name) {
+        lock.lock()
+        names.append(name)
+        lock.unlock()
+    }
+
+    func contains(_ name: Notification.Name) -> Bool {
+        lock.lock()
+        let result = names.contains(name)
+        lock.unlock()
+        return result
+    }
+}
+
+private final class DispatcherProjectPersistenceStub: ProjectPersisting {
+    func loadProjects() throws -> [Project] { [] }
+    func saveProjects(_: [Project]) throws {}
+}
+
+private final class DispatcherWorktreePersistenceStub: WorktreePersisting {
+    func loadWorktrees(projectID _: UUID) throws -> [Worktree] { [] }
+    func saveWorktrees(_: [Worktree], projectID _: UUID) throws {}
+    func removeWorktrees(projectID _: UUID) throws {}
+}
+
+private final class DispatcherProjectGroupPersistenceStub: ProjectGroupPersisting {
+    func loadProjectGroups() throws -> [ProjectGroup] { [] }
+    func saveProjectGroups(_: [ProjectGroup]) throws {}
+    func loadActiveGroupID() -> UUID? { nil }
+    func saveActiveGroupID(_: UUID?) {}
+}
+
+private final class DispatcherWorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class DispatcherSelectionStoreStub: ActiveProjectSelectionStoring {
+    func loadActiveProjectID() -> UUID? { nil }
+    func saveActiveProjectID(_: UUID?) {}
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { [:] }
+    func saveActiveWorktreeIDs(_: [UUID: UUID]) {}
+}
+
+@MainActor
+private final class DispatcherTerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}

--- a/Tests/MuxyTests/Services/Socket/NotificationSocketAcceptLoopTests.swift
+++ b/Tests/MuxyTests/Services/Socket/NotificationSocketAcceptLoopTests.swift
@@ -50,9 +50,30 @@ struct NotificationSocketAcceptLoopTests {
         defer { close(fd) }
         try writeLine(command, to: fd)
         shutdown(fd, SHUT_WR)
-        let payload = try readUntilEOF(fd)
-        #expect(payload.last == NotificationSocketServer.commandReplyTerminator)
-        return String(decoding: payload.dropLast(), as: UTF8.self)
+        let payload = try readCommandReply(fd)
+        return String(decoding: payload, as: UTF8.self)
+    }
+
+    private static func readCommandReply(_ fd: Int32, deadline: TimeInterval = 5) throws -> Data {
+        var collected = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let end = Date().addingTimeInterval(deadline)
+        while Date() < end {
+            try waitForRead(fd, timeout: end.timeIntervalSinceNow)
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            if count > 0 {
+                if let terminator = buffer[0 ..< count].firstIndex(of: NotificationSocketServer.commandReplyTerminator) {
+                    collected.append(contentsOf: buffer[0 ..< terminator])
+                    return collected
+                }
+                collected.append(contentsOf: buffer[0 ..< count])
+                continue
+            }
+            if count == 0 { throw SocketError.missingReplyTerminator }
+            if errno == EINTR { continue }
+            throw SocketError.readFailed(errno)
+        }
+        throw SocketError.timedOut
     }
 
     private static func connect(to path: String) throws -> Int32 {
@@ -94,13 +115,14 @@ struct NotificationSocketAcceptLoopTests {
         var buffer = [UInt8](repeating: 0, count: 4096)
         let end = Date().addingTimeInterval(deadline)
         while Date() < end {
+            try waitForRead(fd, timeout: end.timeIntervalSinceNow)
             let count = Darwin.read(fd, &buffer, buffer.count)
             if count > 0 {
                 collected.append(contentsOf: buffer[0 ..< count])
                 continue
             }
             if count == 0 { return collected }
-            if errno == EAGAIN || errno == EWOULDBLOCK {
+            if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK {
                 usleep(2000)
                 continue
             }
@@ -109,10 +131,23 @@ struct NotificationSocketAcceptLoopTests {
         throw SocketError.timedOut
     }
 
+    private static func waitForRead(_ fd: Int32, timeout: TimeInterval) throws {
+        var event = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        let milliseconds = max(1, Int32(min(timeout * 1000, Double(Int32.max))))
+        while true {
+            let ready = poll(&event, 1, milliseconds)
+            if ready > 0 { return }
+            if ready == 0 { throw SocketError.timedOut }
+            if errno == EINTR { continue }
+            throw SocketError.readFailed(errno)
+        }
+    }
+
     private enum SocketError: Error {
         case connectFailed(Int32)
         case writeFailed(Int32)
         case readFailed(Int32)
+        case missingReplyTerminator
         case timedOut
     }
 }

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -44,6 +44,8 @@ Every shortcut listed here can be remapped in **Settings → Keyboard Shortcuts*
 | Previous Project | `Ctrl+[` |
 | Project 1–9 | `Ctrl+1` … `Ctrl+9` |
 | Refresh Worktrees | `Cmd+Opt+R` |
+| New Worktree | `Cmd+Opt+N` |
+| Remove Current Worktree | _Unassigned_ |
 
 ## Navigation history
 


### PR DESCRIPTION
## Summary

You can now create a new worktree or remove the current one from the keyboard instead of reaching for the sidebar. 

New Worktree is bound to `Cmd+Opt+N`; removing is available as an action but ships unassigned so nobody deletes a worktree by accident.

## Changes

- Add `createWorktree` and `removeCurrentWorktree` shortcut actions, with menu items under the app commands
- Dispatch both through notifications so `MainWindow` can open the create sheet or the removal confirmation alert
- Removal picks a sensible replacement worktree (active, then primary, then first remaining) and warns about uncommitted changes before deleting
- Document the new shortcuts in the keyboard shortcuts guide

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

https://github.com/user-attachments/assets/33dd67e3-aa90-46be-9807-ed46a9d3d648