### PR TITLE
fix split divider hit area

### DIFF
--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -37,7 +37,7 @@ enum UIMetrics {
     static var controlSmall: CGFloat { scaled(20) }
     static var controlMedium: CGFloat { scaled(24) }
     static var controlLarge: CGFloat { scaled(32) }
-    static var resizeHandleHitArea: CGFloat { scaled(18) }
+    static var resizeHandleHitArea: CGFloat { scaled(10) }
 
     static var radiusSM: CGFloat { scaled(4) }
     static var radiusMD: CGFloat { scaled(6) }

--- a/Muxy/Views/Components/Interaction/ResizeHandle.swift
+++ b/Muxy/Views/Components/Interaction/ResizeHandle.swift
@@ -18,49 +18,57 @@ struct ResizeHandle: View {
     var onEnd: (() -> Void)?
     let onDrag: (DragGesture.Value) -> Void
     @State private var hovering = false
+    @State private var cursorPushed = false
     @GestureState private var dragging = false
 
     private var active: Bool { hovering || dragging }
 
     var body: some View {
-        Rectangle()
-            .fill(active ? MuxyTheme.accent : MuxyTheme.border)
-            .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
-            .overlay(alignment: overlayAlignment) {
-                Color.clear
-                    .frame(
-                        width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
-                        height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
-                    )
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 1, coordinateSpace: .global)
-                            .updating($dragging) { _, state, _ in state = true }
-                            .onChanged { value in
-                                cursor.set()
-                                onDrag(value)
-                            }
-                            .onEnded { _ in
-                                onEnd?()
-                            }
-                    )
-                    .onContinuousHover { phase in
-                        switch phase {
-                        case .active:
-                            hovering = true
-                            cursor.set()
-                        case .ended:
-                            hovering = false
-                            if !dragging {
-                                NSCursor.arrow.set()
+        ZStack(alignment: handleAlignment) {
+            Rectangle()
+                .fill(active ? MuxyTheme.accent : MuxyTheme.border)
+                .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
+            Rectangle()
+                .fill(Color.black.opacity(0.001))
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 1, coordinateSpace: .global)
+                        .updating($dragging) { _, state, _ in state = true }
+                        .onChanged { value in
+                            activateCursor()
+                            onDrag(value)
+                        }
+                        .onEnded { _ in
+                            onEnd?()
+                            if !hovering {
+                                releaseCursor()
                             }
                         }
+                )
+                .onContinuousHover { phase in
+                    switch phase {
+                    case .active:
+                        hovering = true
+                        activateCursor()
+                    case .ended:
+                        hovering = false
+                        if !dragging {
+                            releaseCursor()
+                        }
                     }
-            }
-            .zIndex(1)
+                }
+        }
+        .frame(
+            width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
+            height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
+        )
+        .zIndex(1)
+        .onDisappear {
+            releaseCursor()
+        }
     }
 
-    private var overlayAlignment: Alignment {
+    private var handleAlignment: Alignment {
         switch hitAreaBias {
         case .centered:
             .center
@@ -73,6 +81,21 @@ struct ResizeHandle: View {
 
     private var cursor: NSCursor {
         axis == .horizontal ? .resizeLeftRight : .resizeUpDown
+    }
+
+    private func activateCursor() {
+        if cursorPushed {
+            cursor.set()
+        } else {
+            cursor.push()
+            cursorPushed = true
+        }
+    }
+
+    private func releaseCursor() {
+        guard cursorPushed else { return }
+        NSCursor.pop()
+        cursorPushed = false
     }
 }
 

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -22,8 +22,9 @@ struct SplitContainer: View {
         GeometryReader { geo in
             let h = branch.direction == .horizontal
             let total = h ? geo.size.width : geo.size.height
-            let first = max(0, total * branch.ratio - 0.5)
-            let second = max(0, total * (1 - branch.ratio) - 0.5)
+            let dividerInset = UIMetrics.resizeHandleHitArea / 2
+            let first = max(0, total * branch.ratio - dividerInset)
+            let second = max(0, total * (1 - branch.ratio) - dividerInset)
 
             let layout = h ? AnyLayout(HStackLayout(spacing: 0)) : AnyLayout(VStackLayout(spacing: 0))
 

--- a/Tests/MuxyTests/Models/ModelCoverageTests.swift
+++ b/Tests/MuxyTests/Models/ModelCoverageTests.swift
@@ -82,7 +82,7 @@ struct ModelCoverageTests {
         #expect(UIMetrics.controlSmall == 20)
         #expect(UIMetrics.controlMedium == 24)
         #expect(UIMetrics.controlLarge == 32)
-        #expect(UIMetrics.resizeHandleHitArea == 18)
+        #expect(UIMetrics.resizeHandleHitArea == 10)
         #expect(UIMetrics.radiusSM == 4)
         #expect(UIMetrics.radiusMD == 6)
         #expect(UIMetrics.radiusLG == 8)


### PR DESCRIPTION
<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

<!-- What does this PR do and why? Write this yourself — no AI-generated text. -->
Reduce the resize handle hit area so terminal text near dividers is easier to click and select, especially the first character next to a divider.

Fixes muxy-app/muxy#737

## Changes

<!-- List the key changes -->

- Reduced resizeHandleHitArea from 18pt to 10pt
- Updated the metric coverage test to match the new value

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS
