### PR TITLE
Assign a random unused icon color to new projects instead of leaving as gray

### DIFF
--- a/Muxy/Services/Project/ProjectStore.swift
+++ b/Muxy/Services/Project/ProjectStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MuxyShared
 import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "ProjectStore")
@@ -20,7 +21,15 @@ final class ProjectStore {
         [Project.home] + storedProjects
     }
 
+    private var usedIconColors: Set<String> {
+        Set(storedProjects.compactMap(\.iconColor))
+    }
+
     func add(_ project: Project) {
+        var project = project
+        if project.iconColor == nil {
+            project.iconColor = ProjectIconColor.randomSwatch(excluding: usedIconColors)?.id
+        }
         storedProjects.append(project)
         save()
     }

--- a/MuxyShared/ProjectIconColor.swift
+++ b/MuxyShared/ProjectIconColor.swift
@@ -44,6 +44,12 @@ public enum ProjectIconColor {
         return palette.first { $0.hex.caseInsensitiveCompare(identifier) == .orderedSame }
     }
 
+    public static func randomSwatch(excluding usedIdentifiers: Set<String>) -> Swatch? {
+        let usedIDs = Set(usedIdentifiers.compactMap { swatch(for: $0)?.id })
+        let available = palette.filter { !usedIDs.contains($0.id) }
+        return (available.isEmpty ? palette : available).randomElement()
+    }
+
     public static func rgb(fromHex hex: String) -> (Double, Double, Double)? {
         var normalized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         if normalized.hasPrefix("#") { normalized.removeFirst() }

--- a/Tests/MuxyTests/Models/ModelCoverageTests.swift
+++ b/Tests/MuxyTests/Models/ModelCoverageTests.swift
@@ -28,6 +28,21 @@ struct ModelCoverageTests {
         #expect(!ProjectIconColor.Swatch(id: "bad", name: "Bad", hex: "bad").prefersDarkForeground)
     }
 
+    @Test("Random swatch avoids used identifiers and falls back to the full palette")
+    func randomSwatchAvoidsUsedIdentifiers() {
+        let allButBlue = Set(ProjectIconColor.palette.map(\.id)).subtracting(["blue"])
+        #expect(ProjectIconColor.randomSwatch(excluding: allButBlue)?.id == "blue")
+
+        let allByHex = Set(ProjectIconColor.palette.map(\.hex)).subtracting(["#3E63DD"])
+        #expect(ProjectIconColor.randomSwatch(excluding: allByHex)?.id == "blue")
+
+        let everyID = Set(ProjectIconColor.palette.map(\.id))
+        #expect(ProjectIconColor.randomSwatch(excluding: everyID) != nil)
+
+        let picked = ProjectIconColor.randomSwatch(excluding: ["unknown"])
+        #expect(picked != nil)
+    }
+
     @Test("UIMetrics exposes scaled values for every metric")
     func uiMetricsExposeScaledValues() {
         let scale = UIScale.shared

--- a/Tests/MuxyTests/Services/Project/ProjectStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectStoreTests.swift
@@ -2,10 +2,57 @@ import Foundation
 import Testing
 
 @testable import Muxy
+@testable import MuxyShared
 
 @Suite("ProjectStore")
 @MainActor
 struct ProjectStoreTests {
+    @Test("add assigns a random icon color not used by other projects")
+    func addAssignsUnusedIconColor() {
+        var existing = Project(name: "Repo", path: "/tmp/repo")
+        existing.iconColor = "blue"
+        let persistence = ProjectPersistenceStub(initial: [existing])
+        let store = ProjectStore(persistence: persistence)
+
+        let project = Project(name: "New", path: "/tmp/new")
+        store.add(project)
+
+        let stored = store.storedProjects.first { $0.id == project.id }
+        #expect(stored?.iconColor != nil)
+        #expect(stored?.iconColor != "blue")
+        #expect(ProjectIconColor.swatch(for: stored?.iconColor) != nil)
+        #expect(persistence.projects.first { $0.id == project.id }?.iconColor == stored?.iconColor)
+    }
+
+    @Test("add keeps an explicitly set icon color")
+    func addKeepsExplicitIconColor() {
+        let persistence = ProjectPersistenceStub(initial: [])
+        let store = ProjectStore(persistence: persistence)
+
+        var project = Project(name: "New", path: "/tmp/new")
+        project.iconColor = "red"
+        store.add(project)
+
+        #expect(store.storedProjects.first { $0.id == project.id }?.iconColor == "red")
+    }
+
+    @Test("add still assigns a palette color when every color is in use")
+    func addAssignsColorWhenPaletteExhausted() {
+        let existing = ProjectIconColor.palette.map { swatch in
+            var project = Project(name: swatch.id, path: "/tmp/\(swatch.id)")
+            project.iconColor = swatch.id
+            return project
+        }
+        let persistence = ProjectPersistenceStub(initial: existing)
+        let store = ProjectStore(persistence: persistence)
+
+        let project = Project(name: "New", path: "/tmp/new")
+        store.add(project)
+
+        let stored = store.storedProjects.first { $0.id == project.id }
+        #expect(ProjectIconColor.swatch(for: stored?.iconColor) != nil)
+    }
+
     @Test("setPreferredWorktreeParentPath persists normalized path")
     func setPreferredWorktreeParentPath() {
         let project = Project(name: "Repo", path: "/tmp/repo")


### PR DESCRIPTION

## Summary

Puts a random color as the project color instead of defaulting to gray so it is easier to find projects right when creating. You can still manually go back to gray if needed


## Testing
added multiple test cases

