### PR TITLE
Disable titlebar vibrancy over traffic lights in icon sidebar

### DIFF
--- a/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
@@ -36,6 +36,17 @@ enum SidebarLayout {
     static func isHidden(expanded: Bool, collapsedStyle: SidebarCollapsedStyle) -> Bool {
         !expanded && collapsedStyle == .hidden
     }
+
+    static func isIcon(
+        expanded: Bool,
+        collapsedStyle: SidebarCollapsedStyle,
+        expandedStyle: SidebarExpandedStyle
+    ) -> Bool {
+        if expanded {
+            return expandedStyle == .icons
+        }
+        return collapsedStyle == .icons
+    }
 }
 
 struct ProjectFocusedSidebar: View {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -416,7 +416,7 @@ struct MainWindow: View {
                     HStack(spacing: 0) {
                         if titleBarSidebarBackgroundWidth > 0 {
                             AppSidebarBackground(
-                                style: appBackgroundStyle,
+                                style: titleBarSidebarBackgroundStyle,
                                 isFullScreen: isFullScreen
                             )
                             .frame(width: titleBarSidebarBackgroundWidth)
@@ -1026,6 +1026,18 @@ struct MainWindow: View {
 
     private var sidebarIsResizable: Bool {
         SidebarLayout.isWide(expanded: sidebarExpanded, expandedStyle: sidebarExpandedStyle)
+    }
+
+    private var isIconSidebarSize: Bool {
+        SidebarLayout.isIcon(
+            expanded: sidebarExpanded,
+            collapsedStyle: sidebarCollapsedStyle,
+            expandedStyle: sidebarExpandedStyle
+        )
+    }
+
+    private var titleBarSidebarBackgroundStyle: AppBackgroundStyle {
+        isIconSidebarSize ? .solid : appBackgroundStyle
     }
 
     private var sidebarBorderVisible: Bool {


### PR DESCRIPTION
The sidebar vibrancy extends into the titlebar over the traffic-light area, which looked off in icon-sized sidebar mode.

Renders that titlebar strip solid (not vibrant) when the sidebar is icon-sized; the sidebar body and wide/hidden modes are unchanged.