### PR TITLE
fix: skip JSON hooks when TOML present in Codex

### DIFF
--- a/Muxy/Services/Providers/CodexProvider.swift
+++ b/Muxy/Services/Providers/CodexProvider.swift
@@ -20,6 +20,7 @@ struct CodexProvider: AIProviderIntegration {
     private let homeDirectory: String
     private let pathEnvironment: () -> String
     private let hooksPath: String
+    private var configPath: String { "\(homeDirectory)/.codex/config.toml" }
 
     init(
         homeDirectory: String = NSHomeDirectory(),
@@ -54,6 +55,13 @@ struct CodexProvider: AIProviderIntegration {
     }
 
     func install(hookScriptPath: String) throws {
+        if try hasExecutableInlineHooks() {
+            if isHookInstalled() {
+                try uninstall()
+            }
+            throw CodexProviderError.inlineHooksConfigured(configPath)
+        }
+
         let settings = try readSettings()
         let hooks = settings["hooks"] as? [String: Any] ?? [:]
         var updatedSettings = settings
@@ -172,6 +180,30 @@ struct CodexProvider: AIProviderIntegration {
         } ?? 0
     }
 
+    private func hasExecutableInlineHooks() throws -> Bool {
+        guard FileManager.default.fileExists(atPath: configPath) else { return false }
+        let config = try String(contentsOfFile: configPath, encoding: .utf8)
+        let events = Set([
+            "PreToolUse",
+            "PermissionRequest",
+            "PostToolUse",
+            "PreCompact",
+            "PostCompact",
+            "SessionStart",
+            "UserPromptSubmit",
+            "SubagentStart",
+            "SubagentStop",
+            "Stop",
+        ])
+
+        return config.split(whereSeparator: \.isNewline).contains { rawLine in
+            let line = rawLine.prefix { $0 != "#" }
+            let header = line.filter { !$0.isWhitespace && $0 != "\"" && $0 != "'" }
+            guard header.hasPrefix("[[hooks."), header.hasSuffix("]]") else { return false }
+            return events.contains(String(header.dropFirst(8).dropLast(2)))
+        }
+    }
+
     private func readSettings() throws -> [String: Any] {
         guard FileManager.default.fileExists(atPath: hooksPath) else { return [:] }
         let data = try Data(contentsOf: URL(fileURLWithPath: hooksPath))
@@ -197,5 +229,16 @@ struct CodexProvider: AIProviderIntegration {
             [.posixPermissions: FilePermissions.privateFile],
             ofItemAtPath: hooksPath
         )
+    }
+}
+
+enum CodexProviderError: LocalizedError, Equatable {
+    case inlineHooksConfigured(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .inlineHooksConfigured(path):
+            "Codex hooks are configured in \(path); Muxy skipped hooks.json to avoid loading both"
+        }
     }
 }

--- a/Tests/MuxyTests/Services/Providers/CodexProviderTests.swift
+++ b/Tests/MuxyTests/Services/Providers/CodexProviderTests.swift
@@ -119,6 +119,60 @@ struct CodexProviderTests {
         #expect(Self.commands(in: secondInstall, event: "Stop") == Self.commands(in: firstInstall, event: "Stop"))
     }
 
+    @Test("install does not create hooks.json when config.toml contains hooks")
+    func installSkipsConflictingRepresentation() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeConfig(
+            """
+            [[hooks.SessionStart]]
+
+            [[hooks.SessionStart.hooks]]
+            type = "command"
+            command = "/usr/bin/true"
+            """
+        )
+
+        #expect(throws: CodexProviderError.inlineHooksConfigured(fixture.configURL.path)) {
+            try fixture.provider().install(hookScriptPath: "/tmp/muxy-codex-hook.sh")
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.hooksURL.path))
+    }
+
+    @Test("install ignores hooks.state metadata in config.toml")
+    func installAllowsStateOnlyConfig() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.writeConfig(
+            """
+            [hooks.state."/tmp/hooks.json:stop:0:0"]
+            enabled = false
+            """
+        )
+
+        try fixture.provider().install(hookScriptPath: "/tmp/muxy-codex-hook.sh")
+
+        #expect(Self.commands(in: try fixture.readSettings(), event: "Stop") == [
+            "'/tmp/muxy-codex-hook.sh' stop # muxy-notification-hook",
+        ])
+    }
+
+    @Test("install removes existing Muxy JSON hooks when config.toml contains hooks")
+    func installRemovesExistingConflictingHooks() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+
+        try fixture.provider().install(hookScriptPath: "/tmp/muxy-codex-hook.sh")
+        try fixture.writeConfig("[[hooks.Stop]]")
+
+        #expect(throws: CodexProviderError.inlineHooksConfigured(fixture.configURL.path)) {
+            try fixture.provider().install(hookScriptPath: "/tmp/muxy-codex-hook.sh")
+        }
+        #expect(Self.commands(in: try fixture.readSettings(), event: "Stop").isEmpty)
+    }
+
     @Test("uninstall removes Muxy hooks and preserves colocated user hook")
     func uninstallRemovesMuxyHooksAndPreservesColocatedUserHook() throws {
         let fixture = try Fixture()
@@ -201,12 +255,14 @@ struct CodexProviderTests {
         let rootURL: URL
         let homeURL: URL
         let hooksURL: URL
+        let configURL: URL
 
         init() throws {
             rootURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("CodexProviderTests-\(UUID().uuidString)", isDirectory: true)
             homeURL = rootURL.appendingPathComponent("home", isDirectory: true)
             hooksURL = homeURL.appendingPathComponent(".codex/hooks.json")
+            configURL = homeURL.appendingPathComponent(".codex/config.toml")
             try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
         }
 
@@ -234,6 +290,14 @@ struct CodexProviderTests {
             )
             let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
             try data.write(to: hooksURL, options: .atomic)
+        }
+
+        func writeConfig(_ config: String) throws {
+            try FileManager.default.createDirectory(
+                at: configURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try config.write(to: configURL, atomically: true, encoding: .utf8)
         }
 
         func readSettings() throws -> [String: Any] {


### PR DESCRIPTION
Closes #877

Root cause: CodexProvider always wrote hooks.json without checking if there are hooks in config.toml.

Fix: skip JSON installation for TOML hooks, ignore hooks.state, and remove only existing Muxy-marked JSON hooks.

Validation: scripts/checks.sh --fix and all tests passed; exact Xcode 16.4 run awaits CI
