### PR TITLE
Make the full button clickable in the extensions tab

### DIFF
--- a/Muxy/Views/Components/Pickers/SegmentedPicker.swift
+++ b/Muxy/Views/Components/Pickers/SegmentedPicker.swift
@@ -21,6 +21,7 @@ struct SegmentedPicker<T: Hashable>: View {
                                 : Color.clear,
                             in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
                         )
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
 


### PR DESCRIPTION
Inside of the extensions tab only the text was clickable but the rest of the buttons inside of the screen are fully clickable.

This is a one line fix that changes it to make the whole button clickable instead of just the text. Image for reference
<img width="832" height="130" alt="CleanShot 2026-07-10 at 10 58 09@2x" src="https://github.com/user-attachments/assets/8a7c4fb0-b661-4628-847a-789907f9f423" />
