### PR TITLE
Scale status bar with UI size setting

### DIFF
--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -52,6 +52,7 @@ enum UIMetrics {
     static var tabBarHeight: CGFloat { scaled(28) }
     static var headerHeight: CGFloat { scaled(36) }
     static var titleBarHeight: CGFloat { scaled(32) }
+    static var statusBarHeight: CGFloat { scaled(28) }
 
     static func scaled(_ value: CGFloat) -> CGFloat {
         value * UIScale.shared.multiplier

--- a/Muxy/Theme/UIScale.swift
+++ b/Muxy/Theme/UIScale.swift
@@ -12,6 +12,7 @@ final class UIScale {
         case regular
         case large
         case extraLarge
+        case huge
 
         var id: String { rawValue }
 
@@ -20,6 +21,7 @@ final class UIScale {
             case .regular: 1.00
             case .large: 1.12
             case .extraLarge: 1.24
+            case .huge: 1.40
             }
         }
 
@@ -28,6 +30,7 @@ final class UIScale {
             case .regular: "Default"
             case .large: "Large"
             case .extraLarge: "Extra Large"
+            case .huge: "Huge"
             }
         }
     }

--- a/Muxy/Views/Components/Buttons/ResourceUsageButton.swift
+++ b/Muxy/Views/Components/Buttons/ResourceUsageButton.swift
@@ -10,7 +10,7 @@ struct ResourceUsageButton: View {
             showingPopover.toggle()
         } label: {
             Image(systemName: "cpu")
-                .font(.system(size: 11, weight: .semibold))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
                 .padding(.horizontal, 4)
                 .frame(maxHeight: .infinity)

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -85,7 +85,6 @@ struct InterfaceSettingsView: View {
                     }
                     .labelsHidden()
                     .pickerStyle(.segmented)
-                    .frame(width: SettingsMetrics.controlWidth)
                 }
 
                 TabHeaderWidthSettingRow()

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -34,7 +34,7 @@ struct ProjectStatusBar: View {
             rightSide
         }
         .padding(.horizontal, 10)
-        .frame(height: 28)
+        .frame(height: UIMetrics.statusBarHeight)
         .background(MuxyTheme.bg)
         .overlay(
             Rectangle().fill(MuxyTheme.border).frame(height: 1),
@@ -118,9 +118,9 @@ struct ProjectStatusBar: View {
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: remote ? "network" : "folder")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 Text(truncated)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     .lineLimit(1)
             }
             .foregroundStyle(MuxyTheme.fgMuted)
@@ -162,11 +162,11 @@ struct ProjectStatusBar: View {
                 ExtensionIconView(
                     icon: binding.displayIcon,
                     muxyExtension: binding.muxyExtension,
-                    size: 10
+                    size: UIMetrics.iconXS
                 )
                 if let text = binding.displayText, !text.isEmpty {
                     Text(text)
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                         .lineLimit(1)
                 }
             }
@@ -187,7 +187,7 @@ struct ProjectStatusBar: View {
             extensionOutputVisible.toggle()
         } label: {
             Image(systemName: "ladybug")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 .foregroundStyle(extensionOutputVisible ? MuxyTheme.accent : MuxyTheme.fgMuted)
         }
         .buttonStyle(.plain)
@@ -199,9 +199,9 @@ struct ProjectStatusBar: View {
         Button(action: handleToggleRichInput) {
             HStack(spacing: 4) {
                 Image(systemName: "keyboard")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 Text(richInputShortcutLabel)
-                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
         }
@@ -215,9 +215,9 @@ struct ProjectStatusBar: View {
         Button(action: handleToggleVoiceRecording) {
             HStack(spacing: 4) {
                 Image(systemName: "mic")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 Text(voiceShortcutLabel)
-                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
         }
@@ -231,7 +231,7 @@ struct ProjectStatusBar: View {
         HStack(spacing: 2) {
             Button(action: decreaseFontSize) {
                 Image(systemName: "textformat.size.smaller")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
             }
             .buttonStyle(RichInputToolbarButtonStyle())
             .disabled(richInputFontSize <= RichInputPreferences.minFontSize)
@@ -239,14 +239,14 @@ struct ProjectStatusBar: View {
             .help("Decrease font size")
 
             Text("\(Int(clampedFontSize))")
-                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(minWidth: 18)
                 .accessibilityLabel("Editor font size \(Int(clampedFontSize))")
 
             Button(action: increaseFontSize) {
                 Image(systemName: "textformat.size.larger")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
             }
             .buttonStyle(RichInputToolbarButtonStyle())
             .disabled(richInputFontSize >= RichInputPreferences.maxFontSize)
@@ -270,10 +270,10 @@ struct ProjectStatusBar: View {
     private func shortcutHint(keys: String, label: String) -> some View {
         HStack(spacing: 4) {
             Text(keys)
-                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text(label)
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 .foregroundStyle(MuxyTheme.fgMuted)
         }
     }

--- a/Tests/MuxyTests/Theme/UIScaleTests.swift
+++ b/Tests/MuxyTests/Theme/UIScaleTests.swift
@@ -9,14 +9,15 @@ struct UIScaleTests {
     @Test("Each preset returns a distinct, ordered multiplier")
     func presetMultipliersAreOrdered() {
         let presets = UIScale.Preset.allCases
-        #expect(presets == [.regular, .large, .extraLarge])
-        #expect(presets.map(\.id) == ["regular", "large", "extraLarge"])
-        #expect(presets.map(\.title) == ["Default", "Large", "Extra Large"])
+        #expect(presets == [.regular, .large, .extraLarge, .huge])
+        #expect(presets.map(\.id) == ["regular", "large", "extraLarge", "huge"])
+        #expect(presets.map(\.title) == ["Default", "Large", "Extra Large", "Huge"])
 
         let multipliers = presets.map(\.multiplier)
         #expect(multipliers == multipliers.sorted())
         #expect(Set(multipliers).count == multipliers.count)
         #expect(UIScale.Preset.regular.multiplier == 1.0)
+        #expect(UIScale.Preset.huge.multiplier == 1.40)
         #expect(UIScale.defaultPreset == .regular)
     }
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -23,7 +23,7 @@ Open settings with `Cmd+,` (**Muxy -> Settings...**). Use search at the top to f
 
 ## Interface
 
-- **Interface Size** — controls app density.
+- **Interface Size** — controls app density across Default, Large, Extra Large, and Huge. Scales fonts, spacing, icons, and the status bar.
 - **Tab header width** — controls maximum tab header width.
 - **Show Status Bar** — shows or hides the bottom status bar.
 - **Show Resource Usage in Status Bar** — shows CPU and memory usage; disabling it stops sampling.


### PR DESCRIPTION
Status bar fonts and height were hardcoded, ignoring the Interface Size setting.
Route them through UIMetrics so they scale, and add a Huge preset (1.40x).