### PR TITLE
feat: add muxy.gh service for GitHub user API

### DIFF
--- a/Muxy/Models/Extension/Extension.swift
+++ b/Muxy/Models/Extension/Extension.swift
@@ -78,6 +78,7 @@ enum ExtensionPermission: String, Codable, CaseIterable {
     case commandsExec = "commands:exec"
     case shortcutsRegister = "shortcuts:register"
     case remoteServe = "remote:serve"
+    case ghRead = "gh:read"
 
     enum Kind {
         case read
@@ -94,6 +95,7 @@ enum ExtensionPermission: String, Codable, CaseIterable {
              .worktreesRead,
              .agentsRead,
              .gitRead,
+             .ghRead,
              .filesRead,
              .storageRead:
             .read

--- a/Muxy/Services/Extensions/ExtensionWebBridge.swift
+++ b/Muxy/Services/Extensions/ExtensionWebBridge.swift
@@ -418,6 +418,9 @@ enum ExtensionWebBridge {
                 agents: {
                     list() { return send('agents.list', {}); },
                 },
+                gh: {
+                    user(o) { return send('gh.user', { project: gitProject(o) }); },
+                },
                 git: {
                     status(o) { return send('git.status', {
                         project: gitProject(o),
@@ -628,6 +631,7 @@ enum ExtensionWebBridge {
             Object.freeze(muxy.statusbar);
             Object.freeze(muxy.worktrees);
             Object.freeze(muxy.agents);
+            Object.freeze(muxy.gh);
             Object.freeze(muxy.git);
             Object.freeze(muxy.git.pr);
             Object.freeze(muxy.git.branch);

--- a/Muxy/Services/MuxyAPI/GhDTO.swift
+++ b/Muxy/Services/MuxyAPI/GhDTO.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum GhDTO {
+    static func user(_ user: MuxyAPI.Gh.GitHubUser) -> [String: Any] {
+        [
+            "login": user.login,
+            "name": user.name,
+            "avatarUrl": user.avatarUrl,
+        ]
+    }
+}

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -301,7 +301,7 @@ enum MuxyAPI {
             "lifecycle.ackBeforeClose",
             "lifecycle.resolveBeforeClose",
             "lifecycle.closeSelf",
-        ]).union(gitVerbs).union(filesVerbs)
+        ]).union(gitVerbs).union(filesVerbs).union(ghVerbs)
 
         static let filesVerbs: Set<String> = [
             "files.list",
@@ -351,6 +351,10 @@ enum MuxyAPI {
             "git.tag.create",
             "git.pr.checkout",
             "git.pr.checkoutWorktree",
+        ]
+
+        static let ghVerbs: Set<String> = [
+            "gh.user",
         ]
 
         private static let cliAliases: [String: String] = [
@@ -490,6 +494,7 @@ enum MuxyAPI {
             "git.tag.create": .gitWrite,
             "git.pr.checkout": .gitWrite,
             "git.pr.checkoutWorktree": .gitWrite,
+            "gh.user": .ghRead,
             "files.list": .filesRead,
             "files.read": .filesRead,
             "files.stat": .filesRead,

--- a/Muxy/Services/MuxyAPI/MuxyAPIDispatcher.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPIDispatcher.swift
@@ -456,6 +456,9 @@ enum MuxyAPIDispatcher {
             if verb.hasPrefix("files.") {
                 return try await handleFiles(verb: verb, args: args, context: context)
             }
+            if verb.hasPrefix("gh.") {
+                return try await handleGh(verb: verb, args: args, context: context)
+            }
             throw APIError.invalidArguments("unknown verb \(verb)")
         }
     }
@@ -776,6 +779,28 @@ enum MuxyAPIDispatcher {
                 context: files
             ))
             return NSNull()
+        default:
+            throw APIError.invalidArguments("unknown verb \(verb)")
+        }
+    }
+
+    private static func handleGh(verb: String, args: [String: Any], context: Context) async throws -> Any {
+        guard let projectStore = context.projectStore,
+              let worktreeStore = context.worktreeStore,
+              let projectGroupStore = context.projectGroupStore
+        else { throw APIError.worktreeStoreUnavailable }
+        let gh = MuxyAPI.Gh.Context(
+            extensionID: context.extensionID,
+            appState: context.appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+
+        switch verb {
+        case "gh.user":
+            let user = try await unwrap(MuxyAPI.Gh.user(context: gh))
+            return GhDTO.user(user)
         default:
             throw APIError.invalidArguments("unknown verb \(verb)")
         }

--- a/Muxy/Services/MuxyAPI/MuxyAPIGh.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPIGh.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+extension MuxyAPI {
+    @MainActor
+    enum Gh {
+        struct Context {
+            let extensionID: String
+            let appState: AppState
+            let projectStore: ProjectStore
+            let worktreeStore: WorktreeStore
+            let projectGroupStore: ProjectGroupStore
+        }
+
+        struct GitHubUser {
+            let login: String
+            let name: String
+            let avatarUrl: String
+        }
+
+        private static var cachedUser: GitHubUser?
+        private static var cachedUserAt: Date?
+        private static let userTTL: TimeInterval = 300
+
+        static func user(context: Context) async -> Result<GitHubUser, APIError> {
+            if let cached = cachedUser, let at = cachedUserAt,
+               Date().timeIntervalSince(at) < userTTL
+            {
+                return .success(cached)
+            }
+
+            guard let ghPath = GitProcessRunner.resolveExecutable("gh") else {
+                return .failure(.underlying("GitHub CLI (gh) is not installed. Install it from cli.github.com."))
+            }
+
+            do {
+                let result = try await GitProcessRunner.runCommand(
+                    executable: ghPath,
+                    arguments: ["api", "user", "--jq", "{login: .login, name: .name, avatarUrl: .avatar_url}"],
+                    workingDirectory: ""
+                )
+                guard result.status == 0 else {
+                    let msg = result.stderr.isEmpty ? result.stdout : result.stderr
+                    return .failure(.underlying(msg.trimmingCharacters(in: .whitespacesAndNewlines)))
+                }
+                guard let data = result.stdout.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let login = json["login"] as? String
+                else {
+                    return .failure(.underlying("Failed to parse GitHub user info."))
+                }
+                let user = GitHubUser(
+                    login: login,
+                    name: json["name"] as? String ?? "",
+                    avatarUrl: json["avatarUrl"] as? String ?? ""
+                )
+                cachedUser = user
+                cachedUserAt = Date()
+                return .success(user)
+            } catch {
+                return .failure(.underlying(error.localizedDescription))
+            }
+        }
+    }
+}

--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -52,6 +52,7 @@ enum UIMetrics {
     static var tabBarHeight: CGFloat { scaled(28) }
     static var headerHeight: CGFloat { scaled(36) }
     static var titleBarHeight: CGFloat { scaled(32) }
+    static var statusBarHeight: CGFloat { scaled(28) }
 
     static func scaled(_ value: CGFloat) -> CGFloat {
         value * UIScale.shared.multiplier

--- a/Muxy/Theme/UIScale.swift
+++ b/Muxy/Theme/UIScale.swift
@@ -12,6 +12,7 @@ final class UIScale {
         case regular
         case large
         case extraLarge
+        case huge
 
         var id: String { rawValue }
 
@@ -20,6 +21,7 @@ final class UIScale {
             case .regular: 1.00
             case .large: 1.12
             case .extraLarge: 1.24
+            case .huge: 1.40
             }
         }
 
@@ -28,6 +30,7 @@ final class UIScale {
             case .regular: "Default"
             case .large: "Large"
             case .extraLarge: "Extra Large"
+            case .huge: "Huge"
             }
         }
     }

--- a/Muxy/Views/Components/Buttons/ResourceUsageButton.swift
+++ b/Muxy/Views/Components/Buttons/ResourceUsageButton.swift
@@ -10,7 +10,7 @@ struct ResourceUsageButton: View {
             showingPopover.toggle()
         } label: {
             Image(systemName: "cpu")
-                .font(.system(size: 11, weight: .semibold))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
                 .padding(.horizontal, 4)
                 .frame(maxHeight: .infinity)

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -85,7 +85,6 @@ struct InterfaceSettingsView: View {
                     }
                     .labelsHidden()
                     .pickerStyle(.segmented)
-                    .frame(width: SettingsMetrics.controlWidth)
                 }
 
                 TabHeaderWidthSettingRow()

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -34,7 +34,7 @@ struct ProjectStatusBar: View {
             rightSide
         }
         .padding(.horizontal, 10)
-        .frame(height: 28)
+        .frame(height: UIMetrics.statusBarHeight)
         .background(MuxyTheme.bg)
         .overlay(
             Rectangle().fill(MuxyTheme.border).frame(height: 1),
@@ -118,9 +118,9 @@ struct ProjectStatusBar: View {
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: remote ? "network" : "folder")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 Text(truncated)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     .lineLimit(1)
             }
             .foregroundStyle(MuxyTheme.fgMuted)
@@ -162,11 +162,11 @@ struct ProjectStatusBar: View {
                 ExtensionIconView(
                     icon: binding.displayIcon,
                     muxyExtension: binding.muxyExtension,
-                    size: 10
+                    size: UIMetrics.iconXS
                 )
                 if let text = binding.displayText, !text.isEmpty {
                     Text(text)
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                         .lineLimit(1)
                 }
             }
@@ -187,7 +187,7 @@ struct ProjectStatusBar: View {
             extensionOutputVisible.toggle()
         } label: {
             Image(systemName: "ladybug")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                 .foregroundStyle(extensionOutputVisible ? MuxyTheme.accent : MuxyTheme.fgMuted)
         }
         .buttonStyle(.plain)
@@ -199,9 +199,9 @@ struct ProjectStatusBar: View {
         Button(action: handleToggleRichInput) {
             HStack(spacing: 4) {
                 Image(systemName: "keyboard")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 Text(richInputShortcutLabel)
-                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
         }
@@ -215,9 +215,9 @@ struct ProjectStatusBar: View {
         Button(action: handleToggleVoiceRecording) {
             HStack(spacing: 4) {
                 Image(systemName: "mic")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                 Text(voiceShortcutLabel)
-                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                     .foregroundStyle(MuxyTheme.fgDim)
             }
         }
@@ -231,7 +231,7 @@ struct ProjectStatusBar: View {
         HStack(spacing: 2) {
             Button(action: decreaseFontSize) {
                 Image(systemName: "textformat.size.smaller")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
             }
             .buttonStyle(RichInputToolbarButtonStyle())
             .disabled(richInputFontSize <= RichInputPreferences.minFontSize)
@@ -239,14 +239,14 @@ struct ProjectStatusBar: View {
             .help("Decrease font size")
 
             Text("\(Int(clampedFontSize))")
-                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(minWidth: 18)
                 .accessibilityLabel("Editor font size \(Int(clampedFontSize))")
 
             Button(action: increaseFontSize) {
                 Image(systemName: "textformat.size.larger")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
             }
             .buttonStyle(RichInputToolbarButtonStyle())
             .disabled(richInputFontSize >= RichInputPreferences.maxFontSize)
@@ -270,10 +270,10 @@ struct ProjectStatusBar: View {
     private func shortcutHint(keys: String, label: String) -> some View {
         HStack(spacing: 4) {
             Text(keys)
-                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text(label)
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 .foregroundStyle(MuxyTheme.fgMuted)
         }
     }

--- a/MuxyShared/ExtensionBridgeJS.swift
+++ b/MuxyShared/ExtensionBridgeJS.swift
@@ -241,12 +241,14 @@ public enum ExtensionBridgeJS {
         \(surface == .background ? eventsBlock : "")
         \(surface == .background ? remoteBlock : "")
         \(gitBlock)
+        \(ghBlock)
         \(agentsBlock)
             \(surface == .inProcess ?
             "Object.freeze(muxy.tabs); Object.freeze(muxy.browser); Object.freeze(muxy.panes); Object.freeze(muxy.projects); Object.freeze(muxy.worktrees); Object.freeze(muxy.files);" :
             "")
             \(surface == .background ? "Object.freeze(muxy.tabs);" : "")
             Object.freeze(muxy.git); Object.freeze(muxy.git.pr); Object.freeze(muxy.git.branch); Object.freeze(muxy.git.worktree);
+            Object.freeze(muxy.gh);
             Object.freeze(muxy.agents);
             Object.freeze(muxy.notifications);
             Object.freeze(muxy.dialog);
@@ -498,6 +500,13 @@ public enum ExtensionBridgeJS {
     private static let agentsBlock = """
             muxy.agents = {
                 list: () => dispatch('agents.list', {}),
+            };
+    """
+
+    private static let ghBlock = """
+            const ghProject = (o) => (o && o.project != null ? String(o.project) : null);
+            muxy.gh = {
+                user: (o) => dispatch('gh.user', { project: ghProject(o) }),
             };
     """
 

--- a/Tests/MuxyTests/Theme/UIScaleTests.swift
+++ b/Tests/MuxyTests/Theme/UIScaleTests.swift
@@ -9,14 +9,15 @@ struct UIScaleTests {
     @Test("Each preset returns a distinct, ordered multiplier")
     func presetMultipliersAreOrdered() {
         let presets = UIScale.Preset.allCases
-        #expect(presets == [.regular, .large, .extraLarge])
-        #expect(presets.map(\.id) == ["regular", "large", "extraLarge"])
-        #expect(presets.map(\.title) == ["Default", "Large", "Extra Large"])
+        #expect(presets == [.regular, .large, .extraLarge, .huge])
+        #expect(presets.map(\.id) == ["regular", "large", "extraLarge", "huge"])
+        #expect(presets.map(\.title) == ["Default", "Large", "Extra Large", "Huge"])
 
         let multipliers = presets.map(\.multiplier)
         #expect(multipliers == multipliers.sorted())
         #expect(Set(multipliers).count == multipliers.count)
         #expect(UIScale.Preset.regular.multiplier == 1.0)
+        #expect(UIScale.Preset.huge.multiplier == 1.40)
         #expect(UIScale.defaultPreset == .regular)
     }
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -23,7 +23,7 @@ Open settings with `Cmd+,` (**Muxy -> Settings...**). Use search at the top to f
 
 ## Interface
 
-- **Interface Size** — controls app density.
+- **Interface Size** — controls app density across Default, Large, Extra Large, and Huge. Scales fonts, spacing, icons, and the status bar.
 - **Tab header width** — controls maximum tab header width.
 - **Show Status Bar** — shows or hides the bottom status bar.
 - **Show Resource Usage in Status Bar** — shows CPU and memory usage; disabling it stops sampling.


### PR DESCRIPTION
Adds muxy.gh.user() native API that returns authenticated GitHub user info (login, name, avatarUrl) with 5-minute in-memory cache.

- New ghRead permission
- MuxyAPIGh.swift + GhDTO.swift
- Dispatcher routing for gh.* verbs
- JS and WebBridge exposure

Enables extensions to get GitHub user info without shelling out to `gh api`.