### PR TITLE
fix resize handle layout spacing

### DIFF
--- a/Muxy/Views/Components/Interaction/ResizeHandle.swift
+++ b/Muxy/Views/Components/Interaction/ResizeHandle.swift
@@ -24,48 +24,48 @@ struct ResizeHandle: View {
     private var active: Bool { hovering || dragging }
 
     var body: some View {
-        ZStack(alignment: handleAlignment) {
-            Rectangle()
-                .fill(active ? MuxyTheme.accent : MuxyTheme.border)
-                .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
-            Rectangle()
-                .fill(Color.black.opacity(0.001))
-                .contentShape(Rectangle())
-                .gesture(
-                    DragGesture(minimumDistance: 1, coordinateSpace: .global)
-                        .updating($dragging) { _, state, _ in state = true }
-                        .onChanged { value in
+        Rectangle()
+            .fill(active ? MuxyTheme.accent : MuxyTheme.border)
+            .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
+            .overlay(alignment: handleAlignment) {
+                Rectangle()
+                    .fill(Color.black.opacity(0.001))
+                    .frame(
+                        width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
+                        height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
+                    )
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 1, coordinateSpace: .global)
+                            .updating($dragging) { _, state, _ in state = true }
+                            .onChanged { value in
+                                activateCursor()
+                                onDrag(value)
+                            }
+                            .onEnded { _ in
+                                onEnd?()
+                                if !hovering {
+                                    releaseCursor()
+                                }
+                            }
+                    )
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active:
+                            hovering = true
                             activateCursor()
-                            onDrag(value)
-                        }
-                        .onEnded { _ in
-                            onEnd?()
-                            if !hovering {
+                        case .ended:
+                            hovering = false
+                            if !dragging {
                                 releaseCursor()
                             }
                         }
-                )
-                .onContinuousHover { phase in
-                    switch phase {
-                    case .active:
-                        hovering = true
-                        activateCursor()
-                    case .ended:
-                        hovering = false
-                        if !dragging {
-                            releaseCursor()
-                        }
                     }
-                }
-        }
-        .frame(
-            width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
-            height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
-        )
-        .zIndex(1)
-        .onDisappear {
-            releaseCursor()
-        }
+            }
+            .zIndex(1)
+            .onDisappear {
+                releaseCursor()
+            }
     }
 
     private var handleAlignment: Alignment {
@@ -148,13 +148,6 @@ struct PanelResizeHandle: View {
     }
 
     private var hitAreaBias: ResizeHandle.HitAreaBias {
-        switch edge {
-        case .leading,
-             .top:
-            .leading
-        case .trailing,
-             .bottom:
-            .trailing
-        }
+        .trailing
     }
 }

--- a/Muxy/Views/Components/Interaction/ResizeHandle.swift
+++ b/Muxy/Views/Components/Interaction/ResizeHandle.swift
@@ -2,12 +2,16 @@ import AppKit
 import SwiftUI
 
 struct ResizeHandle: View {
-    enum Axis {
+    enum Axis: Equatable {
         case horizontal
         case vertical
+
+        var cursor: NSCursor {
+            self == .horizontal ? .resizeLeftRight : .resizeUpDown
+        }
     }
 
-    enum HitAreaBias {
+    enum HitAreaBias: Equatable {
         case centered
         case leading
         case trailing
@@ -18,7 +22,7 @@ struct ResizeHandle: View {
     var onEnd: (() -> Void)?
     let onDrag: (DragGesture.Value) -> Void
     @State private var hovering = false
-    @State private var cursorPushed = false
+    @State private var dragCursorPushed = false
     @GestureState private var dragging = false
 
     private var active: Bool { hovering || dragging }
@@ -34,37 +38,30 @@ struct ResizeHandle: View {
                         width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
                         height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
                     )
+                    .background {
+                        ResizeCursorRegion(axis: axis) { hovering = $0 }
+                    }
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 1, coordinateSpace: .global)
                             .updating($dragging) { _, state, _ in state = true }
                             .onChanged { value in
-                                activateCursor()
+                                activateDragCursor()
                                 onDrag(value)
                             }
                             .onEnded { _ in
                                 onEnd?()
-                                if !hovering {
-                                    releaseCursor()
-                                }
+                                releaseDragCursor()
                             }
                     )
-                    .onContinuousHover { phase in
-                        switch phase {
-                        case .active:
-                            hovering = true
-                            activateCursor()
-                        case .ended:
-                            hovering = false
-                            if !dragging {
-                                releaseCursor()
-                            }
-                        }
-                    }
             }
             .zIndex(1)
+            .onChange(of: dragging) { _, isDragging in
+                guard !isDragging else { return }
+                releaseDragCursor()
+            }
             .onDisappear {
-                releaseCursor()
+                releaseDragCursor()
             }
     }
 
@@ -79,23 +76,89 @@ struct ResizeHandle: View {
         }
     }
 
-    private var cursor: NSCursor {
-        axis == .horizontal ? .resizeLeftRight : .resizeUpDown
-    }
-
-    private func activateCursor() {
-        if cursorPushed {
-            cursor.set()
+    private func activateDragCursor() {
+        if dragCursorPushed {
+            axis.cursor.set()
         } else {
-            cursor.push()
-            cursorPushed = true
+            axis.cursor.push()
+            dragCursorPushed = true
         }
     }
 
-    private func releaseCursor() {
-        guard cursorPushed else { return }
+    private func releaseDragCursor() {
+        guard dragCursorPushed else { return }
         NSCursor.pop()
-        cursorPushed = false
+        dragCursorPushed = false
+    }
+}
+
+struct ResizeCursorRegion: NSViewRepresentable {
+    let axis: ResizeHandle.Axis
+    let onHoverChange: (Bool) -> Void
+
+    func makeNSView(context: Context) -> ResizeCursorNSView {
+        let view = ResizeCursorNSView(axis: axis)
+        view.onHoverChange = onHoverChange
+        return view
+    }
+
+    func updateNSView(_ nsView: ResizeCursorNSView, context: Context) {
+        nsView.axis = axis
+        nsView.onHoverChange = onHoverChange
+    }
+}
+
+final class ResizeCursorNSView: NSView {
+    var onHoverChange: ((Bool) -> Void)?
+    private var hoverTrackingArea: NSTrackingArea?
+    var axis: ResizeHandle.Axis {
+        didSet {
+            guard oldValue != axis else { return }
+            window?.invalidateCursorRects(for: self)
+        }
+    }
+
+    var cursor: NSCursor {
+        axis.cursor
+    }
+
+    init(axis: ResizeHandle.Axis) {
+        self.axis = axis
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        addCursorRect(bounds, cursor: cursor)
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea {
+            removeTrackingArea(hoverTrackingArea)
+        }
+        let nextTrackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(nextTrackingArea)
+        hoverTrackingArea = nextTrackingArea
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        onHoverChange?(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        onHoverChange?(false)
     }
 }
 
@@ -127,6 +190,17 @@ struct PanelResizeHandle: View {
         case trailing
         case top
         case bottom
+
+        var hitAreaBias: ResizeHandle.HitAreaBias {
+            switch self {
+            case .leading,
+                 .top:
+                .leading
+            case .trailing,
+                 .bottom:
+                .trailing
+            }
+        }
     }
 
     let axis: ResizeHandle.Axis
@@ -137,7 +211,7 @@ struct PanelResizeHandle: View {
     var body: some View {
         AnchoredResizeHandle(
             axis: axis,
-            hitAreaBias: hitAreaBias,
+            hitAreaBias: edge.hitAreaBias,
             captureAnchor: current,
             onTranslate: { start, delta in
                 let signed = (edge == .leading || edge == .top) ? -delta : delta
@@ -145,9 +219,5 @@ struct PanelResizeHandle: View {
             }
         )
         .accessibilityHidden(true)
-    }
-
-    private var hitAreaBias: ResizeHandle.HitAreaBias {
-        .trailing
     }
 }

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -22,9 +22,8 @@ struct SplitContainer: View {
         GeometryReader { geo in
             let h = branch.direction == .horizontal
             let total = h ? geo.size.width : geo.size.height
-            let dividerInset = UIMetrics.resizeHandleHitArea / 2
-            let first = max(0, total * branch.ratio - dividerInset)
-            let second = max(0, total * (1 - branch.ratio) - dividerInset)
+            let first = max(0, total * branch.ratio - 0.5)
+            let second = max(0, total * (1 - branch.ratio) - 0.5)
 
             let layout = h ? AnyLayout(HStackLayout(spacing: 0)) : AnyLayout(VStackLayout(spacing: 0))
 

--- a/Tests/MuxyTests/Views/Components/Interaction/ResizeHandleTests.swift
+++ b/Tests/MuxyTests/Views/Components/Interaction/ResizeHandleTests.swift
@@ -1,0 +1,29 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+@Suite("ResizeHandle")
+struct ResizeHandleTests {
+    @MainActor
+    @Test("cursor region owns the resize pointer surface")
+    func cursorRegionOwnsResizePointerSurface() {
+        let view = ResizeCursorNSView(axis: .horizontal)
+        view.frame = NSRect(x: 0, y: 0, width: 10, height: 100)
+
+        #expect(view.cursor === NSCursor.resizeLeftRight)
+        #expect(view.hitTest(NSPoint(x: 5, y: 50)) === view)
+
+        view.axis = .vertical
+
+        #expect(view.cursor === NSCursor.resizeUpDown)
+    }
+
+    @Test("panel resize hit areas stay inside their panel edge")
+    func panelResizeHitAreasStayInsidePanelEdge() {
+        #expect(PanelResizeHandle.Edge.leading.hitAreaBias == .leading)
+        #expect(PanelResizeHandle.Edge.trailing.hitAreaBias == .trailing)
+        #expect(PanelResizeHandle.Edge.top.hitAreaBias == .leading)
+        #expect(PanelResizeHandle.Edge.bottom.hitAreaBias == .trailing)
+    }
+}


### PR DESCRIPTION
<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

<!-- What does this PR do and why? Write this yourself — no AI-generated text. -->
Follow-up to #868 that fixes the remaining layout gap caused by resize handle hit areas consuming panel space.

## Changes

<!-- List the key changes -->

- Keep split dividers at 1pt while moving the larger drag target into a non-layout overlay
- Restore split container sizing so panes no longer lose extra space around each divider
- Preserve the wider grab area for right-side panel handles without adding visible spacing


## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

<!-- If applicable, add screenshots -->
<img width="1655" height="965" alt="image" src="https://github.com/user-attachments/assets/861469a4-4120-4b73-8cec-2114f1494bc9" />
