### PR TITLE
feat: add configurable global hotkey workspace

### DIFF
--- a/Muxy/Services/Keyboard/GlobalHotkeyPreferences.swift
+++ b/Muxy/Services/Keyboard/GlobalHotkeyPreferences.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+enum GlobalHotkeyTrigger: String, CaseIterable, Identifiable {
+    case doubleCommand
+    case doubleControl
+    case doubleOption
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .doubleCommand:
+            "Double Command"
+        case .doubleControl:
+            "Double Control"
+        case .doubleOption:
+            "Double Option"
+        }
+    }
+}
+
+enum GlobalHotkeyPreferences {
+    static let enabledKey = "muxy.globalHotkey.enabled"
+    static let triggerKey = "muxy.globalHotkey.trigger"
+    static let doubleTapIntervalMillisecondsKey = "muxy.globalHotkey.doubleTapIntervalMilliseconds"
+    static let toggleToHideKey = "muxy.globalHotkey.toggleToHide"
+
+    static let defaultEnabled = false
+    static let defaultTrigger = GlobalHotkeyTrigger.doubleCommand
+    static let defaultDoubleTapIntervalMilliseconds = 300.0
+    static let minimumDoubleTapIntervalMilliseconds = 100.0
+    static let maximumDoubleTapIntervalMilliseconds = 1000.0
+    static let doubleTapIntervalStepMilliseconds = 25.0
+    static let defaultToggleToHide = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: enabledKey) != nil else { return defaultEnabled }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    static func trigger(defaults: UserDefaults = .standard) -> GlobalHotkeyTrigger {
+        guard let rawValue = defaults.string(forKey: triggerKey),
+              let trigger = GlobalHotkeyTrigger(rawValue: rawValue)
+        else { return defaultTrigger }
+        return trigger
+    }
+
+    static func doubleTapIntervalMilliseconds(defaults: UserDefaults = .standard) -> Double {
+        guard defaults.object(forKey: doubleTapIntervalMillisecondsKey) != nil else {
+            return defaultDoubleTapIntervalMilliseconds
+        }
+        return clampedDoubleTapIntervalMilliseconds(defaults.double(forKey: doubleTapIntervalMillisecondsKey))
+    }
+
+    static func doubleTapInterval(defaults: UserDefaults = .standard) -> TimeInterval {
+        doubleTapIntervalMilliseconds(defaults: defaults) / 1000
+    }
+
+    static func toggleToHide(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: toggleToHideKey) != nil else { return defaultToggleToHide }
+        return defaults.bool(forKey: toggleToHideKey)
+    }
+
+    static func resetToDefaults(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: enabledKey)
+        defaults.removeObject(forKey: triggerKey)
+        defaults.removeObject(forKey: doubleTapIntervalMillisecondsKey)
+        defaults.removeObject(forKey: toggleToHideKey)
+    }
+
+    static func clampedDoubleTapIntervalMilliseconds(_ value: Double) -> Double {
+        min(max(value, minimumDoubleTapIntervalMilliseconds), maximumDoubleTapIntervalMilliseconds)
+    }
+}

--- a/Muxy/Services/Keyboard/HotkeyWindowController.swift
+++ b/Muxy/Services/Keyboard/HotkeyWindowController.swift
@@ -1,0 +1,480 @@
+import AppKit
+import CoreGraphics
+import SwiftUI
+
+@MainActor
+private final class HotkeyWorkspaceModel {
+    let appState: AppState
+    let projectStore: ProjectStore
+    let worktreeStore: WorktreeStore
+    let projectGroupStore: ProjectGroupStore
+    let remoteDeviceStore: RemoteDeviceStore
+    let browserProfileStore: BrowserProfileStore
+    let browserHistoryStore: BrowserHistoryStore
+
+    init() {
+        let environment = AppEnvironment.live
+        let projectStore = ProjectStore(persistence: environment.projectPersistence)
+        let worktreeStore = WorktreeStore(
+            persistence: environment.worktreePersistence,
+            projects: projectStore.projects
+        )
+        let remoteDeviceStore = RemoteDeviceStore(
+            persistence: environment.remoteDevicePersistence
+        )
+        let browserProfileStore = BrowserProfileStore(
+            persistence: environment.browserProfilePersistence
+        )
+        let browserHistoryStore = BrowserHistoryStore(
+            persistence: environment.browserHistoryPersistence
+        )
+        let projectGroupStore = ProjectGroupStore(
+            persistence: environment.projectGroupPersistence,
+            remoteDeviceStore: remoteDeviceStore
+        )
+        let appState = AppState(
+            selectionStore: UserDefaultsActiveProjectSelectionStore(
+                projectKey: "muxy.hotkey.activeProjectID",
+                worktreesKey: "muxy.hotkey.activeWorktreeIDs"
+            ),
+            terminalViews: environment.terminalViews,
+            workspacePersistence: FileWorkspacePersistence(
+                fileURL: MuxyFileStorage.fileURL(filename: "hotkey-workspaces.json")
+            )
+        )
+        appState.restoreSelection(
+            projects: projectStore.projects,
+            worktrees: worktreeStore.worktrees,
+            skippingProjectIDs: projectGroupStore.activeRemoteProjectIDs
+        )
+
+        self.appState = appState
+        self.projectStore = projectStore
+        self.worktreeStore = worktreeStore
+        self.projectGroupStore = projectGroupStore
+        self.remoteDeviceStore = remoteDeviceStore
+        self.browserProfileStore = browserProfileStore
+        self.browserHistoryStore = browserHistoryStore
+    }
+
+    func ensureWorkspaceReady() {
+        if appState.activeProjectID == nil {
+            _ = HomeProjectService.openHomeTab(
+                appState: appState,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
+            )
+        }
+        guard let projectID = appState.activeProjectID else { return }
+        if !appState.hasTabs(for: projectID) {
+            appState.createTab(projectID: projectID)
+        }
+    }
+}
+
+private final class HotkeyWorkspaceWindow: NSPanel {
+    var suppressConfiguratorClose = true
+
+    override var canBecomeKey: Bool { true }
+
+    override func close() {
+        if suppressConfiguratorClose {
+            suppressConfiguratorClose = false
+            return
+        }
+        super.close()
+    }
+}
+
+@MainActor
+final class HotkeyWindowController: NSObject, NSWindowDelegate {
+    static let shared = HotkeyWindowController()
+
+    private var window: HotkeyWorkspaceWindow?
+    private var model: HotkeyWorkspaceModel?
+    private var previousApplication: NSRunningApplication?
+    private var fullScreenShortcutMonitor: Any?
+    private var isFullScreenTransitioning = false
+    private var pendingHideAfterFullScreenExit = false
+    private var isOverlayFullScreen = false
+    private var overlayRestoreFrame: NSRect?
+    private var overlayRestoreStyleMask: NSWindow.StyleMask?
+    private var overlayRestoreHasShadow = true
+
+    private(set) var isPresented = false
+
+    private static let hotkeyCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
+        .transient,
+        .ignoresCycle,
+    ]
+
+    private static let hotkeyWindowLevel = NSWindow.Level(
+        rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) - 2
+    )
+
+    private static let overlayFullScreenWindowLevel = NSWindow.Level(
+        rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 1
+    )
+
+    override private init() {
+        super.init()
+    }
+
+    func prepareWhenMainWindowAvailable(remainingAttempts: Int = 20) {
+        guard window == nil else { return }
+        guard AppDelegate.mainAppWindow() != nil else {
+            guard remainingAttempts > 0 else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.prepareWhenMainWindowAvailable(remainingAttempts: remainingAttempts - 1)
+            }
+            return
+        }
+        createWindow()
+    }
+
+    func toggle() {
+        if isPresented {
+            hide()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        if window == nil {
+            prepareWhenMainWindowAvailable()
+        }
+        guard let window, let model else { return }
+
+        model.ensureWorkspaceReady()
+        capturePreviousApplication()
+        pendingHideAfterFullScreenExit = false
+
+        if !isOverlayFullScreen,
+           !window.styleMask.contains(.fullScreen),
+           !isFullScreenTransitioning
+        {
+            applyHotkeyPresentation(to: window)
+            window.setFrame(hotkeyFrame(), display: true)
+        } else if isOverlayFullScreen {
+            postFullScreenChange(true, for: window)
+        }
+
+        isPresented = true
+        window.orderFrontRegardless()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    func hide() {
+        guard isPresented, let window else { return }
+        if window.styleMask.contains(.fullScreen) || isFullScreenTransitioning {
+            pendingHideAfterFullScreenExit = true
+            if window.styleMask.contains(.fullScreen), !isFullScreenTransitioning {
+                window.toggleFullScreen(nil)
+            }
+            return
+        }
+        if isOverlayFullScreen {
+            postFullScreenChange(false, for: window)
+        }
+        finishHide()
+    }
+
+    func toggleOverlayFullScreen() {
+        guard let window else { return }
+        if isOverlayFullScreen {
+            exitOverlayFullScreen(window, animated: true)
+        } else {
+            enterOverlayFullScreen(window, animated: true)
+        }
+    }
+
+    private func createWindow() {
+        guard window == nil else { return }
+
+        let model = HotkeyWorkspaceModel()
+        let window = HotkeyWorkspaceWindow(
+            contentRect: hotkeyFrame(),
+            styleMask: [
+                .titled,
+                .closable,
+                .miniaturizable,
+                .resizable,
+                .fullSizeContentView,
+                .nonactivatingPanel,
+            ],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = ShortcutContext.hotkeyWindowIdentifier
+        window.delegate = self
+        window.isReleasedWhenClosed = false
+        window.isFloatingPanel = true
+        window.hidesOnDeactivate = false
+        window.becomesKeyOnlyIfNeeded = false
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.isMovable = false
+        window.isMovableByWindowBackground = false
+        applyHotkeyPresentation(to: window)
+        installFullScreenShortcutMonitor(for: window)
+
+        let rootView = MainWindow()
+            .environment(model.appState)
+            .environment(model.projectStore)
+            .environment(model.worktreeStore)
+            .environment(model.projectGroupStore)
+            .environment(model.remoteDeviceStore)
+            .environment(model.browserProfileStore)
+            .environment(model.browserHistoryStore)
+            .environment(SSHConnectionService.shared)
+            .environment(GhosttyService.shared)
+            .environment(MuxyConfig.shared)
+            .environment(ThemeService.shared)
+            .environment(ExtensionStore.shared)
+            .environment(ExtensionSettingsStore.shared)
+            .environment(\.isHotkeyWorkspace, true)
+            .preferredColorScheme(MuxyTheme.colorScheme)
+
+        window.contentViewController = NSHostingController(rootView: rootView)
+        window.orderOut(nil)
+
+        self.model = model
+        self.window = window
+
+        // MainWindow embeds WindowConfigurator, which assumes a single WindowGroup main window.
+        // It will try to relabel this window as the main window and close it as a duplicate.
+        // HotkeyWorkspaceWindow suppresses that one close; after the configurator pass, restore
+        // the dedicated hotkey identity and apply the same native chrome without the quit hook.
+        DispatchQueue.main.async { [weak self, weak window] in
+            DispatchQueue.main.async {
+                guard let self, let window else { return }
+                self.finalizeWindowConfiguration(window)
+            }
+        }
+    }
+
+    private func finalizeWindowConfiguration(_ window: HotkeyWorkspaceWindow) {
+        window.identifier = ShortcutContext.hotkeyWindowIdentifier
+        window.suppressConfiguratorClose = false
+        window.delegate = self
+        configureWindowChrome(window)
+        applyHotkeyPresentation(to: window)
+        window.orderOut(nil)
+    }
+
+    private func configureWindowChrome(_ window: HotkeyWorkspaceWindow) {
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.styleMask.insert(.fullSizeContentView)
+        window.isMovable = false
+        window.isMovableByWindowBackground = false
+        WindowConfigurator.disableWindowTabbing(for: window)
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.contentView?.wantsLayer = true
+        window.contentView?.layer?.backgroundColor = MuxyTheme.nsBg.cgColor
+        WindowConfigurator.repositionTrafficLights(in: window)
+        WindowConfigurator.hideTitlebarDecorationView(in: window)
+        WindowConfigurator.neutralizeSafeAreaInsets(in: window)
+
+        if let closeButton = window.standardWindowButton(.closeButton) {
+            closeButton.target = self
+            closeButton.action = #selector(handleCloseButton(_:))
+        }
+        if let zoomButton = window.standardWindowButton(.zoomButton) {
+            zoomButton.target = self
+            zoomButton.action = #selector(handleFullScreenButton(_:))
+        }
+    }
+
+    private func installFullScreenShortcutMonitor(for window: NSWindow) {
+        guard fullScreenShortcutMonitor == nil else { return }
+        fullScreenShortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self, weak window] event in
+            guard let self,
+                  let window,
+                  window.isKeyWindow,
+                  ShortcutContext.isHotkeyWindow(window),
+                  KeyBindingStore.shared.combo(for: .toggleFullScreen).matches(event: event)
+            else { return event }
+            self.toggleOverlayFullScreen()
+            return nil
+        }
+    }
+
+    private func enterOverlayFullScreen(_ window: HotkeyWorkspaceWindow, animated: Bool) {
+        guard !isOverlayFullScreen else { return }
+        guard let screen = window.screen ?? screenUnderMouse() ?? NSScreen.main else { return }
+
+        overlayRestoreFrame = window.frame
+        overlayRestoreStyleMask = window.styleMask
+        overlayRestoreHasShadow = window.hasShadow
+        isOverlayFullScreen = true
+
+        window.styleMask = [.borderless, .resizable, .nonactivatingPanel]
+        window.isMovable = false
+        window.isMovableByWindowBackground = false
+        window.hasShadow = false
+        applyOverlayFullScreenPresentation(to: window)
+        window.setFrame(screen.frame, display: true, animate: animated)
+        WindowConfigurator.neutralizeSafeAreaInsets(in: window)
+        postFullScreenChange(true, for: window)
+        window.orderFrontRegardless()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private func exitOverlayFullScreen(_ window: HotkeyWorkspaceWindow, animated: Bool) {
+        guard isOverlayFullScreen else { return }
+
+        let restoreFrame = overlayRestoreFrame ?? hotkeyFrame()
+        let restoreStyleMask = overlayRestoreStyleMask ?? [
+            .titled,
+            .closable,
+            .miniaturizable,
+            .resizable,
+            .fullSizeContentView,
+            .nonactivatingPanel,
+        ]
+
+        isOverlayFullScreen = false
+        overlayRestoreFrame = nil
+        overlayRestoreStyleMask = nil
+
+        postFullScreenChange(false, for: window)
+        window.styleMask = restoreStyleMask
+        window.hasShadow = overlayRestoreHasShadow
+        configureWindowChrome(window)
+        applyHotkeyPresentation(to: window)
+        WindowConfigurator.neutralizeSafeAreaInsets(in: window)
+        window.setFrame(restoreFrame, display: true, animate: animated)
+        window.orderFrontRegardless()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private func postFullScreenChange(_ isFullScreen: Bool, for window: NSWindow) {
+        NotificationCenter.default.post(
+            name: .windowFullScreenDidChange,
+            object: window,
+            userInfo: ["isFullScreen": isFullScreen]
+        )
+    }
+
+    private func applyHotkeyPresentation(to window: NSWindow) {
+        window.collectionBehavior = Self.hotkeyCollectionBehavior
+        window.level = Self.hotkeyWindowLevel
+    }
+
+    private func applyOverlayFullScreenPresentation(to window: NSWindow) {
+        window.collectionBehavior = Self.hotkeyCollectionBehavior
+        window.level = Self.overlayFullScreenWindowLevel
+    }
+
+    private func prepareForNativeFullScreen(_ window: NSWindow) {
+        var behavior = window.collectionBehavior
+        behavior.remove(.canJoinAllSpaces)
+        behavior.remove(.fullScreenAuxiliary)
+        behavior.remove(.transient)
+        behavior.insert(.fullScreenPrimary)
+        window.collectionBehavior = behavior
+        window.level = .normal
+    }
+
+    private func capturePreviousApplication() {
+        guard let frontmost = NSWorkspace.shared.frontmostApplication,
+              frontmost.processIdentifier != ProcessInfo.processInfo.processIdentifier
+        else {
+            previousApplication = nil
+            return
+        }
+        previousApplication = frontmost
+    }
+
+    private func finishHide() {
+        window?.orderOut(nil)
+        isPresented = false
+        pendingHideAfterFullScreenExit = false
+
+        let applicationToRestore = previousApplication
+        previousApplication = nil
+        guard let applicationToRestore, !applicationToRestore.isTerminated else { return }
+        DispatchQueue.main.async {
+            applicationToRestore.activate(options: [.activateIgnoringOtherApps])
+        }
+    }
+
+    private func hotkeyFrame() -> NSRect {
+        let screen = screenUnderMouse() ?? NSScreen.main ?? NSScreen.screens.first
+        guard let visibleFrame = screen?.visibleFrame else {
+            return NSRect(x: 120, y: 100, width: 1200, height: 800)
+        }
+        let width = min(visibleFrame.width, max(900, visibleFrame.width * 0.86))
+        let height = min(visibleFrame.height, max(600, visibleFrame.height * 0.82))
+        return NSRect(
+            x: visibleFrame.midX - width / 2,
+            y: visibleFrame.midY - height / 2,
+            width: width,
+            height: height
+        )
+    }
+
+    private func screenUnderMouse() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        return NSScreen.screens.first { NSMouseInRect(mouseLocation, $0.frame, false) }
+    }
+
+    @objc
+    private func handleCloseButton(_: Any?) {
+        hide()
+    }
+
+    @objc
+    private func handleFullScreenButton(_: Any?) {
+        toggleOverlayFullScreen()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        hide()
+        return false
+    }
+
+    func windowWillEnterFullScreen(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              ShortcutContext.isHotkeyWindow(window)
+        else { return }
+        isFullScreenTransitioning = true
+        prepareForNativeFullScreen(window)
+    }
+
+    func windowDidEnterFullScreen(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              ShortcutContext.isHotkeyWindow(window)
+        else { return }
+        isFullScreenTransitioning = false
+        postFullScreenChange(true, for: window)
+    }
+
+    func windowWillExitFullScreen(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              ShortcutContext.isHotkeyWindow(window)
+        else { return }
+        isFullScreenTransitioning = true
+    }
+
+    func windowDidExitFullScreen(_ notification: Notification) {
+        guard let window = notification.object as? HotkeyWorkspaceWindow,
+              ShortcutContext.isHotkeyWindow(window)
+        else { return }
+        isFullScreenTransitioning = false
+        configureWindowChrome(window)
+        applyHotkeyPresentation(to: window)
+        postFullScreenChange(false, for: window)
+        if pendingHideAfterFullScreenExit {
+            finishHide()
+        } else if isPresented {
+            window.orderFrontRegardless()
+            window.makeKeyAndOrderFront(nil)
+        }
+    }
+}

--- a/Muxy/Services/Keyboard/ModifierKeyMonitor.swift
+++ b/Muxy/Services/Keyboard/ModifierKeyMonitor.swift
@@ -1,6 +1,101 @@
 import AppKit
 import SwiftUI
 
+struct DoubleModifierTapDetector {
+    let doubleTapInterval: TimeInterval
+    let maxTapDuration: TimeInterval
+
+    private(set) var modifierIsDown = false
+    private(set) var modifierDownTime: TimeInterval?
+    private(set) var modifierWasUsedWithKey = false
+    private(set) var lastModifierTapTime: TimeInterval?
+
+    init(
+        doubleTapInterval: TimeInterval = 0.30,
+        maxTapDuration: TimeInterval = 0.30
+    ) {
+        self.doubleTapInterval = doubleTapInterval
+        self.maxTapDuration = maxTapDuration
+    }
+
+    mutating func handleFlagsChanged(modifierPressed: Bool, at time: TimeInterval) -> Bool {
+        if modifierPressed, !modifierIsDown {
+            modifierIsDown = true
+            modifierDownTime = time
+            modifierWasUsedWithKey = false
+            return false
+        }
+
+        guard !modifierPressed, modifierIsDown else { return false }
+
+        modifierIsDown = false
+        defer {
+            modifierDownTime = nil
+            modifierWasUsedWithKey = false
+        }
+
+        guard let modifierDownTime,
+              !modifierWasUsedWithKey,
+              time - modifierDownTime <= maxTapDuration
+        else {
+            lastModifierTapTime = nil
+            return false
+        }
+
+        if let lastModifierTapTime,
+           time - lastModifierTapTime <= doubleTapInterval
+        {
+            self.lastModifierTapTime = nil
+            return true
+        }
+
+        lastModifierTapTime = time
+        return false
+    }
+
+    mutating func handleKeyDown() {
+        guard modifierIsDown else { return }
+        modifierWasUsedWithKey = true
+        lastModifierTapTime = nil
+    }
+
+    mutating func reset() {
+        modifierIsDown = false
+        modifierDownTime = nil
+        modifierWasUsedWithKey = false
+        lastModifierTapTime = nil
+    }
+}
+
+private extension GlobalHotkeyTrigger {
+    var modifierFlag: NSEvent.ModifierFlags {
+        switch self {
+        case .doubleCommand:
+            .command
+        case .doubleControl:
+            .control
+        case .doubleOption:
+            .option
+        }
+    }
+}
+
+private struct GlobalHotkeyConfiguration: Equatable {
+    let isEnabled: Bool
+    let trigger: GlobalHotkeyTrigger
+    let doubleTapInterval: TimeInterval
+    let toggleToHide: Bool
+
+    static var current: GlobalHotkeyConfiguration {
+        GlobalHotkeyConfiguration(
+            isEnabled: GlobalHotkeyPreferences.isEnabled(),
+            trigger: GlobalHotkeyPreferences.trigger(),
+            doubleTapInterval: GlobalHotkeyPreferences.doubleTapInterval(),
+            toggleToHide: GlobalHotkeyPreferences.toggleToHide()
+        )
+    }
+}
+
 @MainActor
 @Observable
 final class ModifierKeyMonitor {
@@ -11,24 +106,42 @@ final class ModifierKeyMonitor {
     private(set) var shiftHeld = false
     private(set) var optionHeld = false
     private(set) var showHints = false
-    private var monitor: Any?
+    private var localFlagsMonitor: Any?
+    private var localKeyMonitor: Any?
+    private var globalMonitor: Any?
     private var activationObserver: NSObjectProtocol?
+    private var settingsObserver: NSObjectProtocol?
     private var hintTimer: Timer?
+    private var globalHotkeyConfiguration = GlobalHotkeyConfiguration.current
+    private var doubleModifierDetector = DoubleModifierTapDetector(
+        doubleTapInterval: GlobalHotkeyPreferences.doubleTapInterval()
+    )
 
     private static let hintDelay: TimeInterval = 0.5
 
     private init() {}
 
     func start() {
-        guard monitor == nil else { return }
-        monitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+        guard localFlagsMonitor == nil, localKeyMonitor == nil else { return }
+
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             guard let self else { return event }
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let now = ProcessInfo.processInfo.systemUptime
             MainActor.assumeIsolated {
-                self.updateFlags(flags)
+                self.handleFlagsChanged(flags, at: now)
             }
             return event
         }
+
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            MainActor.assumeIsolated {
+                self.handleKeyDown()
+            }
+            return event
+        }
+
         activationObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,
@@ -38,20 +151,44 @@ final class ModifierKeyMonitor {
                 guard let self else { return }
                 let flags = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
                 self.updateFlags(flags)
+                self.doubleModifierDetector.reset()
             }
         }
+
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshGlobalHotkeyConfiguration()
+            }
+        }
+
+        refreshGlobalHotkeyConfiguration()
     }
 
     func stop() {
-        if let monitor {
-            NSEvent.removeMonitor(monitor)
+        if let localFlagsMonitor {
+            NSEvent.removeMonitor(localFlagsMonitor)
         }
+        if let localKeyMonitor {
+            NSEvent.removeMonitor(localKeyMonitor)
+        }
+        removeGlobalMonitor()
         if let activationObserver {
             NotificationCenter.default.removeObserver(activationObserver)
         }
-        monitor = nil
+        if let settingsObserver {
+            NotificationCenter.default.removeObserver(settingsObserver)
+        }
+        localFlagsMonitor = nil
+        localKeyMonitor = nil
         activationObserver = nil
+        settingsObserver = nil
         cancelHint()
+        doubleModifierDetector.reset()
+        HotkeyWindowController.shared.hide()
         commandHeld = false
         controlHeld = false
         shiftHeld = false
@@ -73,6 +210,78 @@ final class ModifierKeyMonitor {
         let combo = KeyBindingStore.shared.combo(for: action)
         guard isHolding(modifiers: combo.modifiers) else { return nil }
         return combo
+    }
+
+    private func handleFlagsChanged(_ flags: NSEvent.ModifierFlags, at time: TimeInterval) {
+        updateFlags(flags)
+        guard globalHotkeyConfiguration.isEnabled else {
+            doubleModifierDetector.reset()
+            return
+        }
+
+        let modifierPressed = flags.contains(globalHotkeyConfiguration.trigger.modifierFlag)
+        guard doubleModifierDetector.handleFlagsChanged(modifierPressed: modifierPressed, at: time) else { return }
+        if globalHotkeyConfiguration.toggleToHide {
+            HotkeyWindowController.shared.toggle()
+        } else {
+            HotkeyWindowController.shared.show()
+        }
+    }
+
+    private func handleKeyDown() {
+        guard globalHotkeyConfiguration.isEnabled else { return }
+        doubleModifierDetector.handleKeyDown()
+    }
+
+    private func refreshGlobalHotkeyConfiguration() {
+        let newConfiguration = GlobalHotkeyConfiguration.current
+        let monitorMatchesConfiguration = newConfiguration.isEnabled == (globalMonitor != nil)
+        guard newConfiguration != globalHotkeyConfiguration || !monitorMatchesConfiguration else { return }
+
+        let detectorConfigurationChanged = newConfiguration.isEnabled != globalHotkeyConfiguration.isEnabled
+            || newConfiguration.trigger != globalHotkeyConfiguration.trigger
+            || newConfiguration.doubleTapInterval != globalHotkeyConfiguration.doubleTapInterval
+
+        globalHotkeyConfiguration = newConfiguration
+        if detectorConfigurationChanged {
+            doubleModifierDetector = DoubleModifierTapDetector(
+                doubleTapInterval: newConfiguration.doubleTapInterval
+            )
+        }
+
+        if newConfiguration.isEnabled {
+            installGlobalMonitorIfNeeded()
+        } else {
+            removeGlobalMonitor()
+            doubleModifierDetector.reset()
+            HotkeyWindowController.shared.hide()
+        }
+    }
+
+    private func installGlobalMonitorIfNeeded() {
+        guard globalMonitor == nil else { return }
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.flagsChanged, .keyDown]) { [weak self] event in
+            let eventType = event.type
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let now = ProcessInfo.processInfo.systemUptime
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                switch eventType {
+                case .flagsChanged:
+                    self.handleFlagsChanged(flags, at: now)
+                case .keyDown:
+                    self.handleKeyDown()
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    private func removeGlobalMonitor() {
+        guard let globalMonitor else { return }
+        NSEvent.removeMonitor(globalMonitor)
+        self.globalMonitor = nil
     }
 
     private func updateFlags(_ flags: NSEvent.ModifierFlags) {

--- a/Muxy/Services/Keyboard/ShortcutContext.swift
+++ b/Muxy/Services/Keyboard/ShortcutContext.swift
@@ -3,9 +3,15 @@ import AppKit
 @MainActor
 enum ShortcutContext {
     static let mainWindowIdentifier = NSUserInterfaceItemIdentifier("app.muxy.main-window")
+    static let hotkeyWindowIdentifier = NSUserInterfaceItemIdentifier("app.muxy.hotkey-window")
 
     static func isMainWindow(_ window: NSWindow?) -> Bool {
-        window?.identifier == mainWindowIdentifier
+        guard let identifier = window?.identifier else { return false }
+        return identifier == mainWindowIdentifier || identifier == hotkeyWindowIdentifier
+    }
+
+    static func isHotkeyWindow(_ window: NSWindow?) -> Bool {
+        window?.identifier == hotkeyWindowIdentifier
     }
 
     static func activeScopes(

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -201,6 +201,7 @@ enum SettingsJSONStore {
         let allowedValues: [String: Set<String>] = [
             UpdateChannel.storageKey: Set(UpdateChannel.allCases.map(\.rawValue)),
             ProjectPickerPreferences.storageKey: Set(ProjectPickerMode.allCases.map(\.rawValue)),
+            GlobalHotkeyPreferences.triggerKey: Set(GlobalHotkeyTrigger.allCases.map(\.rawValue)),
             SentryConsent.storageKey: Set(["", SentryConsent.allowed.rawValue, SentryConsent.denied.rawValue]),
             "muxy.ui.scale": Set(UIScale.Preset.allCases.map(\.rawValue)),
             AppBackgroundStyle.storageKey: Set(AppBackgroundStyle.allCases.map(\.rawValue)),
@@ -226,6 +227,10 @@ enum SettingsJSONStore {
 
     private static func validateAllowedDouble(_ value: Double, key: String) throws {
         switch key {
+        case GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey:
+            guard (GlobalHotkeyPreferences.minimumDoubleTapIntervalMilliseconds
+                ... GlobalHotkeyPreferences.maximumDoubleTapIntervalMilliseconds).contains(value)
+            else { throw SettingsJSONError.invalidValue(key) }
         case TabWidthPreferences.maxWidthKey:
             guard TabWidthPreferences.isAllowedStoredValue(value) else { throw SettingsJSONError.invalidValue(key) }
         case "editor.richInputLineHeightMultiplier":

--- a/Muxy/Views/Components/Support/AppSidebarBackground.swift
+++ b/Muxy/Views/Components/Support/AppSidebarBackground.swift
@@ -1,6 +1,10 @@
 import AppKit
 import SwiftUI
 
+extension EnvironmentValues {
+    @Entry var isHotkeyWorkspace: Bool = false
+}
+
 enum AppSidebarVibrancy {
     static let material = NSVisualEffectView.Material.sidebar
     static let blendingMode = NSVisualEffectView.BlendingMode.behindWindow
@@ -14,9 +18,11 @@ struct AppSidebarBackground: View {
 
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @Environment(\.isHotkeyWorkspace) private var isHotkeyWorkspace
 
     private var usesVibrancy: Bool {
-        AppSidebarVibrancyPolicy.isActive(
+        guard !isHotkeyWorkspace else { return false }
+        return AppSidebarVibrancyPolicy.isActive(
             style: style,
             reduceTransparency: reduceTransparency,
             increaseContrast: colorSchemeContrast == .increased,

--- a/Muxy/Views/Settings/GlobalHotkeySettingsSection.swift
+++ b/Muxy/Views/Settings/GlobalHotkeySettingsSection.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct GlobalHotkeySettingsSection: View {
+    @AppStorage(GlobalHotkeyPreferences.enabledKey)
+    private var isEnabled = GlobalHotkeyPreferences.defaultEnabled
+    @AppStorage(GlobalHotkeyPreferences.triggerKey)
+    private var triggerRaw = GlobalHotkeyPreferences.defaultTrigger.rawValue
+    @AppStorage(GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey)
+    private var doubleTapIntervalMilliseconds = GlobalHotkeyPreferences.defaultDoubleTapIntervalMilliseconds
+    @AppStorage(GlobalHotkeyPreferences.toggleToHideKey)
+    private var toggleToHide = GlobalHotkeyPreferences.defaultToggleToHide
+
+    private var selectedTrigger: GlobalHotkeyTrigger {
+        GlobalHotkeyTrigger(rawValue: triggerRaw) ?? GlobalHotkeyPreferences.defaultTrigger
+    }
+
+    private var intervalBinding: Binding<Double> {
+        Binding(
+            get: {
+                GlobalHotkeyPreferences.clampedDoubleTapIntervalMilliseconds(doubleTapIntervalMilliseconds)
+            },
+            set: { newValue in
+                let clampedValue = GlobalHotkeyPreferences.clampedDoubleTapIntervalMilliseconds(newValue)
+                let step = GlobalHotkeyPreferences.doubleTapIntervalStepMilliseconds
+                doubleTapIntervalMilliseconds = (clampedValue / step).rounded() * step
+            }
+        )
+    }
+
+    private var intervalLabel: String {
+        "\(Int(intervalBinding.wrappedValue.rounded())) ms"
+    }
+
+    var body: some View {
+        SettingsSection(
+            "Global Hotkey",
+            footer: "Double-tap the selected modifier to show the hotkey workspace. "
+                + "Disable Toggle to Hide to make the hotkey show-only."
+        ) {
+            SettingsToggleRow(label: "Enable Global Hotkey", isOn: $isEnabled)
+
+            SettingsRow("Trigger") {
+                Menu {
+                    ForEach(GlobalHotkeyTrigger.allCases) { trigger in
+                        Button {
+                            triggerRaw = trigger.rawValue
+                        } label: {
+                            if trigger == selectedTrigger {
+                                Label(trigger.title, systemImage: "checkmark")
+                            } else {
+                                Text(trigger.title)
+                            }
+                        }
+                    }
+                } label: {
+                    HStack(spacing: UIMetrics.spacing2) {
+                        Text(selectedTrigger.title)
+                            .foregroundStyle(SettingsStyle.foreground)
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(SettingsStyle.mutedForeground)
+                    }
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                    .padding(.horizontal, 8)
+                    .frame(width: SettingsMetrics.controlWidth, height: 26)
+                    .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(SettingsStyle.border, lineWidth: 1)
+                    )
+                    .contentShape(Rectangle())
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .disabled(!isEnabled)
+            }
+
+            SettingsRow("Double Tap Interval") {
+                HStack(spacing: UIMetrics.spacing3) {
+                    Slider(
+                        value: intervalBinding,
+                        in: GlobalHotkeyPreferences.minimumDoubleTapIntervalMilliseconds
+                            ... GlobalHotkeyPreferences.maximumDoubleTapIntervalMilliseconds
+                    )
+                    Text(intervalLabel)
+                        .font(.system(size: SettingsMetrics.labelFontSize).monospacedDigit())
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                        .frame(width: 58, alignment: .trailing)
+                }
+                .frame(width: SettingsMetrics.controlWidth)
+                .disabled(!isEnabled)
+            }
+
+            SettingsToggleRow(label: "Toggle to Hide", isOn: $toggleToHide)
+                .disabled(!isEnabled)
+        }
+    }
+}

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -14,7 +14,7 @@ struct KeyboardShortcutsSettingsView: View {
         VStack(spacing: 0) {
             header
             SettingsDivider()
-            appShortcutsList
+            shortcutSettingsList
         }
     }
 
@@ -35,6 +35,7 @@ struct KeyboardShortcutsSettingsView: View {
 
             Button("Reset All") {
                 store.resetToDefaults()
+                GlobalHotkeyPreferences.resetToDefaults()
                 recordingAction = nil
                 conflictWarning = nil
             }
@@ -45,11 +46,12 @@ struct KeyboardShortcutsSettingsView: View {
         .padding(SettingsMetrics.horizontalPadding)
     }
 
-    private var appShortcutsList: some View {
+    private var shortcutSettingsList: some View {
         let visibleCategories = ShortcutAction.categories.filter { !filteredActions(for: $0).isEmpty }
         let extensionGroups = filteredExtensionGroups
         return ScrollView(.vertical, showsIndicators: true) {
             VStack(spacing: 0) {
+                GlobalHotkeySettingsSection()
                 ForEach(visibleCategories, id: \.self) { category in
                     categorySection(
                         title: category,

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -431,6 +431,42 @@ enum SettingsCatalog {
             defaultValue: TerminalOfflinePreferences.defaultIdleThreshold
         ),
         SettingsCatalogItem(
+            key: GlobalHotkeyPreferences.enabledKey,
+            title: "Enable Global Hotkey",
+            description: "Enables the system-wide hotkey workspace trigger.",
+            category: .shortcuts,
+            section: "Global Hotkey",
+            defaultValue: GlobalHotkeyPreferences.defaultEnabled,
+            aliases: ["hotkey window", "quick terminal", "double command", "double control", "double option"]
+        ),
+        SettingsCatalogItem(
+            key: GlobalHotkeyPreferences.triggerKey,
+            title: "Global Hotkey Trigger",
+            description: "Chooses the modifier double-tap gesture used to show the hotkey workspace.",
+            category: .shortcuts,
+            section: "Global Hotkey",
+            defaultValue: GlobalHotkeyPreferences.defaultTrigger.rawValue,
+            aliases: ["command", "control", "option", "modifier"]
+        ),
+        SettingsCatalogItem(
+            key: GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey,
+            title: "Double Tap Interval",
+            description: "Sets the maximum interval between modifier taps in milliseconds.",
+            category: .shortcuts,
+            section: "Global Hotkey",
+            defaultValue: GlobalHotkeyPreferences.defaultDoubleTapIntervalMilliseconds,
+            aliases: ["timing", "milliseconds", "double tap"]
+        ),
+        SettingsCatalogItem(
+            key: GlobalHotkeyPreferences.toggleToHideKey,
+            title: "Toggle to Hide",
+            description: "Hides the hotkey workspace when the trigger is used while it is visible.",
+            category: .shortcuts,
+            section: "Global Hotkey",
+            defaultValue: GlobalHotkeyPreferences.defaultToggleToHide,
+            aliases: ["show only", "hide", "toggle"]
+        ),
+        SettingsCatalogItem(
             key: "shortcuts.app",
             title: "App Shortcuts",
             description: "Configures Muxy keyboard shortcuts.",

--- a/Tests/MuxyTests/Services/Keyboard/DoubleModifierTapDetectorTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/DoubleModifierTapDetectorTests.swift
@@ -1,0 +1,94 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("DoubleModifierTapDetector")
+struct DoubleModifierTapDetectorTests {
+    @Test("double tap within interval triggers")
+    func doubleTapWithinIntervalTriggers() {
+        var detector = DoubleModifierTapDetector()
+        let firstDown = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        let firstUp = detector.handleFlagsChanged(modifierPressed: false, at: 1.05)
+        let secondDown = detector.handleFlagsChanged(modifierPressed: true, at: 1.20)
+        let secondUp = detector.handleFlagsChanged(modifierPressed: false, at: 1.25)
+        #expect(!firstDown)
+        #expect(!firstUp)
+        #expect(!secondDown)
+        #expect(secondUp)
+    }
+
+    @Test("configured interval controls double tap recognition")
+    func configuredIntervalControlsRecognition() {
+        var detector = DoubleModifierTapDetector(doubleTapInterval: 0.50)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        _ = detector.handleFlagsChanged(modifierPressed: false, at: 1.05)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.40)
+        let result = detector.handleFlagsChanged(modifierPressed: false, at: 1.45)
+        #expect(result)
+    }
+
+    @Test("tap outside interval does not trigger")
+    func tapOutsideIntervalDoesNotTrigger() {
+        var detector = DoubleModifierTapDetector()
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        _ = detector.handleFlagsChanged(modifierPressed: false, at: 1.05)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.40)
+        let result = detector.handleFlagsChanged(modifierPressed: false, at: 1.45)
+        #expect(!result)
+    }
+
+    @Test("modifier combination with a key does not count as tap")
+    func modifierCombinationDoesNotCountAsTap() {
+        var detector = DoubleModifierTapDetector()
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        detector.handleKeyDown()
+        _ = detector.handleFlagsChanged(modifierPressed: false, at: 1.05)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.20)
+        let result = detector.handleFlagsChanged(modifierPressed: false, at: 1.25)
+        #expect(!result)
+    }
+
+    @Test("long press does not count as tap")
+    func longPressDoesNotCountAsTap() {
+        var detector = DoubleModifierTapDetector()
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        _ = detector.handleFlagsChanged(modifierPressed: false, at: 1.40)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.50)
+        let result = detector.handleFlagsChanged(modifierPressed: false, at: 1.55)
+        #expect(!result)
+    }
+
+    @Test("single tap does not trigger")
+    func singleTapDoesNotTrigger() {
+        var detector = DoubleModifierTapDetector()
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        let result = detector.handleFlagsChanged(modifierPressed: false, at: 1.05)
+        #expect(!result)
+    }
+
+    @Test("trigger resets state")
+    func triggerResetsState() {
+        var detector = DoubleModifierTapDetector()
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        _ = detector.handleFlagsChanged(modifierPressed: false, at: 1.05)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.20)
+        let firstResult = detector.handleFlagsChanged(modifierPressed: false, at: 1.25)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.30)
+        let secondResult = detector.handleFlagsChanged(modifierPressed: false, at: 1.35)
+        #expect(firstResult)
+        #expect(!secondResult)
+    }
+
+    @Test("triple tap only triggers once")
+    func tripleTapOnlyTriggersOnce() {
+        var detector = DoubleModifierTapDetector()
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.00)
+        _ = detector.handleFlagsChanged(modifierPressed: false, at: 1.05)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.10)
+        let secondTapResult = detector.handleFlagsChanged(modifierPressed: false, at: 1.15)
+        _ = detector.handleFlagsChanged(modifierPressed: true, at: 1.20)
+        let thirdTapResult = detector.handleFlagsChanged(modifierPressed: false, at: 1.25)
+        #expect(secondTapResult)
+        #expect(!thirdTapResult)
+    }
+}

--- a/Tests/MuxyTests/Services/Keyboard/GlobalHotkeyPreferencesTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/GlobalHotkeyPreferencesTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GlobalHotkeyPreferences")
+struct GlobalHotkeyPreferencesTests {
+    @Test("defaults keep global hotkey opt-in")
+    func defaultsKeepGlobalHotkeyOptIn() throws {
+        let defaults = try #require(UserDefaults(suiteName: "GlobalHotkeyPreferencesTests.defaults"))
+        defaults.removePersistentDomain(forName: "GlobalHotkeyPreferencesTests.defaults")
+        defer { defaults.removePersistentDomain(forName: "GlobalHotkeyPreferencesTests.defaults") }
+
+        #expect(!GlobalHotkeyPreferences.isEnabled(defaults: defaults))
+        #expect(GlobalHotkeyPreferences.trigger(defaults: defaults) == .doubleCommand)
+        #expect(GlobalHotkeyPreferences.doubleTapIntervalMilliseconds(defaults: defaults) == 300)
+        #expect(GlobalHotkeyPreferences.toggleToHide(defaults: defaults))
+    }
+
+    @Test(
+        "supported modifier triggers round trip",
+        arguments: [
+            GlobalHotkeyTrigger.doubleCommand,
+            GlobalHotkeyTrigger.doubleControl,
+            GlobalHotkeyTrigger.doubleOption,
+        ]
+    )
+    func supportedModifierTriggersRoundTrip(trigger: GlobalHotkeyTrigger) throws {
+        let suiteName = "GlobalHotkeyPreferencesTests.trigger.\(trigger.rawValue)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(trigger.rawValue, forKey: GlobalHotkeyPreferences.triggerKey)
+
+        #expect(GlobalHotkeyPreferences.trigger(defaults: defaults) == trigger)
+    }
+
+    @Test("invalid stored trigger falls back to double command")
+    func invalidTriggerFallsBack() throws {
+        let suiteName = "GlobalHotkeyPreferencesTests.trigger"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("unsupported", forKey: GlobalHotkeyPreferences.triggerKey)
+
+        #expect(GlobalHotkeyPreferences.trigger(defaults: defaults) == .doubleCommand)
+    }
+
+    @Test("stored interval is clamped to supported range")
+    func intervalIsClamped() throws {
+        let suiteName = "GlobalHotkeyPreferencesTests.interval"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(50, forKey: GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey)
+        #expect(
+            GlobalHotkeyPreferences.doubleTapIntervalMilliseconds(defaults: defaults)
+                == GlobalHotkeyPreferences.minimumDoubleTapIntervalMilliseconds
+        )
+
+        defaults.set(1500, forKey: GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey)
+        #expect(
+            GlobalHotkeyPreferences.doubleTapIntervalMilliseconds(defaults: defaults)
+                == GlobalHotkeyPreferences.maximumDoubleTapIntervalMilliseconds
+        )
+    }
+
+    @Test("reset removes stored global hotkey overrides")
+    func resetRemovesStoredOverrides() throws {
+        let suiteName = "GlobalHotkeyPreferencesTests.reset"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: GlobalHotkeyPreferences.enabledKey)
+        defaults.set(GlobalHotkeyTrigger.doubleOption.rawValue, forKey: GlobalHotkeyPreferences.triggerKey)
+        defaults.set(450, forKey: GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey)
+        defaults.set(false, forKey: GlobalHotkeyPreferences.toggleToHideKey)
+
+        GlobalHotkeyPreferences.resetToDefaults(defaults: defaults)
+
+        #expect(!GlobalHotkeyPreferences.isEnabled(defaults: defaults))
+        #expect(GlobalHotkeyPreferences.trigger(defaults: defaults) == .doubleCommand)
+        #expect(GlobalHotkeyPreferences.doubleTapIntervalMilliseconds(defaults: defaults) == 300)
+        #expect(GlobalHotkeyPreferences.toggleToHide(defaults: defaults))
+    }
+}

--- a/Tests/MuxyTests/Services/Keyboard/ShortcutContextTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/ShortcutContextTests.swift
@@ -12,6 +12,12 @@ struct ShortcutContextTests {
         return window
     }
 
+    private func hotkeyWindow() -> NSWindow {
+        let window = NSWindow()
+        window.identifier = ShortcutContext.hotkeyWindowIdentifier
+        return window
+    }
+
     @Test("non-main window only exposes the global scope")
     func nonMainWindowScopes() {
         let scopes = ShortcutContext.activeScopes(for: NSWindow(), isTerminalFocused: true)
@@ -38,6 +44,15 @@ struct ShortcutContextTests {
             isBrowserFocused: true
         )
         #expect(scopes == [.global, .mainWindow, .browser])
+    }
+
+    @Test("hotkey window exposes workspace and terminal scopes")
+    func hotkeyWindowScopes() {
+        let window = hotkeyWindow()
+        #expect(ShortcutContext.isMainWindow(window))
+        #expect(ShortcutContext.isHotkeyWindow(window))
+        let scopes = ShortcutContext.activeScopes(for: window, isTerminalFocused: true)
+        #expect(scopes == [.global, .mainWindow, .terminal])
     }
 
     @Test("find action is gated to the terminal scope")

--- a/Tests/MuxyTests/Services/Persistence/GlobalHotkeySettingsJSONTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/GlobalHotkeySettingsJSONTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Global hotkey JSON settings", .serialized)
+@MainActor
+struct GlobalHotkeySettingsJSONTests {
+    @Test
+    func settingsPersistThroughJSON() throws {
+        let keys = [
+            GlobalHotkeyPreferences.enabledKey,
+            GlobalHotkeyPreferences.triggerKey,
+            GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey,
+            GlobalHotkeyPreferences.toggleToHideKey,
+        ]
+        let snapshot = GlobalHotkeySettingsJSONSnapshot.capture(keys: keys)
+        defer { snapshot.restore() }
+
+        try SettingsJSONStore.saveUserSettingsText("""
+        {
+          "\(GlobalHotkeyPreferences.enabledKey)": true,
+          "\(GlobalHotkeyPreferences.triggerKey)": "doubleOption",
+          "\(GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey)": 450,
+          "\(GlobalHotkeyPreferences.toggleToHideKey)": false
+        }
+        """)
+
+        #expect(GlobalHotkeyPreferences.isEnabled())
+        #expect(GlobalHotkeyPreferences.trigger() == .doubleOption)
+        #expect(GlobalHotkeyPreferences.doubleTapIntervalMilliseconds() == 450)
+        #expect(!GlobalHotkeyPreferences.toggleToHide())
+    }
+
+    @Test
+    func rejectsUnsupportedTrigger() throws {
+        let snapshot = GlobalHotkeySettingsJSONSnapshot.capture(keys: [GlobalHotkeyPreferences.triggerKey])
+        defer { snapshot.restore() }
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "\(GlobalHotkeyPreferences.triggerKey)": "unsupported"
+            }
+            """)
+        }
+    }
+
+    @Test
+    func rejectsOutOfRangeInterval() throws {
+        let snapshot = GlobalHotkeySettingsJSONSnapshot.capture(
+            keys: [GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey]
+        )
+        defer { snapshot.restore() }
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "\(GlobalHotkeyPreferences.doubleTapIntervalMillisecondsKey)": 5000
+            }
+            """)
+        }
+    }
+}
+
+private struct GlobalHotkeySettingsJSONSnapshot {
+    let data: Data?
+    let defaults: [String: Any]
+
+    @MainActor
+    static func capture(keys: [String]) -> GlobalHotkeySettingsJSONSnapshot {
+        GlobalHotkeySettingsJSONSnapshot(
+            data: try? Data(contentsOf: SettingsJSONStore.userSettingsURL),
+            defaults: Dictionary(uniqueKeysWithValues: keys.map { key in
+                (key, UserDefaults.standard.object(forKey: key) ?? NSNull())
+            })
+        )
+    }
+
+    @MainActor
+    func restore() {
+        if let data {
+            try? data.write(to: SettingsJSONStore.userSettingsURL, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: SettingsJSONStore.userSettingsURL)
+        }
+
+        for (key, value) in defaults {
+            if value is NSNull {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else {
+                UserDefaults.standard.set(value, forKey: key)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Muxy currently requires switching to its main window before using a terminal. This adds an optional hotkey workspace that can appear over the current macOS Space, including another app's fullscreen Space, without moving or rehosting the normal Muxy window.

## What changed

- Adds a dedicated, nonactivating hotkey workspace window.
- Supports Double Command, Double Control, and Double Option triggers.
- Adds a configurable 100–1000 ms double-tap interval (300 ms by default).
- Optionally uses the trigger to both show and hide the workspace.
- Preserves normal and overlay-fullscreen presentation across hide/show.
- Keeps the normal Muxy window and hotkey workspace tabs/workspace state independent.
- Leaves the global hotkey disabled by default; enabling it installs the global event monitor.
- Creates the hotkey workspace lazily on the first successful trigger.

## Settings

Adds **Settings → Shortcuts → Global Hotkey**:

- Enable Global Hotkey
- Trigger
- Double Tap Interval
- Toggle to Hide

The preferences use Muxy's existing `@AppStorage` / `UserDefaults` pattern, are registered in `SettingsCatalog`, and participate in `settings.json` / `default-settings.json` sync and validation. **Reset All** on the Shortcuts page also restores the Global Hotkey defaults.

Modifier double-tap detection remains separate from `KeyBindingStore` because `KeyCombo` does not model modifier-only down/up timing or double-tap intervals. Using the selected modifier with a normal key, or holding it too long, does not count as a tap.

The Trigger control uses a theme-aware `Menu` so its label explicitly follows Muxy's custom Settings foreground/background colors in dark themes.

## Implementation notes

The workspace uses a dedicated `NSPanel` and `AppState`. It reuses Muxy's project persistence and shared services, but does not mutate the normal main window.

Overlay fullscreen is used so the workspace can remain on the current Space instead of creating or switching to a separate native fullscreen Space.

## Testing

Covers:

- modifier double-tap recognition and interval handling
- normal key-combination and long-press rejection
- Command, Control, and Option trigger persistence
- opt-in defaults, interval clamping, and preference reset
- Settings JSON persistence and invalid trigger/interval rejection
- hotkey window shortcut scope recognition

Repository Checks run SwiftFormat, SwiftLint, `swift build --build-tests --quiet`, and the full `swift test --quiet` suite.

## Manual validation

Validated on macOS for:

- presentation over normal and fullscreen apps
- show/hide from another application's Space
- overlay-fullscreen state preservation
- tabs, panes, sidebar, and workspace switching
- live Global Hotkey settings changes