### PR TITLE
Improve PR merge flow and confirmation UX in tab-focused toolbar

### DIFF
--- a/Muxy/Models/Layout/TabFocusedRepositoryState.swift
+++ b/Muxy/Models/Layout/TabFocusedRepositoryState.swift
@@ -215,8 +215,13 @@ final class TabFocusedRepositoryState {
                 deleteBranch: false
             )
             guard repository == activeRepository else { return }
-            ToastState.shared.show("Merged PR #\(info.number)")
+            try await repository.service.switchBranch(repoPath: repository.path, branch: info.baseBranch)
+            guard repository == activeRepository else { return }
+            try await repository.service.pull(repoPath: repository.path)
+            guard repository == activeRepository else { return }
+            ToastState.shared.show("Merged PR #\(info.number) into \(info.baseBranch)")
             _ = await refreshSummary(refreshPullRequestOnHeadChange: false)
+            await loadBranches()
             await refreshPullRequest(forceFresh: true)
             postRepositoryChange(repository)
         } catch {

--- a/Muxy/Models/Layout/TabFocusedRepositoryState.swift
+++ b/Muxy/Models/Layout/TabFocusedRepositoryState.swift
@@ -214,19 +214,32 @@ final class TabFocusedRepositoryState {
                 method: method,
                 deleteBranch: false
             )
-            guard repository == activeRepository else { return }
-            try await repository.service.switchBranch(repoPath: repository.path, branch: info.baseBranch)
-            guard repository == activeRepository else { return }
-            try await repository.service.pull(repoPath: repository.path)
-            guard repository == activeRepository else { return }
-            ToastState.shared.show("Merged PR #\(info.number) into \(info.baseBranch)")
-            _ = await refreshSummary(refreshPullRequestOnHeadChange: false)
-            await loadBranches()
-            await refreshPullRequest(forceFresh: true)
-            postRepositoryChange(repository)
         } catch {
             guard repository == activeRepository else { return }
             ToastState.shared.show(title: "Failed to merge PR #\(info.number)", body: error.localizedDescription)
+            return
+        }
+        guard repository == activeRepository else { return }
+        await checkoutBaseBranch(info.baseBranch, on: repository)
+        guard repository == activeRepository else { return }
+        ToastState.shared.show("Merged PR #\(info.number) into \(info.baseBranch)")
+        _ = await refreshSummary(refreshPullRequestOnHeadChange: false)
+        await loadBranches()
+        await refreshPullRequest(forceFresh: true)
+        postRepositoryChange(repository)
+    }
+
+    private func checkoutBaseBranch(_ baseBranch: String, on repository: ActiveRepository) async {
+        do {
+            try await repository.service.switchBranch(repoPath: repository.path, branch: baseBranch)
+            guard repository == activeRepository else { return }
+            try await repository.service.pull(repoPath: repository.path)
+        } catch {
+            guard repository == activeRepository else { return }
+            ToastState.shared.show(
+                title: "Merged, but couldn't switch to \(baseBranch)",
+                body: error.localizedDescription
+            )
         }
     }
 

--- a/Muxy/Views/Layouts/TabFocused/RepositoryAIActionSplitButton.swift
+++ b/Muxy/Views/Layouts/TabFocused/RepositoryAIActionSplitButton.swift
@@ -29,9 +29,6 @@ struct RepositoryAIActionSplitButton: View {
     var body: some View {
         HStack(spacing: 0) {
             primaryButton
-            Rectangle()
-                .fill(MuxyTheme.border)
-                .frame(width: 1, height: UIMetrics.scaled(14))
             menuButton
         }
         .fixedSize(horizontal: true, vertical: false)

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedPullRequestPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedPullRequestPopover.swift
@@ -17,6 +17,7 @@ struct TabFocusedPullRequestPopover: View {
     @State private var mergeMethod: GitRepositoryService.PRMergeMethod = .squash
     @State private var confirmationState = PullRequestActionConfirmation.State()
     @State private var confirmationProgress: CGFloat = 0
+    @State private var remainingSeconds = Int(PullRequestActionConfirmation.duration)
     @State private var confirmationTask: Task<Void, Never>?
     @State private var isCancelHovered = false
 
@@ -254,16 +255,25 @@ struct TabFocusedPullRequestPopover: View {
     private func armConfirmation(for action: PullRequestActionConfirmation.Kind) {
         cancelConfirmation()
         let confirmation = confirmationState.arm(action)
+        let totalSeconds = Int(PullRequestActionConfirmation.duration)
+        remainingSeconds = totalSeconds
         confirmationTask = Task { @MainActor in
             await Task.yield()
             guard pendingConfirmation == confirmation else { return }
             withAnimation(.linear(duration: PullRequestActionConfirmation.duration)) {
                 confirmationProgress = 1
             }
+            for second in stride(from: totalSeconds - 1, through: 1, by: -1) {
+                do {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                } catch {
+                    return
+                }
+                guard pendingConfirmation == confirmation else { return }
+                remainingSeconds = second
+            }
             do {
-                try await Task.sleep(
-                    nanoseconds: UInt64(PullRequestActionConfirmation.duration * 1_000_000_000)
-                )
+                try await Task.sleep(nanoseconds: 1_000_000_000)
             } catch {
                 return
             }
@@ -290,6 +300,7 @@ struct TabFocusedPullRequestPopover: View {
         withTransaction(transaction) {
             confirmationState.cancel()
             confirmationProgress = 0
+            remainingSeconds = Int(PullRequestActionConfirmation.duration)
             isCancelHovered = false
         }
     }
@@ -305,7 +316,7 @@ struct TabFocusedPullRequestPopover: View {
     private var mergeButtonLabel: String {
         if isMerging { return "Merging…" }
         if pendingConfirmation?.kind == .merge(mergeMethod) {
-            return "\(mergeMethod.shortLabel) in 5s · click again"
+            return "\(mergeMethod.shortLabel) in \(remainingSeconds)s · click again"
         }
         return mergeMethod.label
     }
@@ -318,7 +329,7 @@ struct TabFocusedPullRequestPopover: View {
 
     private var closeButtonLabel: String {
         if isClosing { return "Closing…" }
-        if pendingConfirmation?.kind == .close { return "Close in 5s · click again" }
+        if pendingConfirmation?.kind == .close { return "Close in \(remainingSeconds)s · click again" }
         return "Close PR"
     }
 

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedRepositoryToolbar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedRepositoryToolbar.swift
@@ -174,8 +174,7 @@ struct TabFocusedRepositoryToolbar: View {
     @ViewBuilder
     private func pullRequestActionContent(_ summary: GitRepositorySummary) -> some View {
         switch repositoryState.pullRequestState {
-        case .loading,
-             .unavailable:
+        case .loading:
             EmptyView()
         case .noPullRequest:
             aiRepositoryAction(
@@ -183,9 +182,33 @@ struct TabFocusedRepositoryToolbar: View {
                 summary: summary,
                 providerID: $pullRequestProviderID
             )
+        case .unavailable:
+            pullRequestUnavailableChip
         case let .found(info):
             pullRequestChip(info)
         }
+    }
+
+    private var pullRequestUnavailableChip: some View {
+        RepositoryToolbarChip(
+            isOpen: false,
+            action: {
+                Task { await repositoryState.refreshPullRequest(forceFresh: true) }
+            },
+            content: {
+                Image(systemName: "arrow.triangle.pull")
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+            }
+        )
+        .disabled(
+            repositoryState.isRefreshingPullRequest
+                || repositoryState.isSwitchingBranch
+                || isWorktreeRemovalInProgress
+                || hasRunningAIWorkflow
+        )
+        .help("Click to retry. GitHub pull requests require an installed and authenticated gh CLI.")
+        .accessibilityLabel("Pull request unavailable. Retry GitHub connection.")
     }
 
     private func pullRequestChip(_ info: GitRepositoryService.PRInfo) -> some View {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedRepositoryToolbar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedRepositoryToolbar.swift
@@ -53,6 +53,11 @@ struct TabFocusedRepositoryToolbar: View {
                     showPullRequestPopover = false
                 }
             }
+            .onChange(of: isPerformingPullRequestAction) { wasPerforming, isPerforming in
+                if wasPerforming, !isPerforming {
+                    showPullRequestPopover = false
+                }
+            }
     }
 
     @ViewBuilder
@@ -169,7 +174,8 @@ struct TabFocusedRepositoryToolbar: View {
     @ViewBuilder
     private func pullRequestActionContent(_ summary: GitRepositorySummary) -> some View {
         switch repositoryState.pullRequestState {
-        case .loading:
+        case .loading,
+             .unavailable:
             EmptyView()
         case .noPullRequest:
             aiRepositoryAction(
@@ -177,30 +183,6 @@ struct TabFocusedRepositoryToolbar: View {
                 summary: summary,
                 providerID: $pullRequestProviderID
             )
-        case .unavailable:
-            RepositoryToolbarChip(
-                isOpen: false,
-                action: {
-                    Task { await repositoryState.refreshPullRequest(forceFresh: true) }
-                },
-                content: {
-                    HStack(spacing: UIMetrics.spacing2) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.system(size: UIMetrics.fontXS, weight: .bold))
-                        Text("PR unavailable")
-                            .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
-                    }
-                    .foregroundStyle(MuxyTheme.fgMuted)
-                }
-            )
-            .disabled(
-                repositoryState.isRefreshingPullRequest
-                    || repositoryState.isSwitchingBranch
-                    || isWorktreeRemovalInProgress
-                    || hasRunningAIWorkflow
-            )
-            .help("Click to retry. GitHub pull requests require an installed and authenticated gh CLI.")
-            .accessibilityLabel("Pull request unavailable. Retry GitHub connection.")
         case let .found(info):
             pullRequestChip(info)
         }
@@ -493,14 +475,12 @@ struct TabFocusedRepositoryToolbar: View {
                 ToastState.shared.show(title: "Pull request is no longer mergeable", body: availability.help)
                 return
             }
-            showPullRequestPopover = false
             Task { await repositoryState.mergePullRequest(info, method: method) }
         case .close:
             guard info.state == .open else {
                 ToastState.shared.show("Pull request #\(info.number) is no longer open.")
                 return
             }
-            showPullRequestPopover = false
             Task { await repositoryState.closePullRequest(info) }
         }
     }

--- a/Tests/MuxyTests/Services/ProjectPicker/ProjectPickerWorkflowTests.swift
+++ b/Tests/MuxyTests/Services/ProjectPicker/ProjectPickerWorkflowTests.swift
@@ -72,31 +72,6 @@ struct ProjectPickerWorkflowTests {
         #expect(fastWorkflow.session.directoryLoadState == .loaded)
     }
 
-    @Test("cancel ignores pending directory snapshot")
-    func cancelStopsPendingReloadWork() async {
-        let loader = ProjectPickerWorkflowTestDirectoryLoader()
-        let workflow = ProjectPickerWorkflow(
-            defaultDisplayPath: "~/Canceled",
-            homeDirectory: "/Users/alice",
-            projectPaths: [],
-            directoryLoader: { await loader.load($0) },
-            reloadDelay: .zero,
-            loadingMessageDelay: .seconds(5)
-        )
-
-        _ = workflow.setInput("~/Canceled")
-        await waitUntil { await loader.hasRequest(for: "~/Canceled") }
-        workflow.cancel()
-        await loader.resolve(
-            input: "~/Canceled",
-            snapshot: ProjectPickerDirectorySnapshot(rows: ["Canceled"], readFailed: false)
-        )
-        try? await Task.sleep(for: .milliseconds(20))
-
-        #expect(workflow.session.rows.isEmpty)
-        #expect(workflow.session.directoryLoadState == .loading(showsMessage: false))
-    }
-
     @Test("folder search applies only the latest query and confirms the selected absolute path")
     func latestFolderSearchWins() async {
         let loader = ProjectPickerWorkflowTestFolderSearchLoader()


### PR DESCRIPTION
Checkout and pull the base branch after merging a PR, refreshing branches and toast messaging. Show a live countdown in merge/close confirmation buttons and auto-dismiss the popover when an action completes. Hide the unavailable PR chip and drop the AI action split-button divider.