### PR TITLE
Isolate Application Support storage during tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ swiftlint lint --strict       # Check linting only
 
 Run `scripts/checks.sh --fix` after every task.
 
+Test processes use isolated Application Support storage.
+
 ## Top Level Rules
 
 - Security first

--- a/Muxy/Services/Persistence/JSONFilePersistence.swift
+++ b/Muxy/Services/Persistence/JSONFilePersistence.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 enum MuxyFileStorage {
+    static var isTestProcess: Bool {
+        let name = ProcessInfo.processInfo.processName
+        return name == "swiftpm-testing-helper" || name == "xctest" || name.hasSuffix("Tests")
+    }
+
     static func fileURL(filename: String) -> URL {
         let dir = appSupportDirectory()
         return dir.appendingPathComponent(filename)
@@ -11,14 +16,7 @@ enum MuxyFileStorage {
     }
 
     static func appSupportDirectory(create: Bool = true) -> URL {
-        guard let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first
-        else {
-            fatalError("Application Support directory unavailable")
-        }
-        let dir = appSupport.appendingPathComponent("Muxy", isDirectory: true)
+        let dir = resolvedAppSupportDirectory()
         guard create else { return dir }
         try? FileManager.default.createDirectory(
             at: dir,
@@ -26,6 +24,26 @@ enum MuxyFileStorage {
             attributes: [.posixPermissions: FilePermissions.privateDirectory]
         )
         return dir
+    }
+
+    private static func resolvedAppSupportDirectory() -> URL {
+        if isTestProcess {
+            if let override = ProcessInfo.processInfo.environment["MUXY_TEST_APPLICATION_SUPPORT_DIRECTORY"],
+               !override.isEmpty
+            {
+                return URL(fileURLWithPath: override, isDirectory: true)
+            }
+            return FileManager.default.temporaryDirectory
+                .appendingPathComponent("MuxyTests-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+        }
+        guard let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+        else {
+            fatalError("Application Support directory unavailable")
+        }
+        return appSupport.appendingPathComponent("Muxy", isDirectory: true)
     }
 
     static func worktreeRoot(forProjectID projectID: UUID, create: Bool = true) -> URL {

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Download the latest release from the [releases page](https://github.com/muxy-app
 scripts/setup.sh          # downloads GhosttyKit.xcframework
 swift build               # debug build
 swift run Muxy             # run
+scripts/checks.sh         # format, lint, build, and test in isolated app storage
 ```
 
 ## License

--- a/Tests/MuxyTests/Utilities/TestIsolationScriptTests.swift
+++ b/Tests/MuxyTests/Utilities/TestIsolationScriptTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Test isolation script", .serialized)
+struct TestIsolationScriptTests {
+    @Test("test processes never resolve production app storage")
+    func testProcessUsesIsolatedAppStorage() {
+        let path = MuxyFileStorage.appSupportDirectory().path
+
+        #expect(MuxyFileStorage.isTestProcess)
+        #expect(Bundle.main.bundleIdentifier != "com.muxy.app")
+        #expect(path.contains("muxy-tests.") || path.contains("MuxyTests-"))
+    }
+
+    @Test("runs commands with a disposable Core Foundation home")
+    func runsWithDisposableHome() throws {
+        let scriptURL = RepositoryRoot.find().appendingPathComponent("scripts/run-tests-isolated.sh")
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = scriptURL
+        process.arguments = [
+            "/usr/bin/swift",
+            "-e",
+            "import Foundation; let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent(\"Muxy\"); try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true); print(url.path)",
+        ]
+        process.standardOutput = output
+        process.standardError = output
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        let path = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        #expect(process.terminationStatus == 0)
+        #expect(path.contains("muxy-tests."))
+        #expect(path.hasSuffix("Library/Application Support/Muxy"))
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test("all local test entry points use isolation")
+    func localTestEntryPointsUseIsolation() throws {
+        let root = RepositoryRoot.find()
+        let checks = try String(contentsOf: root.appendingPathComponent("scripts/checks.sh"), encoding: .utf8)
+        let coverage = try String(contentsOf: root.appendingPathComponent("scripts/coverage.sh"), encoding: .utf8)
+
+        #expect(checks.contains("run-tests-isolated.sh\" swift test --quiet"))
+        #expect(coverage.contains("run-tests-isolated.sh\" swift test --enable-code-coverage"))
+    }
+}

--- a/Tests/MuxyTests/Views/Extensions/ExtensionConsentDialogTests.swift
+++ b/Tests/MuxyTests/Views/Extensions/ExtensionConsentDialogTests.swift
@@ -7,10 +7,6 @@ import Testing
 @MainActor
 @Suite("ExtensionConsentDialog")
 struct ExtensionConsentDialogTests {
-    init() {
-        UIScale.shared.preset = .regular
-    }
-
     @Test("sheet height is capped to the visible screen")
     func sheetHeightIsCappedToVisibleScreen() {
         let fitting = NSSize(width: 520, height: 1_200)

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -149,7 +149,7 @@ if [ "$failed" -eq 0 ]; then
 fi
 
 if [ "$failed" -eq 0 ]; then
-  run_step "Test" swift test --quiet || failed=1
+  run_step "Test" "$SCRIPT_DIR/run-tests-isolated.sh" swift test --quiet || failed=1
 fi
 
 if [ "$failed" -eq 0 ] && [ "$COVERAGE" -eq 1 ]; then

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -7,7 +7,7 @@ TEST_BINARY="$BUILD_DIR/MuxyPackageTests.xctest/Contents/MacOS/MuxyPackageTests"
 PROFILE="$BUILD_DIR/codecov/default.profdata"
 IGNORE_REGEX='\.build|Tests|Muxy/Views|Muxy/Commands|Muxy/MuxyApp\.swift|Muxy/Services|MuxyServer|Muxy/Models/AppState\.swift|Muxy/Models/VCSTabState\.swift|Muxy/Models/VoiceRecordingState\.swift|Muxy/Extensions/View\+'
 
-swift test --enable-code-coverage --parallel --num-workers 1
+"$(dirname "$0")/run-tests-isolated.sh" swift test --enable-code-coverage --parallel --num-workers 1
 
 report=$(xcrun llvm-cov report "$TEST_BINARY" -instr-profile "$PROFILE" -ignore-filename-regex="$IGNORE_REGEX")
 total_line=$(printf "%s\n" "$report" | awk '/^TOTAL[[:space:]]/ { print $(NF-3) }')

--- a/scripts/run-tests-isolated.sh
+++ b/scripts/run-tests-isolated.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+isolated_home=$(mktemp -d "${TMPDIR:-/tmp}/muxy-tests.XXXXXX")
+
+cleanup() {
+  rm -rf -- "$isolated_home"
+}
+
+trap cleanup EXIT INT TERM
+
+export CFFIXED_USER_HOME="$isolated_home"
+export MUXY_TEST_APPLICATION_SUPPORT_DIRECTORY="$isolated_home/Library/Application Support/Muxy"
+"$@"


### PR DESCRIPTION
Run test and coverage commands with disposable Application Support storage, add safeguards and tests for storage isolation, and document the isolated test environment.