### PR TITLE
Compact tab-focused branch and changes popovers

### DIFF
--- a/Muxy/Views/Layouts/TabFocused/TabFocusedBranchPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedBranchPopover.swift
@@ -50,7 +50,7 @@ struct TabFocusedBranchPopover: View {
             Divider().overlay(MuxyTheme.border)
             branchCreationFooter
         }
-        .frame(width: UIMetrics.scaled(340), height: UIMetrics.scaled(440))
+        .frame(width: UIMetrics.scaled(300), height: UIMetrics.scaled(400))
         .background(MuxyTheme.bg)
         .onChange(of: branches) { _, branches in
             if let pendingDeletion, !branches.contains(pendingDeletion) {
@@ -106,19 +106,19 @@ struct TabFocusedBranchPopover: View {
             VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
                 HStack(spacing: UIMetrics.spacing2) {
                     Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                         .foregroundStyle(MuxyTheme.accent)
                     Text("New branch")
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                         .foregroundStyle(MuxyTheme.fg)
                 }
                 HStack(spacing: UIMetrics.spacing2) {
                     TextField("feature/name", text: $newBranchName)
                         .textFieldStyle(.plain)
-                        .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fg)
                         .padding(.horizontal, UIMetrics.spacing3)
-                        .frame(height: UIMetrics.controlMedium)
+                        .frame(height: UIMetrics.controlSmall)
                         .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
                         .focused($isNewBranchFieldFocused)
                         .disabled(isInteractionDisabled || isSubmittingNewBranch)
@@ -126,7 +126,7 @@ struct TabFocusedBranchPopover: View {
                         .onExitCommand(perform: cancelBranchCreation)
                     Button("Cancel", action: cancelBranchCreation)
                         .buttonStyle(.plain)
-                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                        .font(.system(size: UIMetrics.fontXS, weight: .medium))
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .disabled(isSubmittingNewBranch)
                         .keyboardShortcut(.cancelAction)
@@ -138,7 +138,7 @@ struct TabFocusedBranchPopover: View {
                                 Text("Create")
                             }
                         }
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                         .foregroundStyle(canCreateBranch ? MuxyTheme.accent : MuxyTheme.fgDim)
                     }
                     .buttonStyle(.plain)
@@ -153,15 +153,15 @@ struct TabFocusedBranchPopover: View {
             Button(action: beginBranchCreation) {
                 HStack(spacing: UIMetrics.spacing3) {
                     Image(systemName: "plus")
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .bold))
-                        .frame(width: UIMetrics.scaled(14))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+                        .frame(width: UIMetrics.iconSM)
                     Text("New branch")
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                     Spacer(minLength: UIMetrics.spacing3)
                 }
                 .foregroundStyle(isInteractionDisabled ? MuxyTheme.fgDim : MuxyTheme.accent)
                 .padding(.horizontal, UIMetrics.spacing4)
-                .frame(height: UIMetrics.controlLarge)
+                .frame(height: UIMetrics.controlMedium)
                 .background(
                     isNewBranchButtonHovered && !isInteractionDisabled ? MuxyTheme.hover : .clear,
                     in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
@@ -274,7 +274,7 @@ private struct BranchPopoverRow: View {
             }
         }
         .padding(.horizontal, UIMetrics.spacing3)
-        .frame(height: isDeletionPending ? UIMetrics.scaled(40) : UIMetrics.controlLarge)
+        .frame(height: isDeletionPending ? UIMetrics.scaled(34) : UIMetrics.controlMedium)
         .background(rowBackground, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
         .padding(.horizontal, UIMetrics.spacing3)
         .padding(.vertical, UIMetrics.spacing1)
@@ -286,12 +286,12 @@ private struct BranchPopoverRow: View {
             Button(action: onSelect) {
                 HStack(spacing: UIMetrics.spacing3) {
                     Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                         .foregroundStyle(isSelected ? MuxyTheme.accent : MuxyTheme.fgMuted)
-                        .frame(width: UIMetrics.scaled(14))
+                        .frame(width: UIMetrics.iconSM)
                     Text(name)
                         .font(.system(
-                            size: UIMetrics.fontBody,
+                            size: UIMetrics.fontFootnote,
                             weight: isSelected ? .semibold : .regular,
                             design: .monospaced
                         ))
@@ -322,7 +322,7 @@ private struct BranchPopoverRow: View {
         } else {
             Button(action: onRequestDelete) {
                 Image(systemName: "trash")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
                     .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
                     .contentShape(Rectangle())

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
@@ -36,7 +36,7 @@ struct TabFocusedChangesPopover: View {
             content
             worktreeRemovalFooter
         }
-        .frame(width: UIMetrics.scaled(420), height: UIMetrics.scaled(420))
+        .frame(width: UIMetrics.scaled(360), height: UIMetrics.scaled(380))
         .background(MuxyTheme.bg)
         .alert(item: $pendingDiscard) { file in
             Alert(
@@ -58,14 +58,14 @@ struct TabFocusedChangesPopover: View {
     private var header: some View {
         HStack(spacing: UIMetrics.spacing4) {
             Image(systemName: "arrow.left.arrow.right")
-                .font(.system(size: UIMetrics.iconLG, weight: .semibold))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                 .foregroundStyle(summary.isDirty ? MuxyTheme.warning : MuxyTheme.diffAddFg)
             VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                 Text("Changes")
-                    .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
                     .foregroundStyle(MuxyTheme.fg)
                 Text(workingTreeDescription)
-                    .font(.system(size: UIMetrics.fontFootnote))
+                    .font(.system(size: UIMetrics.fontCaption))
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .lineLimit(1)
             }
@@ -78,11 +78,11 @@ struct TabFocusedChangesPopover: View {
                         ProgressView().controlSize(.mini)
                     } else {
                         Image(systemName: "arrow.clockwise")
-                            .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     }
                 }
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
+                .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
             }
             .buttonStyle(.plain)
             .disabled(isInteractionDisabled)
@@ -152,17 +152,17 @@ struct TabFocusedChangesPopover: View {
         } header: {
             HStack(spacing: UIMetrics.spacing3) {
                 Text(title)
-                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     .foregroundStyle(side == .conflicted ? MuxyTheme.warning : MuxyTheme.fgMuted)
                 Text("\(files.count)")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .bold, design: .rounded))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold, design: .rounded))
                     .foregroundStyle(MuxyTheme.fgDim)
                 lineStats(sectionLineStats)
                 Spacer(minLength: UIMetrics.spacing3)
                 if let batchAction {
                     Button(batchAction.title, action: batchAction.action)
                         .buttonStyle(.plain)
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                         .foregroundStyle(MuxyTheme.accent)
                         .disabled(isInteractionDisabled)
                 }
@@ -178,18 +178,18 @@ struct TabFocusedChangesPopover: View {
         ChangesPopoverFileRow {
             HStack(spacing: UIMetrics.spacing3) {
                 Text(file.displayStatusText(isStaged: side == .staged))
-                    .font(.system(size: UIMetrics.fontCaption, weight: .bold, design: .monospaced))
+                    .font(.system(size: UIMetrics.fontXS, weight: .bold, design: .monospaced))
                     .foregroundStyle(statusColor(file, side: side))
-                    .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
+                    .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
                     .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
 
                 VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                     Text((file.path as NSString).lastPathComponent)
-                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                         .foregroundStyle(MuxyTheme.fg)
                         .lineLimit(1)
                     Text(fileDetail(file))
-                        .font(.system(size: UIMetrics.fontFootnote, design: .monospaced))
+                        .font(.system(size: UIMetrics.fontXS, design: .monospaced))
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .lineLimit(1)
                         .truncationMode(.middle)
@@ -197,7 +197,7 @@ struct TabFocusedChangesPopover: View {
 
                 Spacer(minLength: UIMetrics.spacing2)
                 fileLineStats(file, side: side)
-                    .frame(minWidth: UIMetrics.scaled(68), alignment: .trailing)
+                    .frame(minWidth: UIMetrics.scaled(56), alignment: .trailing)
                 rowActions(file, side: side)
             }
         }
@@ -253,7 +253,7 @@ struct TabFocusedChangesPopover: View {
                 Text("−\(stats.deletions)")
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
             }
-            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold, design: .monospaced))
+            .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
             .fixedSize()
             .accessibilityLabel("\(stats.additions) additions, \(stats.deletions) deletions")
         }
@@ -269,7 +269,7 @@ struct TabFocusedChangesPopover: View {
             ))
         } else if file.isBinary {
             Text("Binary")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                 .foregroundStyle(MuxyTheme.fgMuted)
         } else {
             let stats = RepositoryChangesPresentation.lineStats(file, staged: side.stagedValue)
@@ -277,7 +277,7 @@ struct TabFocusedChangesPopover: View {
                 lineStats(stats)
             } else {
                 Text("—")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     .foregroundStyle(MuxyTheme.fgDim)
                     .accessibilityLabel("Line counts unavailable")
             }
@@ -287,10 +287,10 @@ struct TabFocusedChangesPopover: View {
     private var cleanState: some View {
         VStack(spacing: UIMetrics.spacing3) {
             Image(systemName: "checkmark.circle")
-                .font(.system(size: UIMetrics.scaled(28), weight: .medium))
+                .font(.system(size: UIMetrics.fontDisplay, weight: .medium))
                 .foregroundStyle(MuxyTheme.diffAddFg)
             Text("Working tree is clean")
-                .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 .foregroundStyle(MuxyTheme.fg)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -299,17 +299,20 @@ struct TabFocusedChangesPopover: View {
     private func errorState(_ error: String) -> some View {
         VStack(spacing: UIMetrics.spacing3) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: UIMetrics.scaled(24), weight: .medium))
+                .font(.system(size: UIMetrics.fontDisplay, weight: .medium))
                 .foregroundStyle(MuxyTheme.warning)
             Text("Changes unavailable")
-                .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 .foregroundStyle(MuxyTheme.fg)
             Text(error)
-                .font(.system(size: UIMetrics.fontCaption))
+                .font(.system(size: UIMetrics.fontXS))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .multilineTextAlignment(.center)
                 .lineLimit(3)
             Button("Retry", action: requestRefresh)
+                .buttonStyle(.plain)
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .foregroundStyle(isInteractionDisabled ? MuxyTheme.fgDim : MuxyTheme.accent)
                 .disabled(isInteractionDisabled)
         }
         .padding(UIMetrics.spacing6)
@@ -323,10 +326,10 @@ struct TabFocusedChangesPopover: View {
             Button(role: .destructive, action: onRemoveWorktree) {
                 HStack(spacing: UIMetrics.spacing3) {
                     Image(systemName: "trash")
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
-                        .frame(width: UIMetrics.scaled(14))
+                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                        .frame(width: UIMetrics.iconSM)
                     Text(worktreeRemovalLabel)
-                        .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     Spacer(minLength: UIMetrics.spacing3)
                 }
                 .foregroundStyle(isWorktreeRemovalDisabled ? MuxyTheme.fgMuted : MuxyTheme.diffRemoveFg)
@@ -425,9 +428,9 @@ private struct ChangesPopoverActionButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: symbol)
-                .font(.system(size: UIMetrics.iconSM, weight: .bold))
+                .font(.system(size: UIMetrics.fontCaption, weight: .bold))
                 .foregroundStyle(foreground)
-                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
+                .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
                 .background(isHovered && !isDisabled ? MuxyTheme.hover : .clear, in: RoundedRectangle(
                     cornerRadius: UIMetrics.radiusSM
                 ))
@@ -458,7 +461,7 @@ private struct ChangesPopoverFileRow<Content: View>: View {
     var body: some View {
         content
             .padding(.horizontal, UIMetrics.spacing4)
-            .frame(height: UIMetrics.scaled(40))
+            .frame(height: UIMetrics.scaled(34))
             .background(
                 isHovered ? MuxyTheme.hover : .clear,
                 in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)


### PR DESCRIPTION
Reduce the dimensions, typography, controls, icons, and row heights in the branch and working tree changes popovers for a denser, consistent layout. Refine retry styling and preserve existing interaction states and accessibility details.