### PR TITLE
Add recently removed project restoration

### DIFF
--- a/Muxy/Models/Keyboard/KeyBinding.swift
+++ b/Muxy/Models/Keyboard/KeyBinding.swift
@@ -28,6 +28,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
     case toggleThemePicker
     case newProject
     case openProject
+    case recentlyRemovedProjects
     case reloadConfig
     case refreshWorktrees
     case createWorktree
@@ -91,6 +92,7 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         .previousTab,
         .toggleThemePicker,
         .openProject,
+        .recentlyRemovedProjects,
         .reloadConfig,
         .refreshWorktrees,
         .createWorktree,
@@ -225,6 +227,11 @@ enum ShortcutAction: String, Codable, CaseIterable, Identifiable {
         case .toggleThemePicker: ShortcutMetadata(displayName: "Theme Picker", category: "App", scope: .mainWindow)
         case .newProject: ShortcutMetadata(displayName: "New Project", category: "App", scope: .mainWindow)
         case .openProject: ShortcutMetadata(displayName: "Open Project", category: "App", scope: .mainWindow)
+        case .recentlyRemovedProjects: ShortcutMetadata(
+                displayName: "Recently Removed Projects",
+                category: "App",
+                scope: .mainWindow
+            )
         case .reloadConfig: ShortcutMetadata(displayName: "Reload Configuration", category: "App", scope: .global)
         case .refreshWorktrees: ShortcutMetadata(displayName: "Refresh Worktrees", category: "App", scope: .mainWindow)
         case .createWorktree: ShortcutMetadata(displayName: "New Worktree", category: "App", scope: .mainWindow)
@@ -336,6 +343,7 @@ struct KeyBinding: Codable, Identifiable {
         Self(action: .cyclePreviousTabAcrossPanes, combo: KeyCombo(key: KeyCombo.tabKey, shift: true, control: true)),
         Self(action: .toggleThemePicker, combo: KeyCombo(key: "k", command: true, shift: true)),
         Self(action: .openProject, combo: KeyCombo(key: "o", command: true)),
+        Self(action: .recentlyRemovedProjects, combo: KeyCombo(key: "", modifiers: 0)),
         Self(action: .reloadConfig, combo: KeyCombo(key: "r", command: true, shift: true)),
         Self(action: .refreshWorktrees, combo: KeyCombo(key: "r", command: true, option: true)),
         Self(action: .createWorktree, combo: KeyCombo(key: "n", command: true, option: true)),

--- a/Muxy/Models/Project/RecentlyRemovedProject.swift
+++ b/Muxy/Models/Project/RecentlyRemovedProject.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct RecentlyRemovedProject: Codable, Hashable, Identifiable {
+    let project: Project
+    let removedAt: Date
+
+    var id: UUID { project.id }
+}

--- a/Muxy/Models/Terminal/TerminalOmniboxItem.swift
+++ b/Muxy/Models/Terminal/TerminalOmniboxItem.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum TerminalOmniboxLaunchScope: String {
     case projects
+    case recentlyRemovedProjects
     case worktrees
     case workspaces
     case openTabs
@@ -47,6 +48,19 @@ struct TerminalOmniboxProjectItem: Identifiable, Equatable {
     }
 }
 
+struct TerminalOmniboxRecentlyRemovedProjectItem: Identifiable, Equatable {
+    let projectID: UUID
+    let name: String
+    let path: String
+    let icon: String?
+
+    var id: String { "recent-project-\(projectID.uuidString)" }
+
+    var searchKey: String {
+        [name, path, "recently removed project"].joined(separator: " ")
+    }
+}
+
 struct TerminalOmniboxWorktreeItem: Identifiable, Equatable {
     let projectID: UUID
     let worktreeID: UUID
@@ -88,6 +102,7 @@ struct ExtensionPaletteItem: Identifiable, Equatable {
 
 enum TerminalOmniboxItem: Identifiable, Equatable {
     case project(TerminalOmniboxProjectItem)
+    case recentlyRemovedProject(TerminalOmniboxRecentlyRemovedProjectItem)
     case worktree(TerminalOmniboxWorktreeItem)
     case workspace(TerminalOmniboxWorkspaceItem)
     case openTab(OpenTerminalTabItem)
@@ -97,6 +112,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
     var id: String {
         switch self {
         case let .project(project):
+            project.id
+        case let .recentlyRemovedProject(project):
             project.id
         case let .worktree(wt):
             wt.id
@@ -115,6 +132,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
         switch self {
         case let .project(project):
             project.name
+        case let .recentlyRemovedProject(project):
+            project.name
         case let .worktree(wt):
             wt.name
         case let .workspace(workspace):
@@ -131,6 +150,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
     var subtitle: String? {
         switch self {
         case let .project(project):
+            project.path
+        case let .recentlyRemovedProject(project):
             project.path
         case let .worktree(wt):
             wt.branch.map { "(\($0)) \(wt.path)" } ?? wt.path
@@ -151,6 +172,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
         switch self {
         case .project:
             "Projects"
+        case .recentlyRemovedProject:
+            "Recently Removed"
         case .worktree:
             "Worktrees"
         case .workspace:
@@ -168,6 +191,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
         switch self {
         case .project:
             "folder"
+        case let .recentlyRemovedProject(project):
+            project.icon ?? "folder"
         case let .worktree(wt):
             wt.isPrimary ? "folder.badge.gearshape" : "arrow.triangle.branch"
         case let .workspace(workspace):
@@ -185,6 +210,8 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
         switch self {
         case let .project(project):
             project.searchKey
+        case let .recentlyRemovedProject(project):
+            project.searchKey
         case let .worktree(wt):
             wt.searchKey
         case let .workspace(workspace):
@@ -201,6 +228,7 @@ enum TerminalOmniboxItem: Identifiable, Equatable {
 
 struct TerminalOmniboxItemContext {
     let projects: [TerminalOmniboxProjectItem]
+    let recentlyRemovedProjects: [TerminalOmniboxRecentlyRemovedProjectItem]
     let worktrees: [TerminalOmniboxWorktreeItem]
     let workspaces: [TerminalOmniboxWorkspaceItem]
     let openTabs: [OpenTerminalTabItem]
@@ -212,6 +240,7 @@ struct TerminalOmniboxItemContext {
 
     init(
         projects: [TerminalOmniboxProjectItem],
+        recentlyRemovedProjects: [TerminalOmniboxRecentlyRemovedProjectItem] = [],
         worktrees: [TerminalOmniboxWorktreeItem],
         workspaces: [TerminalOmniboxWorkspaceItem] = [],
         openTabs: [OpenTerminalTabItem],
@@ -222,6 +251,7 @@ struct TerminalOmniboxItemContext {
         commandProjectIDs: Set<UUID>
     ) {
         self.projects = projects
+        self.recentlyRemovedProjects = recentlyRemovedProjects
         self.worktrees = worktrees
         self.workspaces = workspaces
         self.openTabs = openTabs
@@ -245,6 +275,8 @@ enum TerminalOmniboxItemResolver {
         switch launchScope {
         case .projects:
             return context.projects.map(TerminalOmniboxItem.project)
+        case .recentlyRemovedProjects:
+            return context.recentlyRemovedProjects.map(TerminalOmniboxItem.recentlyRemovedProject)
         case .worktrees:
             guard let activeProjectID = context.activeProjectID else { return [] }
             return context.worktrees

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -146,15 +146,13 @@ struct MuxyApp: App {
                                 worktreeStore.removeProject(id)
                                 continue
                             }
-                            let knownWorktrees = worktreeStore.list(for: id)
                             Task {
                                 do {
-                                    try await WorktreeStore.cleanupOnDisk(
-                                        for: project,
-                                        knownWorktrees: knownWorktrees
+                                    try await ProjectRemovalService.removeLocalProjectData(
+                                        project,
+                                        projectStore: projectStore,
+                                        worktreeStore: worktreeStore
                                     )
-                                    projectStore.remove(id: id)
-                                    worktreeStore.removeProject(id)
                                 } catch {
                                     ToastState.shared.show("Could not remove \(project.name): \(error.localizedDescription)")
                                 }

--- a/Muxy/Services/Backup/BackupArchive.swift
+++ b/Muxy/Services/Backup/BackupArchive.swift
@@ -37,6 +37,7 @@ enum BackupArchive {
     static let exportableFiles = [
         "settings.json",
         "projects.json",
+        "recently-removed-projects.json",
         "project-groups.json",
         "remote-devices.json",
         "workspaces.json",

--- a/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
@@ -194,6 +194,9 @@ struct ShortcutActionDispatcher {
                 projectGroupStore: projectGroupStore
             )
             return true
+        case .recentlyRemovedProjects:
+            postTerminalOmnibox(scope: .recentlyRemovedProjects)
+            return true
         case .reloadConfig:
             ghostty.reloadConfig()
             return true

--- a/Muxy/Services/Project/ProjectGroupStore.swift
+++ b/Muxy/Services/Project/ProjectGroupStore.swift
@@ -267,6 +267,7 @@ final class ProjectGroupStore {
     func addProject(projectID: UUID, toGroup groupID: UUID) {
         guard projectID != Project.homeID else { return }
         guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
+        guard groups[index].type == .local else { return }
         for otherIndex in groups.indices where otherIndex != index {
             groups[otherIndex].projectIDs.removeAll { $0 == projectID }
         }

--- a/Muxy/Services/Project/ProjectOpenService.swift
+++ b/Muxy/Services/Project/ProjectOpenService.swift
@@ -2,6 +2,32 @@ import AppKit
 
 @MainActor
 enum ProjectOpenService {
+    enum RestoreError: LocalizedError, Equatable {
+        case unavailable
+        case missingDirectory(String)
+        case notDirectory(String)
+        case worktreeUnavailable
+        case remoteWorkspaceActive
+        case persistenceFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable:
+                "This project is no longer available in Recently Removed."
+            case let .missingDirectory(path):
+                "The project folder no longer exists at \(path)."
+            case let .notDirectory(path):
+                "The project path is no longer a folder: \(path)."
+            case .worktreeUnavailable:
+                "Muxy could not prepare the project workspace."
+            case .remoteWorkspaceActive:
+                "Switch to a local workspace before restoring this project."
+            case .persistenceFailed:
+                "Muxy could not save the restored project."
+            }
+        }
+    }
+
     static func openProject(
         appState: AppState,
         projectStore: ProjectStore,
@@ -14,16 +40,13 @@ enum ProjectOpenService {
         panel.allowsMultipleSelection = false
         panel.message = "Select a project folder"
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        let project = Project(
-            name: url.lastPathComponent,
-            path: url.path(percentEncoded: false),
-            sortOrder: projectStore.projects.count
+        confirmProjectPath(
+            url.path(percentEncoded: false),
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
         )
-        projectStore.add(project)
-        projectGroupStore.addProjectToActiveGroup(projectID: project.id)
-        worktreeStore.ensurePrimary(for: project)
-        guard let primary = worktreeStore.primary(for: project.id) else { return }
-        appState.selectProject(project, worktree: primary)
     }
 
     static func openProjectViaPicker(
@@ -52,6 +75,46 @@ enum ProjectOpenService {
             customPicker: ProjectOpenCustomPickerPresentationAdapter(notificationCenter: notificationCenter),
             finder: finder
         )
+    }
+
+    @discardableResult
+    static func restoreRecentlyRemovedProject(
+        id: UUID,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore,
+        fileSystem: any ProjectPathConfirmationFileSystem = FileManagerProjectPathConfirmationFileSystem()
+    ) throws -> Project {
+        guard !projectGroupStore.isRemoteWorkspaceActive else {
+            throw RestoreError.remoteWorkspaceActive
+        }
+        guard let entry = projectStore.recentlyRemovedProjects.first(where: { $0.id == id }) else {
+            throw RestoreError.unavailable
+        }
+        let project = entry.project
+        switch fileSystem.directoryState(atPath: project.path) {
+        case .missing:
+            throw RestoreError.missingDirectory(project.path)
+        case .notDirectory:
+            throw RestoreError.notDirectory(project.path)
+        case .directory:
+            break
+        }
+
+        let previousWorktrees = worktreeStore.list(for: project.id)
+        worktreeStore.ensurePrimary(for: project)
+        guard let primary = worktreeStore.primary(for: project.id) else {
+            worktreeStore.restoreProjectWorktrees(previousWorktrees, for: project.id)
+            throw RestoreError.worktreeUnavailable
+        }
+        guard let restoredProject = projectStore.restoreRecentlyRemovedProject(id: id) else {
+            worktreeStore.restoreProjectWorktrees(previousWorktrees, for: project.id)
+            throw RestoreError.persistenceFailed
+        }
+        projectGroupStore.addProjectToActiveGroup(projectID: restoredProject.id)
+        appState.selectProject(restoredProject, worktree: primary)
+        return restoredProject
     }
 
     static func presentOpenProject(

--- a/Muxy/Services/Project/ProjectPathConfirmationService.swift
+++ b/Muxy/Services/Project/ProjectPathConfirmationService.swift
@@ -74,7 +74,7 @@ struct ProjectPathConfirmationService {
             return failure
         }
 
-        let project = project(at: standardizedPath)
+        guard let project = project(at: standardizedPath) else { return .failed }
         projectGroupStore.addProjectToActiveGroup(projectID: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return .failed }
@@ -102,11 +102,16 @@ struct ProjectPathConfirmationService {
         }
     }
 
-    private func project(at standardizedPath: String) -> Project {
+    private func project(at standardizedPath: String) -> Project? {
         if let existing = projectStore.projects.first(where: {
             ProjectPickerPathService.standardizedPath($0.path) == standardizedPath
         }) {
             return existing
+        }
+        if let recentlyRemoved = projectStore.recentlyRemovedProjects.first(where: {
+            ProjectPickerPathService.standardizedPath($0.project.path) == standardizedPath
+        }) {
+            return projectStore.restoreRecentlyRemovedProject(id: recentlyRemoved.id)
         }
 
         let url = URL(fileURLWithPath: standardizedPath)
@@ -115,8 +120,7 @@ struct ProjectPathConfirmationService {
             path: standardizedPath,
             sortOrder: projectStore.projects.count
         )
-        projectStore.add(project)
-        return project
+        return projectStore.add(project) ? project : nil
     }
 }
 
@@ -134,7 +138,9 @@ struct RemoteDeviceProjectConfirmationService {
             return .failed
         }
 
-        let project = project(at: path, standardizedPath: standardizedPath, device: device)
+        guard let project = project(at: path, standardizedPath: standardizedPath, device: device) else {
+            return .failed
+        }
         projectGroupStore.addProjectToActiveGroup(projectID: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else { return .failed }
@@ -142,7 +148,7 @@ struct RemoteDeviceProjectConfirmationService {
         return .success
     }
 
-    private func project(at path: String, standardizedPath: String, device: RemoteDevice) -> Project {
+    private func project(at path: String, standardizedPath: String, device: RemoteDevice) -> Project? {
         if let existing = projectStore.storedProjects.first(where: {
             $0.remoteDeviceID == device.id
                 && ProjectPickerPathService.standardizedRemotePath($0.path) == standardizedPath
@@ -157,7 +163,6 @@ struct RemoteDeviceProjectConfirmationService {
             sortOrder: projectStore.storedProjects.count,
             remoteDeviceID: device.id
         )
-        projectStore.add(project)
-        return project
+        return projectStore.add(project) ? project : nil
     }
 }

--- a/Muxy/Services/Project/ProjectPersistence.swift
+++ b/Muxy/Services/Project/ProjectPersistence.swift
@@ -3,20 +3,43 @@ import Foundation
 protocol ProjectPersisting {
     func loadProjects() throws -> [Project]
     func saveProjects(_ projects: [Project]) throws
+    func loadRecentlyRemovedProjects() throws -> [RecentlyRemovedProject]
+    func saveRecentlyRemovedProjects(_ projects: [RecentlyRemovedProject]) throws
+}
+
+extension ProjectPersisting {
+    func loadRecentlyRemovedProjects() throws -> [RecentlyRemovedProject] {
+        []
+    }
+
+    func saveRecentlyRemovedProjects(_: [RecentlyRemovedProject]) throws {}
 }
 
 final class FileProjectPersistence: ProjectPersisting {
-    private let store: CodableFileStore<[Project]>
+    private let projectsStore: CodableFileStore<[Project]>
+    private let recentlyRemovedProjectsStore: CodableFileStore<[RecentlyRemovedProject]>
 
-    init(fileURL: URL = MuxyFileStorage.fileURL(filename: "projects.json")) {
-        store = CodableFileStore(fileURL: fileURL)
+    init(
+        fileURL: URL = MuxyFileStorage.fileURL(filename: "projects.json"),
+        recentlyRemovedFileURL: URL = MuxyFileStorage.fileURL(filename: "recently-removed-projects.json")
+    ) {
+        projectsStore = CodableFileStore(fileURL: fileURL)
+        recentlyRemovedProjectsStore = CodableFileStore(fileURL: recentlyRemovedFileURL)
     }
 
     func loadProjects() throws -> [Project] {
-        try store.load() ?? []
+        try projectsStore.load() ?? []
     }
 
     func saveProjects(_ projects: [Project]) throws {
-        try store.save(projects)
+        try projectsStore.save(projects)
+    }
+
+    func loadRecentlyRemovedProjects() throws -> [RecentlyRemovedProject] {
+        try recentlyRemovedProjectsStore.load() ?? []
+    }
+
+    func saveRecentlyRemovedProjects(_ projects: [RecentlyRemovedProject]) throws {
+        try recentlyRemovedProjectsStore.save(projects)
     }
 }

--- a/Muxy/Services/Project/ProjectRemovalService.swift
+++ b/Muxy/Services/Project/ProjectRemovalService.swift
@@ -2,6 +2,14 @@ import Foundation
 
 @MainActor
 enum ProjectRemovalService {
+    enum RemovalError: LocalizedError {
+        case persistenceFailed
+
+        var errorDescription: String? {
+            "Muxy could not save the project removal."
+        }
+    }
+
     static func remove(
         _ project: Project,
         appState: AppState,
@@ -9,27 +17,90 @@ enum ProjectRemovalService {
         worktreeStore: WorktreeStore,
         projectGroupStore: ProjectGroupStore
     ) async throws {
+        if project.isRemote {
+            try await removeRemoteProject(
+                project,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
+            )
+            return
+        }
+
         GitRepoStatusCache.shared.remove(
             path: project.path,
             context: projectGroupStore.workspaceContext(for: project)
         )
 
-        guard !project.isRemote else {
-            if let workspaceID = project.remoteWorkspaceID {
-                projectGroupStore.removeRemoteProject(id: project.id, fromGroup: workspaceID)
-            } else {
-                projectStore.remove(id: project.id)
-                projectGroupStore.removeProjectFromAllGroups(projectID: project.id)
-            }
-            appState.removeProject(project.id)
-            worktreeStore.removeProject(project.id)
-            return
+        try await removeLocalProjectData(
+            project,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore
+        )
+        appState.removeProject(project.id)
+    }
+
+    private static func removeRemoteProject(
+        _ project: Project,
+        appState: AppState,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore
+    ) async throws {
+        guard await worktreeStore.beginProjectRemoval(project.id) else {
+            throw RemovalError.persistenceFailed
         }
 
-        let knownWorktrees = worktreeStore.list(for: project.id)
-        try await WorktreeStore.cleanupOnDisk(for: project, knownWorktrees: knownWorktrees)
+        GitRepoStatusCache.shared.remove(
+            path: project.path,
+            context: projectGroupStore.workspaceContext(for: project)
+        )
+
+        if let workspaceID = project.remoteWorkspaceID {
+            projectGroupStore.removeRemoteProject(id: project.id, fromGroup: workspaceID)
+        } else {
+            guard await projectStore.prepareRemovalWhenAvailable(id: project.id) else {
+                worktreeStore.cancelProjectRemoval(project.id)
+                throw RemovalError.persistenceFailed
+            }
+            guard projectStore.commitRemoval(id: project.id) else {
+                worktreeStore.cancelProjectRemoval(project.id)
+                throw RemovalError.persistenceFailed
+            }
+            projectGroupStore.removeProjectFromAllGroups(projectID: project.id)
+        }
+
         appState.removeProject(project.id)
-        projectStore.remove(id: project.id)
-        worktreeStore.removeProject(project.id)
+        worktreeStore.completeProjectRemoval(project.id)
+    }
+
+    static func removeLocalProjectData(
+        _ project: Project,
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore,
+        cleanupOnDisk: (Project, [Worktree]) async throws -> Void = { project, worktrees in
+            try await WorktreeStore.cleanupOnDisk(for: project, knownWorktrees: worktrees)
+        }
+    ) async throws {
+        guard await projectStore.prepareRemovalWhenAvailable(id: project.id) else {
+            throw RemovalError.persistenceFailed
+        }
+        guard await worktreeStore.beginProjectRemoval(project.id) else {
+            projectStore.cancelRemoval(id: project.id)
+            throw RemovalError.persistenceFailed
+        }
+        do {
+            try await cleanupOnDisk(project, worktreeStore.list(for: project.id))
+        } catch {
+            worktreeStore.cancelProjectRemoval(project.id)
+            projectStore.cancelRemoval(id: project.id)
+            throw error
+        }
+        guard projectStore.commitRemoval(id: project.id) else {
+            worktreeStore.cancelProjectRemoval(project.id)
+            throw RemovalError.persistenceFailed
+        }
+        worktreeStore.completeProjectRemoval(project.id)
     }
 }

--- a/Muxy/Services/Project/ProjectStore.swift
+++ b/Muxy/Services/Project/ProjectStore.swift
@@ -1,14 +1,28 @@
+import AppKit
 import Foundation
 import MuxyShared
 import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "ProjectStore")
 
+private struct PendingProjectRemoval {
+    let project: Project
+    let previousRecentlyRemovedProjects: [RecentlyRemovedProject]
+    let finalRecentlyRemovedProjects: [RecentlyRemovedProject]
+    let logoIDsToRemove: Set<UUID>
+}
+
 @MainActor
 @Observable
 final class ProjectStore {
+    static let recentlyRemovedProjectLimit = 10
+
     private(set) var storedProjects: [Project] = []
+    private(set) var recentlyRemovedProjects: [RecentlyRemovedProject] = []
     private let persistence: any ProjectPersisting
+    private var pendingRemoval: PendingProjectRemoval?
+    private var removalSlotReserved = false
+    private var removalSlotWaiters: [CheckedContinuation<Void, Never>] = []
     var onProjectRemoved: ((UUID) -> Void)?
     var onProjectsChanged: (() -> Void)?
 
@@ -25,29 +39,149 @@ final class ProjectStore {
         Set(storedProjects.compactMap(\.iconColor))
     }
 
-    func add(_ project: Project) {
+    @discardableResult
+    func add(_ project: Project) -> Bool {
+        if let pendingRemoval {
+            guard !projectsMatch(pendingRemoval.project, project) else { return false }
+            guard !recentlyRemovedProjects.contains(where: { projectsMatch($0.project, project) }) else {
+                return false
+            }
+        }
         var project = project
         if project.iconColor == nil {
             project.iconColor = ProjectIconColor.randomSwatch(excluding: usedIconColors)?.id
         }
         storedProjects.append(project)
-        save()
+        guard save(notify: false) else {
+            storedProjects.removeAll { $0.id == project.id }
+            return false
+        }
+        removeRecentlyRemovedProject(matching: project)
+        onProjectsChanged?()
+        return true
     }
 
-    func remove(id: UUID) {
-        guard id != Project.homeID else { return }
-        storedProjects.removeAll { $0.id == id }
-        save()
+    @discardableResult
+    func remove(id: UUID) -> Bool {
+        guard !removalSlotReserved else { return false }
+        removalSlotReserved = true
+        guard prepareRemoval(id: id) else {
+            releaseRemovalSlot()
+            return false
+        }
+        return commitRemoval(id: id)
+    }
+
+    func prepareRemovalWhenAvailable(id: UUID) async -> Bool {
+        await reserveRemovalSlot()
+        guard prepareRemoval(id: id) else {
+            releaseRemovalSlot()
+            return false
+        }
+        return true
+    }
+
+    private func prepareRemoval(id: UUID) -> Bool {
+        guard pendingRemoval == nil else { return false }
+        guard id != Project.homeID else { return false }
+        guard let project = storedProjects.first(where: { $0.id == id }) else { return false }
+        let previous = recentlyRemovedProjects
+        guard !project.isRemote else {
+            pendingRemoval = PendingProjectRemoval(
+                project: project,
+                previousRecentlyRemovedProjects: previous,
+                finalRecentlyRemovedProjects: previous,
+                logoIDsToRemove: []
+            )
+            return true
+        }
+
+        let replacedProjects = previous.filter { projectsMatch($0.project, project) }
+        var stagedProjects = previous.filter { !projectsMatch($0.project, project) }
+        stagedProjects.insert(RecentlyRemovedProject(project: project, removedAt: Date()), at: 0)
+        let finalProjects = Array(stagedProjects.prefix(Self.recentlyRemovedProjectLimit))
+        let evictedProjects = stagedProjects.dropFirst(Self.recentlyRemovedProjectLimit)
+        let replacedLogoIDs = replacedProjects.filter { $0.id != project.id }.map(\.id)
+        let logoIDsToRemove = Set(replacedLogoIDs + evictedProjects.map(\.id))
+        guard saveRecentlyRemovedProjects(stagedProjects) else { return false }
+        guard save(notify: false) else {
+            saveRecentlyRemovedProjects(previous)
+            return false
+        }
+        pendingRemoval = PendingProjectRemoval(
+            project: project,
+            previousRecentlyRemovedProjects: previous,
+            finalRecentlyRemovedProjects: finalProjects,
+            logoIDsToRemove: logoIDsToRemove
+        )
+        return true
+    }
+
+    func cancelRemoval(id: UUID) {
+        guard let pendingRemoval, pendingRemoval.project.id == id else { return }
+        recentlyRemovedProjects = pendingRemoval.previousRecentlyRemovedProjects
+        if !pendingRemoval.project.isRemote {
+            saveRecentlyRemovedProjects(recentlyRemovedProjects)
+        }
+        self.pendingRemoval = nil
+        releaseRemovalSlot()
+    }
+
+    @discardableResult
+    func commitRemoval(id: UUID) -> Bool {
+        guard let pendingRemoval, pendingRemoval.project.id == id else { return false }
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else {
+            cancelRemoval(id: id)
+            return false
+        }
+        let project = storedProjects.remove(at: index)
+        guard save(notify: false) else {
+            storedProjects.insert(project, at: index)
+            cancelRemoval(id: id)
+            return false
+        }
+
+        recentlyRemovedProjects = pendingRemoval.finalRecentlyRemovedProjects
+        let didSaveFinalHistory = project.isRemote || saveRecentlyRemovedProjects(recentlyRemovedProjects)
+        if didSaveFinalHistory {
+            for logoID in pendingRemoval.logoIDsToRemove {
+                ProjectLogoStorage.remove(forProjectID: logoID)
+            }
+        }
+        self.pendingRemoval = nil
+        releaseRemovalSlot()
+        onProjectsChanged?()
         onProjectRemoved?(id)
+        return true
+    }
+
+    @discardableResult
+    func restoreRecentlyRemovedProject(id: UUID) -> Project? {
+        guard pendingRemoval == nil else { return nil }
+        guard let index = recentlyRemovedProjects.firstIndex(where: { $0.id == id }) else { return nil }
+        let entry = recentlyRemovedProjects[index]
+        var project = entry.project
+        project.sortOrder = (storedProjects.map(\.sortOrder).max() ?? -1) + 1
+        storedProjects.append(project)
+        guard save(notify: false) else {
+            storedProjects.removeAll { $0.id == project.id }
+            return nil
+        }
+        recentlyRemovedProjects.remove(at: index)
+        saveRecentlyRemovedProjects()
+        onProjectsChanged?()
+        return project
     }
 
     func rename(id: UUID, to newName: String) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].name = newName
         save()
     }
 
     func setLogo(id: UUID, to logo: String?) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         if logo == nil {
             ProjectLogoStorage.remove(forProjectID: id)
@@ -56,49 +190,65 @@ final class ProjectStore {
         save()
     }
 
+    func setLogo(id: UUID, croppedImage: NSImage) {
+        guard pendingRemoval?.project.id != id else { return }
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
+        let logo = ProjectLogoStorage.save(croppedImage: croppedImage, forProjectID: id)
+        storedProjects[index].logo = logo
+        save()
+    }
+
     func setIcon(id: UUID, to icon: String?) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].icon = icon
         save()
     }
 
     func setIconColor(id: UUID, to color: String?) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].iconColor = color
         save()
     }
 
     func setPinned(id: UUID, to pinned: Bool) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].isPinned = pinned
         save()
     }
 
     func setWorktreesEnabled(id: UUID, to enabled: Bool) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].worktreesEnabled = enabled
         save()
     }
 
     func setPreferredWorktreeParentPath(id: UUID, to path: String?) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].preferredWorktreeParentPath = WorktreeLocationResolver.normalizedPath(path)
         save()
     }
 
     func setPullRequestPrompt(id: UUID, to prompt: String?) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].pullRequestPrompt = RepositoryAIActionPreferences.normalizedPrompt(prompt)
         save()
     }
 
     func markActive(id: UUID) {
+        guard pendingRemoval?.project.id != id else { return }
         guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
         storedProjects[index].lastActiveAt = Date()
         save(notify: false)
     }
 
     func persistOrder(_ orderedIDs: [UUID]) {
+        guard pendingRemoval == nil else { return }
         let positions = Dictionary(uniqueKeysWithValues: orderedIDs.enumerated().map { ($1, $0) })
         storedProjects.sort { positions[$0.id, default: Int.max] < positions[$1.id, default: Int.max] }
         for index in storedProjects.indices {
@@ -108,6 +258,7 @@ final class ProjectStore {
     }
 
     func persistOrder(_ orderedIDs: [UUID], scopedTo scopedIDs: Set<UUID>) {
+        guard pendingRemoval == nil else { return }
         let projectsByID = Dictionary(uniqueKeysWithValues: storedProjects.map { ($0.id, $0) })
         var scopedProjects = orderedIDs.compactMap { projectsByID[$0] }
         storedProjects = storedProjects.map { project in
@@ -121,6 +272,7 @@ final class ProjectStore {
     }
 
     func reorder(fromOffsets source: IndexSet, toOffset destination: Int) {
+        guard pendingRemoval == nil else { return }
         storedProjects.move(fromOffsets: source, toOffset: destination)
         for index in storedProjects.indices {
             storedProjects[index].sortOrder = index
@@ -128,13 +280,17 @@ final class ProjectStore {
         save()
     }
 
-    func save(notify: Bool = true) {
+    @discardableResult
+    func save(notify: Bool = true) -> Bool {
         do {
             try persistence.saveProjects(storedProjects)
         } catch {
             logger.error("Failed to save projects: \(error)")
+            if notify { onProjectsChanged?() }
+            return false
         }
         if notify { onProjectsChanged?() }
+        return true
     }
 
     private func load() {
@@ -144,5 +300,66 @@ final class ProjectStore {
         } catch {
             logger.error("Failed to load projects: \(error)")
         }
+        do {
+            let loaded = try persistence.loadRecentlyRemovedProjects().sorted { $0.removedAt > $1.removedAt }
+            recentlyRemovedProjects = []
+            for entry in loaded {
+                guard !entry.project.isHome, !entry.project.isRemote else { continue }
+                guard !storedProjects.contains(where: { projectsMatch($0, entry.project) }) else { continue }
+                guard !recentlyRemovedProjects.contains(where: { projectsMatch($0.project, entry.project) }) else {
+                    continue
+                }
+                recentlyRemovedProjects.append(entry)
+                guard recentlyRemovedProjects.count < Self.recentlyRemovedProjectLimit else { break }
+            }
+        } catch {
+            logger.error("Failed to load recently removed projects: \(error)")
+        }
+    }
+
+    private func removeRecentlyRemovedProject(matching project: Project) {
+        let removedProjects = recentlyRemovedProjects.filter { projectsMatch($0.project, project) }
+        guard !removedProjects.isEmpty else { return }
+        recentlyRemovedProjects.removeAll { projectsMatch($0.project, project) }
+        for entry in removedProjects where entry.id != project.id {
+            ProjectLogoStorage.remove(forProjectID: entry.id)
+        }
+        saveRecentlyRemovedProjects()
+    }
+
+    private func projectsMatch(_ lhs: Project, _ rhs: Project) -> Bool {
+        if lhs.id == rhs.id { return true }
+        guard !lhs.isRemote, !rhs.isRemote else { return false }
+        return ProjectPickerPathService.standardizedPath(lhs.path)
+            == ProjectPickerPathService.standardizedPath(rhs.path)
+    }
+
+    @discardableResult
+    private func saveRecentlyRemovedProjects(_ projects: [RecentlyRemovedProject]? = nil) -> Bool {
+        do {
+            try persistence.saveRecentlyRemovedProjects(projects ?? recentlyRemovedProjects)
+        } catch {
+            logger.error("Failed to save recently removed projects: \(error)")
+            return false
+        }
+        return true
+    }
+
+    private func reserveRemovalSlot() async {
+        guard removalSlotReserved else {
+            removalSlotReserved = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            removalSlotWaiters.append(continuation)
+        }
+    }
+
+    private func releaseRemovalSlot() {
+        guard !removalSlotWaiters.isEmpty else {
+            removalSlotReserved = false
+            return
+        }
+        removalSlotWaiters.removeFirst().resume()
     }
 }

--- a/Muxy/Services/Project/WorktreeStore.swift
+++ b/Muxy/Services/Project/WorktreeStore.swift
@@ -3,6 +3,14 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "WorktreeStore")
 
+enum WorktreeMutationError: LocalizedError {
+    case projectRemovalInProgress
+
+    var errorDescription: String? {
+        "This project is being removed."
+    }
+}
+
 struct WorktreeCreationRequest {
     let name: String
     let path: String
@@ -18,6 +26,9 @@ final class WorktreeStore {
     private(set) var preparingRemovalWorktreeIDs: Set<UUID> = []
     private(set) var removingWorktreeIDs: Set<UUID> = []
     private var projectIDByPath: [String: UUID] = [:]
+    private var projectsBeingRemoved: Set<UUID> = []
+    private var activeProjectMutationCounts: [UUID: Int] = [:]
+    private var projectMutationWaiters: [UUID: [CheckedContinuation<Void, Never>]] = [:]
     private let persistence: any WorktreePersisting
     private let listGitWorktrees: @Sendable (String) async throws -> [GitWorktreeRecord]
     private let addGitWorktree: @Sendable (String, String, String, Bool, String?) async throws -> Void
@@ -47,6 +58,7 @@ final class WorktreeStore {
 
     func loadAll(projects: [Project]) {
         for project in projects {
+            guard !projectsBeingRemoved.contains(project.id) else { continue }
             do {
                 var loaded = try persistence.loadWorktrees(projectID: project.id)
                 if !loaded.contains(where: \.isPrimary) {
@@ -63,6 +75,7 @@ final class WorktreeStore {
     }
 
     func ensurePrimary(for project: Project) {
+        guard !projectsBeingRemoved.contains(project.id) else { return }
         var list = worktrees[project.id] ?? []
         if list.contains(where: \.isPrimary) { return }
         list.insert(makePrimary(for: project), at: 0)
@@ -94,6 +107,11 @@ final class WorktreeStore {
     }
 
     func add(_ worktree: Worktree, to projectID: UUID, context: WorkspaceContext = .local) {
+        guard !projectsBeingRemoved.contains(projectID) else { return }
+        store(worktree, for: projectID, context: context)
+    }
+
+    private func store(_ worktree: Worktree, for projectID: UUID, context: WorkspaceContext) {
         var list = worktrees[projectID] ?? []
         let key = GitWorktreeService.canonicalPath(worktree.path, context: context)
         if let index = list.firstIndex(where: {
@@ -112,6 +130,10 @@ final class WorktreeStore {
         request: WorktreeCreationRequest,
         context: WorkspaceContext = .local
     ) async throws -> Worktree {
+        guard beginProjectMutation(project.id) else {
+            throw WorktreeMutationError.projectRemovalInProgress
+        }
+        defer { endProjectMutation(project.id) }
         let parentPath = parentDirectory(of: request.path, context: context)
         try await context.fileOps.makeDirectory(at: parentPath)
 
@@ -122,7 +144,7 @@ final class WorktreeStore {
             branch: request.branch,
             isPrimary: false
         )
-        add(worktree, to: project.id, context: context)
+        store(worktree, for: project.id, context: context)
         return worktree
     }
 
@@ -161,6 +183,11 @@ final class WorktreeStore {
     }
 
     func remove(worktreeID: UUID, from projectID: UUID) {
+        guard !projectsBeingRemoved.contains(projectID) else { return }
+        removeWorktree(worktreeID, from: projectID)
+    }
+
+    private func removeWorktree(_ worktreeID: UUID, from projectID: UUID) {
         guard var list = worktrees[projectID] else { return }
         list.removeAll { $0.id == worktreeID && $0.canBeRemoved }
         setWorktrees(list, for: projectID)
@@ -184,6 +211,9 @@ final class WorktreeStore {
     }
 
     func beginRemovalPreparation(worktree: Worktree) -> Bool {
+        if let projectID = projectIDByPath[worktree.path], projectsBeingRemoved.contains(projectID) {
+            return false
+        }
         guard worktree.canBeRemoved, !isRemoving(worktreeID: worktree.id) else { return false }
         return preparingRemovalWorktreeIDs.insert(worktree.id).inserted
     }
@@ -194,6 +224,7 @@ final class WorktreeStore {
 
     func beginRemoval(
         worktree: Worktree,
+        projectID: UUID,
         repoPath: String,
         context: WorkspaceContext,
         onSuccess: @escaping @MainActor () -> Void
@@ -202,7 +233,12 @@ final class WorktreeStore {
               !isPreparingRemoval(worktreeID: worktree.id),
               removingWorktreeIDs.insert(worktree.id).inserted
         else { return }
+        guard beginProjectMutation(projectID) else {
+            removingWorktreeIDs.remove(worktree.id)
+            return
+        }
         Task { [weak self] in
+            defer { self?.endProjectMutation(projectID) }
             do {
                 try await WorktreeStore.cleanupOnDisk(
                     worktree: worktree,
@@ -210,6 +246,7 @@ final class WorktreeStore {
                     context: context
                 )
                 self?.removingWorktreeIDs.remove(worktree.id)
+                self?.removeWorktree(worktree.id, from: projectID)
                 onSuccess()
             } catch {
                 self?.removingWorktreeIDs.remove(worktree.id)
@@ -222,6 +259,10 @@ final class WorktreeStore {
     }
 
     func refreshFromGit(project: Project, context: WorkspaceContext = .local) async throws -> [Worktree] {
+        guard beginProjectMutation(project.id) else {
+            throw WorktreeMutationError.projectRemovalInProgress
+        }
+        defer { endProjectMutation(project.id) }
         ensurePrimary(for: project)
         let records = try await listWorktreesForContext(project: project, context: context)
             .filter { !$0.isBare && !$0.isPrunable }
@@ -389,6 +430,7 @@ final class WorktreeStore {
     }
 
     func rename(worktreeID: UUID, in projectID: UUID, to newName: String) {
+        guard !projectsBeingRemoved.contains(projectID) else { return }
         guard var list = worktrees[projectID],
               let index = list.firstIndex(where: { $0.id == worktreeID })
         else { return }
@@ -398,6 +440,7 @@ final class WorktreeStore {
     }
 
     func updateBranch(worktreeID: UUID, in projectID: UUID, branch: String?) {
+        guard !projectsBeingRemoved.contains(projectID) else { return }
         guard var list = worktrees[projectID],
               let index = list.firstIndex(where: { $0.id == worktreeID })
         else { return }
@@ -407,18 +450,54 @@ final class WorktreeStore {
     }
 
     func removeProject(_ projectID: UUID) {
+        guard !projectsBeingRemoved.contains(projectID) else { return }
+        removeProjectState(projectID)
+    }
+
+    func completeProjectRemoval(_ projectID: UUID) {
+        removeProjectState(projectID)
+    }
+
+    private func removeProjectState(_ projectID: UUID) {
         if let existing = worktrees[projectID] {
             for worktree in existing where projectIDByPath[worktree.path] == projectID {
                 projectIDByPath.removeValue(forKey: worktree.path)
             }
         }
         worktrees.removeValue(forKey: projectID)
+        projectsBeingRemoved.remove(projectID)
         pruneRemovalState()
         do {
             try persistence.removeWorktrees(projectID: projectID)
         } catch {
             logger.error("Failed to remove worktrees file for project \(projectID): \(error)")
         }
+    }
+
+    func beginProjectRemoval(_ projectID: UUID) async -> Bool {
+        guard projectsBeingRemoved.insert(projectID).inserted else { return false }
+        guard activeProjectMutationCounts[projectID, default: 0] > 0 else { return true }
+        await withCheckedContinuation { continuation in
+            projectMutationWaiters[projectID, default: []].append(continuation)
+        }
+        return true
+    }
+
+    func cancelProjectRemoval(_ projectID: UUID) {
+        projectsBeingRemoved.remove(projectID)
+    }
+
+    func isProjectRemovalInProgress(_ projectID: UUID) -> Bool {
+        projectsBeingRemoved.contains(projectID)
+    }
+
+    func restoreProjectWorktrees(_ list: [Worktree], for projectID: UUID) {
+        guard !list.isEmpty else {
+            removeProject(projectID)
+            return
+        }
+        setWorktrees(list, for: projectID)
+        save(projectID: projectID)
     }
 
     private func setWorktrees(_ list: [Worktree], for projectID: UUID) {
@@ -462,6 +541,25 @@ final class WorktreeStore {
             try persistence.saveWorktrees(list, projectID: projectID)
         } catch {
             logger.error("Failed to save worktrees for project \(projectID): \(error)")
+        }
+    }
+
+    private func beginProjectMutation(_ projectID: UUID) -> Bool {
+        guard !projectsBeingRemoved.contains(projectID) else { return false }
+        activeProjectMutationCounts[projectID, default: 0] += 1
+        return true
+    }
+
+    private func endProjectMutation(_ projectID: UUID) {
+        guard let count = activeProjectMutationCounts[projectID] else { return }
+        guard count == 1 else {
+            activeProjectMutationCounts[projectID] = count - 1
+            return
+        }
+        activeProjectMutationCounts.removeValue(forKey: projectID)
+        let waiters = projectMutationWaiters.removeValue(forKey: projectID) ?? []
+        for waiter in waiters {
+            waiter.resume()
         }
     }
 

--- a/Muxy/Utilities/CLIAccessor.swift
+++ b/Muxy/Utilities/CLIAccessor.swift
@@ -10,32 +10,16 @@ enum CLIAccessor {
         worktreeStore: WorktreeStore,
         projectGroupStore: ProjectGroupStore
     ) {
-        let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: standardizedPath, isDirectory: &isDirectory),
-              isDirectory.boolValue
-        else { return }
-
-        if let existing = projectStore.projects.first(where: { $0.path == standardizedPath }),
-           let primary = worktreeStore.primary(for: existing.id)
-        {
-            projectGroupStore.addProjectToActiveGroup(projectID: existing.id)
-            appState.selectProject(existing, worktree: primary)
-            activateApp()
+        guard ProjectOpenService.confirmProjectPath(
+            path,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+        else {
             return
         }
-
-        let url = URL(fileURLWithPath: standardizedPath)
-        let project = Project(
-            name: url.lastPathComponent,
-            path: standardizedPath,
-            sortOrder: projectStore.projects.count
-        )
-        projectStore.add(project)
-        projectGroupStore.addProjectToActiveGroup(projectID: project.id)
-        worktreeStore.ensurePrimary(for: project)
-        guard let primary = worktreeStore.primary(for: project.id) else { return }
-        appState.selectProject(project, worktree: primary)
         activateApp()
     }
 

--- a/Muxy/Views/Components/Overlays/TerminalOmniboxOverlay.swift
+++ b/Muxy/Views/Components/Overlays/TerminalOmniboxOverlay.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TerminalOmniboxOverlay: View {
     let projects: [TerminalOmniboxProjectItem]
+    let recentlyRemovedProjects: [TerminalOmniboxRecentlyRemovedProjectItem]
     let worktrees: [TerminalOmniboxWorktreeItem]
     let workspaces: [TerminalOmniboxWorkspaceItem]
     let openTabs: [OpenTerminalTabItem]
@@ -31,6 +32,7 @@ struct TerminalOmniboxOverlay: View {
         TerminalOmniboxItemResolver.items(
             in: TerminalOmniboxItemContext(
                 projects: projects,
+                recentlyRemovedProjects: recentlyRemovedProjects,
                 worktrees: worktrees,
                 workspaces: workspaces,
                 openTabs: openTabs,
@@ -101,6 +103,8 @@ struct TerminalOmniboxOverlay: View {
         switch launchScope {
         case .projects:
             "Search project..."
+        case .recentlyRemovedProjects:
+            "Search recently removed projects..."
         case .worktrees:
             "Search worktree..."
         case .workspaces:
@@ -167,6 +171,8 @@ struct TerminalOmniboxOverlay: View {
         switch launchScope {
         case .projects:
             "No projects found"
+        case .recentlyRemovedProjects:
+            "No recently removed projects"
         case .worktrees:
             "No worktrees found"
         case .workspaces:
@@ -184,6 +190,8 @@ struct TerminalOmniboxOverlay: View {
              .worktrees,
              .workspaces:
             "Switch"
+        case .recentlyRemovedProjects:
+            "Restore"
         default:
             "Open"
         }
@@ -237,6 +245,7 @@ struct TerminalOmniboxOverlay: View {
     private func dispatchSelection(_ item: TerminalOmniboxItem) {
         switch item {
         case .project,
+             .recentlyRemovedProject,
              .worktree,
              .workspace:
             onSelect(item, nil, nil)

--- a/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
@@ -16,6 +16,7 @@ struct ExpandedProjectRow: View {
     let onSetPinned: (Bool) -> Void
 
     @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
 
@@ -148,11 +149,7 @@ struct ExpandedProjectRow: View {
                 sourceImage: item.image,
                 onConfirm: { cropped in
                     logoCropImage = nil
-                    let logoPath = ProjectLogoStorage.save(
-                        croppedImage: cropped,
-                        forProjectID: project.id
-                    )
-                    onSetLogo(logoPath)
+                    projectStore.setLogo(id: project.id, croppedImage: cropped)
                 },
                 onCancel: { logoCropImage = nil }
             )
@@ -539,6 +536,7 @@ struct ExpandedProjectRow: View {
             ?? remaining.first
         worktreeStore.beginRemoval(
             worktree: worktree,
+            projectID: project.id,
             repoPath: project.path,
             context: projectGroupStore.workspaceContext(for: project),
             onSuccess: {

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
@@ -134,6 +134,19 @@ struct ProjectFocusedSidebar: View {
                 } label: {
                     Label("Local", systemImage: "folder")
                 }
+                if !projectStore.recentlyRemovedProjects.isEmpty {
+                    Divider()
+                    Section("Recently Removed") {
+                        ForEach(projectStore.recentlyRemovedProjects) { entry in
+                            Button {
+                                restoreRecentlyRemovedProject(id: entry.id)
+                            } label: {
+                                Label(entry.project.name, systemImage: entry.project.icon ?? "folder")
+                            }
+                        }
+                    }
+                    Divider()
+                }
                 remoteProjectMenu
             } label: {
                 AddProjectButton.Label(expanded: isWide)
@@ -200,6 +213,20 @@ struct ProjectFocusedSidebar: View {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
+    }
+
+    private func restoreRecentlyRemovedProject(id: UUID) {
+        do {
+            try ProjectOpenService.restoreRecentlyRemovedProject(
+                id: id,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
+            )
+        } catch {
+            ToastState.shared.show(title: "Could not restore project", body: error.localizedDescription)
+        }
     }
 
     private var homeProject: Project? {

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
@@ -16,6 +16,7 @@ struct ProjectRow: View {
     let onSetPinned: (Bool) -> Void
 
     @Environment(AppState.self) private var appState
+    @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
 
@@ -151,11 +152,7 @@ struct ProjectRow: View {
                     sourceImage: item.image,
                     onConfirm: { cropped in
                         logoCropImage = nil
-                        let logoPath = ProjectLogoStorage.save(
-                            croppedImage: cropped,
-                            forProjectID: project.id
-                        )
-                        onSetLogo(logoPath)
+                        projectStore.setLogo(id: project.id, croppedImage: cropped)
                     },
                     onCancel: { logoCropImage = nil }
                 )
@@ -394,6 +391,7 @@ struct ProjectRow: View {
             ?? remaining.first
         worktreeStore.beginRemoval(
             worktree: worktree,
+            projectID: project.id,
             repoPath: project.path,
             context: projectGroupStore.workspaceContext(for: project),
             onSuccess: {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -160,8 +160,7 @@ struct TabFocusedProjectRow: View {
                 sourceImage: item.image,
                 onConfirm: { cropped in
                     logoCropImage = nil
-                    let path = ProjectLogoStorage.save(croppedImage: cropped, forProjectID: project.id)
-                    projectStore.setLogo(id: project.id, to: path)
+                    projectStore.setLogo(id: project.id, croppedImage: cropped)
                 },
                 onCancel: { logoCropImage = nil }
             )
@@ -282,7 +281,12 @@ struct TabFocusedProjectRow: View {
 
     private func requestRemoveWorktree(_ worktree: Worktree) async {
         let context = projectGroupStore.workspaceContext(for: project)
-        worktreeStore.beginRemoval(worktree: worktree, repoPath: project.path, context: context) {
+        worktreeStore.beginRemoval(
+            worktree: worktree,
+            projectID: project.id,
+            repoPath: project.path,
+            context: context
+        ) {
             appState.removeWorktree(
                 projectID: project.id,
                 worktree: worktree,
@@ -473,13 +477,17 @@ struct TabFocusedProjectRow: View {
 
     private func performRemove() {
         Task {
-            try? await ProjectRemovalService.remove(
-                project,
-                appState: appState,
-                projectStore: projectStore,
-                worktreeStore: worktreeStore,
-                projectGroupStore: projectGroupStore
-            )
+            do {
+                try await ProjectRemovalService.remove(
+                    project,
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore,
+                    projectGroupStore: projectGroupStore
+                )
+            } catch {
+                ToastState.shared.show(title: "Could not remove project", body: error.localizedDescription)
+            }
         }
     }
 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -71,7 +71,11 @@ struct TabFocusedSidebar: View {
                         )
                     }
                     if !expansionStore.focusMode {
-                        TabFocusedAddProjectRow(action: openProjectPicker)
+                        TabFocusedAddProjectRow(
+                            recentlyRemovedProjects: displayedRecentlyRemovedProjects,
+                            openProject: openProjectPicker,
+                            restoreProject: restoreRecentlyRemovedProject
+                        )
                     }
                 }
                 .padding(.top, UIMetrics.spacing5)
@@ -91,6 +95,25 @@ struct TabFocusedSidebar: View {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
+    }
+
+    private var displayedRecentlyRemovedProjects: [RecentlyRemovedProject] {
+        guard !projectGroupStore.isRemoteWorkspaceActive else { return [] }
+        return projectStore.recentlyRemovedProjects
+    }
+
+    private func restoreRecentlyRemovedProject(id: UUID) {
+        do {
+            try ProjectOpenService.restoreRecentlyRemovedProject(
+                id: id,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
+            )
+        } catch {
+            ToastState.shared.show(title: "Could not restore project", body: error.localizedDescription)
+        }
     }
 }
 
@@ -131,38 +154,68 @@ enum TabFocusedSidebarRowItem: Identifiable {
 }
 
 private struct TabFocusedAddProjectRow: View {
-    let action: () -> Void
+    let recentlyRemovedProjects: [RecentlyRemovedProject]
+    let openProject: () -> Void
+    let restoreProject: (UUID) -> Void
     @State private var hovered = false
 
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: TabFocusedSidebarMetrics.iconTitleGap) {
-                Image(systemName: "plus")
-                    .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
-                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
-                    .frame(
-                        width: TabFocusedSidebarMetrics.folderIconSize,
-                        height: TabFocusedSidebarMetrics.folderIconSize
-                    )
-                Text("Add Project")
-                    .font(.system(size: UIMetrics.fontHeadline, weight: .medium))
-                    .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
-                Spacer(minLength: 0)
+        if recentlyRemovedProjects.isEmpty {
+            Button(action: openProject) {
+                label
             }
-            .padding(.horizontal, TabFocusedSidebarMetrics.rowHorizontalInset)
-            .frame(minHeight: TabFocusedSidebarMetrics.rowHeight)
-            .background {
-                RoundedRectangle(cornerRadius: TabFocusedSidebarMetrics.rowCornerRadius, style: .continuous)
-                    .fill(hovered ? MuxyTheme.hover : Color.clear)
+            .buttonStyle(.plain)
+            .accessibilityLabel("Add Project")
+        } else {
+            Menu {
+                Button(action: openProject) {
+                    Label("Choose Folder…", systemImage: "folder")
+                }
+                Divider()
+                Section("Recently Removed") {
+                    ForEach(recentlyRemovedProjects) { entry in
+                        Button {
+                            restoreProject(entry.id)
+                        } label: {
+                            Label(entry.project.name, systemImage: entry.project.icon ?? "folder")
+                        }
+                    }
+                }
+            } label: {
+                label
             }
-            .contentShape(RoundedRectangle(cornerRadius: TabFocusedSidebarMetrics.rowCornerRadius, style: .continuous))
+            .menuStyle(.button)
+            .menuIndicator(.hidden)
+            .buttonStyle(.plain)
+            .accessibilityLabel("Add Project")
         }
+    }
+
+    private var label: some View {
+        HStack(spacing: TabFocusedSidebarMetrics.iconTitleGap) {
+            Image(systemName: "plus")
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+                .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
+                .frame(
+                    width: TabFocusedSidebarMetrics.folderIconSize,
+                    height: TabFocusedSidebarMetrics.folderIconSize
+                )
+            Text("Add Project")
+                .font(.system(size: UIMetrics.fontHeadline, weight: .medium))
+                .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, TabFocusedSidebarMetrics.rowHorizontalInset)
+        .frame(minHeight: TabFocusedSidebarMetrics.rowHeight)
+        .background {
+            RoundedRectangle(cornerRadius: TabFocusedSidebarMetrics.rowCornerRadius, style: .continuous)
+                .fill(hovered ? MuxyTheme.hover : Color.clear)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: TabFocusedSidebarMetrics.rowCornerRadius, style: .continuous))
         .padding(.horizontal, TabFocusedSidebarMetrics.rowOuterInset)
         .padding(.vertical, TabFocusedSidebarMetrics.rowVerticalPadding)
-        .buttonStyle(.plain)
         .onHover { hovered = $0 }
         .help(shortcutTooltip)
-        .accessibilityLabel("Add Project")
     }
 
     private var shortcutTooltip: String {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -721,6 +721,7 @@ struct MainWindow: View {
         if showTerminalOmnibox {
             TerminalOmniboxOverlay(
                 projects: terminalOmniboxProjects,
+                recentlyRemovedProjects: terminalOmniboxRecentlyRemovedProjects,
                 worktrees: terminalOmniboxWorktrees,
                 workspaces: terminalOmniboxWorkspaces,
                 openTabs: terminalOmniboxOpenTabs,
@@ -797,6 +798,18 @@ struct MainWindow: View {
         switch item {
         case let .project(project):
             _ = selectOmniboxProject(project.projectID)
+        case let .recentlyRemovedProject(project):
+            do {
+                try ProjectOpenService.restoreRecentlyRemovedProject(
+                    id: project.projectID,
+                    appState: appState,
+                    projectStore: projectStore,
+                    worktreeStore: worktreeStore,
+                    projectGroupStore: projectGroupStore
+                )
+            } catch {
+                ToastState.shared.show(title: "Could not restore project", body: error.localizedDescription)
+            }
         case let .worktree(worktree):
             _ = selectOmniboxProject(worktree.projectID, worktreeID: worktree.worktreeID)
         case let .workspace(workspace):
@@ -850,6 +863,18 @@ struct MainWindow: View {
     private var terminalOmniboxProjects: [TerminalOmniboxProjectItem] {
         omniboxProjects.map {
             TerminalOmniboxProjectItem(projectID: $0.id, name: $0.name, path: $0.path)
+        }
+    }
+
+    private var terminalOmniboxRecentlyRemovedProjects: [TerminalOmniboxRecentlyRemovedProjectItem] {
+        guard !projectGroupStore.isRemoteWorkspaceActive else { return [] }
+        return projectStore.recentlyRemovedProjects.map { entry in
+            TerminalOmniboxRecentlyRemovedProjectItem(
+                projectID: entry.project.id,
+                name: entry.project.name,
+                path: entry.project.path,
+                icon: entry.project.icon
+            )
         }
     }
 
@@ -1265,6 +1290,7 @@ struct MainWindow: View {
         worktreeStore.endRemovalPreparation(worktreeID: worktree.id)
         worktreeStore.beginRemoval(
             worktree: worktree,
+            projectID: project.id,
             repoPath: project.path,
             context: projectGroupStore.workspaceContext(for: project),
             onSuccess: {

--- a/Tests/MuxyTests/Models/Keyboard/KeyBindingTests.swift
+++ b/Tests/MuxyTests/Models/Keyboard/KeyBindingTests.swift
@@ -87,6 +87,13 @@ struct KeyBindingTests {
         #expect(combos[.renameTab]?.isAssigned == false)
     }
 
+    @Test("Recently Removed Projects is available without a default shortcut")
+    func recentlyRemovedProjectsIsUnassigned() {
+        let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })
+        #expect(ShortcutAction.allCases.contains(.recentlyRemovedProjects))
+        #expect(combos[.recentlyRemovedProjects]?.isAssigned == false)
+    }
+
     @Test("KeyBinding.defaults includes cycle tab across panes shortcuts")
     func defaultsIncludesCycleTabAcrossPanesShortcuts() {
         let combos = Dictionary(uniqueKeysWithValues: KeyBinding.defaults.map { ($0.action, $0.combo) })

--- a/Tests/MuxyTests/Models/Terminal/TerminalOmniboxItemTests.swift
+++ b/Tests/MuxyTests/Models/Terminal/TerminalOmniboxItemTests.swift
@@ -14,6 +14,12 @@ struct TerminalOmniboxItemResolverTests {
         let shortcutID = UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
 
         let project = TerminalOmniboxProjectItem(projectID: projectID, name: "Muxy", path: "/repo/muxy")
+        let recentlyRemovedProject = TerminalOmniboxRecentlyRemovedProjectItem(
+            projectID: projectID,
+            name: "Muxy",
+            path: "/repo/muxy",
+            icon: "shippingbox"
+        )
         let primaryWorktree = TerminalOmniboxWorktreeItem(
             projectID: projectID,
             worktreeID: worktreeID,
@@ -55,6 +61,15 @@ struct TerminalOmniboxItemResolverTests {
         #expect(TerminalOmniboxItem.project(project).sectionTitle == "Projects")
         #expect(TerminalOmniboxItem.project(project).symbol == "folder")
         #expect(TerminalOmniboxItem.project(project).searchKey == "Muxy /repo/muxy project")
+
+        #expect(TerminalOmniboxItem.recentlyRemovedProject(recentlyRemovedProject).id ==
+            "recent-project-\(projectID.uuidString)")
+        #expect(TerminalOmniboxItem.recentlyRemovedProject(recentlyRemovedProject).title == "Muxy")
+        #expect(TerminalOmniboxItem.recentlyRemovedProject(recentlyRemovedProject).subtitle == "/repo/muxy")
+        #expect(TerminalOmniboxItem.recentlyRemovedProject(recentlyRemovedProject).sectionTitle == "Recently Removed")
+        #expect(TerminalOmniboxItem.recentlyRemovedProject(recentlyRemovedProject).symbol == "shippingbox")
+        #expect(TerminalOmniboxItem.recentlyRemovedProject(recentlyRemovedProject).searchKey ==
+            "Muxy /repo/muxy recently removed project")
 
         #expect(TerminalOmniboxItem.worktree(primaryWorktree).subtitle == "(main) /repo/muxy")
         #expect(TerminalOmniboxItem.worktree(primaryWorktree).symbol == "folder.badge.gearshape")
@@ -142,6 +157,12 @@ struct TerminalOmniboxItemResolverTests {
         let activeWorktreeID = UUID()
         let otherWorktreeID = UUID()
         let project = TerminalOmniboxProjectItem(projectID: activeProjectID, name: "Muxy", path: "/repo/muxy")
+        let recentlyRemovedProject = TerminalOmniboxRecentlyRemovedProjectItem(
+            projectID: otherProjectID,
+            name: "Removed",
+            path: "/repo/removed",
+            icon: nil
+        )
         let activeWorktree = TerminalOmniboxWorktreeItem(
             projectID: activeProjectID,
             worktreeID: activeWorktreeID,
@@ -178,6 +199,7 @@ struct TerminalOmniboxItemResolverTests {
         let emptyShortcut = CommandShortcut(name: "Empty", command: "   ")
         let context = TerminalOmniboxItemContext(
             projects: [project],
+            recentlyRemovedProjects: [recentlyRemovedProject],
             worktrees: [
                 activeWorktree,
                 TerminalOmniboxWorktreeItem(
@@ -197,6 +219,8 @@ struct TerminalOmniboxItemResolverTests {
         )
 
         #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .projects) == [.project(project)])
+        #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .recentlyRemovedProjects) ==
+            [.recentlyRemovedProject(recentlyRemovedProject)])
         #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .worktrees) == [.worktree(activeWorktree)])
         #expect(TerminalOmniboxItemResolver.items(in: context, launchScope: .openTabs) ==
             [.openTab(activeOpenTab), .openTab(otherOpenTab)])
@@ -215,6 +239,36 @@ struct TerminalOmniboxItemResolverTests {
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .worktrees).isEmpty)
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .openTabs) == [.openTab(activeOpenTab)])
         #expect(TerminalOmniboxItemResolver.items(in: inactiveContext, launchScope: .commandShortcuts).isEmpty)
+    }
+
+    @Test("Recently Removed Projects scope preserves stored order and excludes unrelated items")
+    func recentlyRemovedProjectsScopePreservesOrder() {
+        let first = TerminalOmniboxRecentlyRemovedProjectItem(
+            projectID: UUID(),
+            name: "Newest",
+            path: "/repo/newest",
+            icon: nil
+        )
+        let second = TerminalOmniboxRecentlyRemovedProjectItem(
+            projectID: UUID(),
+            name: "Older",
+            path: "/repo/older",
+            icon: "archivebox"
+        )
+        let context = TerminalOmniboxItemContext(
+            projects: [TerminalOmniboxProjectItem(projectID: UUID(), name: "Active", path: "/repo/active")],
+            recentlyRemovedProjects: [first, second],
+            worktrees: [],
+            openTabs: [],
+            commandShortcuts: [],
+            activeProjectID: nil,
+            activeWorktreeID: nil,
+            commandProjectIDs: []
+        )
+
+        let items = TerminalOmniboxItemResolver.items(in: context, launchScope: .recentlyRemovedProjects)
+
+        #expect(items == [.recentlyRemovedProject(first), .recentlyRemovedProject(second)])
     }
 
     @Test("Open tabs scope includes every project and worktree with the active one first")

--- a/Tests/MuxyTests/Services/Backup/BackupServiceTests.swift
+++ b/Tests/MuxyTests/Services/Backup/BackupServiceTests.swift
@@ -19,6 +19,7 @@ struct BackupServiceTests {
     private func seedSource() throws -> URL {
         let source = tempDirectory()
         try write(Data("[]".utf8), named: "projects.json", in: source)
+        try write(Data("[]".utf8), named: "recently-removed-projects.json", in: source)
         try write(Data(#"{"muxy.showStatusBar":true,"mobile.approvedDevices":[{"id":"x","tokenHash":"secret"}]}"#.utf8), named: "settings.json", in: source)
 
         let device = RemoteDevice(
@@ -46,6 +47,9 @@ struct BackupServiceTests {
         try await BackupService(baseDirectory: target).importBackup(from: archive, backupStamp: "stamp")
 
         #expect(FileManager.default.fileExists(atPath: target.appendingPathComponent("projects.json").path))
+        #expect(FileManager.default.fileExists(
+            atPath: target.appendingPathComponent("recently-removed-projects.json").path
+        ))
         let logo = target.appendingPathComponent("logos/logo.png")
         #expect(try Data(contentsOf: logo) == Data("png".utf8))
         let ghostty = target.appendingPathComponent("ghostty.conf")

--- a/Tests/MuxyTests/Services/Keyboard/KeyBindingStoreTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/KeyBindingStoreTests.swift
@@ -108,6 +108,26 @@ struct KeyBindingStoreTests {
 
         #expect(store.combo(for: .openProject) == customOpenProject.combo)
         #expect(store.combo(for: .refreshWorktrees) == KeyCombo(key: "r", command: true, option: true))
+        #expect(store.combo(for: .recentlyRemovedProjects).isAssigned == false)
+    }
+
+    @Test("Recently Removed Projects can be assigned by the user")
+    func recentlyRemovedProjectsCanBeAssigned() throws {
+        let store = KeyBindingStore(persistence: StubKeyBindingPersistence(bindings: KeyBinding.defaults))
+        let combo = KeyCombo(key: "u", command: true, shift: true, option: true)
+        let keyCode = try #require(KeyCombo.keyCode(for: "u"))
+        let event = try keyEvent(
+            characters: "U",
+            charactersIgnoringModifiers: "u",
+            keyCode: keyCode,
+            modifiers: [.command, .option, .shift]
+        )
+
+        #expect(store.action(for: event, scopes: [.mainWindow]) == nil)
+
+        store.updateBinding(action: .recentlyRemovedProjects, combo: combo)
+
+        #expect(store.action(for: event, scopes: [.mainWindow]) == .recentlyRemovedProjects)
     }
 
     @Test("new default shortcuts do not shadow saved custom bindings")

--- a/Tests/MuxyTests/Services/Keyboard/ShortcutActionDispatcherTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/ShortcutActionDispatcherTests.swift
@@ -38,6 +38,25 @@ struct ShortcutActionDispatcherTests {
         #expect(capture.contains(.removeCurrentWorktreeRequested))
     }
 
+    @Test("recently removed projects opens its omnibox scope")
+    func recentlyRemovedProjectsOpensOmniboxScope() {
+        let center = NotificationCenter()
+        let capture = NotificationCapture()
+        let token = center.addObserver(forName: .terminalOmnibox, object: nil, queue: nil) { notification in
+            capture.record(notification)
+        }
+        defer { center.removeObserver(token) }
+
+        let performed = makeDispatcher(notificationCenter: center).perform(
+            .recentlyRemovedProjects,
+            activeProject: nil
+        )
+
+        #expect(performed)
+        #expect(capture.contains(.terminalOmnibox))
+        #expect(capture.containsLaunchScope(.recentlyRemovedProjects))
+    }
+
     @Test("worktree requests return false without an active project")
     func worktreeRequestsReturnFalseWithoutActiveProject() {
         let dispatcher = makeDispatcher(notificationCenter: NotificationCenter())
@@ -73,6 +92,7 @@ struct ShortcutActionDispatcherTests {
 private final class NotificationCapture: @unchecked Sendable {
     private let lock = NSLock()
     private var names: [Notification.Name] = []
+    private var launchScopes: [String] = []
 
     func record(_ name: Notification.Name) {
         lock.lock()
@@ -80,9 +100,25 @@ private final class NotificationCapture: @unchecked Sendable {
         lock.unlock()
     }
 
+    func record(_ notification: Notification) {
+        lock.lock()
+        names.append(notification.name)
+        if let launchScope = notification.userInfo?["launchScope"] as? String {
+            launchScopes.append(launchScope)
+        }
+        lock.unlock()
+    }
+
     func contains(_ name: Notification.Name) -> Bool {
         lock.lock()
         let result = names.contains(name)
+        lock.unlock()
+        return result
+    }
+
+    func containsLaunchScope(_ scope: TerminalOmniboxLaunchScope) -> Bool {
+        lock.lock()
+        let result = launchScopes.contains(scope.rawValue)
         lock.unlock()
         return result
     }

--- a/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectDeleteTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectDeleteTests.swift
@@ -69,11 +69,268 @@ struct MuxyAPIProjectDeleteRoutingTests {
         )
 
         #expect(env.projectStore.storedProjects.contains { $0.id == project.id } == false)
+        #expect(env.projectStore.recentlyRemovedProjects.first?.project.id == project.id)
+    }
+
+    @Test("ProjectRemovalService keeps a local project when recent history cannot be saved")
+    func removalServicePreservesProjectAfterPersistenceFailure() async {
+        let project = Project(name: "Repo", path: "/tmp/muxy-delete-test-\(UUID().uuidString)")
+        let env = makeEnvironment(projects: [project])
+        let worktreeDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-removal-worktree-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: worktreeDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: worktreeDirectory) }
+        let worktree = Worktree(
+            name: "Feature",
+            path: worktreeDirectory.path,
+            branch: "feature",
+            isPrimary: false
+        )
+        env.worktreeStore.add(worktree, to: project.id)
+        env.projectPersistence.recentlyRemovedSaveError = ProjectDeletePersistenceStub.SaveError()
+
+        await #expect(throws: ProjectRemovalService.RemovalError.self) {
+            try await ProjectRemovalService.remove(
+                project,
+                appState: env.appState,
+                projectStore: env.projectStore,
+                worktreeStore: env.worktreeStore,
+                projectGroupStore: env.projectGroupStore
+            )
+        }
+
+        #expect(env.projectStore.storedProjects.contains { $0.id == project.id })
+        #expect(env.projectStore.recentlyRemovedProjects.isEmpty)
+        #expect(env.worktreeStore.list(for: project.id).contains { $0.id == worktree.id })
+        #expect(FileManager.default.fileExists(atPath: worktreeDirectory.path))
+    }
+
+    @Test("ProjectRemovalService rolls back staged history when worktree cleanup fails")
+    func removalServiceRollsBackHistoryAfterCleanupFailure() async {
+        let project = Project(name: "Repo", path: "/tmp/muxy-delete-test-\(UUID().uuidString)")
+        let env = makeEnvironment(projects: [project])
+
+        await #expect(throws: ProjectRemovalCleanupError.self) {
+            try await ProjectRemovalService.removeLocalProjectData(
+                project,
+                projectStore: env.projectStore,
+                worktreeStore: env.worktreeStore,
+                cleanupOnDisk: { _, _ in throw ProjectRemovalCleanupError() }
+            )
+        }
+
+        #expect(env.projectStore.storedProjects.contains { $0.id == project.id })
+        #expect(env.projectStore.recentlyRemovedProjects.isEmpty)
+        #expect(env.projectPersistence.recentlyRemovedProjects.isEmpty)
+    }
+
+    @Test("ProjectRemovalService freezes project and worktree mutations during cleanup")
+    func removalServiceFreezesMutationsDuringCleanup() async throws {
+        var project = Project(name: "Repo", path: "/tmp/muxy-delete-test-\(UUID().uuidString)")
+        project.logo = "logo.png"
+        let env = makeEnvironment(projects: [project])
+        let secondary = Worktree(
+            name: "Feature",
+            path: "/tmp/muxy-delete-feature-\(UUID().uuidString)",
+            branch: "feature",
+            isPrimary: false
+        )
+        env.worktreeStore.add(secondary, to: project.id)
+        let worktreesBeforeRemoval = env.worktreeStore.list(for: project.id)
+        let gate = ProjectRemovalTestGate()
+
+        let removal = Task { @MainActor in
+            try await ProjectRemovalService.removeLocalProjectData(
+                project,
+                projectStore: env.projectStore,
+                worktreeStore: env.worktreeStore,
+                cleanupOnDisk: { _, _ in await gate.enterAndWait() }
+            )
+        }
+        await gate.waitForEntries(1)
+
+        env.projectStore.rename(id: project.id, to: "Changed")
+        env.projectStore.setLogo(id: project.id, to: nil)
+        env.projectStore.setPinned(id: project.id, to: true)
+        env.worktreeStore.rename(worktreeID: secondary.id, in: project.id, to: "Changed")
+        env.worktreeStore.remove(worktreeID: secondary.id, from: project.id)
+        env.worktreeStore.add(
+            Worktree(name: "Late", path: "/tmp/late", branch: "late", isPrimary: false),
+            to: project.id
+        )
+
+        let activeProject = try #require(env.projectStore.storedProjects.first)
+        #expect(activeProject.name == "Repo")
+        #expect(activeProject.logo == "logo.png")
+        #expect(!activeProject.isPinned)
+        #expect(env.worktreeStore.list(for: project.id) == worktreesBeforeRemoval)
+
+        await gate.releaseNext()
+        try await removal.value
+
+        let archivedProject = try #require(env.projectStore.recentlyRemovedProjects.first?.project)
+        #expect(archivedProject.name == "Repo")
+        #expect(archivedProject.logo == "logo.png")
+        #expect(!archivedProject.isPinned)
+    }
+
+    @Test("ProjectRemovalService serializes overlapping removals")
+    func removalServiceSerializesOverlappingRemovals() async throws {
+        let firstProject = Project(name: "First", path: "/tmp/muxy-delete-first-\(UUID().uuidString)")
+        let secondProject = Project(name: "Second", path: "/tmp/muxy-delete-second-\(UUID().uuidString)")
+        let env = makeEnvironment(projects: [firstProject, secondProject])
+        let gate = ProjectRemovalTestGate()
+
+        let firstRemoval = Task { @MainActor in
+            try await ProjectRemovalService.removeLocalProjectData(
+                firstProject,
+                projectStore: env.projectStore,
+                worktreeStore: env.worktreeStore,
+                cleanupOnDisk: { _, _ in await gate.enterAndWait() }
+            )
+        }
+        await gate.waitForEntries(1)
+
+        let secondRemoval = Task { @MainActor in
+            try await ProjectRemovalService.removeLocalProjectData(
+                secondProject,
+                projectStore: env.projectStore,
+                worktreeStore: env.worktreeStore,
+                cleanupOnDisk: { _, _ in await gate.enterAndWait() }
+            )
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        let enteredBeforeRelease = await gate.entryCount
+        #expect(enteredBeforeRelease == 1)
+
+        await gate.releaseNext()
+        try await firstRemoval.value
+        await gate.waitForEntries(2)
+        await gate.releaseNext()
+        try await secondRemoval.value
+
+        #expect(env.projectStore.storedProjects.isEmpty)
+        #expect(env.projectStore.recentlyRemovedProjects.map(\.id) == [secondProject.id, firstProject.id])
+    }
+
+    @Test("ProjectRemovalService waits for active worktree creation before removing an SSH workspace project")
+    func removalServiceWaitsForSSHWorkspaceMutation() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-remote-workspace-removal-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let persistence = WorktreeDeletePersistenceStub()
+        let gate = ProjectRemovalTestGate()
+        let worktreeStore = WorktreeStore(
+            persistence: persistence,
+            addGitWorktree: { _, _, _, _, _ in await gate.enterAndWait() }
+        )
+        let env = makeEnvironment(projects: [], worktreeStore: worktreeStore)
+        let group = env.projectGroupStore.addRemoteWorkspace(name: "Remote", deviceID: UUID())
+        let remoteProject = try #require(env.projectGroupStore.addRemoteProject(
+            name: "Repo",
+            path: "~/repo",
+            toGroup: group.id
+        ))
+        let project = remoteProject.asProject(workspaceID: group.id, sortOrder: 0)
+        let request = WorktreeCreationRequest(
+            name: "Feature",
+            path: root.appendingPathComponent("feature").path,
+            branch: "feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        let creation = Task { @MainActor in
+            try await worktreeStore.createWorktree(project: project, request: request)
+        }
+        await gate.waitForEntries(1)
+        let removal = Task { @MainActor in
+            try await ProjectRemovalService.remove(
+                project,
+                appState: env.appState,
+                projectStore: env.projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: env.projectGroupStore
+            )
+        }
+        for _ in 0 ..< 10 where !worktreeStore.isProjectRemovalInProgress(project.id) {
+            await Task.yield()
+        }
+
+        #expect(worktreeStore.isProjectRemovalInProgress(project.id))
+        #expect(env.projectGroupStore.groups.first?.remoteProjects.contains { $0.id == project.id } == true)
+
+        await gate.releaseNext()
+        _ = try await creation.value
+        try await removal.value
+
+        #expect(env.projectGroupStore.groups.first?.remoteProjects.contains { $0.id == project.id } == false)
+        #expect(worktreeStore.list(for: project.id).isEmpty)
+        #expect(try persistence.loadWorktrees(projectID: project.id).isEmpty)
+    }
+
+    @Test("ProjectRemovalService waits for active worktree creation before removing a remote-device project")
+    func removalServiceWaitsForRemoteDeviceMutation() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-remote-device-removal-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let project = Project(
+            name: "Repo",
+            path: "~/repo",
+            remoteDeviceID: UUID()
+        )
+        let persistence = WorktreeDeletePersistenceStub()
+        let gate = ProjectRemovalTestGate()
+        let worktreeStore = WorktreeStore(
+            persistence: persistence,
+            addGitWorktree: { _, _, _, _, _ in await gate.enterAndWait() },
+            projects: [project]
+        )
+        let env = makeEnvironment(projects: [project], worktreeStore: worktreeStore)
+        let request = WorktreeCreationRequest(
+            name: "Feature",
+            path: root.appendingPathComponent("feature").path,
+            branch: "feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        let creation = Task { @MainActor in
+            try await worktreeStore.createWorktree(project: project, request: request)
+        }
+        await gate.waitForEntries(1)
+        let removal = Task { @MainActor in
+            try await ProjectRemovalService.remove(
+                project,
+                appState: env.appState,
+                projectStore: env.projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: env.projectGroupStore
+            )
+        }
+        for _ in 0 ..< 10 where !worktreeStore.isProjectRemovalInProgress(project.id) {
+            await Task.yield()
+        }
+
+        #expect(worktreeStore.isProjectRemovalInProgress(project.id))
+        #expect(env.projectStore.storedProjects.contains { $0.id == project.id })
+
+        await gate.releaseNext()
+        _ = try await creation.value
+        try await removal.value
+
+        #expect(env.projectStore.storedProjects.contains { $0.id == project.id } == false)
+        #expect(env.projectStore.recentlyRemovedProjects.isEmpty)
+        #expect(worktreeStore.list(for: project.id).isEmpty)
+        #expect(try persistence.loadWorktrees(projectID: project.id).isEmpty)
     }
 
     private struct Environment {
         let appState: AppState
         let projectStore: ProjectStore
+        let projectPersistence: ProjectDeletePersistenceStub
         let worktreeStore: WorktreeStore
         let projectGroupStore: ProjectGroupStore
 
@@ -88,11 +345,11 @@ struct MuxyAPIProjectDeleteRoutingTests {
         }
     }
 
-    private func makeEnvironment(projects: [Project]) -> Environment {
-        let projectStore = ProjectStore(persistence: ProjectDeletePersistenceStub(initial: projects))
-        let worktreeStore = WorktreeStore(
-            persistence: WorktreeDeletePersistenceStub(),
-            projects: projects
+    private func makeEnvironment(projects: [Project], worktreeStore: WorktreeStore? = nil) -> Environment {
+        let projectPersistence = ProjectDeletePersistenceStub(initial: projects)
+        let projectStore = ProjectStore(persistence: projectPersistence)
+        let worktreeStore = worktreeStore ?? WorktreeStore(
+            persistence: WorktreeDeletePersistenceStub(), projects: projects
         )
         let appState = AppState(
             selectionStore: ProjectDeleteSelectionStoreStub(),
@@ -107,6 +364,7 @@ struct MuxyAPIProjectDeleteRoutingTests {
         return Environment(
             appState: appState,
             projectStore: projectStore,
+            projectPersistence: projectPersistence,
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
@@ -114,10 +372,52 @@ struct MuxyAPIProjectDeleteRoutingTests {
 }
 
 private final class ProjectDeletePersistenceStub: ProjectPersisting {
+    struct SaveError: Error {}
+
     var projects: [Project]
+    var recentlyRemovedProjects: [RecentlyRemovedProject] = []
+    var recentlyRemovedSaveError: Error?
+
     init(initial: [Project]) { projects = initial }
     func loadProjects() throws -> [Project] { projects }
     func saveProjects(_ projects: [Project]) throws { self.projects = projects }
+    func loadRecentlyRemovedProjects() throws -> [RecentlyRemovedProject] { recentlyRemovedProjects }
+    func saveRecentlyRemovedProjects(_ projects: [RecentlyRemovedProject]) throws {
+        if let recentlyRemovedSaveError { throw recentlyRemovedSaveError }
+        recentlyRemovedProjects = projects
+    }
+}
+
+private struct ProjectRemovalCleanupError: Error {}
+
+private actor ProjectRemovalTestGate {
+    private(set) var entryCount = 0
+    private var entryWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func enterAndWait() async {
+        entryCount += 1
+        let readyWaiters = entryWaiters.filter { $0.0 <= entryCount }
+        entryWaiters.removeAll { $0.0 <= entryCount }
+        for waiter in readyWaiters {
+            waiter.1.resume()
+        }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitForEntries(_ count: Int) async {
+        guard entryCount < count else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append((count, continuation))
+        }
+    }
+
+    func releaseNext() {
+        guard !releaseWaiters.isEmpty else { return }
+        releaseWaiters.removeFirst().resume()
+    }
 }
 
 private final class WorktreeDeletePersistenceStub: WorktreePersisting {

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -112,6 +112,18 @@ struct ProjectGroupStoreTests {
         #expect(store.groups.first?.projectIDs.count == 1)
     }
 
+    @Test("addProject never adds a local project to an SSH workspace")
+    func addProjectIgnoresSSHWorkspace() {
+        let group = ProjectGroup(name: "Remote", type: .ssh)
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+
+        store.addProject(projectID: UUID(), toGroup: group.id)
+
+        #expect(store.groups.first?.projectIDs.isEmpty == true)
+        #expect(persistence.savedGroups == nil)
+    }
+
     @Test("addProjectToActiveGroup adds project to selected group and persists")
     func addProjectToActiveGroup() {
         let group = ProjectGroup(name: "Work")

--- a/Tests/MuxyTests/Services/Project/ProjectOpenServiceTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectOpenServiceTests.swift
@@ -252,6 +252,196 @@ struct ProjectOpenServiceTests {
         #expect(projectStore.storedProjects.first?.path == dir.standardizedFileURL.path)
     }
 
+    @Test("recently removed path restores project metadata and selects a fresh primary worktree")
+    func recentlyRemovedPathRestoresProject() throws {
+        let (appState, projectStore, worktreeStore, _) = makeStores()
+        let group = ProjectGroup(name: "Work")
+        let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
+        let projectGroupStore = ProjectGroupStore(
+            persistence: groupPersistence,
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        projectGroupStore.selectGroup(id: group.id)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-recent-project-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        var project = Project(name: "Custom Name", path: directory.path, sortOrder: 0)
+        project.icon = "star.fill"
+        project.logo = "stored-logo.png"
+        project.iconColor = "purple"
+        project.worktreesEnabled = true
+        project.isPinned = true
+        projectStore.add(project)
+        projectStore.remove(id: project.id)
+        worktreeStore.removeProject(project.id)
+
+        let result = ProjectOpenService.confirmProjectPathResult(
+            directory.path,
+            appState: appState,
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore
+        )
+
+        let restored = try #require(projectStore.storedProjects.first)
+        #expect(result == .success)
+        #expect(restored.id == project.id)
+        #expect(restored.name == "Custom Name")
+        #expect(restored.icon == "star.fill")
+        #expect(restored.logo == "stored-logo.png")
+        #expect(restored.iconColor == "purple")
+        #expect(restored.worktreesEnabled)
+        #expect(restored.isPinned)
+        #expect(projectStore.recentlyRemovedProjects.isEmpty)
+        #expect(worktreeStore.primary(for: project.id) != nil)
+        #expect(appState.activeProjectID == project.id)
+        #expect(groupPersistence.savedGroups?.first?.projectIDs == [project.id])
+    }
+
+    @Test("missing recently removed path stays archived")
+    func missingRecentlyRemovedPathStaysArchived() {
+        let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
+        let project = Project(name: "Missing", path: "/tmp/missing-recent-project")
+        projectStore.add(project)
+        projectStore.remove(id: project.id)
+
+        #expect(throws: ProjectOpenService.RestoreError.missingDirectory(project.path)) {
+            try ProjectOpenService.restoreRecentlyRemovedProject(
+                id: project.id,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore,
+                fileSystem: ProjectPathConfirmationFileSystemStub(state: .missing)
+            )
+        }
+        #expect(projectStore.storedProjects.isEmpty)
+        #expect(projectStore.recentlyRemovedProjects.first?.id == project.id)
+        #expect(worktreeStore.primary(for: project.id) == nil)
+        #expect(appState.activeProjectID == nil)
+    }
+
+    @Test("failed recent restore stays archived and is not selected")
+    func failedRecentlyRemovedRestoreStaysArchived() {
+        let persistence = ProjectPersistenceStub()
+        let projectStore = ProjectStore(persistence: persistence)
+        let worktreeStore = WorktreeStore(persistence: WorktreePersistenceStub(), projects: [])
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let group = ProjectGroup(name: "Work")
+        let groupPersistence = ProjectGroupPersistenceStub(initial: [group])
+        let projectGroupStore = ProjectGroupStore(
+            persistence: groupPersistence,
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        projectGroupStore.selectGroup(id: group.id)
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        projectStore.add(project)
+        projectStore.remove(id: project.id)
+        persistence.projectSaveError = ProjectPersistenceStub.SaveError()
+
+        #expect(throws: ProjectOpenService.RestoreError.persistenceFailed) {
+            try ProjectOpenService.restoreRecentlyRemovedProject(
+                id: project.id,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore,
+                fileSystem: ProjectPathConfirmationFileSystemStub(state: .directory)
+            )
+        }
+        #expect(projectStore.storedProjects.isEmpty)
+        #expect(projectStore.recentlyRemovedProjects.first?.id == project.id)
+        #expect(worktreeStore.primary(for: project.id) == nil)
+        #expect(appState.activeProjectID == nil)
+        #expect(groupPersistence.savedGroups == nil)
+    }
+
+    @Test("failed recent restore preserves pre-existing worktrees")
+    func failedRecentlyRemovedRestorePreservesExistingWorktrees() {
+        let persistence = ProjectPersistenceStub()
+        let projectStore = ProjectStore(persistence: persistence)
+        let worktreeStore = WorktreeStore(persistence: WorktreePersistenceStub(), projects: [])
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let projectGroupStore = ProjectGroupStore(
+            persistence: ProjectGroupPersistenceStub(),
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        projectStore.add(project)
+        projectStore.remove(id: project.id)
+        let secondary = Worktree(
+            name: "Feature",
+            path: "/tmp/repo-feature",
+            branch: "feature",
+            isPrimary: false
+        )
+        worktreeStore.add(secondary, to: project.id)
+        let existingWorktrees = worktreeStore.list(for: project.id)
+        persistence.projectSaveError = ProjectPersistenceStub.SaveError()
+
+        #expect(throws: ProjectOpenService.RestoreError.persistenceFailed) {
+            try ProjectOpenService.restoreRecentlyRemovedProject(
+                id: project.id,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore,
+                fileSystem: ProjectPathConfirmationFileSystemStub(state: .directory)
+            )
+        }
+
+        #expect(worktreeStore.list(for: project.id) == existingWorktrees)
+        #expect(worktreeStore.primary(for: project.id) == nil)
+        #expect(worktreeStore.worktree(projectID: project.id, worktreeID: secondary.id) == secondary)
+        #expect(projectStore.storedProjects.isEmpty)
+        #expect(projectStore.recentlyRemovedProjects.first?.id == project.id)
+    }
+
+    @Test("recent restore is rejected while an SSH workspace is active")
+    func recentlyRemovedRestoreRejectsActiveSSHWorkspace() {
+        let (appState, projectStore, worktreeStore, _) = makeStores()
+        let remoteGroup = ProjectGroup(name: "Remote", type: .ssh)
+        let groupPersistence = ProjectGroupPersistenceStub(initial: [remoteGroup])
+        let projectGroupStore = ProjectGroupStore(
+            persistence: groupPersistence,
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        projectGroupStore.selectGroup(id: remoteGroup.id)
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        projectStore.add(project)
+        projectStore.remove(id: project.id)
+
+        #expect(throws: ProjectOpenService.RestoreError.remoteWorkspaceActive) {
+            try ProjectOpenService.restoreRecentlyRemovedProject(
+                id: project.id,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore,
+                fileSystem: ProjectPathConfirmationFileSystemStub(state: .directory)
+            )
+        }
+        #expect(projectStore.storedProjects.isEmpty)
+        #expect(projectStore.recentlyRemovedProjects.first?.id == project.id)
+        #expect(worktreeStore.primary(for: project.id) == nil)
+        #expect(appState.activeProjectID == nil)
+        #expect(projectGroupStore.groups.first?.projectIDs.isEmpty == true)
+        #expect(groupPersistence.savedGroups == nil)
+    }
+
     @Test("create failure returns create failed without adding a project")
     func createFailureReturnsCreateFailedWithoutAddingProject() {
         let (appState, projectStore, worktreeStore, projectGroupStore) = makeStores()
@@ -457,9 +647,25 @@ private struct ProjectPathConfirmationFileSystemStub: ProjectPathConfirmationFil
 }
 
 private final class ProjectPersistenceStub: ProjectPersisting {
+    struct SaveError: Error {}
+
     private var projects: [Project] = []
+    private var recentlyRemovedProjects: [RecentlyRemovedProject] = []
+    var projectSaveError: Error?
+
     func loadProjects() throws -> [Project] { projects }
-    func saveProjects(_ projects: [Project]) throws { self.projects = projects }
+    func saveProjects(_ projects: [Project]) throws {
+        if let projectSaveError { throw projectSaveError }
+        self.projects = projects
+    }
+
+    func loadRecentlyRemovedProjects() throws -> [RecentlyRemovedProject] {
+        recentlyRemovedProjects
+    }
+
+    func saveRecentlyRemovedProjects(_ projects: [RecentlyRemovedProject]) throws {
+        recentlyRemovedProjects = projects
+    }
 }
 
 private final class WorktreePersistenceStub: WorktreePersisting {

--- a/Tests/MuxyTests/Services/Project/ProjectStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectStoreTests.swift
@@ -201,13 +201,239 @@ struct ProjectStoreTests {
         #expect(store.storedProjects.map(\.sortOrder) == [0, 1, 2])
         #expect(persistence.projects.map(\.id) == [third.id, first.id, second.id])
     }
+
+    @Test("remove archives the complete local project snapshot")
+    func removeArchivesCompleteProject() throws {
+        var project = Project(name: "Custom Repo", path: "/tmp/repo", sortOrder: 4)
+        project.icon = "shippingbox.fill"
+        project.logo = "logo.png"
+        project.iconColor = "purple"
+        project.preferredWorktreeParentPath = "/tmp/worktrees"
+        project.pullRequestPrompt = "Keep it short"
+        project.worktreesEnabled = true
+        project.isPinned = true
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let store = ProjectStore(persistence: persistence)
+
+        store.remove(id: project.id)
+
+        let archived = try #require(store.recentlyRemovedProjects.first)
+        #expect(archived.project == project)
+        #expect(persistence.recentlyRemovedProjects == store.recentlyRemovedProjects)
+        #expect(store.storedProjects.isEmpty)
+    }
+
+    @Test("recently removed projects are newest first and bounded")
+    func recentlyRemovedProjectsAreBounded() {
+        let persistence = ProjectPersistenceStub(initial: [])
+        let store = ProjectStore(persistence: persistence)
+
+        for index in 0 ..< ProjectStore.recentlyRemovedProjectLimit + 2 {
+            let project = Project(name: "Repo \(index)", path: "/tmp/repo-\(index)")
+            store.add(project)
+            store.remove(id: project.id)
+        }
+
+        #expect(store.recentlyRemovedProjects.count == ProjectStore.recentlyRemovedProjectLimit)
+        #expect(store.recentlyRemovedProjects.first?.project.name == "Repo 11")
+        #expect(store.recentlyRemovedProjects.last?.project.name == "Repo 2")
+        #expect(persistence.recentlyRemovedProjects == store.recentlyRemovedProjects)
+    }
+
+    @Test("load removes duplicate and active paths from recent history")
+    func loadSanitizesRecentlyRemovedProjects() {
+        let active = Project(name: "Active", path: "/tmp/active")
+        let oldDuplicate = Project(name: "Old", path: "/tmp/duplicate/.")
+        let newDuplicate = Project(name: "New", path: "/tmp/duplicate")
+        let history = [
+            RecentlyRemovedProject(project: oldDuplicate, removedAt: Date(timeIntervalSince1970: 1)),
+            RecentlyRemovedProject(project: active, removedAt: Date(timeIntervalSince1970: 3)),
+            RecentlyRemovedProject(project: newDuplicate, removedAt: Date(timeIntervalSince1970: 2)),
+        ]
+        let persistence = ProjectPersistenceStub(initial: [active], recentlyRemovedProjects: history)
+        let store = ProjectStore(persistence: persistence)
+
+        #expect(store.recentlyRemovedProjects.map(\.project.name) == ["New"])
+    }
+
+    @Test("remote projects and unknown ids are not archived")
+    func removeExcludesRemoteAndUnknownProjects() {
+        let remote = Project(
+            name: "Remote",
+            path: "/srv/repo",
+            remoteDeviceID: UUID()
+        )
+        let persistence = ProjectPersistenceStub(initial: [remote])
+        let store = ProjectStore(persistence: persistence)
+
+        store.remove(id: UUID())
+        store.remove(id: remote.id)
+
+        #expect(store.recentlyRemovedProjects.isEmpty)
+        #expect(persistence.recentlyRemovedProjects.isEmpty)
+    }
+
+    @Test("remote paths do not hide matching local recent projects")
+    func remotePathsDoNotMatchLocalHistory() {
+        let local = Project(name: "Local", path: "/srv/repo")
+        let remote = Project(
+            name: "Remote",
+            path: "/srv/repo",
+            remoteDeviceID: UUID()
+        )
+        let history = [RecentlyRemovedProject(project: local, removedAt: Date())]
+        let persistence = ProjectPersistenceStub(initial: [remote], recentlyRemovedProjects: history)
+        let store = ProjectStore(persistence: persistence)
+
+        store.add(Project(
+            name: "Another Remote",
+            path: "/srv/repo",
+            remoteDeviceID: UUID()
+        ))
+
+        #expect(store.recentlyRemovedProjects.first?.id == local.id)
+    }
+
+    @Test("restore preserves metadata and removes the history entry")
+    func restorePreservesMetadata() throws {
+        var project = Project(name: "Custom", path: "/tmp/custom", sortOrder: 0)
+        project.icon = "star.fill"
+        project.logo = "stored-logo.png"
+        project.iconColor = nil
+        project.worktreesEnabled = true
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let store = ProjectStore(persistence: persistence)
+        store.remove(id: project.id)
+
+        let restored = try #require(store.restoreRecentlyRemovedProject(id: project.id))
+
+        #expect(restored.id == project.id)
+        #expect(restored.name == project.name)
+        #expect(restored.icon == project.icon)
+        #expect(restored.logo == project.logo)
+        #expect(restored.iconColor == nil)
+        #expect(restored.worktreesEnabled)
+        #expect(store.recentlyRemovedProjects.isEmpty)
+        #expect(persistence.recentlyRemovedProjects.isEmpty)
+    }
+
+    @Test("adding an equivalent path clears stale recent history")
+    func addClearsEquivalentRecentlyRemovedProject() {
+        let removed = Project(name: "Old", path: "/tmp/repo/.")
+        let history = [RecentlyRemovedProject(project: removed, removedAt: Date())]
+        let persistence = ProjectPersistenceStub(initial: [], recentlyRemovedProjects: history)
+        let store = ProjectStore(persistence: persistence)
+
+        store.add(Project(name: "New", path: "/tmp/repo"))
+
+        #expect(store.recentlyRemovedProjects.isEmpty)
+        #expect(persistence.recentlyRemovedProjects.isEmpty)
+    }
+
+    @Test("failed add preserves matching recent history")
+    func failedAddPreservesRecentlyRemovedProject() {
+        let removed = Project(name: "Old", path: "/tmp/repo")
+        let history = [RecentlyRemovedProject(project: removed, removedAt: Date())]
+        let persistence = ProjectPersistenceStub(initial: [], recentlyRemovedProjects: history)
+        let store = ProjectStore(persistence: persistence)
+        persistence.projectSaveError = ProjectPersistenceTestError.saveFailed
+
+        let didAdd = store.add(Project(name: "New", path: "/tmp/repo"))
+
+        #expect(!didAdd)
+        #expect(store.storedProjects.isEmpty)
+        #expect(store.recentlyRemovedProjects == history)
+        #expect(persistence.recentlyRemovedProjects == history)
+    }
+
+    @Test("failed restore preserves recent history")
+    func failedRestorePreservesRecentlyRemovedProject() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let history = [RecentlyRemovedProject(project: project, removedAt: Date())]
+        let persistence = ProjectPersistenceStub(initial: [], recentlyRemovedProjects: history)
+        let store = ProjectStore(persistence: persistence)
+        persistence.projectSaveError = ProjectPersistenceTestError.saveFailed
+
+        let restored = store.restoreRecentlyRemovedProject(id: project.id)
+
+        #expect(restored == nil)
+        #expect(store.storedProjects.isEmpty)
+        #expect(store.recentlyRemovedProjects == history)
+        #expect(persistence.projects.isEmpty)
+        #expect(persistence.recentlyRemovedProjects == history)
+    }
+
+    @Test("failed recent history save keeps project active")
+    func failedArchiveSaveKeepsProjectActive() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let store = ProjectStore(persistence: persistence)
+        persistence.recentlyRemovedSaveError = ProjectPersistenceTestError.saveFailed
+
+        let didRemove = store.remove(id: project.id)
+
+        #expect(!didRemove)
+        #expect(store.storedProjects.first?.id == project.id)
+        #expect(store.recentlyRemovedProjects.isEmpty)
+        #expect(persistence.projects.first?.id == project.id)
+        #expect(persistence.recentlyRemovedProjects.isEmpty)
+    }
+
+    @Test("failed active project verification preserves a full recent history")
+    func failedActiveProjectVerificationPreservesFullHistory() {
+        let project = Project(name: "Active", path: "/tmp/active")
+        let history = (0 ..< ProjectStore.recentlyRemovedProjectLimit).map { index in
+            RecentlyRemovedProject(
+                project: Project(name: "Recent \(index)", path: "/tmp/recent-\(index)"),
+                removedAt: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+        }
+        let persistence = ProjectPersistenceStub(initial: [project], recentlyRemovedProjects: history)
+        let store = ProjectStore(persistence: persistence)
+        persistence.projectSaveError = ProjectPersistenceTestError.saveFailed
+
+        let didRemove = store.remove(id: project.id)
+        let expectedHistory = Array(history.reversed())
+
+        #expect(!didRemove)
+        #expect(store.storedProjects.first?.id == project.id)
+        #expect(store.recentlyRemovedProjects == expectedHistory)
+        #expect(persistence.projects.first?.id == project.id)
+        #expect(persistence.recentlyRemovedProjects == expectedHistory)
+    }
+
+    @Test("file persistence restores recently removed projects after relaunch")
+    func filePersistenceRestoresHistory() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProjectStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let projectsURL = directory.appendingPathComponent("projects.json")
+        let recentURL = directory.appendingPathComponent("recently-removed-projects.json")
+        let persistence = FileProjectPersistence(fileURL: projectsURL, recentlyRemovedFileURL: recentURL)
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let store = ProjectStore(persistence: persistence)
+        store.add(project)
+        store.remove(id: project.id)
+
+        let reloaded = ProjectStore(
+            persistence: FileProjectPersistence(fileURL: projectsURL, recentlyRemovedFileURL: recentURL)
+        )
+
+        #expect(reloaded.recentlyRemovedProjects.first?.project.id == project.id)
+        #expect(reloaded.recentlyRemovedProjects.first?.project.name == project.name)
+    }
 }
 
 private final class ProjectPersistenceStub: ProjectPersisting {
     var projects: [Project]
+    var recentlyRemovedProjects: [RecentlyRemovedProject]
+    var projectSaveError: Error?
+    var recentlyRemovedSaveError: Error?
 
-    init(initial: [Project]) {
+    init(initial: [Project], recentlyRemovedProjects: [RecentlyRemovedProject] = []) {
         projects = initial
+        self.recentlyRemovedProjects = recentlyRemovedProjects
     }
 
     func loadProjects() throws -> [Project] {
@@ -215,6 +441,20 @@ private final class ProjectPersistenceStub: ProjectPersisting {
     }
 
     func saveProjects(_ projects: [Project]) throws {
+        if let projectSaveError { throw projectSaveError }
         self.projects = projects
     }
+
+    func loadRecentlyRemovedProjects() throws -> [RecentlyRemovedProject] {
+        recentlyRemovedProjects
+    }
+
+    func saveRecentlyRemovedProjects(_ projects: [RecentlyRemovedProject]) throws {
+        if let recentlyRemovedSaveError { throw recentlyRemovedSaveError }
+        recentlyRemovedProjects = projects
+    }
+}
+
+private enum ProjectPersistenceTestError: Error {
+    case saveFailed
 }

--- a/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
@@ -181,6 +181,56 @@ struct WorktreeStoreTests {
         #expect(imported.isExternallyManaged)
     }
 
+    @Test("project removal waits for an active worktree creation and freezes later mutations")
+    func projectRemovalWaitsForActiveCreation() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-worktree-removal-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let project = Project(name: "Repo", path: root.appendingPathComponent("repo").path)
+        let gate = WorktreeMutationTestGate()
+        let store = WorktreeStore(
+            persistence: WorktreePersistenceStub(initial: [:]),
+            addGitWorktree: { _, _, _, _, _ in await gate.enterAndWait() }
+        )
+        let request = WorktreeCreationRequest(
+            name: "Feature",
+            path: root.appendingPathComponent("feature").path,
+            branch: "feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        let creation = Task { @MainActor in
+            try await store.createWorktree(project: project, request: request)
+        }
+        await gate.waitUntilEntered()
+        let removal = Task { @MainActor in
+            await store.beginProjectRemoval(project.id)
+        }
+        for _ in 0 ..< 10 where !store.isProjectRemovalInProgress(project.id) {
+            await Task.yield()
+        }
+        #expect(store.isProjectRemovalInProgress(project.id))
+
+        await #expect(throws: WorktreeMutationError.self) {
+            try await store.createWorktree(project: project, request: request)
+        }
+        let lateWorktree = Worktree(
+            name: "Late",
+            path: root.appendingPathComponent("late").path,
+            branch: "late",
+            isPrimary: false
+        )
+        store.add(lateWorktree, to: project.id)
+        #expect(!store.list(for: project.id).contains(lateWorktree))
+
+        await gate.release()
+        let created = try await creation.value
+        #expect(await removal.value)
+        #expect(store.list(for: project.id).contains(created))
+        store.cancelProjectRemoval(project.id)
+    }
+
     @Test("refreshFromGit re-syncs branch-derived name on branch rename but keeps custom names")
     func refreshFromGitSyncsBranchDerivedName() async throws {
         let project = Project(name: "Repo", path: "/tmp/repo")
@@ -719,5 +769,34 @@ private struct GitWorktreeListingStub: GitWorktreeListing {
 
     func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord] {
         recordsByRepoPath[repoPath] ?? []
+    }
+}
+
+private actor WorktreeMutationTestGate {
+    private var entered = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+    func enterAndWait() async {
+        entered = true
+        for waiter in entryWaiters {
+            waiter.resume()
+        }
+        entryWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            releaseWaiter = continuation
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        releaseWaiter?.resume()
+        releaseWaiter = nil
     }
 }

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -18,3 +18,5 @@ A project is just a directory you've added to Muxy.
 2. Click **+** at the bottom of the sidebar — or **File → Open Project…** (`⌘O`).
 3. Type the folder name, choose the matching path, and press Return. Add parent names with a space or `/` to narrow results, such as `muxy Projects`. You can also type an explicit path such as `~/Projects/muxy`.
 4. Right-click the project to rename, recolor, change its icon, or copy its absolute path.
+
+Removing a project keeps its files on disk. To add it back with its name, icon, and settings intact, open **Add Project** and choose it under **Recently Removed**. You can assign **Recently Removed Projects** in **Settings → Keyboard Shortcuts** to open the chooser; it is unassigned by default.


### PR DESCRIPTION
Adds persistent recently removed projects with safe restoration from both sidebars and a user-assignable chooser shortcut.
Preserves project metadata with a fresh primary worktree; verified by scripts/checks.sh --fix.
Closes #521