### PR TITLE
Add one-time custom prompt to AI commit and Create PR confirmations

### DIFF
--- a/Muxy/Models/Preferences/RepositoryAIActionPreferences.swift
+++ b/Muxy/Models/Preferences/RepositoryAIActionPreferences.swift
@@ -56,6 +56,7 @@ enum RepositoryAIAction: String, CaseIterable, Identifiable {
 
 enum RepositoryAIActionPreferences {
     static let automaticProviderID = ""
+    static let maximumAdditionalPromptLength = 2000
 
     static func configuredProviderID(
         for action: RepositoryAIAction,
@@ -78,11 +79,27 @@ enum RepositoryAIActionPreferences {
         return stored
     }
 
+    static func instructions(
+        for action: RepositoryAIAction,
+        projectPrompt: String? = nil,
+        additionalPrompt: String? = nil,
+        defaults: UserDefaults = .standard
+    ) -> String {
+        let resolvedPrompt = prompt(for: action, projectPrompt: projectPrompt, defaults: defaults)
+        guard let additionalPrompt = normalizedAdditionalPrompt(additionalPrompt) else { return resolvedPrompt }
+        return "\(resolvedPrompt)\n\n\(additionalPrompt)"
+    }
+
     static func normalizedPrompt(_ prompt: String?) -> String? {
         guard let prompt,
               !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { return nil }
         return prompt
+    }
+
+    private static func normalizedAdditionalPrompt(_ prompt: String?) -> String? {
+        guard let prompt else { return nil }
+        return normalizedPrompt(String(prompt.prefix(maximumAdditionalPromptLength)))
     }
 }
 

--- a/Muxy/Views/Terminal/RepositoryAIActionConfirmationSheet.swift
+++ b/Muxy/Views/Terminal/RepositoryAIActionConfirmationSheet.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct RepositoryAIActionConfirmationSheet: View {
+    let confirmation: RepositoryAIActionConfirmation
+    let onCancel: () -> Void
+    let onConfirm: (String?) -> Void
+
+    @State private var isAddingPrompt = false
+    @State private var additionalPrompt = ""
+    @FocusState private var isPromptFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(14)) {
+            Text(confirmation.title)
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+
+            Text(confirmation.message)
+                .font(.system(size: UIMetrics.fontBody))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if isAddingPrompt {
+                additionalPromptEditor
+            }
+
+            HStack(spacing: UIMetrics.spacing3) {
+                if !isAddingPrompt {
+                    Button("Add Prompt") {
+                        isAddingPrompt = true
+                        isPromptFocused = true
+                    }
+                }
+                Spacer(minLength: 0)
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(confirmation.confirmTitle) {
+                    onConfirm(RepositoryAIActionPreferences.normalizedPrompt(additionalPrompt))
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(460))
+        .background(MuxyTheme.bg)
+    }
+
+    private var additionalPromptEditor: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
+            HStack {
+                Text("Additional Prompt")
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                Spacer(minLength: 0)
+                Text("\(additionalPrompt.count)/\(RepositoryAIActionPreferences.maximumAdditionalPromptLength)")
+                    .font(.system(size: UIMetrics.fontCaption, design: .monospaced))
+                    .foregroundStyle(MuxyTheme.fgDim)
+            }
+
+            TextEditor(text: $additionalPrompt)
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fg)
+                .scrollContentBackground(.hidden)
+                .padding(UIMetrics.spacing3)
+                .frame(height: UIMetrics.scaled(140))
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+                .overlay {
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
+                        .stroke(MuxyTheme.border, lineWidth: 1)
+                }
+                .focused($isPromptFocused)
+                .accessibilityLabel("Additional prompt")
+                .onChange(of: additionalPrompt) { _, newValue in
+                    guard newValue.count > RepositoryAIActionPreferences.maximumAdditionalPromptLength else { return }
+                    additionalPrompt = String(newValue.prefix(RepositoryAIActionPreferences.maximumAdditionalPromptLength))
+                }
+
+            Text("Appended after the configured prompt for this action only.")
+                .font(.system(size: UIMetrics.fontCaption))
+                .foregroundStyle(MuxyTheme.fgMuted)
+        }
+    }
+}

--- a/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
+++ b/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
@@ -67,26 +67,23 @@ struct RepositoryStatusBarItems: View {
             .onChange(of: confirmationContext) { _, _ in
                 pendingAIAction = nil
             }
-            .alert(
-                pendingAIAction?.title ?? "",
-                isPresented: aiRepositoryActionAlertBinding,
-                presenting: pendingAIAction
-            ) { confirmation in
-                Button(confirmation.confirmTitle) {
-                    pendingAIAction = nil
-                    confirmAIRepositoryAction(confirmation)
+            .sheet(isPresented: aiRepositoryActionConfirmationBinding) {
+                if let confirmation = pendingAIAction {
+                    RepositoryAIActionConfirmationSheet(
+                        confirmation: confirmation,
+                        onCancel: {
+                            pendingAIAction = nil
+                        },
+                        onConfirm: { additionalPrompt in
+                            pendingAIAction = nil
+                            confirmAIRepositoryAction(confirmation, additionalPrompt: additionalPrompt)
+                        }
+                    )
                 }
-                .keyboardShortcut(.defaultAction)
-                Button("Cancel", role: .cancel) {
-                    pendingAIAction = nil
-                }
-                .keyboardShortcut(.cancelAction)
-            } message: { confirmation in
-                Text(confirmation.message)
             }
     }
 
-    private var aiRepositoryActionAlertBinding: Binding<Bool> {
+    private var aiRepositoryActionConfirmationBinding: Binding<Bool> {
         Binding(
             get: { pendingAIAction != nil },
             set: { newValue in
@@ -697,7 +694,10 @@ struct RepositoryStatusBarItems: View {
         )
     }
 
-    private func confirmAIRepositoryAction(_ confirmation: RepositoryAIActionConfirmation) {
+    private func confirmAIRepositoryAction(
+        _ confirmation: RepositoryAIActionConfirmation,
+        additionalPrompt: String?
+    ) {
         let action = confirmation.action
         let availability = aiRepositoryActionAvailability(action, summary: repositoryState.summary)
         guard availability == .available,
@@ -707,12 +707,18 @@ struct RepositoryStatusBarItems: View {
             ToastState.shared.show("\(action.settingsTitle) is no longer available. Try again.")
             return
         }
-        runAIRepositoryAction(action, availability: availability)
+        let instructions = RepositoryAIActionPreferences.instructions(
+            for: action,
+            projectPrompt: action == .createPullRequest ? activeProject?.pullRequestPrompt : nil,
+            additionalPrompt: additionalPrompt
+        )
+        runAIRepositoryAction(action, availability: availability, instructions: instructions)
     }
 
     private func runAIRepositoryAction(
         _ action: RepositoryAIAction,
-        availability: RepositoryAIActionAvailability
+        availability: RepositoryAIActionAvailability,
+        instructions: String
     ) {
         guard availability == .available,
               !hasRunningAIWorkflow,
@@ -736,17 +742,18 @@ struct RepositoryStatusBarItems: View {
                     }
                     return
                 }
-                startAIRepositoryAction(action, context: context)
+                startAIRepositoryAction(action, context: context, instructions: instructions)
             }
             return
         }
 
-        startAIRepositoryAction(action, context: context)
+        startAIRepositoryAction(action, context: context, instructions: instructions)
     }
 
     private func startAIRepositoryAction(
         _ action: RepositoryAIAction,
-        context: RepositoryContext
+        context: RepositoryContext,
+        instructions: String
     ) {
         guard let summary = repositoryState.summary else { return }
         let serviceContext = RepositoryAIActionsService.Context(
@@ -763,10 +770,7 @@ struct RepositoryStatusBarItems: View {
                 context: serviceContext,
                 providers: agentLaunchProviders,
                 installedProviderIDs: installedProviderIDs,
-                instructions: RepositoryAIActionPreferences.prompt(
-                    for: action,
-                    projectPrompt: action == .createPullRequest ? activeProject?.pullRequestPrompt : nil
-                )
+                instructions: instructions
             )
         } catch {
             ToastState.shared.show(title: "Could not start \(action.settingsTitle)", body: error.localizedDescription)

--- a/Tests/MuxyTests/Models/Preferences/RepositoryAIActionPreferencesTests.swift
+++ b/Tests/MuxyTests/Models/Preferences/RepositoryAIActionPreferencesTests.swift
@@ -64,6 +64,51 @@ struct RepositoryAIActionPreferencesTests {
         ) == "Global commit prompt")
     }
 
+    @Test("additional prompt follows the resolved action prompt")
+    func additionalPromptOrder() {
+        let defaults = makeDefaults()
+        defaults.set("Global commit prompt", forKey: RepositoryAIAction.commit.promptKey)
+        defaults.set("Global PR prompt", forKey: RepositoryAIAction.createPullRequest.promptKey)
+
+        #expect(RepositoryAIActionPreferences.instructions(
+            for: .commit,
+            additionalPrompt: "Mention the migration",
+            defaults: defaults
+        ) == "Global commit prompt\n\nMention the migration")
+        #expect(RepositoryAIActionPreferences.instructions(
+            for: .createPullRequest,
+            projectPrompt: "Project PR prompt",
+            additionalPrompt: "Call out the rollback plan",
+            defaults: defaults
+        ) == "Project PR prompt\n\nCall out the rollback plan")
+    }
+
+    @Test("blank additional prompt leaves the resolved prompt unchanged")
+    func blankAdditionalPrompt() {
+        let defaults = makeDefaults()
+        defaults.set("Configured prompt", forKey: RepositoryAIAction.commit.promptKey)
+
+        #expect(RepositoryAIActionPreferences.instructions(
+            for: .commit,
+            additionalPrompt: " \n ",
+            defaults: defaults
+        ) == "Configured prompt")
+    }
+
+    @Test("additional prompt is bounded")
+    func boundedAdditionalPrompt() {
+        let maximumLength = RepositoryAIActionPreferences.maximumAdditionalPromptLength
+        let additionalPrompt = String(repeating: "a", count: maximumLength + 1)
+        let instructions = RepositoryAIActionPreferences.instructions(
+            for: .commit,
+            additionalPrompt: additionalPrompt,
+            defaults: makeDefaults()
+        )
+
+        #expect(instructions == RepositoryAIAction.commit.defaultPrompt + "\n\n"
+            + String(repeating: "a", count: maximumLength))
+    }
+
     @Test("commit presentation protects repository state")
     func commitPresentation() {
         #expect(RepositoryAIActionPresentation.commit(

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -50,6 +50,7 @@ After authenticating, restart Muxy so it picks up the new credentials.
 - For an SSH workspace, the selected provider CLI and `gh` must be installed and authenticated on the remote host. If **Auto** selects a CLI that is unavailable remotely, choose the installed provider explicitly from the action dropdown.
 - Provider CLIs run headlessly and cannot show interactive authentication or permission prompts. Authenticate the chosen CLI in a terminal first, then retry the button; failures are shown in a toast.
 - AI only generates metadata. Muxy always owns staging, branch creation, commits, pushes, and pull request creation. Update the prompt when the provider returns invalid JSON or unsuitable metadata, not to change the native Git sequence.
+- **Add Prompt** appends one-time instructions after the configured global or project prompt for the current action without changing Settings.
 
 ## Mobile server won't start
 


### PR DESCRIPTION
Replaces the AI action confirmation alert with a sheet that offers an optional "Add Prompt" field, appending up to 2000 characters after the configured global or project prompt for that run only. Adds `RepositoryAIActionPreferences.instructions` to resolve and bound the combined prompt, with tests covering ordering, blank input, and truncation.