### PR TITLE
Add seamless remote Mac workspaces

### DIFF
--- a/Muxy/Commands/MuxyCommands.swift
+++ b/Muxy/Commands/MuxyCommands.swift
@@ -6,6 +6,7 @@ struct MuxyCommands: Commands {
     @AppStorage(BrowserPreferences.enabledKey) private var browserEnabled = true
 
     let appState: AppState
+    let remoteMacWorkspace: RemoteMacWorkspaceStore
     let projectStore: ProjectStore
     let worktreeStore: WorktreeStore
     let projectGroupStore: ProjectGroupStore
@@ -20,6 +21,7 @@ struct MuxyCommands: Commands {
     }
 
     private var activeProject: Project? {
+        guard remoteMacWorkspace.activeDeviceID == nil else { return nil }
         guard let projectID = appState.activeProjectID else { return nil }
         return projectStore.projects.first { $0.id == projectID }
     }
@@ -58,11 +60,15 @@ struct MuxyCommands: Commands {
     }
 
     private func performShortcutAction(_ action: ShortcutAction) {
+        if remoteMacWorkspace.performShortcutAction(action) {
+            return
+        }
         _ = shortcutDispatcher.perform(action, activeProject: activeProject)
     }
 
     private func performCommandShortcut(_ shortcut: CommandShortcut) {
         guard isMainWindowFocused,
+              remoteMacWorkspace.activeDeviceID == nil,
               let projectID = appState.activeProjectID,
               appState.workspaceRoot(for: projectID) != nil,
               !shortcut.trimmedCommand.isEmpty

--- a/Muxy/Info.plist
+++ b/Muxy/Info.plist
@@ -45,7 +45,16 @@
 	<key>NSContactsUsageDescription</key>
 	<string>A process running in Muxy's terminal would like to access your contacts.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>A process running in Muxy's terminal would like to access the local network.</string>
+	<string>Muxy uses the local network to discover and connect to your other Macs and to support terminal processes.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_muxy._tcp</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>NSLocationUsageDescription</key>
 	<string>A process running in Muxy's terminal would like to access your location information.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Muxy/Models/Project/Project.swift
+++ b/Muxy/Models/Project/Project.swift
@@ -16,6 +16,7 @@ struct Project: Identifiable, Codable, Hashable {
     var isPinned: Bool
     var remoteWorkspaceID: UUID?
     var remoteDeviceID: UUID?
+    var remoteMacDeviceID: UUID?
 
     init(
         id: UUID = UUID(),
@@ -23,7 +24,8 @@ struct Project: Identifiable, Codable, Hashable {
         path: String,
         sortOrder: Int = 0,
         remoteWorkspaceID: UUID? = nil,
-        remoteDeviceID: UUID? = nil
+        remoteDeviceID: UUID? = nil,
+        remoteMacDeviceID: UUID? = nil
     ) {
         self.id = id
         self.name = name
@@ -40,9 +42,12 @@ struct Project: Identifiable, Codable, Hashable {
         self.isPinned = false
         self.remoteWorkspaceID = remoteWorkspaceID
         self.remoteDeviceID = remoteDeviceID
+        self.remoteMacDeviceID = remoteMacDeviceID
     }
 
-    var isRemote: Bool { remoteWorkspaceID != nil || remoteDeviceID != nil }
+    var isRemote: Bool { remoteWorkspaceID != nil || remoteDeviceID != nil || remoteMacDeviceID != nil }
+
+    var isRemoteMac: Bool { remoteMacDeviceID != nil }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -61,6 +66,7 @@ struct Project: Identifiable, Codable, Hashable {
         isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         remoteWorkspaceID = try container.decodeIfPresent(UUID.self, forKey: .remoteWorkspaceID)
         remoteDeviceID = try container.decodeIfPresent(UUID.self, forKey: .remoteDeviceID)
+        remoteMacDeviceID = try container.decodeIfPresent(UUID.self, forKey: .remoteMacDeviceID)
     }
 
     var pathExists: Bool {

--- a/Muxy/Models/Project/RemoteDevice.swift
+++ b/Muxy/Models/Project/RemoteDevice.swift
@@ -2,6 +2,47 @@ import Foundation
 
 enum RemoteDeviceKind: String, Codable, Hashable {
     case ssh
+    case muxy
+}
+
+struct MuxyRemoteServerData: Codable, Hashable {
+    var host: String
+    var port: UInt16
+    var serviceName: String?
+
+    init(host: String, port: UInt16 = 4865, serviceName: String? = nil) {
+        self.host = Self.sanitizedHost(host)
+        self.port = port
+        self.serviceName = serviceName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        host = try Self.sanitizedHost(container.decode(String.self, forKey: .host))
+        port = try container.decodeIfPresent(UInt16.self, forKey: .port) ?? 4865
+        serviceName = try container.decodeIfPresent(String.self, forKey: .serviceName)?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    var displayAddress: String { "\(host):\(port)" }
+
+    var credentialScope: String { "\(host.lowercased()):\(port)" }
+
+    var webSocketURL: URL? {
+        var components = URLComponents()
+        components.scheme = "ws"
+        components.host = host
+        components.port = Int(port)
+        return components.url
+    }
+
+    static func isValidHost(_ host: String) -> Bool {
+        !sanitizedHost(host).isEmpty
+    }
+
+    private static func sanitizedHost(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }
 
 struct SSHWorkspaceData: Codable, Hashable {
@@ -54,30 +95,96 @@ private extension String {
     var nilIfEmpty: String? { isEmpty ? nil : self }
 }
 
+enum RemoteDeviceConnection: Hashable {
+    case ssh(SSHWorkspaceData)
+    case muxy(MuxyRemoteServerData)
+}
+
 struct RemoteDevice: Identifiable, Codable, Hashable {
     let id: UUID
     var name: String
-    var kind: RemoteDeviceKind
-    var ssh: SSHWorkspaceData
+    private var connection: RemoteDeviceConnection
 
     init(id: UUID = UUID(), name: String, kind: RemoteDeviceKind = .ssh, ssh: SSHWorkspaceData) {
+        precondition(kind == .ssh)
         self.id = id
         self.name = name
-        self.kind = kind
-        self.ssh = ssh
+        connection = .ssh(ssh)
+    }
+
+    init(id: UUID = UUID(), name: String, muxy: MuxyRemoteServerData) {
+        self.id = id
+        self.name = name
+        connection = .muxy(muxy)
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
-        kind = try container.decodeIfPresent(RemoteDeviceKind.self, forKey: .kind) ?? .ssh
-        ssh = try container.decode(SSHWorkspaceData.self, forKey: .ssh)
+        let kind = try container.decodeIfPresent(RemoteDeviceKind.self, forKey: .kind) ?? .ssh
+        switch kind {
+        case .ssh:
+            connection = try .ssh(container.decode(SSHWorkspaceData.self, forKey: .ssh))
+        case .muxy:
+            connection = try .muxy(container.decode(MuxyRemoteServerData.self, forKey: .muxy))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(kind, forKey: .kind)
+        switch connection {
+        case let .ssh(data):
+            try container.encode(data, forKey: .ssh)
+        case let .muxy(data):
+            try container.encode(data, forKey: .muxy)
+        }
+    }
+
+    var kind: RemoteDeviceKind {
+        switch connection {
+        case .ssh: .ssh
+        case .muxy: .muxy
+        }
+    }
+
+    var ssh: SSHWorkspaceData {
+        get {
+            guard case let .ssh(data) = connection else { preconditionFailure("Device is not SSH") }
+            return data
+        }
+        set { connection = .ssh(newValue) }
+    }
+
+    var muxy: MuxyRemoteServerData? {
+        get {
+            guard case let .muxy(data) = connection else { return nil }
+            return data
+        }
+        set {
+            guard let newValue else { return }
+            connection = .muxy(newValue)
+        }
     }
 
     var destination: SSHDestination { ssh.destination }
 
     var displayName: String {
-        name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? ssh.host
+        if let name = name.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty { return name }
+        switch connection {
+        case let .ssh(data): return data.host
+        case let .muxy(data): return data.serviceName ?? data.host
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case kind
+        case ssh
+        case muxy
     }
 }

--- a/Muxy/Models/Terminal/TerminalPaneState.swift
+++ b/Muxy/Models/Terminal/TerminalPaneState.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+enum TerminalPaneBackend: Equatable {
+    case local
+    case remoteMac(paneID: UUID)
+}
+
 struct TerminalPaneLaunch: Equatable {
     let command: String?
     let interactive: Bool
@@ -17,6 +22,7 @@ final class TerminalPaneState: Identifiable {
     let startupCommandInteractive: Bool
     let closesOnStartupCommandExit: Bool
     let externalEditorFilePath: String?
+    let backend: TerminalPaneBackend
     var isOffline = false
     let searchState = TerminalSearchState()
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
@@ -29,7 +35,8 @@ final class TerminalPaneState: Identifiable {
         startupCommand: String? = nil,
         startupCommandInteractive: Bool = false,
         closesOnStartupCommandExit: Bool = true,
-        externalEditorFilePath: String? = nil
+        externalEditorFilePath: String? = nil,
+        backend: TerminalPaneBackend = .local
     ) {
         self.id = id
         self.projectPath = projectPath
@@ -39,6 +46,7 @@ final class TerminalPaneState: Identifiable {
         self.startupCommandInteractive = startupCommandInteractive
         self.closesOnStartupCommandExit = closesOnStartupCommandExit
         self.externalEditorFilePath = externalEditorFilePath
+        self.backend = backend
     }
 
     func consumeRestoredLaunch() -> TerminalPaneLaunch {

--- a/Muxy/Models/Terminal/TerminalTab.swift
+++ b/Muxy/Models/Terminal/TerminalTab.swift
@@ -13,12 +13,14 @@ final class TerminalTab: Identifiable {
         case terminal(TerminalPaneState)
         case extensionWebView(ExtensionTabState)
         case browser(BrowserTabState)
+        case remotePlaceholder(RemoteTabPlaceholder)
 
         var kind: Kind {
             switch self {
             case .terminal: .terminal
             case .extensionWebView: .extensionWebView
             case .browser: .browser
+            case let .remotePlaceholder(placeholder): placeholder.kind
             }
         }
 
@@ -42,6 +44,7 @@ final class TerminalTab: Identifiable {
             case let .terminal(pane): pane.projectPath
             case let .extensionWebView(state): state.projectPath
             case let .browser(state): state.projectPath
+            case let .remotePlaceholder(placeholder): placeholder.projectPath
             }
         }
     }
@@ -66,6 +69,8 @@ final class TerminalTab: Identifiable {
             return state.displayTitle
         case let .browser(state):
             return state.displayTitle
+        case let .remotePlaceholder(placeholder):
+            return placeholder.title
         }
     }
 
@@ -82,6 +87,28 @@ final class TerminalTab: Identifiable {
     init(browserState: BrowserTabState) {
         id = UUID()
         content = .browser(browserState)
+    }
+
+    init(
+        id: UUID,
+        title: String,
+        isPinned: Bool,
+        projectPath: String,
+        kind: Kind,
+        pane: TerminalPaneState?
+    ) {
+        self.id = id
+        self.isPinned = isPinned
+        if let pane {
+            content = .terminal(pane)
+        } else {
+            content = .remotePlaceholder(RemoteTabPlaceholder(
+                title: title,
+                projectPath: projectPath,
+                kind: kind
+            ))
+        }
+        customTitle = title
     }
 
     init(restoring snapshot: TerminalTabSnapshot) {
@@ -160,4 +187,10 @@ final class TerminalTab: Identifiable {
         }
         return path
     }
+}
+
+struct RemoteTabPlaceholder {
+    let title: String
+    let projectPath: String
+    let kind: TerminalTab.Kind
 }

--- a/Muxy/Models/Workspace/SplitNode.swift
+++ b/Muxy/Models/Workspace/SplitNode.swift
@@ -25,18 +25,20 @@ enum SplitNode: Identifiable {
 
 @Observable
 final class SplitBranch: Identifiable {
-    let id = UUID()
+    let id: UUID
     var direction: SplitDirection
     var ratio: CGFloat
     var first: SplitNode
     var second: SplitNode
 
     init(
+        id: UUID = UUID(),
         direction: SplitDirection,
         ratio: CGFloat = 0.5,
         first: SplitNode,
         second: SplitNode
     ) {
+        self.id = id
         self.direction = direction
         self.ratio = ratio
         self.first = first
@@ -164,6 +166,16 @@ extension SplitNode {
         case let .tabArea(area): area.id == id ? area : nil
         case let .split(branch):
             branch.first.findArea(id: id) ?? branch.second.findArea(id: id)
+        }
+    }
+
+    func findBranch(id: UUID) -> SplitBranch? {
+        switch self {
+        case .tabArea:
+            return nil
+        case let .split(branch):
+            if branch.id == id { return branch }
+            return branch.first.findBranch(id: id) ?? branch.second.findBranch(id: id)
         }
     }
 

--- a/Muxy/Models/Workspace/TabArea.swift
+++ b/Muxy/Models/Workspace/TabArea.swift
@@ -38,6 +38,13 @@ final class TabArea: Identifiable {
         activeTabID = tab.id
     }
 
+    init(id: UUID, projectPath: String, tabs: [TerminalTab], activeTabID: UUID?) {
+        self.id = id
+        self.projectPath = projectPath
+        self.tabs = tabs
+        self.activeTabID = tabs.contains(where: { $0.id == activeTabID }) ? activeTabID : tabs.first?.id
+    }
+
     init(restoring snapshot: TabAreaSnapshot) {
         id = snapshot.id
         projectPath = snapshot.projectPath

--- a/Muxy/Muxy.entitlements
+++ b/Muxy/Muxy.entitlements
@@ -24,5 +24,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -14,6 +14,7 @@ struct MuxyApp: App {
     @State private var worktreeStore: WorktreeStore
     @State private var projectGroupStore: ProjectGroupStore
     @State private var remoteDeviceStore: RemoteDeviceStore
+    @State private var remoteMacWorkspaceStore: RemoteMacWorkspaceStore
     @State private var browserProfileStore: BrowserProfileStore
     @State private var browserHistoryStore: BrowserHistoryStore
     @State private var worktreeAutoRefresher: VCSWorktreeAutoRefresher?
@@ -58,6 +59,7 @@ struct MuxyApp: App {
         _worktreeStore = State(initialValue: worktreeStore)
         _projectGroupStore = State(initialValue: projectGroupStore)
         _remoteDeviceStore = State(initialValue: remoteDeviceStore)
+        _remoteMacWorkspaceStore = State(initialValue: RemoteMacWorkspaceStore())
         _browserProfileStore = State(initialValue: browserProfileStore)
         _browserHistoryStore = State(initialValue: browserHistoryStore)
     }
@@ -70,6 +72,7 @@ struct MuxyApp: App {
                 .environment(worktreeStore)
                 .environment(projectGroupStore)
                 .environment(remoteDeviceStore)
+                .environment(remoteMacWorkspaceStore)
                 .environment(browserProfileStore)
                 .environment(browserHistoryStore)
                 .environment(SSHConnectionService.shared)
@@ -93,11 +96,12 @@ struct MuxyApp: App {
                         browserHistoryStore.saveImmediately()
                     }
                     appDelegate.settingsContent = {
-                        [projectGroupStore, remoteDeviceStore, browserProfileStore, browserHistoryStore] in
+                        [projectGroupStore, remoteDeviceStore, remoteMacWorkspaceStore, browserProfileStore, browserHistoryStore] in
                         AnyView(
                             SettingsView()
                                 .environment(projectGroupStore)
                                 .environment(remoteDeviceStore)
+                                .environment(remoteMacWorkspaceStore)
                                 .environment(browserProfileStore)
                                 .environment(browserHistoryStore)
                                 .environment(SSHConnectionService.shared)
@@ -180,6 +184,7 @@ struct MuxyApp: App {
         .commands {
             MuxyCommands(
                 appState: appState,
+                remoteMacWorkspace: remoteMacWorkspaceStore,
                 projectStore: projectStore,
                 worktreeStore: worktreeStore,
                 projectGroupStore: projectGroupStore,

--- a/Muxy/Services/Backup/BackupSanitizer.swift
+++ b/Muxy/Services/Backup/BackupSanitizer.swift
@@ -5,6 +5,7 @@ enum BackupSanitizer {
         let devices = try JSONDecoder().decode([RemoteDevice].self, from: Data(contentsOf: url))
         let sanitized = devices.map { device -> RemoteDevice in
             var copy = device
+            guard copy.kind == .ssh else { return copy }
             copy.ssh.environment = SSHEnvironmentVariables.default
             return copy
         }

--- a/Muxy/Services/Mobile/ApprovedDevicesStore.swift
+++ b/Muxy/Services/Mobile/ApprovedDevicesStore.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import MuxyShared
 import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "ApprovedDevicesStore")
@@ -10,6 +11,33 @@ struct ApprovedDevice: Codable, Identifiable, Equatable {
     let tokenHash: String
     let approvedAt: Date
     var lastSeenAt: Date?
+    var clientKind: RemoteClientKindDTO
+
+    init(
+        id: UUID,
+        name: String,
+        tokenHash: String,
+        approvedAt: Date,
+        lastSeenAt: Date?,
+        clientKind: RemoteClientKindDTO = .mobile
+    ) {
+        self.id = id
+        self.name = name
+        self.tokenHash = tokenHash
+        self.approvedAt = approvedAt
+        self.lastSeenAt = lastSeenAt
+        self.clientKind = clientKind
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        tokenHash = try container.decode(String.self, forKey: .tokenHash)
+        approvedAt = try container.decode(Date.self, forKey: .approvedAt)
+        lastSeenAt = try container.decodeIfPresent(Date.self, forKey: .lastSeenAt)
+        clientKind = try container.decodeIfPresent(RemoteClientKindDTO.self, forKey: .clientKind) ?? .mobile
+    }
 }
 
 @MainActor
@@ -31,7 +59,12 @@ final class ApprovedDevicesStore {
         }
     }
 
-    func approve(deviceID: UUID, name: String, token: String) {
+    func approve(
+        deviceID: UUID,
+        name: String,
+        token: String,
+        clientKind: RemoteClientKindDTO = .mobile
+    ) {
         let hash = Self.hash(token)
         let now = Date()
         if let index = devices.firstIndex(where: { $0.id == deviceID }) {
@@ -40,7 +73,8 @@ final class ApprovedDevicesStore {
                 name: name,
                 tokenHash: hash,
                 approvedAt: devices[index].approvedAt,
-                lastSeenAt: now
+                lastSeenAt: now,
+                clientKind: clientKind
             )
         } else {
             devices.append(ApprovedDevice(
@@ -48,14 +82,16 @@ final class ApprovedDevicesStore {
                 name: name,
                 tokenHash: hash,
                 approvedAt: now,
-                lastSeenAt: now
+                lastSeenAt: now,
+                clientKind: clientKind
             ))
         }
         save()
     }
 
-    func validate(deviceID: UUID, token: String) -> ApprovedDevice? {
+    func validate(deviceID: UUID, token: String, clientKind: RemoteClientKindDTO) -> ApprovedDevice? {
         guard let device = devices.first(where: { $0.id == deviceID }) else { return nil }
+        guard device.clientKind == clientKind else { return nil }
         let provided = Self.hash(token)
         guard Self.constantTimeEquals(device.tokenHash, provided) else { return nil }
         return device

--- a/Muxy/Services/Mobile/MobileServerService.swift
+++ b/Muxy/Services/Mobile/MobileServerService.swift
@@ -1,9 +1,10 @@
 import Foundation
 import MuxyServer
+import MuxyShared
 import Network
 import os
 
-private let logger = Logger(subsystem: "app.muxy", category: "MobileServerService")
+private let logger = Logger(subsystem: "app.muxy", category: "RemoteServerService")
 
 @MainActor
 @Observable
@@ -22,24 +23,38 @@ final class MobileServerService {
             : "app.muxy.mobile.serverEnabled"
     }
 
+    static var desktopEnabledKey: String {
+        AppEnvironment.isDevelopment
+            ? "app.muxy.desktop.serverEnabled.dev"
+            : "app.muxy.desktop.serverEnabled"
+    }
+
     static var portKey: String {
         AppEnvironment.isDevelopment
             ? "app.muxy.mobile.serverPort.dev"
             : "app.muxy.mobile.serverPort"
     }
 
-    private(set) var isEnabled: Bool {
+    private(set) var allowsMobileConnections: Bool {
         didSet {
-            UserDefaults.standard.set(isEnabled, forKey: Self.enabledKey)
+            UserDefaults.standard.set(allowsMobileConnections, forKey: Self.enabledKey)
         }
     }
+
+    private(set) var allowsDesktopConnections: Bool {
+        didSet {
+            UserDefaults.standard.set(allowsDesktopConnections, forKey: Self.desktopEnabledKey)
+        }
+    }
+
+    var isEnabled: Bool { allowsMobileConnections || allowsDesktopConnections }
 
     var port: UInt16 {
         didSet {
             guard port != oldValue else { return }
             UserDefaults.standard.set(Int(port), forKey: Self.portKey)
             if isEnabled {
-                setEnabled(false)
+                disableAllConnections()
             }
             lastError = nil
         }
@@ -55,10 +70,12 @@ final class MobileServerService {
 
     private init() {
         if AppEnvironment.isDevelopment {
-            isEnabled = true
+            allowsMobileConnections = true
+            allowsDesktopConnections = true
             port = Self.defaultPort
         } else {
-            isEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey)
+            allowsMobileConnections = UserDefaults.standard.bool(forKey: Self.enabledKey)
+            allowsDesktopConnections = UserDefaults.standard.bool(forKey: Self.desktopEnabledKey)
             let storedPort = UserDefaults.standard.object(forKey: Self.portKey) as? Int
             if let storedPort, let value = UInt16(exactly: storedPort), Self.isValid(port: value) {
                 port = value
@@ -79,10 +96,44 @@ final class MobileServerService {
     }
 
     func setEnabled(_ enabled: Bool) {
-        if enabled, isEnabled, server != nil { return }
-        if !enabled, !isEnabled { return }
-        isEnabled = enabled
-        if enabled {
+        setMobileConnectionsEnabled(enabled)
+    }
+
+    func setMobileConnectionsEnabled(_ enabled: Bool) {
+        guard allowsMobileConnections != enabled else { return }
+        allowsMobileConnections = enabled
+        updateServerState()
+    }
+
+    func setDesktopConnectionsEnabled(_ enabled: Bool) {
+        guard allowsDesktopConnections != enabled else { return }
+        allowsDesktopConnections = enabled
+        updateServerState()
+    }
+
+    func allows(_ clientKind: RemoteClientKindDTO) -> Bool {
+        Self.allows(
+            clientKind,
+            mobileConnections: allowsMobileConnections,
+            desktopConnections: allowsDesktopConnections
+        )
+    }
+
+    static func allows(
+        _ clientKind: RemoteClientKindDTO,
+        mobileConnections: Bool,
+        desktopConnections: Bool
+    ) -> Bool {
+        switch clientKind {
+        case .mobile:
+            mobileConnections
+        case .desktop:
+            desktopConnections
+        }
+    }
+
+    private func updateServerState() {
+        if isEnabled {
             start()
         } else {
             retireCurrentServer()
@@ -92,7 +143,13 @@ final class MobileServerService {
     }
 
     func stop() {
-        setEnabled(false)
+        disableAllConnections()
+    }
+
+    func disableAllConnections() {
+        allowsMobileConnections = false
+        allowsDesktopConnections = false
+        updateServerState()
     }
 
     func stopForTermination() {
@@ -143,7 +200,7 @@ final class MobileServerService {
                 self.handleStartResult(result, port: port, server: newServer)
             }
         }
-        logger.info("Mobile server starting on port \(port)")
+        logger.info("Remote server starting on port \(port)")
     }
 
     private func handleStartResult(_ result: Result<Void, Error>, port: UInt16, server: MuxyRemoteServer) {
@@ -151,9 +208,9 @@ final class MobileServerService {
         case .success:
             lastError = nil
             isPortInUse = false
-            logger.info("Mobile server started on port \(port)")
+            logger.info("Remote server started on port \(port)")
         case let .failure(error):
-            logger.error("Mobile server failed to start on port \(port): \(error.localizedDescription)")
+            logger.error("Remote server failed to start on port \(port): \(error.localizedDescription)")
             isPortInUse = Self.isAddressInUseError(error)
             retireCurrentServer()
             lastError = friendlyMessage(for: error, port: port)
@@ -193,7 +250,7 @@ final class MobileServerService {
                 } else {
                     self.lastError = nil
                     self.isPortInUse = false
-                    self.setEnabled(true)
+                    self.start()
                 }
             }
         }

--- a/Muxy/Services/Mobile/PairingRequestCoordinator.swift
+++ b/Muxy/Services/Mobile/PairingRequestCoordinator.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import MuxyShared
 import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "PairingRequestCoordinator")
@@ -9,6 +10,7 @@ struct PairingRequest: Identifiable, Equatable {
     let deviceID: UUID
     let deviceName: String
     let token: String
+    let clientKind: RemoteClientKindDTO
     let receivedAt: Date
 }
 
@@ -24,11 +26,17 @@ final class PairingRequestCoordinator {
 
     private init() {}
 
-    func requestApproval(deviceID: UUID, deviceName: String, token: String) async -> Bool {
+    func requestApproval(
+        deviceID: UUID,
+        deviceName: String,
+        token: String,
+        clientKind: RemoteClientKindDTO
+    ) async -> Bool {
         let request = PairingRequest(
             deviceID: deviceID,
             deviceName: deviceName,
             token: token,
+            clientKind: clientKind,
             receivedAt: Date()
         )
         return await withCheckedContinuation { continuation in
@@ -45,7 +53,8 @@ final class PairingRequestCoordinator {
         ApprovedDevicesStore.shared.approve(
             deviceID: request.deviceID,
             name: request.deviceName,
-            token: request.token
+            token: request.token,
+            clientKind: request.clientKind
         )
         finish(request, approved: true)
     }
@@ -81,7 +90,8 @@ final class PairingRequestCoordinator {
 
         let alert = NSAlert()
         alert.messageText = "Allow \(request.deviceName) to connect?"
-        alert.informativeText = "This device is requesting access to Muxy. Only approve devices you recognize."
+        let clientKind = request.clientKind.displayName.lowercased()
+        alert.informativeText = "This \(clientKind) is requesting access to Muxy. Only approve devices you recognize."
         alert.alertStyle = .warning
         alert.icon = NSApp.applicationIconImage
         alert.addButton(withTitle: "Approve")
@@ -96,6 +106,15 @@ final class PairingRequestCoordinator {
             approve(request)
         } else {
             deny(request)
+        }
+    }
+}
+
+private extension RemoteClientKindDTO {
+    var displayName: String {
+        switch self {
+        case .mobile: "Mobile device"
+        case .desktop: "Mac"
         }
     }
 }

--- a/Muxy/Services/Mobile/RemoteDeviceStore.swift
+++ b/Muxy/Services/Mobile/RemoteDeviceStore.swift
@@ -23,9 +23,26 @@ final class RemoteDeviceStore {
         devices.filter { $0.kind == .ssh }
     }
 
+    func muxyDevices() -> [RemoteDevice] {
+        devices.filter { $0.kind == .muxy }
+    }
+
     @discardableResult
     func add(name: String, kind: RemoteDeviceKind = .ssh, ssh: SSHWorkspaceData) -> RemoteDevice {
         let device = RemoteDevice(name: name, kind: kind, ssh: ssh)
+        devices.append(device)
+        save()
+        return device
+    }
+
+    @discardableResult
+    func add(id: UUID = UUID(), name: String, muxy: MuxyRemoteServerData) -> RemoteDevice {
+        let device = RemoteDevice(id: id, name: name, muxy: muxy)
+        if let index = devices.firstIndex(where: { $0.id == id }) {
+            devices[index] = device
+            save()
+            return device
+        }
         devices.append(device)
         save()
         return device

--- a/Muxy/Services/Mobile/RemoteServerDelegate.swift
+++ b/Muxy/Services/Mobile/RemoteServerDelegate.swift
@@ -384,11 +384,22 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         PaneOwnershipStore.shared.registerDevice(clientID: clientID, name: name)
     }
 
-    func authenticateDevice(deviceID: UUID, token: String, name: String) -> DeviceAuthDecision {
+    func authenticateDevice(
+        deviceID: UUID,
+        token: String,
+        name: String,
+        clientKind: RemoteClientKindDTO
+    ) -> DeviceAuthDecision {
+        guard MobileServerService.shared.allows(clientKind) else { return .denied }
         guard ApprovedDevicesStore.shared.devices.contains(where: { $0.id == deviceID }) else {
             return .unknown
         }
-        guard let device = ApprovedDevicesStore.shared.validate(deviceID: deviceID, token: token) else {
+        guard let device = ApprovedDevicesStore.shared.validate(
+            deviceID: deviceID,
+            token: token,
+            clientKind: clientKind
+        )
+        else {
             return .denied
         }
         if device.name != name {
@@ -398,14 +409,21 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         return .approved(deviceName: name)
     }
 
-    func requestPairing(deviceID: UUID, token: String, name: String) async -> DeviceAuthDecision {
+    func requestPairing(
+        deviceID: UUID,
+        token: String,
+        name: String,
+        clientKind: RemoteClientKindDTO
+    ) async -> DeviceAuthDecision {
+        guard MobileServerService.shared.allows(clientKind) else { return .denied }
         if ApprovedDevicesStore.shared.devices.contains(where: { $0.id == deviceID }) {
             return .denied
         }
         let approved = await PairingRequestCoordinator.shared.requestApproval(
             deviceID: deviceID,
             deviceName: name,
-            token: token
+            token: token,
+            clientKind: clientKind
         )
         guard approved else { return .denied }
         return .approved(deviceName: name)

--- a/Muxy/Services/Remote/RemoteMacConnection.swift
+++ b/Muxy/Services/Remote/RemoteMacConnection.swift
@@ -1,0 +1,528 @@
+import AppKit
+import Foundation
+import MuxyShared
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "RemoteMacConnection")
+
+enum RemoteMacConnectionState: Equatable {
+    case disconnected
+    case connecting
+    case awaitingApproval
+    case connected
+    case failed(String)
+}
+
+enum RemoteMacConnectionError: LocalizedError {
+    case disconnected
+    case invalidAddress
+    case invalidMessage
+    case unexpectedResult(String)
+    case requestTimedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .disconnected:
+            "The remote Mac disconnected."
+        case .invalidAddress:
+            "The remote Mac address is invalid."
+        case .invalidMessage:
+            "The remote Mac sent an invalid message."
+        case let .unexpectedResult(method):
+            "The remote Mac returned an unexpected result for \(method)."
+        case .requestTimedOut:
+            "The remote Mac did not respond in time."
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class RemoteMacConnection {
+    typealias SocketFactory = @MainActor () -> any RemoteMacSocket
+
+    private struct PendingRequest {
+        let continuation: CheckedContinuation<MuxyResponse, Never>
+        let timeoutTask: Task<Void, Never>
+    }
+
+    let deviceID: UUID
+    private(set) var endpoint: MuxyRemoteServerData
+    private(set) var deviceName: String
+    private(set) var state: RemoteMacConnectionState = .disconnected
+    private(set) var projects: [ProjectDTO] = []
+    private(set) var activeProjectID: UUID?
+    private(set) var workspace: WorkspaceDTO?
+    private(set) var clientID: UUID?
+    private(set) var deviceTheme: DeviceThemeEventDTO?
+    private(set) var paneOwners: [UUID: PaneOwnerDTO] = [:]
+
+    private let credentialStore: any RemoteMacCredentialStoring
+    private let socketFactory: SocketFactory
+    private var socket: (any RemoteMacSocket)?
+    private var receiveTask: Task<Void, Never>?
+    private var pendingRequests: [String: PendingRequest] = [:]
+    private var eventObservers: [UUID: (MuxyEvent) -> Void] = [:]
+    private var desiredOwnedPanes: Set<UUID> = []
+    private var paneTakeoverGenerations: [UUID: UUID] = [:]
+    private var shouldReportDisconnect = true
+    private var connectionGeneration = UUID()
+    private var projectSelectionGeneration = UUID()
+    private var projectSelectionTargetID: UUID?
+
+    init(
+        device: RemoteDevice,
+        credentialStore: any RemoteMacCredentialStoring,
+        socketFactory: @escaping SocketFactory = { URLSessionRemoteMacSocket() }
+    ) {
+        precondition(device.kind == .muxy)
+        guard let endpoint = device.muxy else { preconditionFailure() }
+        deviceID = device.id
+        self.endpoint = endpoint
+        deviceName = device.displayName
+        self.credentialStore = credentialStore
+        self.socketFactory = socketFactory
+    }
+
+    var isConnected: Bool { state == .connected }
+
+    func update(device: RemoteDevice) {
+        guard device.id == deviceID, let endpoint = device.muxy else { return }
+        self.endpoint = endpoint
+        deviceName = device.displayName
+    }
+
+    func connect(allowPairing: Bool, loadProjects: Bool = true) async throws {
+        disconnect()
+        let generation = UUID()
+        connectionGeneration = generation
+        guard let url = endpoint.webSocketURL else {
+            state = .failed(RemoteMacConnectionError.invalidAddress.localizedDescription)
+            throw RemoteMacConnectionError.invalidAddress
+        }
+
+        state = .connecting
+        shouldReportDisconnect = true
+        let socket = socketFactory()
+        self.socket = socket
+        socket.connect(to: url)
+        startReceiveLoop()
+
+        do {
+            let credentials = try credentialStore.loadOrCreate(
+                for: deviceID,
+                endpointScope: endpoint.credentialScope
+            )
+            do {
+                try await authenticate(credentials)
+            } catch let error as MuxyError where error.code == MuxyError.unauthorized.code && allowPairing {
+                state = .awaitingApproval
+                try await pair(credentials)
+            }
+            if loadProjects {
+                try await refreshProjects()
+            }
+            state = .connected
+        } catch {
+            guard connectionGeneration == generation else { throw CancellationError() }
+            fail(error)
+            throw error
+        }
+    }
+
+    func disconnect() {
+        shouldReportDisconnect = false
+        connectionGeneration = UUID()
+        projectSelectionGeneration = UUID()
+        projectSelectionTargetID = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        socket?.disconnect()
+        socket = nil
+        cancelPendingRequests()
+        state = .disconnected
+        activeProjectID = nil
+        workspace = nil
+        clientID = nil
+        deviceTheme = nil
+        paneOwners.removeAll()
+        desiredOwnedPanes.removeAll()
+        paneTakeoverGenerations.removeAll()
+    }
+
+    func refreshProjects() async throws {
+        guard case let .projects(projects) = try await request(.listProjects) else {
+            throw RemoteMacConnectionError.unexpectedResult(MuxyMethod.listProjects.rawValue)
+        }
+        self.projects = sortedProjects(projects)
+    }
+
+    func selectProject(_ projectID: UUID) async throws {
+        let generation = UUID()
+        projectSelectionGeneration = generation
+        projectSelectionTargetID = projectID
+        defer {
+            if projectSelectionGeneration == generation {
+                projectSelectionTargetID = nil
+            }
+        }
+        guard case .ok = try await request(
+            .selectProject,
+            params: .selectProject(SelectProjectParams(projectID: projectID))
+        )
+        else {
+            throw RemoteMacConnectionError.unexpectedResult(MuxyMethod.selectProject.rawValue)
+        }
+        guard projectSelectionGeneration == generation else { return }
+        activeProjectID = projectID
+        workspace = nil
+        paneOwners.removeAll()
+        let workspace = try await workspace(projectID: projectID)
+        guard projectSelectionGeneration == generation,
+              activeProjectID == projectID
+        else { return }
+        self.workspace = workspace
+    }
+
+    func refreshWorkspace(projectID: UUID) async throws {
+        let workspace = try await workspace(projectID: projectID)
+        guard activeProjectID == projectID else { return }
+        self.workspace = workspace
+    }
+
+    private func workspace(projectID: UUID) async throws -> WorkspaceDTO {
+        guard case let .workspace(workspace) = try await request(
+            .getWorkspace,
+            params: .getWorkspace(GetWorkspaceParams(projectID: projectID))
+        )
+        else {
+            throw RemoteMacConnectionError.unexpectedResult(MuxyMethod.getWorkspace.rawValue)
+        }
+        return workspace
+    }
+
+    func createTab(projectID: UUID, areaID: UUID?) async throws {
+        guard case .tab = try await request(
+            .createTab,
+            params: .createTab(CreateTabParams(projectID: projectID, areaID: areaID))
+        )
+        else {
+            throw RemoteMacConnectionError.unexpectedResult(MuxyMethod.createTab.rawValue)
+        }
+    }
+
+    func closeTab(projectID: UUID, areaID: UUID, tabID: UUID) async throws {
+        try await requestOK(
+            .closeTab,
+            params: .closeTab(CloseTabParams(projectID: projectID, areaID: areaID, tabID: tabID))
+        )
+    }
+
+    func selectTab(projectID: UUID, areaID: UUID, tabID: UUID) async throws {
+        try await requestOK(
+            .selectTab,
+            params: .selectTab(SelectTabParams(projectID: projectID, areaID: areaID, tabID: tabID))
+        )
+    }
+
+    func splitArea(projectID: UUID, areaID: UUID, direction: SplitDirectionDTO, position: SplitPositionDTO) async throws {
+        try await requestOK(
+            .splitArea,
+            params: .splitArea(SplitAreaParams(
+                projectID: projectID,
+                areaID: areaID,
+                direction: direction,
+                position: position
+            ))
+        )
+    }
+
+    func closeArea(projectID: UUID, areaID: UUID) async throws {
+        try await requestOK(
+            .closeArea,
+            params: .closeArea(CloseAreaParams(projectID: projectID, areaID: areaID))
+        )
+    }
+
+    func focusArea(projectID: UUID, areaID: UUID) async throws {
+        try await requestOK(
+            .focusArea,
+            params: .focusArea(FocusAreaParams(projectID: projectID, areaID: areaID))
+        )
+    }
+
+    func takeOverPane(paneID: UUID, cols: UInt32, rows: UInt32) -> Task<Void, any Error> {
+        let generation = UUID()
+        desiredOwnedPanes.insert(paneID)
+        paneTakeoverGenerations[paneID] = generation
+        return Task { @MainActor [weak self] in
+            guard let self else { throw CancellationError() }
+            do {
+                guard case .ok = try await request(
+                    .takeOverPane,
+                    params: .takeOverPane(TakeOverPaneParams(paneID: paneID, cols: cols, rows: rows))
+                )
+                else {
+                    throw RemoteMacConnectionError.unexpectedResult(MuxyMethod.takeOverPane.rawValue)
+                }
+            } catch {
+                if paneTakeoverGenerations[paneID] == generation {
+                    paneTakeoverGenerations.removeValue(forKey: paneID)
+                    desiredOwnedPanes.remove(paneID)
+                }
+                throw error
+            }
+            if paneTakeoverGenerations[paneID] == generation {
+                paneTakeoverGenerations.removeValue(forKey: paneID)
+            }
+            if !desiredOwnedPanes.contains(paneID) {
+                await releasePane(paneID: paneID)
+            }
+        }
+    }
+
+    func releasePane(paneID: UUID) async {
+        desiredOwnedPanes.remove(paneID)
+        paneTakeoverGenerations.removeValue(forKey: paneID)
+        _ = try? await request(
+            .releasePane,
+            params: .releasePane(ReleasePaneParams(paneID: paneID))
+        )
+        paneOwners.removeValue(forKey: paneID)
+    }
+
+    func resizeTerminal(paneID: UUID, cols: UInt32, rows: UInt32) async throws {
+        try await requestOK(
+            .terminalResize,
+            params: .terminalResize(TerminalResizeParams(paneID: paneID, cols: cols, rows: rows))
+        )
+    }
+
+    func sendTerminalInput(paneID: UUID, bytes: Data) {
+        sendFireAndForget(
+            .terminalInput,
+            params: .terminalInput(TerminalInputParams(paneID: paneID, bytes: bytes))
+        )
+    }
+
+    @discardableResult
+    func addEventObserver(_ observer: @escaping (MuxyEvent) -> Void) -> UUID {
+        let id = UUID()
+        eventObservers[id] = observer
+        return id
+    }
+
+    func removeEventObserver(_ id: UUID) {
+        eventObservers.removeValue(forKey: id)
+    }
+
+    func isPaneOwnedByThisMac(_ paneID: UUID) -> Bool {
+        guard let clientID, case let .remote(ownerID, _)? = paneOwners[paneID] else { return false }
+        return clientID == ownerID
+    }
+
+    private func authenticate(_ credentials: RemoteMacCredentials) async throws {
+        let params = AuthenticateDeviceParams(
+            deviceID: credentials.deviceID,
+            deviceName: Host.current().localizedName ?? "Mac",
+            token: credentials.token,
+            clientKind: .desktop
+        )
+        try await applyPairingResult(request(.authenticateDevice, params: .authenticateDevice(params)))
+    }
+
+    private func pair(_ credentials: RemoteMacCredentials) async throws {
+        let params = PairDeviceParams(
+            deviceID: credentials.deviceID,
+            deviceName: Host.current().localizedName ?? "Mac",
+            token: credentials.token,
+            clientKind: .desktop
+        )
+        try await applyPairingResult(request(
+            .pairDevice,
+            params: .pairDevice(params),
+            timeout: .seconds(120)
+        ))
+    }
+
+    private func applyPairingResult(_ result: MuxyResult) throws {
+        guard case let .pairing(info) = result else {
+            throw RemoteMacConnectionError.unexpectedResult("authentication")
+        }
+        clientID = info.clientID
+        if let fg = info.themeFg, let bg = info.themeBg {
+            deviceTheme = DeviceThemeEventDTO(fg: fg, bg: bg, palette: info.themePalette)
+        }
+    }
+
+    private func request(
+        _ method: MuxyMethod,
+        params: MuxyParams? = nil,
+        timeout: Duration = .seconds(15)
+    ) async throws -> MuxyResult {
+        guard let socket else { throw RemoteMacConnectionError.disconnected }
+        let id = UUID().uuidString
+        let message = MuxyMessage.request(MuxyRequest(id: id, method: method, params: params))
+        let data = try MuxyCodec.encode(message)
+
+        let response = await withCheckedContinuation { continuation in
+            let timeoutTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: timeout)
+                guard !Task.isCancelled else { return }
+                self?.resolveRequest(
+                    id: id,
+                    response: MuxyResponse(id: id, error: .timeout)
+                )
+            }
+            pendingRequests[id] = PendingRequest(continuation: continuation, timeoutTask: timeoutTask)
+            Task { @MainActor [weak self] in
+                do {
+                    try await socket.send(data)
+                } catch {
+                    self?.resolveRequest(
+                        id: id,
+                        response: MuxyResponse(id: id, error: MuxyError(code: 503, message: error.localizedDescription))
+                    )
+                }
+            }
+        }
+
+        if let error = response.error {
+            if error.code == MuxyError.timeout.code { throw RemoteMacConnectionError.requestTimedOut }
+            throw error
+        }
+        guard let result = response.result else {
+            throw RemoteMacConnectionError.unexpectedResult(method.rawValue)
+        }
+        return result
+    }
+
+    private func requestOK(_ method: MuxyMethod, params: MuxyParams) async throws {
+        guard case .ok = try await request(method, params: params) else {
+            throw RemoteMacConnectionError.unexpectedResult(method.rawValue)
+        }
+    }
+
+    private func sendFireAndForget(_ method: MuxyMethod, params: MuxyParams) {
+        guard let socket,
+              let data = try? MuxyCodec.encode(.request(MuxyRequest(
+                  id: UUID().uuidString,
+                  method: method,
+                  params: params
+              )))
+        else { return }
+        Task {
+            do {
+                try await socket.send(data)
+            } catch {
+                logger.error("Failed to send \(method.rawValue): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func startReceiveLoop() {
+        receiveTask?.cancel()
+        let generation = connectionGeneration
+        receiveTask = Task { @MainActor [weak self] in
+            guard let self, let socket else { return }
+            do {
+                while !Task.isCancelled {
+                    let data = try await socket.receive()
+                    try handle(MuxyCodec.decode(data))
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                guard connectionGeneration == generation, shouldReportDisconnect else { return }
+                fail(error)
+            }
+        }
+    }
+
+    private func handle(_ message: MuxyMessage) throws {
+        switch message {
+        case let .response(response):
+            resolveRequest(id: response.id, response: response)
+        case let .event(event):
+            handle(event)
+        case .request:
+            throw RemoteMacConnectionError.invalidMessage
+        }
+    }
+
+    private func handle(_ event: MuxyEvent) {
+        switch event.data {
+        case let .projects(projects):
+            let projects = sortedProjects(projects)
+            self.projects = projects
+            let projectIDs = Set(projects.map(\.id))
+            if let projectSelectionTargetID, !projectIDs.contains(projectSelectionTargetID) {
+                projectSelectionGeneration = UUID()
+                self.projectSelectionTargetID = nil
+            }
+            if let activeProjectID, !projectIDs.contains(activeProjectID) {
+                self.activeProjectID = nil
+                workspace = nil
+                paneOwners.removeAll()
+            }
+        case let .workspace(workspace):
+            guard workspace.projectID == activeProjectID else { break }
+            self.workspace = workspace
+        case let .paneOwnership(ownership):
+            paneOwners[ownership.paneID] = ownership.owner
+        case let .deviceTheme(theme):
+            deviceTheme = theme
+        case .terminalOutput,
+             .terminalSnapshot,
+             .notification:
+            break
+        }
+        for observer in Array(eventObservers.values) {
+            observer(event)
+        }
+    }
+
+    private func sortedProjects(_ projects: [ProjectDTO]) -> [ProjectDTO] {
+        projects.sorted {
+            if $0.sortOrder != $1.sortOrder { return $0.sortOrder < $1.sortOrder }
+            return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+    }
+
+    private func resolveRequest(id: String, response: MuxyResponse) {
+        guard let pending = pendingRequests.removeValue(forKey: id) else { return }
+        pending.timeoutTask.cancel()
+        pending.continuation.resume(returning: response)
+    }
+
+    private func cancelPendingRequests() {
+        let requests = pendingRequests
+        pendingRequests.removeAll()
+        for (id, pending) in requests {
+            pending.timeoutTask.cancel()
+            pending.continuation.resume(returning: MuxyResponse(
+                id: id,
+                error: MuxyError(code: 499, message: "Connection closed")
+            ))
+        }
+    }
+
+    private func fail(_ error: Error) {
+        logger.error("Remote Mac connection failed: \(error.localizedDescription)")
+        connectionGeneration = UUID()
+        projectSelectionGeneration = UUID()
+        projectSelectionTargetID = nil
+        state = .failed(error.localizedDescription)
+        socket?.disconnect()
+        socket = nil
+        cancelPendingRequests()
+        projects.removeAll()
+        activeProjectID = nil
+        workspace = nil
+        clientID = nil
+        deviceTheme = nil
+        paneOwners.removeAll()
+        desiredOwnedPanes.removeAll()
+        paneTakeoverGenerations.removeAll()
+    }
+}

--- a/Muxy/Services/Remote/RemoteMacCredentialStore.swift
+++ b/Muxy/Services/Remote/RemoteMacCredentialStore.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Security
+
+struct RemoteMacCredentials: Codable, Equatable {
+    let deviceID: UUID
+    let token: String
+    let endpointScope: String?
+
+    init(deviceID: UUID, token: String, endpointScope: String? = nil) {
+        self.deviceID = deviceID
+        self.token = token
+        self.endpointScope = endpointScope
+    }
+}
+
+protocol RemoteMacCredentialStoring: Sendable {
+    func loadOrCreate(for deviceID: UUID, endpointScope: String) throws -> RemoteMacCredentials
+    func delete(for deviceID: UUID, endpointScope: String?) throws
+}
+
+extension RemoteMacCredentialStoring {
+    func delete(for deviceID: UUID) throws {
+        try delete(for: deviceID, endpointScope: nil)
+    }
+}
+
+enum RemoteMacCredentialStoreError: LocalizedError {
+    case randomGenerationFailed(OSStatus)
+    case keychainReadFailed(OSStatus)
+    case keychainWriteFailed(OSStatus)
+    case invalidStoredCredentials
+
+    var errorDescription: String? {
+        switch self {
+        case let .randomGenerationFailed(status):
+            "Could not generate remote access credentials (\(status))."
+        case let .keychainReadFailed(status):
+            "Could not read remote access credentials (\(status))."
+        case let .keychainWriteFailed(status):
+            "Could not save remote access credentials (\(status))."
+        case .invalidStoredCredentials:
+            "The stored remote access credentials are invalid."
+        }
+    }
+}
+
+final class KeychainRemoteMacCredentialStore: RemoteMacCredentialStoring, @unchecked Sendable {
+    private let service: String
+
+    init(service: String = "app.muxy.remote-mac") {
+        self.service = service
+    }
+
+    func loadOrCreate(for deviceID: UUID, endpointScope: String) throws -> RemoteMacCredentials {
+        if let credentials = try read(for: deviceID, endpointScope: endpointScope),
+           credentials.endpointScope == endpointScope
+        {
+            return credentials
+        }
+        try delete(for: deviceID, endpointScope: endpointScope)
+        let credentials = try RemoteMacCredentials(
+            deviceID: UUID(),
+            token: generateToken(),
+            endpointScope: endpointScope
+        )
+        try save(credentials, for: deviceID)
+        return credentials
+    }
+
+    func delete(for deviceID: UUID, endpointScope: String?) throws {
+        let status = SecItemDelete(query(for: deviceID, endpointScope: endpointScope) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw RemoteMacCredentialStoreError.keychainWriteFailed(status)
+        }
+    }
+
+    private func read(for deviceID: UUID, endpointScope: String) throws -> RemoteMacCredentials? {
+        var query = query(for: deviceID, endpointScope: endpointScope)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else {
+            throw RemoteMacCredentialStoreError.keychainReadFailed(status)
+        }
+        guard let data = item as? Data,
+              let credentials = try? JSONDecoder().decode(RemoteMacCredentials.self, from: data),
+              !credentials.token.isEmpty
+        else {
+            throw RemoteMacCredentialStoreError.invalidStoredCredentials
+        }
+        return credentials
+    }
+
+    private func save(_ credentials: RemoteMacCredentials, for deviceID: UUID) throws {
+        let data = try JSONEncoder().encode(credentials)
+        var attributes = query(for: deviceID, endpointScope: credentials.endpointScope)
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw RemoteMacCredentialStoreError.keychainWriteFailed(status)
+        }
+    }
+
+    private func generateToken() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw RemoteMacCredentialStoreError.randomGenerationFailed(status)
+        }
+        return Data(bytes).base64EncodedString()
+    }
+
+    private func query(for deviceID: UUID, endpointScope: String?) -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "\(service).\(deviceID.uuidString)",
+        ]
+        if let endpointScope {
+            query[kSecAttrAccount as String] = endpointScope
+        }
+        return query
+    }
+}
+
+final class InMemoryRemoteMacCredentialStore: RemoteMacCredentialStoring, @unchecked Sendable {
+    private struct CredentialKey: Hashable {
+        let deviceID: UUID
+        let endpointScope: String
+    }
+
+    private let lock = NSLock()
+    private var values: [CredentialKey: RemoteMacCredentials]
+
+    init(values: [UUID: RemoteMacCredentials] = [:]) {
+        self.values = Dictionary(uniqueKeysWithValues: values.compactMap { deviceID, credentials in
+            guard let endpointScope = credentials.endpointScope else { return nil }
+            return (CredentialKey(deviceID: deviceID, endpointScope: endpointScope), credentials)
+        })
+    }
+
+    func loadOrCreate(for deviceID: UUID, endpointScope: String) throws -> RemoteMacCredentials {
+        lock.lock()
+        defer { lock.unlock() }
+        let key = CredentialKey(deviceID: deviceID, endpointScope: endpointScope)
+        if let credentials = values[key] { return credentials }
+        let credentials = RemoteMacCredentials(
+            deviceID: UUID(),
+            token: UUID().uuidString,
+            endpointScope: endpointScope
+        )
+        values[key] = credentials
+        return credentials
+    }
+
+    func delete(for deviceID: UUID, endpointScope: String?) throws {
+        lock.lock()
+        if let endpointScope {
+            values.removeValue(forKey: CredentialKey(deviceID: deviceID, endpointScope: endpointScope))
+        } else {
+            values = values.filter { $0.key.deviceID != deviceID }
+        }
+        lock.unlock()
+    }
+}

--- a/Muxy/Services/Remote/RemoteMacDiscovery.swift
+++ b/Muxy/Services/Remote/RemoteMacDiscovery.swift
@@ -1,0 +1,105 @@
+@preconcurrency import Foundation
+import os
+
+private let discoveryLogger = Logger(subsystem: "app.muxy", category: "RemoteMacDiscovery")
+
+struct DiscoveredRemoteMac: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let host: String
+    let port: UInt16
+}
+
+@MainActor
+@Observable
+final class RemoteMacDiscovery: NSObject {
+    private(set) var devices: [DiscoveredRemoteMac] = []
+    private(set) var isSearching = false
+
+    private let browser = NetServiceBrowser()
+    private var services: [String: NetService] = [:]
+
+    override init() {
+        super.init()
+        browser.delegate = self
+    }
+
+    func start() {
+        guard !isSearching else { return }
+        isSearching = true
+        browser.schedule(in: .main, forMode: .common)
+        browser.searchForServices(ofType: "_muxy._tcp.", inDomain: "local.")
+    }
+
+    func stop() {
+        guard isSearching else { return }
+        browser.stop()
+        browser.remove(from: .main, forMode: .common)
+        for service in services.values {
+            service.stop()
+        }
+        services.removeAll()
+        isSearching = false
+    }
+
+    private func add(_ service: NetService) {
+        services[service.name] = service
+        service.delegate = self
+        service.schedule(in: .main, forMode: .common)
+        service.resolve(withTimeout: 5)
+    }
+
+    private func remove(_ service: NetService) {
+        services.removeValue(forKey: service.name)
+        devices.removeAll { $0.id == service.name }
+    }
+
+    private func resolved(_ service: NetService) {
+        guard let hostName = service.hostName,
+              let port = UInt16(exactly: service.port)
+        else { return }
+        let host = hostName.hasSuffix(".") ? String(hostName.dropLast()) : hostName
+        let device = DiscoveredRemoteMac(
+            id: service.name,
+            name: service.name,
+            host: host,
+            port: port
+        )
+        devices.removeAll { $0.id == device.id }
+        devices.append(device)
+        devices.sort { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+}
+
+extension RemoteMacDiscovery: @preconcurrency NetServiceBrowserDelegate {
+    func netServiceBrowser(
+        _: NetServiceBrowser,
+        didFind service: NetService,
+        moreComing _: Bool
+    ) {
+        add(service)
+    }
+
+    func netServiceBrowser(
+        _: NetServiceBrowser,
+        didRemove service: NetService,
+        moreComing _: Bool
+    ) {
+        remove(service)
+    }
+
+    func netServiceBrowser(_: NetServiceBrowser, didNotSearch error: [String: NSNumber]) {
+        discoveryLogger.error("Remote Mac discovery failed: \(String(describing: error))")
+        isSearching = false
+    }
+}
+
+extension RemoteMacDiscovery: @preconcurrency NetServiceDelegate {
+    func netServiceDidResolveAddress(_ sender: NetService) {
+        resolved(sender)
+    }
+
+    func netService(_: NetService, didNotResolve errorDict: [String: NSNumber]) {
+        discoveryLogger.error("Remote Mac resolution failed: \(String(describing: errorDict))")
+    }
+}

--- a/Muxy/Services/Remote/RemoteMacSocket.swift
+++ b/Muxy/Services/Remote/RemoteMacSocket.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+@MainActor
+protocol RemoteMacSocket: AnyObject {
+    func connect(to url: URL)
+    func send(_ data: Data) async throws
+    func receive() async throws -> Data
+    func disconnect()
+}
+
+@MainActor
+final class URLSessionRemoteMacSocket: RemoteMacSocket {
+    private var session: URLSession?
+    private var task: URLSessionWebSocketTask?
+
+    func connect(to url: URL) {
+        disconnect()
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: url)
+        self.session = session
+        self.task = task
+        task.resume()
+    }
+
+    func send(_ data: Data) async throws {
+        guard let task else { throw RemoteMacConnectionError.disconnected }
+        try await task.send(.data(data))
+    }
+
+    func receive() async throws -> Data {
+        guard let task else { throw RemoteMacConnectionError.disconnected }
+        switch try await task.receive() {
+        case let .data(data):
+            return data
+        case let .string(text):
+            return Data(text.utf8)
+        @unknown default:
+            throw RemoteMacConnectionError.invalidMessage
+        }
+    }
+
+    func disconnect() {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        session?.invalidateAndCancel()
+        session = nil
+    }
+}

--- a/Muxy/Services/Remote/RemoteMacWorkspaceStore.swift
+++ b/Muxy/Services/Remote/RemoteMacWorkspaceStore.swift
@@ -1,0 +1,515 @@
+import Foundation
+import MuxyShared
+import os
+
+private let workspaceLogger = Logger(subsystem: "app.muxy", category: "RemoteMacWorkspace")
+
+@MainActor
+@Observable
+final class RemoteMacWorkspaceStore {
+    typealias ConnectionFactory = @MainActor (RemoteDevice) -> RemoteMacConnection
+
+    private(set) var activeDeviceID: UUID?
+    private(set) var operationError: String?
+    private var connections: [UUID: RemoteMacConnection] = [:]
+    private var setupConnections: [UUID: RemoteMacConnection] = [:]
+    private var activationGenerations: [UUID: UUID] = [:]
+    @ObservationIgnored private var identityMaps: [UUID: RemoteWorkspaceIdentityMap] = [:]
+    private let connectionFactory: ConnectionFactory
+    private let credentialStore: any RemoteMacCredentialStoring
+
+    init(
+        credentialStore: any RemoteMacCredentialStoring = KeychainRemoteMacCredentialStore(),
+        connectionFactory: ConnectionFactory? = nil
+    ) {
+        self.credentialStore = credentialStore
+        self.connectionFactory = connectionFactory ?? { device in
+            RemoteMacConnection(device: device, credentialStore: credentialStore)
+        }
+    }
+
+    var activeConnection: RemoteMacConnection? {
+        guard let activeDeviceID else { return nil }
+        return connections[activeDeviceID]
+    }
+
+    var state: RemoteMacConnectionState {
+        activeConnection?.state ?? .disconnected
+    }
+
+    var projects: [ProjectDTO] {
+        activeConnection?.projects ?? []
+    }
+
+    var activeProject: ProjectDTO? {
+        guard let activeProjectID = activeConnection?.activeProjectID else { return nil }
+        return projects.first(where: { $0.id == activeProjectID })
+    }
+
+    var workspace: WorkspaceDTO? {
+        activeConnection?.workspace
+    }
+
+    var presentedProjects: [Project] {
+        guard let activeDeviceID, let connection = activeConnection else { return [] }
+        return RemoteWorkspacePresentationBuilder.projects(
+            from: connection.projects,
+            deviceID: activeDeviceID,
+            identities: identityMap(for: activeDeviceID)
+        )
+    }
+
+    var presentedProject: Project? {
+        guard let activeProjectID = activeConnection?.activeProjectID else { return nil }
+        let presentationID = identityMapForActiveDevice?.presentationID(for: activeProjectID, entity: .project)
+        return presentedProjects.first(where: { $0.id == presentationID })
+    }
+
+    var presentedWorkspace: RemoteWorkspacePresentation? {
+        guard let workspace, let identities = identityMapForActiveDevice else { return nil }
+        return RemoteWorkspacePresentationBuilder.workspace(from: workspace, identities: identities)
+    }
+
+    func connectionState(for deviceID: UUID) -> RemoteMacConnectionState {
+        connections[deviceID]?.state ?? .disconnected
+    }
+
+    func activate(_ device: RemoteDevice, allowPairing: Bool = false) async {
+        guard device.kind == .muxy else { return }
+        if activeDeviceID == device.id,
+           let connection = activeConnection,
+           connection.state == .connecting || connection.state == .awaitingApproval
+        {
+            return
+        }
+        if activeDeviceID != device.id {
+            if let activeDeviceID {
+                activationGenerations[activeDeviceID] = UUID()
+            }
+            activeConnection?.disconnect()
+            activeDeviceID = device.id
+        }
+        let generation = UUID()
+        activationGenerations[device.id] = generation
+        defer {
+            if activationGenerations[device.id] == generation {
+                activationGenerations.removeValue(forKey: device.id)
+            }
+        }
+        operationError = nil
+        let connection = connection(for: device)
+        do {
+            if !connection.isConnected {
+                try await connection.connect(allowPairing: allowPairing)
+            }
+            if connection.activeProjectID == nil, let project = connection.projects.first {
+                try await connection.selectProject(project.id)
+            }
+        } catch {
+            guard activationGenerations[device.id] == generation,
+                  activeDeviceID == device.id
+            else { return }
+            report(error)
+        }
+    }
+
+    func connectForSetup(_ device: RemoteDevice) async throws {
+        try Task.checkCancellation()
+        operationError = nil
+        setupConnections.removeValue(forKey: device.id)?.disconnect()
+        let connection = connectionFactory(device)
+        setupConnections[device.id] = connection
+        defer {
+            if setupConnections[device.id] === connection {
+                setupConnections.removeValue(forKey: device.id)
+            }
+            connection.disconnect()
+        }
+        try Task.checkCancellation()
+        try await connection.connect(allowPairing: true, loadProjects: false)
+    }
+
+    func cancelSetup(for deviceID: UUID, discardCredentialScope: String?) {
+        setupConnections.removeValue(forKey: deviceID)?.disconnect()
+        guard let discardCredentialScope else { return }
+        do {
+            try credentialStore.delete(for: deviceID, endpointScope: discardCredentialScope)
+        } catch {
+            workspaceLogger.error("Failed to delete setup credentials: \(error.localizedDescription)")
+        }
+    }
+
+    func deactivate() {
+        if let activeDeviceID {
+            activationGenerations[activeDeviceID] = UUID()
+        }
+        activeConnection?.disconnect()
+        activeDeviceID = nil
+        operationError = nil
+    }
+
+    func retryActiveDevice(from deviceStore: RemoteDeviceStore) async {
+        guard let device = deviceStore.device(id: activeDeviceID) else { return }
+        await activate(device)
+    }
+
+    func selectProject(_ projectID: UUID) async {
+        guard let connection = activeConnection else { return }
+        operationError = nil
+        do {
+            try await connection.selectProject(projectID)
+        } catch {
+            report(error)
+        }
+    }
+
+    func selectPresentedProject(_ projectID: UUID) async {
+        guard let remoteID = identityMapForActiveDevice?.remoteID(for: projectID) else { return }
+        await selectProject(remoteID)
+    }
+
+    func remoteID(for presentationID: UUID) -> UUID? {
+        identityMapForActiveDevice?.remoteID(for: presentationID)
+    }
+
+    func workspaceActions() -> WorkspaceViewActions? {
+        guard let connection = activeConnection,
+              let workspace = connection.workspace
+        else { return nil }
+        let projectID = workspace.projectID
+        return WorkspaceViewActions(
+            projectID: presentedWorkspace?.projectID ?? projectID,
+            focusArea: { [weak self, weak connection] areaID in
+                self?.performPresentationAction(areaID: areaID) { remoteAreaID in
+                    try await connection?.focusArea(projectID: projectID, areaID: remoteAreaID)
+                }
+            },
+            selectTab: { [weak self, weak connection] areaID, tabID in
+                self?.performPresentationAction(areaID: areaID, tabID: tabID) { remoteAreaID, remoteTabID in
+                    try await connection?.selectTab(
+                        projectID: projectID,
+                        areaID: remoteAreaID,
+                        tabID: remoteTabID
+                    )
+                }
+            },
+            createTab: { [weak self, weak connection] areaID in
+                self?.performPresentationAction(areaID: areaID) { remoteAreaID in
+                    try await connection?.createTab(projectID: projectID, areaID: remoteAreaID)
+                }
+            },
+            closeTab: { [weak self, weak connection] areaID, tabID in
+                self?.performPresentationAction(areaID: areaID, tabID: tabID) { remoteAreaID, remoteTabID in
+                    try await connection?.closeTab(
+                        projectID: projectID,
+                        areaID: remoteAreaID,
+                        tabID: remoteTabID
+                    )
+                }
+            },
+            forceCloseTab: { [weak self, weak connection] areaID, tabID in
+                self?.performPresentationAction(areaID: areaID, tabID: tabID) { remoteAreaID, remoteTabID in
+                    try await connection?.closeTab(
+                        projectID: projectID,
+                        areaID: remoteAreaID,
+                        tabID: remoteTabID
+                    )
+                }
+            },
+            splitArea: { [weak self, weak connection] areaID, direction, position in
+                self?.performPresentationAction(areaID: areaID) { remoteAreaID in
+                    try await connection?.splitArea(
+                        projectID: projectID,
+                        areaID: remoteAreaID,
+                        direction: direction == .horizontal ? .horizontal : .vertical,
+                        position: position == .first ? .first : .second
+                    )
+                }
+            },
+            closeArea: { [weak self, weak connection] areaID in
+                self?.performPresentationAction(areaID: areaID) { remoteAreaID in
+                    try await connection?.closeArea(projectID: projectID, areaID: remoteAreaID)
+                }
+            }
+        )
+    }
+
+    func refreshWorkspace() async {
+        guard let connection = activeConnection,
+              let projectID = connection.activeProjectID
+        else { return }
+        do {
+            try await connection.refreshWorkspace(projectID: projectID)
+        } catch {
+            report(error)
+        }
+    }
+
+    func removeDevice(_ deviceID: UUID) {
+        activationGenerations[deviceID] = UUID()
+        connections.removeValue(forKey: deviceID)?.disconnect()
+        identityMaps.removeValue(forKey: deviceID)
+        if activeDeviceID == deviceID {
+            activeDeviceID = nil
+            operationError = nil
+        }
+        do {
+            try credentialStore.delete(for: deviceID)
+        } catch {
+            workspaceLogger.error("Failed to delete remote Mac credentials: \(error.localizedDescription)")
+        }
+    }
+
+    func resetConnection(for deviceID: UUID, retiringCredentialScope: String? = nil) {
+        activationGenerations[deviceID] = UUID()
+        connections.removeValue(forKey: deviceID)?.disconnect()
+        identityMaps.removeValue(forKey: deviceID)
+        operationError = nil
+        guard let retiringCredentialScope else { return }
+        do {
+            try credentialStore.delete(for: deviceID, endpointScope: retiringCredentialScope)
+        } catch {
+            workspaceLogger.error("Failed to retire remote Mac credentials: \(error.localizedDescription)")
+        }
+    }
+
+    func clearOperationError() {
+        operationError = nil
+    }
+
+    func performShortcutAction(_ action: ShortcutAction) -> Bool {
+        guard activeDeviceID != nil else { return false }
+
+        switch action {
+        case .toggleThemePicker,
+             .reloadConfig,
+             .toggleSidebar,
+             .toggleAppLayout,
+             .toggleVoiceRecording,
+             .toggleFullScreen,
+             .toggleExtensionConsole:
+            return false
+        default:
+            break
+        }
+
+        guard let connection = activeConnection,
+              let workspace = connection.workspace,
+              let area = RemoteWorkspaceNavigation.focusedArea(in: workspace)
+        else { return true }
+
+        if let index = action.tabSelectionIndex {
+            guard area.tabs.indices.contains(index) else { return true }
+            selectTab(area.tabs[index], in: area, workspace: workspace, connection: connection)
+            return true
+        }
+
+        if let index = action.projectSelectionIndex {
+            guard connection.projects.indices.contains(index) else { return true }
+            Task { await selectProject(connection.projects[index].id) }
+            return true
+        }
+
+        switch action {
+        case .newTab:
+            perform {
+                try await connection.createTab(projectID: workspace.projectID, areaID: area.id)
+            }
+        case .closeTab:
+            guard let tab = area.tabs.first(where: { $0.id == area.activeTabID }) else { return true }
+            perform {
+                try await connection.closeTab(projectID: workspace.projectID, areaID: area.id, tabID: tab.id)
+            }
+        case .splitRight:
+            split(.horizontal, area: area, workspace: workspace, connection: connection)
+        case .splitDown:
+            split(.vertical, area: area, workspace: workspace, connection: connection)
+        case .closePane:
+            guard RemoteWorkspaceNavigation.areas(in: workspace.root).count > 1 else { return true }
+            perform {
+                try await connection.closeArea(projectID: workspace.projectID, areaID: area.id)
+            }
+        case .nextTab:
+            selectTab(offset: 1, in: area, workspace: workspace, connection: connection)
+        case .previousTab:
+            selectTab(offset: -1, in: area, workspace: workspace, connection: connection)
+        case .cycleNextTabAcrossPanes:
+            selectTabAcrossPanes(offset: 1, workspace: workspace, connection: connection)
+        case .cyclePreviousTabAcrossPanes:
+            selectTabAcrossPanes(offset: -1, workspace: workspace, connection: connection)
+        case .nextProject:
+            selectProject(offset: 1, connection: connection)
+        case .previousProject:
+            selectProject(offset: -1, connection: connection)
+        case .newHomeTab,
+             .newBrowserTab,
+             .renameTab,
+             .pinUnpinTab,
+             .focusPaneLeft,
+             .focusPaneRight,
+             .focusPaneUp,
+             .focusPaneDown,
+             .toggleMaximizePane,
+             .findInTerminal,
+             .terminalOmnibox,
+             .terminalOmniboxProjects,
+             .terminalOmniboxWorktrees,
+             .terminalOmniboxWorkspaces,
+             .terminalOmniboxCommands,
+             .toggleRichInput,
+             .submitRichInput,
+             .submitRichInputWithoutReturn,
+             .refreshWorktrees,
+             .createWorktree,
+             .removeCurrentWorktree,
+             .openProject,
+             .newProject,
+             .navigateBack,
+             .navigateForward,
+             .inspectElement:
+            break
+        case .toggleThemePicker,
+             .reloadConfig,
+             .selectTab1,
+             .selectTab2,
+             .selectTab3,
+             .selectTab4,
+             .selectTab5,
+             .selectTab6,
+             .selectTab7,
+             .selectTab8,
+             .selectTab9,
+             .selectProject1,
+             .selectProject2,
+             .selectProject3,
+             .selectProject4,
+             .selectProject5,
+             .selectProject6,
+             .selectProject7,
+             .selectProject8,
+             .selectProject9,
+             .toggleSidebar,
+             .toggleAppLayout,
+             .toggleVoiceRecording,
+             .toggleFullScreen,
+             .toggleExtensionConsole:
+            return false
+        }
+        return true
+    }
+
+    private func connection(for device: RemoteDevice) -> RemoteMacConnection {
+        if let connection = connections[device.id] {
+            connection.update(device: device)
+            return connection
+        }
+        let connection = connectionFactory(device)
+        connections[device.id] = connection
+        return connection
+    }
+
+    private func split(
+        _ direction: SplitDirectionDTO,
+        area: TabAreaDTO,
+        workspace: WorkspaceDTO,
+        connection: RemoteMacConnection
+    ) {
+        perform {
+            try await connection.splitArea(
+                projectID: workspace.projectID,
+                areaID: area.id,
+                direction: direction,
+                position: .second
+            )
+        }
+    }
+
+    private func selectTab(
+        offset: Int,
+        in area: TabAreaDTO,
+        workspace: WorkspaceDTO,
+        connection: RemoteMacConnection
+    ) {
+        guard let tab = RemoteWorkspaceNavigation.tab(in: area, offset: offset) else { return }
+        selectTab(tab, in: area, workspace: workspace, connection: connection)
+    }
+
+    private func selectTabAcrossPanes(
+        offset: Int,
+        workspace: WorkspaceDTO,
+        connection: RemoteMacConnection
+    ) {
+        guard let selection = RemoteWorkspaceNavigation.tabAcrossAreas(in: workspace, offset: offset) else { return }
+        selectTab(selection.tab, in: selection.area, workspace: workspace, connection: connection)
+    }
+
+    private func selectTab(
+        _ tab: TabDTO,
+        in area: TabAreaDTO,
+        workspace: WorkspaceDTO,
+        connection: RemoteMacConnection
+    ) {
+        perform {
+            if workspace.focusedAreaID != area.id {
+                try await connection.focusArea(projectID: workspace.projectID, areaID: area.id)
+            }
+            try await connection.selectTab(projectID: workspace.projectID, areaID: area.id, tabID: tab.id)
+        }
+    }
+
+    private func selectProject(offset: Int, connection: RemoteMacConnection) {
+        guard !connection.projects.isEmpty else { return }
+        let currentIndex = connection.projects.firstIndex { $0.id == connection.activeProjectID } ?? 0
+        let index = (currentIndex + offset + connection.projects.count) % connection.projects.count
+        Task { await selectProject(connection.projects[index].id) }
+    }
+
+    private func perform(_ operation: @escaping () async throws -> Void) {
+        Task {
+            do {
+                try await operation()
+            } catch {
+                report(error)
+                ToastState.shared.show(error.localizedDescription)
+            }
+        }
+    }
+
+    private func report(_ error: Error) {
+        workspaceLogger.error("Remote workspace operation failed: \(error.localizedDescription)")
+        operationError = error.localizedDescription
+    }
+
+    private func performPresentationAction(
+        areaID: UUID,
+        operation: @escaping (UUID) async throws -> Void
+    ) {
+        guard let remoteAreaID = remoteID(for: areaID) else { return }
+        perform { try await operation(remoteAreaID) }
+    }
+
+    private func performPresentationAction(
+        areaID: UUID,
+        tabID: UUID,
+        operation: @escaping (UUID, UUID) async throws -> Void
+    ) {
+        guard let remoteAreaID = remoteID(for: areaID),
+              let remoteTabID = remoteID(for: tabID)
+        else { return }
+        perform { try await operation(remoteAreaID, remoteTabID) }
+    }
+
+    private var identityMapForActiveDevice: RemoteWorkspaceIdentityMap? {
+        guard let activeDeviceID else { return nil }
+        return identityMap(for: activeDeviceID)
+    }
+
+    private func identityMap(for deviceID: UUID) -> RemoteWorkspaceIdentityMap {
+        if let existing = identityMaps[deviceID] {
+            return existing
+        }
+        let identities = RemoteWorkspaceIdentityMap()
+        identityMaps[deviceID] = identities
+        return identities
+    }
+}

--- a/Muxy/Services/Remote/RemoteWorkspaceNavigation.swift
+++ b/Muxy/Services/Remote/RemoteWorkspaceNavigation.swift
@@ -1,0 +1,38 @@
+import Foundation
+import MuxyShared
+
+enum RemoteWorkspaceNavigation {
+    static func areas(in node: SplitNodeDTO) -> [TabAreaDTO] {
+        switch node {
+        case let .tabArea(area):
+            [area]
+        case let .split(branch):
+            areas(in: branch.first) + areas(in: branch.second)
+        }
+    }
+
+    static func focusedArea(in workspace: WorkspaceDTO) -> TabAreaDTO? {
+        let areas = areas(in: workspace.root)
+        guard let focusedAreaID = workspace.focusedAreaID else { return areas.first }
+        return areas.first(where: { $0.id == focusedAreaID }) ?? areas.first
+    }
+
+    static func tab(in area: TabAreaDTO, offset: Int) -> TabDTO? {
+        guard !area.tabs.isEmpty else { return nil }
+        let currentIndex = area.tabs.firstIndex(where: { $0.id == area.activeTabID }) ?? 0
+        let index = (currentIndex + offset + area.tabs.count) % area.tabs.count
+        return area.tabs[index]
+    }
+
+    static func tabAcrossAreas(in workspace: WorkspaceDTO, offset: Int) -> (area: TabAreaDTO, tab: TabDTO)? {
+        let selections = areas(in: workspace.root).flatMap { area in
+            area.tabs.map { (area: area, tab: $0) }
+        }
+        guard !selections.isEmpty else { return nil }
+        let currentIndex = selections.firstIndex { selection in
+            selection.area.id == workspace.focusedAreaID && selection.tab.id == selection.area.activeTabID
+        } ?? 0
+        let index = (currentIndex + offset + selections.count) % selections.count
+        return selections[index]
+    }
+}

--- a/Muxy/Services/Remote/RemoteWorkspacePresentation.swift
+++ b/Muxy/Services/Remote/RemoteWorkspacePresentation.swift
@@ -1,0 +1,151 @@
+import Foundation
+import MuxyShared
+
+@MainActor
+struct RemoteWorkspacePresentation {
+    let projectID: UUID
+    let worktreeID: UUID
+    let focusedAreaID: UUID?
+    let root: SplitNode
+
+    var focusedArea: TabArea? {
+        guard let focusedAreaID else { return root.allAreas().first }
+        return root.findArea(id: focusedAreaID)
+    }
+
+    var activeTab: TerminalTab? {
+        focusedArea?.activeTab
+    }
+}
+
+@MainActor
+final class RemoteWorkspaceIdentityMap {
+    enum Entity: Hashable {
+        case project
+        case worktree
+        case split
+        case area
+        case tab
+        case pane
+    }
+
+    private struct Key: Hashable {
+        let entity: Entity
+        let remoteID: UUID
+    }
+
+    private var presentationIDs: [Key: UUID] = [:]
+    private var remoteIDs: [UUID: UUID] = [:]
+
+    func presentationID(for remoteID: UUID, entity: Entity) -> UUID {
+        let key = Key(entity: entity, remoteID: remoteID)
+        if let existing = presentationIDs[key] {
+            return existing
+        }
+        let presentationID = UUID()
+        presentationIDs[key] = presentationID
+        remoteIDs[presentationID] = remoteID
+        return presentationID
+    }
+
+    func remoteID(for presentationID: UUID) -> UUID? {
+        remoteIDs[presentationID]
+    }
+}
+
+@MainActor
+enum RemoteWorkspacePresentationBuilder {
+    static func projects(
+        from projects: [ProjectDTO],
+        deviceID: UUID,
+        identities: RemoteWorkspaceIdentityMap
+    ) -> [Project] {
+        projects.map { dto in
+            var project = Project(
+                id: identities.presentationID(for: dto.id, entity: .project),
+                name: dto.name,
+                path: dto.path,
+                sortOrder: dto.sortOrder,
+                remoteMacDeviceID: deviceID
+            )
+            project.icon = dto.icon
+            project.iconColor = dto.iconColor
+            return project
+        }
+    }
+
+    static func workspace(
+        from workspace: WorkspaceDTO,
+        identities: RemoteWorkspaceIdentityMap
+    ) -> RemoteWorkspacePresentation {
+        RemoteWorkspacePresentation(
+            projectID: identities.presentationID(for: workspace.projectID, entity: .project),
+            worktreeID: identities.presentationID(for: workspace.worktreeID, entity: .worktree),
+            focusedAreaID: workspace.focusedAreaID.map {
+                identities.presentationID(for: $0, entity: .area)
+            },
+            root: node(from: workspace.root, identities: identities)
+        )
+    }
+
+    private static func node(
+        from dtoNode: SplitNodeDTO,
+        identities: RemoteWorkspaceIdentityMap
+    ) -> SplitNode {
+        switch dtoNode {
+        case let .tabArea(area):
+            let tabs = area.tabs.map {
+                tab(from: $0, projectPath: area.projectPath, identities: identities)
+            }
+            let activeTabID = area.activeTabID.map {
+                identities.presentationID(for: $0, entity: .tab)
+            }
+            return .tabArea(TabArea(
+                id: identities.presentationID(for: area.id, entity: .area),
+                projectPath: area.projectPath,
+                tabs: tabs,
+                activeTabID: activeTabID
+            ))
+        case let .split(branch):
+            return .split(SplitBranch(
+                id: identities.presentationID(for: branch.id, entity: .split),
+                direction: branch.direction == .horizontal ? .horizontal : .vertical,
+                ratio: branch.ratio,
+                first: node(from: branch.first, identities: identities),
+                second: node(from: branch.second, identities: identities)
+            ))
+        }
+    }
+
+    private static func tab(
+        from tab: TabDTO,
+        projectPath: String,
+        identities: RemoteWorkspaceIdentityMap
+    ) -> TerminalTab {
+        let pane = tab.paneID.map { remotePaneID in
+            TerminalPaneState(
+                id: identities.presentationID(for: remotePaneID, entity: .pane),
+                projectPath: projectPath,
+                title: tab.title,
+                backend: .remoteMac(paneID: remotePaneID)
+            )
+        }
+        return TerminalTab(
+            id: identities.presentationID(for: tab.id, entity: .tab),
+            title: tab.title,
+            isPinned: tab.isPinned,
+            projectPath: projectPath,
+            kind: kind(for: tab.kind),
+            pane: pane
+        )
+    }
+
+    private static func kind(for kind: TabKindDTO) -> TerminalTab.Kind {
+        switch kind {
+        case .terminal: .terminal
+        case .browser: .browser
+        case .vcs,
+             .extensionWebView: .extensionWebView
+        }
+    }
+}

--- a/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
@@ -14,6 +14,8 @@ struct ExpandedProjectRow: View {
     let onSetIconColor: (String?) -> Void
     let onSetWorktreesEnabled: (Bool) -> Void
     let onSetPinned: (Bool) -> Void
+    var activeOverride: Bool?
+    var allowsManagement = true
 
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -36,7 +38,7 @@ struct ExpandedProjectRow: View {
     @State private var pendingWorktreeRemoval: WorktreeRemovalConfirmation?
 
     private var isActive: Bool {
-        appState.activeProjectID == project.id
+        activeOverride ?? (appState.activeProjectID == project.id)
     }
 
     private var worktrees: [Worktree] {
@@ -52,6 +54,7 @@ struct ExpandedProjectRow: View {
     }
 
     private var projectActivity: TerminalActivity? {
+        guard !project.isRemoteMac else { return nil }
         let progressStore = TerminalProgressStore.shared
         let agentStore = AgentStatusStore.shared
         let hasProgress = progressStore.hasActiveProgress(for: project.id)
@@ -94,6 +97,10 @@ struct ExpandedProjectRow: View {
             }
         }
         .task(id: project.path) {
+            guard !project.isRemoteMac else {
+                isCheckingGitRepo = false
+                return
+            }
             guard !project.isHome else {
                 isCheckingGitRepo = false
                 return
@@ -125,7 +132,9 @@ struct ExpandedProjectRow: View {
             }
         }
         .contextMenu {
-            if project.isHome {
+            if !allowsManagement {
+                EmptyView()
+            } else if project.isHome {
                 Button("Hide Home") { hideHome() }
             } else {
                 projectContextMenu

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
@@ -54,6 +54,7 @@ struct ProjectFocusedSidebar: View {
     @Environment(ProjectStore.self) private var projectStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @Environment(RemoteDeviceStore.self) private var remoteDeviceStore
+    @Environment(RemoteMacWorkspaceStore.self) private var remoteMacWorkspace
     @Environment(WorktreeStore.self) private var worktreeStore
     @State private var dragState = ProjectDragState()
     @State private var isExternalDropTargeted = false
@@ -124,7 +125,9 @@ struct ProjectFocusedSidebar: View {
     }
 
     @ViewBuilder private var addButton: some View {
-        if projectGroupStore.isRemoteWorkspaceActive {
+        if remoteMacWorkspace.activeDeviceID != nil {
+            EmptyView()
+        } else if projectGroupStore.isRemoteWorkspaceActive {
             AddProjectButton(expanded: isWide, action: openLocalProjectPicker)
                 .help(shortcutTooltip("Add Project", for: .openProject))
         } else {
@@ -203,6 +206,7 @@ struct ProjectFocusedSidebar: View {
     }
 
     private var homeProject: Project? {
+        guard remoteMacWorkspace.activeDeviceID == nil else { return nil }
         guard showHomeProject else { return nil }
         guard !projectGroupStore.isRemoteWorkspaceActive else {
             return projectGroupStore.activeRemoteHomeProject
@@ -215,7 +219,10 @@ struct ProjectFocusedSidebar: View {
     }
 
     private var displayedProjects: [Project] {
-        projectGroupStore.displayProjects(localProjects: projectStore.storedProjects, sortMode: sortMode)
+        if remoteMacWorkspace.activeDeviceID != nil {
+            return remoteMacWorkspace.presentedProjects
+        }
+        return projectGroupStore.displayProjects(localProjects: projectStore.storedProjects, sortMode: sortMode)
     }
 
     private var pinnedBoundaryIndex: Int? {
@@ -243,7 +250,7 @@ struct ProjectFocusedSidebar: View {
     }
 
     private var showSortMenu: Bool {
-        isWide && !projectGroupStore.isRemoteWorkspaceActive && !displayedProjects.isEmpty
+        isWide && remoteMacWorkspace.activeDeviceID == nil && !projectGroupStore.isRemoteWorkspaceActive && !displayedProjects.isEmpty
     }
 
     private var projectList: some View {
@@ -275,7 +282,10 @@ struct ProjectFocusedSidebar: View {
                                 }
                             }
                         }
-                        .gesture(projectDragGesture(for: project))
+                        .gesture(
+                            projectDragGesture(for: project),
+                            including: remoteMacWorkspace.activeDeviceID == nil ? .all : .none
+                        )
                         .overlay(alignment: .bottom) {
                             PinnedProjectsDivider()
                                 .offset(y: pinnedDividerOffset)
@@ -301,7 +311,8 @@ struct ProjectFocusedSidebar: View {
         }
         .animation(.easeInOut(duration: 0.15), value: isExternalDropTargeted)
         .onDrop(of: [.fileURL], isTargeted: $isExternalDropTargeted) { providers in
-            ProjectSidebarDropHandler.handle(providers: providers) { path in
+            guard remoteMacWorkspace.activeDeviceID == nil else { return false }
+            return ProjectSidebarDropHandler.handle(providers: providers) { path in
                 ProjectOpenService.confirmProjectPathResult(
                     path,
                     appState: appState,
@@ -327,7 +338,9 @@ struct ProjectFocusedSidebar: View {
                 onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
                 onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) },
                 onSetWorktreesEnabled: { setWorktreesEnabled(project, to: $0) },
-                onSetPinned: { projectStore.setPinned(id: project.id, to: $0) }
+                onSetPinned: { projectStore.setPinned(id: project.id, to: $0) },
+                activeOverride: project.isRemoteMac ? remoteMacWorkspace.presentedProject?.id == project.id : nil,
+                allowsManagement: !project.isRemoteMac
             )
         } else {
             ProjectRow(
@@ -341,7 +354,9 @@ struct ProjectFocusedSidebar: View {
                 onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
                 onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) },
                 onSetWorktreesEnabled: { setWorktreesEnabled(project, to: $0) },
-                onSetPinned: { projectStore.setPinned(id: project.id, to: $0) }
+                onSetPinned: { projectStore.setPinned(id: project.id, to: $0) },
+                activeOverride: project.isRemoteMac ? remoteMacWorkspace.presentedProject?.id == project.id : nil,
+                allowsManagement: !project.isRemoteMac
             )
         }
     }
@@ -391,6 +406,10 @@ struct ProjectFocusedSidebar: View {
     }
 
     private func select(_ project: Project) {
+        if project.isRemoteMac {
+            Task { await remoteMacWorkspace.selectPresentedProject(project.id) }
+            return
+        }
         worktreeStore.ensurePrimary(for: project)
         guard let worktree = worktreeStore.preferred(
             for: project.id,

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
@@ -14,6 +14,8 @@ struct ProjectRow: View {
     let onSetIconColor: (String?) -> Void
     let onSetWorktreesEnabled: (Bool) -> Void
     let onSetPinned: (Bool) -> Void
+    var activeOverride: Bool?
+    var allowsManagement = true
 
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -32,10 +34,11 @@ struct ProjectRow: View {
     @State private var showSymbolPicker = false
 
     private var isActive: Bool {
-        appState.activeProjectID == project.id
+        activeOverride ?? (appState.activeProjectID == project.id)
     }
 
     private var projectActivity: TerminalActivity? {
+        guard !project.isRemoteMac else { return nil }
         let progressStore = TerminalProgressStore.shared
         let agentStore = AgentStatusStore.shared
         let hasProgress = progressStore.hasActiveProgress(for: project.id)
@@ -92,6 +95,10 @@ struct ProjectRow: View {
                 onSelect()
             }
             .task(id: project.path) {
+                guard !project.isRemoteMac else {
+                    isCheckingGitRepo = false
+                    return
+                }
                 guard !project.isHome else {
                     isCheckingGitRepo = false
                     return
@@ -111,7 +118,9 @@ struct ProjectRow: View {
                 GitRepoStatusCache.shared.update(path: project.path, context: context, isGitRepo: isGitRepo)
             }
             .contextMenu {
-                if project.isHome {
+                if !allowsManagement {
+                    EmptyView()
+                } else if project.isHome {
                     Button("Hide Home") { hideHome() }
                 } else {
                     projectContextMenu

--- a/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
@@ -6,6 +6,7 @@ struct WorkspaceSwitcher: View {
 
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @Environment(RemoteDeviceStore.self) private var deviceStore
+    @Environment(RemoteMacWorkspaceStore.self) private var remoteMacWorkspace
     @Environment(SSHConnectionService.self) private var sshConnections
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
@@ -15,6 +16,7 @@ struct WorkspaceSwitcher: View {
     @State private var isTriggerHovered = false
     @State private var editorMode: WorkspaceEditorMode?
     @State private var remoteEditor: RemoteWorkspaceEditorMode?
+    @State private var remoteMacEditor: RemoteMacDeviceEditorMode?
     @State private var groupPendingDelete: ProjectGroup?
 
     private var activeGroup: ProjectGroup? {
@@ -23,7 +25,10 @@ struct WorkspaceSwitcher: View {
     }
 
     private var activeLabel: String {
-        activeGroup?.name ?? "All Projects"
+        if let device = deviceStore.device(id: remoteMacWorkspace.activeDeviceID) {
+            return device.displayName
+        }
+        return activeGroup?.name ?? "All Projects"
     }
 
     var body: some View {
@@ -54,6 +59,23 @@ struct WorkspaceSwitcher: View {
                 onCancel: { remoteEditor = nil }
             )
         }
+        .sheet(item: $remoteMacEditor) { mode in
+            RemoteMacDeviceEditorSheet(
+                mode: mode,
+                onSave: { id, name, connection in
+                    let device = deviceStore.add(id: id, name: name, muxy: connection)
+                    let previousScope = mode.existingCredentialScope
+                    let retiredScope = previousScope == connection.credentialScope ? nil : previousScope
+                    remoteMacWorkspace.resetConnection(
+                        for: device.id,
+                        retiringCredentialScope: retiredScope
+                    )
+                    remoteMacEditor = nil
+                    select(device)
+                },
+                onCancel: { remoteMacEditor = nil }
+            )
+        }
         .alert(
             "Delete “\(groupPendingDelete?.name ?? "")”?",
             isPresented: deleteAlertBinding,
@@ -77,8 +99,8 @@ struct WorkspaceSwitcher: View {
             isShowingPopover.toggle()
         } label: {
             HStack(spacing: UIMetrics.spacing2) {
-                if activeGroup?.type == .ssh {
-                    Image(systemName: "network")
+                if activeGroup?.type == .ssh || remoteMacWorkspace.activeDeviceID != nil {
+                    Image(systemName: remoteMacWorkspace.activeDeviceID == nil ? "network" : "desktopcomputer")
                         .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                         .foregroundStyle(MuxyTheme.accent)
                 }
@@ -151,7 +173,19 @@ struct WorkspaceSwitcher: View {
                     }
                 )
             }
-            if !projectGroupStore.groups.isEmpty {
+            ForEach(deviceStore.muxyDevices()) { device in
+                RemoteMacWorkspaceRow(
+                    device: device,
+                    isActive: remoteMacWorkspace.activeDeviceID == device.id,
+                    state: remoteMacWorkspace.connectionState(for: device.id),
+                    onSelect: { select(device) },
+                    onEdit: {
+                        isShowingPopover = false
+                        remoteMacEditor = .edit(device)
+                    }
+                )
+            }
+            if !projectGroupStore.groups.isEmpty || !deviceStore.muxyDevices().isEmpty {
                 Divider()
                     .padding(.vertical, UIMetrics.spacing1)
             }
@@ -163,12 +197,13 @@ struct WorkspaceSwitcher: View {
 
     private var allProjectsRow: some View {
         Button {
+            remoteMacWorkspace.deactivate()
             projectGroupStore.clearGroupSelection()
             selectFirstProject()
             isShowingPopover = false
         } label: {
             HStack(spacing: UIMetrics.spacing2) {
-                Image(systemName: projectGroupStore.activeGroupID == nil ? "checkmark" : "")
+                Image(systemName: projectGroupStore.activeGroupID == nil && remoteMacWorkspace.activeDeviceID == nil ? "checkmark" : "")
                     .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                     .foregroundStyle(MuxyTheme.accent)
                     .frame(width: UIMetrics.fontCaption)
@@ -201,6 +236,12 @@ struct WorkspaceSwitcher: View {
                 remoteEditor = .create
             } label: {
                 Label("Remote (SSH)", systemImage: "network")
+            }
+            Button {
+                isShowingPopover = false
+                remoteMacEditor = .create
+            } label: {
+                Label("Muxy Mac", systemImage: "desktopcomputer")
             }
         } label: {
             HStack(spacing: UIMetrics.spacing2) {
@@ -265,6 +306,7 @@ struct WorkspaceSwitcher: View {
     }
 
     private func select(_ group: ProjectGroup) {
+        remoteMacWorkspace.deactivate()
         guard group.type == .ssh, let destination = destination(for: group) else {
             projectGroupStore.selectGroup(id: group.id)
             selectFirstProject()
@@ -280,6 +322,18 @@ struct WorkspaceSwitcher: View {
             }
             projectGroupStore.selectGroup(id: group.id)
             selectFirstProject()
+        }
+    }
+
+    private func select(_ device: RemoteDevice) {
+        guard device.kind == .muxy else { return }
+        isShowingPopover = false
+        projectGroupStore.clearGroupSelection()
+        Task {
+            await remoteMacWorkspace.activate(device)
+            if case let .failed(message) = remoteMacWorkspace.state {
+                ToastState.shared.show("Could not connect to \(device.displayName): \(message)")
+            }
         }
     }
 
@@ -467,6 +521,69 @@ private struct WorkspaceRow: View {
 
     private var connectionHelp: String {
         guard case let .failed(message) = connectionState else { return "" }
+        return message
+    }
+}
+
+private struct RemoteMacWorkspaceRow: View {
+    let device: RemoteDevice
+    let isActive: Bool
+    let state: RemoteMacConnectionState
+    let onSelect: () -> Void
+    let onEdit: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: UIMetrics.spacing2) {
+                Image(systemName: isActive ? "checkmark" : "")
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.accent)
+                    .frame(width: UIMetrics.fontCaption)
+                Image(systemName: "desktopcomputer")
+                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    .frame(width: UIMetrics.fontBody)
+                Text(device.displayName)
+                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .lineLimit(1)
+                Spacer()
+                connectionIndicator
+            }
+            .padding(.horizontal, UIMetrics.spacing3)
+            .padding(.vertical, UIMetrics.spacing2)
+            .background(isHovered ? MuxyTheme.hover : Color.clear, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .help(connectionHelp)
+        .contextMenu {
+            Button("Edit Connection", action: onEdit)
+        }
+    }
+
+    @ViewBuilder
+    private var connectionIndicator: some View {
+        switch state {
+        case .connecting,
+             .awaitingApproval:
+            ProgressView().controlSize(.mini)
+        case .connected:
+            Circle().fill(.green).frame(width: UIMetrics.spacing2, height: UIMetrics.spacing2)
+        case .failed:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: UIMetrics.fontCaption))
+                .foregroundStyle(.orange)
+        case .disconnected:
+            EmptyView()
+        }
+    }
+
+    private var connectionHelp: String {
+        guard case let .failed(message) = state else { return "" }
         return message
     }
 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -6,11 +6,14 @@ struct TabFocusedProjectRow: View {
     let project: Project
     var worktree: Worktree?
     let shortcutNumbers: [UUID: Int]
+    var remotePresentation: RemoteWorkspacePresentation?
+    var remoteActions: WorkspaceViewActions?
 
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
+    @Environment(RemoteMacWorkspaceStore.self) private var remoteMacWorkspace
     @State private var expansionStore = TabFocusedSidebarState.shared
     @State private var notificationStore = NotificationStore.shared
     @State private var progressStore = TerminalProgressStore.shared
@@ -25,6 +28,7 @@ struct TabFocusedProjectRow: View {
     @State private var showCreateWorktreeSheet = false
     @State private var logoCropImage: IdentifiableProjectImage?
     @State private var projectPendingRemoval = false
+    @State private var remoteExpanded = false
     @FocusState private var renameFieldFocused: Bool
 
     private var isWorktreeRow: Bool { worktree != nil }
@@ -36,10 +40,14 @@ struct TabFocusedProjectRow: View {
     }
 
     private var listWorktree: Worktree? {
-        worktree ?? worktreeStore.primary(for: project.id)
+        guard !project.isRemoteMac else { return nil }
+        return worktree ?? worktreeStore.primary(for: project.id)
     }
 
     private var isActive: Bool {
+        if project.isRemoteMac {
+            return remoteMacWorkspace.presentedProject?.id == project.id
+        }
         guard appState.activeProjectID == project.id else { return false }
         guard let worktree else { return isActiveWorktreePrimary }
         return appState.activeWorktreeID[project.id] == worktree.id
@@ -51,6 +59,7 @@ struct TabFocusedProjectRow: View {
     }
 
     private var rowActivity: TerminalActivity? {
+        guard !project.isRemoteMac else { return nil }
         let agentStore = AgentStatusStore.shared
         let hasProgress: Bool
         let agentStatus: AgentStatus?
@@ -80,13 +89,24 @@ struct TabFocusedProjectRow: View {
     }
 
     private var isExpanded: Bool {
-        expansionStore.isExpanded(rowID, default: false)
+        if project.isRemoteMac {
+            return remoteExpanded
+        }
+        return expansionStore.isExpanded(rowID, default: false)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
-            if isExpanded, let listWorktree {
+            if isExpanded, let remotePresentation, let remoteActions {
+                TabFocusedTabsList(
+                    project: project,
+                    worktree: nil,
+                    shortcutNumbers: shortcutNumbers,
+                    remotePresentation: remotePresentation,
+                    remoteActions: remoteActions
+                )
+            } else if isExpanded, let listWorktree {
                 TabFocusedTabsList(project: project, worktree: listWorktree, shortcutNumbers: shortcutNumbers)
             }
         }
@@ -94,10 +114,16 @@ struct TabFocusedProjectRow: View {
         .onChange(of: isActive) { _, active in
             guard active, !isExpanded else { return }
             withAnimation(.easeInOut(duration: 0.15)) {
-                expansionStore.set(rowID, expanded: true)
+                setExpanded(true)
             }
         }
-        .task(id: project.path) { await checkGitRepo() }
+        .task(id: project.path) {
+            guard !project.isRemoteMac else {
+                isCheckingGitRepo = false
+                return
+            }
+            await checkGitRepo()
+        }
     }
 
     private var header: some View {
@@ -133,9 +159,16 @@ struct TabFocusedProjectRow: View {
         .padding(.vertical, TabFocusedSidebarMetrics.rowVerticalPadding)
         .contentShape(RoundedRectangle(cornerRadius: TabFocusedSidebarMetrics.rowCornerRadius, style: .continuous))
         .onHover { hovered = $0 }
-        .onTapGesture { toggle() }
+        .onTapGesture {
+            if project.isRemoteMac, !isActive {
+                Task { await remoteMacWorkspace.selectPresentedProject(project.id) }
+            }
+            toggle()
+        }
         .contextMenu {
-            if let worktree {
+            if project.isRemoteMac {
+                EmptyView()
+            } else if let worktree {
                 worktreeContextMenu(worktree)
             } else if project.isHome {
                 Button("Hide Home") { HomeProjectPreferences.isVisible = false }
@@ -311,7 +344,15 @@ struct TabFocusedProjectRow: View {
 
     @ViewBuilder
     private var actions: some View {
-        TabFocusedTabActions(project: project, worktree: worktree)
+        if project.isRemoteMac {
+            if let remotePresentation, let remoteActions, let area = remotePresentation.focusedArea {
+                SidebarActionButton(symbol: "plus", label: "New Terminal Tab") {
+                    remoteActions.createTab(area.id)
+                }
+            }
+        } else {
+            TabFocusedTabActions(project: project, worktree: worktree)
+        }
         if !isWorktreeRow, !project.isHome, !isFocused {
             focusModeButton
         }
@@ -340,6 +381,12 @@ struct TabFocusedProjectRow: View {
     }
 
     private func activateProjectIfNeeded() {
+        guard !project.isRemoteMac else {
+            if !isActive {
+                Task { await remoteMacWorkspace.selectPresentedProject(project.id) }
+            }
+            return
+        }
         guard !isActive else { return }
         worktreeStore.ensurePrimary(for: project)
         guard let target = worktreeStore.preferred(
@@ -384,14 +431,26 @@ struct TabFocusedProjectRow: View {
 
     private func toggle() {
         withAnimation(.easeInOut(duration: 0.15)) {
-            expansionStore.set(rowID, expanded: !isExpanded)
+            setExpanded(!isExpanded)
         }
     }
 
     private func applyDefaultExpansion() {
+        if project.isRemoteMac {
+            remoteExpanded = isActive
+            return
+        }
         let key = TabFocusedSidebarPreferences.projectExpandedKey(rowID)
         guard UserDefaults.standard.object(forKey: key) == nil, isActive, !isExpanded else { return }
         expansionStore.set(rowID, expanded: true)
+    }
+
+    private func setExpanded(_ expanded: Bool) {
+        if project.isRemoteMac {
+            remoteExpanded = expanded
+            return
+        }
+        expansionStore.set(rowID, expanded: expanded)
     }
 
     private func checkGitRepo() async {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -5,6 +5,7 @@ struct TabFocusedSidebar: View {
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
+    @Environment(RemoteMacWorkspaceStore.self) private var remoteMacWorkspace
     @State private var expansionStore = TabFocusedSidebarState.shared
     @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
     @AppStorage(ProjectSortMode.storageKey) private var sortModeRaw = ProjectSortMode.defaultValue.rawValue
@@ -14,6 +15,7 @@ struct TabFocusedSidebar: View {
     }
 
     private var homeProject: Project? {
+        guard remoteMacWorkspace.activeDeviceID == nil else { return nil }
         guard showHomeProject else { return nil }
         guard !projectGroupStore.isRemoteWorkspaceActive else {
             return projectGroupStore.activeRemoteHomeProject
@@ -22,12 +24,16 @@ struct TabFocusedSidebar: View {
     }
 
     private var projects: [Project] {
-        let stored = projectGroupStore.displayProjects(localProjects: projectStore.storedProjects, sortMode: sortMode)
+        let stored = if remoteMacWorkspace.activeDeviceID != nil {
+            remoteMacWorkspace.presentedProjects
+        } else {
+            projectGroupStore.displayProjects(localProjects: projectStore.storedProjects, sortMode: sortMode)
+        }
         let all = homeProject.map { [$0] + stored } ?? stored
         return TabFocusedSidebarProjectSelection.resolve(
             projects: all,
             focusMode: expansionStore.focusMode,
-            activeProjectID: appState.activeProjectID
+            activeProjectID: remoteMacWorkspace.presentedProject?.id ?? appState.activeProjectID
         )
     }
 
@@ -45,6 +51,13 @@ struct TabFocusedSidebar: View {
     }
 
     private var shortcutNumbers: [UUID: Int] {
+        if let presentation = remoteMacWorkspace.presentedWorkspace {
+            var map: [UUID: Int] = [:]
+            for (index, tab) in presentation.root.allAreas().flatMap(\.tabs).prefix(9).enumerated() {
+                map[tab.id] = index + 1
+            }
+            return map
+        }
         let entries = TabFocusedTabOrder.entries(
             appState: appState,
             projectStore: projectStore,
@@ -59,6 +72,10 @@ struct TabFocusedSidebar: View {
     }
 
     var body: some View {
+        localSidebar
+    }
+
+    private var localSidebar: some View {
         let numbers = shortcutNumbers
         return VStack(spacing: 0) {
             ScrollView {
@@ -67,10 +84,16 @@ struct TabFocusedSidebar: View {
                         TabFocusedProjectRow(
                             project: row.project,
                             worktree: row.worktree,
-                            shortcutNumbers: numbers
+                            shortcutNumbers: numbers,
+                            remotePresentation: row.project.id == remoteMacWorkspace.presentedProject?.id
+                                ? remoteMacWorkspace.presentedWorkspace
+                                : nil,
+                            remoteActions: row.project.id == remoteMacWorkspace.presentedProject?.id
+                                ? remoteMacWorkspace.workspaceActions()
+                                : nil
                         )
                     }
-                    if !expansionStore.focusMode {
+                    if !expansionStore.focusMode, remoteMacWorkspace.activeDeviceID == nil {
                         TabFocusedAddProjectRow(action: openProjectPicker)
                     }
                 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -43,8 +43,10 @@ struct TabFocusedTabActions: View {
 
 struct TabFocusedTabsList: View {
     let project: Project
-    let worktree: Worktree
+    let worktree: Worktree?
     let shortcutNumbers: [UUID: Int]
+    var remotePresentation: RemoteWorkspacePresentation?
+    var remoteActions: WorkspaceViewActions?
 
     @Environment(AppState.self) private var appState
     @State private var dragState = TabFocusedDragState()
@@ -52,21 +54,31 @@ struct TabFocusedTabsList: View {
     private struct AreaTab: Identifiable {
         let area: TabArea
         let tab: TerminalTab
-        let worktree: Worktree
+        let worktree: Worktree?
         var id: UUID { tab.id }
     }
 
     private var worktreeKey: WorktreeKey {
-        WorktreeKey(projectID: project.id, worktreeID: worktree.id)
+        WorktreeKey(projectID: project.id, worktreeID: worktree?.id ?? UUID())
     }
 
     private var areaTabs: [AreaTab] {
-        appState.areas(for: worktreeKey).flatMap { area in
+        if let remotePresentation {
+            return remotePresentation.root.allAreas().flatMap { area in
+                area.tabs.map { AreaTab(area: area, tab: $0, worktree: nil) }
+            }
+        }
+        guard let worktree else { return [] }
+        return appState.areas(for: worktreeKey).flatMap { area in
             area.tabs.map { AreaTab(area: area, tab: $0, worktree: worktree) }
         }
     }
 
     private var activeTabID: UUID? {
+        if let remotePresentation {
+            return remotePresentation.activeTab?.id
+        }
+        guard let worktree else { return nil }
         guard appState.activeProjectID == project.id,
               appState.activeWorktreeID[project.id] == worktree.id
         else { return nil }
@@ -92,7 +104,8 @@ struct TabFocusedTabsList: View {
                 tab: item.tab,
                 active: item.tab.id == activeTabID,
                 worktree: item.worktree,
-                shortcutNumber: numbers[item.tab.id]
+                shortcutNumber: numbers[item.tab.id],
+                actions: remoteActions
             )
             .opacity(dragState.draggedID == item.tab.id ? 0.5 : 1)
             .background {
@@ -112,7 +125,8 @@ struct TabFocusedTabsList: View {
                     }
                     .onEnded { _ in
                         handleDragEnded()
-                    }
+                    },
+                including: remoteActions == nil ? .all : .none
             )
         }
     }
@@ -184,6 +198,7 @@ private struct TabFocusedTabRow: View {
     let active: Bool
     var worktree: Worktree?
     var shortcutNumber: Int?
+    var actions: WorkspaceViewActions?
 
     @Environment(AppState.self) private var appState
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -357,8 +372,10 @@ private struct TabFocusedTabRow: View {
             }
         }
         .overlay {
-            DoubleClickView { startRename() }
-                .accessibilityHidden(true)
+            if actions == nil || actions?.setCustomTitle != nil {
+                DoubleClickView { startRename() }
+                    .accessibilityHidden(true)
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(tab.title)
@@ -366,42 +383,44 @@ private struct TabFocusedTabRow: View {
         .contextMenu { contextMenu }
         .popover(isPresented: $showColorPicker, arrowEdge: .trailing) {
             ProjectIconColorPicker(title: "Tab Color", selectedID: tab.colorID) { id in
-                area.setColorID(tab.id, colorID: id)
-                appState.saveWorkspaces()
+                if let setColorID = actions?.setColorID {
+                    setColorID(area.id, tab.id, id)
+                } else {
+                    area.setColorID(tab.id, colorID: id)
+                    appState.saveWorkspaces()
+                }
                 showColorPicker = false
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .renameActiveTab)) { _ in
-            guard active else { return }
+            guard active, actions == nil || actions?.setCustomTitle != nil else { return }
             startRename()
         }
     }
 
     @ViewBuilder
     private var contextMenu: some View {
-        Button("New Tab to the Left") {
-            appState.dispatch(.createTabAdjacent(projectID: projectID, areaID: area.id, tabID: tab.id, side: .left))
+        if actions == nil || actions?.createTabAdjacent != nil {
+            Button("New Tab to the Left") { createAdjacent(.left) }
+            Button("New Tab to the Right") { createAdjacent(.right) }
+            Divider()
         }
-        Button("New Tab to the Right") {
-            appState.dispatch(.createTabAdjacent(projectID: projectID, areaID: area.id, tabID: tab.id, side: .right))
-        }
-        Divider()
-        Button("Rename Tab") { startRename() }
-        if tab.customTitle != nil {
-            Button("Reset Title") {
-                area.setCustomTitle(tab.id, title: nil)
-                appState.saveWorkspaces()
+        if actions == nil || actions?.setCustomTitle != nil {
+            Button("Rename Tab") { startRename() }
+            if tab.customTitle != nil {
+                Button("Reset Title") { setCustomTitle(nil) }
             }
         }
-        Button("Set Tab Color…") { showColorPicker = true }
-        if tab.colorID != nil {
-            Button("Reset Tab Color") {
-                area.setColorID(tab.id, colorID: nil)
-                appState.saveWorkspaces()
+        if actions == nil || actions?.setColorID != nil {
+            Button("Set Tab Color…") { showColorPicker = true }
+            if tab.colorID != nil {
+                Button("Reset Tab Color") { setColorID(nil) }
             }
         }
-        Divider()
-        Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") { area.togglePin(tab.id) }
+        if actions == nil || actions?.togglePin != nil {
+            Divider()
+            Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") { togglePin() }
+        }
         if !tab.isPinned || hasClosableSiblings {
             Divider()
             if !tab.isPinned {
@@ -524,6 +543,11 @@ private struct TabFocusedTabRow: View {
     }
 
     private func select() {
+        if let actions {
+            actions.focusArea(area.id)
+            actions.selectTab(area.id, tab.id)
+            return
+        }
         activateProjectIfNeeded()
         if let worktree, appState.activeWorktreeID[projectID] != worktree.id {
             appState.selectWorktree(projectID: projectID, worktree: worktree)
@@ -543,23 +567,39 @@ private struct TabFocusedTabRow: View {
     }
 
     private func close() {
+        if let actions {
+            actions.closeTab(area.id, tab.id)
+            return
+        }
         appState.closeTab(tab.id, areaID: area.id, projectID: projectID)
     }
 
     private func closeOthers() {
         let ids = area.tabs.filter { $0.id != tab.id && !$0.isPinned }.map(\.id)
+        if let actions {
+            ids.forEach { actions.closeTab(area.id, $0) }
+            return
+        }
         appState.closeTabs(ids, areaID: area.id, projectID: projectID)
     }
 
     private func closeLeft() {
         guard let currentIndex else { return }
         let ids = area.tabs.prefix(currentIndex).filter { !$0.isPinned }.map(\.id)
+        if let actions {
+            ids.forEach { actions.closeTab(area.id, $0) }
+            return
+        }
         appState.closeTabs(ids, areaID: area.id, projectID: projectID)
     }
 
     private func closeRight() {
         guard let currentIndex else { return }
         let ids = area.tabs.suffix(from: currentIndex + 1).filter { !$0.isPinned }.map(\.id)
+        if let actions {
+            ids.forEach { actions.closeTab(area.id, $0) }
+            return
+        }
         appState.closeTabs(ids, areaID: area.id, projectID: projectID)
     }
 
@@ -571,9 +611,42 @@ private struct TabFocusedTabRow: View {
 
     private func commitRename() {
         let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-        area.setCustomTitle(tab.id, title: trimmed.isEmpty ? nil : trimmed)
-        appState.saveWorkspaces()
+        setCustomTitle(trimmed.isEmpty ? nil : trimmed)
         isRenaming = false
+    }
+
+    private func createAdjacent(_ side: TabArea.InsertSide) {
+        if let createTabAdjacent = actions?.createTabAdjacent {
+            createTabAdjacent(area.id, tab.id, side)
+            return
+        }
+        appState.dispatch(.createTabAdjacent(projectID: projectID, areaID: area.id, tabID: tab.id, side: side))
+    }
+
+    private func setCustomTitle(_ title: String?) {
+        if let setCustomTitle = actions?.setCustomTitle {
+            setCustomTitle(area.id, tab.id, title)
+            return
+        }
+        area.setCustomTitle(tab.id, title: title)
+        appState.saveWorkspaces()
+    }
+
+    private func setColorID(_ colorID: String?) {
+        if let setColorID = actions?.setColorID {
+            setColorID(area.id, tab.id, colorID)
+            return
+        }
+        area.setColorID(tab.id, colorID: colorID)
+        appState.saveWorkspaces()
+    }
+
+    private func togglePin() {
+        if let togglePin = actions?.togglePin {
+            togglePin(area.id, tab.id)
+            return
+        }
+        area.togglePin(tab.id)
     }
 
     private func cancelRename() {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -38,6 +38,7 @@ struct MainWindow: View {
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @Environment(RemoteDeviceStore.self) private var remoteDeviceStore
+    @Environment(RemoteMacWorkspaceStore.self) private var remoteMacWorkspace
     @Environment(BrowserProfileStore.self) private var browserProfileStore
     @Environment(GhosttyService.self) private var ghostty
     @AppStorage(BrowserPreferences.enabledKey) private var browserEnabled = true
@@ -452,9 +453,20 @@ struct MainWindow: View {
             HStack(spacing: 0) {
                 ZStack {
                     MuxyTheme.bg
-                    if let project = activeProject,
-                       !appState.hasTabs(for: project.id),
-                       let worktree = resolvedActiveWorktree(for: project)
+                    if let presentation = remoteMacWorkspace.presentedWorkspace,
+                       let project = remoteMacWorkspace.presentedProject,
+                       let actions = remoteMacWorkspace.workspaceActions()
+                    {
+                        RemoteWorkspaceArea(
+                            project: project,
+                            presentation: presentation,
+                            actions: actions
+                        )
+                    } else if remoteMacWorkspace.activeDeviceID != nil {
+                        remoteWorkspaceStatus
+                    } else if let project = activeProject,
+                              !appState.hasTabs(for: project.id),
+                              let worktree = resolvedActiveWorktree(for: project)
                     {
                         EmptyProjectPlaceholder(project: project) {
                             appState.openInitialTab(projectID: project.id, worktree: worktree)
@@ -491,11 +503,12 @@ struct MainWindow: View {
             if showStatusBar {
                 ProjectStatusBar(
                     activePane: activeTerminalPane,
-                    activeWorktree: activeProject.flatMap { resolvedActiveWorktree(for: $0) },
+                    activeWorktree: activeProject.flatMap { project in
+                        project.isRemoteMac ? nil : resolvedActiveWorktree(for: project)
+                    },
                     fallbackProjectPath: activeProject.map { activeWorktreePath(for: $0) },
-                    isRemoteWorkspace: activeProject.map {
-                        projectGroupStore.workspaceContext(for: $0).isRemote
-                    } ?? false,
+                    isRemoteWorkspace: activeProject?.isRemote ?? false,
+                    supportsLocalActions: remoteMacWorkspace.activeDeviceID == nil,
                     isInteractive: activeTerminalPane != nil && !overlayAnimatingOut,
                     richInputVisible: richInputPanelVisible,
                     richInputFontSize: $richInputFontSize,
@@ -518,18 +531,42 @@ struct MainWindow: View {
         }
     }
 
+    @ViewBuilder
+    private var remoteWorkspaceStatus: some View {
+        switch remoteMacWorkspace.state {
+        case .connecting:
+            ProgressView("Connecting…")
+        case .awaitingApproval:
+            ProgressView("Approve this Mac on the remote device…")
+        case let .failed(message):
+            ContentUnavailableView(
+                "Connection Failed",
+                systemImage: "exclamationmark.triangle.fill",
+                description: Text(message)
+            )
+        case .connected:
+            if remoteMacWorkspace.projects.isEmpty {
+                ContentUnavailableView("No Projects", systemImage: "folder")
+            } else {
+                ProgressView("Loading Workspace…")
+            }
+        case .disconnected:
+            ContentUnavailableView("Disconnected", systemImage: "network.slash")
+        }
+    }
+
     private var navigationArrows: some View {
         HStack(spacing: UIMetrics.spacing1) {
             NavigationArrowButton(
                 symbol: "chevron.left",
-                isEnabled: appState.navigation.canGoBack,
+                isEnabled: remoteMacWorkspace.activeDeviceID == nil && appState.navigation.canGoBack,
                 label: "Back (\(KeyBindingStore.shared.combo(for: .navigateBack).displayString))"
             ) {
                 appState.goBack()
             }
             NavigationArrowButton(
                 symbol: "chevron.right",
-                isEnabled: appState.navigation.canGoForward,
+                isEnabled: remoteMacWorkspace.activeDeviceID == nil && appState.navigation.canGoForward,
                 label: "Forward (\(KeyBindingStore.shared.combo(for: .navigateForward).displayString))"
             ) {
                 appState.goForward()
@@ -549,8 +586,8 @@ struct MainWindow: View {
     private var topBarContent: some View {
         if showsTabsInTitleBar,
            let project = activeProject,
-           let root = appState.workspaceRoot(for: project.id),
-           case let .tabArea(area) = root
+           let titleBarWorkspace,
+           case let .tabArea(area) = titleBarWorkspace.root
         {
             PaneTabStrip(
                 areaID: area.id,
@@ -560,70 +597,52 @@ struct MainWindow: View {
                 isWindowTitleBar: true,
                 showDevelopmentBadge: AppEnvironment.isDevelopment,
                 openInIDEProjectPath: project.isRemote ? nil : activeWorktreePath(for: project),
+                showsWorkspaceControls: !project.isRemoteMac,
                 projectID: project.id,
                 onSelectTab: { tabID in
-                    appState.dispatch(.selectTab(projectID: project.id, areaID: area.id, tabID: tabID))
+                    titleBarWorkspace.actions.selectTab(area.id, tabID)
                 },
                 onCreateTab: {
-                    appState.dispatch(.createTab(projectID: project.id, areaID: area.id))
+                    titleBarWorkspace.actions.createTab(area.id)
                 },
-                onOpenBrowser: browserEnabled ? {
-                    appState.dispatch(.createBrowserTab(
-                        projectID: project.id,
-                        areaID: area.id,
-                        url: BrowserURL.homeURL,
-                        profileID: browserProfileStore.defaultProfileID
-                    ))
+                onOpenBrowser: browserEnabled ? titleBarWorkspace.actions.createBrowserTab.map { create in
+                    { create(area.id) }
                 } : nil,
                 onCloseTab: { tabID in
-                    appState.closeTab(tabID, areaID: area.id, projectID: project.id)
+                    titleBarWorkspace.actions.closeTab(area.id, tabID)
                 },
                 onCloseOtherTabs: { tabID in
                     let ids = area.tabs.filter { $0.id != tabID && !$0.isPinned }.map(\.id)
-                    appState.closeTabs(ids, areaID: area.id, projectID: project.id)
+                    ids.forEach { titleBarWorkspace.actions.closeTab(area.id, $0) }
                 },
                 onCloseTabsToLeft: { tabID in
                     guard let index = area.tabs.firstIndex(where: { $0.id == tabID }) else { return }
                     let ids = area.tabs.prefix(index).filter { !$0.isPinned }.map(\.id)
-                    appState.closeTabs(ids, areaID: area.id, projectID: project.id)
+                    ids.forEach { titleBarWorkspace.actions.closeTab(area.id, $0) }
                 },
                 onCloseTabsToRight: { tabID in
                     guard let index = area.tabs.firstIndex(where: { $0.id == tabID }) else { return }
                     let ids = area.tabs.suffix(from: index + 1).filter { !$0.isPinned }.map(\.id)
-                    appState.closeTabs(ids, areaID: area.id, projectID: project.id)
+                    ids.forEach { titleBarWorkspace.actions.closeTab(area.id, $0) }
                 },
                 onSplit: { dir in
-                    appState.dispatch(.splitArea(.init(
-                        projectID: project.id,
-                        areaID: area.id,
-                        direction: dir,
-                        position: .second
-                    )))
+                    titleBarWorkspace.actions.splitArea(area.id, dir, .second)
                 },
-                onDropAction: { result in
-                    appState.dispatch(result.action(projectID: project.id))
+                onDropAction: titleBarWorkspace.actions.dropTab,
+                onCreateTabAdjacent: titleBarWorkspace.actions.createTabAdjacent.map { create in
+                    { tabID, side in create(area.id, tabID, side) }
                 },
-                onCreateTabAdjacent: { tabID, side in
-                    appState.dispatch(.createTabAdjacent(
-                        projectID: project.id,
-                        areaID: area.id,
-                        tabID: tabID,
-                        side: side
-                    ))
+                onTogglePin: titleBarWorkspace.actions.togglePin.map { toggle in
+                    { tabID in toggle(area.id, tabID) }
                 },
-                onTogglePin: { tabID in
-                    area.togglePin(tabID)
+                onSetCustomTitle: titleBarWorkspace.actions.setCustomTitle.map { setTitle in
+                    { tabID, title in setTitle(area.id, tabID, title) }
                 },
-                onSetCustomTitle: { tabID, title in
-                    area.setCustomTitle(tabID, title: title)
-                    appState.saveWorkspaces()
+                onSetColorID: titleBarWorkspace.actions.setColorID.map { setColor in
+                    { tabID, colorID in setColor(area.id, tabID, colorID) }
                 },
-                onSetColorID: { tabID, colorID in
-                    area.setColorID(tabID, colorID: colorID)
-                    appState.saveWorkspaces()
-                },
-                onReorderTab: { fromOffsets, toOffset in
-                    area.reorderTab(fromOffsets: fromOffsets, toOffset: toOffset)
+                onReorderTab: titleBarWorkspace.actions.reorderTab.map { reorder in
+                    { source, destination in reorder(area.id, source, destination) }
                 }
             )
         } else {
@@ -666,10 +685,12 @@ struct MainWindow: View {
             if let project = activeProject {
                 if !project.isRemote {
                     OpenInIDEControl(projectPath: activeWorktreePath(for: project), projectID: project.id)
+                    LayoutPickerMenu(projectID: project.id)
                 }
-                LayoutPickerMenu(projectID: project.id)
             }
-            ExtensionTopbarItems()
+            if remoteMacWorkspace.activeDeviceID == nil {
+                ExtensionTopbarItems()
+            }
         }
         .padding(.trailing, UIMetrics.spacing2)
         .fixedSize(horizontal: true, vertical: false)
@@ -1126,16 +1147,35 @@ struct MainWindow: View {
     }
 
     private var activeProject: Project? {
+        if remoteMacWorkspace.activeDeviceID != nil {
+            return remoteMacWorkspace.presentedProject
+        }
         guard let pid = appState.activeProjectID else { return nil }
         return allActiveProjects.first { $0.id == pid }
     }
 
     private var windowTitle: String {
         guard let project = activeProject else { return "Muxy" }
-        guard let tabTitle = appState.activeTab(for: project.id)?.title,
+        let activeTab = project.isRemoteMac
+            ? remoteMacWorkspace.presentedWorkspace?.activeTab
+            : appState.activeTab(for: project.id)
+        guard let tabTitle = activeTab?.title,
               !tabTitle.isEmpty
         else { return project.name }
         return "\(project.name) — \(tabTitle)"
+    }
+
+    private var titleBarWorkspace: (root: SplitNode, actions: WorkspaceViewActions)? {
+        if remoteMacWorkspace.activeDeviceID != nil {
+            guard let presentation = remoteMacWorkspace.presentedWorkspace,
+                  let actions = remoteMacWorkspace.workspaceActions()
+            else { return nil }
+            return (presentation.root, actions)
+        }
+        guard let project = activeProject,
+              let root = appState.workspaceRoot(for: project.id)
+        else { return nil }
+        return (root, .local(projectID: project.id, appState: appState))
     }
 
     private var activeProjectWithWorkspace: Project? {
@@ -1308,6 +1348,7 @@ struct MainWindow: View {
     }
 
     private var isTerminalPaneFocused: Bool {
+        if remoteMacWorkspace.activeConnection != nil { return true }
         guard let projectID = appState.activeProjectID else { return false }
         return appState.activeTab(for: projectID)?.content.pane != nil
     }
@@ -1323,6 +1364,9 @@ struct MainWindow: View {
         if action == .toggleVoiceRecording {
             return openVoiceRecorder()
         }
+        if remoteMacWorkspace.performShortcutAction(action) {
+            return true
+        }
         return shortcutDispatcher.perform(action, activeProject: activeProject)
     }
 
@@ -1336,6 +1380,7 @@ struct MainWindow: View {
     }
 
     private func handleCommandShortcut(_ shortcut: CommandShortcut) -> Bool {
+        guard remoteMacWorkspace.activeDeviceID == nil else { return true }
         guard let projectID = appState.activeProjectID,
               appState.workspaceRoot(for: projectID) != nil,
               !shortcut.trimmedCommand.isEmpty
@@ -1345,6 +1390,7 @@ struct MainWindow: View {
     }
 
     private func handleExtensionShortcut(_ shortcut: ExtensionShortcut) -> Bool {
+        guard remoteMacWorkspace.activeDeviceID == nil else { return true }
         if shortcut.source == .runtime {
             ExtensionStore.shared.triggerRuntimeShortcut(
                 extensionID: shortcut.extensionID,
@@ -1560,6 +1606,9 @@ struct MainWindow: View {
 
     private var activeTerminalPane: TerminalPaneState? {
         guard let project = activeProject else { return nil }
+        if project.isRemoteMac {
+            return remoteMacWorkspace.presentedWorkspace?.activeTab?.content.pane
+        }
         return appState.activeTab(for: project.id)?.content.pane
     }
 

--- a/Muxy/Views/Settings/BackupSettingsView.swift
+++ b/Muxy/Views/Settings/BackupSettingsView.swift
@@ -5,7 +5,7 @@ import UniformTypeIdentifiers
 struct BackupSettingsView: View {
     private static let exportFooter = """
     Saves your settings, projects, remote devices, shortcuts and customizations to a single .muxy file. \
-    Credentials such as SSH keys, passwords and paired mobile devices are never included.
+    Credentials such as SSH keys, passwords and paired remote-access devices are never included.
     """
 
     private static let importFooter = """

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MuxyShared
 import Network
 import SwiftUI
 
@@ -22,12 +23,22 @@ struct MobileSettingsView: View {
     @State private var selectedNetwork: MobilePairingNetwork = .local
     @State private var pathMonitor: NWPathMonitor?
 
-    private var enabledBinding: Binding<Bool> {
+    private var mobileEnabledBinding: Binding<Bool> {
         Binding(
-            get: { service.isEnabled },
+            get: { service.allowsMobileConnections },
             set: { newValue in
                 if newValue, !commitPort() { return }
-                service.setEnabled(newValue)
+                service.setMobileConnectionsEnabled(newValue)
+            }
+        )
+    }
+
+    private var desktopEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { service.allowsDesktopConnections },
+            set: { newValue in
+                if newValue, !commitPort() { return }
+                service.setDesktopConnectionsEnabled(newValue)
             }
         )
     }
@@ -35,10 +46,11 @@ struct MobileSettingsView: View {
     var body: some View {
         SettingsContainer {
             SettingsSection(
-                "Mobile",
-                footer: "Muxy listens on the configured port for the iOS app over your local network or a private VPN such as Tailscale."
+                "Remote Access",
+                footer: "Muxy listens on the configured port over your trusted local network or a private VPN such as Tailscale."
             ) {
-                SettingsToggleRow(label: "Allow mobile device connections", isOn: enabledBinding)
+                SettingsToggleRow(label: "Allow mobile device connections", isOn: mobileEnabledBinding)
+                SettingsToggleRow(label: "Allow desktop connections", isOn: desktopEnabledBinding)
 
                 SettingsRow("Port") {
                     TextField("\(MobileServerService.defaultPort)", text: $portText)
@@ -48,7 +60,7 @@ struct MobileSettingsView: View {
                             guard portText != String(service.port) else { return }
                             portValidationError = nil
                             if service.isEnabled {
-                                service.setEnabled(false)
+                                service.disableAllConnections()
                             }
                         }
                         .onSubmit { _ = commitPort() }
@@ -74,7 +86,7 @@ struct MobileSettingsView: View {
                 }
             }
 
-            if service.isEnabled, let selectedHost, let uri = pairingURI(for: selectedHost) {
+            if service.allowsMobileConnections, let selectedHost, let uri = pairingURI(for: selectedHost) {
                 SettingsSection(
                     "Pair Mobile Device",
                     footer: Self.pairingFooter
@@ -358,7 +370,7 @@ struct MobileSettingsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(device.name)
                     .font(.system(size: SettingsMetrics.labelFontSize))
-                Text(lastSeenText(device))
+                Text("\(device.clientKind.displayName) · \(lastSeenText(device))")
                     .font(.system(size: SettingsMetrics.footnoteFontSize))
                     .foregroundStyle(SettingsStyle.mutedForeground)
             }
@@ -391,5 +403,14 @@ struct MobileSettingsView: View {
             return "Last seen \(formatter.localizedString(for: seen, relativeTo: Date()))"
         }
         return "Approved \(formatter.localizedString(for: device.approvedAt, relativeTo: Date()))"
+    }
+}
+
+private extension RemoteClientKindDTO {
+    var displayName: String {
+        switch self {
+        case .mobile: "Mobile"
+        case .desktop: "Mac"
+        }
     }
 }

--- a/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
+++ b/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
@@ -5,13 +5,15 @@ struct RemoteDevicesSettingsView: View {
     @Environment(RemoteDeviceStore.self) private var deviceStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @Environment(SSHConnectionService.self) private var sshConnections
+    @Environment(RemoteMacWorkspaceStore.self) private var remoteMacWorkspace
 
-    @State private var editorMode: RemoteDeviceEditorMode?
+    @State private var sshEditorMode: RemoteDeviceEditorMode?
+    @State private var remoteMacEditorMode: RemoteMacDeviceEditorMode?
     @State private var devicePendingDelete: RemoteDevice?
 
     private static let footerText = """
-    Remote devices are reusable SSH connections. Workspaces connect through a device, \
-    so you can reuse the same server without re-entering its details.
+    SSH devices provide remote shells. Muxy Macs expose their projects and live terminal workspaces. \
+    Connect only over a trusted local network or VPN.
     """
 
     var body: some View {
@@ -26,8 +28,8 @@ struct RemoteDevicesSettingsView: View {
                     ForEach(deviceStore.devices) { device in
                         RemoteDeviceRow(
                             device: device,
-                            connectionState: sshConnections.state(for: device.destination),
-                            onEdit: { editorMode = .edit(device) },
+                            connectionState: connectionState(for: device),
+                            onEdit: { edit(device) },
                             onDelete: { devicePendingDelete = device }
                         )
                     }
@@ -35,14 +37,24 @@ struct RemoteDevicesSettingsView: View {
                 addButton
             }
         }
-        .sheet(item: $editorMode) { mode in
+        .sheet(item: $sshEditorMode) { mode in
             RemoteDeviceEditorSheet(
                 mode: mode,
                 onSave: { name, ssh in
                     save(mode: mode, name: name, ssh: ssh)
-                    editorMode = nil
+                    sshEditorMode = nil
                 },
-                onCancel: { editorMode = nil }
+                onCancel: { sshEditorMode = nil }
+            )
+        }
+        .sheet(item: $remoteMacEditorMode) { mode in
+            RemoteMacDeviceEditorSheet(
+                mode: mode,
+                onSave: { id, name, connection in
+                    saveRemoteMac(mode: mode, id: id, name: name, connection: connection)
+                    remoteMacEditorMode = nil
+                },
+                onCancel: { remoteMacEditorMode = nil }
             )
         }
         .alert(
@@ -73,8 +85,17 @@ struct RemoteDevicesSettingsView: View {
     }
 
     private var addButton: some View {
-        Button {
-            editorMode = .create
+        Menu {
+            Button {
+                remoteMacEditorMode = .create
+            } label: {
+                Label("Muxy Mac", systemImage: "desktopcomputer")
+            }
+            Button {
+                sshEditorMode = .create
+            } label: {
+                Label("SSH Server", systemImage: "network")
+            }
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "plus")
@@ -88,6 +109,7 @@ struct RemoteDevicesSettingsView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .menuIndicator(.hidden)
     }
 
     private var deleteAlertBinding: Binding<Bool> {
@@ -98,6 +120,9 @@ struct RemoteDevicesSettingsView: View {
     }
 
     private func deleteMessage(for device: RemoteDevice) -> String {
+        if device.kind == .muxy {
+            return "This removes the saved connection and credentials from this Mac. Revoke it separately on the host Mac."
+        }
         let names = projectGroupStore.workspaceNames(usingDevice: device.id)
         guard !names.isEmpty else {
             return "This device is not used by any workspace."
@@ -118,15 +143,57 @@ struct RemoteDevicesSettingsView: View {
         }
     }
 
+    private func saveRemoteMac(
+        mode: RemoteMacDeviceEditorMode,
+        id: UUID,
+        name: String,
+        connection: MuxyRemoteServerData
+    ) {
+        let wasActive = remoteMacWorkspace.activeDeviceID == id
+        let device = deviceStore.add(id: id, name: name, muxy: connection)
+        let previousScope = mode.existingCredentialScope
+        let retiredScope = previousScope == connection.credentialScope ? nil : previousScope
+        remoteMacWorkspace.resetConnection(for: id, retiringCredentialScope: retiredScope)
+        if wasActive {
+            Task { await remoteMacWorkspace.activate(device) }
+        }
+    }
+
+    private func edit(_ device: RemoteDevice) {
+        switch device.kind {
+        case .ssh:
+            sshEditorMode = .edit(device)
+        case .muxy:
+            remoteMacEditorMode = .edit(device)
+        }
+    }
+
+    private func connectionState(for device: RemoteDevice) -> RemoteDeviceConnectionDisplayState {
+        switch device.kind {
+        case .ssh:
+            .ssh(sshConnections.state(for: device.destination))
+        case .muxy:
+            .muxy(remoteMacWorkspace.connectionState(for: device.id))
+        }
+    }
+
     private func deleteDevice(_ device: RemoteDevice) {
         projectGroupStore.removeWorkspaces(usingDevice: device.id)
+        if device.kind == .muxy {
+            remoteMacWorkspace.removeDevice(device.id)
+        }
         deviceStore.remove(id: device.id)
     }
 }
 
+private enum RemoteDeviceConnectionDisplayState {
+    case ssh(SSHConnectionState)
+    case muxy(RemoteMacConnectionState)
+}
+
 private struct RemoteDeviceRow: View {
     let device: RemoteDevice
-    let connectionState: SSHConnectionState
+    let connectionState: RemoteDeviceConnectionDisplayState
     let onEdit: () -> Void
     let onDelete: () -> Void
 
@@ -139,7 +206,7 @@ private struct RemoteDeviceRow: View {
                 Text(device.displayName)
                     .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
                     .foregroundStyle(SettingsStyle.foreground)
-                Text(device.destination.target)
+                Text(connectionDetails)
                     .font(.system(size: SettingsMetrics.footnoteFontSize))
                     .foregroundStyle(SettingsStyle.mutedForeground)
             }
@@ -169,15 +236,29 @@ private struct RemoteDeviceRow: View {
     @ViewBuilder
     private var connectionDot: some View {
         switch connectionState {
-        case .testing,
-             .connecting:
+        case .ssh(.testing),
+             .ssh(.connecting),
+             .muxy(.connecting),
+             .muxy(.awaitingApproval):
             ProgressView().controlSize(.mini)
-        case .connected:
+        case .ssh(.connected),
+             .muxy(.connected):
             Circle().fill(.green).frame(width: 6, height: 6)
-        case .failed:
+        case .ssh(.failed),
+             .muxy(.failed):
             Circle().fill(SettingsStyle.warning).frame(width: 6, height: 6)
-        case .disconnected:
+        case .ssh(.disconnected),
+             .muxy(.disconnected):
             Circle().fill(SettingsStyle.mutedForeground.opacity(0.4)).frame(width: 6, height: 6)
+        }
+    }
+
+    private var connectionDetails: String {
+        switch device.kind {
+        case .ssh:
+            device.destination.target
+        case .muxy:
+            device.muxy?.displayAddress ?? "Invalid address"
         }
     }
 }

--- a/Muxy/Views/Settings/RemoteMacDeviceEditorSheet.swift
+++ b/Muxy/Views/Settings/RemoteMacDeviceEditorSheet.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+
+enum RemoteMacDeviceEditorMode: Identifiable {
+    case create
+    case edit(RemoteDevice)
+
+    var id: String {
+        switch self {
+        case .create: "remote-mac-create"
+        case let .edit(device): "remote-mac-edit-\(device.id.uuidString)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .create: "Connect to Muxy Mac"
+        case .edit: "Edit Muxy Mac"
+        }
+    }
+
+    var existingDeviceID: UUID? {
+        switch self {
+        case .create: nil
+        case let .edit(device): device.id
+        }
+    }
+
+    var existingCredentialScope: String? {
+        switch self {
+        case .create: nil
+        case let .edit(device): device.muxy?.credentialScope
+        }
+    }
+}
+
+struct RemoteMacDeviceEditorSheet: View {
+    let mode: RemoteMacDeviceEditorMode
+    let onSave: (_ id: UUID, _ name: String, _ connection: MuxyRemoteServerData) -> Void
+    let onCancel: () -> Void
+
+    @Environment(RemoteMacWorkspaceStore.self) private var workspaceStore
+    @State private var deviceID: UUID
+    @State private var discovery = RemoteMacDiscovery()
+    @State private var name = ""
+    @State private var host = ""
+    @State private var port = "4865"
+    @State private var serviceName: String?
+    @State private var isConnecting = false
+    @State private var connectionTask: Task<Void, Never>?
+    @State private var didSave = false
+    @State private var pendingCredentialScope: String?
+    @State private var errorMessage: String?
+    @FocusState private var hostFocused: Bool
+
+    private var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedHost: String { host.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var parsedPort: UInt16? { UInt16(port) }
+    private var canConnect: Bool {
+        !trimmedName.isEmpty && MuxyRemoteServerData.isValidHost(trimmedHost) && parsedPort != nil && !isConnecting
+    }
+
+    init(
+        mode: RemoteMacDeviceEditorMode,
+        onSave: @escaping (_ id: UUID, _ name: String, _ connection: MuxyRemoteServerData) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.mode = mode
+        self.onSave = onSave
+        self.onCancel = onCancel
+        _deviceID = State(initialValue: mode.existingDeviceID ?? UUID())
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+            Text(mode.title)
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+
+            if !discovery.devices.isEmpty {
+                discoveredDevices
+            }
+
+            VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
+                field("Name", placeholder: "Studio Mac", text: $name)
+                field("Host", placeholder: "mac.local or 192.168.1.10", text: $host)
+                    .focused($hostFocused)
+                field("Port", placeholder: "4865", text: $port)
+            }
+
+            Text("The first connection asks for approval on the remote Mac. Use a trusted network or VPN.")
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fgMuted)
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: UIMetrics.fontFootnote))
+                    .foregroundStyle(.orange)
+            }
+
+            HStack(spacing: UIMetrics.spacing3) {
+                Spacer()
+                Button("Cancel") {
+                    cancel()
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+                .disabled(isConnecting)
+                Button {
+                    connect()
+                } label: {
+                    if isConnecting {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Connect")
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canConnect)
+            }
+        }
+        .padding(UIMetrics.spacing8)
+        .frame(width: UIMetrics.scaled(460))
+        .onAppear {
+            loadInitialValues()
+            discovery.start()
+            hostFocused = host.isEmpty
+        }
+        .onDisappear {
+            discovery.stop()
+            cancel()
+        }
+    }
+
+    private var discoveredDevices: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
+            Text("Nearby Macs")
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+            ForEach(discovery.devices) { device in
+                Button {
+                    name = device.name
+                    host = device.host
+                    port = String(device.port)
+                    serviceName = device.name
+                } label: {
+                    HStack {
+                        Image(systemName: "desktopcomputer")
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(device.name)
+                            Text("\(device.host):\(device.port)")
+                                .font(.system(size: UIMetrics.fontCaption))
+                                .foregroundStyle(MuxyTheme.fgMuted)
+                        }
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(UIMetrics.spacing3)
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+            }
+        }
+    }
+
+    private func field(_ label: String, placeholder: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
+            Text(label)
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fgMuted)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private func loadInitialValues() {
+        guard case let .edit(device) = mode, let connection = device.muxy else { return }
+        name = device.name
+        host = connection.host
+        port = String(connection.port)
+        serviceName = connection.serviceName
+    }
+
+    private func connect() {
+        guard let parsedPort, connectionTask == nil else { return }
+        let connection = MuxyRemoteServerData(host: trimmedHost, port: parsedPort, serviceName: serviceName)
+        let device = RemoteDevice(id: deviceID, name: trimmedName, muxy: connection)
+        pendingCredentialScope = connection.credentialScope
+        isConnecting = true
+        errorMessage = nil
+        connectionTask = Task {
+            defer {
+                connectionTask = nil
+                isConnecting = false
+            }
+            do {
+                try Task.checkCancellation()
+                try await workspaceStore.connectForSetup(device)
+                try Task.checkCancellation()
+                didSave = true
+                onSave(device.id, device.name, connection)
+            } catch {
+                guard !Task.isCancelled else { return }
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func cancel() {
+        connectionTask?.cancel()
+        connectionTask = nil
+        let discardCredentialScope: String? = if didSave || pendingCredentialScope == mode.existingCredentialScope {
+            nil
+        } else {
+            pendingCredentialScope
+        }
+        workspaceStore.cancelSetup(for: deviceID, discardCredentialScope: discardCredentialScope)
+    }
+}

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -34,7 +34,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .ai: "AI"
         case .voice: "Voice"
         case .notifications: "Notifications"
-        case .mobile: "Mobile"
+        case .mobile: "Remote Access"
         case .backup: "Backup"
         case .json: "JSON"
         }
@@ -54,7 +54,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .ai: "sparkles"
         case .voice: "mic"
         case .notifications: "bell"
-        case .mobile: "iphone"
+        case .mobile: "network"
         case .backup: "externaldrive"
         case .json: "curlybraces"
         }
@@ -210,10 +210,10 @@ enum SettingsCatalog {
         SettingsCatalogItem(
             key: "muxy.remoteDevices.manage",
             title: "Remote Devices",
-            description: "Adds and manages reusable SSH connections used by remote workspaces.",
+            description: "Adds and manages SSH servers and Muxy Macs used by remote workspaces.",
             category: .remoteDevices,
             section: "Remote Devices",
-            aliases: ["ssh", "server", "host", "remote", "connection", "device"]
+            aliases: ["ssh", "server", "host", "remote", "connection", "device", "mac"]
         ),
         SettingsCatalogItem(
             key: ProjectPickerDefaultLocation.storageKey,
@@ -546,15 +546,23 @@ enum SettingsCatalog {
             title: "Allow Mobile Connections",
             description: "Allows mobile devices to connect to this Mac.",
             category: .mobile,
-            section: "Mobile",
+            section: "Remote Access",
+            defaultValue: false
+        ),
+        SettingsCatalogItem(
+            key: MobileServerService.desktopEnabledKey,
+            title: "Allow Desktop Connections",
+            description: "Allows other Muxy Macs to connect to this Mac.",
+            category: .mobile,
+            section: "Remote Access",
             defaultValue: false
         ),
         SettingsCatalogItem(
             key: MobileServerService.portKey,
-            title: "Mobile Port",
-            description: "Controls the local server port for mobile pairing.",
+            title: "Remote Access Port",
+            description: "Controls the local server port for remote clients.",
             category: .mobile,
-            section: "Mobile",
+            section: "Remote Access",
             defaultValue: MobileServerService.defaultPort
         ),
         SettingsCatalogItem(
@@ -567,7 +575,7 @@ enum SettingsCatalog {
         SettingsCatalogItem(
             key: "mobile.approvedDevices",
             title: "Approved Devices",
-            description: "Manages mobile devices that can connect.",
+            description: "Manages mobile devices and Macs that can connect.",
             category: .mobile,
             section: "Approved Devices"
         ),

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -10,6 +10,7 @@ struct ProjectStatusBar: View {
     let activeWorktree: Worktree?
     let fallbackProjectPath: String?
     let isRemoteWorkspace: Bool
+    let supportsLocalActions: Bool
     let isInteractive: Bool
     let richInputVisible: Bool
     @Binding var richInputFontSize: Double
@@ -53,37 +54,41 @@ struct ProjectStatusBar: View {
                 pathButton(statusContext.path)
                 separator
             }
-            RepositoryStatusBarItems()
-            ForEach(extensionStore.statusBarItems(side: .left)) { binding in
-                extensionItem(binding: binding)
-                separator
+            if supportsLocalActions {
+                RepositoryStatusBarItems()
+                ForEach(extensionStore.statusBarItems(side: .left)) { binding in
+                    extensionItem(binding: binding)
+                    separator
+                }
             }
         }
     }
 
     private var rightSide: some View {
         HStack(spacing: 8) {
-            separator
-            extensionOutputChip
-            ForEach(extensionStore.statusBarItems(side: .right)) { binding in
+            if supportsLocalActions {
                 separator
-                extensionItem(binding: binding)
-            }
-            if richInputVisible {
-                separator
-                zoomControls
-                separator
-                shortcutHints
-            }
-            if activePane != nil {
-                separator
-                richInputToggleButton
-                separator
-                voiceRecordingButton
-            }
-            if showResourceUsage {
-                separator
-                ResourceUsageButton()
+                extensionOutputChip
+                ForEach(extensionStore.statusBarItems(side: .right)) { binding in
+                    separator
+                    extensionItem(binding: binding)
+                }
+                if richInputVisible {
+                    separator
+                    zoomControls
+                    separator
+                    shortcutHints
+                }
+                if activePane != nil {
+                    separator
+                    richInputToggleButton
+                    separator
+                    voiceRecordingButton
+                }
+                if showResourceUsage {
+                    separator
+                    ResourceUsageButton()
+                }
             }
         }
     }

--- a/Muxy/Views/Terminal/RemoteTerminalBridge.swift
+++ b/Muxy/Views/Terminal/RemoteTerminalBridge.swift
@@ -1,0 +1,337 @@
+import AppKit
+import MuxyShared
+import SwiftTerm
+import SwiftUI
+
+struct RemoteTerminalBridge: View {
+    let paneID: UUID
+    let focused: Bool
+    let visible: Bool
+    let onFocus: () -> Void
+
+    @Environment(RemoteMacWorkspaceStore.self) private var workspaceStore
+
+    @State private var size: (cols: UInt32, rows: UInt32)?
+    @State private var isTakingOver = false
+    @State private var didAttemptTakeover = false
+
+    private var connection: RemoteMacConnection? { workspaceStore.activeConnection }
+
+    private var ownsPane: Bool { connection?.isPaneOwnedByThisMac(paneID) == true }
+
+    var body: some View {
+        ZStack {
+            if let connection, visible {
+                RemoteMacTerminalRepresentable(
+                    connection: connection,
+                    paneID: paneID,
+                    focused: focused,
+                    onFocus: onFocus,
+                    onSize: handleSize
+                )
+                .opacity(ownsPane ? 1 : 0.01)
+                .allowsHitTesting(ownsPane)
+            }
+
+            if visible, !ownsPane {
+                takeoverOverlay
+            }
+        }
+        .background(themeColor(connection?.deviceTheme?.bg ?? 0x000000))
+        .contentShape(Rectangle())
+        .onDisappear {
+            releasePane()
+        }
+        .onChange(of: paneID) { previousPaneID, _ in
+            if let connection {
+                Task { await connection.releasePane(paneID: previousPaneID) }
+            }
+            didAttemptTakeover = false
+            attemptTakeover()
+        }
+        .onChange(of: visible) { _, isVisible in
+            guard isVisible else {
+                releasePane()
+                return
+            }
+            didAttemptTakeover = false
+            attemptTakeover()
+        }
+    }
+
+    private var takeoverOverlay: some View {
+        VStack(spacing: UIMetrics.spacing4) {
+            if isTakingOver {
+                ProgressView().controlSize(.small)
+                Text("Connecting terminal…")
+                    .font(.system(size: UIMetrics.fontFootnote))
+            } else {
+                Image(systemName: "desktopcomputer")
+                    .font(.system(size: UIMetrics.iconXL))
+                Text(ownerMessage)
+                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                Button("Take Over", action: takeOver)
+            }
+        }
+        .foregroundStyle(themeColor(connection?.deviceTheme?.fg ?? 0xFFFFFF))
+        .padding(UIMetrics.spacing6)
+    }
+
+    private var ownerMessage: String {
+        guard let owner = connection?.paneOwners[paneID] else { return "Terminal is available" }
+        return "Controlled on \(owner.displayName)"
+    }
+
+    private func handleSize(_ cols: UInt32, _ rows: UInt32) {
+        size = (cols, rows)
+        attemptTakeover()
+    }
+
+    private func attemptTakeover() {
+        guard visible, !didAttemptTakeover, size != nil else { return }
+        didAttemptTakeover = true
+        takeOver()
+    }
+
+    private func takeOver() {
+        guard visible, let size, let connection else { return }
+        isTakingOver = true
+        let takeoverTask = connection.takeOverPane(paneID: paneID, cols: size.cols, rows: size.rows)
+        Task {
+            do {
+                try await takeoverTask.value
+            } catch {
+                ToastState.shared.show(error.localizedDescription)
+            }
+            isTakingOver = false
+        }
+    }
+
+    private func releasePane() {
+        guard let connection else { return }
+        Task { await connection.releasePane(paneID: paneID) }
+    }
+
+    private func themeColor(_ rgb: UInt32) -> SwiftUI.Color {
+        SwiftUI.Color(
+            red: Double((rgb >> 16) & 0xFF) / 255,
+            green: Double((rgb >> 8) & 0xFF) / 255,
+            blue: Double(rgb & 0xFF) / 255
+        )
+    }
+}
+
+private struct RemoteMacTerminalRepresentable: NSViewRepresentable {
+    let connection: RemoteMacConnection
+    let paneID: UUID
+    let focused: Bool
+    let onFocus: () -> Void
+    let onSize: (UInt32, UInt32) -> Void
+
+    func makeNSView(context: Context) -> RemoteSwiftTermView {
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        let view = RemoteSwiftTermView(frame: .zero, font: font)
+        view.terminalDelegate = context.coordinator
+        view.backspaceSendsControlH = false
+        view.allowMouseReporting = true
+        view.onFocus = onFocus
+        context.coordinator.bind(
+            view: view,
+            connection: connection,
+            paneID: paneID,
+            onSize: onSize
+        )
+        view.apply(theme: connection.deviceTheme)
+        updateFocus(view)
+        return view
+    }
+
+    func updateNSView(_ view: RemoteSwiftTermView, context: Context) {
+        context.coordinator.update(
+            view: view,
+            connection: connection,
+            paneID: paneID,
+            onSize: onSize
+        )
+        view.onFocus = onFocus
+        view.apply(theme: connection.deviceTheme)
+        updateFocus(view)
+    }
+
+    static func dismantleNSView(_: RemoteSwiftTermView, coordinator: Coordinator) {
+        coordinator.unbind()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    private func updateFocus(_ view: RemoteSwiftTermView) {
+        guard focused else { return }
+        DispatchQueue.main.async { [weak view] in
+            view?.window?.makeFirstResponder(view)
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, TerminalViewDelegate {
+        weak var view: RemoteSwiftTermView?
+        weak var connection: RemoteMacConnection?
+        private var paneID: UUID?
+        private var observerID: UUID?
+        private var onSize: ((UInt32, UInt32) -> Void)?
+        private var lastSize: (Int, Int)?
+        private var resizeTask: Task<Void, Never>?
+
+        func bind(
+            view: RemoteSwiftTermView,
+            connection: RemoteMacConnection,
+            paneID: UUID,
+            onSize: @escaping (UInt32, UInt32) -> Void
+        ) {
+            self.view = view
+            self.connection = connection
+            self.paneID = paneID
+            self.onSize = onSize
+            subscribe()
+        }
+
+        func update(
+            view: RemoteSwiftTermView,
+            connection: RemoteMacConnection,
+            paneID: UUID,
+            onSize: @escaping (UInt32, UInt32) -> Void
+        ) {
+            self.onSize = onSize
+            guard self.connection !== connection || self.paneID != paneID else { return }
+            unbind()
+            view.getTerminal().resetToInitialState()
+            bind(view: view, connection: connection, paneID: paneID, onSize: onSize)
+        }
+
+        func unbind() {
+            resizeTask?.cancel()
+            resizeTask = nil
+            if let observerID {
+                connection?.removeEventObserver(observerID)
+            }
+            observerID = nil
+            view = nil
+            connection = nil
+            paneID = nil
+            onSize = nil
+            lastSize = nil
+        }
+
+        private func subscribe() {
+            guard let connection else { return }
+            observerID = connection.addEventObserver { [weak self] event in
+                guard let self, let view, let paneID else { return }
+                let output: TerminalOutputEventDTO? = switch event.data {
+                case let .terminalOutput(value):
+                    value
+                case let .terminalSnapshot(value):
+                    value
+                default:
+                    nil
+                }
+                guard let output, output.paneID == paneID else { return }
+                view.feed(byteArray: [UInt8](output.bytes)[...])
+            }
+        }
+
+        nonisolated func send(source _: SwiftTerm.TerminalView, data: ArraySlice<UInt8>) {
+            MainActor.assumeIsolated {
+                guard let connection, let paneID else { return }
+                connection.sendTerminalInput(paneID: paneID, bytes: Data(data))
+            }
+        }
+
+        nonisolated func sizeChanged(source _: SwiftTerm.TerminalView, newCols: Int, newRows: Int) {
+            MainActor.assumeIsolated {
+                guard newCols > 0, newRows > 0 else { return }
+                if let lastSize, lastSize.0 == newCols, lastSize.1 == newRows { return }
+                lastSize = (newCols, newRows)
+                let cols = UInt32(newCols)
+                let rows = UInt32(newRows)
+                onSize?(cols, rows)
+                resizeTask?.cancel()
+                resizeTask = Task { @MainActor [weak self] in
+                    try? await Task.sleep(for: .milliseconds(100))
+                    guard !Task.isCancelled, let self, let connection, let paneID else { return }
+                    try? await connection.resizeTerminal(paneID: paneID, cols: cols, rows: rows)
+                }
+            }
+        }
+
+        nonisolated func setTerminalTitle(source _: SwiftTerm.TerminalView, title _: String) {}
+        nonisolated func hostCurrentDirectoryUpdate(source _: SwiftTerm.TerminalView, directory _: String?) {}
+        nonisolated func scrolled(source _: SwiftTerm.TerminalView, position _: Double) {}
+        nonisolated func requestOpenLink(source _: SwiftTerm.TerminalView, link: String, params _: [String: String]) {
+            guard let url = URL(string: link),
+                  let scheme = url.scheme?.lowercased(),
+                  scheme == "https" || scheme == "http"
+            else { return }
+            Task { @MainActor in NSWorkspace.shared.open(url) }
+        }
+
+        nonisolated func bell(source _: SwiftTerm.TerminalView) {}
+        nonisolated func clipboardCopy(source _: SwiftTerm.TerminalView, content _: Data) {}
+
+        nonisolated func clipboardRead(source _: SwiftTerm.TerminalView) -> Data? {
+            nil
+        }
+
+        nonisolated func iTermContent(source _: SwiftTerm.TerminalView, content _: ArraySlice<UInt8>) {}
+        nonisolated func rangeChanged(source _: SwiftTerm.TerminalView, startY _: Int, endY _: Int) {}
+    }
+}
+
+private final class RemoteSwiftTermView: SwiftTerm.TerminalView {
+    var onFocus: (() -> Void)?
+    private var appliedTheme: DeviceThemeEventDTO?
+    private var hasAppliedTheme = false
+
+    override func mouseDown(with event: NSEvent) {
+        onFocus?()
+        super.mouseDown(with: event)
+    }
+
+    func apply(theme: DeviceThemeEventDTO?) {
+        if hasAppliedTheme,
+           appliedTheme?.fg == theme?.fg,
+           appliedTheme?.bg == theme?.bg,
+           appliedTheme?.palette == theme?.palette
+        {
+            return
+        }
+        let foreground = theme?.fg ?? 0xFFFFFF
+        let background = theme?.bg ?? 0x000000
+        let terminal = getTerminal()
+        setForegroundColor(source: terminal, color: Self.swiftTermColor(foreground))
+        setBackgroundColor(source: terminal, color: Self.swiftTermColor(background))
+        if let palette = theme?.palette, palette.count == 16 {
+            installColors(palette.map(Self.swiftTermColor))
+        }
+        caretColor = Self.nsColor(foreground)
+        appliedTheme = theme
+        hasAppliedTheme = true
+    }
+
+    private static func swiftTermColor(_ rgb: UInt32) -> SwiftTerm.Color {
+        SwiftTerm.Color(
+            red: UInt16((rgb >> 16) & 0xFF) * 0x0101,
+            green: UInt16((rgb >> 8) & 0xFF) * 0x0101,
+            blue: UInt16(rgb & 0xFF) * 0x0101
+        )
+    }
+
+    private static func nsColor(_ rgb: UInt32) -> NSColor {
+        NSColor(
+            red: CGFloat((rgb >> 16) & 0xFF) / 255,
+            green: CGFloat((rgb >> 8) & 0xFF) / 255,
+            blue: CGFloat(rgb & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -14,7 +14,9 @@ struct TerminalPane: View {
     @Environment(\.overlayActive) private var overlayActive
 
     private var remoteOwnerName: String? {
-        if case let .remote(_, name) = ownership.owner(for: state.id) { name } else { nil }
+        guard state.backend == .local else { return nil }
+        guard case let .remote(_, name) = ownership.owner(for: state.id) else { return nil }
+        return name
     }
 
     private var showsSleepingPlaceholder: Bool {
@@ -43,20 +45,12 @@ struct TerminalPane: View {
 
     private var terminalLayer: some View {
         ZStack(alignment: .topTrailing) {
-            TerminalBridge(
-                state: state,
-                focused: focused,
-                visible: visible,
-                areaID: areaID,
-                onFocus: onFocus,
-                onProcessExit: onProcessExit,
-                onSplitRequest: onSplitRequest
-            )
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel("Terminal")
-            .accessibilityAddTraits(.allowsDirectInteraction)
-            .opacity(remoteOwnerName == nil ? 1 : 0)
-            .allowsHitTesting(remoteOwnerName == nil)
+            terminalContent
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Terminal")
+                .accessibilityAddTraits(.allowsDirectInteraction)
+                .opacity(remoteOwnerName == nil ? 1 : 0)
+                .allowsHitTesting(remoteOwnerName == nil)
 
             if let name = remoteOwnerName {
                 RemoteControlledPlaceholder(deviceName: name) {
@@ -91,6 +85,29 @@ struct TerminalPane: View {
                 SleepingTabPlaceholder(isFocused: focused, onWake: wakePane)
                     .transition(.opacity)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var terminalContent: some View {
+        switch state.backend {
+        case .local:
+            TerminalBridge(
+                state: state,
+                focused: focused,
+                visible: visible,
+                areaID: areaID,
+                onFocus: onFocus,
+                onProcessExit: onProcessExit,
+                onSplitRequest: onSplitRequest
+            )
+        case let .remoteMac(paneID):
+            RemoteTerminalBridge(
+                paneID: paneID,
+                focused: focused,
+                visible: visible,
+                onFocus: onFocus
+            )
         }
     }
 }

--- a/Muxy/Views/Workspace/PaneNode.swift
+++ b/Muxy/Views/Workspace/PaneNode.swift
@@ -5,16 +5,8 @@ struct PaneNode: View {
     let focusedAreaID: UUID?
     let isActiveProject: Bool
     var showTabStrip = true
-    let projectID: UUID
     let shortcutOffsets: [UUID: Int]
-    let onFocusArea: (UUID) -> Void
-    let onSelectTab: (UUID, UUID) -> Void
-    let onCreateTab: (UUID) -> Void
-    let onCloseTab: (UUID, UUID) -> Void
-    let onForceCloseTab: (UUID, UUID) -> Void
-    let onSplit: (UUID, SplitDirection) -> Void
-    let onCloseArea: (UUID) -> Void
-    let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    let actions: WorkspaceViewActions
     var showMaximizeButton = false
     var onToggleMaximize: ((UUID) -> Void)?
 
@@ -26,15 +18,9 @@ struct PaneNode: View {
                 isFocused: focusedAreaID == area.id,
                 isActiveProject: isActiveProject,
                 showTabStrip: showTabStrip,
-                projectID: projectID,
+                projectID: actions.projectID,
                 shortcutIndexOffset: shortcutOffsets[area.id] ?? 0,
-                onFocus: { onFocusArea(area.id) },
-                onSelectTab: { tabID in onSelectTab(area.id, tabID) },
-                onCreateTab: { onCreateTab(area.id) },
-                onCloseTab: { tabID in onCloseTab(area.id, tabID) },
-                onForceCloseTab: { tabID in onForceCloseTab(area.id, tabID) },
-                onSplit: { dir in onSplit(area.id, dir) },
-                onDropAction: onDropAction,
+                actions: actions,
                 showMaximizeButton: showMaximizeButton,
                 onToggleMaximize: onToggleMaximize.map { toggle in { toggle(area.id) } }
             )
@@ -43,16 +29,8 @@ struct PaneNode: View {
                 branch: branch,
                 focusedAreaID: focusedAreaID,
                 isActiveProject: isActiveProject,
-                projectID: projectID,
                 shortcutOffsets: shortcutOffsets,
-                onFocusArea: onFocusArea,
-                onSelectTab: onSelectTab,
-                onCreateTab: onCreateTab,
-                onCloseTab: onCloseTab,
-                onForceCloseTab: onForceCloseTab,
-                onSplit: onSplit,
-                onCloseArea: onCloseArea,
-                onDropAction: onDropAction,
+                actions: actions,
                 showMaximizeButton: showMaximizeButton,
                 onToggleMaximize: onToggleMaximize
             )

--- a/Muxy/Views/Workspace/SplitContainer.swift
+++ b/Muxy/Views/Workspace/SplitContainer.swift
@@ -5,16 +5,8 @@ struct SplitContainer: View {
     let branch: SplitBranch
     let focusedAreaID: UUID?
     let isActiveProject: Bool
-    let projectID: UUID
     let shortcutOffsets: [UUID: Int]
-    let onFocusArea: (UUID) -> Void
-    let onSelectTab: (UUID, UUID) -> Void
-    let onCreateTab: (UUID) -> Void
-    let onCloseTab: (UUID, UUID) -> Void
-    let onForceCloseTab: (UUID, UUID) -> Void
-    let onSplit: (UUID, SplitDirection) -> Void
-    let onCloseArea: (UUID) -> Void
-    let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    let actions: WorkspaceViewActions
     var showMaximizeButton = false
     var onToggleMaximize: ((UUID) -> Void)?
 
@@ -31,31 +23,43 @@ struct SplitContainer: View {
                 child(branch.first)
                     .frame(width: h ? first : nil, height: h ? nil : first)
 
-                AnchoredResizeHandle(
-                    axis: h ? .horizontal : .vertical,
-                    captureAnchor: { branch.ratio },
-                    onTranslate: { start, delta in
-                        guard total > 0 else { return }
-                        branch.ratio = min(max(start + delta / total, 0.15), 0.85)
-                    }
-                )
-                .accessibilityLabel(h ? "Horizontal Split Divider" : "Vertical Split Divider")
-                .accessibilityValue("Split ratio: \(Int(branch.ratio * 100))%")
-                .accessibilityAdjustableAction { direction in
-                    let step: CGFloat = 0.05
-                    switch direction {
-                    case .increment:
-                        branch.ratio = min(branch.ratio + step, 0.85)
-                    case .decrement:
-                        branch.ratio = max(branch.ratio - step, 0.15)
-                    @unknown default:
-                        break
-                    }
-                }
+                divider(horizontal: h, total: total)
 
                 child(branch.second)
                     .frame(width: h ? second : nil, height: h ? nil : second)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func divider(horizontal: Bool, total: CGFloat) -> some View {
+        if let resizeSplit = actions.resizeSplit {
+            AnchoredResizeHandle(
+                axis: horizontal ? .horizontal : .vertical,
+                captureAnchor: { branch.ratio },
+                onTranslate: { start, delta in
+                    guard total > 0 else { return }
+                    resizeSplit(branch.id, min(max(start + delta / total, 0.15), 0.85))
+                }
+            )
+            .accessibilityLabel(horizontal ? "Horizontal Split Divider" : "Vertical Split Divider")
+            .accessibilityValue("Split ratio: \(Int(branch.ratio * 100))%")
+            .accessibilityAdjustableAction { direction in
+                let step: CGFloat = 0.05
+                switch direction {
+                case .increment:
+                    resizeSplit(branch.id, min(branch.ratio + step, 0.85))
+                case .decrement:
+                    resizeSplit(branch.id, max(branch.ratio - step, 0.15))
+                @unknown default:
+                    break
+                }
+            }
+        } else {
+            Rectangle()
+                .fill(MuxyTheme.border)
+                .frame(width: horizontal ? 1 : nil, height: horizontal ? nil : 1)
+                .accessibilityHidden(true)
         }
     }
 
@@ -64,16 +68,8 @@ struct SplitContainer: View {
             node: node,
             focusedAreaID: focusedAreaID,
             isActiveProject: isActiveProject,
-            projectID: projectID,
             shortcutOffsets: shortcutOffsets,
-            onFocusArea: onFocusArea,
-            onSelectTab: onSelectTab,
-            onCreateTab: onCreateTab,
-            onCloseTab: onCloseTab,
-            onForceCloseTab: onForceCloseTab,
-            onSplit: onSplit,
-            onCloseArea: onCloseArea,
-            onDropAction: onDropAction,
+            actions: actions,
             showMaximizeButton: showMaximizeButton,
             onToggleMaximize: onToggleMaximize
         )

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -7,18 +7,11 @@ struct TabAreaView: View {
     let showTabStrip: Bool
     let projectID: UUID
     let shortcutIndexOffset: Int
-    let onFocus: () -> Void
-    let onSelectTab: (UUID) -> Void
-    let onCreateTab: () -> Void
-    let onCloseTab: (UUID) -> Void
-    let onForceCloseTab: (UUID) -> Void
-    let onSplit: (SplitDirection) -> Void
-    let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    let actions: WorkspaceViewActions
     var showMaximizeButton = false
     var isMaximized = false
     var onToggleMaximize: (() -> Void)?
     @Environment(TabDragCoordinator.self) private var dragCoordinator
-    @Environment(AppState.self) private var appState
     @AppStorage(BrowserPreferences.enabledKey) private var browserEnabled = true
     @State private var isExternalDragHovering = false
     @State private var externalDragHideTask: Task<Void, any Error>?
@@ -27,7 +20,7 @@ struct TabAreaView: View {
 
     private func closeTabs(_ tabIDs: [UUID]) {
         for tabID in tabIDs {
-            onCloseTab(tabID)
+            actions.closeTab(area.id, tabID)
         }
     }
 
@@ -41,17 +34,12 @@ struct TabAreaView: View {
                     isFocused: isFocused,
                     projectID: projectID,
                     shortcutIndexOffset: shortcutIndexOffset,
-                    onSelectTab: onSelectTab,
-                    onCreateTab: onCreateTab,
-                    onOpenBrowser: browserEnabled ? {
-                        appState.dispatch(.createBrowserTab(
-                            projectID: projectID,
-                            areaID: area.id,
-                            url: BrowserURL.homeURL,
-                            profileID: BrowserPreferences.defaultProfileID
-                        ))
+                    onSelectTab: { actions.selectTab(area.id, $0) },
+                    onCreateTab: { actions.createTab(area.id) },
+                    onOpenBrowser: browserEnabled ? actions.createBrowserTab.map { create in
+                        { create(area.id) }
                     } : nil,
-                    onCloseTab: onCloseTab,
+                    onCloseTab: { actions.closeTab(area.id, $0) },
                     onCloseOtherTabs: { tabID in
                         closeTabs(area.tabs.filter { $0.id != tabID && !$0.isPinned }.map(\.id))
                     },
@@ -63,32 +51,25 @@ struct TabAreaView: View {
                         guard let index = area.tabs.firstIndex(where: { $0.id == tabID }) else { return }
                         closeTabs(area.tabs.suffix(from: index + 1).filter { !$0.isPinned }.map(\.id))
                     },
-                    onSplit: onSplit,
-                    onDropAction: onDropAction,
+                    onSplit: { actions.splitArea(area.id, $0, .second) },
+                    onDropAction: actions.dropTab,
                     showMaximizeButton: showMaximizeButton,
                     isMaximized: isMaximized,
                     onToggleMaximize: onToggleMaximize,
-                    onCreateTabAdjacent: { tabID, side in
-                        appState.dispatch(.createTabAdjacent(
-                            projectID: projectID,
-                            areaID: area.id,
-                            tabID: tabID,
-                            side: side
-                        ))
+                    onCreateTabAdjacent: actions.createTabAdjacent.map { create in
+                        { tabID, side in create(area.id, tabID, side) }
                     },
-                    onTogglePin: { tabID in
-                        area.togglePin(tabID)
+                    onTogglePin: actions.togglePin.map { toggle in
+                        { tabID in toggle(area.id, tabID) }
                     },
-                    onSetCustomTitle: { tabID, title in
-                        area.setCustomTitle(tabID, title: title)
-                        appState.saveWorkspaces()
+                    onSetCustomTitle: actions.setCustomTitle.map { setTitle in
+                        { tabID, title in setTitle(area.id, tabID, title) }
                     },
-                    onSetColorID: { tabID, colorID in
-                        area.setColorID(tabID, colorID: colorID)
-                        appState.saveWorkspaces()
+                    onSetColorID: actions.setColorID.map { setColor in
+                        { tabID, colorID in setColor(area.id, tabID, colorID) }
                     },
-                    onReorderTab: { fromOffsets, toOffset in
-                        area.reorderTab(fromOffsets: fromOffsets, toOffset: toOffset)
+                    onReorderTab: actions.reorderTab.map { reorder in
+                        { source, destination in reorder(area.id, source, destination) }
                     }
                 )
                 Rectangle().fill(MuxyTheme.border).frame(height: 1)
@@ -102,15 +83,10 @@ struct TabAreaView: View {
                         focused: isActive && isFocused && isActiveProject,
                         visible: isActive && isActiveProject,
                         areaID: area.id,
-                        onFocus: onFocus,
-                        onProcessExit: { onForceCloseTab(tab.id) },
+                        onFocus: { actions.focusArea(area.id) },
+                        onProcessExit: { actions.forceCloseTab(area.id, tab.id) },
                         onSplitRequest: { direction, position in
-                            appState.dispatch(.splitArea(.init(
-                                projectID: projectID,
-                                areaID: area.id,
-                                direction: direction,
-                                position: position
-                            )))
+                            actions.splitArea(area.id, direction, position)
                         }
                     )
                     .zIndex(isActive ? 1 : 0)
@@ -225,6 +201,37 @@ private struct TabContentView: View {
                     .contentShape(Rectangle())
                     .onTapGesture { onFocus() }
             }
+        case let .remotePlaceholder(placeholder):
+            RemoteTabUnavailableView(placeholder: placeholder)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onFocus)
+        }
+    }
+}
+
+private struct RemoteTabUnavailableView: View {
+    let placeholder: RemoteTabPlaceholder
+
+    var body: some View {
+        VStack(spacing: UIMetrics.spacing4) {
+            Image(systemName: icon)
+                .font(.system(size: UIMetrics.iconXXL))
+            Text("\(placeholder.title) is open on the remote Mac")
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Text("This tab type cannot be streamed yet.")
+                .font(.system(size: UIMetrics.fontFootnote))
+        }
+        .foregroundStyle(MuxyTheme.fgMuted)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(MuxyTheme.bg)
+    }
+
+    private var icon: String {
+        switch placeholder.kind {
+        case .terminal: "terminal"
+        case .extensionWebView: "puzzlepiece.extension"
+        case .browser: "globe"
         }
     }
 }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -27,6 +27,7 @@ struct PaneTabStrip: View {
     var isWindowTitleBar: Bool = false
     var showDevelopmentBadge = false
     var openInIDEProjectPath: String?
+    var showsWorkspaceControls = true
     let projectID: UUID
     var shortcutIndexOffset: Int = 0
     let onSelectTab: (UUID) -> Void
@@ -37,15 +38,15 @@ struct PaneTabStrip: View {
     let onCloseTabsToLeft: (UUID) -> Void
     let onCloseTabsToRight: (UUID) -> Void
     let onSplit: (SplitDirection) -> Void
-    let onDropAction: (TabDragCoordinator.DropResult) -> Void
+    var onDropAction: ((TabDragCoordinator.DropResult) -> Void)?
     var showMaximizeButton = false
     var isMaximized = false
     var onToggleMaximize: (() -> Void)?
-    let onCreateTabAdjacent: (UUID, TabArea.InsertSide) -> Void
-    let onTogglePin: (UUID) -> Void
-    let onSetCustomTitle: (UUID, String?) -> Void
-    let onSetColorID: (UUID, String?) -> Void
-    let onReorderTab: (IndexSet, Int) -> Void
+    var onCreateTabAdjacent: ((UUID, TabArea.InsertSide) -> Void)?
+    var onTogglePin: ((UUID) -> Void)?
+    var onSetCustomTitle: ((UUID, String?) -> Void)?
+    var onSetColorID: ((UUID, String?) -> Void)?
+    var onReorderTab: ((IndexSet, Int) -> Void)?
     @AppStorage(TabWidthPreferences.maxWidthKey) private var maxTabWidth = TabWidthPreferences.defaultMaxWidth
     @Environment(TabDragCoordinator.self) private var dragCoordinator
     @State private var dragState = TabDragState()
@@ -99,8 +100,10 @@ struct PaneTabStrip: View {
                     if let openInIDEProjectPath {
                         OpenInIDEControl(projectPath: openInIDEProjectPath, projectID: projectID, areaID: areaID)
                     }
-                    LayoutPickerMenu(projectID: projectID)
-                    ExtensionTopbarItems()
+                    if showsWorkspaceControls {
+                        LayoutPickerMenu(projectID: projectID)
+                        ExtensionTopbarItems()
+                    }
                 }
                 if showMaximizeButton || isMaximized, let onToggleMaximize {
                     let symbol = isMaximized
@@ -161,11 +164,11 @@ struct PaneTabStrip: View {
                     onCloseOthers: { onCloseOtherTabs(tab.id) },
                     onCloseLeft: { onCloseTabsToLeft(tab.id) },
                     onCloseRight: { onCloseTabsToRight(tab.id) },
-                    onCreateLeft: { onCreateTabAdjacent(tab.id, .left) },
-                    onCreateRight: { onCreateTabAdjacent(tab.id, .right) },
-                    onTogglePin: { onTogglePin(tab.id) },
-                    onSetCustomTitle: { onSetCustomTitle(tab.id, $0) },
-                    onSetColorID: { onSetColorID(tab.id, $0) }
+                    onCreateLeft: onCreateTabAdjacent.map { create in { create(tab.id, .left) } },
+                    onCreateRight: onCreateTabAdjacent.map { create in { create(tab.id, .right) } },
+                    onTogglePin: onTogglePin.map { toggle in { toggle(tab.id) } },
+                    onSetCustomTitle: onSetCustomTitle.map { setTitle in { setTitle(tab.id, $0) } },
+                    onSetColorID: onSetColorID.map { setColor in { setColor(tab.id, $0) } }
                 )
                 .frame(width: perTabWidth)
                 .background {
@@ -193,7 +196,8 @@ struct PaneTabStrip: View {
                                 globalLocation: value.location,
                                 dragStartGlobalLocation: value.startLocation
                             )
-                        }
+                        },
+                    including: supportsTabDrag ? .all : .none
                 )
             }
         }
@@ -220,6 +224,10 @@ struct PaneTabStrip: View {
     }
 
     private static let dragActivationDistance: CGFloat = 4
+
+    private var supportsTabDrag: Bool {
+        onReorderTab != nil || onDropAction != nil
+    }
 
     private func handleDragChanged(
         tab: TabSnapshot,
@@ -265,7 +273,7 @@ struct PaneTabStrip: View {
             onSelectTab(tab.id)
         }
         if dragState.isInSplitMode {
-            if let result = dragCoordinator.endDrag() {
+            if let result = dragCoordinator.endDrag(), let onDropAction {
                 onDropAction(result)
             }
         }
@@ -279,7 +287,7 @@ struct PaneTabStrip: View {
     }
 
     private func reorderIfNeeded(at location: CGPoint) {
-        guard let draggedID = dragState.draggedID else { return }
+        guard let draggedID = dragState.draggedID, let onReorderTab else { return }
         var hoveredTargetID: UUID?
 
         for (id, frame) in dragState.frames where id != draggedID {
@@ -342,11 +350,11 @@ private struct TabCell: View {
     let onCloseOthers: () -> Void
     let onCloseLeft: () -> Void
     let onCloseRight: () -> Void
-    let onCreateLeft: () -> Void
-    let onCreateRight: () -> Void
-    let onTogglePin: () -> Void
-    let onSetCustomTitle: (String?) -> Void
-    let onSetColorID: (String?) -> Void
+    var onCreateLeft: (() -> Void)?
+    var onCreateRight: (() -> Void)?
+    var onTogglePin: (() -> Void)?
+    var onSetCustomTitle: ((String?) -> Void)?
+    var onSetColorID: ((String?) -> Void)?
     @State private var hovered = false
     @State private var isRenaming = false
     @State private var renameText = ""
@@ -502,28 +510,36 @@ private struct TabCell: View {
                 }
             }
             .overlay {
-                DoubleClickView(action: startRename)
-                    .accessibilityHidden(true)
+                if onSetCustomTitle != nil {
+                    DoubleClickView(action: startRename)
+                        .accessibilityHidden(true)
+                }
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel(tabAccessibilityLabel)
             .accessibilityAddTraits(active ? .isSelected : [])
             .accessibilityAddTraits(.isButton)
             .contextMenu {
-                Button("New Tab to the Left") { onCreateLeft() }
-                Button("New Tab to the Right") { onCreateRight() }
-                Divider()
-                Button("Rename Tab") { startRename() }
-                if tab.hasCustomTitle {
-                    Button("Reset Title") { onSetCustomTitle(nil) }
+                if let onCreateLeft, let onCreateRight {
+                    Button("New Tab to the Left", action: onCreateLeft)
+                    Button("New Tab to the Right", action: onCreateRight)
+                    Divider()
                 }
-                Button("Set Tab Color…") { showColorPicker = true }
-                if tab.colorID != nil {
-                    Button("Reset Tab Color") { onSetColorID(nil) }
+                if let onSetCustomTitle {
+                    Button("Rename Tab") { startRename() }
+                    if tab.hasCustomTitle {
+                        Button("Reset Title") { onSetCustomTitle(nil) }
+                    }
                 }
-                Divider()
-                Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
-                    onTogglePin()
+                if onSetColorID != nil {
+                    Button("Set Tab Color…") { showColorPicker = true }
+                    if tab.colorID != nil {
+                        Button("Reset Tab Color") { onSetColorID?(nil) }
+                    }
+                }
+                if let onTogglePin {
+                    Divider()
+                    Button(tab.isPinned ? "Unpin Tab" : "Pin Tab", action: onTogglePin)
                 }
                 if !tab.isPinned || hasClosableSiblings {
                     Divider()
@@ -540,7 +556,7 @@ private struct TabCell: View {
             }
             .popover(isPresented: $showColorPicker, arrowEdge: .bottom) {
                 ProjectIconColorPicker(title: "Tab Color", selectedID: tab.colorID) { id in
-                    onSetColorID(id)
+                    onSetColorID?(id)
                     showColorPicker = false
                 }
             }
@@ -548,7 +564,7 @@ private struct TabCell: View {
             Rectangle().fill(MuxyTheme.border).frame(width: 1)
         }
         .onReceive(NotificationCenter.default.publisher(for: .renameActiveTab)) { _ in
-            guard active else { return }
+            guard active, onSetCustomTitle != nil else { return }
             startRename()
         }
         .onDrop(of: [.fileURL], isTargeted: $externalDragOverCell) { _, _ in false }
@@ -631,7 +647,7 @@ private struct TabCell: View {
 
     private func commitRename() {
         let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-        onSetCustomTitle(trimmed.isEmpty ? nil : trimmed)
+        onSetCustomTitle?(trimmed.isEmpty ? nil : trimmed)
         isRenaming = false
     }
 

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -26,6 +26,10 @@ struct TerminalArea: View {
         return false
     }
 
+    private var actions: WorkspaceViewActions {
+        .local(projectID: project.id, appState: appState)
+    }
+
     private var maximizedArea: TabArea? {
         guard let areaID = appState.maximizedAreaID[worktreeKey] else { return nil }
         return root?.findArea(id: areaID)
@@ -51,31 +55,9 @@ struct TerminalArea: View {
                 area: area,
                 isActiveProject: isActiveProject,
                 projectID: project.id,
+                actions: actions,
                 onToggleMaximize: {
                     appState.toggleMaximize(areaID: area.id, for: project.id)
-                },
-                onSelectTab: { tabID in
-                    appState.dispatch(.selectTab(projectID: project.id, areaID: area.id, tabID: tabID))
-                },
-                onCreateTab: {
-                    appState.dispatch(.createTab(projectID: project.id, areaID: area.id))
-                },
-                onCloseTab: { tabID in
-                    appState.closeTab(tabID, areaID: area.id, projectID: project.id)
-                },
-                onForceCloseTab: { tabID in
-                    appState.forceCloseTab(tabID, areaID: area.id, projectID: project.id)
-                },
-                onSplit: { dir in
-                    appState.dispatch(.splitArea(.init(
-                        projectID: project.id,
-                        areaID: area.id,
-                        direction: dir,
-                        position: .second
-                    )))
-                },
-                onDropAction: { result in
-                    appState.dispatch(result.action(projectID: project.id))
                 }
             )
             .padding(16)
@@ -85,37 +67,8 @@ struct TerminalArea: View {
                 focusedAreaID: focusedAreaID,
                 isActiveProject: isActiveProject,
                 showTabStrip: !rootIsTabArea,
-                projectID: project.id,
                 shortcutOffsets: appState.shortcutOffsets(for: project.id),
-                onFocusArea: { areaID in
-                    appState.dispatch(.focusArea(projectID: project.id, areaID: areaID))
-                },
-                onSelectTab: { areaID, tabID in
-                    appState.dispatch(.selectTab(projectID: project.id, areaID: areaID, tabID: tabID))
-                },
-                onCreateTab: { areaID in
-                    appState.dispatch(.createTab(projectID: project.id, areaID: areaID))
-                },
-                onCloseTab: { areaID, tabID in
-                    appState.closeTab(tabID, areaID: areaID, projectID: project.id)
-                },
-                onForceCloseTab: { areaID, tabID in
-                    appState.forceCloseTab(tabID, areaID: areaID, projectID: project.id)
-                },
-                onSplit: { areaID, dir in
-                    appState.dispatch(.splitArea(.init(
-                        projectID: project.id,
-                        areaID: areaID,
-                        direction: dir,
-                        position: .second
-                    )))
-                },
-                onCloseArea: { areaID in
-                    appState.dispatch(.closeArea(projectID: project.id, areaID: areaID))
-                },
-                onDropAction: { result in
-                    appState.dispatch(result.action(projectID: project.id))
-                },
+                actions: actions,
                 showMaximizeButton: !rootIsTabArea,
                 onToggleMaximize: { areaID in
                     appState.toggleMaximize(areaID: areaID, for: project.id)
@@ -125,17 +78,64 @@ struct TerminalArea: View {
     }
 }
 
-private struct MaximizedAreaView: View {
+struct RemoteWorkspaceArea: View {
+    let project: Project
+    let presentation: RemoteWorkspacePresentation
+    let actions: WorkspaceViewActions
+
+    @State private var maximizedAreaID: UUID?
+
+    private var rootIsTabArea: Bool {
+        if case .tabArea = presentation.root { return true }
+        return false
+    }
+
+    private var maximizedArea: TabArea? {
+        guard let maximizedAreaID else { return nil }
+        return presentation.root.findArea(id: maximizedAreaID)
+    }
+
+    private var shortcutOffsets: [UUID: Int] {
+        var offset = 0
+        var result: [UUID: Int] = [:]
+        for area in presentation.root.allAreas() {
+            result[area.id] = offset
+            offset += area.tabs.count
+        }
+        return result
+    }
+
+    var body: some View {
+        if let area = maximizedArea {
+            MaximizedAreaView(
+                area: area,
+                isActiveProject: true,
+                projectID: project.id,
+                actions: actions,
+                onToggleMaximize: { maximizedAreaID = nil }
+            )
+            .padding(16)
+        } else {
+            PaneNode(
+                node: presentation.root,
+                focusedAreaID: presentation.focusedAreaID,
+                isActiveProject: true,
+                showTabStrip: !rootIsTabArea,
+                shortcutOffsets: shortcutOffsets,
+                actions: actions,
+                showMaximizeButton: !rootIsTabArea,
+                onToggleMaximize: { maximizedAreaID = $0 }
+            )
+        }
+    }
+}
+
+struct MaximizedAreaView: View {
     let area: TabArea
     let isActiveProject: Bool
     let projectID: UUID
+    let actions: WorkspaceViewActions
     let onToggleMaximize: () -> Void
-    let onSelectTab: (UUID) -> Void
-    let onCreateTab: () -> Void
-    let onCloseTab: (UUID) -> Void
-    let onForceCloseTab: (UUID) -> Void
-    let onSplit: (SplitDirection) -> Void
-    let onDropAction: (TabDragCoordinator.DropResult) -> Void
 
     var body: some View {
         TabAreaView(
@@ -145,13 +145,7 @@ private struct MaximizedAreaView: View {
             showTabStrip: true,
             projectID: projectID,
             shortcutIndexOffset: 0,
-            onFocus: {},
-            onSelectTab: onSelectTab,
-            onCreateTab: onCreateTab,
-            onCloseTab: onCloseTab,
-            onForceCloseTab: onForceCloseTab,
-            onSplit: onSplit,
-            onDropAction: onDropAction,
+            actions: actions,
             showMaximizeButton: true,
             isMaximized: true,
             onToggleMaximize: onToggleMaximize

--- a/Muxy/Views/Workspace/WorkspaceViewActions.swift
+++ b/Muxy/Views/Workspace/WorkspaceViewActions.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+@MainActor
+struct WorkspaceViewActions {
+    let projectID: UUID
+    let focusArea: (UUID) -> Void
+    let selectTab: (UUID, UUID) -> Void
+    let createTab: (UUID) -> Void
+    let closeTab: (UUID, UUID) -> Void
+    let forceCloseTab: (UUID, UUID) -> Void
+    let splitArea: (UUID, SplitDirection, SplitPosition) -> Void
+    let closeArea: (UUID) -> Void
+    var dropTab: ((TabDragCoordinator.DropResult) -> Void)?
+    var createBrowserTab: ((UUID) -> Void)?
+    var createTabAdjacent: ((UUID, UUID, TabArea.InsertSide) -> Void)?
+    var togglePin: ((UUID, UUID) -> Void)?
+    var setCustomTitle: ((UUID, UUID, String?) -> Void)?
+    var setColorID: ((UUID, UUID, String?) -> Void)?
+    var reorderTab: ((UUID, IndexSet, Int) -> Void)?
+    var resizeSplit: ((UUID, CGFloat) -> Void)?
+
+    static func local(projectID: UUID, appState: AppState) -> WorkspaceViewActions {
+        WorkspaceViewActions(
+            projectID: projectID,
+            focusArea: { areaID in
+                appState.dispatch(.focusArea(projectID: projectID, areaID: areaID))
+            },
+            selectTab: { areaID, tabID in
+                appState.dispatch(.selectTab(projectID: projectID, areaID: areaID, tabID: tabID))
+            },
+            createTab: { areaID in
+                appState.dispatch(.createTab(projectID: projectID, areaID: areaID))
+            },
+            closeTab: { areaID, tabID in
+                appState.closeTab(tabID, areaID: areaID, projectID: projectID)
+            },
+            forceCloseTab: { areaID, tabID in
+                appState.forceCloseTab(tabID, areaID: areaID, projectID: projectID)
+            },
+            splitArea: { areaID, direction, position in
+                appState.dispatch(.splitArea(.init(
+                    projectID: projectID,
+                    areaID: areaID,
+                    direction: direction,
+                    position: position
+                )))
+            },
+            closeArea: { areaID in
+                appState.dispatch(.closeArea(projectID: projectID, areaID: areaID))
+            },
+            dropTab: { result in
+                appState.dispatch(result.action(projectID: projectID))
+            },
+            createBrowserTab: { areaID in
+                appState.dispatch(.createBrowserTab(
+                    projectID: projectID,
+                    areaID: areaID,
+                    url: BrowserURL.homeURL,
+                    profileID: BrowserPreferences.defaultProfileID
+                ))
+            },
+            createTabAdjacent: { areaID, tabID, side in
+                appState.dispatch(.createTabAdjacent(
+                    projectID: projectID,
+                    areaID: areaID,
+                    tabID: tabID,
+                    side: side
+                ))
+            },
+            togglePin: { areaID, tabID in
+                appState.workspaceRoot(for: projectID)?.findArea(id: areaID)?.togglePin(tabID)
+            },
+            setCustomTitle: { areaID, tabID, title in
+                appState.workspaceRoot(for: projectID)?.findArea(id: areaID)?.setCustomTitle(tabID, title: title)
+                appState.saveWorkspaces()
+            },
+            setColorID: { areaID, tabID, colorID in
+                appState.workspaceRoot(for: projectID)?.findArea(id: areaID)?.setColorID(tabID, colorID: colorID)
+                appState.saveWorkspaces()
+            },
+            reorderTab: { areaID, source, destination in
+                appState.workspaceRoot(for: projectID)?.findArea(id: areaID)?.reorderTab(
+                    fromOffsets: source,
+                    toOffset: destination
+                )
+            },
+            resizeSplit: { branchID, ratio in
+                appState.workspaceRoot(for: projectID)?.findBranch(id: branchID)?.ratio = ratio
+            }
+        )
+    }
+}

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -48,8 +48,18 @@ public protocol MuxyRemoteServerDelegate: AnyObject {
     func releasePane(paneID: UUID, clientID: UUID)
     func setClientTheme(_ theme: ClientThemeDTO?, clientID: UUID)
     func registerDevice(clientID: UUID, name: String)
-    func authenticateDevice(deviceID: UUID, token: String, name: String) -> DeviceAuthDecision
-    func requestPairing(deviceID: UUID, token: String, name: String) async -> DeviceAuthDecision
+    func authenticateDevice(
+        deviceID: UUID,
+        token: String,
+        name: String,
+        clientKind: RemoteClientKindDTO
+    ) -> DeviceAuthDecision
+    func requestPairing(
+        deviceID: UUID,
+        token: String,
+        name: String,
+        clientKind: RemoteClientKindDTO
+    ) async -> DeviceAuthDecision
     func getDeviceTheme() -> DeviceThemeEventDTO?
     func clientDisconnected(clientID: UUID)
     func getPaneOwner(paneID: UUID) -> PaneOwnerDTO?
@@ -291,7 +301,8 @@ public final class MuxyRemoteServer: @unchecked Sendable {
             let decision = await delegate.requestPairing(
                 deviceID: params.deviceID,
                 token: params.token,
-                name: params.deviceName
+                name: params.deviceName,
+                clientKind: params.resolvedClientKind
             )
             return finalizeAuth(
                 requestID: request.id,
@@ -308,7 +319,8 @@ public final class MuxyRemoteServer: @unchecked Sendable {
             let decision = delegate.authenticateDevice(
                 deviceID: params.deviceID,
                 token: params.token,
-                name: params.deviceName
+                name: params.deviceName,
+                clientKind: params.resolvedClientKind
             )
             return finalizeAuth(
                 requestID: request.id,

--- a/MuxyShared/MuxyProtocol.swift
+++ b/MuxyShared/MuxyProtocol.swift
@@ -40,7 +40,7 @@ public struct MuxyEvent: Codable, Sendable {
     }
 }
 
-public struct MuxyError: Codable, Sendable, Error {
+public struct MuxyError: Codable, Sendable, LocalizedError {
     public let code: Int
     public let message: String
 
@@ -48,6 +48,8 @@ public struct MuxyError: Codable, Sendable, Error {
         self.code = code
         self.message = message
     }
+
+    public var errorDescription: String? { message }
 
     public static let notFound = MuxyError(code: 404, message: "Not found")
     public static let invalidParams = MuxyError(code: 400, message: "Invalid parameters")

--- a/MuxyShared/ProtocolParams.swift
+++ b/MuxyShared/ProtocolParams.swift
@@ -153,17 +153,32 @@ public struct RegisterDeviceParams: Codable, Sendable {
     }
 }
 
+public enum RemoteClientKindDTO: String, Codable, Sendable {
+    case mobile
+    case desktop
+}
+
 public struct PairDeviceParams: Codable, Sendable {
     public let deviceID: UUID
     public let deviceName: String
     public let token: String
     public let theme: ClientThemeDTO?
-    public init(deviceID: UUID, deviceName: String, token: String, theme: ClientThemeDTO? = nil) {
+    public let clientKind: RemoteClientKindDTO?
+    public init(
+        deviceID: UUID,
+        deviceName: String,
+        token: String,
+        theme: ClientThemeDTO? = nil,
+        clientKind: RemoteClientKindDTO? = nil
+    ) {
         self.deviceID = deviceID
         self.deviceName = deviceName
         self.token = token
         self.theme = theme
+        self.clientKind = clientKind
     }
+
+    public var resolvedClientKind: RemoteClientKindDTO { clientKind ?? .mobile }
 }
 
 public struct AuthenticateDeviceParams: Codable, Sendable {
@@ -171,12 +186,22 @@ public struct AuthenticateDeviceParams: Codable, Sendable {
     public let deviceName: String
     public let token: String
     public let theme: ClientThemeDTO?
-    public init(deviceID: UUID, deviceName: String, token: String, theme: ClientThemeDTO? = nil) {
+    public let clientKind: RemoteClientKindDTO?
+    public init(
+        deviceID: UUID,
+        deviceName: String,
+        token: String,
+        theme: ClientThemeDTO? = nil,
+        clientKind: RemoteClientKindDTO? = nil
+    ) {
         self.deviceID = deviceID
         self.deviceName = deviceName
         self.token = token
         self.theme = theme
+        self.clientKind = clientKind
     }
+
+    public var resolvedClientKind: RemoteClientKindDTO { clientKind ?? .mobile }
 }
 
 public struct PairingResultDTO: Codable, Sendable {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "066ab307b4a0e89ca1cb729d2423eb57ebcd8a19de8762c00940d2cb612c1569",
+  "originHash" : "498281a2f5570e88781bc918eec63c1643bebf350ba61730dc2094cbd4bfd793",
   "pins" : [
     {
       "identity" : "sentry-cocoa",
@@ -17,6 +17,23 @@
       "state" : {
         "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
         "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/muxy-app/SwiftTerm.git",
+      "state" : {
+        "revision" : "9adb62463d2264e7403feb7a1471aaf27eaab2f4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.1"),
         .package(url: "https://github.com/jpsim/Yams", from: "5.1.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa", from: "8.40.0"),
+        .package(
+            url: "https://github.com/muxy-app/SwiftTerm.git",
+            revision: "9adb62463d2264e7403feb7a1471aaf27eaab2f4"
+        ),
     ],
     targets: [
         .target(
@@ -52,6 +56,7 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "Sentry", package: "sentry-cocoa"),
+                .product(name: "SwiftTerm", package: "SwiftTerm"),
             ],
             path: "Muxy",
             exclude: ["Info.plist", "Muxy.entitlements"],

--- a/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyProtocolVariantTests.swift
@@ -57,6 +57,24 @@ struct MuxyProtocolVariantTests {
         #expect(PaneOwnerDTO.remote(deviceID: deviceID, deviceName: "iPad").displayName == "iPad")
     }
 
+    @Test("desktop client kind round-trips and legacy clients default to mobile")
+    func remoteClientKindCompatibility() throws {
+        let params = PairDeviceParams(
+            deviceID: deviceID,
+            deviceName: "Mac",
+            token: "token",
+            clientKind: .desktop
+        )
+        let decoded = try roundTrip(params, as: PairDeviceParams.self)
+        let legacy = try JSONDecoder().decode(
+            AuthenticateDeviceParams.self,
+            from: Data(#"{"deviceID":"00000000-0000-0000-0000-000000000006","deviceName":"Phone","token":"token"}"#.utf8)
+        )
+
+        #expect(decoded.resolvedClientKind == .desktop)
+        #expect(legacy.resolvedClientKind == .mobile)
+    }
+
     @Test("terminal cell flags remain stable bit masks")
     func terminalCellFlags() {
         #expect(TerminalCellFlag.bold == 1)

--- a/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
+++ b/Tests/MuxyTests/Remote/MuxyRemoteServerRoutingTests.swift
@@ -14,6 +14,8 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
     var setClientThemeCalls: [(theme: ClientThemeDTO?, clientID: UUID)] = []
     var registerDeviceCalls: [(clientID: UUID, name: String)] = []
     var clientDisconnectedCalls: [UUID] = []
+    var authenticationKinds: [RemoteClientKindDTO] = []
+    var pairingKinds: [RemoteClientKindDTO] = []
     var markNotificationReadCalls: [UUID] = []
     var vcsPushCalls: [UUID] = []
     var vcsPullCalls: [UUID] = []
@@ -94,12 +96,24 @@ private final class MockDelegate: MuxyRemoteServerDelegate {
         registerDeviceCalls.append((clientID, name))
     }
 
-    func authenticateDevice(deviceID _: UUID, token _: String, name: String) -> DeviceAuthDecision {
-        .approved(deviceName: name)
+    func authenticateDevice(
+        deviceID _: UUID,
+        token _: String,
+        name: String,
+        clientKind: RemoteClientKindDTO
+    ) -> DeviceAuthDecision {
+        authenticationKinds.append(clientKind)
+        return .approved(deviceName: name)
     }
 
-    func requestPairing(deviceID _: UUID, token _: String, name: String) async -> DeviceAuthDecision {
-        .approved(deviceName: name)
+    func requestPairing(
+        deviceID _: UUID,
+        token _: String,
+        name: String,
+        clientKind: RemoteClientKindDTO
+    ) async -> DeviceAuthDecision {
+        pairingKinds.append(clientKind)
+        return .approved(deviceName: name)
     }
 
     func getDeviceTheme() -> DeviceThemeEventDTO? { nil }
@@ -489,6 +503,27 @@ struct MuxyRemoteServerRoutingTests {
         )
 
         #expect(delegate.setClientThemeCalls.first?.theme == theme)
+    }
+
+    @Test("authenticateDevice forwards desktop client kind")
+    func authenticateDeviceForwardsDesktopKind() async {
+        let (server, delegate) = makeServer()
+
+        _ = await server.processRequest(
+            MuxyRequest(
+                id: "auth-desktop",
+                method: .authenticateDevice,
+                params: .authenticateDevice(AuthenticateDeviceParams(
+                    deviceID: UUID(),
+                    deviceName: "Mac",
+                    token: "token",
+                    clientKind: .desktop
+                ))
+            ),
+            clientID: UUID()
+        )
+
+        #expect(delegate.authenticationKinds == [.desktop])
     }
 
     @Test("registerDevice returns device info with clientID")

--- a/Tests/MuxyTests/Services/Mobile/ApprovedDevicesStoreTests.swift
+++ b/Tests/MuxyTests/Services/Mobile/ApprovedDevicesStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MuxyShared
 import Testing
 
 @testable import Muxy
@@ -64,6 +65,35 @@ struct ApprovedDevicesStoreTests {
 
         #expect(store.devices.map(\.id) == [seeded[0].id, seeded[2].id])
         #expect(recorder.ids == [seeded[1].id])
+    }
+
+    @Test("approved devices preserve desktop client kind")
+    func desktopClientKind() {
+        let store = ApprovedDevicesStore(persistence: ApprovedDevicesPersistenceStub())
+        let deviceID = UUID()
+        store.approve(deviceID: deviceID, name: "Mac", token: "token", clientKind: .desktop)
+
+        #expect(store.devices.first?.clientKind == .desktop)
+        #expect(store.validate(deviceID: deviceID, token: "token", clientKind: .desktop) != nil)
+        #expect(store.validate(deviceID: deviceID, token: "token", clientKind: .mobile) == nil)
+    }
+
+    @Test("legacy approved devices default to mobile")
+    func legacyClientKind() throws {
+        let data = Data(#"{"id":"00000000-0000-0000-0000-000000000001","name":"Phone","tokenHash":"hash","approvedAt":0}"#.utf8)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let device = try decoder.decode(ApprovedDevice.self, from: data)
+
+        #expect(device.clientKind == .mobile)
+    }
+
+    @Test("desktop and mobile access toggles are enforced independently")
+    func clientAccessPolicy() {
+        #expect(MobileServerService.allows(.desktop, mobileConnections: false, desktopConnections: true))
+        #expect(!MobileServerService.allows(.desktop, mobileConnections: true, desktopConnections: false))
+        #expect(MobileServerService.allows(.mobile, mobileConnections: true, desktopConnections: false))
+        #expect(!MobileServerService.allows(.mobile, mobileConnections: false, desktopConnections: true))
     }
 }
 

--- a/Tests/MuxyTests/Services/Mobile/RemoteDeviceStoreTests.swift
+++ b/Tests/MuxyTests/Services/Mobile/RemoteDeviceStoreTests.swift
@@ -39,9 +39,24 @@ struct RemoteDeviceStoreTests {
     @Test("sshDevices returns only ssh-kind devices")
     func sshDevicesFilter() {
         let ssh = RemoteDevice(name: "Prod", kind: .ssh, ssh: SSHWorkspaceData(host: "example.com"))
-        let (store, _) = makeStore([ssh])
+        let muxy = RemoteDevice(name: "Studio", muxy: MuxyRemoteServerData(host: "studio.local"))
+        let (store, _) = makeStore([ssh, muxy])
 
         #expect(store.sshDevices().map(\.id) == [ssh.id])
+        #expect(store.muxyDevices().map(\.id) == [muxy.id])
+    }
+
+    @Test("adding a Muxy Mac with an existing ID updates it")
+    func muxyDeviceUpdate() {
+        let (store, _) = makeStore()
+        let id = UUID()
+        store.add(id: id, name: "Old", muxy: MuxyRemoteServerData(host: "old.local"))
+
+        store.add(id: id, name: "New", muxy: MuxyRemoteServerData(host: "new.local", port: 5000))
+
+        #expect(store.devices.count == 1)
+        #expect(store.device(id: id)?.name == "New")
+        #expect(store.device(id: id)?.muxy == MuxyRemoteServerData(host: "new.local", port: 5000))
     }
 
     @Test("update mutates the device and persists")
@@ -93,13 +108,20 @@ struct RemoteDeviceStoreTests {
                 environment: ["TERM": "screen-256color", "LANG": "C.UTF-8"]
             )
         )
+        let remoteMac = store.add(
+            name: "Studio Mac",
+            muxy: MuxyRemoteServerData(host: "studio.local", port: 4865, serviceName: "Studio")
+        )
 
         let reloaded = RemoteDeviceStore(persistence: persistence)
 
-        #expect(reloaded.devices.count == 1)
+        #expect(reloaded.devices.count == 2)
         #expect(reloaded.devices.first?.ssh.port == 2222)
         #expect(reloaded.devices.first?.ssh.user == "deploy")
         #expect(reloaded.devices.first?.ssh.environment["TERM"] == "screen-256color")
+        #expect(reloaded.device(id: remoteMac.id)?.kind == .muxy)
+        #expect(reloaded.device(id: remoteMac.id)?.muxy?.host == "studio.local")
+        #expect(reloaded.device(id: remoteMac.id)?.muxy?.serviceName == "Studio")
     }
 
     @Test("file persistence round-trips environment")

--- a/Tests/MuxyTests/Services/Remote/RemoteMacConnectionTests.swift
+++ b/Tests/MuxyTests/Services/Remote/RemoteMacConnectionTests.swift
@@ -1,0 +1,298 @@
+import Foundation
+import MuxyShared
+import Testing
+
+@testable import Muxy
+
+@Suite("Remote Mac connection")
+@MainActor
+struct RemoteMacConnectionTests {
+    @Test("unknown desktop client pairs, loads projects, and selects a workspace")
+    func pairingAndWorkspaceLoad() async throws {
+        let remoteDeviceID = UUID()
+        let credentials = RemoteMacCredentials(
+            deviceID: UUID(),
+            token: "secret",
+            endpointScope: "studio.local:4865"
+        )
+        let credentialStore = InMemoryRemoteMacCredentialStore(values: [remoteDeviceID: credentials])
+        let socket = FakeRemoteMacSocket()
+        let project = ProjectDTO(id: UUID(), name: "Muxy", path: "/repo", sortOrder: 0, createdAt: .now)
+        let workspace = workspace(projectID: project.id)
+        var receivedKinds: [RemoteClientKindDTO] = []
+
+        socket.handler = { request in
+            switch request.method {
+            case .authenticateDevice:
+                guard case let .authenticateDevice(params) = request.params else { return nil }
+                receivedKinds.append(params.resolvedClientKind)
+                #expect(params.deviceID == credentials.deviceID)
+                return MuxyResponse(id: request.id, error: .unauthorized)
+            case .pairDevice:
+                guard case let .pairDevice(params) = request.params else { return nil }
+                receivedKinds.append(params.resolvedClientKind)
+                return MuxyResponse(
+                    id: request.id,
+                    result: .pairing(PairingResultDTO(clientID: UUID(), deviceName: "Test Mac"))
+                )
+            case .listProjects:
+                return MuxyResponse(id: request.id, result: .projects([project]))
+            case .selectProject:
+                return MuxyResponse(id: request.id, result: .ok)
+            case .getWorkspace:
+                return MuxyResponse(id: request.id, result: .workspace(workspace))
+            default:
+                return MuxyResponse(id: request.id, result: .ok)
+            }
+        }
+
+        let device = RemoteDevice(
+            id: remoteDeviceID,
+            name: "Studio",
+            muxy: MuxyRemoteServerData(host: "studio.local")
+        )
+        let connection = RemoteMacConnection(
+            device: device,
+            credentialStore: credentialStore,
+            socketFactory: { socket }
+        )
+
+        try await connection.connect(allowPairing: true)
+        try await connection.selectProject(project.id)
+
+        #expect(connection.state == .connected)
+        #expect(connection.projects.map(\.id) == [project.id])
+        #expect(connection.workspace?.projectID == project.id)
+        #expect(receivedKinds == [.desktop, .desktop])
+    }
+
+    @Test("terminal input is sent without a pending response")
+    func terminalInput() async throws {
+        let remoteDeviceID = UUID()
+        let credentialStore = InMemoryRemoteMacCredentialStore()
+        let socket = FakeRemoteMacSocket()
+        let paneID = UUID()
+        var input: Data?
+        socket.handler = { request in
+            if case let .terminalInput(params) = request.params {
+                input = params.bytes
+                return nil
+            }
+            switch request.method {
+            case .authenticateDevice:
+                return MuxyResponse(
+                    id: request.id,
+                    result: .pairing(PairingResultDTO(clientID: UUID(), deviceName: "Test Mac"))
+                )
+            case .listProjects:
+                return MuxyResponse(id: request.id, result: .projects([]))
+            default:
+                return MuxyResponse(id: request.id, result: .ok)
+            }
+        }
+        let connection = RemoteMacConnection(
+            device: RemoteDevice(
+                id: remoteDeviceID,
+                name: "Studio",
+                muxy: MuxyRemoteServerData(host: "studio.local")
+            ),
+            credentialStore: credentialStore,
+            socketFactory: { socket }
+        )
+        try await connection.connect(allowPairing: false)
+
+        connection.sendTerminalInput(paneID: paneID, bytes: Data([1, 2, 3]))
+        await Task.yield()
+
+        #expect(input == Data([1, 2, 3]))
+    }
+
+    @Test("a slower project selection cannot overwrite a newer workspace")
+    func projectSelectionOrdering() async throws {
+        let socket = FakeRemoteMacSocket()
+        let firstProject = ProjectDTO(id: UUID(), name: "First", path: "/first", sortOrder: 0, createdAt: .now)
+        let secondProject = ProjectDTO(id: UUID(), name: "Second", path: "/second", sortOrder: 1, createdAt: .now)
+        let firstWorkspace = workspace(projectID: firstProject.id)
+        let secondWorkspace = workspace(projectID: secondProject.id)
+        socket.handler = { request in
+            switch request.method {
+            case .authenticateDevice:
+                return MuxyResponse(
+                    id: request.id,
+                    result: .pairing(PairingResultDTO(clientID: UUID(), deviceName: "Test Mac"))
+                )
+            case .listProjects:
+                return MuxyResponse(id: request.id, result: .projects([firstProject, secondProject]))
+            case .selectProject:
+                guard case let .selectProject(params) = request.params else { return nil }
+                if params.projectID == firstProject.id {
+                    try? await Task.sleep(for: .milliseconds(50))
+                }
+                return MuxyResponse(id: request.id, result: .ok)
+            case .getWorkspace:
+                guard case let .getWorkspace(params) = request.params else { return nil }
+                let workspace = params.projectID == firstProject.id ? firstWorkspace : secondWorkspace
+                return MuxyResponse(id: request.id, result: .workspace(workspace))
+            default:
+                return MuxyResponse(id: request.id, result: .ok)
+            }
+        }
+        let connection = RemoteMacConnection(
+            device: RemoteDevice(name: "Studio", muxy: MuxyRemoteServerData(host: "studio.local")),
+            credentialStore: InMemoryRemoteMacCredentialStore(),
+            socketFactory: { socket }
+        )
+        try await connection.connect(allowPairing: false)
+
+        async let first: Void = connection.selectProject(firstProject.id)
+        await Task.yield()
+        async let second: Void = connection.selectProject(secondProject.id)
+        try await first
+        try await second
+
+        #expect(connection.activeProjectID == secondProject.id)
+        #expect(connection.workspace?.projectID == secondProject.id)
+    }
+
+    @Test("release remains the final ownership operation when takeover is in flight")
+    func takeoverReleaseOrdering() async throws {
+        let socket = FakeRemoteMacSocket()
+        let paneID = UUID()
+        var completedMethods: [MuxyMethod] = []
+        socket.handler = { request in
+            switch request.method {
+            case .authenticateDevice:
+                return MuxyResponse(
+                    id: request.id,
+                    result: .pairing(PairingResultDTO(clientID: UUID(), deviceName: "Test Mac"))
+                )
+            case .listProjects:
+                return MuxyResponse(id: request.id, result: .projects([]))
+            case .takeOverPane:
+                try? await Task.sleep(for: .milliseconds(50))
+                completedMethods.append(.takeOverPane)
+                return MuxyResponse(id: request.id, result: .ok)
+            case .releasePane:
+                completedMethods.append(.releasePane)
+                return MuxyResponse(id: request.id, result: .ok)
+            default:
+                return MuxyResponse(id: request.id, result: .ok)
+            }
+        }
+        let connection = RemoteMacConnection(
+            device: RemoteDevice(name: "Studio", muxy: MuxyRemoteServerData(host: "studio.local")),
+            credentialStore: InMemoryRemoteMacCredentialStore(),
+            socketFactory: { socket }
+        )
+        try await connection.connect(allowPairing: false)
+
+        let takeover = connection.takeOverPane(paneID: paneID, cols: 80, rows: 24)
+        await connection.releasePane(paneID: paneID)
+        try await takeover.value
+
+        #expect(completedMethods.last == .releasePane)
+        #expect(completedMethods.filter { $0 == .releasePane }.count == 2)
+    }
+
+    @Test("removing the active project clears its workspace")
+    func activeProjectRemoval() async throws {
+        let socket = FakeRemoteMacSocket()
+        let project = ProjectDTO(id: UUID(), name: "Removed", path: "/removed", sortOrder: 0, createdAt: .now)
+        let workspace = workspace(projectID: project.id)
+        socket.handler = { request in
+            switch request.method {
+            case .authenticateDevice:
+                return MuxyResponse(
+                    id: request.id,
+                    result: .pairing(PairingResultDTO(clientID: UUID(), deviceName: "Test Mac"))
+                )
+            case .listProjects:
+                return MuxyResponse(id: request.id, result: .projects([project]))
+            case .selectProject:
+                return MuxyResponse(id: request.id, result: .ok)
+            case .getWorkspace:
+                return MuxyResponse(id: request.id, result: .workspace(workspace))
+            default:
+                return MuxyResponse(id: request.id, result: .ok)
+            }
+        }
+        let connection = RemoteMacConnection(
+            device: RemoteDevice(name: "Studio", muxy: MuxyRemoteServerData(host: "studio.local")),
+            credentialStore: InMemoryRemoteMacCredentialStore(),
+            socketFactory: { socket }
+        )
+        try await connection.connect(allowPairing: false)
+        try await connection.selectProject(project.id)
+
+        try socket.sendEvent(MuxyEvent(event: .projectsChanged, data: .projects([])))
+        for _ in 0 ..< 10 where connection.activeProjectID != nil {
+            await Task.yield()
+        }
+
+        #expect(connection.projects.isEmpty)
+        #expect(connection.activeProjectID == nil)
+        #expect(connection.workspace == nil)
+    }
+
+    private func workspace(projectID: UUID) -> WorkspaceDTO {
+        let tab = TabDTO(id: UUID(), kind: .terminal, title: "Shell", isPinned: false, paneID: UUID())
+        let area = TabAreaDTO(id: UUID(), projectPath: "/repo", tabs: [tab], activeTabID: tab.id)
+        return WorkspaceDTO(
+            projectID: projectID,
+            worktreeID: UUID(),
+            focusedAreaID: area.id,
+            root: .tabArea(area)
+        )
+    }
+}
+
+@MainActor
+private final class FakeRemoteMacSocket: RemoteMacSocket {
+    var handler: (MuxyRequest) async -> MuxyResponse? = { _ in nil }
+    private var queuedMessages: [Data] = []
+    private var receiver: CheckedContinuation<Data, any Error>?
+    private var isConnected = false
+
+    func connect(to _: URL) {
+        isConnected = true
+    }
+
+    func send(_ data: Data) async throws {
+        guard isConnected else { throw RemoteMacConnectionError.disconnected }
+        guard case let .request(request) = try MuxyCodec.decode(data) else {
+            throw RemoteMacConnectionError.invalidMessage
+        }
+        guard let response = await handler(request) else { return }
+        enqueue(try MuxyCodec.encode(.response(response)))
+    }
+
+    func receive() async throws -> Data {
+        guard isConnected else { throw RemoteMacConnectionError.disconnected }
+        if !queuedMessages.isEmpty {
+            return queuedMessages.removeFirst()
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            receiver = continuation
+        }
+    }
+
+    func disconnect() {
+        isConnected = false
+        receiver?.resume(throwing: RemoteMacConnectionError.disconnected)
+        receiver = nil
+        queuedMessages.removeAll()
+    }
+
+    func sendEvent(_ event: MuxyEvent) throws {
+        enqueue(try MuxyCodec.encode(.event(event)))
+    }
+
+    private func enqueue(_ data: Data) {
+        guard let receiver else {
+            queuedMessages.append(data)
+            return
+        }
+        self.receiver = nil
+        receiver.resume(returning: data)
+    }
+}

--- a/Tests/MuxyTests/Services/Remote/RemoteMacCredentialStoreTests.swift
+++ b/Tests/MuxyTests/Services/Remote/RemoteMacCredentialStoreTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Remote Mac credential store")
+struct RemoteMacCredentialStoreTests {
+    @Test("credentials are stable and scoped per remote device")
+    func scopedCredentials() throws {
+        let store = InMemoryRemoteMacCredentialStore()
+        let firstDevice = UUID()
+        let secondDevice = UUID()
+
+        let first = try store.loadOrCreate(for: firstDevice, endpointScope: "studio.local:4865")
+        let firstReloaded = try store.loadOrCreate(for: firstDevice, endpointScope: "studio.local:4865")
+        let second = try store.loadOrCreate(for: secondDevice, endpointScope: "studio.local:4865")
+
+        #expect(first == firstReloaded)
+        #expect(first != second)
+        #expect(!first.token.isEmpty)
+    }
+
+    @Test("deleting a credential creates a new identity")
+    func deletion() throws {
+        let store = InMemoryRemoteMacCredentialStore()
+        let deviceID = UUID()
+        let original = try store.loadOrCreate(for: deviceID, endpointScope: "studio.local:4865")
+
+        try store.delete(for: deviceID)
+        let replacement = try store.loadOrCreate(for: deviceID, endpointScope: "studio.local:4865")
+
+        #expect(original != replacement)
+    }
+
+    @Test("credentials remain independently scoped when endpoints change")
+    func endpointBinding() throws {
+        let store = InMemoryRemoteMacCredentialStore()
+        let deviceID = UUID()
+        let original = try store.loadOrCreate(for: deviceID, endpointScope: "studio.local:4865")
+
+        let replacement = try store.loadOrCreate(for: deviceID, endpointScope: "laptop.local:4865")
+        let originalReloaded = try store.loadOrCreate(for: deviceID, endpointScope: "studio.local:4865")
+
+        #expect(original != replacement)
+        #expect(original == originalReloaded)
+        #expect(replacement.endpointScope == "laptop.local:4865")
+    }
+
+    @Test("deleting one endpoint preserves credentials for other endpoints")
+    func endpointDeletion() throws {
+        let store = InMemoryRemoteMacCredentialStore()
+        let deviceID = UUID()
+        let first = try store.loadOrCreate(for: deviceID, endpointScope: "studio.local:4865")
+        let second = try store.loadOrCreate(for: deviceID, endpointScope: "laptop.local:4865")
+
+        try store.delete(for: deviceID, endpointScope: "laptop.local:4865")
+
+        let firstReloaded = try store.loadOrCreate(for: deviceID, endpointScope: "studio.local:4865")
+        let secondReplacement = try store.loadOrCreate(for: deviceID, endpointScope: "laptop.local:4865")
+        #expect(first == firstReloaded)
+        #expect(second != secondReplacement)
+    }
+}

--- a/Tests/MuxyTests/Services/Remote/RemoteWorkspaceNavigationTests.swift
+++ b/Tests/MuxyTests/Services/Remote/RemoteWorkspaceNavigationTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MuxyShared
+import Testing
+
+@testable import Muxy
+
+@Suite("Remote workspace navigation")
+struct RemoteWorkspaceNavigationTests {
+    @Test("flattens split areas and resolves the focused area")
+    func areaResolution() {
+        let first = area(title: "One")
+        let second = area(title: "Two")
+        let workspace = WorkspaceDTO(
+            projectID: UUID(),
+            worktreeID: UUID(),
+            focusedAreaID: second.id,
+            root: .split(SplitBranchDTO(
+                id: UUID(),
+                direction: .horizontal,
+                ratio: 0.4,
+                first: .tabArea(first),
+                second: .tabArea(second)
+            ))
+        )
+
+        #expect(RemoteWorkspaceNavigation.areas(in: workspace.root).map(\.id) == [first.id, second.id])
+        #expect(RemoteWorkspaceNavigation.focusedArea(in: workspace)?.id == second.id)
+    }
+
+    @Test("cycles tabs in both directions")
+    func tabCycling() {
+        let first = TabDTO(id: UUID(), kind: .terminal, title: "One", isPinned: false)
+        let second = TabDTO(id: UUID(), kind: .terminal, title: "Two", isPinned: false)
+        let area = TabAreaDTO(id: UUID(), projectPath: "/tmp", tabs: [first, second], activeTabID: first.id)
+
+        #expect(RemoteWorkspaceNavigation.tab(in: area, offset: 1)?.id == second.id)
+        #expect(RemoteWorkspaceNavigation.tab(in: area, offset: -1)?.id == second.id)
+    }
+
+    @Test("cycles tabs across split panes")
+    func crossPaneTabCycling() {
+        let first = area(title: "One")
+        let second = area(title: "Two")
+        let workspace = WorkspaceDTO(
+            projectID: UUID(),
+            worktreeID: UUID(),
+            focusedAreaID: first.id,
+            root: .split(SplitBranchDTO(
+                id: UUID(),
+                direction: .horizontal,
+                ratio: 0.5,
+                first: .tabArea(first),
+                second: .tabArea(second)
+            ))
+        )
+
+        let next = RemoteWorkspaceNavigation.tabAcrossAreas(in: workspace, offset: 1)
+        let previous = RemoteWorkspaceNavigation.tabAcrossAreas(in: workspace, offset: -1)
+
+        #expect(next?.area.id == second.id)
+        #expect(next?.tab.id == second.activeTabID)
+        #expect(previous?.area.id == second.id)
+        #expect(previous?.tab.id == second.activeTabID)
+    }
+
+    private func area(title: String) -> TabAreaDTO {
+        let tab = TabDTO(id: UUID(), kind: .terminal, title: title, isPinned: false)
+        return TabAreaDTO(id: UUID(), projectPath: "/tmp", tabs: [tab], activeTabID: tab.id)
+    }
+}

--- a/Tests/MuxyTests/Services/Remote/RemoteWorkspacePresentationTests.swift
+++ b/Tests/MuxyTests/Services/Remote/RemoteWorkspacePresentationTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import MuxyShared
+import Testing
+
+@testable import Muxy
+
+@Suite("Remote workspace presentation")
+@MainActor
+struct RemoteWorkspacePresentationTests {
+    @Test("remote identities are stable, reversible, and scoped by entity")
+    func identityMapping() {
+        let identities = RemoteWorkspaceIdentityMap()
+        let remoteID = UUID()
+
+        let projectID = identities.presentationID(for: remoteID, entity: .project)
+        let repeatedProjectID = identities.presentationID(for: remoteID, entity: .project)
+        let paneID = identities.presentationID(for: remoteID, entity: .pane)
+
+        #expect(projectID == repeatedProjectID)
+        #expect(projectID != paneID)
+        #expect(projectID != remoteID)
+        #expect(identities.remoteID(for: projectID) == remoteID)
+        #expect(identities.remoteID(for: paneID) == remoteID)
+    }
+
+    @Test("workspace DTOs hydrate shared models without local terminal backends")
+    func sharedModelHydration() {
+        let identities = RemoteWorkspaceIdentityMap()
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let paneID = UUID()
+        let terminal = TabDTO(
+            id: UUID(),
+            kind: .terminal,
+            title: "Shell",
+            isPinned: false,
+            paneID: paneID
+        )
+        let browser = TabDTO(
+            id: UUID(),
+            kind: .browser,
+            title: "Docs",
+            isPinned: true
+        )
+        let area = TabAreaDTO(
+            id: UUID(),
+            projectPath: "/repo",
+            tabs: [terminal, browser],
+            activeTabID: terminal.id
+        )
+        let workspace = WorkspaceDTO(
+            projectID: projectID,
+            worktreeID: worktreeID,
+            focusedAreaID: area.id,
+            root: .tabArea(area)
+        )
+
+        let presentation = RemoteWorkspacePresentationBuilder.workspace(
+            from: workspace,
+            identities: identities
+        )
+        let presentedArea = presentation.focusedArea
+
+        #expect(presentation.projectID != projectID)
+        #expect(presentation.worktreeID != worktreeID)
+        #expect(presentedArea?.tabs.count == 2)
+        #expect(presentedArea?.activeTab?.title == "Shell")
+        #expect(presentedArea?.tabs.last?.isPinned == true)
+        #expect(presentedArea?.tabs.last?.kind == .browser)
+        #expect(presentedArea?.tabs.last?.content.pane == nil)
+        #expect(presentedArea?.activeTab?.content.pane?.backend == .remoteMac(paneID: paneID))
+    }
+
+    @Test("remote project DTOs use normal Project models with a distinct origin")
+    func projectHydration() {
+        let identities = RemoteWorkspaceIdentityMap()
+        let deviceID = UUID()
+        let dto = ProjectDTO(
+            id: UUID(),
+            name: "Muxy",
+            path: "/repo",
+            sortOrder: 2,
+            createdAt: .now,
+            icon: "terminal",
+            iconColor: "blue"
+        )
+
+        let project = RemoteWorkspacePresentationBuilder.projects(
+            from: [dto],
+            deviceID: deviceID,
+            identities: identities
+        ).first
+
+        #expect(project?.name == dto.name)
+        #expect(project?.path == dto.path)
+        #expect(project?.isRemoteMac == true)
+        #expect(project?.remoteMacDeviceID == deviceID)
+        #expect(project?.id != dto.id)
+    }
+}

--- a/docs/remote-server/methods.md
+++ b/docs/remote-server/methods.md
@@ -174,7 +174,8 @@ Result shapes: [`vcsStatus`](#vcsstatus-shape) and [`vcsBranches`](#vcsbranches-
       "value": {
         "deviceID": "2f8d1f9f-e065-4f62-af30-8c4b3d0bfc53",
         "deviceName": "Android Client",
-        "token": "random-secret-token"
+        "token": "random-secret-token",
+        "clientKind": "desktop"
       }
     }
   }

--- a/docs/remote-server/overview.md
+++ b/docs/remote-server/overview.md
@@ -1,12 +1,12 @@
 # Remote Server Overview
 
-Muxy embeds a WebSocket server that lets external clients connect to the desktop app over the local network — for mobile companions, dashboards, and custom integrations.
+Muxy embeds a WebSocket server that lets other Muxy Macs, mobile companions, dashboards, and custom integrations connect over the local network.
 
 ```mermaid
 flowchart TB
-  Client[Mobile / dashboard client]
+  Client[Muxy Mac / mobile / dashboard]
   Client <-->|WebSocket / JSON| Muxy[Muxy.app]
-  Muxy --> Settings[Settings → Mobile]
+  Muxy --> Settings[Settings → Remote Access]
   Muxy --> Approved[approved-devices.json]
   Muxy -.->|Bonjour _muxy._tcp| Client
 ```
@@ -26,7 +26,7 @@ flowchart TB
 
 - Endpoint: `ws://<host>:<port>` (default port `4865`; `4866` in development builds)
 - Format: JSON, UTF-8, ISO-8601 dates, UUID strings, RGB colors as `0xRRGGBB` integers
-- Disabled by default; enable in **Settings -> Mobile** (see [Setup](setup.md))
+- Disabled by default; enable the relevant client kind in **Settings -> Remote Access** (see [Setup](setup.md))
 - All clients must authenticate before any other RPC is accepted
 - The server advertises over Bonjour as `_muxy._tcp`
 

--- a/docs/remote-server/pairing.md
+++ b/docs/remote-server/pairing.md
@@ -6,7 +6,7 @@ Each client should generate and persist:
 - `deviceName` — a user-friendly label
 - `token` — a random secret persisted securely on the client
 
-The desktop stores approved mobile clients in `approved-devices.json`, keeping only a SHA-256 hash of each token (never the token itself) plus the device name and last-seen time.
+The host stores approved clients in `approved-devices.json`, keeping only a SHA-256 hash of each token (never the token itself) plus the device name, client kind, and last-seen time.
 
 ## Connection flow
 
@@ -49,12 +49,13 @@ Authenticates a previously approved device.
     "deviceID": "2f8d1f9f-e065-4f62-af30-8c4b3d0bfc53",
     "deviceName": "Pixel 9",
     "token": "random-secret-token",
-    "theme": null
+    "theme": null,
+    "clientKind": "desktop"
   }
 }
 ```
 
-`theme` is an optional [`clientTheme`](data-objects.md#client-theme). When present, the colors are stored for this connection and applied to every pane the client takes over (see [`setClientTheme`](methods.md)). It is the client→server counterpart to the `theme*` fields the server returns below, and may be omitted entirely. `pairDevice` accepts the same optional field.
+`theme` is an optional [`clientTheme`](data-objects.md#client-theme). When present, the colors are stored for this connection and applied to every pane the client takes over (see [`setClientTheme`](methods.md)). It is the client→server counterpart to the `theme*` fields the server returns below, and may be omitted entirely. `clientKind` is `"mobile"` or `"desktop"`; omitting it defaults to `"mobile"` for compatibility. `pairDevice` accepts the same optional fields.
 
 Outcomes:
 
@@ -111,4 +112,4 @@ A token mismatch on a **known** device returns `403 Pairing denied`, not `401`, 
 
 ## Revocation
 
-The Mac's **Settings -> Mobile** lists approved devices. Revoking removes the device from `approved-devices.json` and immediately disconnects any active connection for that `deviceID`.
+The Mac's **Settings -> Remote Access** lists approved devices. Revoking removes the device from `approved-devices.json` and immediately disconnects any active connection for that `deviceID`.

--- a/docs/remote-server/setup.md
+++ b/docs/remote-server/setup.md
@@ -2,11 +2,12 @@
 
 ## Enabling the server
 
-The Mobile server is **disabled by default in release builds**. Development builds start enabled on port `4866` so a debug build can run alongside a release build. Toggle it from **Settings -> Mobile** on macOS.
+Remote access is **disabled by default in release builds**. Development builds start enabled on port `4866` so a debug build can run alongside a release build. Configure it from **Settings -> Remote Access** on macOS.
 
 | Setting | Default | Notes |
 | --- | --- | --- |
-| Allow mobile device connections | off in release, on in development | Starts/stops the WebSocket listener. |
+| Allow mobile device connections | off in release, on in development | Accepts clients that identify as `mobile`. |
+| Allow desktop connections | off in release, on in development | Accepts Muxy Mac clients that identify as `desktop`. |
 | Port | `4865` in release, `4866` in development | Stored in `UserDefaults`. Changing it stops the server and turns the toggle off; re-enable it to start on the new port. A bind failure retires the listener and surfaces the error; the setting remains enabled until the user turns it off or fixes the port. |
 | Approved devices | empty | List of paired clients, each with a **Revoke** button. |
 
@@ -59,10 +60,10 @@ For production integrations, treat the connection as local-network only unless y
 
 ## Integration recommendations
 
-- Persist `deviceID` and `token` securely.
+- Persist `deviceID` and `token` securely. Muxy Mac clients keep them in Keychain, scoped to the remote-device record and endpoint.
 - Re-authenticate after reconnecting; the `clientID` is per-connection and changes.
 - Treat `workspaceChanged` as authoritative for layout and tab state.
 - Cache project logos after decoding the Base64 payload.
 - Call `takeOverPane` before any interactive terminal control; input from a non-owner is dropped.
-- Handle a `401` on `authenticateDevice` by falling back to `pairDevice`; a `403` means a wrong token — re-pair.
+- Handle a `401` on `authenticateDevice` by falling back to `pairDevice`; a `403` means access was denied or the credential is wrong and must not automatically fall back to pairing.
 - Do not rely on `subscribe`/`unsubscribe` for filtering — every event reaches every authenticated client.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -1,3 +1,11 @@
 # Settings
 
 Open settings with `Cmd+,` (**Muxy -> Settings...**). Use search at the top to find settings by name.
+
+## Remote Macs
+
+On the Mac that owns the projects, enable **Allow desktop connections** under **Remote Access**. On the other Mac, open **Remote Devices**, add a **Muxy Mac**, and select a discovered Mac or enter its host and port. Approve the first connection on the host.
+
+The connected Mac then appears in the workspace switcher. Selecting it loads the host's projects into the same project sidebar, tab strip, split layout, title bar, and terminal interface used for local workspaces. Actions supported by the remote-server API operate on the host, while Mac A keeps its local workspace state separate. Terminal panes request control only while visible and release it when hidden. Browser, extension, and source-control tabs use the normal tab UI, but their content is shown only on the host until those content types can be streamed.
+
+Remote access uses unencrypted WebSockets. Use it only on a trusted local network or through a private VPN such as Tailscale. Pairing tokens remain in Keychain and are never included in backups.

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -51,10 +51,10 @@ After authenticating, restart Muxy so it picks up the new credentials.
 - Provider CLIs run headlessly and cannot show interactive authentication or permission prompts. Authenticate the chosen CLI in a terminal first, then retry the button; failures are shown in a toast.
 - AI only generates metadata. Muxy always owns staging, branch creation, commits, pushes, and pull request creation. Update the prompt when the provider returns invalid JSON or unsuitable metadata, not to change the native Git sequence.
 
-## Mobile server won't start
+## Remote access server won't start
 
 - Make sure the port (default 4865) isn't in use: `lsof -i :4865`.
-- Check **Settings → Mobile** for an error message — port conflicts and bind failures are surfaced there.
+- Check **Settings → Remote Access** for an error message — port conflicts and bind failures are surfaced there.
 
 ## Notifications aren't showing
 
@@ -70,7 +70,7 @@ If you want to start fresh, quit Muxy and remove:
 ~/Library/Application Support/Muxy/
 ```
 
-This wipes projects, worktrees, notifications, approved mobile devices, and Muxy's Ghostty config at `~/Library/Application Support/Muxy/ghostty.conf`. Your system Ghostty config at `~/.config/ghostty/config` is left alone.
+This wipes projects, worktrees, notifications, approved remote-access devices, and Muxy's Ghostty config at `~/Library/Application Support/Muxy/ghostty.conf`. Your system Ghostty config at `~/.config/ghostty/config` is left alone.
 
 ## Reporting a bug
 


### PR DESCRIPTION
Adds paired Muxy Mac workspaces through Remote Devices and renders them in the existing project, tab, split, and terminal UI.
Keeps remote credentials and workspace state isolated while enforcing desktop host permissions and visible-pane terminal ownership.
Closes #544. Validated with `scripts/checks.sh --fix` and an independent review.