### PR TITLE
Restore terminal focus after project picker closes

### DIFF
--- a/Muxy/Services/Project/ProjectPickerTerminalFocusRestoration.swift
+++ b/Muxy/Services/Project/ProjectPickerTerminalFocusRestoration.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct ProjectPickerTerminalFocusRestoration {
+    private(set) var isPending = false
+
+    mutating func record(_ result: ProjectOpenConfirmationResult) {
+        guard result.didConfirm else { return }
+        isPending = true
+    }
+
+    mutating func overlayExitCompleted(notificationCenter: NotificationCenter = .default) {
+        guard isPending else { return }
+        isPending = false
+        notificationCenter.post(name: .refocusActiveTerminal, object: nil)
+    }
+}

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -87,6 +87,7 @@ struct MainWindow: View {
     @State private var showProjectPicker = false
     @State private var remoteProjectDevice: RemoteDevice?
     @State private var overlayAnimatingOut = false
+    @State private var projectPickerTerminalFocusRestoration = ProjectPickerTerminalFocusRestoration()
     @State private var isFullScreen = false
     @AppStorage(AppBackgroundStyle.storageKey)
     private var appBackgroundStyleRaw = AppBackgroundStyle.defaultValue.rawValue
@@ -157,7 +158,10 @@ struct MainWindow: View {
             overlayExitTracker: OverlayExitTracker(
                 showTerminalOmnibox: showTerminalOmnibox,
                 showProjectPicker: showProjectPicker,
-                onAnimatingOut: { overlayAnimatingOut = $0 }
+                onAnimatingOut: { overlayAnimatingOut = $0 },
+                onExitCompleted: {
+                    projectPickerTerminalFocusRestoration.overlayExitCompleted()
+                }
             ),
             shortcutInterceptor: MainWindowShortcutInterceptor(
                 isTerminalFocused: { isTerminalPaneFocused },
@@ -752,26 +756,28 @@ struct MainWindow: View {
                 projectPaths: projectPickerPaths,
                 context: projectPickerContext,
                 onConfirm: { path, createIfMissing in
-                    if let device = remoteProjectDevice {
-                        return RemoteDeviceProjectConfirmationService(
+                    let result = if let device = remoteProjectDevice {
+                        RemoteDeviceProjectConfirmationService(
                             appState: appState,
                             projectStore: projectStore,
                             worktreeStore: worktreeStore,
                             projectGroupStore: projectGroupStore
                         )
                         .confirm(path: path, device: device)
+                    } else if projectGroupStore.isRemoteWorkspaceActive {
+                        confirmRemoteProjectPath(path)
+                    } else {
+                        ProjectOpenService.confirmProjectPathResult(
+                            path,
+                            appState: appState,
+                            projectStore: projectStore,
+                            worktreeStore: worktreeStore,
+                            projectGroupStore: projectGroupStore,
+                            createIfMissing: createIfMissing
+                        )
                     }
-                    if projectGroupStore.isRemoteWorkspaceActive {
-                        return confirmRemoteProjectPath(path)
-                    }
-                    return ProjectOpenService.confirmProjectPathResult(
-                        path,
-                        appState: appState,
-                        projectStore: projectStore,
-                        worktreeStore: worktreeStore,
-                        projectGroupStore: projectGroupStore,
-                        createIfMissing: createIfMissing
-                    )
+                    projectPickerTerminalFocusRestoration.record(result)
+                    return result
                 },
                 onChooseFinder: {
                     ProjectOpenService.openProject(
@@ -2289,6 +2295,7 @@ private struct OverlayExitTracker: ViewModifier {
     let showTerminalOmnibox: Bool
     let showProjectPicker: Bool
     let onAnimatingOut: (Bool) -> Void
+    let onExitCompleted: () -> Void
 
     func body(content: Content) -> some View {
         content
@@ -2301,6 +2308,9 @@ private struct OverlayExitTracker: ViewModifier {
         onAnimatingOut(true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             onAnimatingOut(false)
+            DispatchQueue.main.async {
+                onExitCompleted()
+            }
         }
     }
 }

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -34,8 +34,8 @@ struct TerminalPane: View {
         terminalLayer
             .onReceive(NotificationCenter.default.publisher(for: .refocusActiveTerminal)) { _ in
                 guard focused, visible else { return }
-                let view = TerminalViewRegistry.shared.existingView(for: state.id)
-                DispatchQueue.main.async { [weak view] in
+                DispatchQueue.main.async {
+                    let view = TerminalViewRegistry.shared.existingView(for: state.id)
                     view?.window?.makeFirstResponder(view)
                 }
             }
@@ -244,6 +244,7 @@ struct TerminalBridge: NSViewRepresentable {
         configureFileOpenCallback(view)
         configureProgressCallback(view)
         context.coordinator.wasFocused = focused
+        context.coordinator.wasOverlayActive = overlayActive
         if focused, !overlayActive {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak view] in
                 guard let view else { return }
@@ -306,7 +307,11 @@ struct TerminalBridge: NSViewRepresentable {
             if !wasOverlayActive {
                 nsView.notifySurfaceUnfocused()
             }
-        } else if focused, !wasFocused || wasOverlayActive {
+        } else if TerminalFocusRestorationPolicy.shouldClaimFocus(
+            focused: focused,
+            wasFocused: wasFocused,
+            wasOverlayActive: wasOverlayActive
+        ) {
             DispatchQueue.main.async { [weak nsView] in
                 guard let nsView else { return }
                 nsView.window?.makeFirstResponder(nsView)
@@ -585,5 +590,15 @@ struct TerminalBridge: NSViewRepresentable {
         view.onSearchSelected = { [weak state] selected in
             state?.searchState.selected = selected
         }
+    }
+}
+
+enum TerminalFocusRestorationPolicy {
+    static func shouldClaimFocus(
+        focused: Bool,
+        wasFocused: Bool,
+        wasOverlayActive: Bool
+    ) -> Bool {
+        focused && (!wasFocused || wasOverlayActive)
     }
 }

--- a/Tests/MuxyTests/Services/Project/ProjectPickerTerminalFocusRestorationTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectPickerTerminalFocusRestorationTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProjectPickerTerminalFocusRestoration")
+struct ProjectPickerTerminalFocusRestorationTests {
+    @Test("successful project open refocuses the terminal after the picker exits")
+    func successfulProjectOpenRefocusesTerminalAfterPickerExit() {
+        let notificationCenter = NotificationCenter()
+        let counter = NotificationCounter(
+            notificationCenter: notificationCenter,
+            name: .refocusActiveTerminal
+        )
+        var restoration = ProjectPickerTerminalFocusRestoration()
+
+        restoration.record(.success)
+        restoration.overlayExitCompleted(notificationCenter: notificationCenter)
+
+        #expect(counter.count == 1)
+        #expect(!restoration.isPending)
+    }
+
+    @Test("failed project confirmation does not refocus the terminal")
+    func failedProjectConfirmationDoesNotRefocusTerminal() {
+        let notificationCenter = NotificationCenter()
+        let counter = NotificationCounter(
+            notificationCenter: notificationCenter,
+            name: .refocusActiveTerminal
+        )
+        var restoration = ProjectPickerTerminalFocusRestoration()
+
+        restoration.record(.failed)
+        restoration.overlayExitCompleted(notificationCenter: notificationCenter)
+
+        #expect(counter.count == 0)
+        #expect(!restoration.isPending)
+    }
+
+    @Test("focus restoration request is consumed once")
+    func focusRestorationRequestIsConsumedOnce() {
+        let notificationCenter = NotificationCenter()
+        let counter = NotificationCounter(
+            notificationCenter: notificationCenter,
+            name: .refocusActiveTerminal
+        )
+        var restoration = ProjectPickerTerminalFocusRestoration()
+
+        restoration.record(.success)
+        restoration.overlayExitCompleted(notificationCenter: notificationCenter)
+        restoration.overlayExitCompleted(notificationCenter: notificationCenter)
+
+        #expect(counter.count == 1)
+    }
+}
+
+private final class NotificationCounter: @unchecked Sendable {
+    private(set) var count = 0
+    private let notificationCenter: NotificationCenter
+    private var token: NSObjectProtocol?
+
+    init(notificationCenter: NotificationCenter, name: Notification.Name) {
+        self.notificationCenter = notificationCenter
+        token = notificationCenter.addObserver(forName: name, object: nil, queue: nil) { [weak self] _ in
+            self?.count += 1
+        }
+    }
+
+    deinit {
+        if let token {
+            notificationCenter.removeObserver(token)
+        }
+    }
+}

--- a/Tests/MuxyTests/Views/Terminal/TerminalFocusRestorationPolicyTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalFocusRestorationPolicyTests.swift
@@ -1,0 +1,42 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalFocusRestorationPolicy")
+struct TerminalFocusRestorationPolicyTests {
+    @Test("focused terminal reclaims focus after its creation overlay closes")
+    func focusedTerminalReclaimsFocusAfterCreationOverlayCloses() {
+        #expect(TerminalFocusRestorationPolicy.shouldClaimFocus(
+            focused: true,
+            wasFocused: true,
+            wasOverlayActive: true
+        ))
+    }
+
+    @Test("focused terminal claims focus when it becomes selected")
+    func focusedTerminalClaimsFocusWhenSelected() {
+        #expect(TerminalFocusRestorationPolicy.shouldClaimFocus(
+            focused: true,
+            wasFocused: false,
+            wasOverlayActive: false
+        ))
+    }
+
+    @Test("unfocused terminal does not claim focus")
+    func unfocusedTerminalDoesNotClaimFocus() {
+        #expect(!TerminalFocusRestorationPolicy.shouldClaimFocus(
+            focused: false,
+            wasFocused: true,
+            wasOverlayActive: true
+        ))
+    }
+
+    @Test("unchanged focused terminal does not repeatedly claim focus")
+    func unchangedFocusedTerminalDoesNotRepeatedlyClaimFocus() {
+        #expect(!TerminalFocusRestorationPolicy.shouldClaimFocus(
+            focused: true,
+            wasFocused: true,
+            wasOverlayActive: false
+        ))
+    }
+}


### PR DESCRIPTION
Refocuses the active terminal after a successful project selection and when creation overlays close. Adds one-shot restoration state and policy tests covering successful, failed, and repeated focus requests.