### PR TITLE
Stage AI hook scripts in Application Support

### DIFF
--- a/Muxy/Services/AI/AIProviderIntegration.swift
+++ b/Muxy/Services/AI/AIProviderIntegration.swift
@@ -107,12 +107,10 @@ final class AIProviderRegistry {
 
     func installAll() async {
         #if DEBUG
-        let installMissingHooks = shouldInstallHooksInDebug()
-        if !installMissingHooks {
-            logger.info("Reconciling installed AI hooks in dev mode (set FF_AI_HOOKS=true to install missing hooks)")
+        guard shouldInstallHooksInDebug() else {
+            logger.info("Skipping AI hook reconciliation in dev mode (set FF_AI_HOOKS=true to enable)")
+            return
         }
-        #else
-        let installMissingHooks = true
         #endif
 
         for provider in providers {
@@ -126,7 +124,6 @@ final class AIProviderRegistry {
                 continue
             }
 
-            guard installMissingHooks else { continue }
             await loginShellPathHydrationTask().value
 
             guard provider.isToolInstalled() else {

--- a/Muxy/Services/Notifications/MuxyNotificationHooks.swift
+++ b/Muxy/Services/Notifications/MuxyNotificationHooks.swift
@@ -5,31 +5,26 @@ private let logger = Logger(subsystem: "app.muxy", category: "MuxyNotificationHo
 
 enum MuxyNotificationHooks {
     private static let hookScriptName = "muxy-claude-hook"
+    private static let sharedShellRuntimeName = "muxy-agent-hook"
+    private static let scriptsDirectoryName = "hooks"
 
     static var hookScriptPath: String? {
-        if let bundled = findBundledScript(hookScriptName, extension: "sh") {
-            return bundled
-        }
-
-        let devPath = findDevScriptPath(hookScriptName + ".sh")
-        if let devPath, FileManager.default.isExecutableFile(atPath: devPath) {
-            return devPath
-        }
-
-        return nil
+        sourceScriptURL(
+            named: hookScriptName,
+            extension: "sh",
+            bundle: Bundle.appResources,
+            searchDevelopmentDirectory: true
+        )?.path
     }
 
     static func scriptPath(named name: String, extension ext: String) -> String? {
-        if let bundled = findBundledScript(name, extension: ext) {
-            return bundled
-        }
-
-        let devPath = findDevScriptPath(name + "." + ext)
-        if let devPath, FileManager.default.fileExists(atPath: devPath) {
-            return devPath
-        }
-
-        return nil
+        stageScript(
+            named: name,
+            extension: ext,
+            destinationDirectory: MuxyFileStorage.appSupportDirectory()
+                .appendingPathComponent(scriptsDirectoryName, isDirectory: true),
+            searchDevelopmentDirectory: true
+        )
     }
 
     static func findBundledScript(_ name: String, extension ext: String, bundle: Bundle = Bundle.appResources) -> String? {
@@ -44,20 +39,94 @@ enum MuxyNotificationHooks {
         let path = url.path
         guard FileManager.default.fileExists(atPath: path) else { return nil }
 
-        if ext == "sh" || ext == "js" {
-            if !FileManager.default.isExecutableFile(atPath: path) {
-                do {
-                    try FileManager.default.setAttributes(
-                        [.posixPermissions: FilePermissions.executable],
-                        ofItemAtPath: path
-                    )
-                } catch {
-                    logger.error("Failed to set executable permission on \(path): \(error.localizedDescription)")
-                }
-            }
+        return path
+    }
+
+    static func stageScript(
+        named name: String,
+        extension ext: String,
+        bundle: Bundle = Bundle.appResources,
+        destinationDirectory: URL,
+        searchDevelopmentDirectory: Bool = false
+    ) -> String? {
+        guard let sourceURL = sourceScriptURL(
+            named: name,
+            extension: ext,
+            bundle: bundle,
+            searchDevelopmentDirectory: searchDevelopmentDirectory
+        )
+        else {
+            return nil
         }
 
-        return path
+        do {
+            try prepareDestinationDirectory(destinationDirectory)
+            if ext == "sh", name != sharedShellRuntimeName {
+                guard let runtimeURL = sourceScriptURL(
+                    named: sharedShellRuntimeName,
+                    extension: "sh",
+                    bundle: bundle,
+                    searchDevelopmentDirectory: searchDevelopmentDirectory
+                )
+                else {
+                    logger.error("Shared shell hook runtime not found")
+                    return nil
+                }
+                _ = try stageFile(
+                    from: runtimeURL,
+                    to: destinationDirectory,
+                    permissions: FilePermissions.privateExecutable
+                )
+            }
+            let permissions = ext == "sh" ? FilePermissions.privateExecutable : FilePermissions.privateFile
+            return try stageFile(from: sourceURL, to: destinationDirectory, permissions: permissions).path
+        } catch {
+            logger.error("Failed to stage \(name).\(ext): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private static func sourceScriptURL(
+        named name: String,
+        extension ext: String,
+        bundle: Bundle,
+        searchDevelopmentDirectory: Bool
+    ) -> URL? {
+        if let bundled = findBundledScript(name, extension: ext, bundle: bundle) {
+            return URL(fileURLWithPath: bundled)
+        }
+        guard searchDevelopmentDirectory,
+              let devPath = findDevScriptPath(name + "." + ext)
+        else {
+            return nil
+        }
+        return URL(fileURLWithPath: devPath)
+    }
+
+    private static func prepareDestinationDirectory(_ directory: URL) throws {
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: FilePermissions.privateDirectory],
+            ofItemAtPath: directory.path
+        )
+    }
+
+    private static func stageFile(from source: URL, to directory: URL, permissions: Int) throws -> URL {
+        let destination = directory.appendingPathComponent(source.lastPathComponent)
+        let sourceData = try Data(contentsOf: source)
+        let existingData = try? Data(contentsOf: destination)
+        if existingData != sourceData {
+            try sourceData.write(to: destination, options: .atomic)
+        }
+        try FileManager.default.setAttributes(
+            [.posixPermissions: permissions],
+            ofItemAtPath: destination.path
+        )
+        return destination
     }
 
     private static func findDevScriptPath(_ fileName: String) -> String? {

--- a/Muxy/Services/Providers/ClaudeCodeProvider.swift
+++ b/Muxy/Services/Providers/ClaudeCodeProvider.swift
@@ -116,7 +116,7 @@ struct ClaudeCodeProvider: AIProviderIntegration, AIAgentLaunchProvider {
     }
 
     static func hookCommand(hookScript: String, event: String) -> String {
-        "'\(hookScript)' \(event) # \(muxyMarker)"
+        "\(ShellEscaper.quote(hookScript)) \(event) # \(muxyMarker)"
     }
 
     private static func buildHookEntry(command: String) -> [String: Any] {

--- a/Muxy/Services/Providers/CodexProvider.swift
+++ b/Muxy/Services/Providers/CodexProvider.swift
@@ -135,7 +135,7 @@ struct CodexProvider: AIProviderIntegration, AIAgentLaunchProvider {
     }
 
     private static func hookCommand(hookScript: String, event: String) -> String {
-        "'\(hookScript)' \(event) # \(muxyMarker)"
+        "\(ShellEscaper.quote(hookScript)) \(event) # \(muxyMarker)"
     }
 
     private static func buildHookEntry(command: String) -> [String: Any] {

--- a/Muxy/Services/Providers/CursorProvider.swift
+++ b/Muxy/Services/Providers/CursorProvider.swift
@@ -104,7 +104,7 @@ struct CursorProvider: AIProviderIntegration, AIAgentLaunchProvider {
     }
 
     private static func hookCommand(hookScript: String, argument: String) -> String {
-        "'\(hookScript)' \(argument) # \(muxyMarker)"
+        "\(ShellEscaper.quote(hookScript)) \(argument) # \(muxyMarker)"
     }
 
     private static func muxyHookMatches(entries: [[String: Any]]?, expectedCommand: String) -> Bool {

--- a/Muxy/Services/Providers/DroidProvider.swift
+++ b/Muxy/Services/Providers/DroidProvider.swift
@@ -108,7 +108,7 @@ struct DroidProvider: AIProviderIntegration, AIAgentLaunchProvider {
     }
 
     static func hookCommand(hookScript: String, event: String) -> String {
-        "'\(hookScript)' \(event) # \(muxyMarker)"
+        "\(ShellEscaper.quote(hookScript)) \(event) # \(muxyMarker)"
     }
 
     private static func buildHookEntry(command: String) -> [String: Any] {

--- a/Muxy/Services/Providers/GrokProvider.swift
+++ b/Muxy/Services/Providers/GrokProvider.swift
@@ -138,7 +138,7 @@ struct GrokProvider: AIProviderIntegration, AIAgentLaunchProvider {
     }
 
     static func hookCommand(hookScript: String, event: String) -> String {
-        "'\(hookScript)' \(event) # \(muxyMarker)"
+        "\(ShellEscaper.quote(hookScript)) \(event) # \(muxyMarker)"
     }
 
     private static func buildHookEntry(command: String) -> [String: Any] {

--- a/Muxy/Utilities/FilePermissions.swift
+++ b/Muxy/Utilities/FilePermissions.swift
@@ -3,5 +3,6 @@ import Foundation
 enum FilePermissions {
     static let privateFile = 0o600
     static let privateDirectory = 0o700
+    static let privateExecutable = 0o700
     static let executable = 0o755
 }

--- a/Muxy/Utilities/ShellEscaper.swift
+++ b/Muxy/Utilities/ShellEscaper.swift
@@ -9,6 +9,10 @@ enum ShellEscaper {
 
     static func escape(_ path: String) -> String {
         guard path.contains(where: { !safeCharacters.contains($0) }) else { return path }
-        return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        return quote(path)
+    }
+
+    static func quote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }

--- a/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
@@ -131,7 +131,7 @@ struct AIProviderRegistryTests {
         let registry = AIProviderRegistry(
             providers: [provider],
             hydrateLoginShellPath: {},
-            shouldInstallHooksInDebug: { false }
+            shouldInstallHooksInDebug: { true }
         )
 
         await registry.installAll()
@@ -140,8 +140,8 @@ struct AIProviderRegistryTests {
         #expect(provider.toolCheckCount == 0)
     }
 
-    @Test("installAll refreshes only providers whose hook is already installed in dev")
-    func installAllRefreshesInstalledHooksInDev() async {
+    @Test("installAll does not reconcile hooks in dev without explicit opt-in")
+    func installAllDoesNotReconcileHooksInDevWithoutExplicitOptIn() async {
         let installed = RefreshRecordingProvider()
         let notInstalled = RefreshRecordingProvider()
         defer {
@@ -164,11 +164,31 @@ struct AIProviderRegistryTests {
 
         await registry.installAll()
 
-        #expect(installed.hookInstalledCheckCount >= 1)
-        #expect(installed.installAttempted)
+        #expect(installed.hookInstalledCheckCount == 0)
+        #expect(!installed.installAttempted)
         #expect(!notInstalled.installAttempted)
         #expect(notInstalled.toolCheckCount == 0)
         #expect(!gate.started)
+    }
+
+    @Test("installAll refreshes installed hooks in dev with explicit opt-in")
+    func installAllRefreshesInstalledHooksInDevWithExplicitOptIn() async {
+        let provider = RefreshRecordingProvider()
+        defer { provider.resetSettings() }
+        provider.isEnabled = true
+        provider.hookInstalled = true
+        let registry = AIProviderRegistry(
+            providers: [provider],
+            hydrateLoginShellPath: {},
+            shouldInstallHooksInDebug: { true },
+            hookScriptPath: { _, _ in "/tmp/muxy-test-hook" }
+        )
+
+        await registry.installAll()
+
+        #expect(provider.hookInstalledCheckCount >= 1)
+        #expect(provider.installAttempted)
+        #expect(provider.toolCheckCount == 0)
     }
 
     @Test("installAll installs missing hooks in dev only with the explicit opt-in")

--- a/Tests/MuxyTests/Services/Notifications/MuxyNotificationHooksTests.swift
+++ b/Tests/MuxyTests/Services/Notifications/MuxyNotificationHooksTests.swift
@@ -66,6 +66,65 @@ struct MuxyNotificationHooksTests {
         #expect(found == rootFile.path)
     }
 
+    @Test("staged shell hooks survive source bundle removal and refresh in place")
+    func stagedShellHooksSurviveSourceRemovalAndRefreshInPlace() throws {
+        let bundleDirectory = try temporaryBundle()
+        let destinationRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Muxy Application Support \(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: bundleDirectory)
+            try? FileManager.default.removeItem(at: destinationRoot)
+        }
+
+        let scriptsDirectory = bundleDirectory.appendingPathComponent("scripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: scriptsDirectory, withIntermediateDirectories: true)
+        let hookSource = scriptsDirectory.appendingPathComponent("muxy-claude-hook.sh")
+        let runtimeSource = scriptsDirectory.appendingPathComponent("muxy-agent-hook.sh")
+        try Data(
+            """
+            #!/bin/bash
+            script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+            exec /bin/bash "$script_dir/muxy-agent-hook.sh"
+            """.utf8
+        ).write(to: hookSource)
+        try Data("#!/bin/bash\nprintf first".utf8).write(to: runtimeSource)
+
+        let bundle = try #require(Bundle(url: bundleDirectory))
+        let destinationDirectory = destinationRoot.appendingPathComponent("hooks", isDirectory: true)
+        let firstPath = try #require(MuxyNotificationHooks.stageScript(
+            named: "muxy-claude-hook",
+            extension: "sh",
+            bundle: bundle,
+            destinationDirectory: destinationDirectory
+        ))
+        let runtimeDestination = destinationDirectory.appendingPathComponent("muxy-agent-hook.sh")
+
+        #expect(firstPath == destinationDirectory.appendingPathComponent("muxy-claude-hook.sh").path)
+        #expect(FileManager.default.isExecutableFile(atPath: firstPath))
+        #expect(FileManager.default.isExecutableFile(atPath: runtimeDestination.path))
+
+        try Data("#!/bin/bash\nprintf second".utf8).write(to: runtimeSource)
+        let refreshedPath = try #require(MuxyNotificationHooks.stageScript(
+            named: "muxy-claude-hook",
+            extension: "sh",
+            bundle: bundle,
+            destinationDirectory: destinationDirectory
+        ))
+        #expect(refreshedPath == firstPath)
+
+        try FileManager.default.removeItem(at: bundleDirectory)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", ShellEscaper.quote(firstPath)]
+        let output = Pipe()
+        process.standardOutput = output
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+        #expect(String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self) == "second")
+    }
+
     @Test("shell hooks delegate to one normalized lifecycle runtime")
     func shellHooksUseSharedRuntime() throws {
         for scriptName in [

--- a/Tests/MuxyTests/Services/Providers/ClaudeCodeProviderTests.swift
+++ b/Tests/MuxyTests/Services/Providers/ClaudeCodeProviderTests.swift
@@ -37,6 +37,16 @@ struct ClaudeCodeProviderTests {
         #expect((result["Stop"] as? [[String: Any]])?.count == 2)
     }
 
+    @Test("hook commands safely quote spaces and apostrophes")
+    func hookCommandSafelyQuotesScriptPath() {
+        let command = ClaudeCodeProvider.hookCommand(
+            hookScript: "/tmp/Muxy's Hook.sh",
+            event: "stop"
+        )
+
+        #expect(command == "'/tmp/Muxy'\\''s Hook.sh' stop # muxy-notification-hook")
+    }
+
     @Test("reinstall with a new script path replaces the stale entry without duplicating")
     func reinstallReplacesStaleEntry() {
         let installed = ClaudeCodeProvider.hooks(installing: commands(script: "/old/hook.sh"), into: [:])!

--- a/Tests/MuxyTests/Utilities/ShellEscaperTests.swift
+++ b/Tests/MuxyTests/Utilities/ShellEscaperTests.swift
@@ -60,6 +60,12 @@ struct ShellEscaperTests {
         #expect(ShellEscaper.escape("it's my file") == "'it'\\''s my file'")
     }
 
+    @Test("quote always wraps values and escapes apostrophes")
+    func quoteAlwaysWrapsValues() {
+        #expect(ShellEscaper.quote("/tmp/hook.sh") == "'/tmp/hook.sh'")
+        #expect(ShellEscaper.quote("/tmp/Muxy's hook.sh") == "'/tmp/Muxy'\\''s hook.sh'")
+    }
+
     @Test("path with only alphanumerics and safe punctuation stays plain")
     func safePunctuation() {
         #expect(ShellEscaper.escape("/Users/a/b-c_d.1.txt") == "/Users/a/b-c_d.1.txt")

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -60,6 +60,7 @@ After authenticating, restart Muxy so it picks up the new credentials.
 ## Notifications aren't showing
 
 - Check **Settings → Notifications** that Toast or Desktop notifications are enabled and that the relevant provider integration is on.
+- If an AI provider reports a failing Muxy hook command, click **Refresh** beside that provider to restage its hook scripts and update its configuration.
 - macOS may have suppressed Muxy's system notifications — check **System Settings → Notifications → Muxy**.
 - For socket‑based integrations, verify the socket exists: `ls -l ~/Library/Application\ Support/Muxy/muxy.sock`.
 

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -10,7 +10,7 @@ for arg in "$@"; do
   case "$arg" in
     --hooks | -H)
       export FF_AI_HOOKS=1
-      print -P "%F{yellow}AI hooks enabled%f — this dev build now owns the ~/.<provider> hook configs (pointing at .build/debug). Relaunch the release app to restore its hooks."
+      print -P "%F{yellow}AI hooks enabled%f — this dev build now owns the ~/.<provider> hook configs and stages hook scripts in Muxy Application Support. Relaunch the release app to restore its hook versions."
       ;;
     *)
       args+=("$arg")


### PR DESCRIPTION
Stage provider hook scripts and their shared runtime in Application Support with private permissions, safely quote hook paths, and require explicit opt-in for hook reconciliation in development. Add regression tests and troubleshooting guidance for refreshing hooks.