### PR TITLE
Pin SwiftFormat 0.62.1 and reformat

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-swiftformat 0.60.1
+swiftformat 0.62.1
 swiftlint 0.57.1
 xcode 16.4

--- a/Muxy/Commands/DiagnosticsMenuController.swift
+++ b/Muxy/Commands/DiagnosticsMenuController.swift
@@ -16,7 +16,9 @@ final class DiagnosticsMenuController {
 
     private func ensureInstalled() {
         guard let mainMenu = NSApp.mainMenu else { return }
-        if mainMenu.indexOfItem(withTitle: "Diagnostics") >= 0 { return }
+        if mainMenu.indexOfItem(withTitle: "Diagnostics") >= 0 {
+            return
+        }
 
         let menu = NSMenu(title: "Diagnostics")
         menu.autoenablesItems = false

--- a/Muxy/Models/Browser/BrowserHistoryEntry.swift
+++ b/Muxy/Models/Browser/BrowserHistoryEntry.swift
@@ -26,7 +26,9 @@ struct BrowserHistoryEntry: Codable, Identifiable, Hashable {
 
     func matches(query: String) -> Bool {
         let needle = query.lowercased()
-        if url.lowercased().contains(needle) { return true }
+        if url.lowercased().contains(needle) {
+            return true
+        }
         guard let title else { return false }
         return title.lowercased().contains(needle)
     }

--- a/Muxy/Models/Browser/BrowserTabState.swift
+++ b/Muxy/Models/Browser/BrowserTabState.swift
@@ -50,9 +50,15 @@ final class BrowserTabState: Identifiable {
     }
 
     var displayTitle: String {
-        if let customTitle, !customTitle.isEmpty { return customTitle }
-        if let pageTitle, !pageTitle.isEmpty { return pageTitle }
-        if let host = url?.host { return host }
+        if let customTitle, !customTitle.isEmpty {
+            return customTitle
+        }
+        if let pageTitle, !pageTitle.isEmpty {
+            return pageTitle
+        }
+        if let host = url?.host {
+            return host
+        }
         return "New Tab"
     }
 

--- a/Muxy/Models/Browser/BrowserURL.swift
+++ b/Muxy/Models/Browser/BrowserURL.swift
@@ -33,7 +33,9 @@ enum BrowserURL {
 
     private static func looksLikeHost(_ value: String) -> Bool {
         guard !value.contains(" ") else { return false }
-        if value == "localhost" || value.hasPrefix("localhost:") || value.hasPrefix("localhost/") { return true }
+        if value == "localhost" || value.hasPrefix("localhost:") || value.hasPrefix("localhost/") {
+            return true
+        }
         let head = value.split(separator: "/", maxSplits: 1).first.map(String.init) ?? value
         let hostOnly = head.split(separator: ":", maxSplits: 1).first.map(String.init) ?? head
         return hostOnly.contains(".") && !hostOnly.hasPrefix(".") && !hostOnly.hasSuffix(".")

--- a/Muxy/Models/Extension/Extension.swift
+++ b/Muxy/Models/Extension/Extension.swift
@@ -448,7 +448,9 @@ enum ExtensionCommandAction: Codable, Equatable {
     case runScript(script: String)
 
     var isAnchored: Bool {
-        if case .openPopover = self { return true }
+        if case .openPopover = self {
+            return true
+        }
         return false
     }
 

--- a/Muxy/Models/Keyboard/KeyCombo.swift
+++ b/Muxy/Models/Keyboard/KeyCombo.swift
@@ -116,10 +116,18 @@ struct KeyCombo: Codable, Equatable, Hashable {
     ) {
         self.key = Self.normalized(key: key)
         var flags: UInt = 0
-        if command { flags |= NSEvent.ModifierFlags.command.rawValue }
-        if shift { flags |= NSEvent.ModifierFlags.shift.rawValue }
-        if control { flags |= NSEvent.ModifierFlags.control.rawValue }
-        if option { flags |= NSEvent.ModifierFlags.option.rawValue }
+        if command {
+            flags |= NSEvent.ModifierFlags.command.rawValue
+        }
+        if shift {
+            flags |= NSEvent.ModifierFlags.shift.rawValue
+        }
+        if control {
+            flags |= NSEvent.ModifierFlags.control.rawValue
+        }
+        if option {
+            flags |= NSEvent.ModifierFlags.option.rawValue
+        }
         self.modifiers = flags
     }
 
@@ -202,10 +210,18 @@ struct KeyCombo: Codable, Equatable, Hashable {
     var swiftUIModifiers: SwiftUI.EventModifiers {
         var result: SwiftUI.EventModifiers = []
         let flags = nsModifierFlags
-        if flags.contains(.command) { result.insert(.command) }
-        if flags.contains(.shift) { result.insert(.shift) }
-        if flags.contains(.control) { result.insert(.control) }
-        if flags.contains(.option) { result.insert(.option) }
+        if flags.contains(.command) {
+            result.insert(.command)
+        }
+        if flags.contains(.shift) {
+            result.insert(.shift)
+        }
+        if flags.contains(.control) {
+            result.insert(.control)
+        }
+        if flags.contains(.option) {
+            result.insert(.option)
+        }
         return result
     }
 
@@ -214,10 +230,18 @@ struct KeyCombo: Codable, Equatable, Hashable {
 
         var parts = ""
         let flags = nsModifierFlags
-        if flags.contains(.control) { parts += "⌃" }
-        if flags.contains(.option) { parts += "⌥" }
-        if flags.contains(.shift) { parts += "⇧" }
-        if flags.contains(.command) { parts += "⌘" }
+        if flags.contains(.control) {
+            parts += "⌃"
+        }
+        if flags.contains(.option) {
+            parts += "⌥"
+        }
+        if flags.contains(.shift) {
+            parts += "⇧"
+        }
+        if flags.contains(.command) {
+            parts += "⌘"
+        }
         let keyDisplay: String = switch key {
         case Self.leftArrowKey: "←"
         case Self.rightArrowKey: "→"
@@ -235,10 +259,18 @@ struct KeyCombo: Codable, Equatable, Hashable {
         guard isAssigned else { return "" }
         var parts: [String] = []
         let flags = nsModifierFlags
-        if flags.contains(.command) { parts.append("cmd") }
-        if flags.contains(.shift) { parts.append("shift") }
-        if flags.contains(.control) { parts.append("ctrl") }
-        if flags.contains(.option) { parts.append("opt") }
+        if flags.contains(.command) {
+            parts.append("cmd")
+        }
+        if flags.contains(.shift) {
+            parts.append("shift")
+        }
+        if flags.contains(.control) {
+            parts.append("ctrl")
+        }
+        if flags.contains(.option) {
+            parts.append("opt")
+        }
         let keyToken: String = switch key {
         case Self.leftArrowKey: "left"
         case Self.rightArrowKey: "right"

--- a/Muxy/Models/Layout/PullRequestPresentation.swift
+++ b/Muxy/Models/Layout/PullRequestPresentation.swift
@@ -9,7 +9,9 @@ enum RepositoryToolbarPresentation {
     }
 
     static func branchLabel(summary: GitRepositorySummary?, worktree: Worktree?) -> String {
-        if let summary { return summary.displayBranch }
+        if let summary {
+            return summary.displayBranch
+        }
         guard let branch = worktree?.branch, !branch.isEmpty else { return "Branch" }
         return branch
     }
@@ -20,7 +22,9 @@ enum RepositoryToolbarPresentation {
         isRemoving: Bool
     ) -> WorktreeRemovalState {
         guard let worktree, worktree.canBeRemoved else { return .hidden }
-        if isRemoving { return .removing }
+        if isRemoving {
+            return .removing
+        }
         return isPreparing ? .preparing : .available
     }
 }

--- a/Muxy/Models/Layout/TabFocusedSidebarState.swift
+++ b/Muxy/Models/Layout/TabFocusedSidebarState.swift
@@ -15,7 +15,9 @@ final class TabFocusedSidebarState {
     private var expanded: [UUID: Bool] = [:]
 
     func isExpanded(_ projectID: UUID, default defaultValue: Bool) -> Bool {
-        if let value = expanded[projectID] { return value }
+        if let value = expanded[projectID] {
+            return value
+        }
         let key = TabFocusedSidebarPreferences.projectExpandedKey(projectID)
         if let stored = defaults.object(forKey: key) as? Bool {
             expanded[projectID] = stored
@@ -30,7 +32,9 @@ final class TabFocusedSidebarState {
     }
 
     func isExpandedPersisted(_ projectID: UUID) -> Bool {
-        if let value = expanded[projectID] { return value }
+        if let value = expanded[projectID] {
+            return value
+        }
         return defaults.bool(forKey: TabFocusedSidebarPreferences.projectExpandedKey(projectID))
     }
 

--- a/Muxy/Models/Preferences/HomeProjectPreferences.swift
+++ b/Muxy/Models/Preferences/HomeProjectPreferences.swift
@@ -7,7 +7,9 @@ enum HomeProjectPreferences {
     static var isVisible: Bool {
         get {
             let defaults = UserDefaults.standard
-            if defaults.object(forKey: visibleKey) == nil { return defaultVisible }
+            if defaults.object(forKey: visibleKey) == nil {
+                return defaultVisible
+            }
             return defaults.bool(forKey: visibleKey)
         }
         set { UserDefaults.standard.set(newValue, forKey: visibleKey) }

--- a/Muxy/Models/Preferences/QuitConfirmationPreferences.swift
+++ b/Muxy/Models/Preferences/QuitConfirmationPreferences.swift
@@ -6,7 +6,9 @@ enum QuitConfirmationPreferences {
     static var confirmQuit: Bool {
         get {
             let defaults = UserDefaults.standard
-            if defaults.object(forKey: confirmQuitKey) == nil { return true }
+            if defaults.object(forKey: confirmQuitKey) == nil {
+                return true
+            }
             return defaults.bool(forKey: confirmQuitKey)
         }
         set {

--- a/Muxy/Models/Preferences/TabCloseConfirmationPreferences.swift
+++ b/Muxy/Models/Preferences/TabCloseConfirmationPreferences.swift
@@ -6,7 +6,9 @@ enum TabCloseConfirmationPreferences {
     static var confirmRunningProcess: Bool {
         get {
             let defaults = UserDefaults.standard
-            if defaults.object(forKey: confirmRunningProcessKey) == nil { return true }
+            if defaults.object(forKey: confirmRunningProcessKey) == nil {
+                return true
+            }
             return defaults.bool(forKey: confirmRunningProcessKey)
         }
         set {

--- a/Muxy/Models/Preferences/TerminalOfflinePreferences.swift
+++ b/Muxy/Models/Preferences/TerminalOfflinePreferences.swift
@@ -10,7 +10,9 @@ enum TerminalOfflinePreferences {
     static var isEnabled: Bool {
         get {
             let defaults = UserDefaults.standard
-            if defaults.object(forKey: enabledKey) == nil { return defaultIsEnabled }
+            if defaults.object(forKey: enabledKey) == nil {
+                return defaultIsEnabled
+            }
             return defaults.bool(forKey: enabledKey)
         }
         set { UserDefaults.standard.set(newValue, forKey: enabledKey) }

--- a/Muxy/Models/Project/Project.swift
+++ b/Muxy/Models/Project/Project.swift
@@ -72,7 +72,9 @@ struct Project: Identifiable, Codable, Hashable {
     }
 
     var isHome: Bool {
-        if id == Project.homeID { return true }
+        if id == Project.homeID {
+            return true
+        }
         guard let remoteWorkspaceID else { return false }
         return id == ProjectGroup.remoteHomeID(for: remoteWorkspaceID)
     }

--- a/Muxy/Models/Terminal/TerminalActivity.swift
+++ b/Muxy/Models/Terminal/TerminalActivity.swift
@@ -7,7 +7,9 @@ enum TerminalActivity: Equatable {
     case finished
 
     var isUnread: Bool {
-        if case .unread = self { return true }
+        if case .unread = self {
+            return true
+        }
         return false
     }
 

--- a/Muxy/Models/Terminal/TerminalOmniboxItem.swift
+++ b/Muxy/Models/Terminal/TerminalOmniboxItem.swift
@@ -290,7 +290,9 @@ enum TerminalOmniboxItemResolver {
                 .sorted { lhs, rhs in
                     let lhsActive = context.isActiveWorktree(lhs.element)
                     let rhsActive = context.isActiveWorktree(rhs.element)
-                    if lhsActive != rhsActive { return lhsActive }
+                    if lhsActive != rhsActive {
+                        return lhsActive
+                    }
                     return lhs.offset < rhs.offset
                 }
                 .map { TerminalOmniboxItem.openTab($0.element) }

--- a/Muxy/Models/Terminal/TerminalProgress.swift
+++ b/Muxy/Models/Terminal/TerminalProgress.swift
@@ -17,7 +17,9 @@ struct TerminalProgress: Equatable {
     }
 
     static func tabIndicator(progress: TerminalProgress?, agentStatus: AgentStatus?) -> TerminalProgress? {
-        if let progress { return progress }
+        if let progress {
+            return progress
+        }
         guard agentStatus == .working else { return nil }
         return TerminalProgress(kind: .indeterminate, percent: nil)
     }

--- a/Muxy/Models/UI/MuxyNotification.swift
+++ b/Muxy/Models/UI/MuxyNotification.swift
@@ -16,7 +16,9 @@ final class MuxyNotification: Identifiable, @preconcurrency Codable {
         }
 
         var isAIProvider: Bool {
-            if case .aiProvider = self { return true }
+            if case .aiProvider = self {
+                return true
+            }
             return false
         }
     }

--- a/Muxy/Models/UI/NavigationHistory.swift
+++ b/Muxy/Models/UI/NavigationHistory.swift
@@ -26,7 +26,9 @@ final class NavigationHistory {
 
     func record(_ entry: NavigationEntry) {
         guard !isRecordingSuppressed else { return }
-        if let current, current == entry { return }
+        if let current, current == entry {
+            return
+        }
         if cursor < entries.count - 1 {
             entries.removeSubrange((cursor + 1)...)
         }
@@ -66,7 +68,9 @@ final class NavigationHistory {
         var kept: [NavigationEntry] = []
         var cursorAtOrBefore: Int = -1
         for (index, entry) in entries.enumerated() {
-            if predicate(entry) { continue }
+            if predicate(entry) {
+                continue
+            }
             kept.append(entry)
             if index <= previousCursor {
                 cursorAtOrBefore = kept.count - 1

--- a/Muxy/Models/Workspace/LayoutWorkspaceBuilder.swift
+++ b/Muxy/Models/Workspace/LayoutWorkspaceBuilder.swift
@@ -21,7 +21,9 @@ enum LayoutWorkspaceBuilder {
         case let .branch(layout, panes):
             let children = panes.compactMap { buildNode(from: $0, projectPath: projectPath) }
             guard let first = children.first else { return nil }
-            if children.count == 1 { return first }
+            if children.count == 1 {
+                return first
+            }
             let direction: SplitDirection = layout == .horizontal ? .horizontal : .vertical
             return children.dropFirst().reduce(first) { partial, next in
                 .split(SplitBranch(direction: direction, first: partial, second: next))

--- a/Muxy/Models/Workspace/Reducer/FocusReducer.swift
+++ b/Muxy/Models/Workspace/Reducer/FocusReducer.swift
@@ -41,7 +41,9 @@ enum FocusReducer {
         let frames = root.areaFrames()
         let sortedAreas = root.allAreas().sorted { lhs, rhs in
             guard let lhsFrame = frames[lhs.id], let rhsFrame = frames[rhs.id] else { return false }
-            if lhsFrame.minY != rhsFrame.minY { return lhsFrame.minY < rhsFrame.minY }
+            if lhsFrame.minY != rhsFrame.minY {
+                return lhsFrame.minY < rhsFrame.minY
+            }
             return lhsFrame.minX < rhsFrame.minX
         }
         let entries = sortedAreas.flatMap { area in
@@ -100,9 +102,15 @@ enum FocusReducer {
         let centerDistance: CGFloat
 
         static func < (lhs: PaneFocusScore, rhs: PaneFocusScore) -> Bool {
-            if lhs.overlapPenalty != rhs.overlapPenalty { return lhs.overlapPenalty < rhs.overlapPenalty }
-            if lhs.axisGap != rhs.axisGap { return lhs.axisGap < rhs.axisGap }
-            if lhs.crossDistance != rhs.crossDistance { return lhs.crossDistance < rhs.crossDistance }
+            if lhs.overlapPenalty != rhs.overlapPenalty {
+                return lhs.overlapPenalty < rhs.overlapPenalty
+            }
+            if lhs.axisGap != rhs.axisGap {
+                return lhs.axisGap < rhs.axisGap
+            }
+            if lhs.crossDistance != rhs.crossDistance {
+                return lhs.crossDistance < rhs.crossDistance
+            }
             return lhs.centerDistance < rhs.centerDistance
         }
     }

--- a/Muxy/Models/Workspace/SplitNode.swift
+++ b/Muxy/Models/Workspace/SplitNode.swift
@@ -73,7 +73,9 @@ extension SplitNode {
                 command: command
             )
             branch.first = newFirst
-            if id1 != nil { return (.split(branch), id1) }
+            if id1 != nil {
+                return (.split(branch), id1)
+            }
             let (newSecond, id2) = branch.second.splitting(
                 areaID: areaID,
                 direction: direction,
@@ -105,7 +107,9 @@ extension SplitNode {
                 areaID: areaID, direction: direction, position: position, tab: tab
             )
             branch.first = newFirst
-            if id1 != nil { return (.split(branch), id1) }
+            if id1 != nil {
+                return (.split(branch), id1)
+            }
             let (newSecond, id2) = branch.second.splittingWithTab(
                 areaID: areaID, direction: direction, position: position, tab: tab
             )

--- a/Muxy/Models/Workspace/WorkspaceSnapshot.swift
+++ b/Muxy/Models/Workspace/WorkspaceSnapshot.swift
@@ -246,7 +246,9 @@ enum WorkspaceRestorer {
         var snapshots: [WorkspaceSnapshot] = []
         for (key, root) in workspaceRoots {
             let path: String? = {
-                if case let .tabArea(area) = root { return area.projectPath }
+                if case let .tabArea(area) = root {
+                    return area.projectPath
+                }
                 return root.allAreas().first?.projectPath
             }()
             snapshots.append(WorkspaceSnapshot(

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -617,9 +617,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         let closed = notification.object as? NSWindow
-        if closed === settingsWindow { settingsWindow = nil }
-        if closed === extensionsWindow { extensionsWindow = nil }
-        if closed === whatsNewWindow { whatsNewWindow = nil }
+        if closed === settingsWindow {
+            settingsWindow = nil
+        }
+        if closed === extensionsWindow {
+            extensionsWindow = nil
+        }
+        if closed === whatsNewWindow {
+            whatsNewWindow = nil
+        }
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
@@ -673,7 +679,9 @@ struct WindowConfigurator: NSViewRepresentable {
         DispatchQueue.main.async {
             guard let w = v.window else { return }
             w.identifier = ShortcutContext.mainWindowIdentifier
-            if Self.closeDuplicateMainWindow(w) { return }
+            if Self.closeDuplicateMainWindow(w) {
+                return
+            }
             w.titlebarAppearsTransparent = true
             w.titleVisibility = .hidden
             w.styleMask.insert(.fullSizeContentView)

--- a/Muxy/Services/AI/AIProviderIntegration.swift
+++ b/Muxy/Services/AI/AIProviderIntegration.swift
@@ -179,7 +179,9 @@ final class AIProviderRegistry {
     }
 
     private func loginShellPathHydrationTask() -> Task<Void, Never> {
-        if let loginShellPathHydration { return loginShellPathHydration }
+        if let loginShellPathHydration {
+            return loginShellPathHydration
+        }
         let hydrateLoginShellPath = hydrateLoginShellPath
         let task = Task.detached(priority: .utility) {
             await hydrateLoginShellPath()

--- a/Muxy/Services/AI/RepositoryAIMetadata.swift
+++ b/Muxy/Services/AI/RepositoryAIMetadata.swift
@@ -164,7 +164,9 @@ enum RepositoryAIResponseDecoder {
                 continue
             }
             if character == "{" {
-                if depth == 0 { start = index }
+                if depth == 0 {
+                    start = index
+                }
                 depth += 1
                 continue
             }

--- a/Muxy/Services/AgentDetection/ForegroundProcessInspector.swift
+++ b/Muxy/Services/AgentDetection/ForegroundProcessInspector.swift
@@ -39,8 +39,12 @@ enum ForegroundProcessInspector {
     }
 
     private static func isScriptInterpreter(executableName: String?, firstArgument: String?) -> Bool {
-        if let executableName, scriptInterpreters.contains(executableName) { return true }
-        if let firstArgument, scriptInterpreters.contains(firstArgument) { return true }
+        if let executableName, scriptInterpreters.contains(executableName) {
+            return true
+        }
+        if let firstArgument, scriptInterpreters.contains(firstArgument) {
+            return true
+        }
         return false
     }
 

--- a/Muxy/Services/Browser/BrowserAutomation.swift
+++ b/Muxy/Services/Browser/BrowserAutomation.swift
@@ -323,7 +323,9 @@ extension MuxyAPI.Browser {
         let bounded = max(0, min(timeoutMs, maxWaitMilliseconds))
         let deadline = ContinuousClock.now + .milliseconds(bounded)
         while ContinuousClock.now < deadline {
-            if !state.isLoading { return .success(state.url?.absoluteString) }
+            if !state.isLoading {
+                return .success(state.url?.absoluteString)
+            }
             do { try await Task.sleep(for: .milliseconds(100)) } catch { break }
         }
         return .success(state.url?.absoluteString)
@@ -522,7 +524,9 @@ extension MuxyAPI.Browser {
 
     private static func allCookies(in store: WKHTTPCookieStore) async -> [HTTPCookie] {
         for _ in 0 ..< cookieFetchAttempts {
-            if let cookies = await allCookiesAttempt(in: store) { return cookies }
+            if let cookies = await allCookiesAttempt(in: store) {
+                return cookies
+            }
         }
         return await allCookiesAttempt(in: store) ?? []
     }
@@ -534,7 +538,9 @@ extension MuxyAPI.Browser {
         }
         let deadline = ContinuousClock.now + .milliseconds(cookieAttemptTimeoutMs)
         while ContinuousClock.now < deadline {
-            if let cookies = box.take() { return cookies }
+            if let cookies = box.take() {
+                return cookies
+            }
             do { try await Task.sleep(for: .milliseconds(20)) } catch { break }
         }
         return nil
@@ -712,7 +718,9 @@ extension MuxyAPI.Browser {
 
     private static func stringify(_ value: Any?) -> String {
         guard let value, !(value is NSNull) else { return "null" }
-        if let string = value as? String { return string }
+        if let string = value as? String {
+            return string
+        }
         if let data = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed]),
            let json = String(data: data, encoding: .utf8)
         {
@@ -722,7 +730,9 @@ extension MuxyAPI.Browser {
     }
 
     private static func waitConditionExpression(_ condition: WaitCondition) -> String {
-        if let function = condition.function, !function.isEmpty { return "(\(function))" }
+        if let function = condition.function, !function.isEmpty {
+            return "(\(function))"
+        }
         if let selector = condition.selector, !selector.isEmpty {
             return "document.querySelector(\(jsString(selector)))"
         }
@@ -819,8 +829,12 @@ private extension BrowserCookieInfo {
             .domain: domain,
             .path: path.isEmpty ? "/" : path,
         ]
-        if secure { properties[.secure] = "TRUE" }
-        if let expires { properties[.expires] = Date(timeIntervalSince1970: expires) }
+        if secure {
+            properties[.secure] = "TRUE"
+        }
+        if let expires {
+            properties[.expires] = Date(timeIntervalSince1970: expires)
+        }
         return HTTPCookie(properties: properties)
     }
 }

--- a/Muxy/Services/Browser/BrowserHistoryStore.swift
+++ b/Muxy/Services/Browser/BrowserHistoryStore.swift
@@ -27,7 +27,9 @@ final class BrowserHistoryStore {
             var entry = entries.remove(at: index)
             entry.lastVisited = Date()
             entry.visitCount += 1
-            if let cleanedTitle, !cleanedTitle.isEmpty { entry.title = cleanedTitle }
+            if let cleanedTitle, !cleanedTitle.isEmpty {
+                entry.title = cleanedTitle
+            }
             entries.insert(entry, at: 0)
         } else {
             let entry = BrowserHistoryEntry(
@@ -61,7 +63,9 @@ final class BrowserHistoryStore {
         }
         let matched = scoped.filter { $0.matches(query: trimmed) }
         let ranked = matched.sorted { lhs, rhs in
-            if lhs.visitCount != rhs.visitCount { return lhs.visitCount > rhs.visitCount }
+            if lhs.visitCount != rhs.visitCount {
+                return lhs.visitCount > rhs.visitCount
+            }
             return lhs.lastVisited > rhs.lastVisited
         }
         return Array(ranked.prefix(limit))

--- a/Muxy/Services/Browser/BrowserWebViewRegistry.swift
+++ b/Muxy/Services/Browser/BrowserWebViewRegistry.swift
@@ -25,7 +25,9 @@ final class BrowserWebViewRegistry {
     }
 
     func unregister(_ tabID: UUID, ifMatches webView: WKWebView? = nil) {
-        if let webView, entries[tabID]?.webView !== webView { return }
+        if let webView, entries[tabID]?.webView !== webView {
+            return
+        }
         entries[tabID] = nil
     }
 

--- a/Muxy/Services/BrowserImport/ChromeImporter.swift
+++ b/Muxy/Services/BrowserImport/ChromeImporter.swift
@@ -61,9 +61,15 @@ final class ChromeImporter: BrowserImporter, Sendable {
             .domain: row.host,
             .path: row.path.isEmpty ? "/" : row.path,
         ]
-        if row.isSecure { properties[.secure] = "TRUE" }
-        if row.isHTTPOnly { properties[HTTPCookiePropertyKey("HttpOnly")] = "TRUE" }
-        if let expiry = expiryDate(from: row.expiresUTC) { properties[.expires] = expiry }
+        if row.isSecure {
+            properties[.secure] = "TRUE"
+        }
+        if row.isHTTPOnly {
+            properties[HTTPCookiePropertyKey("HttpOnly")] = "TRUE"
+        }
+        if let expiry = expiryDate(from: row.expiresUTC) {
+            properties[.expires] = expiry
+        }
 
         return HTTPCookie(properties: properties)
     }

--- a/Muxy/Services/Diagnostics/ProcSampling.swift
+++ b/Muxy/Services/Diagnostics/ProcSampling.swift
@@ -73,7 +73,9 @@ enum ProcSampling {
         let length = proc_name(Int32(pid), &buffer, UInt32(buffer.count))
         if length > 0 {
             let bytes = Array(buffer.prefix { $0 != 0 })
-            if let name = String(bytes: bytes, encoding: .utf8), !name.isEmpty { return name }
+            if let name = String(bytes: bytes, encoding: .utf8), !name.isEmpty {
+                return name
+            }
         }
         return fallback.isEmpty ? "pid \(pid)" : fallback
     }

--- a/Muxy/Services/Diagnostics/ProcessTree.swift
+++ b/Muxy/Services/Diagnostics/ProcessTree.swift
@@ -79,7 +79,9 @@ enum ProcessTree {
         var current: pid_t? = pid
         var visited: Set<pid_t> = []
         while let value = current, value != rootPID, visited.insert(value).inserted {
-            if knownHostPIDs.contains(value) { return true }
+            if knownHostPIDs.contains(value) {
+                return true
+            }
             current = byPID[value]?.ppid
         }
         return false

--- a/Muxy/Services/Editor/EditorSettings.swift
+++ b/Muxy/Services/Editor/EditorSettings.swift
@@ -27,7 +27,9 @@ final class EditorSettings {
     @ObservationIgnored private var isBatchLoading = false
 
     static var availableMonospacedFonts: [String] {
-        if let cached = cachedMonospacedFonts { return cached }
+        if let cached = cachedMonospacedFonts {
+            return cached
+        }
         let result = NSFontManager.shared
             .availableFontFamilies
             .filter { family in

--- a/Muxy/Services/Extensions/ExtensionAuditLog.swift
+++ b/Muxy/Services/Extensions/ExtensionAuditLog.swift
@@ -60,7 +60,9 @@ final class ExtensionAuditLog: @unchecked Sendable {
     }
 
     private func resolveHandle() throws -> FileHandle {
-        if let handle { return handle }
+        if let handle {
+            return handle
+        }
         if !FileManager.default.fileExists(atPath: fileURL.path) {
             FileManager.default.createFile(atPath: fileURL.path, contents: nil)
             try? FileManager.default.setAttributes(

--- a/Muxy/Services/Extensions/ExtensionBridgeHandler.swift
+++ b/Muxy/Services/Extensions/ExtensionBridgeHandler.swift
@@ -370,7 +370,9 @@ final class ExtensionBridgeHandler: NSObject, WKScriptMessageHandlerWithReply, B
     }
 
     private func stringArg(_ args: [String: Any], _ key: String) throws -> String {
-        if let value = args[key] as? String { return value }
+        if let value = args[key] as? String {
+            return value
+        }
         throw APIError.invalidArguments("missing argument '\(key)'")
     }
 }

--- a/Muxy/Services/Extensions/ExtensionCommandExecutor.swift
+++ b/Muxy/Services/Extensions/ExtensionCommandExecutor.swift
@@ -272,7 +272,9 @@ private final class OutputBox: @unchecked Sendable {
     func append(_ chunk: Data) {
         lock.lock()
         defer { lock.unlock() }
-        if overflow { return }
+        if overflow {
+            return
+        }
         let remaining = ExtensionCommandExecutor.maxOutputBytes - data.count
         if chunk.count <= remaining {
             data.append(chunk)

--- a/Muxy/Services/Extensions/ExtensionDialogService.swift
+++ b/Muxy/Services/Extensions/ExtensionDialogService.swift
@@ -95,8 +95,12 @@ enum ExtensionDialogService {
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
         panel.canCreateDirectories = true
-        if !request.title.isEmpty { panel.message = request.title }
-        if !request.message.isEmpty { panel.prompt = request.message }
+        if !request.title.isEmpty {
+            panel.message = request.title
+        }
+        if !request.message.isEmpty {
+            panel.prompt = request.message
+        }
         if let defaultPath = request.defaultPath {
             panel.directoryURL = URL(fileURLWithPath: defaultPath, isDirectory: true)
         }
@@ -183,8 +187,12 @@ enum ExtensionDialogService {
 
     static func keyEquivalents(for request: ConfirmRequest) -> [String] {
         request.buttons.enumerated().map { index, label in
-            if index == 0 { return "\r" }
-            if label == request.cancelButton { return "\u{1B}" }
+            if index == 0 {
+                return "\r"
+            }
+            if label == request.cancelButton {
+                return "\u{1B}"
+            }
             return ""
         }
     }

--- a/Muxy/Services/Extensions/ExtensionEventEmitter.swift
+++ b/Muxy/Services/Extensions/ExtensionEventEmitter.swift
@@ -108,11 +108,21 @@ enum ExtensionEventEmitter {
             "title": context.title,
             "projectPath": context.projectPath,
         ]
-        if let paneID = context.paneID { payload["paneID"] = paneID.uuidString }
-        if let cwd = context.cwd { payload["cwd"] = cwd }
-        if let extensionID = context.extensionID { payload["extensionID"] = extensionID }
-        if let tabTypeID = context.tabTypeID { payload["tabTypeID"] = tabTypeID }
-        if let data = context.data { payload["data"] = data }
+        if let paneID = context.paneID {
+            payload["paneID"] = paneID.uuidString
+        }
+        if let cwd = context.cwd {
+            payload["cwd"] = cwd
+        }
+        if let extensionID = context.extensionID {
+            payload["extensionID"] = extensionID
+        }
+        if let tabTypeID = context.tabTypeID {
+            payload["tabTypeID"] = tabTypeID
+        }
+        if let data = context.data {
+            payload["data"] = data
+        }
         return payload
     }
 

--- a/Muxy/Services/Extensions/ExtensionFileEventEmitter.swift
+++ b/Muxy/Services/Extensions/ExtensionFileEventEmitter.swift
@@ -37,7 +37,9 @@ final class ExtensionFileEventEmitter: @unchecked Sendable {
         var fresh: [String] = []
         for path in paths {
             let key = "\(projectPath)\u{0}\(path)"
-            if let last = lastEmitted[key], now - last < window { continue }
+            if let last = lastEmitted[key], now - last < window {
+                continue
+            }
             lastEmitted[key] = now
             fresh.append(path)
         }

--- a/Muxy/Services/Extensions/ExtensionGrantStore.swift
+++ b/Muxy/Services/Extensions/ExtensionGrantStore.swift
@@ -368,7 +368,9 @@ enum ExtensionGrantSuggestion {
             if let base = argv?.first {
                 return .argvPrefix([base])
             }
-            if let shell { return .shellExact(shell) }
+            if let shell {
+                return .shellExact(shell)
+            }
             return .any
         case let (.remoteInvoke, .remote(action, _)):
             return .remoteActionEquals(action)

--- a/Muxy/Services/Extensions/ExtensionHTTPClient.swift
+++ b/Muxy/Services/Extensions/ExtensionHTTPClient.swift
@@ -170,9 +170,15 @@ private final class HTTPRedirectGuard: NSObject, URLSessionTaskDelegate {
 enum HostSecurityPolicy {
     static func isBlocked(_ host: String) -> Bool {
         let normalized = host.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
-        if normalized.isEmpty { return true }
-        if normalized == "localhost" || normalized.hasSuffix(".localhost") { return true }
-        if normalized.hasSuffix(".local") { return true }
+        if normalized.isEmpty {
+            return true
+        }
+        if normalized == "localhost" || normalized.hasSuffix(".localhost") {
+            return true
+        }
+        if normalized.hasSuffix(".local") {
+            return true
+        }
 
         guard let addresses = resolvedAddresses(for: normalized) else { return true }
         return addresses.contains(where: isPrivateAddress)
@@ -246,11 +252,17 @@ enum HostSecurityPolicy {
     }
 
     private static func isPrivateIPv6(_ host: String) -> Bool {
-        if host == "::1" || host == "::" { return true }
-        if host.hasPrefix("fe80") || host.hasPrefix("fc") || host.hasPrefix("fd") { return true }
+        if host == "::1" || host == "::" {
+            return true
+        }
+        if host.hasPrefix("fe80") || host.hasPrefix("fc") || host.hasPrefix("fd") {
+            return true
+        }
         if host.hasPrefix("::ffff:") {
             let mapped = String(host.dropFirst("::ffff:".count))
-            if let v4 = ipv4Octets(mapped) { return isPrivateIPv4(v4) }
+            if let v4 = ipv4Octets(mapped) {
+                return isPrivateIPv4(v4)
+            }
         }
         return false
     }

--- a/Muxy/Services/Extensions/ExtensionLogStore.swift
+++ b/Muxy/Services/Extensions/ExtensionLogStore.swift
@@ -126,7 +126,9 @@ final class ExtensionLogStore: @unchecked Sendable {
                   let size = attributes[.size] as? Int,
                   let modified = attributes[.modificationDate] as? Date
             else { continue }
-            if modified <= entry.lastTrimChecked, size <= Self.maxSize { continue }
+            if modified <= entry.lastTrimChecked, size <= Self.maxSize {
+                continue
+            }
             entries[id]?.lastTrimChecked = Date()
             guard size > Self.maxSize else { continue }
             trimFile(extensionID: id, url: url, size: size)

--- a/Muxy/Services/Extensions/ExtensionSettingsStore.swift
+++ b/Muxy/Services/Extensions/ExtensionSettingsStore.swift
@@ -69,17 +69,33 @@ final class ExtensionSettingsStore {
     }
 
     private func decodeFromStorage(_ raw: Any) -> ExtensionJSON {
-        if raw is NSNull { return .null }
-        if let value = raw as? Bool { return .bool(value) }
-        if let value = raw as? Double { return .number(value) }
-        if let value = raw as? Int { return .number(Double(value)) }
+        if raw is NSNull {
+            return .null
+        }
+        if let value = raw as? Bool {
+            return .bool(value)
+        }
+        if let value = raw as? Double {
+            return .number(value)
+        }
+        if let value = raw as? Int {
+            return .number(Double(value))
+        }
         if let value = raw as? NSNumber {
-            if CFGetTypeID(value) == CFBooleanGetTypeID() { return .bool(value.boolValue) }
+            if CFGetTypeID(value) == CFBooleanGetTypeID() {
+                return .bool(value.boolValue)
+            }
             return .number(value.doubleValue)
         }
-        if let value = raw as? String { return .string(value) }
-        if let value = raw as? [Any] { return .array(value.map(decodeFromStorage)) }
-        if let value = raw as? [String: Any] { return .object(value.mapValues(decodeFromStorage)) }
+        if let value = raw as? String {
+            return .string(value)
+        }
+        if let value = raw as? [Any] {
+            return .array(value.map(decodeFromStorage))
+        }
+        if let value = raw as? [String: Any] {
+            return .object(value.mapValues(decodeFromStorage))
+        }
         return .null
     }
 }

--- a/Muxy/Services/Extensions/ExtensionStore.swift
+++ b/Muxy/Services/Extensions/ExtensionStore.swift
@@ -288,8 +288,12 @@ final class ExtensionStore {
             return StagedExtension(manifestRoot: manifestRoot, workspace: workspace)
         } catch {
             try? fileManager.removeItem(at: workspace)
-            if error is MarketplaceError { throw error }
-            if error is ExtensionLoadError { throw MarketplaceError.invalidArchive }
+            if error is MarketplaceError {
+                throw error
+            }
+            if error is ExtensionLoadError {
+                throw MarketplaceError.invalidArchive
+            }
             throw MarketplaceError.unpackFailed(error.localizedDescription)
         }
     }
@@ -588,9 +592,15 @@ final class ExtensionStore {
         else { return false }
 
         applyOverride(to: \.statusBarOverrides, extensionID: extensionID, itemID: itemID) {
-            if let icon = update.icon { $0.icon = icon }
-            if update.clearText { $0.text = update.text }
-            if let visible = update.visible { $0.visible = visible }
+            if let icon = update.icon {
+                $0.icon = icon
+            }
+            if update.clearText {
+                $0.text = update.text
+            }
+            if let visible = update.visible {
+                $0.visible = visible
+            }
         }
         return true
     }
@@ -600,8 +610,12 @@ final class ExtensionStore {
         else { return false }
 
         applyOverride(to: \.topbarOverrides, extensionID: extensionID, itemID: itemID) {
-            if let icon { $0.icon = icon }
-            if let visible { $0.visible = visible }
+            if let icon {
+                $0.icon = icon
+            }
+            if let visible {
+                $0.visible = visible
+            }
         }
         return true
     }
@@ -1063,8 +1077,12 @@ final class ExtensionStore {
     }
 
     nonisolated static func classifyTermination(wasIntentional: Bool, terminationStatus: Int32) -> TerminationOutcome {
-        if wasIntentional { return .stopped }
-        if terminationStatus == 0 { return .exitedCleanly }
+        if wasIntentional {
+            return .stopped
+        }
+        if terminationStatus == 0 {
+            return .exitedCleanly
+        }
         return .exitedWithStatus(terminationStatus)
     }
 }

--- a/Muxy/Services/FileSystem/FileSystemOperations.swift
+++ b/Muxy/Services/FileSystem/FileSystemOperations.swift
@@ -95,7 +95,9 @@ enum FileSystemOperations {
         let name = try sanitize(rawName)
         let parent = (absolutePath as NSString).deletingLastPathComponent
         let currentName = (absolutePath as NSString).lastPathComponent
-        if name == currentName { return absolutePath }
+        if name == currentName {
+            return absolutePath
+        }
         let candidate = URL(fileURLWithPath: parent).appendingPathComponent(name).path
         if FileManager.default.fileExists(atPath: candidate) {
             throw FileSystemOperationError.destinationExists(candidate)

--- a/Muxy/Services/FileSystem/FileSystemWatcher.swift
+++ b/Muxy/Services/FileSystem/FileSystemWatcher.swift
@@ -30,7 +30,9 @@ final class FileSystemWatcher: @unchecked Sendable {
                     let isGitInternal = path.contains("/.git/")
                     let isLockFile = path.hasSuffix(".lock")
                     let isDirectory = flag & UInt32(kFSEventStreamEventFlagItemIsDir) != 0
-                    if isGitInternal, isLockFile || isDirectory { return nil }
+                    if isGitInternal, isLockFile || isDirectory {
+                        return nil
+                    }
                     return path
                 }
                 guard !relevant.isEmpty else { return }

--- a/Muxy/Services/FileSystem/FileTreeService.swift
+++ b/Muxy/Services/FileSystem/FileTreeService.swift
@@ -28,7 +28,9 @@ enum FileTreeService {
         entries.reserveCapacity(classification.visible.count)
 
         for name in classification.visible {
-            if name == "." || name == ".." { continue }
+            if name == "." || name == ".." {
+                continue
+            }
             let absolute = directoryAbsolutePath.hasSuffix("/")
                 ? directoryAbsolutePath + name
                 : directoryAbsolutePath + "/" + name
@@ -52,7 +54,9 @@ enum FileTreeService {
         }
 
         entries.sort { lhs, rhs in
-            if lhs.isDirectory != rhs.isDirectory { return lhs.isDirectory && !rhs.isDirectory }
+            if lhs.isDirectory != rhs.isDirectory {
+                return lhs.isDirectory && !rhs.isDirectory
+            }
             return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
         }
 

--- a/Muxy/Services/Git/GitProcessRunner.swift
+++ b/Muxy/Services/Git/GitProcessRunner.swift
@@ -114,7 +114,9 @@ enum GitProcessRunner {
             .map(String.init)
             .filter { !$0.isEmpty }
         let paths = (currentPaths + searchPaths).reduce(into: [String]()) { result, path in
-            if !result.contains(path) { result.append(path) }
+            if !result.contains(path) {
+                result.append(path)
+            }
         }
         return paths.joined(separator: ":")
     }
@@ -362,7 +364,9 @@ enum GitProcessRunner {
             }
             collected.append(chunk)
             currentLineCount += chunk.reduce(into: 0) { count, byte in
-                if byte == 0x0A { count += 1 }
+                if byte == 0x0A {
+                    count += 1
+                }
             }
 
             if currentLineCount >= lineLimit {
@@ -426,7 +430,9 @@ private final class AsyncDataCollector: @unchecked Sendable {
             var didTruncate = false
             while true {
                 let chunk = (try? handle.read(upToCount: 65536)) ?? Data()
-                if chunk.isEmpty { break }
+                if chunk.isEmpty {
+                    break
+                }
                 guard !didTruncate else { continue }
                 guard let byteLimit else {
                     collected.append(chunk)

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -375,27 +375,43 @@ struct GitRepositoryService {
                 argument: String(number),
                 jsonFields: Self.prInfoJSONFields
             )
-            if case let .found(info) = configuredResult { return .found(info) }
+            if case let .found(info) = configuredResult {
+                return .found(info)
+            }
         }
 
         let viewResult = await ghPRView(ghPath: ghPath, repoPath: repoPath, jsonFields: Self.prInfoJSONFields)
-        if case let .found(info) = viewResult { return .found(info) }
+        if case let .found(info) = viewResult {
+            return .found(info)
+        }
 
         let viewByBranch = await ghPRView(
             ghPath: ghPath, repoPath: repoPath, argument: branch, jsonFields: Self.prInfoJSONFields
         )
-        if case let .found(info) = viewByBranch { return .found(info) }
+        if case let .found(info) = viewByBranch {
+            return .found(info)
+        }
 
-        let resolvedSha: String? = if let headSha { headSha } else { await self.headSha(repoPath: repoPath) }
+        let resolvedSha: String? = if let headSha {
+            headSha
+        } else {
+            await self.headSha(repoPath: repoPath)
+        }
         if let resolvedSha {
             let byShaResult = await pullRequestInfoByHeadSha(
                 ghPath: ghPath, repoPath: repoPath, branch: branch, headSha: resolvedSha
             )
-            if case let .found(info) = byShaResult { return .found(info) }
-            if byShaResult == .failed { return .failed }
+            if case let .found(info) = byShaResult {
+                return .found(info)
+            }
+            if byShaResult == .failed {
+                return .failed
+            }
         }
 
-        if viewResult == .failed || viewByBranch == .failed { return .failed }
+        if viewResult == .failed || viewByBranch == .failed {
+            return .failed
+        }
         return .noPR
     }
 
@@ -837,7 +853,9 @@ struct GitRepositoryService {
     static func webURL(fromRemoteURL raw: String) -> URL? {
         guard !raw.isEmpty else { return nil }
         var value = raw
-        if value.hasSuffix(".git") { value = String(value.dropLast(4)) }
+        if value.hasSuffix(".git") {
+            value = String(value.dropLast(4))
+        }
 
         if value.hasPrefix("http://") || value.hasPrefix("https://") {
             return URL(string: value)
@@ -871,7 +889,9 @@ struct GitRepositoryService {
             if value.hasPrefix("origin/") {
                 return String(value.dropFirst("origin/".count))
             }
-            if !value.isEmpty { return value }
+            if !value.isEmpty {
+                return value
+            }
         }
 
         if let ghPath = ghExecutable {
@@ -882,7 +902,9 @@ struct GitRepositoryService {
             )
             if let result, result.status == 0 {
                 let trimmed = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty { return trimmed }
+                if !trimmed.isEmpty {
+                    return trimmed
+                }
             }
         }
 
@@ -1460,7 +1482,9 @@ struct GitRepositoryService {
         let result = try await SSHCommandRunner.run(destination: destination, remoteCommand: remoteCommand)
         guard result.status == 0 else { return nil }
         var lines = result.stdout.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(String.init)
-        if let last = lines.last, last.isEmpty { lines.removeLast() }
+        if let last = lines.last, last.isEmpty {
+            lines.removeLast()
+        }
         guard let lineLimit, lines.count > lineLimit else { return (lines, false) }
         return (Array(lines.prefix(lineLimit)), true)
     }

--- a/Muxy/Services/Git/GitStatusParser.swift
+++ b/Muxy/Services/Git/GitStatusParser.swift
@@ -47,8 +47,12 @@ enum GitStatusParser {
             guard fields.count >= 2, fields[1].count == 2 else { continue }
             let status = Array(fields[1])
             changedCount += 1
-            if status[0] != "." { stagedCount += 1 }
-            if status[1] != "." { unstagedCount += 1 }
+            if status[0] != "." {
+                stagedCount += 1
+            }
+            if status[1] != "." {
+                unstagedCount += 1
+            }
         }
 
         guard let branch else { return nil }

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -135,7 +135,9 @@ actor GitWorktreeService: GitWorktreeListing {
         context: WorkspaceContext = .local
     ) async throws {
         var args: [String] = ["worktree", "remove"]
-        if force { args.append("--force") }
+        if force {
+            args.append("--force")
+        }
         args += ["--", path]
         let result = try await GitProcessRunner.runGit(repoPath: repoPath, arguments: args, context: context)
 

--- a/Muxy/Services/Keyboard/ModifierKeyMonitor.swift
+++ b/Muxy/Services/Keyboard/ModifierKeyMonitor.swift
@@ -61,10 +61,18 @@ final class ModifierKeyMonitor {
     func isHolding(modifiers: UInt) -> Bool {
         guard showHints else { return false }
         let flags = NSEvent.ModifierFlags(rawValue: modifiers).intersection(.deviceIndependentFlagsMask)
-        if flags.contains(.command), !commandHeld { return false }
-        if flags.contains(.control), !controlHeld { return false }
-        if flags.contains(.shift), !shiftHeld { return false }
-        if flags.contains(.option), !optionHeld { return false }
+        if flags.contains(.command), !commandHeld {
+            return false
+        }
+        if flags.contains(.control), !controlHeld {
+            return false
+        }
+        if flags.contains(.shift), !shiftHeld {
+            return false
+        }
+        if flags.contains(.option), !optionHeld {
+            return false
+        }
         guard !flags.isEmpty else { return false }
         return true
     }

--- a/Muxy/Services/Mobile/MobilePairingService.swift
+++ b/Muxy/Services/Mobile/MobilePairingService.swift
@@ -90,7 +90,9 @@ enum MobilePairingService {
             var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
             guard inet_ntop(AF_INET, &raw, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else { continue }
             let ip = String(cString: buffer)
-            if isTailscaleAddress(ip) { return ip }
+            if isTailscaleAddress(ip) {
+                return ip
+            }
         }
         return nil
     }

--- a/Muxy/Services/Mobile/MobileServerService.swift
+++ b/Muxy/Services/Mobile/MobileServerService.swift
@@ -79,8 +79,12 @@ final class MobileServerService {
     }
 
     func setEnabled(_ enabled: Bool) {
-        if enabled, isEnabled, server != nil { return }
-        if !enabled, !isEnabled { return }
+        if enabled, isEnabled, server != nil {
+            return
+        }
+        if !enabled, !isEnabled {
+            return
+        }
         isEnabled = enabled
         if enabled {
             start()

--- a/Muxy/Services/Mobile/RemoteServerDelegate.swift
+++ b/Muxy/Services/Mobile/RemoteServerDelegate.swift
@@ -248,7 +248,9 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
 
     func selectProject(_ projectID: UUID) {
         if let project = projectStore.projects.first(where: { $0.id == projectID }) {
-            if projectGroupStore.isRemoteWorkspaceActive { projectGroupStore.clearGroupSelection() }
+            if projectGroupStore.isRemoteWorkspaceActive {
+                projectGroupStore.clearGroupSelection()
+            }
             selectLoadedProject(project)
             return
         }
@@ -259,7 +261,9 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
     }
 
     private func selectLoadedProject(_ project: Project) {
-        if appState.activeProjectID == project.id { return }
+        if appState.activeProjectID == project.id {
+            return
+        }
         let worktreeList = worktreeStore.list(for: project.id)
         guard let worktree = worktreeList.first(where: \.isPrimary) ?? worktreeList.first else { return }
         appState.selectProject(project, worktree: worktree)

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -2075,7 +2075,9 @@ private func tab(at index: Int, in root: SplitNode) -> TerminalTab? {
     var currentIndex = 0
     for area in root.allAreas() {
         for tab in area.tabs {
-            if currentIndex == index { return tab }
+            if currentIndex == index {
+                return tab
+            }
             currentIndex += 1
         }
     }

--- a/Muxy/Services/MuxyAPI/MuxyAPIDispatcher.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPIDispatcher.swift
@@ -159,7 +159,9 @@ enum MuxyAPIDispatcher {
             )
             ExtensionStore.shared.refreshExtensionSnapshot()
             var result: [String: Any] = ["ok": conflict == nil]
-            if let conflict { result["conflict"] = conflict }
+            if let conflict {
+                result["conflict"] = conflict
+            }
             return result
         case "shortcuts.unregister":
             try ExtensionShortcutStore.shared.unregister(
@@ -703,9 +705,15 @@ enum MuxyAPIDispatcher {
     }
 
     private static func doubleArgOptional(_ args: [String: Any], _ key: String) -> Double? {
-        if let value = args[key] as? Double { return value }
-        if let value = args[key] as? Int { return Double(value) }
-        if let value = args[key] as? NSNumber { return value.doubleValue }
+        if let value = args[key] as? Double {
+            return value
+        }
+        if let value = args[key] as? Int {
+            return Double(value)
+        }
+        if let value = args[key] as? NSNumber {
+            return value.doubleValue
+        }
         return nil
     }
 
@@ -1087,7 +1095,9 @@ enum MuxyAPIDispatcher {
     }
 
     private static func stringArg(_ args: [String: Any], _ key: String) throws -> String {
-        if let value = args[key] as? String { return value }
+        if let value = args[key] as? String {
+            return value
+        }
         throw APIError.invalidArguments("missing argument '\(key)'")
     }
 
@@ -1110,9 +1120,15 @@ enum MuxyAPIDispatcher {
     }
 
     private static func doubleArg(_ args: [String: Any], _ key: String) throws -> Double {
-        if let value = args[key] as? Double { return value }
-        if let value = args[key] as? Int { return Double(value) }
-        if let value = args[key] as? NSNumber { return value.doubleValue }
+        if let value = args[key] as? Double {
+            return value
+        }
+        if let value = args[key] as? Int {
+            return Double(value)
+        }
+        if let value = args[key] as? NSNumber {
+            return value.doubleValue
+        }
         throw APIError.invalidArguments("missing argument '\(key)'")
     }
 
@@ -1241,14 +1257,22 @@ enum MuxyAPIDispatcher {
     }
 
     private static func intArg(_ args: [String: Any], _ key: String) -> Int? {
-        if let value = args[key] as? Int { return value }
-        if let value = args[key] as? NSNumber { return value.intValue }
+        if let value = args[key] as? Int {
+            return value
+        }
+        if let value = args[key] as? NSNumber {
+            return value.intValue
+        }
         return nil
     }
 
     private static func boolArg(_ args: [String: Any], _ key: String) -> Bool? {
-        if let value = args[key] as? Bool { return value }
-        if let value = args[key] as? NSNumber { return value.boolValue }
+        if let value = args[key] as? Bool {
+            return value
+        }
+        if let value = args[key] as? NSNumber {
+            return value.boolValue
+        }
         return nil
     }
 

--- a/Muxy/Services/MuxyAPI/MuxyAPIFiles.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPIFiles.swift
@@ -214,7 +214,9 @@ extension MuxyAPI {
         nonisolated private static func canonicalize(base: URL, relativePath: String) -> URL {
             var current = base
             for component in relativePath.split(separator: "/", omittingEmptySubsequences: true).map(String.init) {
-                if component == "." { continue }
+                if component == "." {
+                    continue
+                }
                 if component == ".." {
                     current = current.deletingLastPathComponent()
                     continue

--- a/Muxy/Services/Persistence/CodableFileStore.swift
+++ b/Muxy/Services/Persistence/CodableFileStore.swift
@@ -28,8 +28,12 @@ struct CodableFileStore<Value: Codable> {
     func save(_ value: Value) throws {
         let encoder = JSONEncoder()
         var formatting: JSONEncoder.OutputFormatting = []
-        if options.prettyPrinted { formatting.insert(.prettyPrinted) }
-        if options.sortedKeys { formatting.insert(.sortedKeys) }
+        if options.prettyPrinted {
+            formatting.insert(.prettyPrinted)
+        }
+        if options.sortedKeys {
+            formatting.insert(.sortedKeys)
+        }
         encoder.outputFormatting = formatting
 
         let data = try encoder.encode(value)

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -172,7 +172,9 @@ enum SettingsJSONStore {
             return double
         }
         guard let defaultValue = item.defaultValue?.base else { throw SettingsJSONError.unsupportedValue(item.key) }
-        if defaultValue is Bool, value is Bool { return value }
+        if defaultValue is Bool, value is Bool {
+            return value
+        }
         if defaultValue is String, let string = value as? String {
             try validateAllowedString(string, key: item.key)
             return string
@@ -193,7 +195,9 @@ enum SettingsJSONStore {
             try validateAllowedDouble(double, key: item.key)
             return double
         }
-        if defaultValue is [String], let strings = value as? [String] { return strings }
+        if defaultValue is [String], let strings = value as? [String] {
+            return strings
+        }
         throw SettingsJSONError.invalidValue(item.key)
     }
 
@@ -367,9 +371,15 @@ enum SettingsJSONStore {
     }
 
     private static func doubleValue(_ value: Any) -> Double? {
-        if let value = value as? Double { return value }
-        if let value = value as? Int { return Double(value) }
-        if let value = value as? NSNumber { return value.doubleValue }
+        if let value = value as? Double {
+            return value
+        }
+        if let value = value as? Int {
+            return Double(value)
+        }
+        if let value = value as? NSNumber {
+            return value.doubleValue
+        }
         return nil
     }
 
@@ -438,8 +448,12 @@ enum SettingsJSONStore {
     }
 
     private static func jsonValue(_ value: AnyHashable) -> Any {
-        if let array = value.base as? [String] { return array }
-        if let value = value.base as? UInt16 { return Int(value) }
+        if let array = value.base as? [String] {
+            return array
+        }
+        if let value = value.base as? UInt16 {
+            return Int(value)
+        }
         return value.base
     }
 

--- a/Muxy/Services/Project/GitWorktreesWatcher.swift
+++ b/Muxy/Services/Project/GitWorktreesWatcher.swift
@@ -92,7 +92,9 @@ final class GitWorktreesWatcher: @unchecked Sendable {
         let dotGit = dotGitURL.path
         var isDirectory: ObjCBool = false
         guard manager.fileExists(atPath: dotGit, isDirectory: &isDirectory) else { return nil }
-        if isDirectory.boolValue { return dotGit }
+        if isDirectory.boolValue {
+            return dotGit
+        }
 
         guard let contents = try? String(contentsOfFile: dotGit, encoding: .utf8) else { return nil }
         guard let line = contents

--- a/Muxy/Services/Project/ProjectGroupStore.swift
+++ b/Muxy/Services/Project/ProjectGroupStore.swift
@@ -88,7 +88,9 @@ final class ProjectGroupStore {
     var activeRemoteProjectIDs: Set<UUID> {
         guard isRemoteWorkspaceActive else { return [] }
         var ids = Set(activeRemoteProjects.map(\.id))
-        if let homeID = activeRemoteHomeProject?.id { ids.insert(homeID) }
+        if let homeID = activeRemoteHomeProject?.id {
+            ids.insert(homeID)
+        }
         return ids
     }
 

--- a/Muxy/Services/Project/ProjectStore.swift
+++ b/Muxy/Services/Project/ProjectStore.swift
@@ -291,10 +291,14 @@ final class ProjectStore {
             try persistence.saveProjects(storedProjects)
         } catch {
             logger.error("Failed to save projects: \(error)")
-            if notify { onProjectsChanged?() }
+            if notify {
+                onProjectsChanged?()
+            }
             return false
         }
-        if notify { onProjectsChanged?() }
+        if notify {
+            onProjectsChanged?()
+        }
         return true
     }
 
@@ -333,7 +337,9 @@ final class ProjectStore {
     }
 
     private func projectsMatch(_ lhs: Project, _ rhs: Project) -> Bool {
-        if lhs.id == rhs.id { return true }
+        if lhs.id == rhs.id {
+            return true
+        }
         guard !lhs.isRemote, !rhs.isRemote else { return false }
         return ProjectPickerPathService.standardizedPath(lhs.path)
             == ProjectPickerPathService.standardizedPath(rhs.path)

--- a/Muxy/Services/Project/WorktreeActionEligibility.swift
+++ b/Muxy/Services/Project/WorktreeActionEligibility.swift
@@ -9,7 +9,9 @@ enum WorktreeActionEligibility {
         allowUnknownGitStatus: Bool
     ) -> Bool {
         guard let project, !project.isHome, project.worktreesEnabled else { return false }
-        if worktreeStore.list(for: project.id).count > 1 { return true }
+        if worktreeStore.list(for: project.id).count > 1 {
+            return true
+        }
         let context = projectGroupStore.workspaceContext(for: project)
         return GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) ?? allowUnknownGitStatus
     }
@@ -20,7 +22,9 @@ enum WorktreeActionEligibility {
         projectGroupStore: ProjectGroupStore
     ) async -> Bool {
         guard !project.isHome, project.worktreesEnabled else { return false }
-        if worktreeStore.list(for: project.id).count > 1 { return true }
+        if worktreeStore.list(for: project.id).count > 1 {
+            return true
+        }
         let context = projectGroupStore.workspaceContext(for: project)
         if let cached = GitRepoStatusCache.shared.cachedStatus(for: project.path, context: context) {
             return cached

--- a/Muxy/Services/Project/WorktreeStore.swift
+++ b/Muxy/Services/Project/WorktreeStore.swift
@@ -77,7 +77,9 @@ final class WorktreeStore {
     func ensurePrimary(for project: Project) {
         guard !projectsBeingRemoved.contains(project.id) else { return }
         var list = worktrees[project.id] ?? []
-        if list.contains(where: \.isPrimary) { return }
+        if list.contains(where: \.isPrimary) {
+            return
+        }
         list.insert(makePrimary(for: project), at: 0)
         setWorktrees(sortPrimaryFirst(list), for: project.id)
         save(projectID: project.id)

--- a/Muxy/Services/ProjectPicker/ProjectPickerFolderSearchService.swift
+++ b/Muxy/Services/ProjectPicker/ProjectPickerFolderSearchService.swift
@@ -313,7 +313,9 @@ actor ProjectPickerFolderSearchService {
                 homeDirectory: homeDirectory
             ), ProjectPickerFolderSearchPath.isInside(changedPath, root: rootPath)
             else { return false }
-            if changedPath == rootPath { return true }
+            if changedPath == rootPath {
+                return true
+            }
             return fileSystem.itemState(atPath: changedPath) != .file
         }
         guard shouldInvalidate else { return }
@@ -630,7 +632,9 @@ private struct SearchMatch: Comparable {
     }
 
     static func < (lhs: SearchMatch, rhs: SearchMatch) -> Bool {
-        if lhs.kind != rhs.kind { return lhs.kind < rhs.kind }
+        if lhs.kind != rhs.kind {
+            return lhs.kind < rhs.kind
+        }
         return lhs.pathScore < rhs.pathScore
     }
 }
@@ -643,11 +647,19 @@ private struct SearchCandidate {
     let depth: Int
 
     static func precedes(_ lhs: SearchCandidate, _ rhs: SearchCandidate) -> Bool {
-        if lhs.match != rhs.match { return lhs.match < rhs.match }
-        if lhs.isExistingProject != rhs.isExistingProject { return lhs.isExistingProject }
-        if lhs.depth != rhs.depth { return lhs.depth < rhs.depth }
+        if lhs.match != rhs.match {
+            return lhs.match < rhs.match
+        }
+        if lhs.isExistingProject != rhs.isExistingProject {
+            return lhs.isExistingProject
+        }
+        if lhs.depth != rhs.depth {
+            return lhs.depth < rhs.depth
+        }
         let nameOrder = lhs.name.localizedStandardCompare(rhs.name)
-        if nameOrder != .orderedSame { return nameOrder == .orderedAscending }
+        if nameOrder != .orderedSame {
+            return nameOrder == .orderedAscending
+        }
         return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
     }
 }
@@ -680,7 +692,9 @@ private enum ProjectPickerFolderSearchPath {
     }
 
     static func isInside(_ path: String, root: String) -> Bool {
-        if root == "/" { return path.hasPrefix("/") }
+        if root == "/" {
+            return path.hasPrefix("/")
+        }
         return path == root || path.hasPrefix(root + "/")
     }
 
@@ -707,7 +721,9 @@ private enum ProjectPickerFolderSearchPath {
         } else {
             path
         }
-        if displayPath == "/" || displayPath.hasSuffix("/") { return displayPath }
+        if displayPath == "/" || displayPath.hasSuffix("/") {
+            return displayPath
+        }
         return displayPath + "/"
     }
 

--- a/Muxy/Services/ProjectPicker/ProjectPickerPathService.swift
+++ b/Muxy/Services/ProjectPicker/ProjectPickerPathService.swift
@@ -169,7 +169,9 @@ struct ProjectPickerPathService {
         var components: [String] = []
         let isAbsolute = path.hasPrefix("/")
         for segment in path.split(separator: "/", omittingEmptySubsequences: true) {
-            if segment == "." { continue }
+            if segment == "." {
+                continue
+            }
             if segment == "..", let last = components.last, last != ".." {
                 components.removeLast()
                 continue
@@ -177,7 +179,9 @@ struct ProjectPickerPathService {
             components.append(String(segment))
         }
         let joined = components.joined(separator: "/")
-        if isAbsolute { return "/" + joined }
+        if isAbsolute {
+            return "/" + joined
+        }
         return joined.isEmpty ? "." : joined
     }
 
@@ -229,7 +233,9 @@ struct ProjectPickerPathService {
     func expandedPath(_ path: String) -> String {
         let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !isRemote else { return trimmedPath }
-        if trimmedPath == "~" { return homeDirectory }
+        if trimmedPath == "~" {
+            return homeDirectory
+        }
         if trimmedPath.hasPrefix("~/") {
             return homeDirectory + trimmedPath.dropFirst()
         }
@@ -263,14 +269,20 @@ struct ProjectPickerPathService {
     private func confirmPath(for trimmedInput: String) -> String {
         guard !trimmedInput.isEmpty else { return isRemote ? homeDirectory : "/" }
         let expandedPath = expandedPath(trimmedInput)
-        if isRemote { return expandedPath }
+        if isRemote {
+            return expandedPath
+        }
         guard expandedPath.hasPrefix("/") else { return "/" + expandedPath }
         return expandedPath
     }
 
     private func directoryPath(for trimmedInput: String, expandedInput: String) -> String {
-        if trimmedInput.isEmpty { return "/" }
-        if trimmedInput == "~" { return standardize(homeDirectory) }
+        if trimmedInput.isEmpty {
+            return "/"
+        }
+        if trimmedInput == "~" {
+            return standardize(homeDirectory)
+        }
         guard !expandedInput.hasSuffix("/") else {
             return standardize(expandedInput)
         }
@@ -278,7 +290,9 @@ struct ProjectPickerPathService {
     }
 
     private func leafFilter(for trimmedInput: String) -> String {
-        if trimmedInput.isEmpty || trimmedInput == "~" || trimmedInput.hasSuffix("/") { return "" }
+        if trimmedInput.isEmpty || trimmedInput == "~" || trimmedInput.hasSuffix("/") {
+            return ""
+        }
         return lastComponent(of: trimmedInput)
     }
 
@@ -308,7 +322,9 @@ struct ProjectPickerPathService {
     }
 
     private func completionDisplayPrefix(for trimmedInput: String, directoryPath: String) -> String {
-        if trimmedInput.hasPrefix("~"), directoryPath == homeDirectory { return "~/" }
+        if trimmedInput.hasPrefix("~"), directoryPath == homeDirectory {
+            return "~/"
+        }
         if trimmedInput.hasPrefix("~"), directoryPath.hasPrefix(homeDirectory + "/") {
             return "~" + directoryPath.dropFirst(homeDirectory.count) + "/"
         }

--- a/Muxy/Services/ProjectPicker/ProjectPickerSession.swift
+++ b/Muxy/Services/ProjectPicker/ProjectPickerSession.swift
@@ -89,14 +89,22 @@ struct ProjectPickerSession {
     }
 
     var actionTitle: String {
-        if isExistingProject { return "Open" }
-        if inputMode == .folderSearch { return "Add" }
+        if isExistingProject {
+            return "Open"
+        }
+        if inputMode == .folderSearch {
+            return "Add"
+        }
         return typedPathState == .missing ? "Create & Add" : "Add"
     }
 
     var topRightActionTitle: String {
-        if isExistingProject { return "Open Project" }
-        if inputMode == .folderSearch { return "Add Project" }
+        if isExistingProject {
+            return "Open Project"
+        }
+        if inputMode == .folderSearch {
+            return "Add Project"
+        }
         return typedPathState == .missing ? "Create & Add Project" : "Add Project"
     }
 
@@ -305,12 +313,16 @@ enum ProjectPickerDirectoryLoadState: Equatable {
     case failed
 
     var isLoading: Bool {
-        if case .loading = self { return true }
+        if case .loading = self {
+            return true
+        }
         return false
     }
 
     var showsMessage: Bool {
-        if case let .loading(showsMessage) = self { return showsMessage }
+        if case let .loading(showsMessage) = self {
+            return showsMessage
+        }
         return false
     }
 

--- a/Muxy/Services/Providers/CursorProvider.swift
+++ b/Muxy/Services/Providers/CursorProvider.swift
@@ -73,7 +73,9 @@ struct CursorProvider: AIProviderIntegration, AIAgentLaunchProvider {
         for binding in Self.bindings {
             let command = Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
             let existing = hooks[binding.event] as? [[String: Any]]
-            if Self.muxyHookMatches(entries: existing, expectedCommand: command) { continue }
+            if Self.muxyHookMatches(entries: existing, expectedCommand: command) {
+                continue
+            }
             hooks[binding.event] = Self.mergeHookArray(existing: existing, command: command)
             changed = true
         }

--- a/Muxy/Services/Providers/ProviderExecutableLocator.swift
+++ b/Muxy/Services/Providers/ProviderExecutableLocator.swift
@@ -59,7 +59,9 @@ enum ProviderExecutableLocator {
         for name in names {
             for directory in directories {
                 let path = URL(fileURLWithPath: directory).appendingPathComponent(name).path
-                if isExecutable(path) { return path }
+                if isExecutable(path) {
+                    return path
+                }
             }
         }
         return nil

--- a/Muxy/Services/Remote/RemoteFileService.swift
+++ b/Muxy/Services/Remote/RemoteFileService.swift
@@ -157,7 +157,9 @@ struct RemoteFileService {
                 )
             }
             .sorted { lhs, rhs in
-                if lhs.isDirectory != rhs.isDirectory { return lhs.isDirectory && !rhs.isDirectory }
+                if lhs.isDirectory != rhs.isDirectory {
+                    return lhs.isDirectory && !rhs.isDirectory
+                }
                 return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
     }

--- a/Muxy/Services/Remote/RemoteProjectPickerFileSystem.swift
+++ b/Muxy/Services/Remote/RemoteProjectPickerFileSystem.swift
@@ -58,7 +58,9 @@ private final class RemoteDirectoryCache: @unchecked Sendable {
     func directoryState(forPath path: String) -> ProjectPickerFileSystemDirectoryState {
         lock.lock()
         defer { lock.unlock() }
-        if entriesByDirectory[path] != nil { return .directory }
+        if entriesByDirectory[path] != nil {
+            return .directory
+        }
         let parent = (path as NSString).deletingLastPathComponent
         let name = (path as NSString).lastPathComponent
         guard let siblings = entriesByDirectory[parent] else { return .directory }

--- a/Muxy/Services/Remote/WorkspaceContext.swift
+++ b/Muxy/Services/Remote/WorkspaceContext.swift
@@ -5,12 +5,16 @@ enum WorkspaceContext: Hashable {
     case ssh(SSHDestination)
 
     var isRemote: Bool {
-        if case .ssh = self { return true }
+        if case .ssh = self {
+            return true
+        }
         return false
     }
 
     var sshDestination: SSHDestination? {
-        if case let .ssh(destination) = self { return destination }
+        if case let .ssh(destination) = self {
+            return destination
+        }
         return nil
     }
 

--- a/Muxy/Services/RichInput/RichInputImageStorage.swift
+++ b/Muxy/Services/RichInput/RichInputImageStorage.swift
@@ -40,11 +40,21 @@ extension Data {
     var detectedImageExtension: String? {
         guard count >= 8 else { return nil }
         let bytes = [UInt8](prefix(8))
-        if bytes.starts(with: [0x89, 0x50, 0x4E, 0x47]) { return "png" }
-        if bytes.starts(with: [0xFF, 0xD8, 0xFF]) { return "jpg" }
-        if bytes.starts(with: [0x47, 0x49, 0x46, 0x38]) { return "gif" }
-        if bytes.starts(with: [0x49, 0x49]) || bytes.starts(with: [0x4D, 0x4D]) { return "tiff" }
-        if count >= 12, Array(self[8 ..< 12]) == [0x57, 0x45, 0x42, 0x50] { return "webp" }
+        if bytes.starts(with: [0x89, 0x50, 0x4E, 0x47]) {
+            return "png"
+        }
+        if bytes.starts(with: [0xFF, 0xD8, 0xFF]) {
+            return "jpg"
+        }
+        if bytes.starts(with: [0x47, 0x49, 0x46, 0x38]) {
+            return "gif"
+        }
+        if bytes.starts(with: [0x49, 0x49]) || bytes.starts(with: [0x4D, 0x4D]) {
+            return "tiff"
+        }
+        if count >= 12, Array(self[8 ..< 12]) == [0x57, 0x45, 0x42, 0x50] {
+            return "webp"
+        }
         return nil
     }
 }

--- a/Muxy/Services/RichInput/RichInputSubmitter.swift
+++ b/Muxy/Services/RichInput/RichInputSubmitter.swift
@@ -44,7 +44,13 @@ enum RichInputSubmitter {
 
         let views = paneIDs.compactMap { TerminalViewRegistry.shared.existingView(for: $0) }
         guard !views.isEmpty else { return }
-        let hasImageSegment = segments.contains { if case .image = $0 { true } else { false } }
+        let hasImageSegment = segments.contains {
+            if case .image = $0 {
+                true
+            } else {
+                false
+            }
+        }
         let focusTarget = views.count == 1 ? views.first : nil
 
         if !hasImageSegment {
@@ -161,14 +167,18 @@ enum RichInputSubmitter {
             else { continue }
             if match.range.location > cursor {
                 let chunk = ns.substring(with: NSRange(location: cursor, length: match.range.location - cursor))
-                if !chunk.isEmpty { segments.append(.text(chunk)) }
+                if !chunk.isEmpty {
+                    segments.append(.text(chunk))
+                }
             }
             segments.append(.image(images[imageIndex - 1]))
             cursor = match.range.location + match.range.length
         }
         if cursor < length {
             let tail = ns.substring(with: NSRange(location: cursor, length: length - cursor))
-            if !tail.isEmpty { segments.append(.text(tail)) }
+            if !tail.isEmpty {
+                segments.append(.text(tail))
+            }
         }
         return segments
     }

--- a/Muxy/Services/Socket/NotificationSocketServer.swift
+++ b/Muxy/Services/Socket/NotificationSocketServer.swift
@@ -457,7 +457,9 @@ final class NotificationSocketServer: @unchecked Sendable {
         while serverFD >= 0 {
             let clientFD = accept(serverFD, nil, nil)
             guard clientFD >= 0 else {
-                if errno == EINTR { continue }
+                if errno == EINTR {
+                    continue
+                }
                 return
             }
 

--- a/Muxy/Services/Terminal/GhosttyService.swift
+++ b/Muxy/Services/Terminal/GhosttyService.swift
@@ -135,7 +135,9 @@ final class GhosttyService {
         ghostty_app_update_config(app, newConfig)
         let oldConfig = config
         config = newConfig
-        if let oldConfig { ghostty_config_free(oldConfig) }
+        if let oldConfig {
+            ghostty_config_free(oldConfig)
+        }
         configVersion += 1
         TerminalViewRegistry.shared.reapplyClientThemes()
         if postThemeChangeNotification {

--- a/Muxy/Services/Terminal/RemoteTerminalSnapshotBuilder.swift
+++ b/Muxy/Services/Terminal/RemoteTerminalSnapshotBuilder.swift
@@ -103,13 +103,17 @@ enum RemoteTerminalSnapshotBuilder {
                 && cell.fg == defaultFg
                 && cell.bg == defaultBg
                 && cell.flags == 0
-            if !isBlank { last = col }
+            if !isBlank {
+                last = col
+            }
         }
         return last
     }
 
     private static func character(for codepoint: UInt32) -> String {
-        if codepoint == 0 { return " " }
+        if codepoint == 0 {
+            return " "
+        }
         guard let scalar = Unicode.Scalar(codepoint) else { return " " }
         return String(Character(scalar))
     }
@@ -123,15 +127,33 @@ enum RemoteTerminalSnapshotBuilder {
     ) -> String {
         var params = ["0"]
 
-        if flags & TerminalCellFlag.bold != 0 { params.append("1") }
-        if flags & TerminalCellFlag.faint != 0 { params.append("2") }
-        if flags & TerminalCellFlag.italic != 0 { params.append("3") }
-        if flags & TerminalCellFlag.underline != 0 { params.append("4") }
-        if flags & TerminalCellFlag.blink != 0 { params.append("5") }
-        if flags & TerminalCellFlag.inverse != 0 { params.append("7") }
-        if flags & TerminalCellFlag.invisible != 0 { params.append("8") }
-        if flags & TerminalCellFlag.strike != 0 { params.append("9") }
-        if flags & TerminalCellFlag.overline != 0 { params.append("53") }
+        if flags & TerminalCellFlag.bold != 0 {
+            params.append("1")
+        }
+        if flags & TerminalCellFlag.faint != 0 {
+            params.append("2")
+        }
+        if flags & TerminalCellFlag.italic != 0 {
+            params.append("3")
+        }
+        if flags & TerminalCellFlag.underline != 0 {
+            params.append("4")
+        }
+        if flags & TerminalCellFlag.blink != 0 {
+            params.append("5")
+        }
+        if flags & TerminalCellFlag.inverse != 0 {
+            params.append("7")
+        }
+        if flags & TerminalCellFlag.invisible != 0 {
+            params.append("8")
+        }
+        if flags & TerminalCellFlag.strike != 0 {
+            params.append("9")
+        }
+        if flags & TerminalCellFlag.overline != 0 {
+            params.append("53")
+        }
 
         if fg != defaultFg {
             params.append("38;2;\((fg >> 16) & 0xFF);\((fg >> 8) & 0xFF);\(fg & 0xFF)")

--- a/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
+++ b/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
@@ -16,7 +16,9 @@ final class RemoteTerminalStreamer {
     private init() {}
 
     func attach(paneID: UUID, surface: ghostty_surface_t) {
-        if tokenByPane[paneID] != nil { return }
+        if tokenByPane[paneID] != nil {
+            return
+        }
         let token = nextToken
         nextToken += 1
         tokenByPane[paneID] = token

--- a/Muxy/Services/Theme/ThemeService.swift
+++ b/Muxy/Services/Theme/ThemeService.swift
@@ -29,8 +29,12 @@ struct ThemeSelection: Equatable {
     }
 
     func resolvedName(isDark: Bool) -> String? {
-        if isDark, let darkName { return darkName }
-        if !isDark, let lightName { return lightName }
+        if isDark, let darkName {
+            return darkName
+        }
+        if !isDark, let lightName {
+            return lightName
+        }
         return fallbackName ?? darkName ?? lightName
     }
 }
@@ -135,7 +139,9 @@ final class ThemeService {
 
     func migrateToPairedThemeIfNeeded() {
         guard let selection = currentThemeSelection() else { return }
-        if selection.darkName != nil, selection.lightName != nil { return }
+        if selection.darkName != nil, selection.lightName != nil {
+            return
+        }
         let unified = selection.darkName ?? selection.lightName ?? selection.fallbackName ?? Self.defaultThemeName
         applyTheme(dark: selection.darkName ?? unified, light: selection.lightName ?? unified)
     }
@@ -219,14 +225,18 @@ final class ThemeService {
                 current.append(char)
             } else if char == ",", !isQuoted {
                 let entry = current.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !entry.isEmpty { entries.append(entry) }
+                if !entry.isEmpty {
+                    entries.append(entry)
+                }
                 current = ""
             } else {
                 current.append(char)
             }
         }
         let entry = current.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !entry.isEmpty { entries.append(entry) }
+        if !entry.isEmpty {
+            entries.append(entry)
+        }
         return entries
     }
 
@@ -278,8 +288,12 @@ final class ThemeService {
         return themesByName.values.sorted {
             let pinned0 = pinnedThemeNames.contains($0.name)
             let pinned1 = pinnedThemeNames.contains($1.name)
-            if pinned0 != pinned1 { return pinned0 }
-            if pinned0, pinned1 { return $0.name < $1.name }
+            if pinned0 != pinned1 {
+                return pinned0
+            }
+            if pinned0, pinned1 {
+                return $0.name < $1.name
+            }
             return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
     }
@@ -331,7 +345,9 @@ final class ThemeService {
 
     nonisolated private static func parseHex(_ hex: String) -> NSColor? {
         var h = hex
-        if h.hasPrefix("#") { h = String(h.dropFirst()) }
+        if h.hasPrefix("#") {
+            h = String(h.dropFirst())
+        }
         guard h.count == 6, let val = UInt32(h, radix: 16) else { return nil }
         return NSColor(
             srgbRed: CGFloat((val >> 16) & 0xFF) / 255,

--- a/Muxy/Services/UIHosts/PaneOwnershipStore.swift
+++ b/Muxy/Services/UIHosts/PaneOwnershipStore.swift
@@ -29,17 +29,23 @@ final class PaneOwnershipStore {
     }
 
     func isOwnedByMac(_ paneID: UUID) -> Bool {
-        if case .mac = owner(for: paneID) { return true }
+        if case .mac = owner(for: paneID) {
+            return true
+        }
         return false
     }
 
     func isOwnedBy(clientID: UUID, paneID: UUID) -> Bool {
-        if case let .remote(id, _) = owner(for: paneID), id == clientID { return true }
+        if case let .remote(id, _) = owner(for: paneID), id == clientID {
+            return true
+        }
         return false
     }
 
     func remoteOwner(for paneID: UUID) -> UUID? {
-        if case let .remote(clientID, _) = owners[paneID] { return clientID }
+        if case let .remote(clientID, _) = owners[paneID] {
+            return clientID
+        }
         return nil
     }
 

--- a/Muxy/Services/Voice/SpeechLanguageCatalog.swift
+++ b/Muxy/Services/Voice/SpeechLanguageCatalog.swift
@@ -13,7 +13,9 @@ enum SpeechLanguageCatalog {
     private static var cachedLanguages: [SpeechLanguage]?
 
     static func onDeviceLanguages() -> [SpeechLanguage] {
-        if let cachedLanguages { return cachedLanguages }
+        if let cachedLanguages {
+            return cachedLanguages
+        }
         let computed = computeOnDeviceLanguages()
         cachedLanguages = computed
         return computed
@@ -22,7 +24,9 @@ enum SpeechLanguageCatalog {
     static func defaultIdentifier() -> String? {
         let supported = onDeviceLanguages()
         let current = Locale.current.identifier
-        if supported.contains(where: { $0.identifier == current }) { return current }
+        if supported.contains(where: { $0.identifier == current }) {
+            return current
+        }
         let language = Locale.current.language.languageCode?.identifier
         if let language, let match = supported.first(where: { $0.identifier.hasPrefix(language) }) {
             return match.identifier

--- a/Muxy/Utilities/CLIAccessor.swift
+++ b/Muxy/Utilities/CLIAccessor.swift
@@ -47,7 +47,9 @@ enum CLIAccessor {
                     showInstalledAlert(label: "/usr/local/bin/muxy", pathNote: "")
                     return
                 }
-                if tryFallbackInstalls(wrapper: wrapper) { return }
+                if tryFallbackInstalls(wrapper: wrapper) {
+                    return
+                }
                 alert(
                     title: "CLI Installation Failed",
                     body: """

--- a/Muxy/Utilities/DotEnvLoader.swift
+++ b/Muxy/Utilities/DotEnvLoader.swift
@@ -31,7 +31,9 @@ enum DotEnvLoader {
                 return candidate
             }
             let parent = directory.deletingLastPathComponent()
-            if parent.path == directory.path { break }
+            if parent.path == directory.path {
+                break
+            }
             directory = parent
         }
         return nil

--- a/Muxy/Utilities/DroppedPathsParser.swift
+++ b/Muxy/Utilities/DroppedPathsParser.swift
@@ -7,7 +7,9 @@ enum DroppedPathsParser {
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> [String] {
         let urlPaths = fileURLs.compactMap { $0.isFileURL ? $0.path : nil }
-        if !urlPaths.isEmpty { return urlPaths }
+        if !urlPaths.isEmpty {
+            return urlPaths
+        }
 
         guard let plainString else { return [] }
 

--- a/Muxy/Utilities/LaunchArgumentGuard.swift
+++ b/Muxy/Utilities/LaunchArgumentGuard.swift
@@ -5,8 +5,12 @@ enum LaunchArgumentGuard {
     static func isCLISubcommandLaunch(_ arguments: [String]) -> Bool {
         guard arguments.count > 1 else { return false }
         let first = arguments[1]
-        if first.hasPrefix("-") { return false }
-        if first.hasPrefix("/") || first.hasPrefix("~") { return false }
+        if first.hasPrefix("-") {
+            return false
+        }
+        if first.hasPrefix("/") || first.hasPrefix("~") {
+            return false
+        }
         return true
     }
 

--- a/Muxy/Utilities/LoginShellPath.swift
+++ b/Muxy/Utilities/LoginShellPath.swift
@@ -159,7 +159,9 @@ private final class BoundedPipeReader: @unchecked Sendable {
             var collected = Data()
             while true {
                 let chunk = (try? handle.read(upToCount: 65536)) ?? Data()
-                if chunk.isEmpty { break }
+                if chunk.isEmpty {
+                    break
+                }
                 if chunk.count >= byteLimit {
                     collected = Data(chunk.suffix(byteLimit))
                     continue

--- a/Muxy/Utilities/TranscriptInserter.swift
+++ b/Muxy/Utilities/TranscriptInserter.swift
@@ -65,17 +65,27 @@ enum TranscriptInserter {
 
     private static func firstGhosttyView(in root: NSView?) -> GhosttyTerminalNSView? {
         guard let root else { return nil }
-        if let terminal = root as? GhosttyTerminalNSView { return terminal }
+        if let terminal = root as? GhosttyTerminalNSView {
+            return terminal
+        }
         for subview in root.subviews {
-            if let terminal = firstGhosttyView(in: subview) { return terminal }
+            if let terminal = firstGhosttyView(in: subview) {
+                return terminal
+            }
         }
         return nil
     }
 
     private static func window(for responder: NSResponder) -> NSWindow? {
-        if let view = responder as? NSView { return view.window }
-        if let viewController = responder as? NSViewController { return viewController.view.window }
-        if let window = responder as? NSWindow { return window }
+        if let view = responder as? NSView {
+            return view.window
+        }
+        if let viewController = responder as? NSViewController {
+            return viewController.view.window
+        }
+        if let window = responder as? NSWindow {
+            return window
+        }
         return NSApp.keyWindow
     }
 
@@ -83,7 +93,9 @@ enum TranscriptInserter {
         guard let view = responder as? NSView else { return nil }
         var ancestor: NSView? = view
         while let node = ancestor {
-            if let terminal = node as? GhosttyTerminalNSView { return terminal }
+            if let terminal = node as? GhosttyTerminalNSView {
+                return terminal
+            }
             ancestor = node.superview
         }
         return nil

--- a/Muxy/Views/Browser/BrowserAddressField.swift
+++ b/Muxy/Views/Browser/BrowserAddressField.swift
@@ -234,7 +234,9 @@ struct BrowserAddressField: NSViewRepresentable {
 
         private func handleGlobalClick(_ event: NSEvent) {
             guard let panel, panel.isVisible else { return }
-            if event.window == field?.window || event.window?.parent == field?.window { return }
+            if event.window == field?.window || event.window?.parent == field?.window {
+                return
+            }
             dismissSuggestions()
         }
 

--- a/Muxy/Views/Browser/BrowserToolbar.swift
+++ b/Muxy/Views/Browser/BrowserToolbar.swift
@@ -93,7 +93,9 @@ struct BrowserToolbar: View {
         .disabled(state.url == nil)
         .help("Open in External Browser")
         .onAppear {
-            if installedBrowsers.isEmpty { installedBrowsers = InstalledBrowsers.all() }
+            if installedBrowsers.isEmpty {
+                installedBrowsers = InstalledBrowsers.all()
+            }
         }
     }
 

--- a/Muxy/Views/Components/Buttons/OpenInIDEControl.swift
+++ b/Muxy/Views/Components/Buttons/OpenInIDEControl.swift
@@ -208,7 +208,9 @@ struct OpenInIDEControl: View {
     }
 
     private var defaultTargetIDE: IDEIntegrationService.IDEApplication? {
-        if defaultFileOpener != nil { return nil }
+        if defaultFileOpener != nil {
+            return nil
+        }
         return defaultIDE
     }
 

--- a/Muxy/Views/Components/Overlays/PaletteOverlay.swift
+++ b/Muxy/Views/Components/Overlays/PaletteOverlay.swift
@@ -171,7 +171,9 @@ struct PaletteOverlay<Item: Identifiable & Sendable>: View {
                                     .onTapGesture { onSelect(item) }
                                     .id(item.id)
                                     .onAppear {
-                                        if index >= results.count - 1 { scheduleLoadMore() }
+                                        if index >= results.count - 1 {
+                                            scheduleLoadMore()
+                                        }
                                     }
                             }
                         }
@@ -657,7 +659,9 @@ final class PaletteNSTextField: NSTextField {
     }
 
     override func keyDown(with event: NSEvent) {
-        if handleControlKey(event) { return }
+        if handleControlKey(event) {
+            return
+        }
         if Self.isReturnKey(event),
            let editor = currentEditor() as? NSTextView,
            editor.hasMarkedText()

--- a/Muxy/Views/Components/Overlays/ProjectPickerOverlay.swift
+++ b/Muxy/Views/Components/Overlays/ProjectPickerOverlay.swift
@@ -341,7 +341,9 @@ struct ProjectPickerOverlay: View {
 
     private var unavailableProjectTitle: String {
         guard workflow.session.inputMode == .folderSearch else { return "No project folders found" }
-        if workflow.session.directoryLoadState.readFailed { return "Folder search unavailable" }
+        if workflow.session.directoryLoadState.readFailed {
+            return "Folder search unavailable"
+        }
         return workflow.session.searchQuery.isEmpty ? "Find a project folder" : "No matching folders"
     }
 

--- a/Muxy/Views/Components/Overlays/TerminalOmniboxOverlay.swift
+++ b/Muxy/Views/Components/Overlays/TerminalOmniboxOverlay.swift
@@ -220,7 +220,9 @@ struct TerminalOmniboxOverlay: View {
 
     private func shouldShowSectionHeader(at index: Int) -> Bool {
         guard index < displayList.count else { return false }
-        if index == 0 { return true }
+        if index == 0 {
+            return true
+        }
         return displayList[index].sectionTitle != displayList[index - 1].sectionTitle
     }
 

--- a/Muxy/Views/Components/Pickers/ProjectPickerPathField.swift
+++ b/Muxy/Views/Components/Pickers/ProjectPickerPathField.swift
@@ -92,17 +92,31 @@ private final class ProjectPickerNSTextField: NSTextField {
 
 private enum ProjectPickerPathFieldCommandMapper {
     static func command(for selector: Selector, shouldGoUpOnDeleteBackward: Bool) -> ProjectPickerCommand? {
-        if selector == #selector(NSResponder.insertNewline(_:)) { return .openHighlighted }
-        if selector == #selector(NSResponder.insertTab(_:)) { return .completeHighlighted }
-        if selector == #selector(NSResponder.moveUp(_:)) { return .moveHighlightUp }
-        if selector == #selector(NSResponder.moveDown(_:)) { return .moveHighlightDown }
-        if selector == #selector(NSResponder.deleteWordBackward(_:)) { return shouldGoUpOnDeleteBackward ? .goBack : nil }
+        if selector == #selector(NSResponder.insertNewline(_:)) {
+            return .openHighlighted
+        }
+        if selector == #selector(NSResponder.insertTab(_:)) {
+            return .completeHighlighted
+        }
+        if selector == #selector(NSResponder.moveUp(_:)) {
+            return .moveHighlightUp
+        }
+        if selector == #selector(NSResponder.moveDown(_:)) {
+            return .moveHighlightDown
+        }
+        if selector == #selector(NSResponder.deleteWordBackward(_:)) {
+            return shouldGoUpOnDeleteBackward ? .goBack : nil
+        }
         return nil
     }
 
     static func command(for event: NSEvent) -> ProjectPickerCommand? {
-        if event.keyCode == kVK_Escape { return .dismiss }
-        if event.keyCode == kVK_Return, event.modifierFlags.contains(.command) { return .confirmTypedPath }
+        if event.keyCode == kVK_Escape {
+            return .dismiss
+        }
+        if event.keyCode == kVK_Return, event.modifierFlags.contains(.command) {
+            return .confirmTypedPath
+        }
         return nil
     }
 }

--- a/Muxy/Views/Extensions/ExtensionFolderPicker.swift
+++ b/Muxy/Views/Extensions/ExtensionFolderPicker.swift
@@ -11,7 +11,9 @@ enum ExtensionFolderPicker {
         panel.prompt = "Select"
         panel.title = title
         panel.message = message
-        if let directory { panel.directoryURL = directory }
+        if let directory {
+            panel.directoryURL = directory
+        }
         guard panel.runModal() == .OK else { return nil }
         return panel.url
     }

--- a/Muxy/Views/Extensions/ExtensionInstallPage.swift
+++ b/Muxy/Views/Extensions/ExtensionInstallPage.swift
@@ -206,7 +206,9 @@ struct ExtensionInstallPage: View {
     }
 
     private var installButtonTitle: String {
-        if isInstalling { return isInstalled ? "Reinstalling…" : "Installing…" }
+        if isInstalling {
+            return isInstalled ? "Reinstalling…" : "Installing…"
+        }
         return isInstalled ? "Reinstall" : "Install"
     }
 

--- a/Muxy/Views/Extensions/ExtensionOutputPanel.swift
+++ b/Muxy/Views/Extensions/ExtensionOutputPanel.swift
@@ -163,8 +163,12 @@ struct ExtensionOutputPanel: View {
     }
 
     private func color(for line: String) -> Color {
-        if line.hasPrefix("[err]") { return MuxyTheme.diffRemoveFg }
-        if line.hasPrefix("[warn]") { return MuxyTheme.warning }
+        if line.hasPrefix("[err]") {
+            return MuxyTheme.diffRemoveFg
+        }
+        if line.hasPrefix("[warn]") {
+            return MuxyTheme.warning
+        }
         return MuxyTheme.fgMuted
     }
 }

--- a/Muxy/Views/Extensions/ExtensionWebView.swift
+++ b/Muxy/Views/Extensions/ExtensionWebView.swift
@@ -146,7 +146,9 @@ struct ExtensionWebView: NSViewRepresentable {
             guard focusChanged || overlayChanged else { return }
             self.focused = focused
             self.overlayActive = overlayActive
-            if focusChanged { pushFocusUpdate(in: webView) }
+            if focusChanged {
+                pushFocusUpdate(in: webView)
+            }
             updateFirstResponder(for: webView)
         }
 

--- a/Muxy/Views/Extensions/ExtensionWebViewPane.swift
+++ b/Muxy/Views/Extensions/ExtensionWebViewPane.swift
@@ -11,32 +11,30 @@ struct ExtensionWebViewPane: View {
     @Environment(ProjectGroupStore.self) private var projectGroupStore
 
     var body: some View {
-        Group {
-            if let muxyExtension = ExtensionStore.shared.loadedExtension(id: state.extensionID),
-               let tabType = muxyExtension.manifest.tabType(id: state.tabTypeID),
-               let entryURL = ExtensionWebView.entryURL(for: muxyExtension, entry: tabType.entry)
-            {
-                ExtensionWebView(
-                    extensionID: muxyExtension.id,
-                    instanceID: state.id.uuidString,
-                    surfaceKind: .tab,
-                    entryURL: entryURL,
-                    initialData: state.data,
-                    appState: appState,
-                    projectStore: projectStore,
-                    worktreeStore: worktreeStore,
-                    projectGroupStore: projectGroupStore,
-                    focused: focused,
-                    onFocus: onFocus
-                )
+        if let muxyExtension = ExtensionStore.shared.loadedExtension(id: state.extensionID),
+           let tabType = muxyExtension.manifest.tabType(id: state.tabTypeID),
+           let entryURL = ExtensionWebView.entryURL(for: muxyExtension, entry: tabType.entry)
+        {
+            ExtensionWebView(
+                extensionID: muxyExtension.id,
+                instanceID: state.id.uuidString,
+                surfaceKind: .tab,
+                entryURL: entryURL,
+                initialData: state.data,
+                appState: appState,
+                projectStore: projectStore,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore,
+                focused: focused,
+                onFocus: onFocus
+            )
+            .contentShape(Rectangle())
+            .onTapGesture { onFocus() }
+        } else {
+            placeholder
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contentShape(Rectangle())
                 .onTapGesture { onFocus() }
-            } else {
-                placeholder
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .contentShape(Rectangle())
-                    .onTapGesture { onFocus() }
-            }
         }
     }
 

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -563,9 +563,15 @@ private struct ExtensionStatusBadge: View {
 
     @MainActor
     private var info: (String, Color) {
-        if status.isRunning { return ("running", MuxyTheme.diffAddFg) }
-        if status.isEnabled, status.muxyExtension.backgroundScriptURL == nil { return ("active", MuxyTheme.diffAddFg) }
-        if status.isEnabled { return ("stopped", MuxyTheme.fgMuted) }
+        if status.isRunning {
+            return ("running", MuxyTheme.diffAddFg)
+        }
+        if status.isEnabled, status.muxyExtension.backgroundScriptURL == nil {
+            return ("active", MuxyTheme.diffAddFg)
+        }
+        if status.isEnabled {
+            return ("stopped", MuxyTheme.fgMuted)
+        }
         return ("disabled", MuxyTheme.fgDim)
     }
 }
@@ -719,9 +725,15 @@ private struct ExtensionDetailPage: View {
                     errorBlock(error)
                 }
                 permissionsBlock
-                if !ext.manifest.commands.isEmpty { commandsBlock }
-                if !ext.manifest.tabTypes.isEmpty { tabTypesBlock }
-                if !ext.manifest.panels.isEmpty { panelsBlock }
+                if !ext.manifest.commands.isEmpty {
+                    commandsBlock
+                }
+                if !ext.manifest.tabTypes.isEmpty {
+                    tabTypesBlock
+                }
+                if !ext.manifest.panels.isEmpty {
+                    panelsBlock
+                }
                 grantsBlock
                 logsBlock
             }
@@ -1067,7 +1079,9 @@ private struct DetailSection<Content: View>: View {
                     .textCase(.uppercase)
                     .tracking(0.6)
                 Spacer()
-                if let trailing { trailing }
+                if let trailing {
+                    trailing
+                }
             }
             content
         }

--- a/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
@@ -82,7 +82,9 @@ struct ExpandedProjectRow: View {
             get: { project.worktreesEnabled },
             set: { enabled in
                 onSetWorktreesEnabled(enabled)
-                if !enabled { worktreesExpanded = false }
+                if !enabled {
+                    worktreesExpanded = false
+                }
             }
         )
     }
@@ -232,7 +234,9 @@ struct ExpandedProjectRow: View {
             hovered = hovering
         }
         .onChange(of: isAnyDragging) { _, dragging in
-            if dragging { hovered = false }
+            if dragging {
+                hovered = false
+            }
         }
         .onTapGesture {
             guard !isAnyDragging else { return }
@@ -442,11 +446,15 @@ struct ExpandedProjectRow: View {
         if project.isHome {
             return AnyShapeStyle(hovered ? MuxyTheme.accent.opacity(0.85) : MuxyTheme.accent)
         }
-        if hasLogo { return AnyShapeStyle(Color.clear) }
+        if hasLogo {
+            return AnyShapeStyle(Color.clear)
+        }
         if let tint = ProjectIconColor.color(for: project.iconColor) {
             return AnyShapeStyle(hovered ? tint.opacity(0.85) : tint)
         }
-        if hovered { return AnyShapeStyle(MuxyTheme.fg.opacity(0.22)) }
+        if hovered {
+            return AnyShapeStyle(MuxyTheme.fg.opacity(0.22))
+        }
         return AnyShapeStyle(MuxyTheme.fg.opacity(0.18))
     }
 
@@ -458,8 +466,12 @@ struct ExpandedProjectRow: View {
     }
 
     private var headerBackground: AnyShapeStyle {
-        if isActive { return AnyShapeStyle(MuxyTheme.surface) }
-        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        if isActive {
+            return AnyShapeStyle(MuxyTheme.surface)
+        }
+        if hovered {
+            return AnyShapeStyle(MuxyTheme.hover)
+        }
         return AnyShapeStyle(Color.clear)
     }
 
@@ -594,7 +606,9 @@ private struct ExpandedWorktreeRow: View {
     @FocusState private var renameFieldFocused: Bool
 
     private var displayName: String {
-        if worktree.isPrimary, worktree.name.isEmpty { return "main" }
+        if worktree.isPrimary, worktree.name.isEmpty {
+            return "main"
+        }
         return worktree.name
     }
 
@@ -677,7 +691,9 @@ private struct ExpandedWorktreeRow: View {
 
     private var worktreeAccessibilityLabel: String {
         var label = displayName
-        if worktree.isPrimary { label += ", primary" }
+        if worktree.isPrimary {
+            label += ", primary"
+        }
         return label
     }
 
@@ -695,7 +711,9 @@ private struct ExpandedWorktreeRow: View {
     private var activeStyle: Bool { selected && projectActive }
 
     private var rowBackground: AnyShapeStyle {
-        if activeStyle || hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        if activeStyle || hovered {
+            return AnyShapeStyle(MuxyTheme.hover)
+        }
         return AnyShapeStyle(Color.clear)
     }
 
@@ -707,7 +725,9 @@ private struct ExpandedWorktreeRow: View {
 
     private func commitRename() {
         let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty { onRename(trimmed) }
+        if !trimmed.isEmpty {
+            onRename(trimmed)
+        }
         isRenaming = false
     }
 

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
@@ -86,7 +86,9 @@ struct ProjectRow: View {
                 hovered = hovering
             }
             .onChange(of: isAnyDragging) { _, dragging in
-                if dragging { hovered = false }
+                if dragging {
+                    hovered = false
+                }
             }
             .onTapGesture {
                 guard !isAnyDragging else { return }
@@ -299,11 +301,15 @@ struct ProjectRow: View {
         if project.isHome {
             return AnyShapeStyle(hovered ? MuxyTheme.accent.opacity(0.85) : MuxyTheme.accent)
         }
-        if hasLogo { return AnyShapeStyle(Color.clear) }
+        if hasLogo {
+            return AnyShapeStyle(Color.clear)
+        }
         if let tint = ProjectIconColor.color(for: project.iconColor) {
             return AnyShapeStyle(hovered ? tint.opacity(0.85) : tint)
         }
-        if hovered { return AnyShapeStyle(MuxyTheme.fg.opacity(0.22)) }
+        if hovered {
+            return AnyShapeStyle(MuxyTheme.fg.opacity(0.22))
+        }
         return AnyShapeStyle(MuxyTheme.fg.opacity(0.18))
     }
 

--- a/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
@@ -293,7 +293,9 @@ struct WorkspaceSwitcher: View {
     }
 
     private func failureMessage(for destination: SSHDestination) -> String {
-        if case let .failed(message) = sshConnections.state(for: destination) { return message }
+        if case let .failed(message) = sshConnections.state(for: destination) {
+            return message
+        }
         return "Connection failed."
     }
 }
@@ -583,7 +585,11 @@ struct RemoteWorkspaceEditorSheet: View {
             TextField(selectedDevice?.displayName ?? "Production", text: $name)
                 .textFieldStyle(.roundedBorder)
                 .focused($nameFocused)
-                .onSubmit { if canSubmit { submit() } }
+                .onSubmit {
+                    if canSubmit {
+                        submit()
+                    }
+                }
         }
     }
 
@@ -621,7 +627,11 @@ struct WorkspaceEditorSheet: View {
                 TextField("Personal", text: $name)
                     .textFieldStyle(.roundedBorder)
                     .focused($nameFocused)
-                    .onSubmit { if canSubmit { onSubmit(trimmed) } }
+                    .onSubmit {
+                        if canSubmit {
+                            onSubmit(trimmed)
+                        }
+                    }
             }
 
             HStack {

--- a/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
@@ -368,8 +368,12 @@ struct CreateWorktreeSheet: View {
 
     private var canCreate: Bool {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else { return false }
-        if project.isRemote, remotePath.trimmingCharacters(in: .whitespaces).isEmpty { return false }
-        if !project.isRemote, localLocationValidationMessage != nil { return false }
+        if project.isRemote, remotePath.trimmingCharacters(in: .whitespaces).isEmpty {
+            return false
+        }
+        if !project.isRemote, localLocationValidationMessage != nil {
+            return false
+        }
         if createNewBranch {
             return !branchName.trimmingCharacters(in: .whitespaces).isEmpty
         }

--- a/Muxy/Views/Layouts/Shared/WorktreePopover.swift
+++ b/Muxy/Views/Layouts/Shared/WorktreePopover.swift
@@ -129,7 +129,9 @@ private struct WorktreePopoverRow: View {
     @FocusState private var renameFieldFocused: Bool
 
     private var displayName: String {
-        if worktree.isPrimary, worktree.name.isEmpty { return "main" }
+        if worktree.isPrimary, worktree.name.isEmpty {
+            return "main"
+        }
         return worktree.name
     }
 
@@ -206,9 +208,15 @@ private struct WorktreePopoverRow: View {
     }
 
     private var rowBackground: AnyShapeStyle {
-        if selected { return AnyShapeStyle(MuxyTheme.accentSoft) }
-        if isHighlighted { return AnyShapeStyle(MuxyTheme.surface) }
-        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        if selected {
+            return AnyShapeStyle(MuxyTheme.accentSoft)
+        }
+        if isHighlighted {
+            return AnyShapeStyle(MuxyTheme.surface)
+        }
+        if hovered {
+            return AnyShapeStyle(MuxyTheme.hover)
+        }
         return AnyShapeStyle(Color.clear)
     }
 
@@ -220,7 +228,9 @@ private struct WorktreePopoverRow: View {
 
     private func commitRename() {
         let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty { onRename(trimmed) }
+        if !trimmed.isEmpty {
+            onRename(trimmed)
+        }
         isRenaming = false
     }
 

--- a/Muxy/Views/Layouts/Shared/WorktreeRefreshHelper.swift
+++ b/Muxy/Views/Layouts/Shared/WorktreeRefreshHelper.swift
@@ -14,7 +14,9 @@ enum WorktreeRefreshHelper {
         isRefreshing: Binding<Bool>? = nil,
         presentErrors: Bool = true
     ) async {
-        if isRefreshing?.wrappedValue == true { return }
+        if isRefreshing?.wrappedValue == true {
+            return
+        }
         let previous = worktreeStore.list(for: project.id)
         isRefreshing?.wrappedValue = true
         defer { isRefreshing?.wrappedValue = false }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedBranchPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedBranchPopover.swift
@@ -386,10 +386,18 @@ private struct BranchPopoverRow: View {
     }
 
     private var rowBackground: AnyShapeStyle {
-        if isDeletionPending { return AnyShapeStyle(MuxyTheme.diffRemoveBg) }
-        if isHovered { return AnyShapeStyle(MuxyTheme.hover) }
-        if isSelected { return AnyShapeStyle(MuxyTheme.accentSoft) }
-        if isHighlighted { return AnyShapeStyle(MuxyTheme.surface) }
+        if isDeletionPending {
+            return AnyShapeStyle(MuxyTheme.diffRemoveBg)
+        }
+        if isHovered {
+            return AnyShapeStyle(MuxyTheme.hover)
+        }
+        if isSelected {
+            return AnyShapeStyle(MuxyTheme.accentSoft)
+        }
+        if isHighlighted {
+            return AnyShapeStyle(MuxyTheme.surface)
+        }
         return AnyShapeStyle(Color.clear)
     }
 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
@@ -391,7 +391,9 @@ struct TabFocusedChangesPopover: View {
     }
 
     private func statusColor(_ file: GitStatusFile, side: ChangeSide) -> Color {
-        if side == .conflicted { return MuxyTheme.warning }
+        if side == .conflicted {
+            return MuxyTheme.warning
+        }
         return switch file.displayStatusText(isStaged: side == .staged) {
         case "A",
              "C": MuxyTheme.diffAddFg
@@ -444,7 +446,9 @@ private struct ChangesPopoverActionButton: View {
     }
 
     private var foreground: Color {
-        if isDisabled { return MuxyTheme.fgDim }
+        if isDisabled {
+            return MuxyTheme.fgDim
+        }
         return isDestructive ? MuxyTheme.diffRemoveFg : MuxyTheme.fgMuted
     }
 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -199,7 +199,9 @@ struct TabFocusedProjectRow: View {
             .onSubmit { commitRename() }
             .onExitCommand { isRenaming = false }
             .onChange(of: renameFieldFocused) { _, focused in
-                if !focused, isRenaming { commitRename() }
+                if !focused, isRenaming {
+                    commitRename()
+                }
             }
     }
 
@@ -392,7 +394,9 @@ struct TabFocusedProjectRow: View {
     }
 
     private var headerBackground: AnyShapeStyle {
-        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        if hovered {
+            return AnyShapeStyle(MuxyTheme.hover)
+        }
         return AnyShapeStyle(Color.clear)
     }
 

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedPullRequestPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedPullRequestPopover.swift
@@ -314,7 +314,9 @@ struct TabFocusedPullRequestPopover: View {
     }
 
     private var mergeButtonLabel: String {
-        if isMerging { return "Merging…" }
+        if isMerging {
+            return "Merging…"
+        }
         if pendingConfirmation?.kind == .merge(mergeMethod) {
             return "\(mergeMethod.shortLabel) in \(remainingSeconds)s · click again"
         }
@@ -322,19 +324,27 @@ struct TabFocusedPullRequestPopover: View {
     }
 
     private var mergeButtonHelp: String {
-        if isRefreshing { return "Wait for the pull request refresh to finish." }
+        if isRefreshing {
+            return "Wait for the pull request refresh to finish."
+        }
         guard pendingConfirmation?.kind == .merge(mergeMethod) else { return mergeAvailability.help }
         return "Click again to merge now. Otherwise it will merge automatically after five seconds."
     }
 
     private var closeButtonLabel: String {
-        if isClosing { return "Closing…" }
-        if pendingConfirmation?.kind == .close { return "Close in \(remainingSeconds)s · click again" }
+        if isClosing {
+            return "Closing…"
+        }
+        if pendingConfirmation?.kind == .close {
+            return "Close in \(remainingSeconds)s · click again"
+        }
         return "Close PR"
     }
 
     private var closeButtonHelp: String {
-        if isRefreshing { return "Wait for the pull request refresh to finish." }
+        if isRefreshing {
+            return "Wait for the pull request refresh to finish."
+        }
         guard pendingConfirmation?.kind == .close else { return "Close this pull request without merging it." }
         return "Click again to close now. Otherwise it will close automatically after five seconds."
     }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebarRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebarRow.swift
@@ -28,12 +28,16 @@ struct SidebarActionButton: View {
     }
 
     private var foreground: Color {
-        if isActive { return MuxyTheme.accent }
+        if isActive {
+            return MuxyTheme.accent
+        }
         return hovered ? MuxyTheme.fg : MuxyTheme.fgMuted
     }
 
     private var background: Color {
-        if isActive { return MuxyTheme.accentSoft }
+        if isActive {
+            return MuxyTheme.accentSoft
+        }
         return hovered ? MuxyTheme.hover : .clear
     }
 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -251,8 +251,12 @@ private struct TabFocusedTabRow: View {
     }
 
     private var rowBackground: AnyShapeStyle {
-        if active { return AnyShapeStyle(MuxyTheme.surface) }
-        if hovered { return AnyShapeStyle(MuxyTheme.hover) }
+        if active {
+            return AnyShapeStyle(MuxyTheme.surface)
+        }
+        if hovered {
+            return AnyShapeStyle(MuxyTheme.hover)
+        }
         return AnyShapeStyle(Color.clear)
     }
 
@@ -303,7 +307,9 @@ private struct TabFocusedTabRow: View {
                     .onSubmit { commitRename() }
                     .onExitCommand { cancelRename() }
                     .onChange(of: renameFieldFocused) { _, focused in
-                        if !focused, isRenaming { commitRename() }
+                        if !focused, isRenaming {
+                            commitRename()
+                        }
                     }
             } else {
                 Text(tab.title)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -229,12 +229,11 @@ struct MainWindow: View {
         )
     }
 
+    @ViewBuilder
     private var voiceRecordingPanel: some View {
-        Group {
-            if voiceRecording.isPanelVisible {
-                VoiceRecordingPanel(state: voiceRecording, autoSend: recordingAutoSend)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
+        if voiceRecording.isPanelVisible {
+            VoiceRecordingPanel(state: voiceRecording, autoSend: recordingAutoSend)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
         }
     }
 
@@ -905,7 +904,9 @@ struct MainWindow: View {
         return items.enumerated().sorted { lhs, rhs in
             let lhsRank = mruRank[WorktreeKey(projectID: lhs.element.projectID, worktreeID: lhs.element.worktreeID)] ?? Int.max
             let rhsRank = mruRank[WorktreeKey(projectID: rhs.element.projectID, worktreeID: rhs.element.worktreeID)] ?? Int.max
-            if lhsRank != rhsRank { return lhsRank < rhsRank }
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank
+            }
             return lhs.offset < rhs.offset
         }.map(\.element)
     }
@@ -948,7 +949,9 @@ struct MainWindow: View {
 
     private func selectOmniboxProject(_ projectID: UUID, worktreeID: UUID? = nil) -> Bool {
         guard let project = resolveOmniboxProject(projectID) else { return false }
-        if project.isRemote { worktreeStore.ensurePrimary(for: project) }
+        if project.isRemote {
+            worktreeStore.ensurePrimary(for: project)
+        }
         let worktree = if let worktreeID {
             worktreeStore.list(for: project.id).first { $0.id == worktreeID }
         } else {
@@ -1577,7 +1580,9 @@ struct MainWindow: View {
         guard let project = activeProject,
               let key = appState.activeWorktreeKey(for: project.id)
         else { return nil }
-        if let existing = richInputStates[key] { return existing }
+        if let existing = richInputStates[key] {
+            return existing
+        }
         let new = RichInputState()
         if let draft = RichInputDraftStore.shared.draft(for: key) {
             new.apply(draft)
@@ -2364,7 +2369,9 @@ private struct WorktreeActionsModifier: ViewModifier {
         Binding(
             get: { pendingRemoval != nil },
             set: { newValue in
-                if !newValue { pendingRemoval = nil }
+                if !newValue {
+                    pendingRemoval = nil
+                }
             }
         )
     }

--- a/Muxy/Views/Panels/NotificationPanel.swift
+++ b/Muxy/Views/Panels/NotificationPanel.swift
@@ -123,9 +123,13 @@ struct NotificationPanel: View {
 
     private func notificationAccessibilityLabel(for item: NotificationPanelItem) -> String {
         var label = item.title
-        if !item.body.isEmpty { label += ": \(item.body)" }
+        if !item.body.isEmpty {
+            label += ": \(item.body)"
+        }
         label += ", \(item.relativeTimestamp)"
-        if !item.isRead { label += ", unread" }
+        if !item.isRead {
+            label += ", unread"
+        }
         return label
     }
 

--- a/Muxy/Views/Panels/VoiceRecordingPanel.swift
+++ b/Muxy/Views/Panels/VoiceRecordingPanel.swift
@@ -253,13 +253,17 @@ final class VoicePanelFocusTrapView: NSView {
 
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
-        if result { onFocusChange?(true) }
+        if result {
+            onFocusChange?(true)
+        }
         return result
     }
 
     override func resignFirstResponder() -> Bool {
         let result = super.resignFirstResponder()
-        if result { onFocusChange?(false) }
+        if result {
+            onFocusChange?(false)
+        }
         return result
     }
 

--- a/Muxy/Views/Settings/BackupSettingsView.swift
+++ b/Muxy/Views/Settings/BackupSettingsView.swift
@@ -20,7 +20,11 @@ struct BackupSettingsView: View {
     private var importConfirmationBinding: Binding<Bool> {
         Binding(
             get: { pendingImportURL != nil },
-            set: { if !$0 { pendingImportURL = nil } }
+            set: {
+                if !$0 {
+                    pendingImportURL = nil
+                }
+            }
         )
     }
 

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -194,14 +194,22 @@ struct BrowserSettingsView: View {
     private var deleteAlertBinding: Binding<Bool> {
         Binding(
             get: { profilePendingDelete != nil },
-            set: { if !$0 { profilePendingDelete = nil } }
+            set: {
+                if !$0 {
+                    profilePendingDelete = nil
+                }
+            }
         )
     }
 
     private var clearAlertBinding: Binding<Bool> {
         Binding(
             get: { profilePendingClear != nil },
-            set: { if !$0 { profilePendingClear = nil } }
+            set: {
+                if !$0 {
+                    profilePendingClear = nil
+                }
+            }
         )
     }
 

--- a/Muxy/Views/Settings/ExtensionCustomSettingsView.swift
+++ b/Muxy/Views/Settings/ExtensionCustomSettingsView.swift
@@ -83,7 +83,9 @@ private struct ExtensionSettingRow: View {
         Binding(
             get: {
                 guard let value = settingsStore.effectiveValue(extensionID: extensionID, entry: entry) else { return false }
-                if case let .bool(value) = value { return value }
+                if case let .bool(value) = value {
+                    return value
+                }
                 return false
             },
             set: { newValue in
@@ -96,7 +98,9 @@ private struct ExtensionSettingRow: View {
         Binding(
             get: {
                 guard let value = settingsStore.effectiveValue(extensionID: extensionID, entry: entry) else { return "" }
-                if case let .string(value) = value { return value }
+                if case let .string(value) = value {
+                    return value
+                }
                 return ""
             },
             set: { newValue in

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -26,7 +26,9 @@ struct MobileSettingsView: View {
         Binding(
             get: { service.isEnabled },
             set: { newValue in
-                if newValue, !commitPort() { return }
+                if newValue, !commitPort() {
+                    return
+                }
                 service.setEnabled(newValue)
             }
         )
@@ -110,7 +112,9 @@ struct MobileSettingsView: View {
         .onDisappear { stopPathMonitor() }
         .onChange(of: service.port) { _, newValue in
             let text = String(newValue)
-            if portText != text { portText = text }
+            if portText != text {
+                portText = text
+            }
         }
         .onChange(of: service.isEnabled) { _, _ in
             refreshPairingHosts()
@@ -136,7 +140,11 @@ struct MobileSettingsView: View {
             "Revoke \(deviceToRevoke?.name ?? "device")?",
             isPresented: Binding(
                 get: { deviceToRevoke != nil },
-                set: { if !$0 { deviceToRevoke = nil } }
+                set: {
+                    if !$0 {
+                        deviceToRevoke = nil
+                    }
+                }
             ),
             presenting: deviceToRevoke
         ) { device in

--- a/Muxy/Views/Settings/RemoteDeviceEditorSheet.swift
+++ b/Muxy/Views/Settings/RemoteDeviceEditorSheet.swift
@@ -60,7 +60,9 @@ struct RemoteDeviceEditorSheet: View {
     }
 
     private var environmentErrorMessage: String? {
-        if case let .failure(error) = environmentResult { return error.localizedDescription }
+        if case let .failure(error) = environmentResult {
+            return error.localizedDescription
+        }
         return nil
     }
 
@@ -265,7 +267,9 @@ struct RemoteDeviceEditorSheet: View {
     }
 
     private func failureMessage(for destination: SSHDestination) -> String {
-        if case let .failed(message) = sshConnections.state(for: destination) { return message }
+        if case let .failed(message) = sshConnections.state(for: destination) {
+            return message
+        }
         return "Connection failed."
     }
 }

--- a/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
+++ b/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
@@ -93,7 +93,11 @@ struct RemoteDevicesSettingsView: View {
     private var deleteAlertBinding: Binding<Bool> {
         Binding(
             get: { devicePendingDelete != nil },
-            set: { if !$0 { devicePendingDelete = nil } }
+            set: {
+                if !$0 {
+                    devicePendingDelete = nil
+                }
+            }
         )
     }
 

--- a/Muxy/Views/Settings/SettingsJSONEditorView.swift
+++ b/Muxy/Views/Settings/SettingsJSONEditorView.swift
@@ -461,11 +461,21 @@ private enum JSONSyntaxHighlighter {
 
     @MainActor
     private static func attributesForMatch(_ match: NSTextCheckingResult) -> [NSAttributedString.Key: Any] {
-        if match.range(at: 1).location != NSNotFound { return [.foregroundColor: NSColor(MuxyTheme.accent)] }
-        if match.range(at: 2).location != NSNotFound { return [.foregroundColor: NSColor.systemGreen] }
-        if match.range(at: 3).location != NSNotFound { return [.foregroundColor: NSColor.systemOrange] }
-        if match.range(at: 4).location != NSNotFound { return [.foregroundColor: NSColor.systemPurple] }
-        if match.range(at: 5).location != NSNotFound { return [.foregroundColor: NSColor.systemBlue] }
+        if match.range(at: 1).location != NSNotFound {
+            return [.foregroundColor: NSColor(MuxyTheme.accent)]
+        }
+        if match.range(at: 2).location != NSNotFound {
+            return [.foregroundColor: NSColor.systemGreen]
+        }
+        if match.range(at: 3).location != NSNotFound {
+            return [.foregroundColor: NSColor.systemOrange]
+        }
+        if match.range(at: 4).location != NSNotFound {
+            return [.foregroundColor: NSColor.systemPurple]
+        }
+        if match.range(at: 5).location != NSNotFound {
+            return [.foregroundColor: NSColor.systemBlue]
+        }
         return [.foregroundColor: SettingsStyle.mutedNSForeground]
     }
 }

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -17,7 +17,9 @@ struct SettingsView: View {
             .filter { status in
                 guard !query.isEmpty else { return true }
                 let displayName = status.muxyExtension.displayName.lowercased()
-                if displayName.contains(query) { return true }
+                if displayName.contains(query) {
+                    return true
+                }
                 return status.muxyExtension.manifest.settings.contains { entry in
                     entry.key.lowercased().contains(query)
                         || entry.title.lowercased().contains(query)
@@ -78,7 +80,9 @@ struct SettingsView: View {
     }
 
     private var selectedBuiltinCategory: SettingsCategory? {
-        if case let .builtin(category) = selectedRoute { return category }
+        if case let .builtin(category) = selectedRoute {
+            return category
+        }
         return nil
     }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -469,7 +469,9 @@ final class GhosttyTerminalNSView: NSView {
 
     func isTerminalIdle() -> Bool {
         guard let surface else { return true }
-        if ghostty_surface_needs_confirm_quit(surface) { return false }
+        if ghostty_surface_needs_confirm_quit(surface) {
+            return false
+        }
         return !isAlternateScreenActive(surface: surface)
     }
 
@@ -679,7 +681,9 @@ final class GhosttyTerminalNSView: NSView {
     private var currentTrackingArea: NSTrackingArea?
 
     private func setupTrackingArea() {
-        if let existing = currentTrackingArea { removeTrackingArea(existing) }
+        if let existing = currentTrackingArea {
+            removeTrackingArea(existing)
+        }
         let area = NSTrackingArea(
             rect: bounds,
             options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow, .inVisibleRect],
@@ -695,7 +699,9 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
-        if overlayActive { return }
+        if overlayActive {
+            return
+        }
         guard let surface else { super.keyDown(with: event)
             return
         }
@@ -705,7 +711,9 @@ final class GhosttyTerminalNSView: NSView {
         let optionAsAlt = translatedOptionAsAlt(for: event)
 
         if flags.contains(.control), !flags.contains(.command), !flags.contains(.option), !hasMarkedText() {
-            if isAppShortcut(event) { return }
+            if isAppShortcut(event) {
+                return
+            }
             var keyEvent = buildKeyEvent(from: event, action: action)
             let text = shortcutText(from: event)
             if text.isEmpty {
@@ -722,7 +730,9 @@ final class GhosttyTerminalNSView: NSView {
         }
 
         if flags.contains(.command) {
-            if isAppShortcut(event) { return }
+            if isAppShortcut(event) {
+                return
+            }
             var keyEvent = buildKeyEvent(from: event, action: action)
             keyEvent.text = nil
             _ = ghostty_surface_key(surface, keyEvent)
@@ -787,7 +797,9 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func keyUp(with event: NSEvent) {
-        if overlayActive { return }
+        if overlayActive {
+            return
+        }
         guard let surface else { return }
         var keyEvent = buildKeyEvent(from: event, action: GHOSTTY_ACTION_RELEASE)
         keyEvent.text = nil
@@ -795,9 +807,13 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func flagsChanged(with event: NSEvent) {
-        if overlayActive { return }
+        if overlayActive {
+            return
+        }
         guard let surface else { return }
-        if hasMarkedText() { return }
+        if hasMarkedText() {
+            return
+        }
         let action: ghostty_input_action_e = isFlagPress(event) ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
         var keyEvent = buildKeyEvent(from: event, action: action)
         keyEvent.text = nil
@@ -806,8 +822,12 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if isAppShortcut(event) { return false }
-        if overlayActive { return false }
+        if isAppShortcut(event) {
+            return false
+        }
+        if overlayActive {
+            return false
+        }
         guard window?.firstResponder === self || window?.firstResponder === inputContext else { return false }
         guard event.type == .keyDown, let surface else { return false }
 
@@ -835,7 +855,9 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
-        if overlayActive { return }
+        if overlayActive {
+            return
+        }
         guard let surface else { return }
         let alreadyFirstResponder = window?.firstResponder === self
         window?.makeFirstResponder(self)
@@ -855,7 +877,9 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
-        if overlayActive { return }
+        if overlayActive {
+            return
+        }
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
@@ -1203,7 +1227,9 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
-        if overlayActive { return }
+        if overlayActive {
+            return
+        }
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
@@ -1214,7 +1240,9 @@ final class GhosttyTerminalNSView: NSView {
     }
 
     override func rightMouseUp(with event: NSEvent) {
-        if overlayActive { return }
+        if overlayActive {
+            return
+        }
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
@@ -1266,7 +1294,9 @@ final class GhosttyTerminalNSView: NSView {
 
     private func pasteboardHasImage() -> Bool {
         let pb = NSPasteboard.general
-        if pb.string(forType: .string) != nil { return false }
+        if pb.string(forType: .string) != nil {
+            return false
+        }
         return pb.canReadObject(forClasses: [NSImage.self], options: nil)
     }
 
@@ -1278,7 +1308,9 @@ final class GhosttyTerminalNSView: NSView {
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
         var mods: ghostty_input_scroll_mods_t = 0
-        if event.hasPreciseScrollingDeltas { mods |= 1 }
+        if event.hasPreciseScrollingDeltas {
+            mods |= 1
+        }
         ghostty_surface_mouse_scroll(surface, event.scrollingDeltaX, event.scrollingDeltaY, mods)
         scrollbarOverlay.flash()
     }
@@ -1333,8 +1365,12 @@ final class GhosttyTerminalNSView: NSView {
         consumeOption: Bool = true
     ) -> ghostty_input_mods_e {
         var mods = GHOSTTY_MODS_NONE.rawValue
-        if flags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
-        if consumeOption, flags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
+        if flags.contains(.shift) {
+            mods |= GHOSTTY_MODS_SHIFT.rawValue
+        }
+        if consumeOption, flags.contains(.option) {
+            mods |= GHOSTTY_MODS_ALT.rawValue
+        }
         return ghostty_input_mods_e(rawValue: mods)
     }
 
@@ -1349,15 +1385,33 @@ final class GhosttyTerminalNSView: NSView {
         var mods = GHOSTTY_MODS_NONE.rawValue
         let flags = event.modifierFlags
         let raw = flags.rawValue
-        if flags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
-        if flags.contains(.control) { mods |= GHOSTTY_MODS_CTRL.rawValue }
-        if flags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
-        if flags.contains(.command) { mods |= GHOSTTY_MODS_SUPER.rawValue }
-        if flags.contains(.capsLock) { mods |= GHOSTTY_MODS_CAPS.rawValue }
-        if raw & RightModifierMask.shift != 0 { mods |= GHOSTTY_MODS_SHIFT_RIGHT.rawValue }
-        if raw & RightModifierMask.control != 0 { mods |= GHOSTTY_MODS_CTRL_RIGHT.rawValue }
-        if raw & RightModifierMask.option != 0 { mods |= GHOSTTY_MODS_ALT_RIGHT.rawValue }
-        if raw & RightModifierMask.command != 0 { mods |= GHOSTTY_MODS_SUPER_RIGHT.rawValue }
+        if flags.contains(.shift) {
+            mods |= GHOSTTY_MODS_SHIFT.rawValue
+        }
+        if flags.contains(.control) {
+            mods |= GHOSTTY_MODS_CTRL.rawValue
+        }
+        if flags.contains(.option) {
+            mods |= GHOSTTY_MODS_ALT.rawValue
+        }
+        if flags.contains(.command) {
+            mods |= GHOSTTY_MODS_SUPER.rawValue
+        }
+        if flags.contains(.capsLock) {
+            mods |= GHOSTTY_MODS_CAPS.rawValue
+        }
+        if raw & RightModifierMask.shift != 0 {
+            mods |= GHOSTTY_MODS_SHIFT_RIGHT.rawValue
+        }
+        if raw & RightModifierMask.control != 0 {
+            mods |= GHOSTTY_MODS_CTRL_RIGHT.rawValue
+        }
+        if raw & RightModifierMask.option != 0 {
+            mods |= GHOSTTY_MODS_ALT_RIGHT.rawValue
+        }
+        if raw & RightModifierMask.command != 0 {
+            mods |= GHOSTTY_MODS_SUPER_RIGHT.rawValue
+        }
         return ghostty_input_mods_e(rawValue: mods)
     }
 
@@ -1419,7 +1473,9 @@ final class GhosttyTerminalNSView: NSView {
     private func filterSpecialCharacters(_ text: String) -> String {
         guard let scalar = text.unicodeScalars.first else { return "" }
         let value = scalar.value
-        if value < 0x20 || (0xF700 ... 0xF8FF).contains(value) { return "" }
+        if value < 0x20 || (0xF700 ... 0xF8FF).contains(value) {
+            return ""
+        }
         return text
     }
 

--- a/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
+++ b/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
@@ -835,8 +835,12 @@ private struct RepositoryToolbarChip<Content: View>: View {
     }
 
     private var background: Color {
-        if isOpen { return MuxyTheme.surface }
-        if hovered { return MuxyTheme.hover }
+        if isOpen {
+            return MuxyTheme.surface
+        }
+        if hovered {
+            return MuxyTheme.hover
+        }
         return .clear
     }
 }

--- a/Muxy/Views/Terminal/RichInputTextEditor.swift
+++ b/Muxy/Views/Terminal/RichInputTextEditor.swift
@@ -292,7 +292,9 @@ final class RichInputTextView: NSTextView {
             for url in urls {
                 onPasteFileURL?(url)
             }
-            if !urls.isEmpty { return }
+            if !urls.isEmpty {
+                return
+            }
         }
         if pasteboard.string(forType: .string) == nil,
            pasteboard.canReadObject(forClasses: [NSImage.self], options: nil),
@@ -305,8 +307,12 @@ final class RichInputTextView: NSTextView {
     }
 
     private func readImageData(from pasteboard: NSPasteboard) -> Data? {
-        if let data = pasteboard.data(forType: .png) { return data }
-        if let data = pasteboard.data(forType: .tiff) { return data }
+        if let data = pasteboard.data(forType: .png) {
+            return data
+        }
+        if let data = pasteboard.data(forType: .tiff) {
+            return data
+        }
         if let image = NSImage(pasteboard: pasteboard), let data = image.tiffRepresentation {
             return data
         }

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -14,7 +14,11 @@ struct TerminalPane: View {
     @Environment(\.overlayActive) private var overlayActive
 
     private var remoteOwnerName: String? {
-        if case let .remote(_, name) = ownership.owner(for: state.id) { name } else { nil }
+        if case let .remote(_, name) = ownership.owner(for: state.id) {
+            name
+        } else {
+            nil
+        }
     }
 
     private var showsSleepingPlaceholder: Bool {

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -377,7 +377,13 @@ private struct TabCell: View {
         guard let tabColor else {
             return active ? MuxyTheme.surface : .clear
         }
-        let opacity = if active { 0.18 } else if hovered { 0.08 } else { 0.04 }
+        let opacity = if active {
+            0.18
+        } else if hovered {
+            0.08
+        } else {
+            0.04
+        }
         return tabColor.opacity(opacity)
     }
 
@@ -447,7 +453,9 @@ private struct TabCell: View {
                         .onSubmit { commitRename() }
                         .onExitCommand { cancelRename() }
                         .onChange(of: renameFieldFocused) { _, focused in
-                            if !focused, isRenaming { commitRename() }
+                            if !focused, isRenaming {
+                                commitRename()
+                            }
                         }
                 } else if !titleHidden {
                     Text(tab.title)
@@ -493,7 +501,9 @@ private struct TabCell: View {
                 hovered = hovering
             }
             .onChange(of: isAnyDragging) { _, dragging in
-                if dragging { hovered = false }
+                if dragging {
+                    hovered = false
+                }
             }
             .overlay {
                 if !tab.isPinned {
@@ -646,9 +656,15 @@ private struct TabCell: View {
         case .extensionWebView: label += ", Extension"
         case .browser: label += ", Browser"
         }
-        if tab.isPinned { label += ", Pinned" }
-        if tab.isOffline, !active { label += ", Idle" }
-        if hasUnread { label += ", Unread" }
+        if tab.isPinned {
+            label += ", Pinned"
+        }
+        if tab.isOffline, !active {
+            label += ", Idle"
+        }
+        if hasUnread {
+            label += ", Unread"
+        }
         return label
     }
 

--- a/Muxy/Views/Workspace/Workspace.swift
+++ b/Muxy/Views/Workspace/Workspace.swift
@@ -22,7 +22,9 @@ struct TerminalArea: View {
 
     private var rootIsTabArea: Bool {
         guard let root else { return false }
-        if case .tabArea = root { return true }
+        if case .tabArea = root {
+            return true
+        }
         return false
     }
 

--- a/MuxyExtensionHost/HostBridge.swift
+++ b/MuxyExtensionHost/HostBridge.swift
@@ -77,7 +77,9 @@ final class HostBridge: @unchecked Sendable {
         }
         timer.setEventHandler { [weak self] in
             callback.call(withArguments: [])
-            if !repeats { self?.cancelTimer(id: id) }
+            if !repeats {
+                self?.cancelTimer(id: id)
+            }
         }
         timers[id] = timer
         timer.resume()
@@ -135,7 +137,9 @@ final class HostBridge: @unchecked Sendable {
         }
         do {
             let reply = try client.sendAndWaitReply(line)
-            if reply == "ok" { return ["ok": true, "value": NSNull()] }
+            if reply == "ok" {
+                return ["ok": true, "value": NSNull()]
+            }
             if reply.hasPrefix("error:") {
                 return ["ok": false, "error": String(reply.dropFirst("error:".count))]
             }

--- a/MuxyExtensionHost/HostSocketClient.swift
+++ b/MuxyExtensionHost/HostSocketClient.swift
@@ -120,7 +120,9 @@ final class HostSocketClient: @unchecked Sendable {
                     offset += written
                     continue
                 }
-                if written < 0, errno == EINTR { continue }
+                if written < 0, errno == EINTR {
+                    continue
+                }
                 throw ClientError.closed
             }
         }
@@ -137,7 +139,9 @@ final class HostSocketClient: @unchecked Sendable {
         replyLock.lock()
         defer { replyLock.unlock() }
         while !hasReply {
-            if closed { throw ClientError.closed }
+            if closed {
+                throw ClientError.closed
+            }
             replyLock.wait()
         }
         guard let reply = pendingReply else { throw ClientError.closed }
@@ -153,7 +157,9 @@ final class HostSocketClient: @unchecked Sendable {
                 drainLines()
                 continue
             }
-            if bytesRead < 0, errno == EINTR { continue }
+            if bytesRead < 0, errno == EINTR {
+                continue
+            }
             break
         }
         markClosed()

--- a/MuxyExtensionHost/main.swift
+++ b/MuxyExtensionHost/main.swift
@@ -72,7 +72,9 @@ func identify() -> Never? {
     for attempt in 1 ... maxAttempts {
         do {
             let reply = try client.sendAndWaitReply("identify|\(extensionID)|\(token)")
-            if reply == "ok" { return nil }
+            if reply == "ok" {
+                return nil
+            }
             lastReply = reply
             guard HostSocketClient.isTransientIdentifyRejection(reply), attempt < maxAttempts else {
                 return fail("identify rejected: \(reply)")
@@ -85,7 +87,9 @@ func identify() -> Never? {
     return fail("identify rejected: \(lastReply)")
 }
 
-if let failure = identify() { failure }
+if let failure = identify() {
+    failure
+}
 
 context.exceptionHandler = { _, exception in
     let message = exception?.toString() ?? "unknown error"

--- a/MuxyServer/MuxyRemoteServer.swift
+++ b/MuxyServer/MuxyRemoteServer.swift
@@ -126,7 +126,9 @@ public final class MuxyRemoteServer: @unchecked Sendable {
                 completion?()
                 return
             }
-            if let completion { self.stopCompletions.append(completion) }
+            if let completion {
+                self.stopCompletions.append(completion)
+            }
             listener.cancel()
         }
     }

--- a/MuxyShared/ProjectIconColor.swift
+++ b/MuxyShared/ProjectIconColor.swift
@@ -40,7 +40,9 @@ public enum ProjectIconColor {
 
     public static func swatch(for identifier: String?) -> Swatch? {
         guard let identifier else { return nil }
-        if let direct = byID[identifier] { return direct }
+        if let direct = byID[identifier] {
+            return direct
+        }
         return palette.first { $0.hex.caseInsensitiveCompare(identifier) == .orderedSame }
     }
 
@@ -52,7 +54,9 @@ public enum ProjectIconColor {
 
     public static func rgb(fromHex hex: String) -> (Double, Double, Double)? {
         var normalized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if normalized.hasPrefix("#") { normalized.removeFirst() }
+        if normalized.hasPrefix("#") {
+            normalized.removeFirst()
+        }
         guard normalized.count == 6,
               let value = UInt32(normalized, radix: 16)
         else { return nil }


### PR DESCRIPTION
CI runs SwiftFormat 0.62.1 from the runner image, not the 0.60.1 we pin, so every PR has failed the format check since 07-16.

Bumps the pin to match and reformats the 135 files the newer rules flag. The result lints clean under both versions, so nobody mid-upgrade reformats it back.

Run `brew upgrade swiftformat` locally — `scripts/checks.sh` enforces the pin.