### PR TITLE
Single-authority agent status with detection grace period (Phase 2)

### DIFF
--- a/Muxy/Services/AI/AgentStatusStore.swift
+++ b/Muxy/Services/AI/AgentStatusStore.swift
@@ -29,6 +29,38 @@ enum AgentLifecyclePhase: String, Equatable {
 }
 
 @MainActor
+protocol AgentGraceScheduler {
+    func schedule(after delay: TimeInterval, _ work: @escaping @MainActor () -> Void) -> AgentGraceCancellable
+}
+
+@MainActor
+protocol AgentGraceCancellable {
+    func cancel()
+}
+
+@MainActor
+final class DispatchAgentGraceScheduler: AgentGraceScheduler {
+    func schedule(after delay: TimeInterval, _ work: @escaping @MainActor () -> Void) -> AgentGraceCancellable {
+        let item = DispatchWorkItem { work() }
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+        return DispatchAgentGraceCancellable(item: item)
+    }
+}
+
+@MainActor
+final class DispatchAgentGraceCancellable: AgentGraceCancellable {
+    private let item: DispatchWorkItem
+
+    init(item: DispatchWorkItem) {
+        self.item = item
+    }
+
+    func cancel() {
+        item.cancel()
+    }
+}
+
+@MainActor
 @Observable
 final class AgentStatusStore {
     static let shared = AgentStatusStore()
@@ -40,15 +72,43 @@ final class AgentStatusStore {
         let providerID: String
         let status: AgentStatus
         let updatedAt: Date
+        var sequence: UInt64 = 0
     }
+
+    static let detectionLossGrace: TimeInterval = 4
 
     private(set) var entries: [UUID: Entry] = [:]
     private(set) var completionPending: Set<UUID> = []
     private var panes: [UUID: Entry] = [:]
+    private var appliedSequence: [UUID: UInt64] = [:]
+    private var pendingGrace: [UUID: AgentGraceCancellable] = [:]
+    private var detectionLost: Set<UUID> = []
+    private var sequenceCounter: UInt64 = 0
 
-    private init() {}
+    private let scheduler: AgentGraceScheduler
+    private let graceDelay: TimeInterval
 
-    func update(paneID: UUID, providerID: String, status: AgentStatus, appState: AppState) {
+    init(
+        scheduler: AgentGraceScheduler = DispatchAgentGraceScheduler(),
+        graceDelay: TimeInterval = AgentStatusStore.detectionLossGrace
+    ) {
+        self.scheduler = scheduler
+        self.graceDelay = graceDelay
+    }
+
+    func nextSequence() -> UInt64 {
+        sequenceCounter += 1
+        return sequenceCounter
+    }
+
+    func update(paneID: UUID, providerID: String, status: AgentStatus, sequence: UInt64, appState: AppState) {
+        if let applied = appliedSequence[paneID], sequence <= applied {
+            return
+        }
+        appliedSequence[paneID] = sequence
+
+        cancelGrace(for: paneID)
+
         if let existing = panes[paneID], existing.status == status, existing.providerID == providerID {
             return
         }
@@ -61,37 +121,38 @@ final class AgentStatusStore {
               )
         else { return }
 
-        let existingStatus = panes[paneID]?.status
-        panes[paneID] = Entry(
+        applyEntry(Entry(
             worktreeID: context.worktreeID,
             projectID: context.projectID,
             paneID: paneID,
             providerID: providerID,
             status: status,
-            updatedAt: Date()
-        )
-        updateCompletion(paneID: paneID, from: existingStatus, to: status)
-        recompute(worktreeID: context.worktreeID)
+            updatedAt: Date(),
+            sequence: sequence
+        ))
     }
 
     func removePane(_ paneID: UUID) {
+        cancelGrace(for: paneID)
+        detectionLost.remove(paneID)
+        appliedSequence.removeValue(forKey: paneID)
         completionPending.remove(paneID)
         guard let removed = panes.removeValue(forKey: paneID) else { return }
         recompute(worktreeID: removed.worktreeID)
     }
 
-    func markIdleIfActive(paneID: UUID) {
-        guard let existing = panes[paneID], existing.status != .idle else { return }
-        panes[paneID] = Entry(
-            worktreeID: existing.worktreeID,
-            projectID: existing.projectID,
-            paneID: paneID,
-            providerID: existing.providerID,
-            status: .idle,
-            updatedAt: Date()
-        )
-        completionPending.insert(paneID)
-        recompute(worktreeID: existing.worktreeID)
+    func noteDetectionActive(paneID: UUID) {
+        detectionLost.remove(paneID)
+        cancelGrace(for: paneID)
+    }
+
+    func noteDetectionLost(paneID: UUID) {
+        detectionLost.insert(paneID)
+        guard let existing = panes[paneID], existing.status == .working else { return }
+        guard pendingGrace[paneID] == nil else { return }
+        pendingGrace[paneID] = scheduler.schedule(after: graceDelay) { [weak self] in
+            self?.resolveGrace(for: paneID)
+        }
     }
 
     func clearCompletion(for paneID: UUID) {
@@ -134,6 +195,34 @@ final class AgentStatusStore {
                 ? lhs.status.priority < rhs.status.priority
                 : lhs.updatedAt < rhs.updatedAt
         }
+    }
+
+    private func resolveGrace(for paneID: UUID) {
+        pendingGrace.removeValue(forKey: paneID)
+        guard detectionLost.contains(paneID) else { return }
+        guard let existing = panes[paneID], existing.status == .working else { return }
+        let sequence = nextSequence()
+        appliedSequence[paneID] = sequence
+        applyEntry(Entry(
+            worktreeID: existing.worktreeID,
+            projectID: existing.projectID,
+            paneID: paneID,
+            providerID: existing.providerID,
+            status: .idle,
+            updatedAt: Date(),
+            sequence: sequence
+        ))
+    }
+
+    private func cancelGrace(for paneID: UUID) {
+        pendingGrace.removeValue(forKey: paneID)?.cancel()
+    }
+
+    private func applyEntry(_ entry: Entry) {
+        let existingStatus = panes[entry.paneID]?.status
+        panes[entry.paneID] = entry
+        updateCompletion(paneID: entry.paneID, from: existingStatus, to: entry.status)
+        recompute(worktreeID: entry.worktreeID)
     }
 
     private func updateCompletion(paneID: UUID, from previous: AgentStatus?, to current: AgentStatus) {

--- a/Muxy/Services/Socket/NotificationSocketServer.swift
+++ b/Muxy/Services/Socket/NotificationSocketServer.swift
@@ -866,6 +866,7 @@ final class NotificationSocketServer: @unchecked Sendable {
             paneID: message.paneID,
             providerID: providerID,
             status: message.status,
+            sequence: AgentStatusStore.shared.nextSequence(),
             appState: appState
         )
     }
@@ -880,6 +881,7 @@ final class NotificationSocketServer: @unchecked Sendable {
             paneID: message.paneID,
             providerID: providerID,
             status: message.phase.status,
+            sequence: AgentStatusStore.shared.nextSequence(),
             appState: appState
         )
         guard !message.title.isEmpty || !message.body.isEmpty else { return }

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -240,8 +240,10 @@ struct TerminalBridge: NSViewRepresentable {
             guard let paneID = state?.id else { return }
             DetectedAgentStore.shared.setAgent(providerID, for: paneID)
             if providerID == nil {
-                AgentStatusStore.shared.markIdleIfActive(paneID: paneID)
+                AgentStatusStore.shared.noteDetectionLost(paneID: paneID)
+                return
             }
+            AgentStatusStore.shared.noteDetectionActive(paneID: paneID)
         }
         view.updateResumeWorkingDirectory(state.currentWorkingDirectory ?? state.projectPath)
         configureSearchCallbacks(view)
@@ -292,8 +294,10 @@ struct TerminalBridge: NSViewRepresentable {
             guard let paneID = state?.id else { return }
             DetectedAgentStore.shared.setAgent(providerID, for: paneID)
             if providerID == nil {
-                AgentStatusStore.shared.markIdleIfActive(paneID: paneID)
+                AgentStatusStore.shared.noteDetectionLost(paneID: paneID)
+                return
             }
+            AgentStatusStore.shared.noteDetectionActive(paneID: paneID)
         }
         configureSearchCallbacks(nsView)
         configureFileOpenCallback(nsView)

--- a/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
+++ b/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
@@ -256,3 +256,213 @@ struct AgentStatusTests {
         #expect(AgentStatusStore.winningEntry(among: [older, newer]) == newer)
     }
 }
+
+@MainActor
+private final class ManualGraceScheduler: AgentGraceScheduler {
+    private(set) var items: [ManualGraceCancellable] = []
+
+    func schedule(after _: TimeInterval, _ work: @escaping @MainActor () -> Void) -> AgentGraceCancellable {
+        let item = ManualGraceCancellable(work: work)
+        items.append(item)
+        return item
+    }
+
+    var pendingCount: Int {
+        items.filter { !$0.isCancelled }.count
+    }
+
+    func fireLast() {
+        items.last?.fire()
+    }
+}
+
+@MainActor
+private final class ManualGraceCancellable: AgentGraceCancellable {
+    private let work: () -> Void
+    private(set) var isCancelled = false
+
+    init(work: @escaping @MainActor () -> Void) {
+        self.work = work
+    }
+
+    func cancel() {
+        isCancelled = true
+    }
+
+    func fire() {
+        guard !isCancelled else { return }
+        work()
+    }
+}
+
+@Suite("AgentStatusStore", .serialized)
+@MainActor
+struct AgentStatusStoreTests {
+    private let projectID = UUID()
+    private let worktreeID = UUID()
+
+    private func makeContext() -> (AgentStatusStore, ManualGraceScheduler, UUID) {
+        let scheduler = ManualGraceScheduler()
+        let store = AgentStatusStore(scheduler: scheduler, graceDelay: 4)
+        let appState = AppState(
+            selectionStore: SelectionStoreStub(),
+            terminalViews: TerminalViewRemovingStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: "/tmp/project")
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        let paneID = area.tabs.last!.content.pane!.id
+
+        NotificationStore.shared.appState = appState
+        NotificationStore.shared.worktreeStore = WorktreeStore(
+            persistence: WorktreePersistenceStub(),
+            projects: []
+        )
+        return (store, scheduler, paneID)
+    }
+
+    private func send(
+        _ store: AgentStatusStore,
+        _ paneID: UUID,
+        _ status: AgentStatus,
+        sequence: UInt64
+    ) {
+        guard let appState = NotificationStore.shared.appState else { return }
+        store.update(paneID: paneID, providerID: "claude", status: status, sequence: sequence, appState: appState)
+    }
+
+    @Test("drops stale out-of-order events")
+    func dropsStaleEvents() {
+        let (store, _, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 5)
+        send(store, paneID, .idle, sequence: 3)
+        #expect(store.status(forPane: paneID) == .working)
+    }
+
+    @Test("applies newer events after older ones")
+    func appliesNewerEvents() {
+        let (store, _, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        send(store, paneID, .waiting, sequence: 2)
+        #expect(store.status(forPane: paneID) == .waiting)
+    }
+
+    @Test("duplicate events are idempotent and mark completion once")
+    func duplicateEventsIdempotent() {
+        let (store, _, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        send(store, paneID, .idle, sequence: 2)
+        #expect(store.isCompletionPending(forPane: paneID))
+        store.clearCompletion(for: paneID)
+        send(store, paneID, .idle, sequence: 2)
+        #expect(!store.isCompletionPending(forPane: paneID))
+    }
+
+    @Test("completion badge fires exactly once per finish")
+    func completionFiresOncePerFinish() {
+        let (store, _, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        send(store, paneID, .idle, sequence: 2)
+        #expect(store.isCompletionPending(forPane: paneID))
+        store.clearCompletion(for: paneID)
+        send(store, paneID, .idle, sequence: 3)
+        #expect(!store.isCompletionPending(forPane: paneID))
+        send(store, paneID, .working, sequence: 4)
+        send(store, paneID, .idle, sequence: 5)
+        #expect(store.isCompletionPending(forPane: paneID))
+    }
+
+    @Test("detection loss idles a working agent only after grace with no hook events")
+    func detectionLossIdlesAfterGrace() {
+        let (store, scheduler, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        store.noteDetectionLost(paneID: paneID)
+        #expect(store.status(forPane: paneID) == .working)
+        scheduler.fireLast()
+        #expect(store.status(forPane: paneID) == .idle)
+        #expect(store.isCompletionPending(forPane: paneID))
+    }
+
+    @Test("hook event cancels a pending grace transition")
+    func hookEventCancelsGrace() {
+        let (store, scheduler, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        store.noteDetectionLost(paneID: paneID)
+        send(store, paneID, .working, sequence: 2)
+        #expect(scheduler.pendingCount == 0)
+        scheduler.fireLast()
+        #expect(store.status(forPane: paneID) == .working)
+    }
+
+    @Test("re-detection cancels a pending grace transition")
+    func reDetectionCancelsGrace() {
+        let (store, scheduler, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        store.noteDetectionLost(paneID: paneID)
+        store.noteDetectionActive(paneID: paneID)
+        #expect(scheduler.pendingCount == 0)
+        scheduler.fireLast()
+        #expect(store.status(forPane: paneID) == .working)
+    }
+
+    @Test("a waiting agent is never idled by detection loss")
+    func waitingNeverIdledByDetectionLoss() {
+        let (store, scheduler, paneID) = makeContext()
+        send(store, paneID, .waiting, sequence: 1)
+        store.noteDetectionLost(paneID: paneID)
+        #expect(scheduler.pendingCount == 0)
+        #expect(store.status(forPane: paneID) == .waiting)
+    }
+
+    @Test("grace does not idle when a hook event arrives before it fires")
+    func graceSkippedWhenHookArrives() {
+        let (store, scheduler, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        store.noteDetectionLost(paneID: paneID)
+        send(store, paneID, .waiting, sequence: 2)
+        scheduler.fireLast()
+        #expect(store.status(forPane: paneID) == .waiting)
+    }
+
+    @Test("pane close drops all session state")
+    func paneCloseDropsSessions() {
+        let (store, _, paneID) = makeContext()
+        send(store, paneID, .working, sequence: 1)
+        store.removePane(paneID)
+        #expect(store.status(forPane: paneID) == nil)
+        #expect(!store.isCompletionPending(forPane: paneID))
+        send(store, paneID, .idle, sequence: 1)
+        #expect(store.status(forPane: paneID) == .idle)
+    }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class SelectionStoreStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}
+
+private final class WorktreePersistenceStub: WorktreePersisting {
+    func loadWorktrees(projectID _: UUID) throws -> [Worktree] { [] }
+    func saveWorktrees(_: [Worktree], projectID _: UUID) throws {}
+    func removeWorktrees(projectID _: UUID) throws {}
+}


### PR DESCRIPTION
Hook events now own agent status: per-pane arrival sequencing drops stale/duplicate events, and detection loss only idles a working pane after a 4s cancellable grace period instead of racing hook lifecycle events.
Removes markIdleIfActive (the premature-completion root cause); UI badges, aggregation, and the agentStatus extension event are unchanged.
Stacked on #917; no UI changes, so no screenshots; verified by scripts/checks.sh (2241 tests green).