### PR TITLE
Self-healing hook installs and Notification Health UI (Phase 3)

### DIFF
--- a/Muxy/Services/AI/AIProviderIntegration.swift
+++ b/Muxy/Services/AI/AIProviderIntegration.swift
@@ -3,6 +3,13 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "AIProviderRegistry")
 
+enum HookVerification: Equatable {
+    case satisfied
+    case needsRepair
+    case conflict(String)
+    case failed(String)
+}
+
 protocol AIProviderIntegration {
     var id: String { get }
     var displayName: String { get }
@@ -11,12 +18,14 @@ protocol AIProviderIntegration {
     var executableNames: [String] { get }
     var hookScriptName: String { get }
     var hookScriptExtension: String { get }
+    var configPaths: [String] { get }
 
     func isToolInstalled() -> Bool
     func isHookInstalled() -> Bool
     func hasManagedState() -> Bool
     func install(hookScriptPath: String) throws
     func uninstall() throws
+    func verify(hookScriptPath: String) -> HookVerification
 }
 
 extension AIProviderIntegration {
@@ -26,6 +35,12 @@ extension AIProviderIntegration {
 
     func hasManagedState() -> Bool {
         isHookInstalled()
+    }
+
+    var configPaths: [String] { [] }
+
+    func verify(hookScriptPath _: String) -> HookVerification {
+        isHookInstalled() ? .satisfied : .needsRepair
     }
 }
 
@@ -71,8 +86,10 @@ final class AIProviderRegistry {
     private let shouldInstallHooksInDebug: @Sendable () -> Bool
     private let hookScriptPath: @Sendable (String, String) -> String?
     private let stageHookResources: @Sendable () -> Bool
+    private let installer: HookInstaller
     private var loginShellPathHydration: Task<Void, Never>?
     private var hookResourcesStaged = false
+    private var configWatchers: [String: HookConfigWatcher] = [:]
 
     lazy var providers: [AIProviderIntegration] = injectedProviders ?? [
         claudeCodeProvider,
@@ -95,13 +112,15 @@ final class AIProviderRegistry {
         },
         stageHookResources: @escaping @Sendable () -> Bool = {
             MuxyNotificationHooks.stageAll()
-        }
+        },
+        installer: HookInstaller? = nil
     ) {
         injectedProviders = providers
         self.hydrateLoginShellPath = hydrateLoginShellPath
         self.shouldInstallHooksInDebug = shouldInstallHooksInDebug
         self.hookScriptPath = hookScriptPath
         self.stageHookResources = stageHookResources
+        self.installer = installer ?? HookInstaller(hookScriptPath: hookScriptPath)
     }
 
     func prepareForInstallation() {
@@ -122,67 +141,43 @@ final class AIProviderRegistry {
 
         stageHookResourcesIfNeeded()
 
-        for provider in providers {
-            guard provider.isEnabled else {
-                removeInstalledHook(for: provider)
-                continue
-            }
-
-            if provider.isHookInstalled() {
-                installHook(for: provider, action: "Refreshed")
-                continue
-            }
-
+        let hasDisabledManagedOnly = providers.allSatisfy { !$0.isEnabled }
+        if !hasDisabledManagedOnly {
             await loginShellPathHydrationTask().value
-
-            guard provider.isToolInstalled() else {
-                logger.info("\(provider.displayName) tool not installed, skipping hook install")
-                continue
-            }
-
-            installHook(for: provider, action: "Installed")
         }
-    }
 
-    private func removeInstalledHook(for provider: AIProviderIntegration) {
-        guard provider.hasManagedState() else { return }
-        logger.info("\(provider.displayName) is disabled, removing managed hook state")
-        do {
-            try provider.uninstall()
-        } catch {
-            logger.warning("Failed to uninstall \(provider.displayName): \(error.localizedDescription)")
-        }
-    }
-
-    private func installHook(for provider: AIProviderIntegration, action: String) {
-        guard let hookScript = hookScriptPath(provider.hookScriptName, provider.hookScriptExtension)
-        else {
-            logger.warning("Staged hook \(provider.hookScriptName) not found, skipping \(provider.displayName)")
-            return
-        }
-        do {
-            try provider.install(hookScriptPath: hookScript)
-            logger.info("\(action) \(provider.displayName) integration")
-        } catch {
-            logger.error("Failed to reconcile \(provider.displayName): \(error.localizedDescription)")
+        for provider in providers {
+            installer.reconcile(provider)
+            updateConfigWatcher(for: provider)
         }
     }
 
     func forceInstall(_ provider: AIProviderIntegration) async {
         guard stageHookResourcesNow() else { return }
-        guard let hookScript = hookScriptPath(provider.hookScriptName, provider.hookScriptExtension)
-        else {
-            logger.warning("Hook script \(provider.hookScriptName) not found, cannot force-install \(provider.displayName)")
+        await loginShellPathHydrationTask().value
+        installer.forceReinstall(provider)
+        updateConfigWatcher(for: provider)
+    }
+
+    func reconcile(_ provider: AIProviderIntegration) {
+        installer.reconcile(provider)
+        updateConfigWatcher(for: provider)
+    }
+
+    private func updateConfigWatcher(for provider: AIProviderIntegration) {
+        guard provider.isEnabled else {
+            configWatchers.removeValue(forKey: provider.id)
             return
         }
-
-        do {
-            try provider.uninstall()
-            try provider.install(hookScriptPath: hookScript)
-            logger.info("Force-installed \(provider.displayName) integration")
-        } catch {
-            logger.error("Failed to force-install \(provider.displayName): \(error.localizedDescription)")
+        guard configWatchers[provider.id] == nil else { return }
+        let providerID = provider.id
+        let watcher = HookConfigWatcher(configPaths: provider.configPaths) { [weak self] in
+            Task { @MainActor in
+                guard let self, let provider = self.providers.first(where: { $0.id == providerID }) else { return }
+                self.installer.reconcile(provider)
+            }
         }
+        configWatchers[providerID] = watcher
     }
 
     private func loginShellPathHydrationTask() -> Task<Void, Never> {

--- a/Muxy/Services/AI/DebouncedTrigger.swift
+++ b/Muxy/Services/AI/DebouncedTrigger.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+protocol DebounceScheduler: Sendable {
+    func schedule(after interval: TimeInterval, _ work: @escaping @Sendable () -> Void) -> DebounceCancellable
+}
+
+protocol DebounceCancellable {
+    func cancel()
+}
+
+struct QueueDebounceScheduler: DebounceScheduler {
+    let queue: DispatchQueue
+
+    func schedule(after interval: TimeInterval, _ work: @escaping @Sendable () -> Void) -> DebounceCancellable {
+        let item = DispatchWorkItem(block: work)
+        queue.asyncAfter(deadline: .now() + interval, execute: item)
+        return WorkItemCancellable(item: item)
+    }
+
+    private struct WorkItemCancellable: DebounceCancellable {
+        let item: DispatchWorkItem
+        func cancel() {
+            item.cancel()
+        }
+    }
+}
+
+final class DebouncedTrigger: @unchecked Sendable {
+    private let lock = NSLock()
+    private let interval: TimeInterval
+    private let scheduler: DebounceScheduler
+    private let handler: @Sendable () -> Void
+    private var pending: DebounceCancellable?
+
+    init(
+        interval: TimeInterval,
+        scheduler: DebounceScheduler,
+        handler: @escaping @Sendable () -> Void
+    ) {
+        self.interval = interval
+        self.scheduler = scheduler
+        self.handler = handler
+    }
+
+    func signal() {
+        lock.lock()
+        pending?.cancel()
+        let handler = handler
+        pending = scheduler.schedule(after: interval) { [weak self] in
+            self?.clearPending()
+            handler()
+        }
+        lock.unlock()
+    }
+
+    private func clearPending() {
+        lock.lock()
+        pending = nil
+        lock.unlock()
+    }
+}

--- a/Muxy/Services/AI/HookConfigWatcher.swift
+++ b/Muxy/Services/AI/HookConfigWatcher.swift
@@ -1,0 +1,70 @@
+import CoreServices
+import Foundation
+
+final class HookConfigWatcher: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "app.muxy.hook-config-watcher", qos: .utility)
+    private var stream: FSEventStreamRef?
+    private let watchedPaths: Set<String>
+    private let trigger: DebouncedTrigger
+
+    init?(
+        configPaths: [String],
+        debounceInterval: TimeInterval = 0.4,
+        handler: @escaping @Sendable () -> Void
+    ) {
+        let directories = Set(configPaths.map { ($0 as NSString).deletingLastPathComponent }).filter { !$0.isEmpty }
+        guard !directories.isEmpty else { return nil }
+
+        watchedPaths = Set(configPaths)
+        trigger = DebouncedTrigger(
+            interval: debounceInterval,
+            scheduler: QueueDebounceScheduler(queue: queue),
+            handler: handler
+        )
+
+        var context = FSEventStreamContext()
+        context.info = Unmanaged.passUnretained(self).toOpaque()
+
+        let paths = Array(directories) as CFArray
+        guard let stream = FSEventStreamCreate(
+            nil,
+            { _, clientInfo, numEvents, eventPaths, _, _ in
+                guard let clientInfo, numEvents > 0 else { return }
+                let watcher = Unmanaged<HookConfigWatcher>.fromOpaque(clientInfo).takeUnretainedValue()
+                guard let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String]
+                else { return }
+                watcher.handleEvents(paths: paths)
+            },
+            &context,
+            paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.3,
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes)
+        )
+        else { return nil }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+    }
+
+    deinit {
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+    }
+
+    static func isRelevantChange(path: String, watchedPaths: Set<String>) -> Bool {
+        guard !path.hasSuffix(".muxy-backup") else { return false }
+        return watchedPaths.contains { watched in
+            path == watched || path.hasPrefix(watched)
+        }
+    }
+
+    private func handleEvents(paths: [String]) {
+        let relevant = paths.contains { Self.isRelevantChange(path: $0, watchedPaths: watchedPaths) }
+        guard relevant else { return }
+        trigger.signal()
+    }
+}

--- a/Muxy/Services/AI/HookHealthStore.swift
+++ b/Muxy/Services/AI/HookHealthStore.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+enum HookInstallState: Equatable {
+    case installed
+    case notInstalled
+    case cliMissing
+    case conflict(String)
+    case error(String)
+}
+
+struct HookHealth: Equatable {
+    var installState: HookInstallState = .notInstalled
+    var lastVerifiedAt: Date?
+    var lastRepairedAt: Date?
+    var lastEventAt: Date?
+    var lastError: String?
+}
+
+@MainActor
+@Observable
+final class HookHealthStore {
+    static let shared = HookHealthStore()
+
+    private(set) var health: [String: HookHealth] = [:]
+
+    private let now: () -> Date
+
+    init(now: @escaping () -> Date = { Date() }) {
+        self.now = now
+    }
+
+    func health(for providerID: String) -> HookHealth {
+        health[providerID] ?? HookHealth()
+    }
+
+    func noteVerified(providerID: String, state: HookInstallState) {
+        var entry = health[providerID] ?? HookHealth()
+        entry.installState = state
+        entry.lastVerifiedAt = now()
+        entry.lastError = Self.errorMessage(for: state)
+        health[providerID] = entry
+    }
+
+    func noteRepaired(providerID: String, state: HookInstallState) {
+        var entry = health[providerID] ?? HookHealth()
+        entry.installState = state
+        entry.lastVerifiedAt = now()
+        entry.lastRepairedAt = now()
+        entry.lastError = Self.errorMessage(for: state)
+        health[providerID] = entry
+    }
+
+    func noteEvent(providerID: String) {
+        var entry = health[providerID] ?? HookHealth()
+        entry.lastEventAt = now()
+        health[providerID] = entry
+    }
+
+    func reset(providerID: String) {
+        health[providerID] = HookHealth()
+    }
+
+    private static func errorMessage(for state: HookInstallState) -> String? {
+        switch state {
+        case let .conflict(message): message
+        case let .error(message): message
+        case .installed,
+             .notInstalled,
+             .cliMissing: nil
+        }
+    }
+}

--- a/Muxy/Services/AI/HookInstaller.swift
+++ b/Muxy/Services/AI/HookInstaller.swift
@@ -1,0 +1,159 @@
+import Foundation
+import os
+
+private let installerLogger = Logger(subsystem: "app.muxy", category: "HookInstaller")
+
+@MainActor
+final class HookInstaller {
+    enum Outcome: Equatable {
+        case healthy
+        case repaired
+        case cliMissing
+        case conflict(String)
+        case failed(String)
+        case skippedDisabled
+    }
+
+    private let hookScriptPath: @Sendable (String, String) -> String?
+    private let stagedFileExists: @Sendable (String) -> Bool
+    private let stagedFileExecutable: @Sendable (String) -> Bool
+    private let health: HookHealthStore
+
+    init(
+        hookScriptPath: @escaping @Sendable (String, String) -> String? = {
+            MuxyNotificationHooks.scriptPath(named: $0, extension: $1)
+        },
+        stagedFileExists: @escaping @Sendable (String) -> Bool = {
+            FileManager.default.fileExists(atPath: $0)
+        },
+        stagedFileExecutable: @escaping @Sendable (String) -> Bool = {
+            FileManager.default.isExecutableFile(atPath: $0)
+        },
+        health: HookHealthStore = .shared
+    ) {
+        self.hookScriptPath = hookScriptPath
+        self.stagedFileExists = stagedFileExists
+        self.stagedFileExecutable = stagedFileExecutable
+        self.health = health
+    }
+
+    @discardableResult
+    func reconcile(_ provider: AIProviderIntegration) -> Outcome {
+        guard provider.isEnabled else {
+            removeManagedState(provider)
+            return .skippedDisabled
+        }
+
+        guard let scriptPath = stagedScriptPath(for: provider) else {
+            let message = "Staged hook \(provider.hookScriptName) not found"
+            health.noteVerified(providerID: provider.id, state: .error(message))
+            return .failed(message)
+        }
+
+        guard stagedResourcesReady(for: provider, scriptPath: scriptPath) else {
+            let message = "Staged hook resource is missing or not executable"
+            health.noteVerified(providerID: provider.id, state: .error(message))
+            return .failed(message)
+        }
+
+        return apply(provider, scriptPath: scriptPath)
+    }
+
+    @discardableResult
+    func forceReinstall(_ provider: AIProviderIntegration) -> Outcome {
+        guard let scriptPath = stagedScriptPath(for: provider) else {
+            let message = "Staged hook \(provider.hookScriptName) not found"
+            health.noteVerified(providerID: provider.id, state: .error(message))
+            return .failed(message)
+        }
+        do {
+            try provider.uninstall()
+            try provider.install(hookScriptPath: scriptPath)
+        } catch let error as CodexProviderError {
+            let message = error.localizedDescription
+            health.noteRepaired(providerID: provider.id, state: .conflict(message))
+            return .conflict(message)
+        } catch {
+            let message = error.localizedDescription
+            health.noteRepaired(providerID: provider.id, state: .error(message))
+            return .failed(message)
+        }
+        return finishVerification(provider, scriptPath: scriptPath, repaired: true)
+    }
+
+    private func apply(_ provider: AIProviderIntegration, scriptPath: String) -> Outcome {
+        switch provider.verify(hookScriptPath: scriptPath) {
+        case .satisfied:
+            health.noteVerified(providerID: provider.id, state: .installed)
+            return .healthy
+        case let .conflict(message):
+            health.noteVerified(providerID: provider.id, state: .conflict(message))
+            return .conflict(message)
+        case let .failed(message):
+            health.noteVerified(providerID: provider.id, state: .error(message))
+            return .failed(message)
+        case .needsRepair:
+            return repair(provider, scriptPath: scriptPath)
+        }
+    }
+
+    private func repair(_ provider: AIProviderIntegration, scriptPath: String) -> Outcome {
+        if !provider.hasManagedState(), !provider.isToolInstalled() {
+            health.noteVerified(providerID: provider.id, state: .cliMissing)
+            return .cliMissing
+        }
+
+        do {
+            try provider.install(hookScriptPath: scriptPath)
+        } catch let error as CodexProviderError {
+            let message = error.localizedDescription
+            health.noteRepaired(providerID: provider.id, state: .conflict(message))
+            return .conflict(message)
+        } catch {
+            let message = error.localizedDescription
+            health.noteRepaired(providerID: provider.id, state: .error(message))
+            return .failed(message)
+        }
+        return finishVerification(provider, scriptPath: scriptPath, repaired: true)
+    }
+
+    private func finishVerification(
+        _ provider: AIProviderIntegration,
+        scriptPath: String,
+        repaired: Bool
+    ) -> Outcome {
+        switch provider.verify(hookScriptPath: scriptPath) {
+        case .satisfied:
+            health.noteRepaired(providerID: provider.id, state: .installed)
+            return repaired ? .repaired : .healthy
+        case let .conflict(message):
+            health.noteRepaired(providerID: provider.id, state: .conflict(message))
+            return .conflict(message)
+        case .needsRepair,
+             .failed:
+            let message = "Hook could not be verified after repair"
+            health.noteRepaired(providerID: provider.id, state: .error(message))
+            return .failed(message)
+        }
+    }
+
+    private func removeManagedState(_ provider: AIProviderIntegration) {
+        defer { health.reset(providerID: provider.id) }
+        guard provider.hasManagedState() else { return }
+        do {
+            try provider.uninstall()
+        } catch {
+            installerLogger.warning("Failed to uninstall \(provider.displayName): \(error.localizedDescription)")
+        }
+    }
+
+    private func stagedScriptPath(for provider: AIProviderIntegration) -> String? {
+        hookScriptPath(provider.hookScriptName, provider.hookScriptExtension)
+    }
+
+    private func stagedResourcesReady(for provider: AIProviderIntegration, scriptPath: String) -> Bool {
+        guard stagedFileExists(scriptPath) else { return false }
+        guard provider.hookScriptExtension == "sh" else { return true }
+        return stagedFileExecutable(scriptPath)
+    }
+}

--- a/Muxy/Services/AI/HookTestRunner.swift
+++ b/Muxy/Services/AI/HookTestRunner.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+enum HookTestResult: Equatable {
+    case passed
+    case failed(String)
+}
+
+struct HookTestRunner {
+    struct ProcessOutcome: Equatable {
+        let terminationStatus: Int32
+        let standardError: String
+    }
+
+    typealias Runner = @Sendable (
+        _ binaryPath: String,
+        _ arguments: [String],
+        _ environment: [String: String],
+        _ timeout: TimeInterval
+    ) throws -> ProcessOutcome
+
+    static let defaultTimeout: TimeInterval = 5
+
+    private let binaryPath: String
+    private let socketPath: String
+    private let fileExists: @Sendable (String) -> Bool
+    private let timeout: TimeInterval
+    private let runner: Runner
+
+    init(
+        binaryPath: String = MuxyNotificationHooks.hookBinaryPath,
+        socketPath: String = NotificationSocketServer.socketPath,
+        fileExists: @escaping @Sendable (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        timeout: TimeInterval = HookTestRunner.defaultTimeout,
+        runner: @escaping Runner = HookTestRunner.runProcess
+    ) {
+        self.binaryPath = binaryPath
+        self.socketPath = socketPath
+        self.fileExists = fileExists
+        self.timeout = timeout
+        self.runner = runner
+    }
+
+    static func arguments(providerSocketType: String, providerTitle: String) -> [String] {
+        [
+            "agent-event",
+            "--provider", providerSocketType,
+            "--provider-title", providerTitle,
+            "--event", "test",
+            "--test",
+        ]
+    }
+
+    func run(providerSocketType: String, providerTitle: String) -> HookTestResult {
+        guard fileExists(binaryPath) else {
+            return .failed("Hook binary is not staged")
+        }
+        let environment = ["MUXY_SOCKET_PATH": socketPath]
+        do {
+            let outcome = try runner(
+                binaryPath,
+                Self.arguments(providerSocketType: providerSocketType, providerTitle: providerTitle),
+                environment,
+                timeout
+            )
+            return Self.interpret(outcome)
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    static func interpret(_ outcome: ProcessOutcome) -> HookTestResult {
+        guard outcome.terminationStatus == 0 else {
+            let detail = outcome.standardError.trimmingCharacters(in: .whitespacesAndNewlines)
+            return .failed(detail.isEmpty ? "Hook exited with status \(outcome.terminationStatus)" : detail)
+        }
+        return .passed
+    }
+
+    static func runProcess(
+        binaryPath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) throws -> ProcessOutcome {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+        process.arguments = arguments
+        process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        let inputPipe = Pipe()
+        process.standardInput = inputPipe
+
+        try process.run()
+        try? inputPipe.fileHandleForWriting.close()
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            usleep(20000)
+        }
+        if process.isRunning {
+            process.terminate()
+            return ProcessOutcome(terminationStatus: -1, standardError: "Hook timed out")
+        }
+
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        let standardError = String(data: errorData, encoding: .utf8) ?? ""
+        return ProcessOutcome(terminationStatus: process.terminationStatus, standardError: standardError)
+    }
+}

--- a/Muxy/Services/Providers/ClaudeCodeProvider.swift
+++ b/Muxy/Services/Providers/ClaudeCodeProvider.swift
@@ -67,6 +67,50 @@ struct ClaudeCodeProvider: AIProviderIntegration, AIAgentLaunchProvider {
         Self.fileContainsMuxyMarker(at: Self.settingsPath)
     }
 
+    var configPaths: [String] { [Self.settingsPath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        let expected = Self.hookEvents.map {
+            Self.hookCommand(hookScript: hookScriptPath, event: $0.event)
+        }
+        return Self.verifyNestedHooks(
+            at: Self.settingsPath,
+            keys: Self.hookEvents.map(\.settingsKey),
+            expectedCommands: expected
+        )
+    }
+
+    static func verifyNestedHooks(
+        at path: String,
+        keys: [String],
+        expectedCommands: [String]
+    ) -> HookVerification {
+        guard fileContainsMuxyMarker(at: path) else { return .needsRepair }
+        guard let settings = try? readJSON(at: path),
+              let hooks = settings["hooks"] as? [String: Any]
+        else { return .needsRepair }
+
+        for (key, expected) in zip(keys, expectedCommands) {
+            let commands = commandStrings(inNested: hooks[key] as? [[String: Any]])
+            guard commands.contains(expected) else { return .needsRepair }
+        }
+        return .satisfied
+    }
+
+    static func readJSON(at path: String) throws -> [String: Any] {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        guard !data.isEmpty, let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [:] }
+        return json
+    }
+
+    static func commandStrings(inNested entries: [[String: Any]]?) -> [String] {
+        guard let entries else { return [] }
+        return entries.flatMap { entry -> [String] in
+            guard let hooks = entry["hooks"] as? [[String: Any]] else { return [] }
+            return hooks.compactMap { $0["command"] as? String }
+        }
+    }
+
     static func fileContainsMuxyMarker(at path: String) -> Bool {
         guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return false }
         return contents.contains(muxyMarker)

--- a/Muxy/Services/Providers/CodexProvider.swift
+++ b/Muxy/Services/Providers/CodexProvider.swift
@@ -72,6 +72,25 @@ struct CodexProvider: AIProviderIntegration, AIAgentLaunchProvider {
         ClaudeCodeProvider.fileContainsMuxyMarker(at: hooksPath)
     }
 
+    var configPaths: [String] { [hooksPath, configPath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        if (try? hasExecutableInlineHooks()) == true {
+            return .conflict(CodexProviderError.inlineHooksConfigured(configPath).localizedDescription)
+        }
+        guard ClaudeCodeProvider.fileContainsMuxyMarker(at: hooksPath) else { return .needsRepair }
+        guard let settings = try? ClaudeCodeProvider.readJSON(at: hooksPath),
+              let hooks = settings["hooks"] as? [String: Any]
+        else { return .needsRepair }
+
+        for event in Self.installedEvents {
+            let expected = Self.hookCommand(hookScript: hookScriptPath, event: event.event)
+            let commands = ClaudeCodeProvider.commandStrings(inNested: hooks[event.settingsKey] as? [[String: Any]])
+            guard commands.contains(expected) else { return .needsRepair }
+        }
+        return .satisfied
+    }
+
     func install(hookScriptPath: String) throws {
         if try hasExecutableInlineHooks() {
             if isHookInstalled() {

--- a/Muxy/Services/Providers/CursorProvider.swift
+++ b/Muxy/Services/Providers/CursorProvider.swift
@@ -51,6 +51,22 @@ struct CursorProvider: AIProviderIntegration, AIAgentLaunchProvider {
         ClaudeCodeProvider.fileContainsMuxyMarker(at: hooksPath)
     }
 
+    var configPaths: [String] { [hooksPath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        guard ClaudeCodeProvider.fileContainsMuxyMarker(at: hooksPath) else { return .needsRepair }
+        guard let settings = try? ClaudeCodeProvider.readJSON(at: hooksPath),
+              let hooks = settings["hooks"] as? [String: Any]
+        else { return .needsRepair }
+
+        for binding in Self.bindings {
+            let expected = Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
+            let commands = (hooks[binding.event] as? [[String: Any]])?.compactMap { $0["command"] as? String } ?? []
+            guard commands.contains(expected) else { return .needsRepair }
+        }
+        return .satisfied
+    }
+
     func install(hookScriptPath: String) throws {
         var settings = try Self.readSettings(at: hooksPath)
         settings["version"] = settings["version"] ?? 1

--- a/Muxy/Services/Providers/DroidProvider.swift
+++ b/Muxy/Services/Providers/DroidProvider.swift
@@ -44,6 +44,18 @@ struct DroidProvider: AIProviderIntegration, AIAgentLaunchProvider {
         ClaudeCodeProvider.fileContainsMuxyMarker(at: Self.settingsPath)
     }
 
+    var configPaths: [String] { [Self.settingsPath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        ClaudeCodeProvider.verifyNestedHooks(
+            at: Self.settingsPath,
+            keys: Self.hookEvents.map(\.settingsKey),
+            expectedCommands: Self.hookEvents.map {
+                Self.hookCommand(hookScript: hookScriptPath, event: $0.event)
+            }
+        )
+    }
+
     func install(hookScriptPath: String) throws {
         let settings = try Self.readSettings()
         let hooks = settings["hooks"] as? [String: Any] ?? [:]

--- a/Muxy/Services/Providers/GrokProvider.swift
+++ b/Muxy/Services/Providers/GrokProvider.swift
@@ -74,6 +74,18 @@ struct GrokProvider: AIProviderIntegration, AIAgentLaunchProvider {
         ClaudeCodeProvider.fileContainsMuxyMarker(at: hookFilePath)
     }
 
+    var configPaths: [String] { [hookFilePath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        ClaudeCodeProvider.verifyNestedHooks(
+            at: hookFilePath,
+            keys: Self.hookEvents.map(\.settingsKey),
+            expectedCommands: Self.hookEvents.map {
+                Self.hookCommand(hookScript: hookScriptPath, event: $0.event)
+            }
+        )
+    }
+
     func install(hookScriptPath: String) throws {
         let existing = try Self.readHooksFile(at: hookFilePath)
         let hooks = existing["hooks"] as? [String: Any] ?? [:]

--- a/Muxy/Services/Providers/OpenCodeProvider.swift
+++ b/Muxy/Services/Providers/OpenCodeProvider.swift
@@ -54,6 +54,16 @@ struct OpenCodeProvider: AIProviderIntegration, AIAgentLaunchProvider {
         FileManager.default.fileExists(atPath: pluginPath)
     }
 
+    var configPaths: [String] { [pluginPath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        guard FileManager.default.fileExists(atPath: pluginPath) else { return .needsRepair }
+        guard FileManager.default.contentsEqual(atPath: hookScriptPath, andPath: pluginPath) else {
+            return .needsRepair
+        }
+        return .satisfied
+    }
+
     func install(hookScriptPath: String) throws {
         let sourceData = try Data(contentsOf: URL(fileURLWithPath: hookScriptPath))
 

--- a/Muxy/Services/Providers/PiProvider.swift
+++ b/Muxy/Services/Providers/PiProvider.swift
@@ -63,6 +63,17 @@ struct PiProvider: AIProviderIntegration, AIAgentLaunchProvider {
         isHookInstalled() || isRegisteredInSettings()
     }
 
+    var configPaths: [String] { [destinationPath, settingsPath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        guard FileManager.default.fileExists(atPath: destinationPath) else { return .needsRepair }
+        guard FileManager.default.contentsEqual(atPath: hookScriptPath, andPath: destinationPath) else {
+            return .needsRepair
+        }
+        guard !isRegisteredInSettings() else { return .needsRepair }
+        return .satisfied
+    }
+
     func install(hookScriptPath: String) throws {
         let sourceURL = URL(fileURLWithPath: hookScriptPath)
         guard FileManager.default.fileExists(atPath: sourceURL.path) else { throw PiProviderError.hookResourceNotFound }

--- a/Muxy/Services/Socket/NotificationSocketServer.swift
+++ b/Muxy/Services/Socket/NotificationSocketServer.swift
@@ -877,6 +877,7 @@ final class NotificationSocketServer: @unchecked Sendable {
         guard case let .aiProvider(providerID) = AIProviderRegistry.shared.notificationSource(for: message.socketType) else {
             return
         }
+        HookHealthStore.shared.noteEvent(providerID: providerID)
         AgentStatusStore.shared.update(
             paneID: message.paneID,
             providerID: providerID,
@@ -895,6 +896,10 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     @MainActor
     private func dispatchAgentHookEvent(_ message: AgentHookEventMessage) {
+        if message.test {
+            dispatchAgentHookTest(message)
+            return
+        }
         let paneID: UUID
         if let paneIDString = message.paneID, let explicitPaneID = UUID(uuidString: paneIDString) {
             paneID = explicitPaneID
@@ -914,6 +919,22 @@ final class NotificationSocketServer: @unchecked Sendable {
             title: message.title,
             body: message.body
         ))
+    }
+
+    @MainActor
+    private func dispatchAgentHookTest(_ message: AgentHookEventMessage) {
+        guard case let .aiProvider(providerID) = AIProviderRegistry.shared.notificationSource(for: message.provider)
+        else { return }
+        HookHealthStore.shared.noteEvent(providerID: providerID)
+
+        let title = message.title.isEmpty ? "Notifications" : message.title
+        let paneIDString = message.paneID.flatMap { UUID(uuidString: $0) }?.uuidString
+        dispatchNotification(
+            type: message.provider,
+            title: title,
+            body: message.body,
+            paneIDString: paneIDString
+        )
     }
 
     @MainActor

--- a/Muxy/Views/Settings/HookHealthPresenter.swift
+++ b/Muxy/Views/Settings/HookHealthPresenter.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum HookHealthDot: Equatable {
+    case healthy
+    case warning
+    case error
+    case idle
+}
+
+enum HookHealthPresenter {
+    static func dot(for health: HookHealth) -> HookHealthDot {
+        switch health.installState {
+        case .installed: .healthy
+        case .cliMissing: .warning
+        case .conflict,
+             .error: .error
+        case .notInstalled: .idle
+        }
+    }
+
+    static func statusLine(for health: HookHealth, now: Date = Date()) -> String {
+        switch health.installState {
+        case .installed:
+            healthyLine(for: health, now: now)
+        case .cliMissing:
+            "CLI not installed"
+        case let .conflict(message):
+            message
+        case let .error(message):
+            message
+        case .notInstalled:
+            "Not installed"
+        }
+    }
+
+    private static func healthyLine(for health: HookHealth, now: Date) -> String {
+        if let repairedAt = health.lastRepairedAt, wasJustRepaired(repairedAt, verifiedAt: health.lastVerifiedAt) {
+            return "Config overwritten — repaired \(relative(from: repairedAt, now: now))"
+        }
+        guard let eventAt = health.lastEventAt else {
+            return "Hook healthy"
+        }
+        return "Hook healthy · last event \(relative(from: eventAt, now: now))"
+    }
+
+    private static func wasJustRepaired(_ repairedAt: Date, verifiedAt: Date?) -> Bool {
+        guard let verifiedAt else { return true }
+        return repairedAt >= verifiedAt.addingTimeInterval(-0.001)
+    }
+
+    static func relative(from date: Date, now: Date = Date()) -> String {
+        let interval = max(0, now.timeIntervalSince(date))
+        guard interval >= 60 else { return "just now" }
+        let minutes = Int(interval / 60)
+        guard minutes >= 60 else { return "\(minutes) min ago" }
+        let hours = minutes / 60
+        guard hours >= 24 else { return "\(hours) hr ago" }
+        return "\(hours / 24) d ago"
+    }
+}

--- a/Muxy/Views/Settings/NotificationSettingsView.swift
+++ b/Muxy/Views/Settings/NotificationSettingsView.swift
@@ -62,36 +62,40 @@ private struct ProviderToggleRow: View {
     let provider: AIProviderIntegration
     @State private var enabled: Bool
     @State private var refreshed = false
+    @State private var testResult: HookTestResult?
+    @State private var testing = false
+    private let healthStore = HookHealthStore.shared
 
     init(provider: AIProviderIntegration) {
         self.provider = provider
         _enabled = State(initialValue: provider.isEnabled)
     }
 
+    private var health: HookHealth {
+        healthStore.health(for: provider.id)
+    }
+
+    private var isCLIMissing: Bool {
+        health.installState == .cliMissing
+    }
+
     var body: some View {
-        HStack {
-            Text(provider.displayName)
-                .font(.system(size: SettingsMetrics.labelFontSize))
+        HStack(alignment: .top, spacing: 8) {
+            statusDot
+                .padding(.top, 4)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(provider.displayName)
+                    .font(.system(size: SettingsMetrics.labelFontSize))
+                if enabled {
+                    Text(secondaryLine)
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                }
+            }
             Spacer()
             if enabled {
-                Button {
-                    Task { @MainActor in
-                        await AIProviderRegistry.shared.forceInstall(provider)
-                        withAnimation { refreshed = true }
-                        try? await Task.sleep(for: .seconds(2))
-                        withAnimation { refreshed = false }
-                    }
-                } label: {
-                    if refreshed {
-                        Label("Done", systemImage: "checkmark")
-                    } else {
-                        Text("Refresh")
-                    }
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: SettingsMetrics.footnoteFontSize))
-                .foregroundStyle(refreshed ? MuxyTheme.diffAddFg : SettingsStyle.accent)
-                .disabled(refreshed)
+                testButton
+                refreshButton
             }
             Toggle("", isOn: $enabled)
                 .labelsHidden()
@@ -99,6 +103,7 @@ private struct ProviderToggleRow: View {
                 .controlSize(.small)
                 .onChange(of: enabled) { _, newValue in
                     provider.isEnabled = newValue
+                    testResult = nil
                     Task { @MainActor in
                         await AIProviderRegistry.shared.installAll()
                     }
@@ -106,5 +111,83 @@ private struct ProviderToggleRow: View {
         }
         .padding(.horizontal, SettingsMetrics.horizontalPadding)
         .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+    }
+
+    private var statusDot: some View {
+        Circle()
+            .fill(dotColor)
+            .frame(width: 7, height: 7)
+    }
+
+    private var dotColor: Color {
+        switch HookHealthPresenter.dot(for: health) {
+        case .healthy: MuxyTheme.diffAddFg
+        case .warning: SettingsStyle.warning
+        case .error: MuxyTheme.diffRemoveFg
+        case .idle: SettingsStyle.dimForeground
+        }
+    }
+
+    private var secondaryLine: String {
+        if let testResult {
+            switch testResult {
+            case .passed: return "Test passed"
+            case let .failed(reason): return "Test failed — \(reason)"
+            }
+        }
+        return HookHealthPresenter.statusLine(for: health)
+    }
+
+    private var testButton: some View {
+        Button {
+            runTest()
+        } label: {
+            if testing {
+                Text("Testing…")
+            } else {
+                Text("Test")
+            }
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: SettingsMetrics.footnoteFontSize))
+        .foregroundStyle(SettingsStyle.accent)
+        .disabled(testing || isCLIMissing)
+    }
+
+    private var refreshButton: some View {
+        Button {
+            Task { @MainActor in
+                await AIProviderRegistry.shared.forceInstall(provider)
+                withAnimation { refreshed = true }
+                try? await Task.sleep(for: .seconds(2))
+                withAnimation { refreshed = false }
+            }
+        } label: {
+            if refreshed {
+                Label("Done", systemImage: "checkmark")
+            } else {
+                Text("Refresh")
+            }
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: SettingsMetrics.footnoteFontSize))
+        .foregroundStyle(refreshed ? MuxyTheme.diffAddFg : SettingsStyle.accent)
+        .disabled(refreshed)
+    }
+
+    private func runTest() {
+        testing = true
+        testResult = nil
+        let socketType = provider.socketTypeKey
+        let title = provider.displayName
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                HookTestRunner().run(providerSocketType: socketType, providerTitle: title)
+            }.value
+            await MainActor.run {
+                testResult = result
+                testing = false
+            }
+        }
     }
 }

--- a/MuxyHookBridge/AgentHookCommand.swift
+++ b/MuxyHookBridge/AgentHookCommand.swift
@@ -2,6 +2,14 @@ struct AgentHookCommand: Equatable {
     let provider: String
     let providerTitle: String
     let event: String
+    let test: Bool
+
+    init(provider: String, providerTitle: String, event: String, test: Bool = false) {
+        self.provider = provider
+        self.providerTitle = providerTitle
+        self.event = event
+        self.test = test
+    }
 
     static func parse(_ arguments: [String]) -> AgentHookCommand? {
         guard arguments.first == "agent-event" else { return nil }
@@ -9,9 +17,15 @@ struct AgentHookCommand: Equatable {
         var provider: String?
         var providerTitle: String?
         var event: String?
+        var test = false
         var index = 1
 
         while index < arguments.count {
+            if arguments[index] == "--test" {
+                test = true
+                index += 1
+                continue
+            }
             guard index + 1 < arguments.count else { return nil }
             let value = arguments[index + 1]
             switch arguments[index] {
@@ -32,6 +46,6 @@ struct AgentHookCommand: Equatable {
               let event, !event.isEmpty
         else { return nil }
 
-        return AgentHookCommand(provider: provider, providerTitle: providerTitle, event: event)
+        return AgentHookCommand(provider: provider, providerTitle: providerTitle, event: event, test: test)
     }
 }

--- a/MuxyHookBridge/AgentHookRuntime.swift
+++ b/MuxyHookBridge/AgentHookRuntime.swift
@@ -22,37 +22,67 @@ struct AgentHookRuntime {
         self.timestamp = timestamp
     }
 
-    func run(command: AgentHookCommand, input: Data) {
+    enum RunResult: Equatable {
+        case success
+        case failure(String)
+    }
+
+    @discardableResult
+    func run(command: AgentHookCommand, input: Data) -> RunResult {
+        guard let message = message(for: command, input: input) else { return .success }
+        guard let socketPath = resolvedSocketPath else {
+            return command.test ? .failure("No socket path configured") : .success
+        }
+
+        do {
+            try socketClient.send(message, to: socketPath)
+            return .success
+        } catch {
+            failureLogger.append(
+                provider: command.provider,
+                event: command.event,
+                error: error,
+                timestamp: message.ts
+            )
+            return command.test ? .failure(String(describing: error)) : .success
+        }
+    }
+
+    private func message(for command: AgentHookCommand, input: Data) -> AgentHookEventMessage? {
+        if command.test {
+            return testMessage(for: command)
+        }
         guard let mapped = AgentHookEventMapper.map(
             event: command.event,
             providerTitle: command.providerTitle,
             input: input
         )
-        else { return }
-        guard let socketPath = resolvedSocketPath else { return }
+        else { return nil }
 
-        let currentTimestamp = timestamp()
         let paneID = resolvedPaneID
-        let message = AgentHookEventMessage(
+        return AgentHookEventMessage(
             provider: command.provider,
             paneID: paneID,
             phase: mapped.phase,
             title: mapped.title,
             body: mapped.body,
             pids: paneID == nil ? ancestorPIDs() : [],
-            ts: currentTimestamp
+            ts: timestamp()
         )
+    }
 
-        do {
-            try socketClient.send(message, to: socketPath)
-        } catch {
-            failureLogger.append(
-                provider: command.provider,
-                event: command.event,
-                error: error,
-                timestamp: currentTimestamp
-            )
-        }
+    private func testMessage(for command: AgentHookCommand) -> AgentHookEventMessage {
+        let title = command.providerTitle.isEmpty ? "Notifications" : "\(command.providerTitle) test"
+        return AgentHookEventMessage(
+            provider: command.provider,
+            paneID: resolvedPaneID,
+            phase: .finished,
+            title: title,
+            body: "Hook pipeline is working",
+            pids: [],
+            ts: timestamp(),
+            test: true
+        )
     }
 
     private var resolvedPaneID: String? {

--- a/MuxyHookBridge/main.swift
+++ b/MuxyHookBridge/main.swift
@@ -6,5 +6,12 @@ guard let command = AgentHookCommand.parse(Array(CommandLine.arguments.dropFirst
 }
 
 let input = FileHandle.standardInput.readDataToEndOfFile()
-AgentHookRuntime().run(command: command, input: input)
-exit(EXIT_SUCCESS)
+let result = AgentHookRuntime().run(command: command, input: input)
+
+switch result {
+case .success:
+    exit(EXIT_SUCCESS)
+case let .failure(message):
+    FileHandle.standardError.write(Data(message.utf8))
+    exit(EXIT_FAILURE)
+}

--- a/MuxyShared/AgentHookProtocol.swift
+++ b/MuxyShared/AgentHookProtocol.swift
@@ -22,6 +22,7 @@ public struct AgentHookEventMessage: Codable, Equatable, Sendable {
     public let body: String
     public let pids: [Int32]
     public let ts: Int64
+    public let test: Bool
 
     public init(
         v: Int = AgentHookProtocol.version,
@@ -32,7 +33,8 @@ public struct AgentHookEventMessage: Codable, Equatable, Sendable {
         title: String,
         body: String,
         pids: [Int32],
-        ts: Int64
+        ts: Int64,
+        test: Bool = false
     ) {
         self.v = v
         self.kind = kind
@@ -43,6 +45,50 @@ public struct AgentHookEventMessage: Codable, Equatable, Sendable {
         self.body = body
         self.pids = pids
         self.ts = ts
+        self.test = test
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case v
+        case kind
+        case provider
+        case paneID
+        case phase
+        case title
+        case body
+        case pids
+        case ts
+        case test
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        v = try container.decode(Int.self, forKey: .v)
+        kind = try container.decode(String.self, forKey: .kind)
+        provider = try container.decode(String.self, forKey: .provider)
+        paneID = try container.decodeIfPresent(String.self, forKey: .paneID)
+        phase = try container.decode(AgentHookPhase.self, forKey: .phase)
+        title = try container.decode(String.self, forKey: .title)
+        body = try container.decode(String.self, forKey: .body)
+        pids = try container.decode([Int32].self, forKey: .pids)
+        ts = try container.decode(Int64.self, forKey: .ts)
+        test = try container.decodeIfPresent(Bool.self, forKey: .test) ?? false
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(v, forKey: .v)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(provider, forKey: .provider)
+        try container.encodeIfPresent(paneID, forKey: .paneID)
+        try container.encode(phase, forKey: .phase)
+        try container.encode(title, forKey: .title)
+        try container.encode(body, forKey: .body)
+        try container.encode(pids, forKey: .pids)
+        try container.encode(ts, forKey: .ts)
+        if test {
+            try container.encode(test, forKey: .test)
+        }
     }
 }
 

--- a/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
@@ -6,6 +6,15 @@ import Testing
 @Suite("AIProviderRegistry")
 @MainActor
 struct AIProviderRegistryTests {
+    private static func stubInstaller() -> HookInstaller {
+        HookInstaller(
+            hookScriptPath: { _, _ in "/tmp/muxy-test-hook" },
+            stagedFileExists: { _ in true },
+            stagedFileExecutable: { _ in true },
+            health: HookHealthStore()
+        )
+    }
+
     @Test("notificationSource resolves built-in socket type keys")
     func notificationSourceResolvesBuiltIn() {
         let source = AIProviderRegistry.shared.notificationSource(for: "claude_hook")
@@ -73,7 +82,8 @@ struct AIProviderRegistryTests {
             providers: [provider],
             hydrateLoginShellPath: { await gate.wait() },
             shouldInstallHooksInDebug: { true },
-            stageHookResources: { true }
+            stageHookResources: { true },
+            installer: Self.stubInstaller()
         )
 
         let installTask = Task {
@@ -184,7 +194,8 @@ struct AIProviderRegistryTests {
         let provider = RefreshRecordingProvider()
         defer { provider.resetSettings() }
         provider.isEnabled = true
-        provider.hookInstalled = true
+        provider.hookInstalled = false
+        provider.toolInstalled = true
         let staging = StagingRecorder()
         let registry = AIProviderRegistry(
             providers: [provider],
@@ -194,7 +205,8 @@ struct AIProviderRegistryTests {
             stageHookResources: {
                 staging.record()
                 return true
-            }
+            },
+            installer: Self.stubInstaller()
         )
 
         registry.prepareForInstallation()
@@ -217,7 +229,8 @@ struct AIProviderRegistryTests {
             stageHookResources: {
                 staging.record()
                 return true
-            }
+            },
+            installer: Self.stubInstaller()
         )
 
         registry.prepareForInstallation()
@@ -239,7 +252,8 @@ struct AIProviderRegistryTests {
             hydrateLoginShellPath: {},
             shouldInstallHooksInDebug: { true },
             hookScriptPath: { _, _ in "/tmp/muxy-test-hook" },
-            stageHookResources: { true }
+            stageHookResources: { true },
+            installer: Self.stubInstaller()
         )
 
         await registry.installAll()
@@ -286,9 +300,16 @@ private final class RefreshRecordingProvider: AIProviderIntegration {
 
     func install(hookScriptPath _: String) throws {
         installAttempted = true
+        hookInstalled = true
     }
 
-    func uninstall() throws {}
+    func verify(hookScriptPath _: String) -> HookVerification {
+        hookInstalled ? .satisfied : .needsRepair
+    }
+
+    func uninstall() throws {
+        hookInstalled = false
+    }
 
     func resetSettings() {
         UserDefaults.standard.removeObject(forKey: settingsKey)
@@ -325,12 +346,18 @@ private final class RecordingProvider: AIProviderIntegration {
         managedStateInstalled || hookInstalled
     }
 
+    func verify(hookScriptPath _: String) -> HookVerification {
+        hookInstalled ? .satisfied : .needsRepair
+    }
+
     func install(hookScriptPath _: String) throws {
         installCount += 1
+        hookInstalled = true
     }
 
     func uninstall() throws {
         uninstallCount += 1
+        hookInstalled = false
     }
 
     func resetSettings() {

--- a/Tests/MuxyTests/Services/AI/HookConfigWatcherTests.swift
+++ b/Tests/MuxyTests/Services/AI/HookConfigWatcherTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("HookConfigWatcher")
+struct HookConfigWatcherTests {
+    private static let watched: Set<String> = [
+        "/home/.claude/settings.json",
+        "/home/.codex/hooks.json",
+    ]
+
+    @Test("matches an exact watched config path")
+    func matchesExactPath() {
+        #expect(HookConfigWatcher.isRelevantChange(path: "/home/.claude/settings.json", watchedPaths: Self.watched))
+    }
+
+    @Test("matches atomic write temp files sharing the config prefix")
+    func matchesAtomicWriteSibling() {
+        #expect(HookConfigWatcher.isRelevantChange(
+            path: "/home/.codex/hooks.json.tmp",
+            watchedPaths: Self.watched
+        ))
+    }
+
+    @Test("ignores muxy backup files")
+    func ignoresBackupFiles() {
+        #expect(!HookConfigWatcher.isRelevantChange(
+            path: "/home/.claude/settings.json.muxy-backup",
+            watchedPaths: Self.watched
+        ))
+    }
+
+    @Test("ignores unrelated files in the same directory")
+    func ignoresUnrelatedFiles() {
+        #expect(!HookConfigWatcher.isRelevantChange(
+            path: "/home/.claude/other.json",
+            watchedPaths: Self.watched
+        ))
+    }
+
+    @Test("returns nil when no directories can be derived")
+    func initReturnsNilWithoutDirectories() {
+        let watcher = HookConfigWatcher(configPaths: []) {}
+        #expect(watcher == nil)
+    }
+
+    @Test("debounce coalesces rapid signals into a single handler call")
+    func debounceCoalescesRapidSignals() {
+        let scheduler = ManualScheduler()
+        let counter = Counter()
+        let trigger = DebouncedTrigger(interval: 0.4, scheduler: scheduler, handler: { counter.increment() })
+
+        trigger.signal()
+        trigger.signal()
+        trigger.signal()
+
+        #expect(counter.value == 0)
+        #expect(scheduler.cancelledCount == 2)
+        scheduler.fireLatest()
+        #expect(counter.value == 1)
+    }
+
+    @Test("a signal after the handler fires schedules a fresh handler call")
+    func debounceReArmsAfterFiring() {
+        let scheduler = ManualScheduler()
+        let counter = Counter()
+        let trigger = DebouncedTrigger(interval: 0.4, scheduler: scheduler, handler: { counter.increment() })
+
+        trigger.signal()
+        scheduler.fireLatest()
+        #expect(counter.value == 1)
+
+        trigger.signal()
+        scheduler.fireLatest()
+        #expect(counter.value == 2)
+    }
+
+    private final class ManualScheduler: DebounceScheduler, @unchecked Sendable {
+        private let lock = NSLock()
+        private var pending: [ManualCancellable] = []
+        private var cancelled = 0
+
+        var cancelledCount: Int { lock.withLock { cancelled } }
+
+        func schedule(after _: TimeInterval, _ work: @escaping @Sendable () -> Void) -> DebounceCancellable {
+            let cancellable = ManualCancellable(work: work) { [weak self] in
+                self?.lock.withLock { self?.cancelled += 1 }
+            }
+            lock.withLock { pending.append(cancellable) }
+            return cancellable
+        }
+
+        func fireLatest() {
+            let work: (@Sendable () -> Void)? = lock.withLock {
+                pending.last(where: { !$0.isCancelled })?.work
+            }
+            work?()
+        }
+
+        final class ManualCancellable: DebounceCancellable {
+            let work: @Sendable () -> Void
+            private let onCancel: @Sendable () -> Void
+            private(set) var isCancelled = false
+
+            init(work: @escaping @Sendable () -> Void, onCancel: @escaping @Sendable () -> Void) {
+                self.work = work
+                self.onCancel = onCancel
+            }
+
+            func cancel() {
+                isCancelled = true
+                onCancel()
+            }
+        }
+    }
+
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage = 0
+        var value: Int { lock.withLock { storage } }
+        func increment() { lock.withLock { storage += 1 } }
+    }
+}

--- a/Tests/MuxyTests/Services/AI/HookHealthStoreTests.swift
+++ b/Tests/MuxyTests/Services/AI/HookHealthStoreTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("HookHealthStore")
+@MainActor
+struct HookHealthStoreTests {
+    @Test("noteVerified records install state and verification time")
+    func noteVerifiedRecordsState() {
+        let clock = Clock()
+        let store = HookHealthStore(now: clock.now)
+        store.noteVerified(providerID: "claude", state: .installed)
+
+        let health = store.health(for: "claude")
+        #expect(health.installState == .installed)
+        #expect(health.lastVerifiedAt == clock.value)
+        #expect(health.lastError == nil)
+        #expect(health.lastRepairedAt == nil)
+    }
+
+    @Test("noteVerified stores error message for conflict and error states")
+    func noteVerifiedStoresErrorMessage() {
+        let store = HookHealthStore(now: { Date() })
+        store.noteVerified(providerID: "codex", state: .conflict("inline hooks"))
+        #expect(store.health(for: "codex").lastError == "inline hooks")
+
+        store.noteVerified(providerID: "codex", state: .error("boom"))
+        #expect(store.health(for: "codex").lastError == "boom")
+
+        store.noteVerified(providerID: "codex", state: .installed)
+        #expect(store.health(for: "codex").lastError == nil)
+    }
+
+    @Test("noteRepaired records both verified and repaired times")
+    func noteRepairedRecordsTimes() {
+        let clock = Clock()
+        let store = HookHealthStore(now: clock.now)
+        store.noteRepaired(providerID: "grok", state: .installed)
+
+        let health = store.health(for: "grok")
+        #expect(health.installState == .installed)
+        #expect(health.lastVerifiedAt == clock.value)
+        #expect(health.lastRepairedAt == clock.value)
+    }
+
+    @Test("noteEvent stamps lastEventAt without altering install state")
+    func noteEventStampsLastEventAt() {
+        let clock = Clock()
+        let store = HookHealthStore(now: clock.now)
+        store.noteVerified(providerID: "claude", state: .installed)
+        store.noteEvent(providerID: "claude")
+
+        let health = store.health(for: "claude")
+        #expect(health.lastEventAt == clock.value)
+        #expect(health.installState == .installed)
+    }
+
+    @Test("noteEvent creates an entry for a previously unknown provider")
+    func noteEventCreatesEntry() {
+        let store = HookHealthStore(now: { Date() })
+        store.noteEvent(providerID: "pi")
+        #expect(store.health(for: "pi").lastEventAt != nil)
+    }
+
+    @Test("reset clears provider health")
+    func resetClearsHealth() {
+        let store = HookHealthStore(now: { Date() })
+        store.noteVerified(providerID: "droid", state: .installed)
+        store.noteEvent(providerID: "droid")
+        store.reset(providerID: "droid")
+
+        #expect(store.health(for: "droid") == HookHealth())
+    }
+
+    private final class Clock: @unchecked Sendable {
+        let value = Date(timeIntervalSince1970: 1_700_000_000)
+        func now() -> Date { value }
+    }
+}

--- a/Tests/MuxyTests/Services/AI/HookInstallerTests.swift
+++ b/Tests/MuxyTests/Services/AI/HookInstallerTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("HookInstaller")
+@MainActor
+struct HookInstallerTests {
+    private static func installer(health: HookHealthStore) -> HookInstaller {
+        HookInstaller(
+            hookScriptPath: { _, _ in Fixture.stagedScriptPath },
+            stagedFileExists: { _ in true },
+            stagedFileExecutable: { _ in true },
+            health: health
+        )
+    }
+
+    @Test("verify reports satisfied when config references the current staged path")
+    func verifySatisfiedForCurrentStagedPath() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.grokProvider()
+        try provider.install(hookScriptPath: Fixture.stagedScriptPath)
+
+        #expect(provider.verify(hookScriptPath: Fixture.stagedScriptPath) == .satisfied)
+    }
+
+    @Test("verify needs repair when config references a stale staged path")
+    func verifyNeedsRepairForStalePath() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.grokProvider()
+        try provider.install(hookScriptPath: "/old/muxy-grok-hook.sh")
+
+        #expect(provider.verify(hookScriptPath: Fixture.stagedScriptPath) == .needsRepair)
+    }
+
+    @Test("reconcile repairs a config broken externally")
+    func reconcileRepairsBrokenConfig() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.grokProvider(toolInstalled: true)
+        provider.isEnabled = true
+        defer { provider.isEnabled = false }
+        try provider.install(hookScriptPath: Fixture.stagedScriptPath)
+
+        try fixture.writeGrokHooks(["hooks": [:]])
+        #expect(provider.verify(hookScriptPath: Fixture.stagedScriptPath) == .needsRepair)
+
+        let health = HookHealthStore()
+        let outcome = Self.installer(health: health).reconcile(provider)
+
+        #expect(outcome == .repaired)
+        #expect(provider.verify(hookScriptPath: Fixture.stagedScriptPath) == .satisfied)
+        #expect(health.health(for: provider.id).installState == .installed)
+        #expect(health.health(for: provider.id).lastRepairedAt != nil)
+    }
+
+    @Test("reconcile repairs a stale staged path")
+    func reconcileRepairsStalePath() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.grokProvider(toolInstalled: true)
+        provider.isEnabled = true
+        defer { provider.isEnabled = false }
+        try provider.install(hookScriptPath: "/old/muxy-grok-hook.sh")
+
+        let outcome = Self.installer(health: HookHealthStore()).reconcile(provider)
+
+        #expect(outcome == .repaired)
+        #expect(provider.verify(hookScriptPath: Fixture.stagedScriptPath) == .satisfied)
+    }
+
+    @Test("reconcile reports Codex conflict without clobbering config")
+    func reconcileReportsCodexConflict() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.codexProvider()
+        provider.isEnabled = true
+        defer { provider.isEnabled = false }
+        try fixture.writeCodexConfig("[[hooks.Stop]]")
+
+        let health = HookHealthStore()
+        let outcome = Self.installer(health: health).reconcile(provider)
+
+        guard case .conflict = outcome else {
+            Issue.record("expected conflict outcome, got \(outcome)")
+            return
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.codexHooksURL.path))
+        guard case .conflict = health.health(for: provider.id).installState else {
+            Issue.record("expected conflict install state")
+            return
+        }
+    }
+
+    @Test("reconcile reports cliMissing when hook absent and CLI not installed")
+    func reconcileReportsCLIMissing() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.grokProvider(toolInstalled: false)
+        provider.isEnabled = true
+        defer { provider.isEnabled = false }
+
+        let health = HookHealthStore()
+        let outcome = Self.installer(health: health).reconcile(provider)
+
+        #expect(outcome == .cliMissing)
+        #expect(health.health(for: provider.id).installState == .cliMissing)
+    }
+
+    @Test("reconcile fails when staged resource is missing")
+    func reconcileFailsWhenStagedResourceMissing() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.grokProvider(toolInstalled: true)
+        provider.isEnabled = true
+        defer { provider.isEnabled = false }
+
+        let installer = HookInstaller(
+            hookScriptPath: { _, _ in Fixture.stagedScriptPath },
+            stagedFileExists: { _ in false },
+            stagedFileExecutable: { _ in true },
+            health: HookHealthStore()
+        )
+        let outcome = installer.reconcile(provider)
+
+        guard case .failed = outcome else {
+            Issue.record("expected failed outcome, got \(outcome)")
+            return
+        }
+    }
+
+    @Test("disabled provider is skipped and health reset")
+    func disabledProviderSkipped() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let provider = fixture.grokProvider()
+        provider.isEnabled = false
+
+        let outcome = Self.installer(health: HookHealthStore()).reconcile(provider)
+        #expect(outcome == .skippedDisabled)
+    }
+
+    private struct Fixture {
+        static let stagedScriptPath = "/tmp/muxy-staged-hook.sh"
+        let rootURL: URL
+        let homeURL: URL
+        let codexHooksURL: URL
+
+        init() throws {
+            rootURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("HookInstallerTests-\(UUID().uuidString)", isDirectory: true)
+            homeURL = rootURL.appendingPathComponent("home", isDirectory: true)
+            codexHooksURL = homeURL.appendingPathComponent(".codex/hooks.json")
+            try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+        }
+
+        func grokProvider(toolInstalled: Bool = false) -> GrokProvider {
+            if toolInstalled {
+                let binURL = rootURL.appendingPathComponent("bin")
+                let executableURL = binURL.appendingPathComponent("grok")
+                try? FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+                try? Data().write(to: executableURL)
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: FilePermissions.executable],
+                    ofItemAtPath: executableURL.path
+                )
+                return GrokProvider(homeDirectory: homeURL.path, pathEnvironment: binURL.path)
+            }
+            return GrokProvider(homeDirectory: homeURL.path, pathEnvironment: "")
+        }
+
+        func codexProvider() -> CodexProvider {
+            CodexProvider(homeDirectory: homeURL.path, pathEnvironment: "", hooksPath: codexHooksURL.path)
+        }
+
+        func writeGrokHooks(_ settings: [String: Any]) throws {
+            let url = homeURL.appendingPathComponent(".grok/hooks/muxy-notify.json")
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: url, options: .atomic)
+        }
+
+        func writeCodexConfig(_ config: String) throws {
+            let url = homeURL.appendingPathComponent(".codex/config.toml")
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try config.write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        func cleanUp() {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+    }
+}

--- a/Tests/MuxyTests/Services/AI/HookTestRunnerTests.swift
+++ b/Tests/MuxyTests/Services/AI/HookTestRunnerTests.swift
@@ -1,0 +1,144 @@
+import Darwin
+import Foundation
+import MuxyShared
+import Testing
+
+@testable import Muxy
+
+@Suite("HookTestRunner")
+struct HookTestRunnerTests {
+    @Test("arguments include the test flag and provider tags")
+    func argumentsIncludeTestFlag() {
+        let arguments = HookTestRunner.arguments(providerSocketType: "claude_hook", providerTitle: "Claude Code")
+        #expect(arguments == [
+            "agent-event",
+            "--provider", "claude_hook",
+            "--provider-title", "Claude Code",
+            "--event", "test",
+            "--test",
+        ])
+    }
+
+    @Test("interpret maps a clean exit to passed")
+    func interpretMapsCleanExit() {
+        let outcome = HookTestRunner.ProcessOutcome(terminationStatus: 0, standardError: "")
+        #expect(HookTestRunner.interpret(outcome) == .passed)
+    }
+
+    @Test("interpret surfaces stderr on failure")
+    func interpretSurfacesStderr() {
+        let outcome = HookTestRunner.ProcessOutcome(terminationStatus: 1, standardError: "deliveryTimedOut\n")
+        #expect(HookTestRunner.interpret(outcome) == .failed("deliveryTimedOut"))
+    }
+
+    @Test("interpret falls back to status when stderr is empty")
+    func interpretFallsBackToStatus() {
+        let outcome = HookTestRunner.ProcessOutcome(terminationStatus: 2, standardError: "")
+        #expect(HookTestRunner.interpret(outcome) == .failed("Hook exited with status 2"))
+    }
+
+    @Test("run reports failure when the binary is not staged")
+    func runReportsMissingBinary() {
+        let runner = HookTestRunner(
+            binaryPath: "/does/not/exist",
+            socketPath: "/tmp/whatever.sock",
+            fileExists: { _ in false },
+            runner: { _, _, _, _ in HookTestRunner.ProcessOutcome(terminationStatus: 0, standardError: "") }
+        )
+        #expect(runner.run(providerSocketType: "claude_hook", providerTitle: "Claude") == .failed("Hook binary is not staged"))
+    }
+
+    @Test("run passes socket path in the environment and interprets the outcome")
+    func runPassesSocketPathAndInterprets() {
+        let capturedEnvironment = EnvironmentCapture()
+        let runner = HookTestRunner(
+            binaryPath: "/staged/muxy-hook",
+            socketPath: "/tmp/live.sock",
+            fileExists: { _ in true },
+            runner: { _, arguments, environment, _ in
+                capturedEnvironment.store(environment: environment, arguments: arguments)
+                return HookTestRunner.ProcessOutcome(terminationStatus: 0, standardError: "")
+            }
+        )
+
+        #expect(runner.run(providerSocketType: "codex_hook", providerTitle: "Codex") == .passed)
+        #expect(capturedEnvironment.environment["MUXY_SOCKET_PATH"] == "/tmp/live.sock")
+        #expect(capturedEnvironment.arguments.contains("--test"))
+    }
+
+    @Test("real muxy-hook binary traverses the socket and receives an ack")
+    func realBinaryReceivesAck() async throws {
+        let binaryPath = try Self.hookBinaryPath()
+        let socketPath = Self.temporarySocketPath()
+        let server = NotificationSocketServer(socketPath: socketPath)
+        server.start()
+        await server.awaitReady()
+        defer {
+            server.stop()
+            unlink(socketPath)
+        }
+
+        let runner = HookTestRunner(
+            binaryPath: binaryPath,
+            socketPath: socketPath,
+            fileExists: { _ in true },
+            timeout: 5
+        )
+
+        let result = runner.run(providerSocketType: "claude_hook", providerTitle: "Claude Code")
+        #expect(result == .passed)
+    }
+
+    @Test("real muxy-hook binary reports failure when nothing is listening")
+    func realBinaryReportsFailureWithoutServer() throws {
+        let binaryPath = try Self.hookBinaryPath()
+        let socketPath = Self.temporarySocketPath()
+
+        let runner = HookTestRunner(
+            binaryPath: binaryPath,
+            socketPath: socketPath,
+            fileExists: { _ in true },
+            timeout: 5
+        )
+
+        let result = runner.run(providerSocketType: "claude_hook", providerTitle: "Claude Code")
+        guard case .failed = result else {
+            Issue.record("expected failure when no server is listening, got \(result)")
+            return
+        }
+    }
+
+    private static func hookBinaryPath() throws -> String {
+        let candidate = RepositoryRoot.find().appendingPathComponent(".build/debug/muxy-hook")
+        guard FileManager.default.isExecutableFile(atPath: candidate.path) else {
+            throw HookBinaryError.notBuilt(candidate.path)
+        }
+        return candidate.path
+    }
+
+    private static func temporarySocketPath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("htr-\(UUID().uuidString.prefix(8)).sock")
+            .path
+    }
+
+    private enum HookBinaryError: Error {
+        case notBuilt(String)
+    }
+
+    private final class EnvironmentCapture: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storedEnvironment: [String: String] = [:]
+        private var storedArguments: [String] = []
+
+        var environment: [String: String] { lock.withLock { storedEnvironment } }
+        var arguments: [String] { lock.withLock { storedArguments } }
+
+        func store(environment: [String: String], arguments: [String]) {
+            lock.withLock {
+                storedEnvironment = environment
+                storedArguments = arguments
+            }
+        }
+    }
+}

--- a/Tests/MuxyTests/Services/Notifications/AgentHookBridgeMappingTests.swift
+++ b/Tests/MuxyTests/Services/Notifications/AgentHookBridgeMappingTests.swift
@@ -24,6 +24,118 @@ struct AgentHookBridgeMappingTests {
         #expect(AgentHookCommand.parse(["other"]) == nil)
     }
 
+    @Test("command parser recognizes the test flag")
+    func parsesTestFlag() {
+        let parsed = AgentHookCommand.parse([
+            "agent-event",
+            "--provider", "claude_hook",
+            "--provider-title", "Claude Code",
+            "--event", "test",
+            "--test",
+        ])
+
+        #expect(parsed == AgentHookCommand(
+            provider: "claude_hook",
+            providerTitle: "Claude Code",
+            event: "test",
+            test: true
+        ))
+    }
+
+    @Test("runtime builds a self-contained synthetic test message flagged as test")
+    func runtimeBuildsTestMessage() {
+        let captured = MessageBox()
+        let runtime = AgentHookRuntime(
+            environment: ["MUXY_SOCKET_PATH": "/tmp/live.sock"],
+            socketClient: AgentHookSocketClient(sendAttempt: { _, line, _ in
+                captured.store(try? AgentHookWireCodec.decodeEventLine(line))
+            }),
+            ancestorPIDs: { [999] },
+            timestamp: { 42 }
+        )
+
+        let result = runtime.run(
+            command: AgentHookCommand(
+                provider: "claude_hook",
+                providerTitle: "Claude Code",
+                event: "test",
+                test: true
+            ),
+            input: Data()
+        )
+
+        #expect(result == .success)
+        let message = captured.value
+        #expect(message?.test == true)
+        #expect(message?.provider == "claude_hook")
+        #expect(message?.phase == .finished)
+        #expect(message?.title == "Claude Code test")
+        #expect(message?.pids.isEmpty == true)
+    }
+
+    @Test("runtime reports failure for a test command when delivery fails")
+    func runtimeTestReportsFailure() {
+        struct DeliveryError: Error {}
+        let runtime = AgentHookRuntime(
+            environment: ["MUXY_SOCKET_PATH": "/tmp/live.sock"],
+            socketClient: AgentHookSocketClient(
+                maximumAttempts: 1,
+                sendAttempt: { _, _, _ in throw DeliveryError() },
+                sleep: { _ in }
+            ),
+            failureLogger: AgentHookFailureLogger(logFileURL: nil),
+            timestamp: { 42 }
+        )
+
+        let result = runtime.run(
+            command: AgentHookCommand(
+                provider: "claude_hook",
+                providerTitle: "Claude Code",
+                event: "test",
+                test: true
+            ),
+            input: Data()
+        )
+
+        guard case .failure = result else {
+            Issue.record("expected failure result")
+            return
+        }
+    }
+
+    @Test("runtime never reports failure for non-test commands even on delivery error")
+    func runtimeNonTestAlwaysSucceeds() {
+        struct DeliveryError: Error {}
+        let runtime = AgentHookRuntime(
+            environment: ["MUXY_SOCKET_PATH": "/tmp/live.sock"],
+            socketClient: AgentHookSocketClient(
+                maximumAttempts: 1,
+                sendAttempt: { _, _, _ in throw DeliveryError() },
+                sleep: { _ in }
+            ),
+            failureLogger: AgentHookFailureLogger(logFileURL: nil),
+            timestamp: { 42 }
+        )
+
+        let result = runtime.run(
+            command: AgentHookCommand(
+                provider: "claude_hook",
+                providerTitle: "Claude Code",
+                event: "stop"
+            ),
+            input: Data()
+        )
+
+        #expect(result == .success)
+    }
+
+    private final class MessageBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: AgentHookEventMessage?
+        var value: AgentHookEventMessage? { lock.withLock { storage } }
+        func store(_ message: AgentHookEventMessage?) { lock.withLock { storage = message } }
+    }
+
     @Test(
         "working event aliases map to an empty working lifecycle",
         arguments: [

--- a/Tests/MuxyTests/Services/Notifications/AgentHookProtocolTests.swift
+++ b/Tests/MuxyTests/Services/Notifications/AgentHookProtocolTests.swift
@@ -47,6 +47,45 @@ struct AgentHookProtocolTests {
         #expect(try AgentHookWireCodec.decodeEventLine(line).pids == [123, 45, 1])
     }
 
+    @Test("test flag is omitted when false and preserved when true")
+    func testFlagEncoding() throws {
+        let normal = AgentHookEventMessage(
+            provider: "claude_hook",
+            paneID: nil,
+            phase: .finished,
+            title: "t",
+            body: "b",
+            pids: [],
+            ts: 1
+        )
+        let normalLine = try AgentHookWireCodec.encodeEventLine(normal)
+        let normalObject = try #require(JSONSerialization.jsonObject(with: normalLine.dropLast()) as? [String: Any])
+        #expect(normalObject["test"] == nil)
+        #expect(try AgentHookWireCodec.decodeEventLine(normalLine).test == false)
+
+        let test = AgentHookEventMessage(
+            provider: "claude_hook",
+            paneID: nil,
+            phase: .finished,
+            title: "t",
+            body: "b",
+            pids: [],
+            ts: 1,
+            test: true
+        )
+        let testLine = try AgentHookWireCodec.encodeEventLine(test)
+        let testObject = try #require(JSONSerialization.jsonObject(with: testLine.dropLast()) as? [String: Any])
+        #expect(testObject["test"] as? Bool == true)
+        #expect(try AgentHookWireCodec.decodeEventLine(testLine).test == true)
+    }
+
+    @Test("legacy events without a test field decode as non-test")
+    func legacyEventDecodesAsNonTest() throws {
+        let legacy = #"{"body":"b","kind":"agent_event","phase":"finished","pids":[],"provider":"pi","title":"t","ts":1,"v":3}"#
+        let message = try AgentHookWireCodec.decodeEventLine(Data(legacy.utf8))
+        #expect(message.test == false)
+    }
+
     @Test("acknowledgement encoding is newline delimited and round trips")
     func acknowledgementRoundTrip() throws {
         let acknowledgement = AgentHookAcknowledgement(ok: true)

--- a/Tests/MuxyTests/Services/Socket/NotificationSocketAgentHookTests.swift
+++ b/Tests/MuxyTests/Services/Socket/NotificationSocketAgentHookTests.swift
@@ -35,6 +35,35 @@ struct NotificationSocketAgentHookTests {
         #expect(acknowledgement == AgentHookAcknowledgement(ok: true))
     }
 
+    @Test("acknowledges a synthetic test event")
+    func acknowledgesTestEvent() async throws {
+        let path = Self.temporarySocketPath()
+        let server = NotificationSocketServer(socketPath: path)
+        server.start()
+        await server.awaitReady()
+        defer { server.stop() }
+
+        let descriptor = try Self.connect(to: path)
+        defer { close(descriptor) }
+        let event = AgentHookEventMessage(
+            provider: "claude_hook",
+            paneID: nil,
+            phase: .finished,
+            title: "Claude Code test",
+            body: "Hook pipeline is working",
+            pids: [],
+            ts: 1_721_234_567,
+            test: true
+        )
+
+        try Self.write(AgentHookWireCodec.encodeEventLine(event), to: descriptor)
+        let acknowledgement = try AgentHookWireCodec.decodeAcknowledgementLine(
+            Self.readLine(from: descriptor)
+        )
+
+        #expect(acknowledgement == AgentHookAcknowledgement(ok: true))
+    }
+
     private static func temporarySocketPath() -> String {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("mah-\(UUID().uuidString.prefix(8)).sock")

--- a/Tests/MuxyTests/Views/Settings/HookHealthPresenterTests.swift
+++ b/Tests/MuxyTests/Views/Settings/HookHealthPresenterTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("HookHealthPresenter")
+struct HookHealthPresenterTests {
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("dot color reflects install state")
+    func dotColorReflectsState() {
+        #expect(HookHealthPresenter.dot(for: health(.installed)) == .healthy)
+        #expect(HookHealthPresenter.dot(for: health(.cliMissing)) == .warning)
+        #expect(HookHealthPresenter.dot(for: health(.conflict("x"))) == .error)
+        #expect(HookHealthPresenter.dot(for: health(.error("x"))) == .error)
+        #expect(HookHealthPresenter.dot(for: health(.notInstalled)) == .idle)
+    }
+
+    @Test("healthy line shows last event time when present")
+    func healthyLineShowsLastEvent() {
+        var value = health(.installed)
+        value.lastVerifiedAt = base
+        value.lastEventAt = base.addingTimeInterval(-120)
+        let line = HookHealthPresenter.statusLine(for: value, now: base)
+        #expect(line == "Hook healthy · last event 2 min ago")
+    }
+
+    @Test("healthy line without events reports healthy")
+    func healthyLineWithoutEvents() {
+        var value = health(.installed)
+        value.lastVerifiedAt = base
+        #expect(HookHealthPresenter.statusLine(for: value, now: base) == "Hook healthy")
+    }
+
+    @Test("repaired install surfaces the repair message")
+    func repairedLine() {
+        var value = health(.installed)
+        value.lastVerifiedAt = base
+        value.lastRepairedAt = base
+        let line = HookHealthPresenter.statusLine(for: value, now: base)
+        #expect(line == "Config overwritten — repaired just now")
+    }
+
+    @Test("cli missing and conflict lines")
+    func stateLines() {
+        #expect(HookHealthPresenter.statusLine(for: health(.cliMissing), now: base) == "CLI not installed")
+        #expect(HookHealthPresenter.statusLine(for: health(.conflict("both configs")), now: base) == "both configs")
+        #expect(HookHealthPresenter.statusLine(for: health(.error("broke")), now: base) == "broke")
+    }
+
+    @Test("relative time formatting")
+    func relativeTimeFormatting() {
+        #expect(HookHealthPresenter.relative(from: base, now: base) == "just now")
+        #expect(HookHealthPresenter.relative(from: base, now: base.addingTimeInterval(180)) == "3 min ago")
+        #expect(HookHealthPresenter.relative(from: base, now: base.addingTimeInterval(7200)) == "2 hr ago")
+        #expect(HookHealthPresenter.relative(from: base, now: base.addingTimeInterval(172_800)) == "2 d ago")
+    }
+
+    private func health(_ state: HookInstallState) -> HookHealth {
+        HookHealth(installState: state)
+    }
+}


### PR DESCRIPTION
Adds a declarative HookInstaller (verify → repair, real config-path verification per provider), FSEvents watchers that auto-repair externally overwritten configs, a per-provider health store, and a settings health row (status dot, last event, Test button firing a real synthetic event through the full binary→socket→ack→toast pipeline).
Stacked on #919.
UI screenshot pending a visual run by the maintainer (agents never launch the app); verified by scripts/checks.sh, full suite green.