### PR TITLE
Remove legacy v2 hook protocol, add e2e pipeline tests and docs (Phase 4)

### DIFF
--- a/Muxy/Resources/scripts/muxy-pi-extension.ts
+++ b/Muxy/Resources/scripts/muxy-pi-extension.ts
@@ -1,23 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
-  async function sendDirect(socketPath: string, payload: string) {
-    try {
-      const { createConnection } = await import("node:net");
-      const conn = createConnection({ path: socketPath });
-      conn.on("error", (err: any) => {
-        process.stderr.write(`[muxy-pi] socket error: ${err?.message ?? err}\n`);
-      });
-      conn.write(`${payload}\n`, () => conn.end());
-      await new Promise((resolve) => {
-        conn.on("close", resolve);
-        setTimeout(resolve, 3000);
-      });
-    } catch (err: any) {
-      process.stderr.write(`[muxy-pi] connection error: ${err?.message ?? err}\n`);
-    }
-  }
-
   const stagedHookBinaryPath = () => {
     if (process.env.MUXY_HOOK_BIN) return process.env.MUXY_HOOK_BIN;
     if (!process.env.HOME) return "";
@@ -84,12 +67,8 @@ export default function (pi: ExtensionAPI) {
 
   const sendEvent = async (phase: string, title = "", body = "") => {
     if (await invokeHookBinary(phase, title, body)) return;
-    const socketPath = process.env.MUXY_SOCKET_PATH;
-    const paneID = process.env.MUXY_PANE_ID;
-    if (!socketPath || !paneID) return;
-    await sendDirect(
-      socketPath,
-      `agent_event|pi|${paneID}|${phase}|${title}|${body}`,
+    process.stderr.write(
+      `[muxy-pi] muxy-hook binary is not staged; skipping ${phase} event\n`,
     );
   };
   let latestBody = "Session completed";

--- a/Muxy/Resources/scripts/opencode-muxy-plugin.js
+++ b/Muxy/Resources/scripts/opencode-muxy-plugin.js
@@ -90,19 +90,6 @@ function clearSettledSession(sessionID, version) {
   activeSessions.delete(sessionID)
 }
 
-async function sendDirect(socketPath, payload) {
-  try {
-    const { createConnection } = await import("net")
-    const conn = createConnection({ path: socketPath })
-    conn.on("error", () => {})
-    conn.write(`${payload}\n`, () => conn.end())
-    await new Promise((resolve) => {
-      conn.on("close", resolve)
-      setTimeout(resolve, 3000)
-    })
-  } catch {}
-}
-
 function stagedHookBinaryPath() {
   if (process.env.MUXY_HOOK_BIN) return process.env.MUXY_HOOK_BIN
   if (!process.env.HOME) return ""
@@ -167,12 +154,8 @@ function sendEvent(phase, title = "", body = "") {
   const cleanBody = sanitize(body)
   const transmit = async () => {
     if (await invokeHookBinary(phase, cleanTitle, cleanBody)) return
-    const socketPath = process.env.MUXY_SOCKET_PATH
-    const paneID = process.env.MUXY_PANE_ID
-    if (!socketPath || !paneID) return
-    await sendDirect(
-      socketPath,
-      `agent_event|opencode|${paneID}|${phase}|${cleanTitle}|${cleanBody}`,
+    process.stderr.write(
+      `[muxy-opencode] muxy-hook binary is not staged; skipping ${phase} event\n`,
     )
   }
   sendQueue = sendQueue.then(transmit, transmit)

--- a/Muxy/Services/Socket/NotificationSocketServer.swift
+++ b/Muxy/Services/Socket/NotificationSocketServer.swift
@@ -316,12 +316,6 @@ final class NotificationSocketServer: @unchecked Sendable {
         let body: Data
     }
 
-    struct AgentStatusMessage: Equatable {
-        let socketType: String
-        let paneID: UUID
-        let status: AgentStatus
-    }
-
     struct AgentLifecycleMessage: Equatable {
         let socketType: String
         let paneID: UUID
@@ -332,34 +326,6 @@ final class NotificationSocketServer: @unchecked Sendable {
 
     private static func pipeFields(_ message: String) -> [String] {
         message.split(separator: "|", maxSplits: 3, omittingEmptySubsequences: false).map(String.init)
-    }
-
-    static func parseAgentStatusMessage(_ message: String) -> AgentStatusMessage? {
-        let parts = pipeFields(message)
-        guard parts.count == 4,
-              parts[0] == "agent_status",
-              !parts[1].isEmpty,
-              let paneID = UUID(uuidString: parts[2]),
-              let status = AgentStatus(rawValue: parts[3])
-        else { return nil }
-        return AgentStatusMessage(socketType: parts[1], paneID: paneID, status: status)
-    }
-
-    static func parseAgentLifecycleMessage(_ message: String) -> AgentLifecycleMessage? {
-        let parts = message.split(separator: "|", maxSplits: 5, omittingEmptySubsequences: false).map(String.init)
-        guard parts.count == 6,
-              parts[0] == "agent_event",
-              !parts[1].isEmpty,
-              let paneID = UUID(uuidString: parts[2]),
-              let phase = AgentLifecyclePhase(rawValue: parts[3])
-        else { return nil }
-        return AgentLifecycleMessage(
-            socketType: parts[1],
-            paneID: paneID,
-            phase: phase,
-            title: parts[4],
-            body: parts[5]
-        )
     }
 
     static func parseAgentHookEventMessage(_ data: Data) -> AgentHookEventMessage? {
@@ -812,20 +778,6 @@ final class NotificationSocketServer: @unchecked Sendable {
             return
         }
 
-        if session.extensionID == nil, let lifecycleMessage = Self.parseAgentLifecycleMessage(message) {
-            DispatchQueue.main.async { [weak self] in
-                self?.dispatchAgentLifecycle(lifecycleMessage)
-            }
-            return
-        }
-
-        if session.extensionID == nil, let statusMessage = Self.parseAgentStatusMessage(message) {
-            DispatchQueue.main.async { [weak self] in
-                self?.dispatchAgentStatus(statusMessage)
-            }
-            return
-        }
-
         let parts = message.split(separator: "|", maxSplits: 3, omittingEmptySubsequences: false).map(String.init)
         guard parts.count >= 3 else {
             logger.warning("Invalid message on notification socket: expected type|paneID|title|body")
@@ -854,21 +806,6 @@ final class NotificationSocketServer: @unchecked Sendable {
         DispatchQueue.main.async { [weak self] in
             self?.dispatchNotification(type: type, title: title, body: body, paneIDString: paneIDString)
         }
-    }
-
-    @MainActor
-    private func dispatchAgentStatus(_ message: AgentStatusMessage) {
-        guard let appState = NotificationStore.shared.appState else { return }
-        guard case let .aiProvider(providerID) = AIProviderRegistry.shared.notificationSource(for: message.socketType) else {
-            return
-        }
-        AgentStatusStore.shared.update(
-            paneID: message.paneID,
-            providerID: providerID,
-            status: message.status,
-            sequence: AgentStatusStore.shared.nextSequence(),
-            appState: appState
-        )
     }
 
     @MainActor

--- a/Muxy/Services/Terminal/TerminalEnvVarBuilder.swift
+++ b/Muxy/Services/Terminal/TerminalEnvVarBuilder.swift
@@ -8,7 +8,6 @@ enum TerminalEnvVarBuilder {
             (key: "MUXY_PROJECT_ID", value: key.projectID.uuidString),
             (key: "MUXY_WORKTREE_ID", value: key.worktreeID.uuidString),
             (key: "MUXY_SOCKET_PATH", value: NotificationSocketServer.socketPath),
-            (key: "MUXY_AGENT_EVENT_PROTOCOL", value: "3"),
             (key: "MUXY_HOOK_BIN", value: MuxyNotificationHooks.hookBinaryPath),
             (
                 key: "MUXY_HOOK_SCRIPT",

--- a/Muxy/Services/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Services/Terminal/TerminalViewRegistry.swift
@@ -11,8 +11,13 @@ final class TerminalViewRegistry {
 
     private var views: [UUID: GhosttyTerminalNSView] = [:]
     private var paneIDs: [ObjectIdentifier: UUID] = [:]
+    private var processIdentityOverride: [PaneProcessIdentity]?
 
     private init() {}
+
+    func overrideProcessIdentities(_ identities: [PaneProcessIdentity]?) {
+        processIdentityOverride = identities
+    }
 
     func isOwnedByRemote(_ paneID: UUID) -> Bool {
         !PaneOwnershipStore.shared.isOwnedByMac(paneID)
@@ -65,7 +70,7 @@ final class TerminalViewRegistry {
     }
 
     func paneID(matchingProcessIDs processIDs: [Int32]) -> UUID? {
-        let identities = views.compactMap { entry -> PaneProcessIdentity? in
+        let identities = processIdentityOverride ?? views.compactMap { entry -> PaneProcessIdentity? in
             let (paneID, view) = entry
             guard let processID = view.foregroundProcessID else { return nil }
             return PaneProcessIdentity(paneID: paneID, processID: processID)

--- a/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
+++ b/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
@@ -6,96 +6,6 @@ import Testing
 
 @Suite("AgentStatus")
 struct AgentStatusTests {
-    @Test("parses a well-formed agent_status message")
-    func parsesValidMessage() {
-        let paneID = UUID()
-        let parsed = NotificationSocketServer.parseAgentStatusMessage("agent_status|claude_hook|\(paneID.uuidString)|working")
-        #expect(parsed == NotificationSocketServer.AgentStatusMessage(
-            socketType: "claude_hook",
-            paneID: paneID,
-            status: .working
-        ))
-    }
-
-    @Test("parses every status value")
-    func parsesEveryStatus() {
-        let paneID = UUID()
-        for status in [AgentStatus.working, .waiting, .idle] {
-            let parsed = NotificationSocketServer.parseAgentStatusMessage(
-                "agent_status|claude_hook|\(paneID.uuidString)|\(status.rawValue)"
-            )
-            #expect(parsed?.status == status)
-        }
-    }
-
-    @Test("parses messages from every provider socket type")
-    func parsesEveryProviderSocketType() {
-        let paneID = UUID()
-        for socketType in ["claude_hook", "cursor_hook", "codex_hook", "droid_hook", "opencode", "pi", "grok_hook"] {
-            let parsed = NotificationSocketServer.parseAgentStatusMessage(
-                "agent_status|\(socketType)|\(paneID.uuidString)|working"
-            )
-            #expect(parsed?.socketType == socketType)
-            #expect(parsed?.status == .working)
-        }
-    }
-
-    @Test("rejects an unknown status")
-    func rejectsUnknownStatus() {
-        let message = "agent_status|claude_hook|\(UUID().uuidString)|busy"
-        #expect(NotificationSocketServer.parseAgentStatusMessage(message) == nil)
-    }
-
-    @Test("rejects a malformed pane id")
-    func rejectsMalformedPaneID() {
-        #expect(NotificationSocketServer.parseAgentStatusMessage("agent_status|claude_hook|not-a-uuid|idle") == nil)
-    }
-
-    @Test("rejects wrong arity and other heads")
-    func rejectsWrongShape() {
-        #expect(NotificationSocketServer.parseAgentStatusMessage("agent_status|claude_hook|\(UUID().uuidString)") == nil)
-        #expect(NotificationSocketServer.parseAgentStatusMessage("claude_hook|\(UUID().uuidString)|Title|Body") == nil)
-        #expect(NotificationSocketServer.parseAgentStatusMessage("agent_status||\(UUID().uuidString)|idle") == nil)
-    }
-
-    @Test("parses every normalized lifecycle phase")
-    func parsesEveryLifecyclePhase() {
-        let paneID = UUID()
-        for phase in [AgentLifecyclePhase.working, .waiting, .finished] {
-            let parsed = NotificationSocketServer.parseAgentLifecycleMessage(
-                "agent_event|codex_hook|\(paneID.uuidString)|\(phase.rawValue)|Codex|Body"
-            )
-            #expect(parsed == NotificationSocketServer.AgentLifecycleMessage(
-                socketType: "codex_hook",
-                paneID: paneID,
-                phase: phase,
-                title: "Codex",
-                body: "Body"
-            ))
-        }
-    }
-
-    @Test("lifecycle parser preserves an empty notification and body pipes")
-    func lifecycleParserPreservesPayload() {
-        let paneID = UUID()
-        let parsed = NotificationSocketServer.parseAgentLifecycleMessage(
-            "agent_event|opencode|\(paneID.uuidString)|working||part one|part two"
-        )
-        #expect(parsed?.title == "")
-        #expect(parsed?.body == "part one|part two")
-    }
-
-    @Test("lifecycle parser rejects malformed messages")
-    func rejectsMalformedLifecycleMessages() {
-        #expect(NotificationSocketServer.parseAgentLifecycleMessage("agent_event|codex_hook|bad|working||") == nil)
-        #expect(NotificationSocketServer.parseAgentLifecycleMessage(
-            "agent_event|codex_hook|\(UUID().uuidString)|idle||"
-        ) == nil)
-        #expect(NotificationSocketServer.parseAgentLifecycleMessage(
-            "agent_event||\(UUID().uuidString)|finished||"
-        ) == nil)
-    }
-
     @Test("parses a protocol v3 lifecycle event")
     func parsesProtocolV3LifecycleEvent() throws {
         let paneID = UUID()
@@ -336,107 +246,186 @@ struct AgentStatusStoreTests {
     }
 
     @Test("drops stale out-of-order events")
-    func dropsStaleEvents() {
-        let (store, _, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 5)
-        send(store, paneID, .idle, sequence: 3)
-        #expect(store.status(forPane: paneID) == .working)
+    func dropsStaleEvents() async {
+        await SharedNotificationStateGate.run {
+            let (store, _, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 5)
+            send(store, paneID, .idle, sequence: 3)
+            #expect(store.status(forPane: paneID) == .working)
+        }
     }
 
     @Test("applies newer events after older ones")
-    func appliesNewerEvents() {
-        let (store, _, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        send(store, paneID, .waiting, sequence: 2)
-        #expect(store.status(forPane: paneID) == .waiting)
+    func appliesNewerEvents() async {
+        await SharedNotificationStateGate.run {
+            let (store, _, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            send(store, paneID, .waiting, sequence: 2)
+            #expect(store.status(forPane: paneID) == .waiting)
+        }
     }
 
     @Test("duplicate events are idempotent and mark completion once")
-    func duplicateEventsIdempotent() {
-        let (store, _, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        send(store, paneID, .idle, sequence: 2)
-        #expect(store.isCompletionPending(forPane: paneID))
-        store.clearCompletion(for: paneID)
-        send(store, paneID, .idle, sequence: 2)
-        #expect(!store.isCompletionPending(forPane: paneID))
+    func duplicateEventsIdempotent() async {
+        await SharedNotificationStateGate.run {
+            let (store, _, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            send(store, paneID, .idle, sequence: 2)
+            #expect(store.isCompletionPending(forPane: paneID))
+            store.clearCompletion(for: paneID)
+            send(store, paneID, .idle, sequence: 2)
+            #expect(!store.isCompletionPending(forPane: paneID))
+        }
     }
 
     @Test("completion badge fires exactly once per finish")
-    func completionFiresOncePerFinish() {
-        let (store, _, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        send(store, paneID, .idle, sequence: 2)
-        #expect(store.isCompletionPending(forPane: paneID))
-        store.clearCompletion(for: paneID)
-        send(store, paneID, .idle, sequence: 3)
-        #expect(!store.isCompletionPending(forPane: paneID))
-        send(store, paneID, .working, sequence: 4)
-        send(store, paneID, .idle, sequence: 5)
-        #expect(store.isCompletionPending(forPane: paneID))
+    func completionFiresOncePerFinish() async {
+        await SharedNotificationStateGate.run {
+            let (store, _, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            send(store, paneID, .idle, sequence: 2)
+            #expect(store.isCompletionPending(forPane: paneID))
+            store.clearCompletion(for: paneID)
+            send(store, paneID, .idle, sequence: 3)
+            #expect(!store.isCompletionPending(forPane: paneID))
+            send(store, paneID, .working, sequence: 4)
+            send(store, paneID, .idle, sequence: 5)
+            #expect(store.isCompletionPending(forPane: paneID))
+        }
     }
 
     @Test("detection loss idles a working agent only after grace with no hook events")
-    func detectionLossIdlesAfterGrace() {
-        let (store, scheduler, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        store.noteDetectionLost(paneID: paneID)
-        #expect(store.status(forPane: paneID) == .working)
-        scheduler.fireLast()
-        #expect(store.status(forPane: paneID) == .idle)
-        #expect(store.isCompletionPending(forPane: paneID))
+    func detectionLossIdlesAfterGrace() async {
+        await SharedNotificationStateGate.run {
+            let (store, scheduler, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            store.noteDetectionLost(paneID: paneID)
+            #expect(store.status(forPane: paneID) == .working)
+            scheduler.fireLast()
+            #expect(store.status(forPane: paneID) == .idle)
+            #expect(store.isCompletionPending(forPane: paneID))
+        }
     }
 
     @Test("hook event cancels a pending grace transition")
-    func hookEventCancelsGrace() {
-        let (store, scheduler, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        store.noteDetectionLost(paneID: paneID)
-        send(store, paneID, .working, sequence: 2)
-        #expect(scheduler.pendingCount == 0)
-        scheduler.fireLast()
-        #expect(store.status(forPane: paneID) == .working)
+    func hookEventCancelsGrace() async {
+        await SharedNotificationStateGate.run {
+            let (store, scheduler, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            store.noteDetectionLost(paneID: paneID)
+            send(store, paneID, .working, sequence: 2)
+            #expect(scheduler.pendingCount == 0)
+            scheduler.fireLast()
+            #expect(store.status(forPane: paneID) == .working)
+        }
     }
 
     @Test("re-detection cancels a pending grace transition")
-    func reDetectionCancelsGrace() {
-        let (store, scheduler, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        store.noteDetectionLost(paneID: paneID)
-        store.noteDetectionActive(paneID: paneID)
-        #expect(scheduler.pendingCount == 0)
-        scheduler.fireLast()
-        #expect(store.status(forPane: paneID) == .working)
+    func reDetectionCancelsGrace() async {
+        await SharedNotificationStateGate.run {
+            let (store, scheduler, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            store.noteDetectionLost(paneID: paneID)
+            store.noteDetectionActive(paneID: paneID)
+            #expect(scheduler.pendingCount == 0)
+            scheduler.fireLast()
+            #expect(store.status(forPane: paneID) == .working)
+        }
     }
 
     @Test("a waiting agent is never idled by detection loss")
-    func waitingNeverIdledByDetectionLoss() {
-        let (store, scheduler, paneID) = makeContext()
-        send(store, paneID, .waiting, sequence: 1)
-        store.noteDetectionLost(paneID: paneID)
-        #expect(scheduler.pendingCount == 0)
-        #expect(store.status(forPane: paneID) == .waiting)
+    func waitingNeverIdledByDetectionLoss() async {
+        await SharedNotificationStateGate.run {
+            let (store, scheduler, paneID) = makeContext()
+            send(store, paneID, .waiting, sequence: 1)
+            store.noteDetectionLost(paneID: paneID)
+            #expect(scheduler.pendingCount == 0)
+            #expect(store.status(forPane: paneID) == .waiting)
+        }
     }
 
     @Test("grace does not idle when a hook event arrives before it fires")
-    func graceSkippedWhenHookArrives() {
-        let (store, scheduler, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        store.noteDetectionLost(paneID: paneID)
-        send(store, paneID, .waiting, sequence: 2)
-        scheduler.fireLast()
-        #expect(store.status(forPane: paneID) == .waiting)
+    func graceSkippedWhenHookArrives() async {
+        await SharedNotificationStateGate.run {
+            let (store, scheduler, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            store.noteDetectionLost(paneID: paneID)
+            send(store, paneID, .waiting, sequence: 2)
+            scheduler.fireLast()
+            #expect(store.status(forPane: paneID) == .waiting)
+        }
+    }
+
+    private func send(
+        _ store: AgentStatusStore,
+        _ paneID: UUID,
+        provider: String,
+        _ status: AgentStatus,
+        sequence: UInt64
+    ) {
+        guard let appState = NotificationStore.shared.appState else { return }
+        store.update(paneID: paneID, providerID: provider, status: status, sequence: sequence, appState: appState)
+    }
+
+    @Test("out-of-order events across two providers on one pane keep the newest sequence")
+    func outOfOrderAcrossProviders() async {
+        await SharedNotificationStateGate.run {
+            let (store, _, paneID) = makeContext()
+            send(store, paneID, provider: "claude", .working, sequence: 2)
+            send(store, paneID, provider: "codex", .waiting, sequence: 4)
+            send(store, paneID, provider: "claude", .idle, sequence: 3)
+            #expect(store.status(forPane: paneID) == .waiting)
+        }
+    }
+
+    @Test("a newer provider event supersedes an older one regardless of arrival order")
+    func newerProviderSupersedesOlder() async {
+        await SharedNotificationStateGate.run {
+            let (store, _, paneID) = makeContext()
+            send(store, paneID, provider: "codex", .idle, sequence: 5)
+            send(store, paneID, provider: "claude", .working, sequence: 2)
+            #expect(store.status(forPane: paneID) == .idle)
+        }
+    }
+
+    @Test("re-detection after loss keeps a working agent alive through the grace window")
+    func reDetectionKeepsWorkingThroughGrace() async {
+        await SharedNotificationStateGate.run {
+            let (store, scheduler, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            store.noteDetectionLost(paneID: paneID)
+            store.noteDetectionActive(paneID: paneID)
+            store.noteDetectionLost(paneID: paneID)
+            store.noteDetectionActive(paneID: paneID)
+            scheduler.fireLast()
+            #expect(store.status(forPane: paneID) == .working)
+        }
+    }
+
+    @Test("a waiting hook event during the grace window blocks the idle transition")
+    func waitingHookDuringGraceBlocksIdle() async {
+        await SharedNotificationStateGate.run {
+            let (store, scheduler, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            store.noteDetectionLost(paneID: paneID)
+            send(store, paneID, .waiting, sequence: 2)
+            scheduler.fireLast()
+            #expect(store.status(forPane: paneID) == .waiting)
+            #expect(!store.isCompletionPending(forPane: paneID))
+        }
     }
 
     @Test("pane close drops all session state")
-    func paneCloseDropsSessions() {
-        let (store, _, paneID) = makeContext()
-        send(store, paneID, .working, sequence: 1)
-        store.removePane(paneID)
-        #expect(store.status(forPane: paneID) == nil)
-        #expect(!store.isCompletionPending(forPane: paneID))
-        send(store, paneID, .idle, sequence: 1)
-        #expect(store.status(forPane: paneID) == .idle)
+    func paneCloseDropsSessions() async {
+        await SharedNotificationStateGate.run {
+            let (store, _, paneID) = makeContext()
+            send(store, paneID, .working, sequence: 1)
+            store.removePane(paneID)
+            #expect(store.status(forPane: paneID) == nil)
+            #expect(!store.isCompletionPending(forPane: paneID))
+            send(store, paneID, .idle, sequence: 1)
+            #expect(store.status(forPane: paneID) == .idle)
+        }
     }
 }
 

--- a/Tests/MuxyTests/Services/Notifications/MuxyNotificationHooksTests.swift
+++ b/Tests/MuxyTests/Services/Notifications/MuxyNotificationHooksTests.swift
@@ -117,8 +117,8 @@ struct MuxyNotificationHooksTests {
             .appendingPathComponent("Muxy/Resources/scripts/muxy-agent-hook.sh").path))
     }
 
-    @Test("OpenCode invokes the bridge and keeps direct v2 as missing-binary fallback")
-    func openCodeUsesBridgeWithV2Fallback() throws {
+    @Test("OpenCode invokes the bridge and logs when the binary is missing")
+    func openCodeUsesBridgeOnly() throws {
         let contents = try String(
             contentsOf: Self.repositoryRoot.appendingPathComponent("Muxy/Resources/scripts/opencode-muxy-plugin.js"),
             encoding: .utf8
@@ -127,14 +127,16 @@ struct MuxyNotificationHooksTests {
         #expect(contents.contains("process.env.MUXY_HOOK_BIN"))
         #expect(contents.contains("node:child_process"))
         #expect(contents.contains("agent-event"))
-        #expect(contents.contains("`agent_event|opencode|${paneID}|${phase}|"))
         #expect(contents.contains("sendQueue = sendQueue.then(transmit, transmit)"))
+        #expect(contents.contains("muxy-hook binary is not staged"))
         #expect(!contents.contains("agent_status|"))
+        #expect(!contents.contains("agent_event|"))
+        #expect(!contents.contains("createConnection"))
         #expect(!contents.contains("MUXY_AGENT_EVENT_PROTOCOL"))
     }
 
-    @Test("Pi invokes the bridge and keeps direct v2 as missing-binary fallback")
-    func piUsesBridgeWithV2Fallback() throws {
+    @Test("Pi invokes the bridge and logs when the binary is missing")
+    func piUsesBridgeOnly() throws {
         let contents = try String(
             contentsOf: Self.repositoryRoot.appendingPathComponent("Muxy/Resources/scripts/muxy-pi-extension.ts"),
             encoding: .utf8
@@ -143,8 +145,10 @@ struct MuxyNotificationHooksTests {
         #expect(contents.contains("process.env.MUXY_HOOK_BIN"))
         #expect(contents.contains("node:child_process"))
         #expect(contents.contains("agent-event"))
-        #expect(contents.contains("`agent_event|pi|${paneID}|${phase}|${title}|${body}`"))
+        #expect(contents.contains("muxy-hook binary is not staged"))
         #expect(!contents.contains("agent_status|"))
+        #expect(!contents.contains("agent_event|"))
+        #expect(!contents.contains("createConnection"))
         #expect(!contents.contains("MUXY_AGENT_EVENT_PROTOCOL"))
     }
 
@@ -245,7 +249,6 @@ struct MuxyNotificationHooksTests {
         var environment = ProcessInfo.processInfo.environment
         environment["MUXY_SOCKET_PATH"] = socketPath
         environment["MUXY_PANE_ID"] = paneID
-        environment["MUXY_AGENT_EVENT_PROTOCOL"] = "3"
         process.environment = environment
         let standardInput = Pipe()
         process.standardInput = standardInput

--- a/Tests/MuxyTests/Services/Providers/GrokProviderTests.swift
+++ b/Tests/MuxyTests/Services/Providers/GrokProviderTests.swift
@@ -331,7 +331,6 @@ struct GrokProviderTests {
         var environment = ProcessInfo.processInfo.environment
         environment["MUXY_SOCKET_PATH"] = socketPath
         environment["MUXY_PANE_ID"] = paneID
-        environment["MUXY_AGENT_EVENT_PROTOCOL"] = "3"
         process.environment = environment
         let stdin = Pipe()
         process.standardInput = stdin

--- a/Tests/MuxyTests/Services/Socket/AgentHookPipelineEndToEndTests.swift
+++ b/Tests/MuxyTests/Services/Socket/AgentHookPipelineEndToEndTests.swift
@@ -1,0 +1,393 @@
+import Darwin
+import Foundation
+import MuxyShared
+import Testing
+
+@testable import Muxy
+
+@Suite("Agent hook pipeline end to end", .serialized)
+@MainActor
+struct AgentHookPipelineEndToEndTests {
+    @Test("working then finished produces exactly one completion")
+    func workingThenFinishedCompletesOnce() async throws {
+        try await SharedNotificationStateGate.run {
+            let harness = try PipelineHarness()
+            defer { harness.tearDown() }
+
+            try await harness.deliver(harness.event(phase: .working))
+            try await harness.deliver(harness.event(phase: .finished, body: "All done"))
+
+            #expect(AgentStatusStore.shared.status(forPane: harness.paneID) == .idle)
+            #expect(AgentStatusStore.shared.isCompletionPending(forPane: harness.paneID))
+
+            let delivered = harness.notifications()
+            #expect(delivered.count == 1)
+            #expect(delivered.first?.source == .aiProvider("claude"))
+            #expect(delivered.first?.body == "All done")
+        }
+    }
+
+    @Test("a waiting event reaches the notification path with the provider source")
+    func waitingEventReachesNotificationPath() async throws {
+        try await SharedNotificationStateGate.run {
+            let harness = try PipelineHarness()
+            defer { harness.tearDown() }
+
+            try await harness.deliver(harness.event(phase: .working))
+            try await harness.deliver(harness.event(
+                phase: .waiting,
+                title: "Claude Code",
+                body: "Permission needed"
+            ))
+
+            #expect(AgentStatusStore.shared.status(forPane: harness.paneID) == .waiting)
+            let delivered = harness.notifications()
+            #expect(delivered.count == 1)
+            #expect(delivered.first?.source == .aiProvider("claude"))
+            #expect(delivered.first?.title == "Claude Code")
+            #expect(delivered.first?.body == "Permission needed")
+        }
+    }
+
+    @Test("a test-flagged event bypasses status and still notifies")
+    func testEventBypassesStatus() async throws {
+        try await SharedNotificationStateGate.run {
+            let harness = try PipelineHarness()
+            defer { harness.tearDown() }
+
+            try await harness.deliver(AgentHookEventMessage(
+                provider: "claude_hook",
+                paneID: harness.paneID.uuidString,
+                phase: .finished,
+                title: "Notifications",
+                body: "Hook pipeline is working",
+                pids: [],
+                ts: 1,
+                test: true
+            ))
+
+            #expect(AgentStatusStore.shared.status(forPane: harness.paneID) == nil)
+            let delivered = harness.notifications()
+            #expect(delivered.count == 1)
+            #expect(delivered.first?.title == "Notifications")
+            #expect(delivered.first?.source == .aiProvider("claude"))
+        }
+    }
+
+    @Test("pane identity resolves through the ancestor process chain")
+    func pidFallbackResolvesPane() async throws {
+        try await SharedNotificationStateGate.run {
+            let harness = try PipelineHarness()
+            defer { harness.tearDown() }
+
+            TerminalViewRegistry.shared.overrideProcessIdentities([
+                TerminalViewRegistry.PaneProcessIdentity(paneID: harness.paneID, processID: 4242),
+            ])
+
+            try await harness.deliver(AgentHookEventMessage(
+                provider: "claude_hook",
+                paneID: nil,
+                phase: .working,
+                title: "",
+                body: "",
+                pids: [9999, 4242, 1],
+                ts: 1
+            ))
+
+            #expect(AgentStatusStore.shared.status(forPane: harness.paneID) == .working)
+        }
+    }
+
+    @Test("malformed and unknown-version lines are rejected without an ack")
+    func malformedLinesAreRejected() async throws {
+        try await SharedNotificationStateGate.run {
+            let harness = try PipelineHarness()
+            defer { harness.tearDown() }
+
+            try await harness.writeRaw(Data("{\"kind\":\"agent_event\"".utf8) + Data([10]))
+            try await harness.writeRaw(try encoded(harness.event(phase: .working, version: 2)))
+
+            #expect(!harness.acknowledged())
+            #expect(AgentStatusStore.shared.status(forPane: harness.paneID) == nil)
+        }
+    }
+
+    @Test("staged bridge binary drives the pipeline over a bound socket")
+    func stagedBinaryDrivesPipeline() async throws {
+        try await SharedNotificationStateGate.run {
+            let harness = try PipelineHarness()
+            defer { harness.tearDown() }
+
+            let binaryURL = RepositoryRoot.find().appendingPathComponent(".build/debug/muxy-hook")
+            try #require(FileManager.default.isExecutableFile(atPath: binaryURL.path))
+
+            try await harness.runHookBinary(
+                binaryURL: binaryURL,
+                arguments: [
+                    "agent-event",
+                    "--provider", "claude_hook",
+                    "--provider-title", "Claude Code",
+                    "--event", "stop",
+                ],
+                input: "{\"last_assistant_message\":\"Bridge complete\"}"
+            )
+
+            try await harness.waitForNotification()
+            let delivered = harness.notifications()
+            #expect(delivered.count == 1)
+            #expect(delivered.first?.source == .aiProvider("claude"))
+            #expect(AgentStatusStore.shared.status(forPane: harness.paneID) == .idle)
+        }
+    }
+
+    private func encoded(_ message: AgentHookEventMessage) throws -> Data {
+        try AgentHookWireCodec.encodeEventLine(message)
+    }
+}
+
+@MainActor
+private final class PipelineHarness {
+    let paneID: UUID
+    let projectID = UUID()
+    let worktreeID = UUID()
+    private let socketPath: String
+    private let server: NotificationSocketServer
+
+    init() throws {
+        socketPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ahp-\(UUID().uuidString.prefix(8)).sock")
+            .path
+        server = NotificationSocketServer(socketPath: socketPath)
+
+        let appState = AppState(
+            selectionStore: SelectionStub(),
+            terminalViews: TerminalViewStub(),
+            workspacePersistence: WorkspacePersistenceStub()
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: "/tmp/pipeline")
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        paneID = area.tabs.last!.content.pane!.id
+
+        AgentStatusStore.shared.removePane(paneID)
+        NotificationStore.shared.clear()
+        NotificationStore.shared.appState = appState
+        NotificationStore.shared.worktreeStore = WorktreeStore(
+            persistence: WorktreePersistenceStub(),
+            projects: []
+        )
+    }
+
+    func tearDown() {
+        if rawDescriptor >= 0 { close(rawDescriptor) }
+        server.stop()
+        AgentStatusStore.shared.removePane(paneID)
+        NotificationStore.shared.clear()
+        TerminalViewRegistry.shared.overrideProcessIdentities(nil)
+        unlink(socketPath)
+    }
+
+    func event(
+        phase: AgentHookPhase,
+        title: String = "",
+        body: String = "",
+        version: Int = AgentHookProtocol.version
+    ) -> AgentHookEventMessage {
+        AgentHookEventMessage(
+            v: version,
+            provider: "claude_hook",
+            paneID: paneID.uuidString,
+            phase: phase,
+            title: title,
+            body: body,
+            pids: [],
+            ts: 1
+        )
+    }
+
+    func notifications() -> [MuxyNotification] {
+        NotificationStore.shared.notifications.filter { $0.projectID == projectID }
+    }
+
+    func deliver(_ message: AgentHookEventMessage) async throws {
+        try await ensureListening()
+        let descriptor = try SocketProbe.connect(to: socketPath)
+        defer { close(descriptor) }
+        try SocketProbe.write(AgentHookWireCodec.encodeEventLine(message), to: descriptor)
+        _ = try SocketProbe.readLine(from: descriptor)
+        try await drainMainQueue()
+    }
+
+    func writeRaw(_ data: Data) async throws {
+        try await ensureListening()
+        if rawDescriptor >= 0 { close(rawDescriptor) }
+        rawDescriptor = try SocketProbe.connect(to: socketPath)
+        try SocketProbe.write(data, to: rawDescriptor)
+        try await drainMainQueue()
+    }
+
+    func acknowledged() -> Bool {
+        guard rawDescriptor >= 0 else { return false }
+        return (try? SocketProbe.readLine(from: rawDescriptor, timeout: 0.5)) != nil
+    }
+
+    func runHookBinary(binaryURL: URL, arguments: [String], input: String) async throws {
+        try await ensureListening()
+        let process = Process()
+        process.executableURL = binaryURL
+        process.arguments = arguments
+        var environment = ProcessInfo.processInfo.environment
+        environment["MUXY_SOCKET_PATH"] = socketPath
+        environment["MUXY_PANE_ID"] = paneID.uuidString
+        process.environment = environment
+        let standardInput = Pipe()
+        process.standardInput = standardInput
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        try process.run()
+        standardInput.fileHandleForWriting.write(Data(input.utf8))
+        try? standardInput.fileHandleForWriting.close()
+        let deadline = Date().addingTimeInterval(5)
+        while process.isRunning, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+
+    func waitForNotification() async throws {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            try await drainMainQueue()
+            if !notifications().isEmpty { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func ensureListening() async throws {
+        guard !didStart else { return }
+        server.start()
+        await server.awaitReady()
+        didStart = true
+    }
+
+    private func drainMainQueue() async throws {
+        for _ in 0 ..< 4 {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+        }
+    }
+
+    private var didStart = false
+    private var rawDescriptor: Int32 = -1
+}
+
+private enum SocketProbe {
+    static func connect(to path: String) throws -> Int32 {
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw Failure.createFailed }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard path.utf8.count < capacity else {
+            close(descriptor)
+            throw Failure.pathTooLong
+        }
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            let destination = pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { $0 }
+            _ = path.withCString { strncpy(destination, $0, capacity - 1) }
+        }
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard result == 0 else {
+            close(descriptor)
+            throw Failure.connectFailed
+        }
+        return descriptor
+    }
+
+    static func write(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var sent = 0
+            while sent < buffer.count {
+                let count = Darwin.write(descriptor, baseAddress.advanced(by: sent), buffer.count - sent)
+                if count > 0 {
+                    sent += count
+                    continue
+                }
+                if count < 0, errno == EINTR { continue }
+                throw Failure.writeFailed
+            }
+        }
+    }
+
+    static func readLine(from descriptor: Int32, timeout: TimeInterval = 3) throws -> Data {
+        var collected = Data()
+        var buffer = [UInt8](repeating: 0, count: 512)
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            var event = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+            let ready = poll(&event, 1, max(1, Int32(deadline.timeIntervalSinceNow * 1_000)))
+            if ready == 0 { throw Failure.timedOut }
+            if ready < 0, errno == EINTR { continue }
+            if ready < 0 { throw Failure.readFailed }
+            let count = Darwin.read(descriptor, &buffer, buffer.count)
+            if count > 0 {
+                collected.append(buffer, count: count)
+                guard let newline = collected.firstIndex(of: UInt8(ascii: "\n")) else { continue }
+                return collected.prefix(through: newline)
+            }
+            if count == 0 { throw Failure.closed }
+            if errno == EINTR { continue }
+            throw Failure.readFailed
+        }
+        throw Failure.timedOut
+    }
+
+    enum Failure: Error {
+        case createFailed
+        case pathTooLong
+        case connectFailed
+        case writeFailed
+        case readFailed
+        case closed
+        case timedOut
+    }
+}
+
+@MainActor
+private final class SelectionStub: ActiveProjectSelectionStoring {
+    private var activeProjectID: UUID?
+    private var activeWorktreeIDs: [UUID: UUID] = [:]
+    func loadActiveProjectID() -> UUID? { activeProjectID }
+    func saveActiveProjectID(_ id: UUID?) { activeProjectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { activeWorktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { activeWorktreeIDs = ids }
+}
+
+@MainActor
+private final class TerminalViewStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}
+
+private final class WorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+private final class WorktreePersistenceStub: WorktreePersisting {
+    func loadWorktrees(projectID _: UUID) throws -> [Worktree] { [] }
+    func saveWorktrees(_: [Worktree], projectID _: UUID) throws {}
+    func removeWorktrees(projectID _: UUID) throws {}
+}

--- a/Tests/MuxyTests/Services/Terminal/TerminalEnvVarBuilderTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/TerminalEnvVarBuilderTests.swift
@@ -6,8 +6,8 @@ import Testing
 @Suite("TerminalEnvVarBuilder")
 @MainActor
 struct TerminalEnvVarBuilderTests {
-    @Test("terminals advertise the normalized agent lifecycle protocol")
-    func advertisesAgentLifecycleProtocol() {
+    @Test("terminals advertise the staged hook binary and pane identity")
+    func advertisesHookEnvironment() {
         let paneID = UUID()
         let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
 
@@ -16,7 +16,7 @@ struct TerminalEnvVarBuilderTests {
                 .map { ($0.key, $0.value) }
         )
 
-        #expect(environment["MUXY_AGENT_EVENT_PROTOCOL"] == "3")
+        #expect(environment["MUXY_AGENT_EVENT_PROTOCOL"] == nil)
         #expect(environment["MUXY_PANE_ID"] == paneID.uuidString)
         #expect(environment["MUXY_HOOK_BIN"] == MuxyNotificationHooks.hookBinaryPath)
         #expect(

--- a/Tests/MuxyTests/Support/SharedNotificationStateGate.swift
+++ b/Tests/MuxyTests/Support/SharedNotificationStateGate.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@MainActor
+enum SharedNotificationStateGate {
+    private static var isBusy = false
+    private static var waiters: [CheckedContinuation<Void, Never>] = []
+
+    static func run<T>(_ body: () async throws -> T) async rethrows -> T {
+        await acquire()
+        defer { release() }
+        return try await body()
+    }
+
+    private static func acquire() async {
+        while isBusy {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                waiters.append(continuation)
+            }
+        }
+        isBusy = true
+    }
+
+    private static func release() {
+        isBusy = false
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+}

--- a/docs/features/ai-notifications.md
+++ b/docs/features/ai-notifications.md
@@ -1,0 +1,60 @@
+# AI notifications
+
+Muxy tracks the AI coding agents running inside its terminals — Claude Code, Codex, Cursor, Droid, Grok, OpenCode, and Pi — and surfaces their lifecycle as pane and worktree status, completion badges, and notifications when a turn finishes or an agent needs attention.
+
+There are two independent sources of truth, and hooks are authoritative.
+
+## Detection vs. hooks
+
+- **Hooks** are the primary signal. Each provider's CLI is configured to run a small Muxy hook when it starts a turn, finishes, or needs input. The hook reports the exact lifecycle phase (`working`, `waiting`, `finished`), so status changes are precise and event-driven.
+- **Detection** is the fallback. Muxy watches the foreground process of each pane to notice when an agent is running even if its hooks are missing or misconfigured. Detection can tell that an agent *stopped* being the foreground process, but not why.
+
+When detection reports that a working agent is no longer active, Muxy waits a short grace window (4 seconds) for a hook `finished` event before falling back to marking the pane idle. A hook event arriving inside the window always wins, so a correctly hooked agent is never idled prematurely by detection.
+
+## Protocol (v3)
+
+Hooks talk to Muxy over a Unix domain socket at `~/Library/Application Support/Muxy/muxy.sock` (`muxy-dev.sock` for debug builds). The wire format is a single newline-delimited JSON object per event, acknowledged by the server:
+
+```json
+{"v":3,"kind":"agent_event","provider":"claude_hook","paneID":"…","phase":"finished","title":"Claude Code","body":"Done","pids":[],"ts":1721234567}
+```
+
+- `paneID` is the target pane. When the CLI cannot know it, the field is omitted and `pids` carries the process's ancestor chain; Muxy resolves the nearest matching pane by foreground process id.
+- `phase` is `working`, `waiting`, or `finished`. `finished` maps to the `idle` status.
+- `test: true` marks a synthetic event from the settings Test button — it is delivered as a notification but never changes agent status.
+
+The server replies with `{"v":3,"kind":"ack","ok":true}`. Events with the wrong version, wrong kind, empty provider, or a malformed pane id are rejected without an ack. This is the only agent protocol Muxy accepts; there is no pipe-format fallback.
+
+## Staging layout
+
+The compiled hook bridge (`muxy-hook`) and the provider shims are staged into `~/Library/Application Support/Muxy/hooks` (`hooks-dev` for debug builds) with private permissions:
+
+- `muxy-hook` — the compiled bridge every hook invokes.
+- `muxy-claude-hook.sh`, `muxy-codex-hook.sh`, `muxy-cursor-hook.sh`, `muxy-droid-hook.sh`, `muxy-grok-hook.sh` — thin shell shims that exec the colocated `muxy-hook`.
+- `opencode-muxy-plugin.js`, `muxy-pi-extension.ts` — plugin/extension entry points that spawn the staged `muxy-hook`. When the binary is missing they log a clear error and skip the event; the health engine restages it.
+
+Terminals export `MUXY_PANE_ID`, `MUXY_SOCKET_PATH`, and `MUXY_HOOK_BIN` so shims and plugins can reach the socket and binary.
+
+## Health and repair engine
+
+Each provider integration is reconciled declaratively: Muxy **verifies** the provider's hook configuration against what it should be and **repairs** it in place when it drifts, preserving any foreign hooks the user configured. Reconciliation runs at launch, when a provider becomes available, and whenever a provider's config file changes — the latter is watched with FSEvents and debounced, so an external edit to `~/.claude`, `~/.codex`, and the like triggers an automatic re-verify without polling.
+
+Results are tracked per provider in the health store — install state, last verified/repaired time, last event time, and last error — and shown in **Settings → Notifications** as a status dot and line per provider. A `conflict` means Muxy found a non-Muxy hook it will not overwrite; the message names it.
+
+## Test button
+
+Each provider row in **Settings → Notifications** has a **Test** button. It runs the staged `muxy-hook` with `--event test --test`, which sends a `test: true` event over the live socket. A passing test confirms the full path end to end — staged binary, socket, server, ack, and notification delivery — without touching agent status. **Refresh** restages the provider's hook files and re-runs reconciliation.
+
+## Extension surface
+
+Agent status is exposed to extensions as the `agent.status` event and `muxy.agents.list()`, and completions post `notification.posted`. See [Extension events](../extensions/events.md).
+
+## Troubleshooting
+
+- **No notifications from an agent.** Open **Settings → Notifications**, check the provider's status dot, and click **Refresh** to restage and re-verify. Run **Test** to confirm the socket path end to end.
+- **Hook delivery failures.** The bridge logs failures to `~/Library/Application Support/Muxy/hooks.log`.
+- **Socket missing.** Verify it exists: `ls -l ~/Library/Application\ Support/Muxy/muxy.sock`.
+- **Conflict reported.** Muxy found a foreign hook in the provider's config and left it untouched. Remove or rename it if you want Muxy to own that hook, then **Refresh**.
+- **Logs.** Stream live: `log stream --predicate 'subsystem == "app.muxy"' --info --debug`.
+
+See also [Terminal notifications](terminal.md) for OSC-based terminal notifications, and the general [Troubleshooting](../user-guide/troubleshooting.md) guide.

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -53,6 +53,8 @@ Inside a terminal pane: **Paste**, **Split Right**, **Split Down**, **Close Pane
 
 OSC 9 and OSC 777 notification escape sequences are routed into Muxy's notification panel and (optionally) macOS notifications.
 
+For AI coding agents (Claude Code, Codex, Cursor, Droid, Grok, OpenCode, Pi), Muxy uses hook-based lifecycle events rather than escape sequences — see [AI notifications](ai-notifications.md).
+
 ## Quick-select labels
 
 Ghostty's quick-select feature lets you focus a pane or surface by typing a label key. Labels and bindings are configured in the Ghostty config.

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -64,6 +64,7 @@ After authenticating, restart Muxy so it picks up the new credentials.
 - Check `~/Library/Application Support/Muxy/hooks.log` for hook delivery failures.
 - macOS may have suppressed Muxy's system notifications — check **System Settings → Notifications → Muxy**.
 - For socket‑based integrations, verify the socket exists: `ls -l ~/Library/Application\ Support/Muxy/muxy.sock`.
+- For AI coding agents, use the per‑provider **Test** button and see [AI notifications](../features/ai-notifications.md) for the hook pipeline and health engine.
 
 ## Reset state
 


### PR DESCRIPTION
Removes the v2 pipe-format agent protocol (server parsing, plugin fallbacks, MUXY_AGENT_EVENT_PROTOCOL) leaving v3 as the only wire format; the extension/CLI pipe protocol is untouched.
Adds 6 end-to-end pipeline tests (staged binary → socket → ack → stores) plus 4 race/ordering tests, and a new docs/features/ai-notifications.md.
Stacked on #920; no UI changes; verified by scripts/checks.sh (2273 tests green, e2e suite stable across repeated runs).