### PR TITLE
Add solid surface and contrast-aware extension theme tokens

### DIFF
--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -35,8 +35,8 @@ Muxy ships paired light/dark themes and a user-chosen accent. Every extension we
 
 1. **No hex literals for chrome.** Use `var(--muxy-…)` for every color. The only exception is decorative art meant to be theme-independent.
 2. **The variables already invert** for light/dark — never sniff the color scheme to pick a color. Only branch on `muxy.theme.colorScheme` for things a variable can't express (e.g. swapping a logo image).
-3. **`--muxy-accent` is the only saturated color.** Use it sparingly — primary action, focus ring, one key number — so it stays distinctive. Text *on* an accent fill should be `--muxy-background` to stay legible in both themes.
-4. **Depth comes from `--muxy-surface` + `--muxy-border` + `--muxy-hover`,** not from new colors. Cards, inputs, code blocks, and buttons all share the one surface color.
+3. **`--muxy-accent` is the only saturated color.** Use it sparingly — primary action, focus ring, one key number — so it stays distinctive. Text *on* an accent fill must use `--muxy-accent-foreground`, which is resolved for contrast against the active theme's accent.
+4. **Use `--muxy-surface-solid` for component backgrounds.** It is the native surface overlay precomposited over the active theme background, so cards, inputs, code blocks, and buttons match Muxy without letting content show through. `--muxy-surface`, `--muxy-border`, `--muxy-hover`, and `--muxy-accent-soft` are translucent overlays for material-relative effects. Do not apply additional opacity to these tokens or to an entire control.
 5. **Re-read the theme for JS-drawn color.** Canvas/SVG that doesn't pick up CSS variables must redraw in `muxy.onThemeChange(theme => …)`.
 6. **Popovers leave the body transparent** (`body { background: transparent; }`) — they sit over native macOS popover material that is already light/dark-aware. Tabs and panels *do* paint `--muxy-background` on the body.
 
@@ -47,10 +47,12 @@ Muxy ships paired light/dark themes and a user-chosen accent. Every extension we
 | `--muxy-background` | Page background |
 | `--muxy-foreground` | Primary text |
 | `--muxy-foreground-muted` | Secondary text, labels, captions |
-| `--muxy-surface` | Cards, inputs, code blocks, buttons |
-| `--muxy-border` | 1px borders and dividers |
-| `--muxy-hover` | Hover state for buttons / rows |
+| `--muxy-surface-solid` | Opaque cards, inputs, code blocks, buttons |
+| `--muxy-surface` | Translucent surface overlay for popovers and intentional layering |
+| `--muxy-border` | Translucent 1px borders and dividers |
+| `--muxy-hover` | Translucent hover state for buttons / rows |
 | `--muxy-accent` | Primary action, links, focus rings |
+| `--muxy-accent-foreground` | Text and icons on an accent fill |
 | `--muxy-accent-soft` | Translucent accent for badges/highlights |
 | `--muxy-diff-add` / `--muxy-diff-remove` / `--muxy-diff-hunk` | Diff / success / error / hunk colors |
 | `--muxy-topbar-height` | The app's tab-bar height (see Sizing) |
@@ -111,13 +113,14 @@ Declare the scale once at the top of your stylesheet and reference it everywhere
 - **Register project file handlers with `fileOpeners`.** Users choose extension-provided openers only in Settings; they never appear in the topbar project-target control. The referenced tab receives `source: "terminal"`, the project-relative `filePath`, and optional `line`/`column` through `muxy.data` or `muxy.onDataChange` when its singleton tab is reused. See [Tabs](https://muxy.app/docs/extensions/tabs#file-openers).
 - **Guard a close with `muxy.lifecycle.onBeforeClose(handler)`** from a tab/panel/popover page when closing could lose work (a dirty editor). Return/resolve `true` (or `{ prevent: true }`) to prevent the close, anything else to allow it; the handler may be `async`, so `await muxy.dialog.confirm(...)` and decide. Call `muxy.lifecycle.close()` to finish the close yourself without re-asking. No permission, no manifest field — registering the handler is the opt-in, and it fails open (no handler / timeout / throw ⇒ closes). It does **not** fire on app quit or an outside-click popover dismiss; for those, persist reactively instead. To merely react after a close, subscribe to `tab.closed` / `panel.closed` / `popover.closed`. See [Lifecycle](https://muxy.app/docs/extensions/lifecycle).
 - **Drive and automate the built-in browser with `muxy.browser.*`.** Tabs: `open(url, { split })` returns the tab ID; `navigate(tabId, url)`, `reload/back/forward(tabId)`, `list()`, `read(tabId)` (`{ title, url, text }`, ~1 MB cap), `close(tabId)`. Automation: `eval(tabId, script)` (returns the parsed JS result), `click`, `type(…, { submit })`, `fill`, `press(tabId, key, selector?)`, `select`, `hover`, `scrollIntoView`, `setChecked`. Waiting: `wait(tabId, { selector|text|urlContains|function, timeoutMs })`, `waitFor`, `waitForNavigation`. Inspection: `getText/getHTML/getValue/getAttribute/getCount`, `is(tabId, property, selector)`, `find(tabId, kind, value)`, `snapshot(tabId, selector?)` (visible interactive elements — let an agent "see" the page), `screenshot(tabId)` (base64 PNG). State: `storage.get/set/clear(tabId, key, value?, kind)` for local/session storage; `cookies.get/set/delete/clear(tabId, ...)` per profile. Reads and JS-running calls (`eval`, `click`, `type`, `waitFor`, `get*`, `screenshot`, `storage.*`) need `browser:read`/`browser:write`; `navigate`, `cookies`, `list` do not. All of them work headlessly on any open tab in the active project — the tab need not be visible or focused (`screenshot` renders off-screen). Every call fails when the user disables the built-in browser. Capture the tab ID from `open`/`list` and reuse it. See [Browser](https://muxy.app/docs/extensions/browser).
-- **Make hover and active states visible** in both light and dark — `background: var(--muxy-hover); border-color: var(--muxy-accent);` is the standard pattern.
+- **Make hover and active states visible** in both light and dark — `background: var(--muxy-hover); border-color: var(--muxy-accent);` is the standard pattern. Change the relevant color instead of lowering the whole control's `opacity`, which also fades its content.
 - **Respect `prefers-reduced-motion`** — Muxy users opt into Reduce Motion at the OS level; avoid long transitions, large translations, autoplay.
 - **No hardcoded `~/.config/muxy` paths** from inside the extension — rely on the working directory Muxy sets, or pass `cwd` to `exec`.
 
 ## Checklist
 
 - [ ] Every color is `var(--muxy-…)`; `muxy.onThemeChange` wired for any JS-drawn color.
+- [ ] Component backgrounds use `--muxy-surface-solid`; translucent overlay tokens are only used intentionally.
 - [ ] Spacing, font, icon, control, and radius values come from the scale above — no off-ramp numbers (rows pad `10px`, body is `12px`, icons `12`–`14px` at weight 600).
 - [ ] Tab topbar uses `--muxy-topbar-height` with `box-sizing: content-box`.
 - [ ] Hover/active states are visible in both themes.

--- a/Muxy/Resources/starter-kits/vanilla/README.md
+++ b/Muxy/Resources/starter-kits/vanilla/README.md
@@ -16,6 +16,6 @@ After rebuilding, click **Reload** in the Muxy Extensions modal to pick up chang
 - `src/main.js` — mounts the panel onto `#root`.
 - `src/panel/app.js` — the panel UI, rendered with the `h()` DOM helper.
 - `src/lib/` — tiny `dom` and `icon` helpers.
-- `src/styles/global.css` — Tailwind, with `--color-*` mapped to the app's `--muxy-*` theme tokens so utilities like `bg-primary` and `text-muted-foreground` follow the active theme.
+- `src/styles/global.css` — Tailwind, with opaque component fills and contrast colors mapped to the app's `--muxy-*` tokens so utilities like `bg-surface`, `bg-primary`, and `text-primary-foreground` follow the active theme.
 
 See the [extension docs](https://github.com/muxy-app/muxy/tree/main/docs/extensions).

--- a/Muxy/Resources/starter-kits/vanilla/src/panel/app.js
+++ b/Muxy/Resources/starter-kits/vanilla/src/panel/app.js
@@ -51,7 +51,7 @@ export class HelloPanel {
         {
           type: "button",
           class:
-            "flex h-8 items-center justify-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground outline-none transition-opacity hover:opacity-95",
+            "flex h-8 items-center justify-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground outline-none",
           onclick: () => this.bump(),
         },
         icon("refresh", 13),

--- a/Muxy/Resources/starter-kits/vanilla/src/styles/global.css
+++ b/Muxy/Resources/starter-kits/vanilla/src/styles/global.css
@@ -3,11 +3,11 @@
 @theme inline {
   --color-background: var(--muxy-background);
   --color-foreground: var(--muxy-foreground);
-  --color-muted: var(--muxy-surface);
+  --color-muted: var(--muxy-surface-solid);
   --color-muted-foreground: var(--muxy-foreground-muted);
-  --color-surface: var(--muxy-surface);
+  --color-surface: var(--muxy-surface-solid);
   --color-primary: var(--muxy-accent);
-  --color-primary-foreground: var(--muxy-background);
+  --color-primary-foreground: var(--muxy-accent-foreground);
   --color-accent: var(--muxy-hover);
   --color-accent-foreground: var(--muxy-foreground);
   --color-border: var(--muxy-border);

--- a/Muxy/Services/Extensions/ExtensionThemeSnapshot.swift
+++ b/Muxy/Services/Extensions/ExtensionThemeSnapshot.swift
@@ -9,10 +9,12 @@ enum ExtensionThemeSnapshot {
         values["background"] = hex(MuxyTheme.nsBg)
         values["foreground"] = hex(MuxyTheme.nsFg)
         values["foregroundMuted"] = hex(MuxyTheme.nsFgMuted)
-        values["surface"] = hex(MuxyTheme.nsFg, alpha: 0.08)
+        values["surface"] = hex(MuxyTheme.nsSurface)
+        values["surfaceSolid"] = hex(opaque(MuxyTheme.nsSurface, over: MuxyTheme.nsBg))
         values["border"] = hex(MuxyTheme.nsFg, alpha: 0.12)
         values["hover"] = hex(MuxyTheme.nsFg, alpha: 0.06)
         values["accent"] = hex(accentNS)
+        values["accentForeground"] = hex(MuxyTheme.nsAccentForeground)
         values["accentSoft"] = hex(accentNS, alpha: 0.1)
         values["diffAdd"] = hex(MuxyTheme.nsDiffAdd)
         values["diffRemove"] = hex(MuxyTheme.nsDiffRemove)
@@ -20,6 +22,18 @@ enum ExtensionThemeSnapshot {
         values["colorScheme"] = MuxyTheme.colorScheme == .dark ? "dark" : "light"
         values["topbarHeight"] = "\(Int(UIMetrics.titleBarHeight.rounded()))px"
         return values
+    }
+
+    static func opaque(_ overlay: NSColor, over background: NSColor) -> NSColor {
+        let source = overlay.usingColorSpace(.sRGB) ?? overlay
+        let base = background.usingColorSpace(.sRGB) ?? background
+        let alpha = source.alphaComponent
+        return NSColor(
+            srgbRed: source.redComponent * alpha + base.redComponent * (1 - alpha),
+            green: source.greenComponent * alpha + base.greenComponent * (1 - alpha),
+            blue: source.blueComponent * alpha + base.blueComponent * (1 - alpha),
+            alpha: 1
+        )
     }
 
     private static func hex(_ color: NSColor, alpha: CGFloat? = nil) -> String {

--- a/Muxy/Theme/MuxyTheme.swift
+++ b/Muxy/Theme/MuxyTheme.swift
@@ -6,6 +6,8 @@ enum MuxyTheme {
     @MainActor static var nsBg: NSColor { snapshot.nsBg }
     @MainActor static var nsFg: NSColor { snapshot.nsFg }
     @MainActor static var nsFgMuted: NSColor { snapshot.nsFgMuted }
+    @MainActor static var nsSurface: NSColor { snapshot.nsSurface }
+    @MainActor static var nsAccentForeground: NSColor { snapshot.nsAccentForeground }
     @MainActor static var fg: Color { snapshot.fg }
     @MainActor static var fgMuted: Color { snapshot.fgMuted }
     @MainActor static var fgDim: Color { snapshot.fgDim }
@@ -58,6 +60,8 @@ extension MuxyTheme {
         let nsBg: NSColor
         let nsFg: NSColor
         let nsFgMuted: NSColor
+        let nsSurface: NSColor
+        let nsAccentForeground: NSColor
         let bg: Color
         let fg: Color
         let fgMuted: Color
@@ -100,16 +104,18 @@ extension MuxyTheme {
             nsBg = bgColor
             nsFg = fgColor
             nsFgMuted = fgColor.withAlphaComponent(0.65)
+            nsSurface = fgColor.withAlphaComponent(0.08)
+            nsAccentForeground = Snapshot.contrastingForeground(for: accentColor)
             bg = Color(nsColor: bgColor)
             fg = Color(nsColor: fgColor)
             fgMuted = Color(nsColor: fgColor.withAlphaComponent(0.65))
             fgDim = Color(nsColor: fgColor.withAlphaComponent(0.4))
-            surface = Color(nsColor: fgColor.withAlphaComponent(0.08))
+            surface = Color(nsColor: nsSurface)
             border = Color(nsColor: fgColor.withAlphaComponent(0.12))
             hover = Color(nsColor: fgColor.withAlphaComponent(0.06))
             accent = Color(nsColor: accentColor)
             accentSoft = Color(nsColor: accentColor.withAlphaComponent(0.1))
-            accentForeground = Color(nsColor: Snapshot.contrastingForeground(for: accentColor))
+            accentForeground = Color(nsColor: nsAccentForeground)
             warning = Color(nsColor: resolvedPalette.paletteColor(at: 3) ?? NSColor.systemYellow)
 
             let addColor = resolvedPalette.paletteColor(at: 2) ?? NSColor.systemGreen

--- a/Tests/MuxyTests/Services/Extensions/ExtensionThemeSnapshotTests.swift
+++ b/Tests/MuxyTests/Services/Extensions/ExtensionThemeSnapshotTests.swift
@@ -1,0 +1,50 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+@Suite("Extension theme snapshot")
+@MainActor
+struct ExtensionThemeSnapshotTests {
+    @Test("solid surface composites the native surface over the active background")
+    func solidSurfaceMatchesActiveTheme() {
+        let theme = ExtensionThemeSnapshot.current()
+        let expected = ExtensionThemeSnapshot.opaque(MuxyTheme.nsSurface, over: MuxyTheme.nsBg)
+
+        #expect(theme["surfaceSolid"] == hex(expected))
+        #expect(theme["surfaceSolid"]?.count == 7)
+        #expect(theme["surface"]?.count == 9)
+    }
+
+    @Test("accent foreground matches the native active theme")
+    func accentForegroundMatchesActiveTheme() {
+        let theme = ExtensionThemeSnapshot.current()
+
+        #expect(theme["accentForeground"] == hex(MuxyTheme.nsAccentForeground))
+    }
+
+    @Test("opaque compositing resolves source alpha")
+    func opaqueCompositingResolvesSourceAlpha() {
+        let overlay = NSColor(srgbRed: 0.8, green: 0.4, blue: 0.2, alpha: 0.25)
+        let background = NSColor(srgbRed: 0.2, green: 0.3, blue: 0.5, alpha: 1)
+
+        let result = ExtensionThemeSnapshot.opaque(overlay, over: background)
+        let resolved = result.usingColorSpace(.sRGB)
+
+        #expect(resolved != nil)
+        #expect(abs((resolved?.redComponent ?? 0) - 0.35) < 0.000_1)
+        #expect(abs((resolved?.greenComponent ?? 0) - 0.325) < 0.000_1)
+        #expect(abs((resolved?.blueComponent ?? 0) - 0.425) < 0.000_1)
+        #expect(resolved?.alphaComponent == 1)
+    }
+
+    private func hex(_ color: NSColor) -> String {
+        let resolved = color.usingColorSpace(.sRGB) ?? color
+        return String(
+            format: "#%02x%02x%02x",
+            Int(round(resolved.redComponent * 255)),
+            Int(round(resolved.greenComponent * 255)),
+            Int(round(resolved.blueComponent * 255))
+        )
+    }
+}

--- a/docs/extensions/popovers.md
+++ b/docs/extensions/popovers.md
@@ -59,4 +59,4 @@ The popover also dismisses on outside click, and closes automatically when the e
 
 ## Theming
 
-The popover renders over native macOS popover material with a transparent webview backing. Keep the page background transparent (`body { background: transparent; }`) so the system material — already light/dark aware — shows through. Use the injected `--muxy-*` theme variables for text, accents, and translucent `--muxy-surface` chips, as in [tabs](tabs.md) and [panels](panels.md).
+The popover renders over native macOS popover material with a transparent webview backing. Keep the page background transparent (`body { background: transparent; }`) so the system material — already light/dark aware — shows through. Use `--muxy-surface` when a chip should blend with that material. Use the opaque `--muxy-surface-solid` for controls whose content must not show through. Both track the active Muxy theme automatically.


### PR DESCRIPTION
Expose opaque surface and contrast-aware accent foreground tokens to extensions. Update the vanilla starter kit and theming docs to use them, with tests covering token generation and surface compositing.