### PR TITLE
Add dedicated Quick Terminal settings and optional shortcut

### DIFF
--- a/Muxy/Models/Keyboard/QuickTerminalShortcut.swift
+++ b/Muxy/Models/Keyboard/QuickTerminalShortcut.swift
@@ -1,10 +1,11 @@
 import AppKit
 
 enum QuickTerminalShortcut: Codable, Equatable {
+    case unassigned
     case doubleShift
     case keyCombo(KeyCombo, virtualKeyCode: UInt16)
 
-    static let `default` = QuickTerminalShortcut.doubleShift
+    static let `default` = QuickTerminalShortcut.unassigned
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -13,15 +14,21 @@ enum QuickTerminalShortcut: Codable, Equatable {
     }
 
     private enum ShortcutType: String, Codable {
+        case unassigned
         case doubleShift
         case keyCombo
     }
 
     var displayString: String {
         switch self {
+        case .unassigned: "Unassigned"
         case .doubleShift: "Double Shift"
         case let .keyCombo(combo, _): combo.displayString
         }
+    }
+
+    var controlLabel: String {
+        self == .unassigned ? "Set Shortcut" : displayString
     }
 
     var keyCombo: KeyCombo? {
@@ -46,6 +53,8 @@ enum QuickTerminalShortcut: Codable, Equatable {
 
     func canonicalized(keyResolver: (UInt16) -> String?) -> QuickTerminalShortcut? {
         switch self {
+        case .unassigned:
+            return .unassigned
         case .doubleShift:
             return .doubleShift
         case let .keyCombo(_, virtualKeyCode):
@@ -61,7 +70,7 @@ enum QuickTerminalShortcut: Codable, Equatable {
         case let (lhs?, rhs?):
             lhs == rhs
         case (nil, nil):
-            self == .doubleShift && other == .doubleShift
+            self == other
         default:
             false
         }
@@ -85,6 +94,8 @@ enum QuickTerminalShortcut: Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         switch try container.decode(ShortcutType.self, forKey: .type) {
+        case .unassigned:
+            self = .unassigned
         case .doubleShift:
             self = .doubleShift
         case .keyCombo:
@@ -105,6 +116,8 @@ enum QuickTerminalShortcut: Codable, Equatable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
+        case .unassigned:
+            try container.encode(ShortcutType.unassigned, forKey: .type)
         case .doubleShift:
             try container.encode(ShortcutType.doubleShift, forKey: .type)
         case let .keyCombo(combo, virtualKeyCode):

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -416,7 +416,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         QuickTerminalAppearancePreferences.migrateLegacyBlur()
         let shortcutService = QuickTerminalShortcutService.shared
         let controller = QuickTerminalController(
-            shortcutLabelProvider: { shortcutService.shortcut.displayString },
+            shortcutLabelProvider: { shortcutService.shortcut.controlLabel },
             onOpenSettings: {
                 SettingsFocusCoordinator.shared.request(.quickTerminalShortcut)
                 NotificationCenter.default.post(name: .openSettingsModal, object: nil)

--- a/Muxy/Services/Keyboard/QuickTerminalShortcutService.swift
+++ b/Muxy/Services/Keyboard/QuickTerminalShortcutService.swift
@@ -83,7 +83,11 @@ final class QuickTerminalShortcutService {
 
     func start() throws {
         guard activeBackend == nil else { return }
-        let backend = makeBackend(for: store.shortcut)
+        guard let backend = makeBackend(for: store.shortcut) else {
+            monitoringState = .stopped
+            errorMessage = nil
+            return
+        }
         do {
             let generation = try start(backend)
             activeRegistrationGeneration = generation
@@ -167,7 +171,14 @@ final class QuickTerminalShortcutService {
             try persistenceCommit()
             return
         }
-        let replacementBackend = makeBackend(for: shortcut)
+        guard let replacementBackend = makeBackend(for: shortcut) else {
+            try persistenceCommit()
+            activeRegistrationGeneration = nil
+            activeBackend?.stop()
+            activeBackend = nil
+            monitoringState = .stopped
+            return
+        }
         let replacementGeneration = try start(replacementBackend)
         do {
             try persistenceCommit()
@@ -187,8 +198,10 @@ final class QuickTerminalShortcutService {
         monitoringState = replacementBackend.monitoringState
     }
 
-    private func makeBackend(for shortcut: QuickTerminalShortcut) -> any QuickTerminalShortcutBackend {
+    private func makeBackend(for shortcut: QuickTerminalShortcut) -> (any QuickTerminalShortcutBackend)? {
         switch shortcut {
+        case .unassigned:
+            nil
         case .doubleShift:
             doubleShiftBackendFactory()
         case let .keyCombo(combo, virtualKeyCode):

--- a/Muxy/Services/QuickTerminal/QuickTerminalController.swift
+++ b/Muxy/Services/QuickTerminal/QuickTerminalController.swift
@@ -94,7 +94,7 @@ final class QuickTerminalController: NSObject {
     }
 
     override convenience init() {
-        self.init(shortcutLabelProvider: { "⇧ ⇧" }, onOpenSettings: {})
+        self.init(shortcutLabelProvider: { QuickTerminalShortcut.default.controlLabel }, onOpenSettings: {})
     }
 
     deinit {
@@ -322,7 +322,7 @@ final class QuickTerminalController: NSObject {
         }
         do {
             try shortcutService.updateShortcut(shortcut)
-            contentView?.setShortcutLabel(shortcut.displayString)
+            contentView?.setShortcutLabel(shortcut.controlLabel)
             return nil
         } catch {
             return error.localizedDescription

--- a/Muxy/Views/QuickTerminal/QuickTerminalContentView.swift
+++ b/Muxy/Views/QuickTerminal/QuickTerminalContentView.swift
@@ -43,6 +43,7 @@ final class QuickTerminalContentView: NSView {
     private let shortcutSettingsView = NSView()
     private let shortcutSettingsTitle = NSTextField(labelWithString: "Quick Terminal Shortcut")
     private let shortcutSettingsStatus = NSTextField(wrappingLabelWithString: "")
+    private let noShortcutButton = NSButton()
     private let doubleShiftButton = NSButton()
     private let customShortcutButton = NSButton()
     private let inputMonitoringButton = NSButton()
@@ -310,12 +311,13 @@ final class QuickTerminalContentView: NSView {
         bridgeView.addSubview(titleLabel)
         bridgeView.addSubview(statusLabel)
 
-        configureButton(shortcutButton, title: "⇧ ⇧", symbolName: nil, action: #selector(toggleShortcutSettings))
+        configureButton(shortcutButton, title: "Set Shortcut", symbolName: nil, action: #selector(toggleShortcutSettings))
         shortcutButton.font = .monospacedSystemFont(ofSize: 10, weight: .medium)
         shortcutButton.wantsLayer = true
         shortcutButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.1).cgColor
         shortcutButton.layer?.cornerRadius = 5
         shortcutButton.setAccessibilityLabel("Change quick terminal shortcut")
+        shortcutButton.setAccessibilityIdentifier("quickTerminalShortcutButton")
 
         configureButton(settingsButton, title: "", symbolName: "gearshape", action: #selector(toggleSettingsPopover))
         settingsButton.setAccessibilityLabel("Open quick terminal settings")
@@ -354,9 +356,12 @@ final class QuickTerminalContentView: NSView {
         shortcutSettingsStatus.textColor = NSColor.white.withAlphaComponent(0.62)
         shortcutSettingsStatus.font = .systemFont(ofSize: 10.5, weight: .regular)
         shortcutSettingsStatus.maximumNumberOfLines = 2
+        shortcutSettingsStatus.setAccessibilityIdentifier("quickTerminalShortcutStatus")
         shortcutSettingsView.addSubview(shortcutSettingsTitle)
         shortcutSettingsView.addSubview(shortcutSettingsStatus)
 
+        configureSettingsChoice(noShortcutButton, title: "No Shortcut", action: #selector(selectNoShortcut))
+        noShortcutButton.setAccessibilityIdentifier("quickTerminalNoShortcutButton")
         configureSettingsChoice(doubleShiftButton, title: "Double Shift", action: #selector(selectDoubleShift))
         configureSettingsChoice(customShortcutButton, title: "Record Custom…", action: #selector(recordCustomShortcut))
         configureSettingsChoice(
@@ -424,7 +429,7 @@ final class QuickTerminalContentView: NSView {
     }
 
     private func layoutShortcutSettings() {
-        let size = NSSize(width: 272, height: inputMonitoringButton.isHidden ? 142 : 174)
+        let size = NSSize(width: 272, height: inputMonitoringButton.isHidden ? 174 : 206)
         shortcutSettingsView.frame = NSRect(
             x: max(12, bounds.maxX - size.width - 12),
             y: max(12, bounds.maxY - Self.bridgeHeight - size.height - 8),
@@ -433,14 +438,16 @@ final class QuickTerminalContentView: NSView {
         )
         shortcutSettingsTitle.frame = NSRect(x: 14, y: size.height - 32, width: size.width - 28, height: 18)
         shortcutSettingsStatus.frame = NSRect(x: 14, y: size.height - 59, width: size.width - 28, height: 24)
-        doubleShiftButton.frame = NSRect(x: 14, y: size.height - 91, width: size.width - 28, height: 26)
-        customShortcutButton.frame = NSRect(x: 14, y: size.height - 123, width: size.width - 28, height: 26)
+        noShortcutButton.frame = NSRect(x: 14, y: size.height - 91, width: size.width - 28, height: 26)
+        doubleShiftButton.frame = NSRect(x: 14, y: size.height - 123, width: size.width - 28, height: 26)
+        customShortcutButton.frame = NSRect(x: 14, y: size.height - 155, width: size.width - 28, height: 26)
         inputMonitoringButton.frame = NSRect(x: 14, y: 14, width: size.width - 28, height: 26)
     }
 
     private func refreshShortcutSettings() {
         guard let snapshot = shortcutSettingsProvider?() else { return }
-        setShortcutLabel(snapshot.shortcut.displayString)
+        setShortcutLabel(snapshot.shortcut.controlLabel)
+        noShortcutButton.state = snapshot.shortcut == .unassigned ? .on : .off
         doubleShiftButton.state = snapshot.shortcut == .doubleShift ? .on : .off
         if case let .keyCombo(combo, _) = snapshot.shortcut {
             customShortcutButton.title = combo.displayString
@@ -631,6 +638,16 @@ final class QuickTerminalContentView: NSView {
     }
 
     @objc
+    private func selectNoShortcut() {
+        if let message = onShortcutChange?(.unassigned) {
+            shortcutSettingsStatus.stringValue = message
+            return
+        }
+        isRecordingShortcut = false
+        refreshShortcutSettings()
+    }
+
+    @objc
     func toggleSettingsPopover() {
         if settingsPopover.isHidden {
             shortcutSettingsView.isHidden = true
@@ -683,7 +700,8 @@ struct QuickTerminalShortcutSettingsSnapshot {
     }
 
     var statusText: String {
-        switch monitoringState {
+        guard shortcut != .unassigned else { return "No keyboard shortcut assigned." }
+        return switch monitoringState {
         case .systemWide,
              .carbonHotKey:
             "Active system-wide"

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -7,20 +7,9 @@ struct KeyboardShortcutsSettingsView: View {
     @State private var conflictWarning: (action: ShortcutAction, message: String)?
     @State private var recordingExtensionShortcutID: String?
     @State private var extensionConflictWarning: (id: String, message: String)?
-    @State private var isRecordingQuickTerminalShortcut = false
-    @State private var quickTerminalShortcutError: String?
-    @AppStorage(QuickTerminalSizePreferences.widthKey)
-    private var quickTerminalWidth = QuickTerminalSizePreferences.defaultWidth
-    @AppStorage(QuickTerminalSizePreferences.heightKey)
-    private var quickTerminalHeight = QuickTerminalSizePreferences.defaultHeight
-    @AppStorage(QuickTerminalAppearancePreferences.transparencyKey)
-    private var quickTerminalTransparency = QuickTerminalAppearancePreferences.defaultTransparency
-    @AppStorage(QuickTerminalAppearancePreferences.blurIntensityKey)
-    private var quickTerminalBlurIntensity = QuickTerminalAppearancePreferences.defaultBlurIntensity
 
     private var store: KeyBindingStore { KeyBindingStore.shared }
     private var extensionStore: ExtensionShortcutStore { ExtensionShortcutStore.shared }
-    private var quickTerminalShortcutService: QuickTerminalShortcutService { QuickTerminalShortcutService.shared }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -46,16 +35,9 @@ struct KeyboardShortcutsSettingsView: View {
             .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
 
             Button("Reset All") {
-                do {
-                    try quickTerminalShortcutService.resetShortcut()
-                    store.resetToDefaults()
-                    quickTerminalShortcutError = nil
-                } catch {
-                    quickTerminalShortcutError = error.localizedDescription
-                }
+                store.resetToDefaults()
                 recordingAction = nil
                 recordingExtensionShortcutID = nil
-                isRecordingQuickTerminalShortcut = false
                 conflictWarning = nil
             }
             .buttonStyle(.plain)
@@ -70,9 +52,6 @@ struct KeyboardShortcutsSettingsView: View {
         let extensionGroups = filteredExtensionGroups
         return ScrollView(.vertical, showsIndicators: true) {
             VStack(spacing: 0) {
-                if quickTerminalMatchesSearch {
-                    quickTerminalSection(showsDivider: !visibleCategories.isEmpty || !extensionGroups.isEmpty)
-                }
                 ForEach(visibleCategories, id: \.self) { category in
                     categorySection(
                         title: category,
@@ -93,248 +72,6 @@ struct KeyboardShortcutsSettingsView: View {
         }
     }
 
-    private var quickTerminalMatchesSearch: Bool {
-        searchText.isEmpty || SettingsCatalog.matchingItems(query: searchText).contains {
-            $0.section == "Quick Terminal"
-        }
-    }
-
-    private func quickTerminalSection(showsDivider: Bool) -> some View {
-        SettingsSection("Quick Terminal", showsDivider: showsDivider) {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Open Quick Terminal")
-                            .font(.system(size: SettingsMetrics.labelFontSize))
-                        Text(quickTerminalStatusText)
-                            .font(.system(size: SettingsMetrics.footnoteFontSize))
-                            .foregroundStyle(quickTerminalStatusColor)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Button {
-                        _ = updateQuickTerminalShortcut(.doubleShift)
-                    } label: {
-                        Label(
-                            "Double Shift",
-                            systemImage: quickTerminalShortcutService.shortcut == .doubleShift
-                                ? "checkmark.circle.fill"
-                                : "circle"
-                        )
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .accessibilityAddTraits(isDoubleShiftShortcutSelected ? .isSelected : [])
-                    .accessibilityValue(isDoubleShiftShortcutSelected ? "Selected" : "Not selected")
-
-                    ZStack {
-                        if isRecordingQuickTerminalShortcut {
-                            ShortcutRecorderView(
-                                onRecord: { _ in false },
-                                onCancel: { isRecordingQuickTerminalShortcut = false },
-                                onRecordWithKeyCode: recordQuickTerminalShortcut
-                            )
-                            .frame(width: 0, height: 0)
-                            .opacity(0)
-                        }
-                        Button(isRecordingQuickTerminalShortcut ? "Press shortcut…" : customShortcutTitle) {
-                            recordingAction = nil
-                            recordingExtensionShortcutID = nil
-                            isRecordingQuickTerminalShortcut = true
-                            quickTerminalShortcutError = nil
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                        .accessibilityAddTraits(isCustomShortcutSelected ? .isSelected : [])
-                        .accessibilityValue(isCustomShortcutSelected ? "Selected" : "Not selected")
-                    }
-                }
-
-                if quickTerminalShortcutService.needsInputMonitoringAccess {
-                    HStack(spacing: 8) {
-                        Text("Double Shift needs Input Monitoring outside Muxy.")
-                            .font(.system(size: SettingsMetrics.footnoteFontSize))
-                            .foregroundStyle(SettingsStyle.mutedForeground)
-                        Spacer()
-                        Button("Enable Input Monitoring") {
-                            _ = quickTerminalShortcutService.requestInputMonitoringAccess()
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
-                    }
-                }
-
-                HStack(spacing: 8) {
-                    Text("Terminal size")
-                        .font(.system(size: SettingsMetrics.labelFontSize))
-                    Spacer()
-                    Text("Width")
-                        .font(.system(size: SettingsMetrics.footnoteFontSize))
-                        .foregroundStyle(SettingsStyle.mutedForeground)
-                    QuickTerminalDimensionField(
-                        label: "Width",
-                        value: $quickTerminalWidth,
-                        range: QuickTerminalSizePreferences.widthRange
-                    )
-                    Text("×")
-                        .foregroundStyle(SettingsStyle.mutedForeground)
-                    Text("Height")
-                        .font(.system(size: SettingsMetrics.footnoteFontSize))
-                        .foregroundStyle(SettingsStyle.mutedForeground)
-                    QuickTerminalDimensionField(
-                        label: "Height",
-                        value: $quickTerminalHeight,
-                        range: QuickTerminalSizePreferences.heightRange
-                    )
-                    Button("Reset") {
-                        quickTerminalWidth = QuickTerminalSizePreferences.defaultWidth
-                        quickTerminalHeight = QuickTerminalSizePreferences.defaultHeight
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
-
-                HStack(spacing: 8) {
-                    Text("Terminal transparency")
-                        .font(.system(size: SettingsMetrics.labelFontSize))
-                    Spacer()
-                    Slider(
-                        value: quickTerminalTransparencyBinding,
-                        in: Double(QuickTerminalAppearancePreferences.transparencyRange.lowerBound)
-                            ... Double(QuickTerminalAppearancePreferences.transparencyRange.upperBound),
-                        step: 1
-                    )
-                    .frame(width: 220)
-                    .accessibilityLabel("Terminal transparency")
-                    Text("\(displayedQuickTerminalTransparency)%")
-                        .font(.system(size: SettingsMetrics.footnoteFontSize).monospacedDigit())
-                        .foregroundStyle(SettingsStyle.mutedForeground)
-                        .frame(width: 34, alignment: .trailing)
-                }
-
-                HStack(spacing: 8) {
-                    Text("Background vibrancy")
-                        .font(.system(size: SettingsMetrics.labelFontSize))
-                    Spacer()
-                    Slider(
-                        value: quickTerminalBlurIntensityBinding,
-                        in: Double(QuickTerminalAppearancePreferences.blurIntensityRange.lowerBound)
-                            ... Double(QuickTerminalAppearancePreferences.blurIntensityRange.upperBound),
-                        step: 1
-                    )
-                    .frame(width: 220)
-                    .accessibilityLabel("Background vibrancy")
-                    Text("\(displayedQuickTerminalBlurIntensity)%")
-                        .font(.system(size: SettingsMetrics.footnoteFontSize).monospacedDigit())
-                        .foregroundStyle(SettingsStyle.mutedForeground)
-                        .frame(width: 34, alignment: .trailing)
-                    Button("Reset") {
-                        quickTerminalTransparency = QuickTerminalAppearancePreferences.defaultTransparency
-                        quickTerminalBlurIntensity = QuickTerminalAppearancePreferences.defaultBlurIntensity
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
-
-                if let errorMessage = quickTerminalShortcutError ?? quickTerminalShortcutService.errorMessage {
-                    Text(errorMessage)
-                        .font(.system(size: 10))
-                        .foregroundStyle(SettingsStyle.warning)
-                }
-            }
-            .padding(.horizontal, SettingsMetrics.horizontalPadding)
-            .padding(.vertical, SettingsMetrics.rowVerticalPadding)
-        }
-        .environment(\.settingsSearchQuery, "")
-    }
-
-    private var customShortcutTitle: String {
-        guard case .keyCombo = quickTerminalShortcutService.shortcut else { return "Record Custom…" }
-        return quickTerminalShortcutService.shortcut.displayString
-    }
-
-    private var isDoubleShiftShortcutSelected: Bool {
-        quickTerminalShortcutService.shortcut == .doubleShift
-    }
-
-    private var isCustomShortcutSelected: Bool {
-        guard case .keyCombo = quickTerminalShortcutService.shortcut else { return false }
-        return true
-    }
-
-    private var quickTerminalTransparencyBinding: Binding<Double> {
-        Binding(
-            get: { Double(displayedQuickTerminalTransparency) },
-            set: { quickTerminalTransparency = Int($0.rounded()) }
-        )
-    }
-
-    private var displayedQuickTerminalTransparency: Int {
-        min(
-            max(quickTerminalTransparency, QuickTerminalAppearancePreferences.transparencyRange.lowerBound),
-            QuickTerminalAppearancePreferences.transparencyRange.upperBound
-        )
-    }
-
-    private var quickTerminalBlurIntensityBinding: Binding<Double> {
-        Binding(
-            get: { Double(displayedQuickTerminalBlurIntensity) },
-            set: { quickTerminalBlurIntensity = Int($0.rounded()) }
-        )
-    }
-
-    private var displayedQuickTerminalBlurIntensity: Int {
-        min(
-            max(quickTerminalBlurIntensity, QuickTerminalAppearancePreferences.blurIntensityRange.lowerBound),
-            QuickTerminalAppearancePreferences.blurIntensityRange.upperBound
-        )
-    }
-
-    private var quickTerminalStatusText: String {
-        switch quickTerminalShortcutService.monitoringState {
-        case .systemWide,
-             .carbonHotKey:
-            "Active system-wide"
-        case .localOnly:
-            "Active while Muxy is focused"
-        case .stopped:
-            "Inactive"
-        }
-    }
-
-    private var quickTerminalStatusColor: Color {
-        switch quickTerminalShortcutService.monitoringState {
-        case .systemWide,
-             .carbonHotKey:
-            SettingsStyle.accent
-        case .localOnly,
-             .stopped:
-            SettingsStyle.warning
-        }
-    }
-
-    private func recordQuickTerminalShortcut(_ combo: KeyCombo, virtualKeyCode: UInt16) -> Bool {
-        updateQuickTerminalShortcut(.keyCombo(combo, virtualKeyCode: virtualKeyCode))
-    }
-
-    private func updateQuickTerminalShortcut(_ shortcut: QuickTerminalShortcut) -> Bool {
-        if case let .keyCombo(combo, _) = shortcut,
-           let conflict = QuickTerminalShortcutConflictResolver.conflictMessage(for: combo)
-        {
-            quickTerminalShortcutError = conflict
-            return false
-        }
-        do {
-            try quickTerminalShortcutService.updateShortcut(shortcut)
-            quickTerminalShortcutError = nil
-            isRecordingQuickTerminalShortcut = false
-            return true
-        } catch {
-            quickTerminalShortcutError = error.localizedDescription
-            return false
-        }
-    }
-
     private func extensionSection(group: ExtensionShortcutGroup, isLast: Bool) -> some View {
         SettingsSection(group.extensionName, showsDivider: !isLast) {
             ForEach(group.entries) { entry in
@@ -345,7 +82,6 @@ struct KeyboardShortcutsSettingsView: View {
                     conflictMessage: extensionConflictWarning?.id == entry.id ? extensionConflictWarning?.message : nil,
                     onStartRecording: {
                         recordingAction = nil
-                        isRecordingQuickTerminalShortcut = false
                         recordingExtensionShortcutID = entry.id
                         extensionConflictWarning = nil
                     },
@@ -417,7 +153,6 @@ struct KeyboardShortcutsSettingsView: View {
                         : nil,
                     onStartRecording: {
                         recordingExtensionShortcutID = nil
-                        isRecordingQuickTerminalShortcut = false
                         recordingAction = action
                         conflictWarning = nil
                     },
@@ -468,65 +203,6 @@ struct KeyboardShortcutsSettingsView: View {
         }
         store.resetBinding(action: action)
         conflictWarning = nil
-    }
-}
-
-private struct QuickTerminalDimensionField: View {
-    let label: String
-    @Binding var value: Int
-    let range: ClosedRange<Int>
-    @State private var input = QuickTerminalDimensionInput()
-    @FocusState private var isFocused: Bool
-
-    var body: some View {
-        HStack(spacing: 4) {
-            TextField("", text: $input.text)
-                .textFieldStyle(.plain)
-                .font(.system(size: SettingsMetrics.labelFontSize).monospacedDigit())
-                .multilineTextAlignment(.trailing)
-                .frame(width: 48)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 4)
-                .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
-                .focused($isFocused)
-                .onSubmit(commit)
-                .accessibilityLabel(label)
-            Text("pt")
-                .font(.system(size: SettingsMetrics.footnoteFontSize))
-                .foregroundStyle(SettingsStyle.mutedForeground)
-        }
-        .onAppear {
-            input.synchronize(with: value)
-        }
-        .onChange(of: isFocused) { wasFocused, focused in
-            guard wasFocused, !focused else { return }
-            commit()
-        }
-        .onChange(of: value) { _, newValue in
-            input.synchronize(with: newValue)
-        }
-    }
-
-    private func commit() {
-        value = input.commit(currentValue: value, range: range)
-    }
-}
-
-struct QuickTerminalDimensionInput: Equatable {
-    var text = ""
-
-    mutating func synchronize(with value: Int) {
-        text = String(value)
-    }
-
-    mutating func commit(currentValue: Int, range: ClosedRange<Int>) -> Int {
-        guard let parsed = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-            synchronize(with: currentValue)
-            return currentValue
-        }
-        let value = min(max(parsed, range.lowerBound), range.upperBound)
-        synchronize(with: value)
-        return value
     }
 }
 

--- a/Muxy/Views/Settings/QuickTerminalSettingsView.swift
+++ b/Muxy/Views/Settings/QuickTerminalSettingsView.swift
@@ -1,0 +1,341 @@
+import SwiftUI
+
+struct QuickTerminalSettingsView: View {
+    @State private var isRecordingShortcut = false
+    @State private var shortcutError: String?
+    @AppStorage(QuickTerminalSizePreferences.widthKey)
+    private var width = QuickTerminalSizePreferences.defaultWidth
+    @AppStorage(QuickTerminalSizePreferences.heightKey)
+    private var height = QuickTerminalSizePreferences.defaultHeight
+    @AppStorage(QuickTerminalAppearancePreferences.transparencyKey)
+    private var transparency = QuickTerminalAppearancePreferences.defaultTransparency
+    @AppStorage(QuickTerminalAppearancePreferences.blurIntensityKey)
+    private var blurIntensity = QuickTerminalAppearancePreferences.defaultBlurIntensity
+
+    private var shortcutService: QuickTerminalShortcutService { QuickTerminalShortcutService.shared }
+
+    var body: some View {
+        SettingsContainer {
+            SettingsSection("Shortcut") {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Open Quick Terminal")
+                                .font(.system(size: SettingsMetrics.labelFontSize))
+                            Text(statusText)
+                                .font(.system(size: SettingsMetrics.footnoteFontSize))
+                                .foregroundStyle(statusColor)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Button {
+                            _ = updateShortcut(.unassigned)
+                        } label: {
+                            Label(
+                                "No Shortcut",
+                                systemImage: shortcutService.shortcut == .unassigned
+                                    ? "checkmark.circle.fill"
+                                    : "circle"
+                            )
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .accessibilityAddTraits(isNoShortcutSelected ? .isSelected : [])
+                        .accessibilityValue(isNoShortcutSelected ? "Selected" : "Not selected")
+
+                        Button {
+                            _ = updateShortcut(.doubleShift)
+                        } label: {
+                            Label(
+                                "Double Shift",
+                                systemImage: shortcutService.shortcut == .doubleShift
+                                    ? "checkmark.circle.fill"
+                                    : "circle"
+                            )
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .accessibilityAddTraits(isDoubleShiftSelected ? .isSelected : [])
+                        .accessibilityValue(isDoubleShiftSelected ? "Selected" : "Not selected")
+
+                        ZStack {
+                            if isRecordingShortcut {
+                                ShortcutRecorderView(
+                                    onRecord: { _ in false },
+                                    onCancel: { isRecordingShortcut = false },
+                                    onRecordWithKeyCode: recordShortcut
+                                )
+                                .frame(width: 0, height: 0)
+                                .opacity(0)
+                            }
+                            Button(isRecordingShortcut ? "Press shortcut…" : customShortcutTitle) {
+                                isRecordingShortcut = true
+                                shortcutError = nil
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .accessibilityAddTraits(isCustomShortcutSelected ? .isSelected : [])
+                            .accessibilityValue(isCustomShortcutSelected ? "Selected" : "Not selected")
+                        }
+                    }
+
+                    if shortcutService.needsInputMonitoringAccess {
+                        HStack(spacing: 8) {
+                            Text("Double Shift needs Input Monitoring outside Muxy.")
+                                .font(.system(size: SettingsMetrics.footnoteFontSize))
+                                .foregroundStyle(SettingsStyle.mutedForeground)
+                            Spacer()
+                            Button("Enable Input Monitoring") {
+                                _ = shortcutService.requestInputMonitoringAccess()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                        }
+                    }
+
+                    if let errorMessage = shortcutError ?? shortcutService.errorMessage {
+                        Text(errorMessage)
+                            .font(.system(size: 10))
+                            .foregroundStyle(SettingsStyle.warning)
+                    }
+                }
+                .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+            }
+
+            SettingsSection("Size") {
+                HStack(spacing: 8) {
+                    Text("Terminal size")
+                        .font(.system(size: SettingsMetrics.labelFontSize))
+                    Spacer()
+                    Text("Width")
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                    QuickTerminalDimensionField(
+                        label: "Width",
+                        value: $width,
+                        range: QuickTerminalSizePreferences.widthRange
+                    )
+                    Text("×")
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                    Text("Height")
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(SettingsStyle.mutedForeground)
+                    QuickTerminalDimensionField(
+                        label: "Height",
+                        value: $height,
+                        range: QuickTerminalSizePreferences.heightRange
+                    )
+                    Button("Reset") {
+                        width = QuickTerminalSizePreferences.defaultWidth
+                        height = QuickTerminalSizePreferences.defaultHeight
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+            }
+
+            SettingsSection("Appearance", showsDivider: false) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        Text("Terminal transparency")
+                            .font(.system(size: SettingsMetrics.labelFontSize))
+                        Spacer()
+                        Slider(
+                            value: transparencyBinding,
+                            in: Double(QuickTerminalAppearancePreferences.transparencyRange.lowerBound)
+                                ... Double(QuickTerminalAppearancePreferences.transparencyRange.upperBound),
+                            step: 1
+                        )
+                        .frame(width: 220)
+                        .accessibilityLabel("Terminal transparency")
+                        Text("\(displayedTransparency)%")
+                            .font(.system(size: SettingsMetrics.footnoteFontSize).monospacedDigit())
+                            .foregroundStyle(SettingsStyle.mutedForeground)
+                            .frame(width: 34, alignment: .trailing)
+                    }
+
+                    HStack(spacing: 8) {
+                        Text("Background vibrancy")
+                            .font(.system(size: SettingsMetrics.labelFontSize))
+                        Spacer()
+                        Slider(
+                            value: blurIntensityBinding,
+                            in: Double(QuickTerminalAppearancePreferences.blurIntensityRange.lowerBound)
+                                ... Double(QuickTerminalAppearancePreferences.blurIntensityRange.upperBound),
+                            step: 1
+                        )
+                        .frame(width: 220)
+                        .accessibilityLabel("Background vibrancy")
+                        Text("\(displayedBlurIntensity)%")
+                            .font(.system(size: SettingsMetrics.footnoteFontSize).monospacedDigit())
+                            .foregroundStyle(SettingsStyle.mutedForeground)
+                            .frame(width: 34, alignment: .trailing)
+                        Button("Reset") {
+                            transparency = QuickTerminalAppearancePreferences.defaultTransparency
+                            blurIntensity = QuickTerminalAppearancePreferences.defaultBlurIntensity
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+                .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+            }
+        }
+    }
+
+    private var customShortcutTitle: String {
+        guard case .keyCombo = shortcutService.shortcut else { return "Record Custom…" }
+        return shortcutService.shortcut.displayString
+    }
+
+    private var isDoubleShiftSelected: Bool {
+        shortcutService.shortcut == .doubleShift
+    }
+
+    private var isNoShortcutSelected: Bool {
+        shortcutService.shortcut == .unassigned
+    }
+
+    private var isCustomShortcutSelected: Bool {
+        guard case .keyCombo = shortcutService.shortcut else { return false }
+        return true
+    }
+
+    private var transparencyBinding: Binding<Double> {
+        Binding(
+            get: { Double(displayedTransparency) },
+            set: { transparency = Int($0.rounded()) }
+        )
+    }
+
+    private var displayedTransparency: Int {
+        min(
+            max(transparency, QuickTerminalAppearancePreferences.transparencyRange.lowerBound),
+            QuickTerminalAppearancePreferences.transparencyRange.upperBound
+        )
+    }
+
+    private var blurIntensityBinding: Binding<Double> {
+        Binding(
+            get: { Double(displayedBlurIntensity) },
+            set: { blurIntensity = Int($0.rounded()) }
+        )
+    }
+
+    private var displayedBlurIntensity: Int {
+        min(
+            max(blurIntensity, QuickTerminalAppearancePreferences.blurIntensityRange.lowerBound),
+            QuickTerminalAppearancePreferences.blurIntensityRange.upperBound
+        )
+    }
+
+    private var statusText: String {
+        guard shortcutService.shortcut != .unassigned else { return "No shortcut assigned" }
+        return switch shortcutService.monitoringState {
+        case .systemWide,
+             .carbonHotKey:
+            "Active system-wide"
+        case .localOnly:
+            "Active while Muxy is focused"
+        case .stopped:
+            "Inactive"
+        }
+    }
+
+    private var statusColor: Color {
+        guard shortcutService.shortcut != .unassigned else { return SettingsStyle.mutedForeground }
+        return switch shortcutService.monitoringState {
+        case .systemWide,
+             .carbonHotKey:
+            SettingsStyle.accent
+        case .localOnly,
+             .stopped:
+            SettingsStyle.warning
+        }
+    }
+
+    private func recordShortcut(_ combo: KeyCombo, virtualKeyCode: UInt16) -> Bool {
+        updateShortcut(.keyCombo(combo, virtualKeyCode: virtualKeyCode))
+    }
+
+    private func updateShortcut(_ shortcut: QuickTerminalShortcut) -> Bool {
+        if case let .keyCombo(combo, _) = shortcut,
+           let conflict = QuickTerminalShortcutConflictResolver.conflictMessage(for: combo)
+        {
+            shortcutError = conflict
+            return false
+        }
+        do {
+            try shortcutService.updateShortcut(shortcut)
+            shortcutError = nil
+            isRecordingShortcut = false
+            return true
+        } catch {
+            shortcutError = error.localizedDescription
+            return false
+        }
+    }
+}
+
+private struct QuickTerminalDimensionField: View {
+    let label: String
+    @Binding var value: Int
+    let range: ClosedRange<Int>
+    @State private var input = QuickTerminalDimensionInput()
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            TextField("", text: $input.text)
+                .textFieldStyle(.plain)
+                .font(.system(size: SettingsMetrics.labelFontSize).monospacedDigit())
+                .multilineTextAlignment(.trailing)
+                .frame(width: 48)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 5))
+                .focused($isFocused)
+                .onSubmit(commit)
+                .accessibilityLabel(label)
+            Text("pt")
+                .font(.system(size: SettingsMetrics.footnoteFontSize))
+                .foregroundStyle(SettingsStyle.mutedForeground)
+        }
+        .onAppear {
+            input.synchronize(with: value)
+        }
+        .onChange(of: isFocused) { wasFocused, focused in
+            guard wasFocused, !focused else { return }
+            commit()
+        }
+        .onChange(of: value) { _, newValue in
+            input.synchronize(with: newValue)
+        }
+    }
+
+    private func commit() {
+        value = input.commit(currentValue: value, range: range)
+    }
+}
+
+struct QuickTerminalDimensionInput: Equatable {
+    var text = ""
+
+    mutating func synchronize(with value: Int) {
+        text = String(value)
+    }
+
+    mutating func commit(currentValue: Int, range: ClosedRange<Int>) -> Int {
+        guard let parsed = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            synchronize(with: currentValue)
+            return currentValue
+        }
+        let value = min(max(parsed, range.lowerBound), range.upperBound)
+        synchronize(with: value)
+        return value
+    }
+}

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -58,8 +58,8 @@ struct SettingsView: View {
         .onAppear {
             selectedRoute = validatedRoute(selectedRoute)
             if SettingsFocusCoordinator.shared.consume(.quickTerminalShortcut) {
-                searchText = "Quick Terminal"
-                selectedRoute = .builtin(.shortcuts)
+                searchText = ""
+                selectedRoute = .builtin(.quickTerminal)
             }
         }
         .onChange(of: searchText) { _, _ in
@@ -83,8 +83,8 @@ struct SettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .focusQuickTerminalShortcut)) { _ in
             _ = SettingsFocusCoordinator.shared.consume(.quickTerminalShortcut)
-            searchText = "Quick Terminal"
-            selectedRoute = .builtin(.shortcuts)
+            searchText = ""
+            selectedRoute = .builtin(.quickTerminal)
         }
     }
 
@@ -142,6 +142,8 @@ struct SettingsView: View {
             InterfaceSettingsView()
         case .terminal:
             TerminalSettingsView()
+        case .quickTerminal:
+            QuickTerminalSettingsView()
         case .browser:
             BrowserSettingsView()
         case .richInput:

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -7,6 +7,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case remoteDevices
     case appearance
     case terminal
+    case quickTerminal
     case browser
     case richInput
     case shortcuts
@@ -27,6 +28,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .remoteDevices: "Remote Devices"
         case .appearance: "Interface"
         case .terminal: "Terminal"
+        case .quickTerminal: "Quick Terminal"
         case .browser: "Browser"
         case .richInput: "Rich Input"
         case .shortcuts: "Shortcuts"
@@ -47,6 +49,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .remoteDevices: "server.rack"
         case .appearance: "macwindow"
         case .terminal: "terminal"
+        case .quickTerminal: "bolt.horizontal.circle"
         case .browser: "globe"
         case .richInput: "text.cursor"
         case .shortcuts: "keyboard"
@@ -454,16 +457,16 @@ enum SettingsCatalog {
             key: "shortcuts.quickTerminal",
             title: "Quick Terminal",
             description: "Configures the system-wide shortcut for the quick terminal.",
-            category: .shortcuts,
-            section: "Quick Terminal",
+            category: .quickTerminal,
+            section: "Shortcut",
             aliases: ["double shift", "quick terminal", "global shortcut", "hotkey"]
         ),
         SettingsCatalogItem(
             key: QuickTerminalSizePreferences.widthKey,
             title: "Quick Terminal Width",
             description: "Sets the width of the quick terminal in points.",
-            category: .shortcuts,
-            section: "Quick Terminal",
+            category: .quickTerminal,
+            section: "Size",
             defaultValue: QuickTerminalSizePreferences.defaultWidth,
             aliases: ["size", "panel", "window"]
         ),
@@ -471,8 +474,8 @@ enum SettingsCatalog {
             key: QuickTerminalSizePreferences.heightKey,
             title: "Quick Terminal Height",
             description: "Sets the height of the quick terminal in points.",
-            category: .shortcuts,
-            section: "Quick Terminal",
+            category: .quickTerminal,
+            section: "Size",
             defaultValue: QuickTerminalSizePreferences.defaultHeight,
             aliases: ["size", "panel", "window"]
         ),
@@ -480,8 +483,8 @@ enum SettingsCatalog {
             key: QuickTerminalAppearancePreferences.transparencyKey,
             title: "Quick Terminal Transparency",
             description: "Controls how much of the desktop shows through the terminal background.",
-            category: .shortcuts,
-            section: "Quick Terminal",
+            category: .quickTerminal,
+            section: "Appearance",
             defaultValue: QuickTerminalAppearancePreferences.defaultTransparency,
             aliases: ["opacity", "glass", "background", "appearance"]
         ),
@@ -489,8 +492,8 @@ enum SettingsCatalog {
             key: QuickTerminalAppearancePreferences.blurIntensityKey,
             title: "Quick Terminal Vibrancy",
             description: "Controls the native macOS material intensity behind the terminal.",
-            category: .shortcuts,
-            section: "Quick Terminal",
+            category: .quickTerminal,
+            section: "Appearance",
             defaultValue: QuickTerminalAppearancePreferences.defaultBlurIntensity,
             aliases: ["blur", "glass", "frost", "background", "appearance"]
         ),

--- a/Tests/MuxyTests/Models/Keyboard/QuickTerminalShortcutTests.swift
+++ b/Tests/MuxyTests/Models/Keyboard/QuickTerminalShortcutTests.swift
@@ -6,10 +6,11 @@ import Testing
 @Suite("QuickTerminalShortcut")
 @MainActor
 struct QuickTerminalShortcutTests {
-    @Test("default is double Shift")
+    @Test("default is unassigned")
     func defaultShortcut() {
-        #expect(QuickTerminalShortcut.default == .doubleShift)
-        #expect(QuickTerminalShortcut.default.displayString == "Double Shift")
+        #expect(QuickTerminalShortcut.default == .unassigned)
+        #expect(QuickTerminalShortcut.default.displayString == "Unassigned")
+        #expect(QuickTerminalShortcut.default.controlLabel == "Set Shortcut")
         #expect(QuickTerminalShortcut.default.isValid)
     }
 
@@ -38,6 +39,7 @@ struct QuickTerminalShortcutTests {
     }
 
     @Test("Codable round-trip preserves both shortcut kinds", arguments: [
+        QuickTerminalShortcut.unassigned,
         QuickTerminalShortcut.doubleShift,
         QuickTerminalShortcut.keyCombo(KeyCombo(key: "space", control: true), virtualKeyCode: 49),
     ])

--- a/Tests/MuxyTests/Services/Keyboard/QuickTerminalShortcutServiceTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/QuickTerminalShortcutServiceTests.swift
@@ -9,7 +9,7 @@ import Testing
 struct QuickTerminalShortcutServiceTests {
     @Test("starts the stored backend and delivers triggers")
     func startAndTrigger() throws {
-        let persistence = ServiceShortcutPersistence()
+        let persistence = ServiceShortcutPersistence(shortcut: .doubleShift)
         let store = makeStore(persistence: persistence)
         let backend = TestShortcutBackend(state: .localOnly)
         let service = makeService(store: store, doubleShiftBackend: backend)
@@ -27,7 +27,7 @@ struct QuickTerminalShortcutServiceTests {
     @Test("replacement starts before the previous registration stops")
     func replacementOrdering() throws {
         let recorder = ShortcutBackendRecorder()
-        let store = makeStore(persistence: ServiceShortcutPersistence())
+        let store = makeStore(persistence: ServiceShortcutPersistence(shortcut: .doubleShift))
         let previous = TestShortcutBackend(name: "previous", state: .localOnly, recorder: recorder)
         let replacement = TestShortcutBackend(name: "replacement", state: .carbonHotKey, recorder: recorder)
         let service = makeService(
@@ -47,7 +47,7 @@ struct QuickTerminalShortcutServiceTests {
     @Test("failed replacement keeps the previous registration working")
     func failedReplacementKeepsPrevious() throws {
         let recorder = ShortcutBackendRecorder()
-        let persistence = ServiceShortcutPersistence()
+        let persistence = ServiceShortcutPersistence(shortcut: .doubleShift)
         let store = makeStore(persistence: persistence)
         let previous = TestShortcutBackend(name: "previous", state: .localOnly, recorder: recorder)
         let replacement = TestShortcutBackend(
@@ -77,7 +77,7 @@ struct QuickTerminalShortcutServiceTests {
 
     @Test("persistence failure stops the replacement and keeps the previous registration")
     func persistenceFailureKeepsPrevious() throws {
-        let persistence = ServiceShortcutPersistence()
+        let persistence = ServiceShortcutPersistence(shortcut: .doubleShift)
         let store = makeStore(persistence: persistence)
         let previous = TestShortcutBackend(state: .localOnly)
         let replacement = TestShortcutBackend(state: .carbonHotKey)
@@ -160,7 +160,7 @@ struct QuickTerminalShortcutServiceTests {
 
     @Test("explicit permission request upgrades double Shift monitoring")
     func explicitPermissionRequestUpgradesMonitoring() throws {
-        let store = makeStore(persistence: ServiceShortcutPersistence())
+        let store = makeStore(persistence: ServiceShortcutPersistence(shortcut: .doubleShift))
         let backend = TestShortcutBackend(state: .localOnly, enabledState: .systemWide)
         var requestCount = 0
         let service = makeService(
@@ -183,7 +183,7 @@ struct QuickTerminalShortcutServiceTests {
 
     @Test("permission refresh never requests access")
     func permissionRefreshDoesNotRequestAccess() throws {
-        let store = makeStore(persistence: ServiceShortcutPersistence())
+        let store = makeStore(persistence: ServiceShortcutPersistence(shortcut: .doubleShift))
         let backend = TestShortcutBackend(state: .localOnly, enabledState: .systemWide)
         var requestCount = 0
         let service = makeService(
@@ -283,7 +283,7 @@ struct QuickTerminalShortcutServiceTests {
 
     @Test("service deinitialization stops its active backend")
     func serviceDeinitializationStopsBackend() throws {
-        let store = makeStore(persistence: ServiceShortcutPersistence())
+        let store = makeStore(persistence: ServiceShortcutPersistence(shortcut: .doubleShift))
         let backend = TestShortcutBackend(state: .localOnly)
         var service: QuickTerminalShortcutService? = makeService(
             store: store,
@@ -294,6 +294,76 @@ struct QuickTerminalShortcutServiceTests {
         service = nil
 
         #expect(backend.stopCount == 1)
+    }
+
+    @Test("unassigned shortcut starts without installing a backend")
+    func unassignedStartsWithoutBackend() throws {
+        let store = makeStore(persistence: ServiceShortcutPersistence())
+        let doubleShift = TestShortcutBackend(state: .localOnly)
+        let carbon = TestShortcutBackend(state: .carbonHotKey)
+        let service = makeService(
+            store: store,
+            doubleShiftBackend: doubleShift,
+            carbonHotKeyBackend: carbon
+        )
+
+        try service.start()
+
+        #expect(service.shortcut == .unassigned)
+        #expect(service.monitoringState == .stopped)
+        #expect(doubleShift.startCount == 0)
+        #expect(carbon.startCount == 0)
+    }
+
+    @Test("assigning a shortcut starts monitoring from an unassigned state")
+    func assignFromUnassignedStartsBackend() throws {
+        let persistence = ServiceShortcutPersistence()
+        let store = makeStore(persistence: persistence)
+        let backend = TestShortcutBackend(state: .localOnly)
+        let service = makeService(store: store, doubleShiftBackend: backend)
+        try service.start()
+
+        try service.updateShortcut(.doubleShift)
+
+        #expect(service.shortcut == .doubleShift)
+        #expect(service.monitoringState == .localOnly)
+        #expect(backend.startCount == 1)
+        #expect(persistence.shortcut == .doubleShift)
+    }
+
+    @Test("unassigning persists before stopping the active backend")
+    func unassignStopsActiveBackend() throws {
+        let recorder = ShortcutBackendRecorder()
+        let persistence = ServiceShortcutPersistence(shortcut: .doubleShift)
+        let store = makeStore(persistence: persistence)
+        let backend = TestShortcutBackend(name: "double shift", state: .localOnly, recorder: recorder)
+        let service = makeService(store: store, doubleShiftBackend: backend)
+        try service.start()
+
+        try service.updateShortcut(.unassigned)
+
+        #expect(service.shortcut == .unassigned)
+        #expect(service.monitoringState == .stopped)
+        #expect(persistence.shortcut == .unassigned)
+        #expect(recorder.events == ["start double shift", "stop double shift"])
+    }
+
+    @Test("failed unassignment persistence keeps the active backend")
+    func failedUnassignmentKeepsActiveBackend() throws {
+        let persistence = ServiceShortcutPersistence(shortcut: .doubleShift)
+        let store = makeStore(persistence: persistence)
+        let backend = TestShortcutBackend(state: .localOnly)
+        let service = makeService(store: store, doubleShiftBackend: backend)
+        try service.start()
+        persistence.saveError = .persistenceFailed
+
+        #expect(throws: ShortcutBackendTestError.persistenceFailed) {
+            try service.updateShortcut(.unassigned)
+        }
+
+        #expect(service.shortcut == .doubleShift)
+        #expect(service.monitoringState == .localOnly)
+        #expect(backend.stopCount == 0)
     }
 
     private func makeStore(persistence: ServiceShortcutPersistence) -> QuickTerminalShortcutStore {

--- a/Tests/MuxyTests/Services/Keyboard/QuickTerminalShortcutStoreTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/QuickTerminalShortcutStoreTests.swift
@@ -26,13 +26,13 @@ struct QuickTerminalShortcutStoreTests {
         #expect(persistence.savedShortcuts == [expected])
     }
 
-    @Test("invalid persisted shortcut falls back to double Shift")
+    @Test("invalid persisted shortcut falls back to unassigned")
     func invalidPersistedShortcutFallsBack() {
         let shortcut = QuickTerminalShortcut.keyCombo(KeyCombo(key: "space", modifiers: 0), virtualKeyCode: 49)
         let persistence = InMemoryQuickTerminalShortcutPersistence(shortcut: shortcut)
         let store = makeStore(persistence: persistence)
 
-        #expect(store.shortcut == .doubleShift)
+        #expect(store.shortcut == .unassigned)
     }
 
     @Test("update persists and runs the change handler")
@@ -55,6 +55,18 @@ struct QuickTerminalShortcutStoreTests {
         #expect(syncCount == 1)
     }
 
+    @Test("reset removes the assigned shortcut")
+    func resetRemovesAssignedShortcut() throws {
+        let shortcut = QuickTerminalShortcut.keyCombo(KeyCombo(key: "space", command: true), virtualKeyCode: 49)
+        let persistence = InMemoryQuickTerminalShortcutPersistence(shortcut: shortcut)
+        let store = makeStore(persistence: persistence)
+
+        try store.resetToDefault()
+
+        #expect(store.shortcut == .unassigned)
+        #expect(persistence.savedShortcuts == [.unassigned])
+    }
+
     @Test("failed change never persists the rejected shortcut")
     func failedChangeNeverPersists() {
         let persistence = InMemoryQuickTerminalShortcutPersistence()
@@ -65,7 +77,7 @@ struct QuickTerminalShortcutStoreTests {
         #expect(throws: QuickTerminalShortcutTestError.registrationFailed) {
             try store.updateShortcut(replacement)
         }
-        #expect(store.shortcut == .doubleShift)
+        #expect(store.shortcut == .unassigned)
         #expect(persistence.savedShortcuts.isEmpty)
     }
 
@@ -92,7 +104,7 @@ struct QuickTerminalShortcutStoreTests {
                 virtualKeyCode: 49
             ))
         }
-        #expect(store.shortcut == .doubleShift)
+        #expect(store.shortcut == .unassigned)
     }
 
     private func makeStore(

--- a/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
@@ -668,7 +668,8 @@ struct SettingsJSONStoreTests {
             #expect(object.keys.contains(item.key))
         }
         #expect(object.keys.contains("shortcuts.app"))
-        #expect(object.keys.contains("shortcuts.quickTerminal"))
+        let quickTerminalShortcut = try #require(object["shortcuts.quickTerminal"] as? [String: Any])
+        #expect(quickTerminalShortcut["type"] as? String == "unassigned")
         #expect(object.keys.contains("shortcuts.customCommands"))
         #expect(object.keys.contains("ai.providers"))
         #expect(object.keys.contains("mobile.approvedDevices"))

--- a/Tests/MuxyTests/Services/UIHosts/SettingsFocusCoordinatorTests.swift
+++ b/Tests/MuxyTests/Services/UIHosts/SettingsFocusCoordinatorTests.swift
@@ -27,8 +27,8 @@ struct SettingsFocusCoordinatorTests {
         #expect(!coordinator.consume(.projectPickerDefaultLocation))
     }
 
-    @Test("quick terminal requests route to shortcut settings")
-    func quickTerminalRequestRoutesToShortcutSettings() {
+    @Test("quick terminal requests route to Quick Terminal settings")
+    func quickTerminalRequestRoutesToQuickTerminalSettings() {
         let notificationCenter = NotificationCenter()
         let coordinator = SettingsFocusCoordinator(notificationCenter: notificationCenter)
         let flag = SettingsFocusNotificationFlag()

--- a/Tests/MuxyTests/Views/QuickTerminal/QuickTerminalContentViewTests.swift
+++ b/Tests/MuxyTests/Views/QuickTerminal/QuickTerminalContentViewTests.swift
@@ -131,6 +131,42 @@ struct QuickTerminalContentViewTests {
         #expect(settingsPopover.isHidden)
     }
 
+    @Test("unassigned shortcut is presented and selectable")
+    func unassignedShortcutPresentation() throws {
+        let contentView = QuickTerminalContentView(frame: NSRect(x: 0, y: 0, width: 720, height: 420))
+        var selectedShortcut: QuickTerminalShortcut?
+        contentView.shortcutSettingsProvider = {
+            QuickTerminalShortcutSettingsSnapshot(
+                shortcut: .unassigned,
+                monitoringState: .stopped,
+                errorMessage: nil
+            )
+        }
+        contentView.onShortcutChange = {
+            selectedShortcut = $0
+            return nil
+        }
+        contentView.layout()
+
+        let shortcutButton = try #require(button("quickTerminalShortcutButton", in: contentView))
+        shortcutButton.performClick(nil)
+        contentView.layout()
+
+        let shortcutPopover = try #require(popover("quickTerminalShortcutPopover", in: contentView))
+        let noShortcutButton = try #require(button("quickTerminalNoShortcutButton", in: contentView))
+        let status = try #require(descendant("quickTerminalShortcutStatus", in: contentView) as? NSTextField)
+
+        #expect(shortcutButton.title == "Set Shortcut")
+        #expect(!shortcutPopover.isHidden)
+        #expect(shortcutPopover.frame.height == 174)
+        #expect(noShortcutButton.state == .on)
+        #expect(status.stringValue == "No keyboard shortcut assigned.")
+
+        noShortcutButton.performClick(nil)
+
+        #expect(selectedShortcut == .unassigned)
+    }
+
     @Test("reset restores default appearance and size through the callbacks")
     func resetAppliesDefaults() {
         let contentView = QuickTerminalContentView(frame: NSRect(x: 0, y: 0, width: 720, height: 420))
@@ -149,6 +185,17 @@ struct QuickTerminalContentViewTests {
 
     private func popover(_ identifier: String, in view: NSView) -> NSView? {
         view.subviews.first { $0.accessibilityIdentifier() == identifier }
+    }
+
+    private func button(_ identifier: String, in view: NSView) -> NSButton? {
+        descendant(identifier, in: view) as? NSButton
+    }
+
+    private func descendant(_ identifier: String, in view: NSView) -> NSView? {
+        if view.accessibilityIdentifier() == identifier {
+            return view
+        }
+        return view.subviews.lazy.compactMap { descendant(identifier, in: $0) }.first
     }
 
     private func colorsMatch(_ lhs: NSColor, _ rhs: NSColor) -> Bool {

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -27,15 +27,16 @@ struct SettingsCatalogTests {
             $0.key == "shortcuts.quickTerminal"
         }
 
-        #expect(item?.category == .shortcuts)
-        #expect(item?.section == "Quick Terminal")
+        #expect(item?.category == .quickTerminal)
+        #expect(item?.section == "Shortcut")
         #expect(!SettingsCatalog.jsonEditableItems.contains { $0.key == "shortcuts.quickTerminal" })
     }
 
     @Test
     func quickTerminalAppearanceAndSizeAreSearchableAndJSONEditable() {
-        let quickTerminalItems = SettingsCatalog.items.filter { $0.section == "Quick Terminal" }
+        let quickTerminalItems = SettingsCatalog.items.filter { $0.category == .quickTerminal }
 
+        #expect(quickTerminalItems.allSatisfy { $0.category == .quickTerminal })
         #expect(quickTerminalItems.contains { $0.key == QuickTerminalSizePreferences.widthKey })
         #expect(quickTerminalItems.contains { $0.key == QuickTerminalSizePreferences.heightKey })
         #expect(quickTerminalItems.contains { $0.key == QuickTerminalAppearancePreferences.transparencyKey })
@@ -55,6 +56,8 @@ struct SettingsCatalogTests {
         #expect(SettingsCatalog.matchingItems(query: "vibrancy").contains {
             $0.key == QuickTerminalAppearancePreferences.blurIntensityKey
         })
+        #expect(SettingsCatalog.sectionMatches(query: "terminal size", category: .quickTerminal, section: "Size"))
+        #expect(SettingsCatalog.sectionMatches(query: "vibrancy", category: .quickTerminal, section: "Appearance"))
     }
 
     @Test
@@ -158,6 +161,7 @@ struct SettingsCatalogTests {
     @Test
     func settingsRoutesRoundTripStoredIDs() throws {
         #expect(SettingsRoute(storedID: "builtin.terminal") == .builtin(.terminal))
+        #expect(SettingsRoute(storedID: "builtin.quickTerminal") == .builtin(.quickTerminal))
         #expect(SettingsRoute(storedID: "ext.com.example.tool") == .ext("com.example.tool"))
         #expect(SettingsRoute(storedID: "builtin.missing") == nil)
         #expect(SettingsRoute(storedID: "ext.") == nil)

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -4,11 +4,11 @@ Muxy's terminals are powered by [libghostty](https://github.com/ghostty-org/ghos
 
 ## Quick terminal
 
-On a display with a camera cutout, hover the cutout for a moment and the terminal expands out of it like a dynamic island. Pressing Shift twice (or a recorded shortcut) opens it from anywhere. It always starts in your home directory and keeps the same shell, working directory, and history while hidden.
+On a display with a camera cutout, hover the cutout for a moment and the terminal expands out of it like a dynamic island. You can assign Double Shift or a conventional global shortcut to open it from anywhere. It always starts in your home directory and keeps the same shell, working directory, and history while hidden.
 
-Dismiss it with the same shortcut or the close button. Moving the pointer away, clicking another app, and pressing Escape no longer close it, so Escape reaches the terminal for `vim`, `less`, and other full-screen programs. On a display without a camera cutout there is no hover zone; the terminal opens only from the shortcut, at the same top-center position.
+Dismiss it with the assigned shortcut or the close button. Moving the pointer away, clicking another app, and pressing Escape no longer close it, so Escape reaches the terminal for `vim`, `less`, and other full-screen programs. On a display without a camera cutout there is no hover zone, so assign a shortcut to open the terminal at the same top-center position.
 
-System-wide double Shift requires **System Settings → Privacy & Security → Input Monitoring**. You can use **Settings → Shortcuts → Quick Terminal** to enable access or assign a conventional global shortcut that does not require Input Monitoring.
+Quick Terminal has no shortcut assigned by default. Open **Settings → Quick Terminal** to choose one. System-wide Double Shift requires **System Settings → Privacy & Security → Input Monitoring**; conventional global shortcuts do not.
 
 The same settings section controls the terminal width, height, transparency, and background vibrancy. These same controls are also available in-place from the gear button in the quick terminal, applied live to the open panel. Sizes are stored in points, constrained to 480–1200 wide and 280–800 high, and automatically reduced when the active display is smaller. Transparency ranges from 0–55%, and vibrancy uses a continuous 0–100% native material intensity.
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -21,9 +21,10 @@ global setting. Remote worktrees keep their remote workspace layout.
 
 ## Quick terminal
 
-On a display with a camera cutout, hovering the cutout briefly expands the terminal out of it like a dynamic island. Open **Shortcuts → Quick Terminal** to choose how it also opens from a shortcut:
+On a display with a camera cutout, hovering the cutout briefly expands the terminal out of it like a dynamic island. Open **Quick Terminal** in Settings to configure its shortcut, size, and appearance:
 
-- **Double Shift** is the default and requires macOS Input Monitoring for use outside Muxy.
+- No shortcut is assigned by default.
+- **Double Shift** requires macOS Input Monitoring for use outside Muxy.
 - **Option Space** or another recorded key combination is registered as a conventional global shortcut without Input Monitoring.
 - **Width** and **Height** set the panel size in points for the next opening. Smaller displays automatically reduce the configured size.
 - **Terminal transparency** controls how much of the desktop shows through the terminal workspace from 0–55%.
@@ -31,6 +32,6 @@ On a display with a camera cutout, hovering the cutout briefly expands the termi
 
 The vibrancy control mixes the system material continuously; it does not set a custom blur radius.
 
-The gear button in the quick terminal opens an in-place settings popover with the transparency, vibrancy, width, and height controls, so those can be adjusted without leaving the terminal. Transparency and vibrancy apply immediately; size applies when the slider is released. The shortcut is also available from the shortcut control in the quick terminal. It is stored as `shortcuts.quickTerminal` in `settings.json` using either `{"type":"doubleShift"}` or `{"type":"keyCombo","keyCombo":{"key":"space","modifiers":...},"virtualKeyCode":49}`. Panel dimensions are stored as `muxy.quickTerminal.width` and `muxy.quickTerminal.height`. Glass settings use `muxy.quickTerminal.transparency` as an integer percentage from 0–55 and `muxy.quickTerminal.blur` as an integer material intensity from 0–100.
+The gear button in the quick terminal opens an in-place settings popover with the transparency, vibrancy, width, and height controls, so those can be adjusted without leaving the terminal. Transparency and vibrancy apply immediately; size applies when the slider is released. The shortcut is also available from the shortcut control in the quick terminal. It is stored as `shortcuts.quickTerminal` in `settings.json` using `{"type":"unassigned"}`, `{"type":"doubleShift"}`, or `{"type":"keyCombo","keyCombo":{"key":"space","modifiers":...},"virtualKeyCode":49}`. Panel dimensions are stored as `muxy.quickTerminal.width` and `muxy.quickTerminal.height`. Glass settings use `muxy.quickTerminal.transparency` as an integer percentage from 0–55 and `muxy.quickTerminal.blur` as an integer material intensity from 0–100.
 
 When macOS Reduce Transparency or Increase Contrast is enabled, Muxy temporarily renders the quick terminal as opaque and unblurred without changing the saved glass settings.

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -24,7 +24,7 @@ log show --predicate 'subsystem == "app.muxy"' --last 10m --info --debug
 
 ## Double Shift doesn't open the quick terminal
 
-- Open **Settings → Shortcuts → Quick Terminal** and check the Input Monitoring status.
+- Open **Settings → Quick Terminal** and check the Input Monitoring status.
 - Enable Muxy under **System Settings → Privacy & Security → Input Monitoring**, then bring Muxy to the foreground so it can retry the listener.
 - If access remains unavailable, assign a conventional global shortcut such as Option Space. Conventional shortcuts do not require Input Monitoring.
 - Double Shift is intentionally ignored while another key or modifier is involved, which prevents normal capital-letter typing from opening the terminal.
@@ -37,7 +37,7 @@ log show --predicate 'subsystem == "app.muxy"' --last 10m --info --debug
 
 ## The quick terminal is not transparent or blurred
 
-- Open **Settings → Shortcuts → Quick Terminal** and set Terminal transparency above 0%.
+- Open **Settings → Quick Terminal** and set Terminal transparency above 0%.
 - Raise Background vibrancy above 0% for a progressively stronger native material effect. At 0%, the wallpaper remains sharp.
 - macOS Reduce Transparency and Increase Contrast intentionally force an opaque, unblurred terminal. Check both under **System Settings → Accessibility → Display**.
 


### PR DESCRIPTION
Move Quick Terminal configuration into its own settings page and make its global shortcut unassigned by default. Add no-shortcut handling across monitoring, controls, persistence, documentation, and tests.