### PR TITLE
Fix stale default branch resolution

### DIFF
--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -880,6 +880,16 @@ struct GitRepositoryService {
     }
 
     private func resolveDefaultBranch(repoPath: String) async -> String? {
+        let remoteHead = try? await runGit(
+            repoPath: repoPath,
+            arguments: ["ls-remote", "--symref", "origin", "HEAD"]
+        )
+        if let remoteHead, remoteHead.status == 0,
+           let branch = Self.defaultBranch(fromRemoteHEAD: remoteHead.stdout)
+        {
+            return branch
+        }
+
         let symbolic = try? await runGit(
             repoPath: repoPath,
             arguments: ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]
@@ -908,6 +918,20 @@ struct GitRepositoryService {
             }
         }
 
+        return nil
+    }
+
+    static func defaultBranch(fromRemoteHEAD output: String) -> String? {
+        let prefix = "refs/heads/"
+        for line in output.split(separator: "\n") {
+            let fields = line.split(whereSeparator: \.isWhitespace)
+            guard fields.count == 3,
+                  fields[0] == "ref:",
+                  fields[1].hasPrefix(prefix),
+                  fields[2] == "HEAD"
+            else { continue }
+            return String(fields[1].dropFirst(prefix.count))
+        }
         return nil
     }
 

--- a/Tests/MuxyTests/Git/GitRepositoryServiceNewAPIsTests.swift
+++ b/Tests/MuxyTests/Git/GitRepositoryServiceNewAPIsTests.swift
@@ -36,6 +36,25 @@ struct GitRepositoryServiceNewAPIsTests {
         #expect(resolved == "gh")
     }
 
+    @Test("uses the branch advertised by the remote HEAD")
+    func parsesRemoteDefaultBranch() {
+        let branch = GitRepositoryService.defaultBranch(fromRemoteHEAD: """
+        ref: refs/heads/develop\tHEAD
+        6afb7d6642b93be44dddd5b13d3eb39901142f18\tHEAD
+        """)
+
+        #expect(branch == "develop")
+    }
+
+    @Test("ignores a remote HEAD response without a symbolic branch")
+    func ignoresRemoteDefaultBranchWithoutSymbolicRef() {
+        let branch = GitRepositoryService.defaultBranch(
+            fromRemoteHEAD: "6afb7d6642b93be44dddd5b13d3eb39901142f18\tHEAD"
+        )
+
+        #expect(branch == nil)
+    }
+
     @Test("repoInfo reports root, gitDir and current branch for a normal repo")
     func repoInfoForNormalRepo() async throws {
         let repo = try TempGitRepo()


### PR DESCRIPTION
## Summary

- Resolve the default branch from the remote HEAD before consulting local metadata.
- Preserve local and GitHub CLI fallbacks when the remote is unavailable.
- Cover remote HEAD parsing with regression tests.

## Verification

- `scripts/checks.sh --fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git repository detection by identifying the default branch directly from the remote repository when available.
  * Preserved fallback behavior when remote branch information cannot be determined.

* **Tests**
  * Added coverage for successful default-branch detection and responses without symbolic branch information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->