### PR TITLE
Fix Chineese characters rendering on terminal

### DIFF
--- a/Muxy/Services/Terminal/GhosttyService.swift
+++ b/Muxy/Services/Terminal/GhosttyService.swift
@@ -148,6 +148,8 @@ final class GhosttyService {
 
     private func loadMuxyGhosttyConfig() -> ghostty_config_t? {
         guard let cfg = ghostty_config_new() else { return nil }
+        let userConfig = muxyConfig.readGhosttyConfig()
+        TerminalCJKFontConfig.load(into: cfg, userConfig: userConfig)
         let configPath = muxyConfig.ghosttyConfigPath
         configPath.withCString { ptr in
             ghostty_config_load_file(cfg, ptr)

--- a/Muxy/Services/Terminal/TerminalCJKFontConfig.swift
+++ b/Muxy/Services/Terminal/TerminalCJKFontConfig.swift
@@ -1,0 +1,96 @@
+import CoreText
+import Foundation
+import GhosttyKit
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "TerminalCJKFontConfig")
+
+enum TerminalCJKFontConfig {
+    private static let configuredFontSampleText = "中文"
+    private static let systemFallbackSampleText = "漢字"
+    private static let codepointRanges = [
+        "U+3000-U+303F",
+        "U+3400-U+4DBF",
+        "U+4E00-U+9FFF",
+        "U+F900-U+FAFF",
+        "U+FF00-U+FFEF",
+    ]
+
+    static func load(into config: ghostty_config_t, userConfig: String) {
+        guard let contents = configText(userConfig: userConfig) else { return }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-cjk-font-\(UUID().uuidString).conf")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        do {
+            try Data(contents.utf8).write(to: url, options: .atomic)
+        } catch {
+            logger.error("Failed to write CJK font config: \(error)")
+            return
+        }
+
+        url.path.withCString { ghostty_config_load_file(config, $0) }
+    }
+
+    static func configText(userConfig: String) -> String? {
+        guard let family = resolvedFontFamily(configuredFamilies: fontFamilies(in: userConfig)),
+              !family.contains("\n"),
+              !family.contains("\r")
+        else { return nil }
+
+        return "font-codepoint-map = \(codepointRanges.joined(separator: ","))=\(family)\n"
+    }
+
+    static func fontFamilies(in config: String) -> [String] {
+        var families: [String] = []
+        let content = config.first == "\u{FEFF}" ? String(config.dropFirst()) : config
+        for line in content.components(separatedBy: .newlines) {
+            guard let value = value(for: "font-family", in: line) else { continue }
+            let family = unquoted(value)
+            if family.isEmpty {
+                families.removeAll(keepingCapacity: true)
+            } else {
+                families.append(family)
+            }
+        }
+        return families
+    }
+
+    private static func resolvedFontFamily(configuredFamilies: [String]) -> String? {
+        for family in configuredFamilies {
+            let font = CTFontCreateWithName(family as CFString, 13, nil)
+            guard supports(configuredFontSampleText, font: font) else { continue }
+            return family
+        }
+
+        let baseFont = configuredFamilies.first.map { CTFontCreateWithName($0 as CFString, 13, nil) }
+            ?? CTFontCreateWithName("Menlo" as CFString, 13, nil)
+        let fallback = CTFontCreateForString(
+            baseFont,
+            systemFallbackSampleText as CFString,
+            CFRange(location: 0, length: systemFallbackSampleText.utf16.count)
+        )
+        guard supports(systemFallbackSampleText, font: fallback) else { return nil }
+        return CTFontCopyFamilyName(fallback) as String
+    }
+
+    private static func supports(_ text: String, font: CTFont) -> Bool {
+        let characterSet = CTFontCopyCharacterSet(font) as CharacterSet
+        return text.unicodeScalars.allSatisfy(characterSet.contains)
+    }
+
+    private static func value(for key: String, in line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix(key) else { return nil }
+        let remainder = trimmed.dropFirst(key.count).trimmingCharacters(in: .whitespaces)
+        guard remainder.first == "=" else { return nil }
+        return remainder.dropFirst().trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func unquoted(_ value: String) -> String {
+        guard value.count >= 2, let first = value.first, let last = value.last,
+              (first == "\"" && last == "\"") || (first == "'" && last == "'")
+        else { return value }
+        return String(value.dropFirst().dropLast())
+    }
+}

--- a/Muxy/Services/Terminal/TerminalCJKFontConfig.swift
+++ b/Muxy/Services/Terminal/TerminalCJKFontConfig.swift
@@ -6,8 +6,7 @@ import os
 private let logger = Logger(subsystem: "app.muxy", category: "TerminalCJKFontConfig")
 
 enum TerminalCJKFontConfig {
-    private static let configuredFontSampleText = "中文"
-    private static let systemFallbackSampleText = "漢字"
+    private static let requiredChineseGlyphs = "中文简体繁體专业專業，。！？"
     private static let codepointRanges = [
         "U+3000-U+303F",
         "U+3400-U+4DBF",
@@ -59,7 +58,7 @@ enum TerminalCJKFontConfig {
     private static func resolvedFontFamily(configuredFamilies: [String]) -> String? {
         for family in configuredFamilies {
             let font = CTFontCreateWithName(family as CFString, 13, nil)
-            guard supports(configuredFontSampleText, font: font) else { continue }
+            guard supports(requiredChineseGlyphs, font: font) else { continue }
             return family
         }
 
@@ -67,10 +66,10 @@ enum TerminalCJKFontConfig {
             ?? CTFontCreateWithName("Menlo" as CFString, 13, nil)
         let fallback = CTFontCreateForString(
             baseFont,
-            systemFallbackSampleText as CFString,
-            CFRange(location: 0, length: systemFallbackSampleText.utf16.count)
+            requiredChineseGlyphs as CFString,
+            CFRange(location: 0, length: requiredChineseGlyphs.utf16.count)
         )
-        guard supports(systemFallbackSampleText, font: fallback) else { return nil }
+        guard supports(requiredChineseGlyphs, font: fallback) else { return nil }
         return CTFontCopyFamilyName(fallback) as String
     }
 

--- a/Tests/MuxyTests/Services/Terminal/TerminalCJKFontConfigTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/TerminalCJKFontConfigTests.swift
@@ -24,9 +24,22 @@ struct TerminalCJKFontConfigTests {
 
     @Test("system CJK fallback is used when configured fonts lack Chinese glyphs")
     func mapsSystemCJKFallback() throws {
-        let generated = try #require(TerminalCJKFontConfig.configText(userConfig: "font-family = Menlo"))
+        let generated = try #require(TerminalCJKFontConfig.configText(userConfig: "font-family = Hiragino Sans"))
+        let systemFallback = try #require(TerminalCJKFontConfig.configText(userConfig: ""))
 
-        #expect(!generated.hasSuffix("=Menlo\n"))
+        #expect(generated == systemFallback)
+    }
+
+    @Test("partial CJK font is skipped for a complete Chinese fallback")
+    func skipsPartialCJKFont() throws {
+        let config = """
+        font-family = Hiragino Sans
+        font-family = PingFang SC
+        """
+
+        let generated = try #require(TerminalCJKFontConfig.configText(userConfig: config))
+
+        #expect(generated.hasSuffix("=PingFang SC\n"))
     }
 
     @Test("UTF-8 BOM is ignored before parsing the first font family")

--- a/Tests/MuxyTests/Services/Terminal/TerminalCJKFontConfigTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/TerminalCJKFontConfigTests.swift
@@ -1,0 +1,72 @@
+import GhosttyKit
+import Testing
+
+@testable import Muxy
+
+@Suite("Terminal CJK font config")
+struct TerminalCJKFontConfigTests {
+    @Test("configured CJK fallback is mapped across Chinese codepoints")
+    func mapsConfiguredCJKFallback() throws {
+        let config = """
+        font-family = JetBrains Mono
+        font-family = "PingFang SC"
+        """
+
+        let generated = try #require(TerminalCJKFontConfig.configText(userConfig: config))
+
+        #expect(generated.hasSuffix("=PingFang SC\n"))
+        #expect(generated.contains("U+3000-U+303F"))
+        #expect(generated.contains("U+3400-U+4DBF"))
+        #expect(generated.contains("U+4E00-U+9FFF"))
+        #expect(generated.contains("U+F900-U+FAFF"))
+        #expect(generated.contains("U+FF00-U+FFEF"))
+    }
+
+    @Test("system CJK fallback is used when configured fonts lack Chinese glyphs")
+    func mapsSystemCJKFallback() throws {
+        let generated = try #require(TerminalCJKFontConfig.configText(userConfig: "font-family = Menlo"))
+
+        #expect(!generated.hasSuffix("=Menlo\n"))
+    }
+
+    @Test("UTF-8 BOM is ignored before parsing the first font family")
+    func ignoresByteOrderMark() {
+        let config = "\u{FEFF}font-family = PingFang SC"
+
+        #expect(TerminalCJKFontConfig.fontFamilies(in: config) == ["PingFang SC"])
+    }
+
+    @Test("font-family reset removes earlier fallback candidates")
+    func honorsFontFamilyReset() {
+        let config = """
+        font-family = PingFang SC
+        font-family = ""
+        font-family = Menlo
+        """
+
+        #expect(TerminalCJKFontConfig.fontFamilies(in: config) == ["Menlo"])
+    }
+
+    @Test("similar Ghostty keys are not parsed as regular font families")
+    func ignoresOtherFontFamilyKeys() {
+        let config = """
+        font-family-bold = PingFang SC
+        font-family = Menlo
+        """
+
+        #expect(TerminalCJKFontConfig.fontFamilies(in: config) == ["Menlo"])
+    }
+
+    @Test("Ghostty accepts the generated codepoint mapping")
+    @MainActor
+    func generatedMappingParses() throws {
+        _ = GhosttyService.shared
+        let config = try #require(ghostty_config_new())
+        defer { ghostty_config_free(config) }
+
+        TerminalCJKFontConfig.load(into: config, userConfig: "font-family = PingFang SC")
+        ghostty_config_finalize(config)
+
+        #expect(ghostty_config_diagnostics_count(config) == 0)
+    }
+}

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -26,7 +26,7 @@ Most Ghostty options work — fonts, colors, padding, keybinds, shell integratio
 
 ### Chinese font rendering
 
-Muxy maps common Chinese Unicode ranges to one font so Ghostty does not mix fallback faces within the same text. It uses the first configured `font-family` that contains Chinese glyphs; otherwise it uses the macOS system fallback.
+Muxy maps common Chinese Unicode ranges to one font so Ghostty does not mix fallback faces within the same text. It uses the first configured `font-family` with broad Simplified Chinese, Traditional Chinese, and punctuation coverage; otherwise it uses the macOS system fallback.
 
 Keep the Latin terminal font first and add the preferred Chinese font as a fallback:
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -24,6 +24,19 @@ Muxy's active Ghostty config is `~/Library/Application Support/Muxy/ghostty.conf
 
 Most Ghostty options work — fonts, colors, padding, keybinds, shell integration. Muxy applies the active light/dark variant automatically when the system appearance changes.
 
+### Chinese font rendering
+
+Muxy maps common Chinese Unicode ranges to one font so Ghostty does not mix fallback faces within the same text. It uses the first configured `font-family` that contains Chinese glyphs; otherwise it uses the macOS system fallback.
+
+Keep the Latin terminal font first and add the preferred Chinese font as a fallback:
+
+```ini
+font-family = JetBrains Mono
+font-family = PingFang SC
+```
+
+Reload the configuration with `⌘⇧R`, then open a new terminal. Ghostty applies codepoint-map changes only to new terminals. Explicit `font-codepoint-map` entries in `ghostty.conf` take priority over Muxy's automatic mapping for overlapping ranges.
+
 ## Find in terminal
 
 `⌘F` opens an inline search overlay scoped to the focused pane. Enter / Shift-Enter cycle through matches; Escape dismisses.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Chinese and CJK rendering by automatically generating a single font mapping for common Unicode ranges.
  * Selects the first configured `font-family` that supports the required CJK glyphs, otherwise falls back to the system CJK font.
  * Explicit `font-codepoint-map` entries in `ghostty.conf` still override the automatic mapping.

* **Documentation**
  * Added “Chinese font rendering” guidance, including how to reload configuration (`⌘⇧R`) and reopen a terminal.
  
* **Tests**
  * Added coverage for CJK mapping generation and configuration parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->