### PR TITLE
Add Agents Focused layout and agent tab launcher

### DIFF
--- a/Muxy/Models/Layout/AgentsFocusedLayout.swift
+++ b/Muxy/Models/Layout/AgentsFocusedLayout.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct AgentsFocusedLayout: AppLayoutProviding {
+    var sidebars: [LayoutSidebar] { [.agentList] }
+    var topbar: LayoutTopbar { .tabStrip }
+}

--- a/Muxy/Models/Layout/AgentsFocusedTabSelection.swift
+++ b/Muxy/Models/Layout/AgentsFocusedTabSelection.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+@MainActor
+enum AgentsFocusedTabSelection {
+    struct Location: Identifiable {
+        let area: TabArea
+        let tab: TerminalTab
+
+        var id: UUID { tab.id }
+    }
+
+    static func resolve(
+        root: SplitNode?,
+        topLevelTabs: [(area: TabArea, tab: TerminalTab)],
+        providerID: (UUID) -> String?
+    ) -> [Location] {
+        guard let root else { return [] }
+        var childrenByParent: [UUID: [Location]] = [:]
+        for area in root.allAreas() {
+            for tab in area.tabs {
+                guard let parentTabID = tab.parentTabID else { continue }
+                childrenByParent[parentTabID, default: []].append(Location(area: area, tab: tab))
+            }
+        }
+        return topLevelTabs.flatMap { topLevel in
+            let locations = [Location(area: topLevel.area, tab: topLevel.tab)]
+                + childrenByParent[topLevel.tab.id, default: []]
+            return locations.filter { location in
+                guard let paneID = location.tab.content.pane?.id else { return false }
+                return providerID(paneID) != nil
+            }
+        }
+    }
+}

--- a/Muxy/Models/Layout/AppLayout.swift
+++ b/Muxy/Models/Layout/AppLayout.swift
@@ -3,6 +3,7 @@ import Foundation
 enum AppLayout: String, CaseIterable, Identifiable {
     case projectFocused
     case tabFocused
+    case agentsFocused
 
     var id: String { rawValue }
 
@@ -10,6 +11,7 @@ enum AppLayout: String, CaseIterable, Identifiable {
         switch self {
         case .projectFocused: "Project Focused"
         case .tabFocused: "Tab Focused"
+        case .agentsFocused: "Agents Focused"
         }
     }
 
@@ -20,6 +22,7 @@ enum AppLayout: String, CaseIterable, Identifiable {
         switch self {
         case .projectFocused: ProjectFocusedLayout()
         case .tabFocused: TabFocusedLayout()
+        case .agentsFocused: AgentsFocusedLayout()
         }
     }
 }

--- a/Muxy/Models/Layout/AppLayoutProviding.swift
+++ b/Muxy/Models/Layout/AppLayoutProviding.swift
@@ -3,6 +3,7 @@ import Foundation
 enum LayoutSidebar: Identifiable {
     case projectList
     case tabList
+    case agentList
 
     var id: Self { self }
 }

--- a/Muxy/Models/Layout/AppLayoutStore.swift
+++ b/Muxy/Models/Layout/AppLayoutStore.swift
@@ -23,6 +23,10 @@ final class AppLayoutStore {
     }
 
     func toggle() {
-        set(layout == .projectFocused ? .tabFocused : .projectFocused)
+        guard let index = AppLayout.allCases.firstIndex(of: layout) else {
+            set(AppLayout.defaultValue)
+            return
+        }
+        set(AppLayout.allCases[(index + 1) % AppLayout.allCases.count])
     }
 }

--- a/Muxy/Services/AI/AIAgentLaunchProvider.swift
+++ b/Muxy/Services/AI/AIAgentLaunchProvider.swift
@@ -70,13 +70,12 @@ extension AIAgentLaunchProvider {
 }
 
 enum AgentTabLaunchCommand {
-    static func resolve(provider: any AIAgentLaunchProvider, isRemote: Bool) -> String? {
-        let executable = if isRemote {
-            provider.agentLaunchConfiguration.executable
-        } else {
-            provider.agentCLIExecutablePath()
-        }
-        return executable.map(ShellEscaper.escape)
+    static func local(provider: any AIAgentLaunchProvider) -> String? {
+        provider.agentCLIExecutablePath().map(ShellEscaper.escape)
+    }
+
+    static func remote(provider: any AIAgentLaunchProvider) -> String {
+        ShellEscaper.escape(provider.agentLaunchConfiguration.executable)
     }
 }
 
@@ -90,12 +89,86 @@ struct AgentTabLaunchOption: Identifiable {
         command == nil ? "\(provider.displayName) · Not installed" : provider.displayName
     }
 
-    static func resolve(providers: [any AIAgentLaunchProvider], isRemote: Bool) -> [Self] {
+    static func resolveLocal(providers: [any AIAgentLaunchProvider]) -> [Self] {
         providers.map { provider in
             Self(
                 provider: provider,
-                command: AgentTabLaunchCommand.resolve(provider: provider, isRemote: isRemote)
+                command: AgentTabLaunchCommand.local(provider: provider)
             )
         }
+    }
+
+    static func resolveRemote(
+        providers: [any AIAgentLaunchProvider],
+        availableProviderIDs: Set<String>
+    ) -> [Self] {
+        providers.map { provider in
+            Self(
+                provider: provider,
+                command: availableProviderIDs.contains(provider.id)
+                    ? AgentTabLaunchCommand.remote(provider: provider)
+                    : nil
+            )
+        }
+    }
+}
+
+enum RemoteAgentLaunchAvailabilityError: LocalizedError {
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .commandFailed(message):
+            message.isEmpty ? "Could not check remote agent providers." : message
+        }
+    }
+}
+
+enum RemoteAgentLaunchAvailability {
+    typealias Runner = @MainActor (SSHDestination, String) async throws -> GitProcessResult
+
+    private static let startMarker = "__MUXY_AGENT_PROVIDERS_START__"
+    private static let endMarker = "__MUXY_AGENT_PROVIDERS_END__"
+
+    @MainActor
+    static func resolve(
+        providers: [any AIAgentLaunchProvider],
+        destination: SSHDestination,
+        runner: Runner = { destination, command in
+            try await SSHCommandRunner.run(destination: destination, remoteCommand: command)
+        }
+    ) async throws -> Set<String> {
+        let result = try await runner(destination, lookupCommand(providers: providers))
+        guard result.status == 0 else {
+            throw RemoteAgentLaunchAvailabilityError.commandFailed(
+                result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+        let supportedProviderIDs = Set(providers.map(\.id))
+        return providerIDs(from: result.stdout).intersection(supportedProviderIDs)
+    }
+
+    static func lookupCommand(providers: [any AIAgentLaunchProvider]) -> String {
+        let checks = providers.map { provider in
+            let executable = ShellEscaper.escape(provider.agentLaunchConfiguration.executable)
+            let providerID = ShellEscaper.escape(provider.id)
+            return "if command -v \(executable) >/dev/null 2>&1; then printf '%s\\n' \(providerID); fi"
+        }
+        let script = ([
+            "printf '%s\\n' \(ShellEscaper.escape(startMarker))",
+        ] + checks + [
+            "printf '%s\\n' \(ShellEscaper.escape(endMarker))",
+        ]).joined(separator: "; ")
+        return "exec \"${SHELL:-/bin/sh}\" -l -i -c \(ShellEscaper.escape(script))"
+    }
+
+    static func providerIDs(from output: String) -> Set<String> {
+        let lines = output.split(whereSeparator: \.isNewline).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard let start = lines.firstIndex(of: startMarker),
+              let end = lines[(start + 1)...].firstIndex(of: endMarker)
+        else { return [] }
+        return Set(lines[(start + 1) ..< end])
     }
 }

--- a/Muxy/Services/AI/AIAgentLaunchProvider.swift
+++ b/Muxy/Services/AI/AIAgentLaunchProvider.swift
@@ -68,3 +68,34 @@ extension AIAgentLaunchProvider {
         agentCLIExecutablePath() != nil
     }
 }
+
+enum AgentTabLaunchCommand {
+    static func resolve(provider: any AIAgentLaunchProvider, isRemote: Bool) -> String? {
+        let executable = if isRemote {
+            provider.agentLaunchConfiguration.executable
+        } else {
+            provider.agentCLIExecutablePath()
+        }
+        return executable.map(ShellEscaper.escape)
+    }
+}
+
+struct AgentTabLaunchOption: Identifiable {
+    let provider: any AIAgentLaunchProvider
+    let command: String?
+
+    var id: String { provider.id }
+
+    var title: String {
+        command == nil ? "\(provider.displayName) · Not installed" : provider.displayName
+    }
+
+    static func resolve(providers: [any AIAgentLaunchProvider], isRemote: Bool) -> [Self] {
+        providers.map { provider in
+            Self(
+                provider: provider,
+                command: AgentTabLaunchCommand.resolve(provider: provider, isRemote: isRemote)
+            )
+        }
+    }
+}

--- a/Muxy/Services/AI/AgentStatusStore.swift
+++ b/Muxy/Services/AI/AgentStatusStore.swift
@@ -189,6 +189,11 @@ final class AgentStatusStore {
         return panes[paneID]?.status
     }
 
+    func providerID(forPane paneID: UUID?) -> String? {
+        guard let paneID else { return nil }
+        return panes[paneID]?.providerID
+    }
+
     func status(forWorktree worktreeID: UUID) -> AgentStatus? {
         entries[worktreeID]?.status
     }

--- a/Muxy/Services/AgentDetection/DetectedAgentStore.swift
+++ b/Muxy/Services/AgentDetection/DetectedAgentStore.swift
@@ -7,6 +7,7 @@ final class DetectedAgentStore {
     static let shared = DetectedAgentStore()
 
     private(set) var agents: [UUID: String] = [:]
+    private var provisionalPaneIDs: Set<UUID> = []
 
     private init() {}
 
@@ -17,11 +18,23 @@ final class DetectedAgentStore {
     }
 
     func setAgent(_ providerID: String?, for paneID: UUID) {
+        provisionalPaneIDs.remove(paneID)
         guard agents[paneID] != providerID else { return }
         if let providerID {
             agents[paneID] = providerID
             return
         }
+        agents.removeValue(forKey: paneID)
+    }
+
+    func setProvisionalAgent(_ providerID: String, for paneID: UUID) {
+        provisionalPaneIDs.insert(paneID)
+        guard agents[paneID] != providerID else { return }
+        agents[paneID] = providerID
+    }
+
+    func clearProvisionalAgent(for paneID: UUID) {
+        guard provisionalPaneIDs.remove(paneID) != nil else { return }
         agents.removeValue(forKey: paneID)
     }
 
@@ -35,6 +48,7 @@ final class DetectedAgentStore {
     }
 
     func resetPane(_ paneID: UUID) {
+        provisionalPaneIDs.remove(paneID)
         agents.removeValue(forKey: paneID)
     }
 }

--- a/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
@@ -174,6 +174,7 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         guard let view = surfaceView(from: target) else { return }
         DispatchQueue.main.async {
             if let paneID = TerminalViewRegistry.shared.paneID(for: view) {
+                DetectedAgentStore.shared.clearProvisionalAgent(for: paneID)
                 AgentStatusStore.shared.removePane(paneID)
             }
             guard view.closesOnCommandExit else { return }

--- a/Muxy/Views/Components/Icons/ProviderIconView.swift
+++ b/Muxy/Views/Components/Icons/ProviderIconView.swift
@@ -8,11 +8,12 @@ struct ProviderIconView: View {
     let iconName: String
     let size: CGFloat
     var monochromeTint: Color = MuxyTheme.fg
+    var forceMonochrome = false
 
     var body: some View {
         #if os(macOS)
         if let image = Self.loadProviderImage(named: iconName) {
-            if Self.isColorful(named: iconName, image: image) {
+            if !forceMonochrome, Self.isColorful(named: iconName, image: image) {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)

--- a/Muxy/Views/Layouts/TabFocused/AgentsFocusedProviderMenu.swift
+++ b/Muxy/Views/Layouts/TabFocused/AgentsFocusedProviderMenu.swift
@@ -24,6 +24,21 @@ struct AgentsFocusedProviderMenu: View {
     }
 }
 
+struct AgentsFocusedProviderLoadingMenu: View {
+    var body: some View {
+        HStack(spacing: UIMetrics.spacing3) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Checking remote providers…")
+                .font(.system(size: UIMetrics.fontBody))
+                .foregroundStyle(MuxyTheme.fgMuted)
+        }
+        .padding(UIMetrics.spacing4)
+        .frame(width: UIMetrics.scaled(252), height: UIMetrics.scaled(68))
+        .background(MuxyTheme.bg)
+    }
+}
+
 private struct AgentsFocusedProviderRow: View {
     let option: AgentTabLaunchOption
     let action: () -> Void

--- a/Muxy/Views/Layouts/TabFocused/AgentsFocusedProviderMenu.swift
+++ b/Muxy/Views/Layouts/TabFocused/AgentsFocusedProviderMenu.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct AgentsFocusedProviderMenu: View {
+    let options: [AgentTabLaunchOption]
+    let onSelect: (AgentTabLaunchOption) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
+            Text("New Agent Tab")
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .padding(.horizontal, UIMetrics.spacing3)
+                .padding(.bottom, UIMetrics.spacing2)
+
+            ForEach(options) { option in
+                AgentsFocusedProviderRow(option: option) {
+                    onSelect(option)
+                }
+            }
+        }
+        .padding(UIMetrics.spacing4)
+        .fixedSize(horizontal: true, vertical: true)
+        .background(MuxyTheme.bg)
+    }
+}
+
+private struct AgentsFocusedProviderRow: View {
+    let option: AgentTabLaunchOption
+    let action: () -> Void
+
+    @State private var hovered = false
+
+    private var foreground: Color {
+        option.command == nil ? MuxyTheme.fgDim : MuxyTheme.fg
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: UIMetrics.spacing3) {
+                ProviderIconView(
+                    iconName: option.provider.iconName,
+                    size: UIMetrics.iconMD,
+                    monochromeTint: foreground,
+                    forceMonochrome: true
+                )
+                Text(option.title)
+                    .font(.system(size: UIMetrics.fontBody))
+                    .lineLimit(1)
+                Spacer(minLength: UIMetrics.spacing6)
+            }
+            .foregroundStyle(foreground)
+            .padding(.horizontal, UIMetrics.spacing3)
+            .frame(width: UIMetrics.scaled(220), height: UIMetrics.controlMedium, alignment: .leading)
+            .background(
+                hovered && option.command != nil ? MuxyTheme.hover : .clear,
+                in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(option.command == nil)
+        .onHover { hovered = $0 }
+    }
+}

--- a/Muxy/Views/Layouts/TabFocused/AgentsFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/AgentsFocusedTabsList.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct AgentsFocusedTabsList: View {
+    let project: Project
+    let worktree: Worktree
+
+    @Environment(AppState.self) private var appState
+    @State private var detectedAgentStore = DetectedAgentStore.shared
+    @State private var agentStatusStore = AgentStatusStore.shared
+
+    private var worktreeKey: WorktreeKey {
+        WorktreeKey(projectID: project.id, worktreeID: worktree.id)
+    }
+
+    private var agentTabs: [AgentsFocusedTabSelection.Location] {
+        AgentsFocusedTabSelection.resolve(
+            root: appState.workspaceRoots[worktreeKey],
+            topLevelTabs: appState.topLevelTabs(for: worktreeKey),
+            providerID: providerID
+        )
+    }
+
+    private var topLevelTabs: [(area: TabArea, tab: TerminalTab)] {
+        appState.topLevelTabs(for: worktreeKey)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(agentTabs) { location in
+                TabFocusedTabRow(
+                    project: project,
+                    area: location.area,
+                    tab: location.tab,
+                    relatedTabs: [location.tab],
+                    topLevelTabs: topLevelTabs,
+                    active: isActive(location),
+                    worktree: worktree
+                )
+            }
+        }
+    }
+
+    private func providerID(for paneID: UUID) -> String? {
+        detectedAgentStore.agent(for: paneID) ?? agentStatusStore.providerID(forPane: paneID)
+    }
+
+    private func isActive(_ location: AgentsFocusedTabSelection.Location) -> Bool {
+        appState.activeProjectID == project.id
+            && appState.activeWorktreeID[project.id] == worktree.id
+            && appState.focusedAreaID[worktreeKey] == location.area.id
+            && location.area.activeTabID == location.tab.id
+    }
+}

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -6,6 +6,7 @@ struct TabFocusedProjectRow: View {
     let project: Project
     var worktree: Worktree?
     let shortcutNumbers: [UUID: Int]
+    var content: TabFocusedSidebarContent = .tabs
 
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
@@ -23,6 +24,7 @@ struct TabFocusedProjectRow: View {
     @State private var showSymbolPicker = false
     @State private var showColorPicker = false
     @State private var showCreateWorktreeSheet = false
+    @State private var showAgentProviderMenu = false
     @State private var logoCropImage: IdentifiableProjectImage?
     @State private var projectPendingRemoval = false
     @FocusState private var renameFieldFocused: Bool
@@ -87,7 +89,12 @@ struct TabFocusedProjectRow: View {
         VStack(alignment: .leading, spacing: 0) {
             header
             if isExpanded, let listWorktree {
-                TabFocusedTabsList(project: project, worktree: listWorktree, shortcutNumbers: shortcutNumbers)
+                switch content {
+                case .tabs:
+                    TabFocusedTabsList(project: project, worktree: listWorktree, shortcutNumbers: shortcutNumbers)
+                case .agents:
+                    AgentsFocusedTabsList(project: project, worktree: listWorktree)
+                }
             }
         }
         .onAppear { applyDefaultExpansion() }
@@ -310,7 +317,7 @@ struct TabFocusedProjectRow: View {
 
     private var trailingControls: some View {
         HStack(spacing: 0) {
-            if hovered {
+            if hovered || showAgentProviderMenu {
                 actions
             } else if !isFocused {
                 if isWorktreeRow {
@@ -327,14 +334,23 @@ struct TabFocusedProjectRow: View {
 
     @ViewBuilder
     private var actions: some View {
-        TabFocusedTabActions(project: project, worktree: worktree)
-        if !isWorktreeRow, !project.isHome, !isFocused {
+        switch content {
+        case .tabs:
+            TabFocusedTabActions(project: project, worktree: worktree)
+        case .agents:
+            AgentsFocusedTabActions(
+                project: project,
+                worktree: listWorktree,
+                showingProviders: $showAgentProviderMenu
+            )
+        }
+        if content == .tabs, !isWorktreeRow, !project.isHome, !isFocused {
             focusModeButton
         }
     }
 
     private var isFocused: Bool {
-        !isWorktreeRow && expansionStore.focusMode && isActive
+        content == .tabs && !isWorktreeRow && expansionStore.focusMode && isActive
     }
 
     private var focusModeButton: some View {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
+enum TabFocusedSidebarContent: Equatable {
+    case tabs
+    case agents
+}
+
 struct TabFocusedSidebar: View {
+    var content: TabFocusedSidebarContent = .tabs
+
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -27,7 +34,8 @@ struct TabFocusedSidebar: View {
         return TabFocusedSidebarProjectSelection.resolve(
             projects: all,
             focusMode: expansionStore.focusMode,
-            activeProjectID: appState.activeProjectID
+            activeProjectID: appState.activeProjectID,
+            content: content
         )
     }
 
@@ -37,7 +45,7 @@ struct TabFocusedSidebar: View {
             guard project.worktreesEnabled, !project.isHome else { return items }
             for worktree in worktreeStore.list(for: project.id) where !worktree.isPrimary {
                 let key = WorktreeKey(projectID: project.id, worktreeID: worktree.id)
-                guard appState.hasTabs(for: key) else { continue }
+                guard content == .agents || appState.hasTabs(for: key) else { continue }
                 items.append(.worktree(project, worktree))
             }
             return items
@@ -45,6 +53,7 @@ struct TabFocusedSidebar: View {
     }
 
     private var shortcutNumbers: [UUID: Int] {
+        guard content == .tabs else { return [:] }
         let entries = TabFocusedTabOrder.entries(
             appState: appState,
             projectStore: projectStore,
@@ -67,10 +76,11 @@ struct TabFocusedSidebar: View {
                         TabFocusedProjectRow(
                             project: row.project,
                             worktree: row.worktree,
-                            shortcutNumbers: numbers
+                            shortcutNumbers: numbers,
+                            content: content
                         )
                     }
-                    if !expansionStore.focusMode {
+                    if content == .agents || !expansionStore.focusMode {
                         TabFocusedAddProjectRow(
                             recentlyRemovedProjects: displayedRecentlyRemovedProjects,
                             openProject: openProjectPicker,
@@ -117,9 +127,21 @@ struct TabFocusedSidebar: View {
     }
 }
 
+struct AgentsFocusedSidebar: View {
+    var body: some View {
+        TabFocusedSidebar(content: .agents)
+    }
+}
+
 enum TabFocusedSidebarProjectSelection {
-    static func resolve(projects: [Project], focusMode: Bool, activeProjectID: UUID?) -> [Project] {
-        guard focusMode,
+    static func resolve(
+        projects: [Project],
+        focusMode: Bool,
+        activeProjectID: UUID?,
+        content: TabFocusedSidebarContent = .tabs
+    ) -> [Project] {
+        guard content == .tabs,
+              focusMode,
               let activeProjectID,
               let activeProject = projects.first(where: { $0.id == activeProjectID })
         else { return projects }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -47,18 +47,17 @@ struct AgentsFocusedTabActions: View {
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @Environment(WorktreeStore.self) private var worktreeStore
     @State private var hovered = false
+    @State private var options: [AgentTabLaunchOption] = []
+    @State private var loadingProviders = false
+    @State private var providerTask: Task<Void, Never>?
 
-    private var isRemote: Bool {
-        projectGroupStore.workspaceContext(for: project).isRemote
+    private var workspaceContext: WorkspaceContext {
+        projectGroupStore.workspaceContext(for: project)
     }
 
     var body: some View {
-        let options = AgentTabLaunchOption.resolve(
-            providers: AIProviderRegistry.shared.agentLaunchProviders,
-            isRemote: isRemote
-        )
         Button {
-            showingProviders.toggle()
+            presentProviders()
         } label: {
             Image(systemName: "plus")
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))
@@ -73,13 +72,60 @@ struct AgentsFocusedTabActions: View {
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
         .popover(isPresented: $showingProviders, arrowEdge: .trailing) {
-            AgentsFocusedProviderMenu(options: options) { option in
-                showingProviders = false
-                launch(option)
+            if loadingProviders {
+                AgentsFocusedProviderLoadingMenu()
+            } else {
+                AgentsFocusedProviderMenu(options: options) { option in
+                    showingProviders = false
+                    launch(option)
+                }
             }
         }
+        .onChange(of: showingProviders) { _, showing in
+            guard !showing else { return }
+            providerTask?.cancel()
+            loadingProviders = false
+        }
+        .onDisappear { providerTask?.cancel() }
         .help("New Agent Tab")
         .accessibilityLabel("New Agent Tab")
+    }
+
+    private func presentProviders() {
+        providerTask?.cancel()
+        let providers = AIProviderRegistry.shared.agentLaunchProviders
+        guard case let .ssh(destination) = workspaceContext else {
+            options = AgentTabLaunchOption.resolveLocal(providers: providers)
+            loadingProviders = false
+            showingProviders = true
+            return
+        }
+
+        options = []
+        loadingProviders = true
+        showingProviders = true
+        providerTask = Task {
+            do {
+                let providerIDs = try await RemoteAgentLaunchAvailability.resolve(
+                    providers: providers,
+                    destination: destination
+                )
+                guard !Task.isCancelled else { return }
+                options = AgentTabLaunchOption.resolveRemote(
+                    providers: providers,
+                    availableProviderIDs: providerIDs
+                )
+                loadingProviders = false
+            } catch {
+                guard !Task.isCancelled else { return }
+                loadingProviders = false
+                showingProviders = false
+                ToastState.shared.show(
+                    title: "Could not check remote agent providers",
+                    body: error.localizedDescription
+                )
+            }
+        }
     }
 
     private func launch(_ option: AgentTabLaunchOption) {
@@ -130,7 +176,7 @@ enum AgentsFocusedTabLauncher {
               let key = appState.activeWorktreeKey(for: request.project.id),
               let paneID = appState.workspaceRoots[key]?.locateTab(id: tabID)?.tab.content.pane?.id
         else { return }
-        DetectedAgentStore.shared.setAgent(request.providerID, for: paneID)
+        DetectedAgentStore.shared.setProvisionalAgent(request.providerID, for: paneID)
     }
 }
 

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -29,9 +29,125 @@ struct TabFocusedTabActions: View {
     }
 
     private func activateTarget() {
+        TabFocusedSidebarTarget.activate(
+            project: project,
+            worktree: worktree,
+            appState: appState,
+            worktreeStore: worktreeStore
+        )
+    }
+}
+
+struct AgentsFocusedTabActions: View {
+    let project: Project
+    let worktree: Worktree?
+    @Binding var showingProviders: Bool
+
+    @Environment(AppState.self) private var appState
+    @Environment(ProjectGroupStore.self) private var projectGroupStore
+    @Environment(WorktreeStore.self) private var worktreeStore
+    @State private var hovered = false
+
+    private var isRemote: Bool {
+        projectGroupStore.workspaceContext(for: project).isRemote
+    }
+
+    var body: some View {
+        let options = AgentTabLaunchOption.resolve(
+            providers: AIProviderRegistry.shared.agentLaunchProviders,
+            isRemote: isRemote
+        )
+        Button {
+            showingProviders.toggle()
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
+                .frame(width: TabFocusedSidebarMetrics.controlSlot, height: TabFocusedSidebarMetrics.controlSlot)
+                .background {
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusSM, style: .continuous)
+                        .fill(hovered || showingProviders ? MuxyTheme.hover : Color.clear)
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .popover(isPresented: $showingProviders, arrowEdge: .trailing) {
+            AgentsFocusedProviderMenu(options: options) { option in
+                showingProviders = false
+                launch(option)
+            }
+        }
+        .help("New Agent Tab")
+        .accessibilityLabel("New Agent Tab")
+    }
+
+    private func launch(_ option: AgentTabLaunchOption) {
+        guard let command = option.command else { return }
+        AgentsFocusedTabLauncher.launch(
+            request: AgentsFocusedTabLaunchRequest(
+                project: project,
+                worktree: worktree,
+                providerID: option.provider.id,
+                name: option.provider.displayName,
+                command: command
+            ),
+            appState: appState,
+            worktreeStore: worktreeStore
+        )
+    }
+}
+
+struct AgentsFocusedTabLaunchRequest {
+    let project: Project
+    let worktree: Worktree?
+    let providerID: String
+    let name: String
+    let command: String
+}
+
+@MainActor
+enum AgentsFocusedTabLauncher {
+    static func launch(
+        request: AgentsFocusedTabLaunchRequest,
+        appState: AppState,
+        worktreeStore: WorktreeStore
+    ) {
+        TabFocusedSidebarTarget.activate(
+            project: request.project,
+            worktree: request.worktree,
+            appState: appState,
+            worktreeStore: worktreeStore
+        )
+        let effects = appState.dispatchReturningEffects(.createCommandTab(CommandTabRequest(
+            projectID: request.project.id,
+            areaID: nil,
+            name: request.name,
+            command: request.command,
+            closesOnCommandExit: false
+        )))
+        guard let tabID = effects.createdTabID,
+              let key = appState.activeWorktreeKey(for: request.project.id),
+              let paneID = appState.workspaceRoots[key]?.locateTab(id: tabID)?.tab.content.pane?.id
+        else { return }
+        DetectedAgentStore.shared.setAgent(request.providerID, for: paneID)
+    }
+}
+
+@MainActor
+private enum TabFocusedSidebarTarget {
+    static func activate(
+        project: Project,
+        worktree: Worktree?,
+        appState: AppState,
+        worktreeStore: WorktreeStore
+    ) {
         if appState.activeProjectID != project.id {
             worktreeStore.ensurePrimary(for: project)
-            if let preferred = worktreeStore.preferred(for: project.id, matching: appState.activeWorktreeID[project.id]) {
+            if let preferred = worktreeStore.preferred(
+                for: project.id,
+                matching: appState.activeWorktreeID[project.id]
+            ) {
                 appState.selectProject(project, worktree: worktree ?? preferred)
             }
         }
@@ -189,7 +305,7 @@ private struct TabFocusedRowFramePreferenceKey: PreferenceKey {
     }
 }
 
-private struct TabFocusedTabRow: View {
+struct TabFocusedTabRow: View {
     let project: Project
     let area: TabArea
     let tab: TerminalTab
@@ -307,6 +423,10 @@ private struct TabFocusedTabRow: View {
         closableOthersCount > 0 || closableLeftCount > 0 || closableRightCount > 0
     }
 
+    private var isTopLevel: Bool {
+        tab.parentTabID == nil
+    }
+
     private var closeButtonVisible: Bool {
         guard !tab.isPinned else { return false }
         return hovered
@@ -405,13 +525,19 @@ private struct TabFocusedTabRow: View {
 
     @ViewBuilder
     private var contextMenu: some View {
-        Button("New Tab to the Left") {
-            appState.dispatch(.createTabAdjacent(projectID: projectID, areaID: area.id, tabID: tab.id, side: .left))
+        if isTopLevel {
+            Button("New Tab to the Left") {
+                appState.dispatch(
+                    .createTabAdjacent(projectID: projectID, areaID: area.id, tabID: tab.id, side: .left)
+                )
+            }
+            Button("New Tab to the Right") {
+                appState.dispatch(
+                    .createTabAdjacent(projectID: projectID, areaID: area.id, tabID: tab.id, side: .right)
+                )
+            }
+            Divider()
         }
-        Button("New Tab to the Right") {
-            appState.dispatch(.createTabAdjacent(projectID: projectID, areaID: area.id, tabID: tab.id, side: .right))
-        }
-        Divider()
         Button("Rename Tab") { startRename() }
         if tab.customTitle != nil {
             Button("Reset Title") {
@@ -426,25 +552,29 @@ private struct TabFocusedTabRow: View {
                 appState.saveWorkspaces()
             }
         }
-        Divider()
-        Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
-            guard let worktree else { return }
-            appState.togglePinTopLevelTab(
-                tab.id,
-                for: WorktreeKey(projectID: projectID, worktreeID: worktree.id)
-            )
+        if isTopLevel {
+            Divider()
+            Button(tab.isPinned ? "Unpin Tab" : "Pin Tab") {
+                guard let worktree else { return }
+                appState.togglePinTopLevelTab(
+                    tab.id,
+                    for: WorktreeKey(projectID: projectID, worktreeID: worktree.id)
+                )
+            }
         }
-        if !tab.isPinned || hasClosableSiblings {
+        if !tab.isPinned || isTopLevel && hasClosableSiblings {
             Divider()
             if !tab.isPinned {
                 Button("Close Tab") { close() }
             }
-            Button("Close Other Tabs") { closeOthers() }
-                .disabled(closableOthersCount == 0)
-            Button("Close Tabs to the Left") { closeLeft() }
-                .disabled(closableLeftCount == 0)
-            Button("Close Tabs to the Right") { closeRight() }
-                .disabled(closableRightCount == 0)
+            if isTopLevel {
+                Button("Close Other Tabs") { closeOthers() }
+                    .disabled(closableOthersCount == 0)
+                Button("Close Tabs to the Left") { closeLeft() }
+                    .disabled(closableLeftCount == 0)
+                Button("Close Tabs to the Right") { closeRight() }
+                    .disabled(closableRightCount == 0)
+            }
         }
     }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -132,7 +132,9 @@ struct MainWindow: View {
 
     private var layout: any AppLayoutProviding { layoutStore.provider }
     private var appBackgroundStyle: AppBackgroundStyle { AppBackgroundStyle.resolve(appBackgroundStyleRaw) }
-    private var isTabFocused: Bool { layoutStore.layout == .tabFocused && !isExtensionSidebarActive }
+    private var usesWideSidebar: Bool {
+        layoutStore.layout != .projectFocused && !isExtensionSidebarActive
+    }
 
     private var showsTabsInTitleBar: Bool { layout.topbar == .tabStrip || isExtensionSidebarActive }
 
@@ -403,6 +405,8 @@ struct MainWindow: View {
         switch sidebar {
         case .tabList:
             TabFocusedSidebar()
+        case .agentList:
+            AgentsFocusedSidebar()
         case .projectList:
             ProjectFocusedSidebar(
                 expanded: sidebarExpanded,
@@ -560,14 +564,37 @@ struct MainWindow: View {
                 appState.goForward()
             }
             if !isExtensionSidebarActive {
-                NavigationArrowButton(
-                    symbol: isTabFocused ? "sidebar.squares.left" : "sidebar.left",
-                    label: isTabFocused ? "Switch to Project Focused Layout" : "Switch to Tab Focused Layout"
-                ) {
-                    NotificationCenter.default.post(name: .toggleAppLayout, object: nil)
-                }
+                appLayoutMenu
             }
         }
+    }
+
+    private var appLayoutMenu: some View {
+        Menu {
+            ForEach(AppLayout.allCases) { appLayout in
+                Button {
+                    layoutStore.set(appLayout)
+                } label: {
+                    HStack {
+                        Text(appLayout.title)
+                        if layoutStore.layout == appLayout {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "square.grid.2x2")
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Choose App Layout")
+        .accessibilityLabel("Choose App Layout")
     }
 
     @ViewBuilder
@@ -1064,12 +1091,12 @@ struct MainWindow: View {
     }
 
     private var sidebarCollapsedStyle: SidebarCollapsedStyle {
-        guard !isTabFocused else { return .hidden }
+        guard !usesWideSidebar else { return .hidden }
         return SidebarCollapsedStyle(rawValue: sidebarCollapsedStyleRaw) ?? .defaultValue
     }
 
     private var sidebarExpandedStyle: SidebarExpandedStyle {
-        guard !isTabFocused else { return .wide }
+        guard !usesWideSidebar else { return .wide }
         return SidebarExpandedStyle(rawValue: sidebarExpandedStyleRaw) ?? .defaultValue
     }
 

--- a/Tests/MuxyTests/Models/Layout/AppLayoutTests.swift
+++ b/Tests/MuxyTests/Models/Layout/AppLayoutTests.swift
@@ -304,6 +304,39 @@ struct AgentsFocusedTabLauncherTests {
 
         #expect(DetectedAgentStore.shared.agents == agentsBeforeLaunch)
     }
+
+    @Test("local agent launches appear before process detection")
+    func localLaunchAppearsBeforeDetection() throws {
+        let project = Project(name: "Target", path: "/tmp/target")
+        let worktree = Worktree(name: "Target", path: project.path, isPrimary: true)
+        let worktreeStore = WorktreeStore(
+            persistence: AgentLaunchWorktreePersistenceStub(storage: [project.id: [worktree]]),
+            projects: [project]
+        )
+        let appState = AppState(
+            selectionStore: AgentLaunchSelectionStoreStub(),
+            terminalViews: AgentLaunchTerminalViewRemovingStub(),
+            workspacePersistence: AgentLaunchWorkspacePersistenceStub()
+        )
+        appState.selectProject(project, worktree: worktree)
+
+        AgentsFocusedTabLauncher.launch(
+            request: AgentsFocusedTabLaunchRequest(
+                project: project,
+                worktree: worktree,
+                providerID: "codex",
+                name: "Codex",
+                command: "codex"
+            ),
+            appState: appState,
+            worktreeStore: worktreeStore
+        )
+
+        let key = WorktreeKey(projectID: project.id, worktreeID: worktree.id)
+        let paneID = try #require(appState.workspaceRoots[key]?.allTabs().last?.content.pane?.id)
+        defer { DetectedAgentStore.shared.resetPane(paneID) }
+        #expect(DetectedAgentStore.shared.agent(for: paneID) == "codex")
+    }
 }
 
 @Suite("TabFocusedSidebarState")

--- a/Tests/MuxyTests/Models/Layout/AppLayoutTests.swift
+++ b/Tests/MuxyTests/Models/Layout/AppLayoutTests.swift
@@ -16,6 +16,11 @@ struct AppLayoutTests {
         #expect(AppLayout.tabFocused.provider is TabFocusedLayout)
     }
 
+    @Test("agents focused resolves the agents focused provider")
+    func agentsFocusedProvider() {
+        #expect(AppLayout.agentsFocused.provider is AgentsFocusedLayout)
+    }
+
     @Test("project focused keeps tabs in the title bar")
     func projectFocusedTitleBar() {
         #expect(ProjectFocusedLayout().topbar == .tabStrip)
@@ -24,6 +29,11 @@ struct AppLayoutTests {
     @Test("tab focused uses the project title")
     func tabFocusedTitleBar() {
         #expect(TabFocusedLayout().topbar == .projectTitle)
+    }
+
+    @Test("agents focused keeps tabs in the title bar")
+    func agentsFocusedTitleBar() {
+        #expect(AgentsFocusedLayout().topbar == .tabStrip)
     }
 
     @Test("default value is project focused")
@@ -65,6 +75,21 @@ struct AppLayoutTests {
 
         #expect(projects == [second])
     }
+
+    @Test("agents focused sidebar ignores tab focused focus mode")
+    func agentsFocusedSidebarKeepsEveryProjectVisible() {
+        let first = Project(name: "First", path: "/tmp/first")
+        let second = Project(name: "Second", path: "/tmp/second")
+
+        let projects = TabFocusedSidebarProjectSelection.resolve(
+            projects: [first, second],
+            focusMode: true,
+            activeProjectID: second.id,
+            content: .agents
+        )
+
+        #expect(projects == [first, second])
+    }
 }
 
 @Suite("AppLayoutStore")
@@ -103,14 +128,17 @@ struct AppLayoutStoreTests {
         #expect(defaults.string(forKey: AppLayout.storageKey) == AppLayout.tabFocused.rawValue)
     }
 
-    @Test("toggle alternates between the two layouts")
-    func toggleAlternates() throws {
+    @Test("toggle cycles through every layout")
+    func toggleCycles() throws {
         let (defaults, name) = try makeDefaults()
         defer { defaults.removePersistentDomain(forName: name) }
         let store = AppLayoutStore(defaults: defaults)
 
         store.toggle()
         #expect(store.layout == .tabFocused)
+
+        store.toggle()
+        #expect(store.layout == .agentsFocused)
 
         store.toggle()
         #expect(store.layout == .projectFocused)
@@ -124,6 +152,157 @@ struct AppLayoutStoreTests {
         }
         defaults.removePersistentDomain(forName: suiteName)
         return (defaults, suiteName)
+    }
+}
+
+@Suite("AgentsFocusedTabSelection")
+@MainActor
+struct AgentsFocusedTabSelectionTests {
+    @Test("includes detected top-level and child agent tabs in parent order")
+    func includesAgentTabs() {
+        let rootArea = TabArea(projectPath: "/tmp/project")
+        let firstRoot = rootArea.tabs[0]
+        let secondRoot = TerminalTab(pane: TerminalPaneState(projectPath: "/tmp/project"))
+        rootArea.insertExistingTab(secondRoot)
+        let child = TerminalTab(
+            pane: TerminalPaneState(projectPath: "/tmp/project"),
+            parentTabID: firstRoot.id
+        )
+        let childArea = TabArea(projectPath: "/tmp/project", existingTab: child)
+        let root = SplitNode.split(SplitBranch(
+            direction: .horizontal,
+            first: .tabArea(rootArea),
+            second: .tabArea(childArea)
+        ))
+        let agentPaneIDs = Set([
+            firstRoot.content.pane?.id,
+            child.content.pane?.id,
+        ].compactMap(\.self))
+
+        let locations = AgentsFocusedTabSelection.resolve(
+            root: root,
+            topLevelTabs: [
+                (area: rootArea, tab: firstRoot),
+                (area: rootArea, tab: secondRoot),
+            ],
+            providerID: { agentPaneIDs.contains($0) ? "codex" : nil }
+        )
+
+        #expect(locations.map(\.tab.id) == [firstRoot.id, child.id])
+        #expect(locations.map(\.area.id) == [rootArea.id, childArea.id])
+    }
+
+    @Test("keeps child agent tabs when their parent is not an agent")
+    func includesChildWithoutAgentParent() {
+        let rootArea = TabArea(projectPath: "/tmp/project")
+        let parent = rootArea.tabs[0]
+        let child = TerminalTab(
+            pane: TerminalPaneState(projectPath: "/tmp/project"),
+            parentTabID: parent.id
+        )
+        let childArea = TabArea(projectPath: "/tmp/project", existingTab: child)
+        let root = SplitNode.split(SplitBranch(
+            direction: .horizontal,
+            first: .tabArea(rootArea),
+            second: .tabArea(childArea)
+        ))
+
+        let locations = AgentsFocusedTabSelection.resolve(
+            root: root,
+            topLevelTabs: [(area: rootArea, tab: parent)],
+            providerID: { $0 == child.content.pane?.id ? "claude" : nil }
+        )
+
+        #expect(locations.map(\.tab.id) == [child.id])
+        #expect(locations.first?.area.id == childArea.id)
+    }
+}
+
+@Suite("AgentsFocusedTabLauncher")
+@MainActor
+struct AgentsFocusedTabLauncherTests {
+    @Test("launching into an inactive worktree creates its workspace and agent tab")
+    func launchesIntoInactiveWorktreeWithoutWorkspace() throws {
+        let activeProject = Project(name: "Active", path: "/tmp/active")
+        let targetProject = Project(name: "Target", path: "/tmp/target")
+        let activeWorktree = Worktree(name: "Active", path: activeProject.path, isPrimary: true)
+        let targetPrimary = Worktree(name: "Target", path: targetProject.path, isPrimary: true)
+        let targetWorktree = Worktree(name: "Agent", path: "/tmp/target-agent", isPrimary: false)
+        let worktreeStore = WorktreeStore(
+            persistence: AgentLaunchWorktreePersistenceStub(storage: [
+                activeProject.id: [activeWorktree],
+                targetProject.id: [targetPrimary, targetWorktree],
+            ]),
+            projects: [activeProject, targetProject]
+        )
+        let appState = AppState(
+            selectionStore: AgentLaunchSelectionStoreStub(),
+            terminalViews: AgentLaunchTerminalViewRemovingStub(),
+            workspacePersistence: AgentLaunchWorkspacePersistenceStub()
+        )
+        appState.selectProject(activeProject, worktree: activeWorktree)
+        let targetKey = WorktreeKey(projectID: targetProject.id, worktreeID: targetWorktree.id)
+        #expect(appState.workspaceRoots[targetKey] == nil)
+
+        AgentsFocusedTabLauncher.launch(
+            request: AgentsFocusedTabLaunchRequest(
+                project: targetProject,
+                worktree: targetWorktree,
+                providerID: "codex",
+                name: "Codex",
+                command: "codex"
+            ),
+            appState: appState,
+            worktreeStore: worktreeStore
+        )
+
+        let root = try #require(appState.workspaceRoots[targetKey])
+        let agentTabs = root.allAreas().flatMap(\.tabs).filter {
+            $0.content.pane?.startupCommand == "codex"
+        }
+        #expect(appState.activeProjectID == targetProject.id)
+        #expect(appState.activeWorktreeID[targetProject.id] == targetWorktree.id)
+        #expect(agentTabs.count == 1)
+        #expect(agentTabs.first?.content.pane?.title == "Codex")
+        let paneID = try #require(agentTabs.first?.content.pane?.id)
+        defer { DetectedAgentStore.shared.resetPane(paneID) }
+        #expect(DetectedAgentStore.shared.agent(for: paneID) == "codex")
+        let otherPaneIDs = root.allAreas()
+            .flatMap(\.tabs)
+            .compactMap(\.content.pane?.id)
+            .filter { $0 != paneID }
+        #expect(otherPaneIDs.allSatisfy { DetectedAgentStore.shared.agent(for: $0) == nil })
+    }
+
+    @Test("failed tab creation does not register an agent")
+    func failedCreationDoesNotRegisterAgent() {
+        let project = Project(name: "Target", path: "/tmp/target")
+        let worktree = Worktree(name: "Target", path: project.path, isPrimary: true)
+        let worktreeStore = WorktreeStore(
+            persistence: AgentLaunchWorktreePersistenceStub(storage: [project.id: [worktree]]),
+            projects: [project]
+        )
+        let appState = AppState(
+            selectionStore: AgentLaunchSelectionStoreStub(),
+            terminalViews: AgentLaunchTerminalViewRemovingStub(),
+            workspacePersistence: AgentLaunchWorkspacePersistenceStub()
+        )
+        appState.selectProject(project, worktree: worktree)
+        let agentsBeforeLaunch = DetectedAgentStore.shared.agents
+
+        AgentsFocusedTabLauncher.launch(
+            request: AgentsFocusedTabLaunchRequest(
+                project: project,
+                worktree: worktree,
+                providerID: "codex",
+                name: "Codex",
+                command: " "
+            ),
+            appState: appState,
+            worktreeStore: worktreeStore
+        )
+
+        #expect(DetectedAgentStore.shared.agents == agentsBeforeLaunch)
     }
 }
 
@@ -170,4 +349,43 @@ struct TabFocusedSidebarStateTests {
 
 private enum AppLayoutTestError: Error {
     case unavailableDefaults
+}
+
+private final class AgentLaunchWorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}
+
+@MainActor
+private final class AgentLaunchSelectionStoreStub: ActiveProjectSelectionStoring {
+    func loadActiveProjectID() -> UUID? { nil }
+    func saveActiveProjectID(_: UUID?) {}
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { [:] }
+    func saveActiveWorktreeIDs(_: [UUID: UUID]) {}
+}
+
+@MainActor
+private final class AgentLaunchTerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}
+
+private final class AgentLaunchWorktreePersistenceStub: WorktreePersisting {
+    private var storage: [UUID: [Worktree]]
+
+    init(storage: [UUID: [Worktree]]) {
+        self.storage = storage
+    }
+
+    func loadWorktrees(projectID: UUID) throws -> [Worktree] {
+        storage[projectID] ?? []
+    }
+
+    func saveWorktrees(_ worktrees: [Worktree], projectID: UUID) throws {
+        storage[projectID] = worktrees
+    }
+
+    func removeWorktrees(projectID: UUID) throws {
+        storage.removeValue(forKey: projectID)
+    }
 }

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -89,32 +89,105 @@ struct AIAgentLaunchProviderTests {
     func localAgentTabCommand() {
         let provider = AgentTabLaunchTestProvider(executablePath: "/tmp/Agent Tools/codex")
 
-        #expect(AgentTabLaunchCommand.resolve(provider: provider, isRemote: false) == "'/tmp/Agent Tools/codex'")
+        #expect(AgentTabLaunchCommand.local(provider: provider) == "'/tmp/Agent Tools/codex'")
     }
 
     @Test("agent tabs omit unavailable local providers")
     func unavailableLocalAgentTabCommand() {
         let provider = AgentTabLaunchTestProvider(executablePath: nil)
 
-        #expect(AgentTabLaunchCommand.resolve(provider: provider, isRemote: false) == nil)
+        #expect(AgentTabLaunchCommand.local(provider: provider) == nil)
     }
 
-    @Test("agent tabs defer executable resolution to remote shells")
+    @Test("agent tabs escape remote executable names")
     func remoteAgentTabCommand() {
         let provider = AgentTabLaunchTestProvider(executablePath: nil)
 
-        #expect(AgentTabLaunchCommand.resolve(provider: provider, isRemote: true) == "test-agent")
+        #expect(AgentTabLaunchCommand.remote(provider: provider) == "test-agent")
     }
 
     @Test("agent launch options resolve each local executable once")
     func launchOptionsSnapshotExecutableResolution() {
         let provider = CountingAgentTabLaunchTestProvider()
 
-        let options = AgentTabLaunchOption.resolve(providers: [provider], isRemote: false)
+        let options = AgentTabLaunchOption.resolveLocal(providers: [provider])
 
         #expect(provider.resolutionCount == 1)
         #expect(options.first?.command == "/tmp/test-agent")
         #expect(options.first?.title == "Test Agent")
+    }
+
+    @Test("remote launch options disable providers missing from the remote PATH")
+    func remoteLaunchOptionsReflectAvailability() {
+        let provider = AgentTabLaunchTestProvider(executablePath: nil)
+
+        let available = AgentTabLaunchOption.resolveRemote(
+            providers: [provider],
+            availableProviderIDs: ["test"]
+        )
+        let unavailable = AgentTabLaunchOption.resolveRemote(
+            providers: [provider],
+            availableProviderIDs: []
+        )
+
+        #expect(available.first?.command == "test-agent")
+        #expect(available.first?.title == "Test Agent")
+        #expect(unavailable.first?.command == nil)
+        #expect(unavailable.first?.title == "Test Agent · Not installed")
+    }
+
+    @Test("remote provider availability uses a login shell and parses marked output")
+    @MainActor
+    func remoteProviderAvailability() async throws {
+        let provider = AgentTabLaunchTestProvider(executablePath: nil)
+        let destination = SSHDestination(host: "example.com")
+        var capturedCommand = ""
+
+        let providerIDs = try await RemoteAgentLaunchAvailability.resolve(
+            providers: [provider],
+            destination: destination
+        ) { receivedDestination, command in
+            capturedCommand = command
+            #expect(receivedDestination == destination)
+            return GitProcessResult(
+                status: 0,
+                stdout: """
+                shell noise
+                __MUXY_AGENT_PROVIDERS_START__
+                test
+                unsupported
+                __MUXY_AGENT_PROVIDERS_END__
+                """,
+                stdoutData: Data(),
+                stderr: "",
+                truncated: false
+            )
+        }
+
+        #expect(providerIDs == ["test"])
+        #expect(capturedCommand.contains(#""${SHELL:-/bin/sh}" -l -i -c"#))
+        #expect(capturedCommand.contains("command -v test-agent"))
+    }
+
+    @Test("remote provider availability surfaces command failures")
+    @MainActor
+    func remoteProviderAvailabilityFailure() async {
+        let provider = AgentTabLaunchTestProvider(executablePath: nil)
+
+        await #expect(throws: RemoteAgentLaunchAvailabilityError.self) {
+            try await RemoteAgentLaunchAvailability.resolve(
+                providers: [provider],
+                destination: SSHDestination(host: "example.com")
+            ) { _, _ in
+                GitProcessResult(
+                    status: 255,
+                    stdout: "",
+                    stdoutData: Data(),
+                    stderr: "Connection failed",
+                    truncated: false
+                )
+            }
+        }
     }
 }
 

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -84,4 +84,75 @@ struct AIAgentLaunchProviderTests {
         let invocation = OpenCodeProvider().agentLaunchConfiguration.invocation(prompt: "metadata")
         #expect(invocation?.environment == ["OPENCODE_PERMISSION": #"{"*":"deny"}"#])
     }
+
+    @Test("agent tabs launch installed local executables safely")
+    func localAgentTabCommand() {
+        let provider = AgentTabLaunchTestProvider(executablePath: "/tmp/Agent Tools/codex")
+
+        #expect(AgentTabLaunchCommand.resolve(provider: provider, isRemote: false) == "'/tmp/Agent Tools/codex'")
+    }
+
+    @Test("agent tabs omit unavailable local providers")
+    func unavailableLocalAgentTabCommand() {
+        let provider = AgentTabLaunchTestProvider(executablePath: nil)
+
+        #expect(AgentTabLaunchCommand.resolve(provider: provider, isRemote: false) == nil)
+    }
+
+    @Test("agent tabs defer executable resolution to remote shells")
+    func remoteAgentTabCommand() {
+        let provider = AgentTabLaunchTestProvider(executablePath: nil)
+
+        #expect(AgentTabLaunchCommand.resolve(provider: provider, isRemote: true) == "test-agent")
+    }
+
+    @Test("agent launch options resolve each local executable once")
+    func launchOptionsSnapshotExecutableResolution() {
+        let provider = CountingAgentTabLaunchTestProvider()
+
+        let options = AgentTabLaunchOption.resolve(providers: [provider], isRemote: false)
+
+        #expect(provider.resolutionCount == 1)
+        #expect(options.first?.command == "/tmp/test-agent")
+        #expect(options.first?.title == "Test Agent")
+    }
+}
+
+private struct AgentTabLaunchTestProvider: AIAgentLaunchProvider {
+    let id = "test"
+    let displayName = "Test Agent"
+    let iconName = "sparkles"
+    let executablePath: String?
+    let agentLaunchConfiguration = AIAgentLaunchConfiguration(
+        executable: "test-agent",
+        headlessArguments: []
+    )
+
+    func agentCLIExecutablePath() -> String? {
+        executablePath
+    }
+
+    func isAgentCLIInstalled() -> Bool {
+        executablePath != nil
+    }
+}
+
+private final class CountingAgentTabLaunchTestProvider: AIAgentLaunchProvider {
+    let id = "counting-test"
+    let displayName = "Test Agent"
+    let iconName = "sparkles"
+    let agentLaunchConfiguration = AIAgentLaunchConfiguration(
+        executable: "test-agent",
+        headlessArguments: []
+    )
+    private(set) var resolutionCount = 0
+
+    func agentCLIExecutablePath() -> String? {
+        resolutionCount += 1
+        return "/tmp/test-agent"
+    }
+
+    func isAgentCLIInstalled() -> Bool {
+        agentCLIExecutablePath() != nil
+    }
 }

--- a/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
@@ -72,6 +72,15 @@ struct AIProviderRegistryTests {
         ])
     }
 
+    @Test("agent launch providers have bundled icon assets")
+    func agentLaunchProvidersHaveIcons() {
+        let iconsURL = RepositoryRoot.find().appendingPathComponent("Muxy/Resources/ProviderIcons")
+        for provider in AIProviderRegistry.shared.agentLaunchProviders {
+            let iconURL = iconsURL.appendingPathComponent("\(provider.iconName).svg")
+            #expect(FileManager.default.fileExists(atPath: iconURL.path))
+        }
+    }
+
     @Test("prepareForInstallation stages resources but skips PATH hydration without dev opt-in")
     func prepareForInstallationStagesWithoutDevOptIn() async {
         let staging = StagingRecorder()
@@ -331,4 +340,3 @@ private final class RecordingProvider: AIProviderIntegration {
         UserDefaults.standard.removeObject(forKey: settingsKey)
     }
 }
-

--- a/Tests/MuxyTests/Services/AgentDetection/DetectedAgentStoreTests.swift
+++ b/Tests/MuxyTests/Services/AgentDetection/DetectedAgentStoreTests.swift
@@ -34,6 +34,27 @@ struct DetectedAgentStoreTests {
         #expect(store.agent(for: paneID) == nil)
     }
 
+    @Test("provisional agents appear immediately and clear when launch exits")
+    func provisionalAgentClears() {
+        let store = DetectedAgentStore.shared
+        let paneID = UUID()
+        store.setProvisionalAgent("claude", for: paneID)
+        #expect(store.agent(for: paneID) == "claude")
+        store.clearProvisionalAgent(for: paneID)
+        #expect(store.agent(for: paneID) == nil)
+    }
+
+    @Test("detected agents remain after provisional launch reconciliation")
+    func detectedAgentRemains() {
+        let store = DetectedAgentStore.shared
+        let paneID = UUID()
+        store.setProvisionalAgent("claude", for: paneID)
+        store.setAgent("claude", for: paneID)
+        store.clearProvisionalAgent(for: paneID)
+        #expect(store.agent(for: paneID) == "claude")
+        store.resetPane(paneID)
+    }
+
     @Test("resetPane removes the entry")
     func resetRemoves() {
         let store = DetectedAgentStore.shared

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -82,7 +82,7 @@ Splitting creates a child pane inside the current top-level tab. Each pane keeps
 
 Dragging a top-level tab toward an edge docks the whole tab beside another top-level tab. Its child-pane layout moves with it and remains independent from the neighboring tab's child panes.
 
-The Agents Focused layout keeps the normal top-level tab strip in the title bar and limits sidebar tab entries to detected AI agents, including idle sessions. Projects and worktrees remain visible when they have no agent sessions, and their add menu can start a new tab with any available agent provider. Tabs started from this menu appear immediately with the selected provider while process detection confirms the running TUI.
+The Agents Focused layout keeps the normal top-level tab strip in the title bar and limits sidebar tab entries to detected AI agents, including idle sessions. Projects and worktrees remain visible when they have no agent sessions, and their add menu can start a new tab with any available agent provider. Tabs started from this menu appear immediately. Local launch attribution is confirmed by process detection and removed if the command exits before confirmation. Remote availability is checked through the configured SSH connection before the menu enables a provider.
 
 ## Notifications from the terminal
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -78,9 +78,11 @@ Define reusable shell command shortcuts in **Settings → Commands**:
 
 Inside a terminal pane: **Paste**, **Split Right**, **Split Down**, **Close Pane**.
 
-Splitting creates a child pane inside the current top-level tab. Each pane keeps its own terminal, browser, source-control, or extension surface, while a one-pixel divider replaces the old per-pane tab strip. Child panes do not appear as separate entries in the window tab strip or the Tab Focused sidebar.
+Splitting creates a child pane inside the current top-level tab. Each pane keeps its own terminal, browser, source-control, or extension surface, while a one-pixel divider replaces the old per-pane tab strip. Child panes do not appear as separate entries in the window tab strip or the Tab Focused sidebar. An agent running in a child pane does appear as its own entry in the Agents Focused sidebar, and selecting it activates both the child pane and its parent top-level tab.
 
 Dragging a top-level tab toward an edge docks the whole tab beside another top-level tab. Its child-pane layout moves with it and remains independent from the neighboring tab's child panes.
+
+The Agents Focused layout keeps the normal top-level tab strip in the title bar and limits sidebar tab entries to detected AI agents, including idle sessions. Projects and worktrees remain visible when they have no agent sessions, and their add menu can start a new tab with any available agent provider. Tabs started from this menu appear immediately with the selected provider while process detection confirms the running TUI.
 
 ## Notifications from the terminal
 


### PR DESCRIPTION
Add an Agents Focused layout that lists detected agent sessions across projects and split panes, supports launching available local and remote agent providers, and introduces a layout picker. Update tab actions, tests, provider icon handling, and terminal documentation for the new workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Agents Focused** layout with a dedicated sidebar and tab area focused on detected agent sessions (including nested pane tabs).
  * Added “New Agent Tab” provider selection, with unavailable providers shown as disabled.
  * Added an app layout menu for switching layouts.
* **Bug Fixes**
  * Improved agent tab/pane actions so context options only appear where appropriate.
  * Provisional agent assignments are now cleared when a terminal process exits.
  * Provider icons can be forced to monochrome when needed.
* **Documentation**
  * Updated the terminal guide with **Agents Focused** layout and pane-splitting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->