### PR TITLE
Keep terminal processes running when the window is backgrounded

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -20,6 +20,7 @@ extension Notification.Name {
     static let focusBrowserSettings = Notification.Name("MuxyFocusBrowserSettings")
     static let focusQuickTerminalShortcut = Notification.Name("MuxyFocusQuickTerminalShortcut")
     static let quickTerminalEnabledDidChange = Notification.Name("MuxyQuickTerminalEnabledDidChange")
+    static let backgroundActivityKeepActiveDidChange = Notification.Name("MuxyBackgroundActivityKeepActiveDidChange")
     static let windowFullScreenDidChange = Notification.Name("MuxyWindowFullScreenDidChange")
     static let toggleSidebar = Notification.Name("MuxyToggleSidebar")
     static let toggleAppLayout = Notification.Name("MuxyToggleAppLayout")

--- a/Muxy/Models/Preferences/BackgroundActivityPreferences.swift
+++ b/Muxy/Models/Preferences/BackgroundActivityPreferences.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum BackgroundActivityPreferences {
+    static let keepActiveKey = "muxy.terminal.keepActiveInBackground"
+    static let defaultKeepActive = true
+
+    static func keepActive(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: keepActiveKey) != nil else { return defaultKeepActive }
+        return defaults.bool(forKey: keepActiveKey)
+    }
+
+    static func setKeepActive(
+        _ keepActive: Bool,
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        guard self.keepActive(defaults: defaults) != keepActive else { return }
+        defaults.set(keepActive, forKey: keepActiveKey)
+        notificationCenter.post(name: .backgroundActivityKeepActiveDidChange, object: defaults)
+    }
+
+    static func effectiveVisibility(
+        keepActive: Bool,
+        isPaneVisible: Bool,
+        isWindowVisible: Bool
+    ) -> Bool {
+        keepActive || (isPaneVisible && isWindowVisible)
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -236,6 +236,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var whatsNewObserver: NSObjectProtocol?
     private var modalThemeObserver: NSObjectProtocol?
     private var quickTerminalEnabledObserver: NSObjectProtocol?
+    private var backgroundActivityObserver: NSObjectProtocol?
     private var quickTerminalController: QuickTerminalController?
     private weak var settingsWindow: NSWindow?
     private weak var extensionsWindow: NSWindow?
@@ -395,6 +396,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         observeSystemAppearanceChanges()
         ModifierKeyMonitor.shared.start()
         observeQuickTerminalEnabledChanges()
+        observeBackgroundActivityChanges()
         startQuickTerminal()
         DesktopNotificationService.shared.prepare()
         NotificationSocketServer.shared.openProjectHandler = { [weak self] path in
@@ -454,6 +456,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 } else {
                     self.stopQuickTerminal(restoresFocus: true)
                 }
+            }
+        }
+    }
+
+    @MainActor
+    private func observeBackgroundActivityChanges() {
+        backgroundActivityObserver = NotificationCenter.default.addObserver(
+            forName: .backgroundActivityKeepActiveDidChange,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                TerminalViewRegistry.shared.reapplyOcclusionToAllViews()
             }
         }
     }
@@ -555,6 +570,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if let quickTerminalEnabledObserver {
             NotificationCenter.default.removeObserver(quickTerminalEnabledObserver)
             self.quickTerminalEnabledObserver = nil
+        }
+        if let backgroundActivityObserver {
+            NotificationCenter.default.removeObserver(backgroundActivityObserver)
+            self.backgroundActivityObserver = nil
         }
         persistUserStateForTermination()
         NotificationStore.shared.saveToDisk()

--- a/Muxy/Services/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Services/Terminal/TerminalViewRegistry.swift
@@ -105,6 +105,12 @@ final class TerminalViewRegistry {
         }
     }
 
+    func reapplyOcclusionToAllViews() {
+        for view in views.values {
+            view.reapplyOcclusion()
+        }
+    }
+
     var liveViews: [GhosttyTerminalNSView] {
         Array(views.values)
     }

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -9,6 +9,8 @@ struct TerminalSettingsView: View {
     private var freeIdleTerminalsEnabled = TerminalOfflinePreferences.defaultIsEnabled
     @AppStorage(TerminalOfflinePreferences.idleThresholdKey)
     private var idleThresholdSeconds = TerminalOfflinePreferences.defaultIdleThreshold
+    @AppStorage(BackgroundActivityPreferences.keepActiveKey)
+    private var keepActiveInBackground = BackgroundActivityPreferences.defaultKeepActive
 
     private var idleTimeoutSelection: Binding<String> {
         Binding(
@@ -18,6 +20,13 @@ struct TerminalSettingsView: View {
                 idleThresholdSeconds = option.seconds
                 TerminalOfflineService.shared.reload()
             }
+        )
+    }
+
+    private var keepActiveBinding: Binding<Bool> {
+        Binding(
+            get: { keepActiveInBackground },
+            set: { BackgroundActivityPreferences.setKeepActive($0) }
         )
     }
 
@@ -37,6 +46,17 @@ struct TerminalSettingsView: View {
                 SettingsToggleRow(
                     label: "Confirm before closing a tab with a running process",
                     isOn: $confirmRunningProcess
+                )
+            }
+
+            SettingsSection(
+                "Background",
+                footer: "When disabled, hidden terminal panes pause rendering and I/O to save resources. "
+                    + "This may cause running processes to freeze until the window is visible again."
+            ) {
+                SettingsToggleRow(
+                    label: "Keep processes running in the background",
+                    isOn: keepActiveBinding
                 )
             }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -438,7 +438,16 @@ final class GhosttyTerminalNSView: NSView {
 
     private func applyOcclusionState() {
         guard let surface else { return }
-        ghostty_surface_set_occlusion(surface, isPaneVisible && isWindowVisible)
+        let visible = BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: BackgroundActivityPreferences.keepActive(),
+            isPaneVisible: isPaneVisible,
+            isWindowVisible: isWindowVisible
+        )
+        ghostty_surface_set_occlusion(surface, visible)
+    }
+
+    func reapplyOcclusion() {
+        applyOcclusionState()
     }
 
     private func updateWindowVisibility() {

--- a/Tests/MuxyTests/Models/Preferences/BackgroundActivityPreferencesTests.swift
+++ b/Tests/MuxyTests/Models/Preferences/BackgroundActivityPreferencesTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Background activity preferences")
+struct BackgroundActivityPreferencesTests {
+    @Test("defaults to keeping background processes active")
+    func defaultsToKeepActive() {
+        let defaults = makeDefaults()
+        #expect(BackgroundActivityPreferences.keepActive(defaults: defaults))
+    }
+
+    @Test("persists changes and only notifies when the effective value changes")
+    func persistsAndNotifiesChanges() {
+        let defaults = makeDefaults()
+        let notificationCenter = NotificationCenter()
+        let notifications = NotificationCounter()
+        let observer = notificationCenter.addObserver(
+            forName: .backgroundActivityKeepActiveDidChange,
+            object: defaults,
+            queue: nil
+        ) { _ in
+            notifications.count += 1
+        }
+        defer { notificationCenter.removeObserver(observer) }
+
+        BackgroundActivityPreferences.setKeepActive(
+            false,
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+        BackgroundActivityPreferences.setKeepActive(
+            false,
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+        BackgroundActivityPreferences.setKeepActive(
+            true,
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+
+        #expect(BackgroundActivityPreferences.keepActive(defaults: defaults))
+        #expect(notifications.count == 2)
+    }
+
+    @Test("keep active reports visible regardless of pane or window state")
+    func keepActiveAlwaysVisible() {
+        #expect(BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: true, isPaneVisible: false, isWindowVisible: false
+        ))
+        #expect(BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: true, isPaneVisible: true, isWindowVisible: false
+        ))
+        #expect(BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: true, isPaneVisible: false, isWindowVisible: true
+        ))
+    }
+
+    @Test("without keep active, visibility follows pane and window state")
+    func withoutKeepActiveFollowsState() {
+        #expect(BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: false, isPaneVisible: true, isWindowVisible: true
+        ))
+        #expect(!BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: false, isPaneVisible: false, isWindowVisible: true
+        ))
+        #expect(!BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: false, isPaneVisible: true, isWindowVisible: false
+        ))
+        #expect(!BackgroundActivityPreferences.effectiveVisibility(
+            keepActive: false, isPaneVisible: false, isWindowVisible: false
+        ))
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "BackgroundActivityPreferencesTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Unable to create isolated UserDefaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}
+
+private final class NotificationCounter: @unchecked Sendable {
+    var count = 0
+}


### PR DESCRIPTION
set_occlusion(false)、pty backpressure / buffer fills、child process blocks on write、freezes.
adds a toggle、defaults to on / enabled、keeps background panes reported as visible to Ghostty.
https://github.com/ghostty-org/ghostty/issues/5492.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Background section in Terminal settings with a “Keep processes running in the background” toggle.
  * The setting is persisted and includes guidance about its impact on hidden rendering and I/O.

* **Bug Fixes**
  * Terminal visibility/occlusion now updates to match the Background setting, including when the toggle changes.

* **Tests**
  * Added tests covering defaults, persistence, notification behavior, and effective visibility logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->