### PR TITLE
Add GitHub Copilot AI provider integration

### DIFF
--- a/Muxy/Resources/scripts/muxy-copilot-hook.sh
+++ b/Muxy/Resources/scripts/muxy-copilot-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+bin="$(dirname "$0")/muxy-hook"
+[ -x "$bin" ] || exit 0
+exec "$bin" agent-event --provider copilot_hook --provider-title "GitHub Copilot" --event "${1:-}"

--- a/Muxy/Services/AI/AIProviderIntegration.swift
+++ b/Muxy/Services/AI/AIProviderIntegration.swift
@@ -78,6 +78,7 @@ final class AIProviderRegistry {
     private let openCodeProvider = OpenCodeProvider()
     private let codexProvider = CodexProvider()
     private let cursorProvider = CursorProvider()
+    private let copilotProvider = CopilotProvider()
     private let droidProvider = DroidProvider()
     private let piProvider = PiProvider()
     private let grokProvider = GrokProvider()
@@ -96,6 +97,7 @@ final class AIProviderRegistry {
         openCodeProvider,
         codexProvider,
         cursorProvider,
+        copilotProvider,
         droidProvider,
         piProvider,
         grokProvider,

--- a/Muxy/Services/AI/AIProviderIntegration.swift
+++ b/Muxy/Services/AI/AIProviderIntegration.swift
@@ -19,6 +19,7 @@ protocol AIProviderIntegration {
     var hookScriptName: String { get }
     var hookScriptExtension: String { get }
     var configPaths: [String] { get }
+    var requiresLoginShellEnvironmentForConfiguration: Bool { get }
 
     func isToolInstalled() -> Bool
     func isHookInstalled() -> Bool
@@ -38,6 +39,7 @@ extension AIProviderIntegration {
     }
 
     var configPaths: [String] { [] }
+    var requiresLoginShellEnvironmentForConfiguration: Bool { false }
 
     func verify(hookScriptPath _: String) -> HookVerification {
         isHookInstalled() ? .satisfied : .needsRepair
@@ -153,8 +155,10 @@ final class AIProviderRegistry {
             return
         }
 
-        let hasDisabledManagedOnly = providers.allSatisfy { !$0.isEnabled }
-        if !hasDisabledManagedOnly {
+        let needsLoginShellEnvironment = providers.contains {
+            $0.isEnabled || $0.requiresLoginShellEnvironmentForConfiguration
+        }
+        if needsLoginShellEnvironment {
             await loginShellPathHydrationTask().value
         }
 

--- a/Muxy/Services/Notifications/MuxyNotificationHooks.swift
+++ b/Muxy/Services/Notifications/MuxyNotificationHooks.swift
@@ -15,6 +15,7 @@ enum MuxyNotificationHooks {
     private static let stagedResources = [
         StagedResource(name: "muxy-claude-hook", extension: "sh", executable: true),
         StagedResource(name: "muxy-codex-hook", extension: "sh", executable: true),
+        StagedResource(name: "muxy-copilot-hook", extension: "sh", executable: true),
         StagedResource(name: "muxy-cursor-hook", extension: "sh", executable: true),
         StagedResource(name: "muxy-droid-hook", extension: "sh", executable: true),
         StagedResource(name: "muxy-grok-hook", extension: "sh", executable: true),

--- a/Muxy/Services/Providers/CopilotProvider.swift
+++ b/Muxy/Services/Providers/CopilotProvider.swift
@@ -7,6 +7,7 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
     let iconName = "copilot"
     let executableNames = ["copilot"]
     let hookScriptName = "muxy-copilot-hook"
+    let requiresLoginShellEnvironmentForConfiguration = true
 
     var agentLaunchConfiguration: AIAgentLaunchConfiguration {
         AIAgentLaunchConfiguration(
@@ -29,37 +30,42 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
     static let bindings: [(settingsKey: String, argument: String)] = [
         ("userPromptSubmitted", "user-prompt-submit"),
         ("preToolUse", "pre-tool-use"),
-        ("permissionRequest", "permission-request"),
         ("notification", "notification"),
         ("agentStop", "stop"),
         ("sessionEnd", "session-end"),
-        ("errorOccurred", "stop-failure"),
+        ("errorOccurred", "errorOccurred"),
     ]
 
-    private static let managedEvents = bindings.map(\.settingsKey)
+    private static let obsoleteEvents = ["permissionRequest"]
+    private static let managedEvents = bindings.map(\.settingsKey) + obsoleteEvents
 
     private let homeDirectory: String
     private let pathEnvironment: @Sendable () -> String
+    private let copilotHomeEnvironment: @Sendable () -> String?
     private let copilotHomeOverride: String?
 
     init(
         homeDirectory: String = NSHomeDirectory(),
         pathEnvironment: @escaping @Sendable () -> String = { LoginShellPath.current },
+        copilotHomeEnvironment: @escaping @Sendable () -> String? = { LoginShellPath.currentCopilotHome },
         copilotHome: String? = nil
     ) {
         self.homeDirectory = homeDirectory
         self.pathEnvironment = pathEnvironment
+        self.copilotHomeEnvironment = copilotHomeEnvironment
         self.copilotHomeOverride = copilotHome
     }
 
     init(
         homeDirectory: String = NSHomeDirectory(),
         pathEnvironment: String,
+        copilotHomeEnvironment: @escaping @Sendable () -> String? = { LoginShellPath.currentCopilotHome },
         copilotHome: String? = nil
     ) {
         self.init(
             homeDirectory: homeDirectory,
             pathEnvironment: { pathEnvironment },
+            copilotHomeEnvironment: copilotHomeEnvironment,
             copilotHome: copilotHome
         )
     }
@@ -68,7 +74,7 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
         if let copilotHomeOverride, !copilotHomeOverride.isEmpty {
             return copilotHomeOverride
         }
-        if let envHome = ProcessInfo.processInfo.environment["COPILOT_HOME"], !envHome.isEmpty {
+        if let envHome = copilotHomeEnvironment(), !envHome.isEmpty {
             return envHome
         }
         return homeDirectory + "/.copilot"
@@ -113,6 +119,10 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
                 return .needsRepair
             }
         }
+        for event in Self.obsoleteEvents {
+            let entries = hooks[event] as? [[String: Any]]
+            guard Self.muxyHookCount(entries) == 0 else { return .needsRepair }
+        }
         return .satisfied
     }
 
@@ -124,6 +134,19 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
             changed = true
         }
         var hooks = settings["hooks"] as? [String: Any] ?? [:]
+
+        for event in Self.obsoleteEvents {
+            guard var entries = hooks[event] as? [[String: Any]] else { continue }
+            let initialCount = entries.count
+            entries.removeAll { Self.isMuxyHookEntry($0) }
+            guard entries.count != initialCount else { continue }
+            if entries.isEmpty {
+                hooks.removeValue(forKey: event)
+            } else {
+                hooks[event] = entries
+            }
+            changed = true
+        }
 
         for binding in Self.bindings {
             let expected = Self.buildHookEntry(
@@ -173,6 +196,10 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
         let muxyEntries = entries?.filter(isMuxyHookEntry) ?? []
         guard muxyEntries.count == 1, let entry = muxyEntries.first else { return false }
         return hookEntriesMatch(entry, expected)
+    }
+
+    private static func muxyHookCount(_ entries: [[String: Any]]?) -> Int {
+        entries?.count(where: isMuxyHookEntry) ?? 0
     }
 
     private static func mergeHookArray(existing: [[String: Any]]?, entry: [String: Any]) -> [[String: Any]] {

--- a/Muxy/Services/Providers/CopilotProvider.swift
+++ b/Muxy/Services/Providers/CopilotProvider.swift
@@ -11,13 +11,20 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
     var agentLaunchConfiguration: AIAgentLaunchConfiguration {
         AIAgentLaunchConfiguration(
             executable: "copilot",
-            headlessArguments: ["-p"]
+            headlessArguments: [
+                "--silent",
+                "--no-ask-user",
+                "--available-tools=",
+                "-p",
+            ],
+            modelArgument: nil
         )
     }
 
     private static let muxyMarker = "muxy-notification-hook"
     private static let hookFileName = "muxy-notify.json"
     private static let hookTimeoutSeconds = 10
+    private static let hookFileVersion = 1
 
     static let bindings: [(settingsKey: String, argument: String)] = [
         ("userPromptSubmitted", "user-prompt-submit"),
@@ -93,13 +100,16 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
     func verify(hookScriptPath: String) -> HookVerification {
         guard ClaudeCodeProvider.fileContainsMuxyMarker(at: hookFilePath) else { return .needsRepair }
         guard let settings = try? ClaudeCodeProvider.readJSON(at: hookFilePath),
+              settings["version"] as? Int == Self.hookFileVersion,
               let hooks = settings["hooks"] as? [String: Any]
         else { return .needsRepair }
 
         for binding in Self.bindings {
-            let expected = Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
+            let expected = Self.buildHookEntry(
+                bash: Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
+            )
             let entries = hooks[binding.settingsKey] as? [[String: Any]]
-            guard Self.hasSingleMuxyHook(entries: entries, expectedBash: expected) else {
+            guard Self.hasSingleMuxyHook(entries: entries, expected: expected) else {
                 return .needsRepair
             }
         }
@@ -108,17 +118,25 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
 
     func install(hookScriptPath: String) throws {
         var settings = try Self.readSettings(at: hookFilePath)
-        settings["version"] = settings["version"] ?? 1
+        var changed = false
+        if settings["version"] as? Int != Self.hookFileVersion {
+            settings["version"] = Self.hookFileVersion
+            changed = true
+        }
         var hooks = settings["hooks"] as? [String: Any] ?? [:]
 
-        var changed = false
         for binding in Self.bindings {
-            let bash = Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
+            let expected = Self.buildHookEntry(
+                bash: Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
+            )
             let existing = hooks[binding.settingsKey] as? [[String: Any]]
-            if Self.hasSingleMuxyHook(entries: existing, expectedBash: bash) {
+            if Self.hasSingleMuxyHook(entries: existing, expected: expected) {
                 continue
             }
-            hooks[binding.settingsKey] = Self.mergeHookArray(existing: existing, bash: bash)
+            hooks[binding.settingsKey] = Self.mergeHookArray(
+                existing: existing,
+                entry: expected
+            )
             changed = true
         }
 
@@ -151,18 +169,16 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
         "\(ShellEscaper.quote(hookScript)) \(argument) # \(muxyMarker)"
     }
 
-    static func hasSingleMuxyHook(entries: [[String: Any]]?, expectedBash: String) -> Bool {
-        let muxyCommands = entries?.compactMap { entry -> String? in
-            guard let bash = entry["bash"] as? String, bash.contains(muxyMarker) else { return nil }
-            return bash
-        } ?? []
-        return muxyCommands == [expectedBash]
+    static func hasSingleMuxyHook(entries: [[String: Any]]?, expected: [String: Any]) -> Bool {
+        let muxyEntries = entries?.filter(isMuxyHookEntry) ?? []
+        guard muxyEntries.count == 1, let entry = muxyEntries.first else { return false }
+        return hookEntriesMatch(entry, expected)
     }
 
-    private static func mergeHookArray(existing: [[String: Any]]?, bash: String) -> [[String: Any]] {
+    private static func mergeHookArray(existing: [[String: Any]]?, entry: [String: Any]) -> [[String: Any]] {
         var entries = existing ?? []
         entries.removeAll { isMuxyHookEntry($0) }
-        entries.append(buildHookEntry(bash: bash))
+        entries.append(entry)
         return entries
     }
 
@@ -177,6 +193,23 @@ struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
     private static func isMuxyHookEntry(_ entry: [String: Any]) -> Bool {
         guard let bash = entry["bash"] as? String else { return false }
         return bash.contains(muxyMarker)
+    }
+
+    private static func hookEntriesMatch(_ lhs: [String: Any], _ rhs: [String: Any]) -> Bool {
+        guard (lhs["bash"] as? String) == (rhs["bash"] as? String),
+              (lhs["type"] as? String) == (rhs["type"] as? String)
+        else { return false }
+        return intValue(lhs["timeoutSec"]) == intValue(rhs["timeoutSec"])
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let value = value as? Int {
+            return value
+        }
+        if let value = value as? NSNumber {
+            return value.intValue
+        }
+        return nil
     }
 
     private static func readSettings(at path: String) throws -> [String: Any] {

--- a/Muxy/Services/Providers/CopilotProvider.swift
+++ b/Muxy/Services/Providers/CopilotProvider.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+struct CopilotProvider: AIProviderIntegration, AIAgentLaunchProvider {
+    let id = "copilot"
+    let displayName = "GitHub Copilot"
+    let socketTypeKey = "copilot_hook"
+    let iconName = "copilot"
+    let executableNames = ["copilot"]
+    let hookScriptName = "muxy-copilot-hook"
+
+    var agentLaunchConfiguration: AIAgentLaunchConfiguration {
+        AIAgentLaunchConfiguration(
+            executable: "copilot",
+            headlessArguments: ["-p"]
+        )
+    }
+
+    private static let muxyMarker = "muxy-notification-hook"
+    private static let hookFileName = "muxy-notify.json"
+    private static let hookTimeoutSeconds = 10
+
+    static let bindings: [(settingsKey: String, argument: String)] = [
+        ("userPromptSubmitted", "user-prompt-submit"),
+        ("preToolUse", "pre-tool-use"),
+        ("permissionRequest", "permission-request"),
+        ("notification", "notification"),
+        ("agentStop", "stop"),
+        ("sessionEnd", "session-end"),
+        ("errorOccurred", "stop-failure"),
+    ]
+
+    private static let managedEvents = bindings.map(\.settingsKey)
+
+    private let homeDirectory: String
+    private let pathEnvironment: @Sendable () -> String
+    private let copilotHomeOverride: String?
+
+    init(
+        homeDirectory: String = NSHomeDirectory(),
+        pathEnvironment: @escaping @Sendable () -> String = { LoginShellPath.current },
+        copilotHome: String? = nil
+    ) {
+        self.homeDirectory = homeDirectory
+        self.pathEnvironment = pathEnvironment
+        self.copilotHomeOverride = copilotHome
+    }
+
+    init(
+        homeDirectory: String = NSHomeDirectory(),
+        pathEnvironment: String,
+        copilotHome: String? = nil
+    ) {
+        self.init(
+            homeDirectory: homeDirectory,
+            pathEnvironment: { pathEnvironment },
+            copilotHome: copilotHome
+        )
+    }
+
+    private var copilotHome: String {
+        if let copilotHomeOverride, !copilotHomeOverride.isEmpty {
+            return copilotHomeOverride
+        }
+        if let envHome = ProcessInfo.processInfo.environment["COPILOT_HOME"], !envHome.isEmpty {
+            return envHome
+        }
+        return homeDirectory + "/.copilot"
+    }
+
+    private var hooksDir: String { copilotHome + "/hooks" }
+    private var hookFilePath: String { hooksDir + "/" + Self.hookFileName }
+
+    func isToolInstalled() -> Bool {
+        agentCLIExecutablePath() != nil
+    }
+
+    func agentCLIExecutablePath() -> String? {
+        ProviderExecutableLocator.executablePath(
+            names: [agentLaunchConfiguration.executable],
+            homeDirectory: homeDirectory,
+            pathEnvironment: pathEnvironment(),
+            includeSystemWide: homeDirectory == NSHomeDirectory(),
+            homeRelativeBins: [".local/bin", ".npm-global/bin"]
+        )
+    }
+
+    func isHookInstalled() -> Bool {
+        ClaudeCodeProvider.fileContainsMuxyMarker(at: hookFilePath)
+    }
+
+    var configPaths: [String] { [hookFilePath] }
+
+    func verify(hookScriptPath: String) -> HookVerification {
+        guard ClaudeCodeProvider.fileContainsMuxyMarker(at: hookFilePath) else { return .needsRepair }
+        guard let settings = try? ClaudeCodeProvider.readJSON(at: hookFilePath),
+              let hooks = settings["hooks"] as? [String: Any]
+        else { return .needsRepair }
+
+        for binding in Self.bindings {
+            let expected = Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
+            let entries = hooks[binding.settingsKey] as? [[String: Any]]
+            guard Self.hasSingleMuxyHook(entries: entries, expectedBash: expected) else {
+                return .needsRepair
+            }
+        }
+        return .satisfied
+    }
+
+    func install(hookScriptPath: String) throws {
+        var settings = try Self.readSettings(at: hookFilePath)
+        settings["version"] = settings["version"] ?? 1
+        var hooks = settings["hooks"] as? [String: Any] ?? [:]
+
+        var changed = false
+        for binding in Self.bindings {
+            let bash = Self.hookCommand(hookScript: hookScriptPath, argument: binding.argument)
+            let existing = hooks[binding.settingsKey] as? [[String: Any]]
+            if Self.hasSingleMuxyHook(entries: existing, expectedBash: bash) {
+                continue
+            }
+            hooks[binding.settingsKey] = Self.mergeHookArray(existing: existing, bash: bash)
+            changed = true
+        }
+
+        guard changed else { return }
+        settings["hooks"] = hooks
+        try Self.writeSettings(settings, at: hookFilePath)
+    }
+
+    func uninstall() throws {
+        guard FileManager.default.fileExists(atPath: hookFilePath) else { return }
+        guard isHookInstalled() else { return }
+        var settings = try Self.readSettings(at: hookFilePath)
+        guard var hooks = settings["hooks"] as? [String: Any] else { return }
+
+        for event in Self.managedEvents {
+            guard var entries = hooks[event] as? [[String: Any]] else { continue }
+            entries.removeAll { Self.isMuxyHookEntry($0) }
+            if entries.isEmpty {
+                hooks.removeValue(forKey: event)
+            } else {
+                hooks[event] = entries
+            }
+        }
+
+        settings["hooks"] = hooks
+        try Self.writeSettings(settings, at: hookFilePath)
+    }
+
+    static func hookCommand(hookScript: String, argument: String) -> String {
+        "\(ShellEscaper.quote(hookScript)) \(argument) # \(muxyMarker)"
+    }
+
+    static func hasSingleMuxyHook(entries: [[String: Any]]?, expectedBash: String) -> Bool {
+        let muxyCommands = entries?.compactMap { entry -> String? in
+            guard let bash = entry["bash"] as? String, bash.contains(muxyMarker) else { return nil }
+            return bash
+        } ?? []
+        return muxyCommands == [expectedBash]
+    }
+
+    private static func mergeHookArray(existing: [[String: Any]]?, bash: String) -> [[String: Any]] {
+        var entries = existing ?? []
+        entries.removeAll { isMuxyHookEntry($0) }
+        entries.append(buildHookEntry(bash: bash))
+        return entries
+    }
+
+    private static func buildHookEntry(bash: String) -> [String: Any] {
+        [
+            "type": "command",
+            "bash": bash,
+            "timeoutSec": hookTimeoutSeconds,
+        ]
+    }
+
+    private static func isMuxyHookEntry(_ entry: [String: Any]) -> Bool {
+        guard let bash = entry["bash"] as? String else { return false }
+        return bash.contains(muxyMarker)
+    }
+
+    private static func readSettings(at path: String) throws -> [String: Any] {
+        guard FileManager.default.fileExists(atPath: path) else { return [:] }
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        guard !data.isEmpty else { return [:] }
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [:] }
+        return json
+    }
+
+    private static func writeSettings(_ settings: [String: Any], at path: String) throws {
+        try HookConfigWriter.write(settings, to: path)
+    }
+}

--- a/Muxy/Utilities/LoginShellPath.swift
+++ b/Muxy/Utilities/LoginShellPath.swift
@@ -3,28 +3,45 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "LoginShellPath")
 
+struct LoginShellEnvironmentValues: Equatable, Sendable {
+    let path: String
+    let copilotHome: String?
+}
+
 final class LoginShellPath: @unchecked Sendable {
     static let shared = LoginShellPath()
     static let shellArguments = [
         "-l",
         "-i",
         "-c",
-        "printf '__MUXY_PATH_START__'; /usr/bin/printenv PATH; printf '__MUXY_PATH_END__'",
+        "printf '__MUXY_PATH_START__'; /usr/bin/printenv PATH; printf '__MUXY_PATH_END__'; "
+            + "printf '__MUXY_COPILOT_HOME_START__'; /usr/bin/printenv COPILOT_HOME; "
+            + "printf '__MUXY_COPILOT_HOME_END__'",
     ]
 
     private static let pathStartMarker = "__MUXY_PATH_START__"
     private static let pathEndMarker = "__MUXY_PATH_END__"
+    private static let copilotHomeStartMarker = "__MUXY_COPILOT_HOME_START__"
+    private static let copilotHomeEndMarker = "__MUXY_COPILOT_HOME_END__"
     private static let shellOutputByteLimit = 262_144
 
     private let lock = NSLock()
     private var cached: String?
+    private var cachedCopilotHome: String?
+    private var environmentHydrated = false
 
     init() {}
 
     static var current: String { shared.value }
+    static var currentCopilotHome: String? { shared.copilotHome }
 
     static var defaultPath: String {
         ProcessInfo.processInfo.environment["PATH"] ?? "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    }
+
+    static var defaultCopilotHome: String? {
+        guard let value = ProcessInfo.processInfo.environment["COPILOT_HOME"], !value.isEmpty else { return nil }
+        return value
     }
 
     static func hydrateInBackground() {
@@ -32,13 +49,15 @@ final class LoginShellPath: @unchecked Sendable {
     }
 
     static func hydrate() async {
-        await shared.hydrate()
+        await shared.hydrateEnvironment()
     }
 
     var value: String {
-        lock.lock()
-        defer { lock.unlock() }
-        return cached ?? Self.defaultPath
+        lock.withLock { cached ?? Self.defaultPath }
+    }
+
+    var copilotHome: String? {
+        lock.withLock { environmentHydrated ? cachedCopilotHome : Self.defaultCopilotHome }
     }
 
     func hydrate(readFromLoginShell: @escaping @Sendable () -> String? = LoginShellPath.readFromLoginShell) async {
@@ -55,9 +74,28 @@ final class LoginShellPath: @unchecked Sendable {
         logger.info("Hydrated PATH from login shell")
     }
 
+    func hydrateEnvironment(
+        readFromLoginShell: @escaping @Sendable () -> LoginShellEnvironmentValues? = LoginShellPath
+            .readEnvironmentFromLoginShell
+    ) async {
+        let resolved = await Task.detached(priority: .utility) {
+            readFromLoginShell()
+        }.value
+        guard let resolved else {
+            logger.info("Login shell environment lookup yielded no value; keeping launch environment")
+            return
+        }
+        lock.withLock {
+            cached = resolved.path
+            cachedCopilotHome = resolved.copilotHome
+            environmentHydrated = true
+        }
+        logger.info("Hydrated environment from login shell")
+    }
+
     private func hydrateInBackground() {
         Task.detached(priority: .utility) { [self] in
-            await hydrate()
+            await hydrateEnvironment()
         }
     }
 
@@ -65,11 +103,37 @@ final class LoginShellPath: @unchecked Sendable {
         readPath(shellPath: UserShell.path(), arguments: shellArguments)
     }
 
+    private static func readEnvironmentFromLoginShell() -> LoginShellEnvironmentValues? {
+        readEnvironment(shellPath: UserShell.path(), arguments: shellArguments)
+    }
+
     static func readPath(
         shellPath: String,
         arguments: [String],
         timeout: DispatchTimeInterval = .seconds(3)
     ) -> String? {
+        guard let output = readShellOutput(shellPath: shellPath, arguments: arguments, timeout: timeout) else {
+            return nil
+        }
+        return extractPath(from: output)
+    }
+
+    static func readEnvironment(
+        shellPath: String,
+        arguments: [String],
+        timeout: DispatchTimeInterval = .seconds(3)
+    ) -> LoginShellEnvironmentValues? {
+        guard let output = readShellOutput(shellPath: shellPath, arguments: arguments, timeout: timeout) else {
+            return nil
+        }
+        return extractEnvironment(from: output)
+    }
+
+    private static func readShellOutput(
+        shellPath: String,
+        arguments: [String],
+        timeout: DispatchTimeInterval
+    ) -> Data? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shellPath)
         process.arguments = arguments
@@ -121,24 +185,59 @@ final class LoginShellPath: @unchecked Sendable {
         }
         guard process.terminationStatus == 0 else { return nil }
 
-        return extractPath(from: stdoutData)
+        return stdoutData
     }
 
     static func extractPath(from shellOutputData: Data) -> String? {
-        let bytes = Array(shellOutputData)
-        guard let validStart = bytes.firstIndex(where: { $0 & 0xC0 != 0x80 }),
-              let output = String(bytes: bytes[validStart...], encoding: .utf8)
-        else { return nil }
+        guard let output = decodedShellOutput(from: shellOutputData) else { return nil }
         return extractPath(from: output)
     }
 
     static func extractPath(from shellOutput: String) -> String? {
-        guard let start = shellOutput.range(of: pathStartMarker, options: .backwards) else { return nil }
-        let outputAfterStart = shellOutput[start.upperBound...]
-        guard let end = outputAfterStart.range(of: pathEndMarker) else { return nil }
-        let path = outputAfterStart[..<end.lowerBound]
+        extractedValue(
+            from: shellOutput,
+            startMarker: pathStartMarker,
+            endMarker: pathEndMarker
+        )
+    }
+
+    static func extractEnvironment(from shellOutputData: Data) -> LoginShellEnvironmentValues? {
+        guard let output = decodedShellOutput(from: shellOutputData) else { return nil }
+        return extractEnvironment(from: output)
+    }
+
+    static func extractEnvironment(from shellOutput: String) -> LoginShellEnvironmentValues? {
+        guard let path = extractPath(from: shellOutput),
+              shellOutput.range(of: copilotHomeStartMarker, options: .backwards) != nil,
+              shellOutput.range(of: copilotHomeEndMarker, options: .backwards) != nil
+        else { return nil }
+        return LoginShellEnvironmentValues(
+            path: path,
+            copilotHome: extractedValue(
+                from: shellOutput,
+                startMarker: copilotHomeStartMarker,
+                endMarker: copilotHomeEndMarker
+            )
+        )
+    }
+
+    private static func decodedShellOutput(from data: Data) -> String? {
+        let bytes = Array(data)
+        guard let validStart = bytes.firstIndex(where: { $0 & 0xC0 != 0x80 }) else { return nil }
+        return String(bytes: bytes[validStart...], encoding: .utf8)
+    }
+
+    private static func extractedValue(
+        from output: String,
+        startMarker: String,
+        endMarker: String
+    ) -> String? {
+        guard let start = output.range(of: startMarker, options: .backwards) else { return nil }
+        let outputAfterStart = output[start.upperBound...]
+        guard let end = outputAfterStart.range(of: endMarker) else { return nil }
+        let value = outputAfterStart[..<end.lowerBound]
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return path.isEmpty ? nil : path
+        return value.isEmpty ? nil : value
     }
 }
 

--- a/MuxyHookKit/AgentHookEventMapper.swift
+++ b/MuxyHookKit/AgentHookEventMapper.swift
@@ -22,10 +22,13 @@ public enum AgentHookEventMapper {
              "pre-tool-use",
              "UserPromptSubmit",
              "PreToolUse",
-             "beforeSubmitPrompt":
+             "beforeSubmitPrompt",
+             "userPromptSubmitted",
+             "preToolUse":
             return MappedAgentHookEvent(phase: .working, title: "", body: "")
         case "permission-request",
-             "PermissionRequest":
+             "PermissionRequest",
+             "permissionRequest":
             return MappedAgentHookEvent(
                 phase: .waiting,
                 title: sanitize(providerTitle),
@@ -35,7 +38,8 @@ public enum AgentHookEventMapper {
              "Notification":
             return mapNotification(providerTitle: providerTitle, payload: payload)
         case "stop",
-             "Stop":
+             "Stop",
+             "agentStop":
             return MappedAgentHookEvent(
                 phase: .finished,
                 title: sanitize(providerTitle),
@@ -43,7 +47,8 @@ public enum AgentHookEventMapper {
                     ?? "Session completed"
             )
         case "stop-failure",
-             "StopFailure":
+             "StopFailure",
+             "errorOccurred":
             return MappedAgentHookEvent(
                 phase: .finished,
                 title: sanitize(providerTitle),
@@ -82,9 +87,12 @@ public enum AgentHookEventMapper {
         switch type {
         case "auth_success",
              "elicitation_complete",
-             "elicitation_response":
+             "elicitation_response",
+             "shell_completed",
+             "shell_detached_completed":
             return nil
-        case "task_complete":
+        case "task_complete",
+             "agent_completed":
             return MappedAgentHookEvent(
                 phase: .finished,
                 title: title,
@@ -108,7 +116,8 @@ public enum AgentHookEventMapper {
                 title: title,
                 body: notificationBody(in: payload, fallback: "Question waiting")
             )
-        case "idle_prompt":
+        case "idle_prompt",
+             "agent_idle":
             return MappedAgentHookEvent(
                 phase: .waiting,
                 title: title,

--- a/MuxyHookKit/AgentHookEventMapper.swift
+++ b/MuxyHookKit/AgentHookEventMapper.swift
@@ -27,8 +27,7 @@ public enum AgentHookEventMapper {
              "preToolUse":
             return MappedAgentHookEvent(phase: .working, title: "", body: "")
         case "permission-request",
-             "PermissionRequest",
-             "permissionRequest":
+             "PermissionRequest":
             return MappedAgentHookEvent(
                 phase: .waiting,
                 title: sanitize(providerTitle),
@@ -47,13 +46,14 @@ public enum AgentHookEventMapper {
                     ?? "Session completed"
             )
         case "stop-failure",
-             "StopFailure",
-             "errorOccurred":
+             "StopFailure":
             return MappedAgentHookEvent(
                 phase: .finished,
                 title: sanitize(providerTitle),
                 body: notificationBody(in: payload, fallback: "Session failed")
             )
+        case "errorOccurred":
+            return mapErrorOccurred(providerTitle: providerTitle, payload: payload)
         case "session-end",
              "SessionEnd",
              "sessionEnd":
@@ -89,10 +89,11 @@ public enum AgentHookEventMapper {
              "elicitation_complete",
              "elicitation_response",
              "shell_completed",
-             "shell_detached_completed":
+             "shell_detached_completed",
+             "agent_completed",
+             "agent_idle":
             return nil
-        case "task_complete",
-             "agent_completed":
+        case "task_complete":
             return MappedAgentHookEvent(
                 phase: .finished,
                 title: title,
@@ -116,8 +117,7 @@ public enum AgentHookEventMapper {
                 title: title,
                 body: notificationBody(in: payload, fallback: "Question waiting")
             )
-        case "idle_prompt",
-             "agent_idle":
+        case "idle_prompt":
             return MappedAgentHookEvent(
                 phase: .waiting,
                 title: title,
@@ -130,6 +130,20 @@ public enum AgentHookEventMapper {
                 body: notificationBody(in: payload, fallback: "Needs attention")
             )
         }
+    }
+
+    private static func mapErrorOccurred(
+        providerTitle: String,
+        payload: [String: Any]
+    ) -> MappedAgentHookEvent? {
+        guard payload["recoverable"] as? Bool != true else { return nil }
+        let error = payload["error"] as? [String: Any] ?? [:]
+        return MappedAgentHookEvent(
+            phase: .finished,
+            title: sanitize(providerTitle),
+            body: firstValue(in: error, keys: ["message"])
+                ?? notificationBody(in: payload, fallback: "Session failed")
+        )
     }
 
     private static func notificationBody(in payload: [String: Any], fallback: String) -> String {

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -25,6 +25,7 @@ struct AIAgentLaunchProviderTests {
             (OpenCodeProvider(), ["run", "--pure", prompt]),
             (CodexProvider(), ["exec", "--ephemeral", "--sandbox", "read-only", "--color", "never", prompt]),
             (CursorProvider(), ["--print", "--output-format", "text", prompt]),
+            (CopilotProvider(), ["-p", prompt]),
             (DroidProvider(), ["exec", "--output-format", "text", prompt]),
             (PiProvider(), ["--print", "--no-session", "--no-tools", prompt]),
             (

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -25,7 +25,16 @@ struct AIAgentLaunchProviderTests {
             (OpenCodeProvider(), ["run", "--pure", prompt]),
             (CodexProvider(), ["exec", "--ephemeral", "--sandbox", "read-only", "--color", "never", prompt]),
             (CursorProvider(), ["--print", "--output-format", "text", prompt]),
-            (CopilotProvider(), ["-p", prompt]),
+            (
+                CopilotProvider(),
+                [
+                    "--silent",
+                    "--no-ask-user",
+                    "--available-tools=",
+                    "-p",
+                    prompt,
+                ]
+            ),
             (DroidProvider(), ["exec", "--output-format", "text", prompt]),
             (PiProvider(), ["--print", "--no-session", "--no-tools", prompt]),
             (
@@ -84,6 +93,21 @@ struct AIAgentLaunchProviderTests {
     func openCodeDeniesTools() {
         let invocation = OpenCodeProvider().agentLaunchConfiguration.invocation(prompt: "metadata")
         #expect(invocation?.environment == ["OPENCODE_PERMISSION": #"{"*":"deny"}"#])
+    }
+
+    @Test("Copilot omits model flags so -p stays adjacent to the prompt")
+    func copilotDoesNotInsertModelBetweenPromptFlag() {
+        let configuration = CopilotProvider().agentLaunchConfiguration
+        let invocation = configuration.invocation(prompt: "metadata", model: "gpt-5")
+
+        #expect(configuration.modelArgument == nil)
+        #expect(invocation?.arguments == [
+            "--silent",
+            "--no-ask-user",
+            "--available-tools=",
+            "-p",
+            "metadata",
+        ])
     }
 
     @Test("agent tabs launch installed local executables safely")

--- a/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
@@ -121,6 +121,25 @@ struct AIProviderRegistryTests {
         #expect(provider.toolCheckCount == 0)
     }
 
+    @Test("installAll hydrates configuration environments for disabled providers that require them")
+    func installAllHydratesConfigurationEnvironmentForDisabledProvider() async {
+        let provider = RecordingProvider()
+        defer { provider.resetSettings() }
+        provider.isEnabled = false
+        provider.requiresLoginShellEnvironmentForConfiguration = true
+        let hydration = StagingRecorder()
+        let registry = AIProviderRegistry(
+            providers: [provider],
+            hydrateLoginShellPath: { hydration.record() },
+            shouldInstallHooksInDebug: { true },
+            stageHookResources: { true }
+        )
+
+        await registry.installAll()
+
+        #expect(hydration.count == 1)
+    }
+
     @Test("installAll does not touch disabled providers without managed state")
     func installAllDoesNotTouchDisabledProvidersWithoutManagedState() async {
         let provider = RecordingProvider()
@@ -303,6 +322,7 @@ private final class RecordingProvider: AIProviderIntegration {
     var hookInstalled = false
     var managedStateInstalled = false
     var toolInstalled = false
+    var requiresLoginShellEnvironmentForConfiguration = false
     var toolCheckCount = 0
     var installCount = 0
     var uninstallCount = 0

--- a/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIProviderRegistryTests.swift
@@ -26,6 +26,7 @@ struct AIProviderRegistryTests {
         let expected: [String: String] = [
             "claude_hook": "claude",
             "cursor_hook": "cursor",
+            "copilot_hook": "copilot",
             "codex_hook": "codex",
             "droid_hook": "droid",
             "opencode": "opencode",
@@ -66,6 +67,7 @@ struct AIProviderRegistryTests {
             "opencode",
             "codex",
             "cursor",
+            "copilot",
             "droid",
             "pi",
             "grok",

--- a/Tests/MuxyTests/Services/Notifications/AgentHookBridgeMappingTests.swift
+++ b/Tests/MuxyTests/Services/Notifications/AgentHookBridgeMappingTests.swift
@@ -143,6 +143,8 @@ struct AgentHookBridgeMappingTests {
             "UserPromptSubmit",
             "PreToolUse",
             "beforeSubmitPrompt",
+            "userPromptSubmitted",
+            "preToolUse",
         ]
     )
     func mapsWorkingAliases(event: String) {
@@ -151,7 +153,7 @@ struct AgentHookBridgeMappingTests {
 
     @Test("permission request aliases map to a waiting notification")
     func mapsPermissionRequests() {
-        for event in ["permission-request", "PermissionRequest"] {
+        for event in ["permission-request", "PermissionRequest", "permissionRequest"] {
             #expect(map(event: event) == MappedAgentHookEvent(
                 phase: .waiting,
                 title: "Claude Code",
@@ -164,10 +166,12 @@ struct AgentHookBridgeMappingTests {
         "notification types map to stable phases and fallbacks",
         arguments: [
             ("task_complete", AgentHookPhase.finished, "Task completed"),
+            ("agent_completed", AgentHookPhase.finished, "Task completed"),
             ("agent_error", AgentHookPhase.finished, "Agent error"),
             ("permission_prompt", AgentHookPhase.waiting, "Permission needed"),
             ("elicitation_dialog", AgentHookPhase.waiting, "Question waiting"),
             ("idle_prompt", AgentHookPhase.waiting, "Idle prompt"),
+            ("agent_idle", AgentHookPhase.waiting, "Idle prompt"),
             ("unknown", AgentHookPhase.waiting, "Needs attention"),
         ]
     )
@@ -206,7 +210,13 @@ struct AgentHookBridgeMappingTests {
 
     @Test(
         "settled notification types do not emit lifecycle events",
-        arguments: ["auth_success", "elicitation_complete", "elicitation_response"]
+        arguments: [
+            "auth_success",
+            "elicitation_complete",
+            "elicitation_response",
+            "shell_completed",
+            "shell_detached_completed",
+        ]
     )
     func ignoresSettledNotifications(type: String) {
         #expect(map(event: "notification", input: data(["notification_type": type])) == nil)
@@ -228,7 +238,9 @@ struct AgentHookBridgeMappingTests {
             body: "Implemented"
         ))
         #expect(map(event: "stop", input: Data("invalid".utf8))?.body == "Session completed")
+        #expect(map(event: "agentStop")?.body == "Session completed")
         #expect(map(event: "stop-failure")?.body == "Session failed")
+        #expect(map(event: "errorOccurred")?.body == "Session failed")
         #expect(map(event: "StopFailure", input: data(["title": "Failed safely"]))?.body == "Failed safely")
     }
 

--- a/Tests/MuxyTests/Services/Notifications/AgentHookBridgeMappingTests.swift
+++ b/Tests/MuxyTests/Services/Notifications/AgentHookBridgeMappingTests.swift
@@ -153,25 +153,24 @@ struct AgentHookBridgeMappingTests {
 
     @Test("permission request aliases map to a waiting notification")
     func mapsPermissionRequests() {
-        for event in ["permission-request", "PermissionRequest", "permissionRequest"] {
+        for event in ["permission-request", "PermissionRequest"] {
             #expect(map(event: event) == MappedAgentHookEvent(
                 phase: .waiting,
                 title: "Claude Code",
                 body: "Needs attention"
             ))
         }
+        #expect(map(event: "permissionRequest") == nil)
     }
 
     @Test(
         "notification types map to stable phases and fallbacks",
         arguments: [
             ("task_complete", AgentHookPhase.finished, "Task completed"),
-            ("agent_completed", AgentHookPhase.finished, "Task completed"),
             ("agent_error", AgentHookPhase.finished, "Agent error"),
             ("permission_prompt", AgentHookPhase.waiting, "Permission needed"),
             ("elicitation_dialog", AgentHookPhase.waiting, "Question waiting"),
             ("idle_prompt", AgentHookPhase.waiting, "Idle prompt"),
-            ("agent_idle", AgentHookPhase.waiting, "Idle prompt"),
             ("unknown", AgentHookPhase.waiting, "Needs attention"),
         ]
     )
@@ -216,6 +215,8 @@ struct AgentHookBridgeMappingTests {
             "elicitation_response",
             "shell_completed",
             "shell_detached_completed",
+            "agent_completed",
+            "agent_idle",
         ]
     )
     func ignoresSettledNotifications(type: String) {
@@ -242,6 +243,25 @@ struct AgentHookBridgeMappingTests {
         #expect(map(event: "stop-failure")?.body == "Session failed")
         #expect(map(event: "errorOccurred")?.body == "Session failed")
         #expect(map(event: "StopFailure", input: data(["title": "Failed safely"]))?.body == "Failed safely")
+    }
+
+    @Test("Copilot errors finish only when they are not recoverable")
+    func mapsCopilotErrors() {
+        let recoverable = data([
+            "recoverable": true,
+            "error": ["message": "Retrying"],
+        ])
+        #expect(map(event: "errorOccurred", input: recoverable) == nil)
+
+        let terminal = data([
+            "recoverable": false,
+            "error": ["message": "Authentication failed"],
+        ])
+        #expect(map(event: "errorOccurred", input: terminal) == MappedAgentHookEvent(
+            phase: .finished,
+            title: "Claude Code",
+            body: "Authentication failed"
+        ))
     }
 
     @Test("session end aliases finish silently and unknown events are ignored")
@@ -272,7 +292,7 @@ struct AgentHookBridgeMappingTests {
         AgentHookEventMapper.map(event: event, providerTitle: "Claude Code", input: input)
     }
 
-    private func data(_ object: [String: String]) -> Data {
+    private func data(_ object: [String: Any]) -> Data {
         (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
     }
 }

--- a/Tests/MuxyTests/Services/Notifications/MuxyNotificationHooksTests.swift
+++ b/Tests/MuxyTests/Services/Notifications/MuxyNotificationHooksTests.swift
@@ -178,6 +178,7 @@ struct MuxyNotificationHooksTests {
     private static let shellScriptNames = [
         "muxy-claude-hook.sh",
         "muxy-codex-hook.sh",
+        "muxy-copilot-hook.sh",
         "muxy-cursor-hook.sh",
         "muxy-droid-hook.sh",
         "muxy-grok-hook.sh",

--- a/Tests/MuxyTests/Services/Providers/CopilotProviderTests.swift
+++ b/Tests/MuxyTests/Services/Providers/CopilotProviderTests.swift
@@ -41,6 +41,7 @@ struct CopilotProviderTests {
                 #expect(entries.first?["type"] as? String == "command")
                 #expect(entries.first?["timeoutSec"] as? Int == 10)
             }
+            #expect(hooks["permissionRequest"] == nil)
         }
     }
 
@@ -64,6 +65,10 @@ struct CopilotProviderTests {
                     fixture.muxyEntry("stop", script: "/old/muxy-copilot-hook.sh"),
                     fixture.foreignEntry,
                 ],
+                "permissionRequest": [
+                    fixture.muxyEntry("permission-request"),
+                    fixture.foreignEntry,
+                ],
             ])
 
             try fixture.provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
@@ -75,6 +80,9 @@ struct CopilotProviderTests {
             #expect(bashCommands.contains("echo foreign"))
             #expect(bashCommands.contains { $0.contains("/tmp/muxy-copilot-hook.sh") && $0.contains(" stop ") })
             #expect(!bashCommands.contains { $0.contains("/old/muxy-copilot-hook.sh") })
+            let permissionEntries = try #require(hooks["permissionRequest"] as? [[String: Any]])
+            #expect(permissionEntries.count == 1)
+            #expect(permissionEntries.first?["bash"] as? String == "echo foreign")
         }
     }
 
@@ -177,9 +185,11 @@ struct CopilotProviderTests {
     func usesCopilotHomeOverride() throws {
         try withFixture { fixture in
             let customHome = fixture.rootURL.appendingPathComponent("custom-copilot")
+            let environmentHomePath = fixture.rootURL.appendingPathComponent("environment-home").path
             let provider = CopilotProvider(
                 homeDirectory: fixture.rootURL.path,
                 pathEnvironment: "",
+                copilotHomeEnvironment: { environmentHomePath },
                 copilotHome: customHome.path
             )
             try provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
@@ -188,6 +198,24 @@ struct CopilotProviderTests {
             #expect(FileManager.default.fileExists(atPath: path))
             #expect(provider.configPaths == [path])
             #expect(provider.isHookInstalled())
+        }
+    }
+
+    @Test("respects Copilot home resolved from the login shell environment")
+    func usesCopilotHomeEnvironment() throws {
+        try withFixture { fixture in
+            let customHome = fixture.rootURL.appendingPathComponent("shell-copilot")
+            let provider = CopilotProvider(
+                homeDirectory: fixture.rootURL.path,
+                pathEnvironment: "",
+                copilotHomeEnvironment: { customHome.path }
+            )
+
+            try provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
+
+            let path = customHome.appendingPathComponent("hooks/muxy-notify.json").path
+            #expect(FileManager.default.fileExists(atPath: path))
+            #expect(provider.configPaths == [path])
         }
     }
 

--- a/Tests/MuxyTests/Services/Providers/CopilotProviderTests.swift
+++ b/Tests/MuxyTests/Services/Providers/CopilotProviderTests.swift
@@ -94,6 +94,48 @@ struct CopilotProviderTests {
         }
     }
 
+    @Test("verify needs repair when hook file version drifts")
+    func verifyNeedsRepairForWrongVersion() throws {
+        try withFixture { fixture in
+            let script = "/tmp/muxy-copilot-hook.sh"
+            try fixture.provider.install(hookScriptPath: script)
+            #expect(fixture.provider.verify(hookScriptPath: script) == .satisfied)
+
+            var settings = try fixture.settings()
+            settings["version"] = 2
+            try fixture.writeSettings(settings)
+            #expect(fixture.provider.verify(hookScriptPath: script) == .needsRepair)
+
+            try fixture.provider.install(hookScriptPath: script)
+            #expect(try fixture.settings()["version"] as? Int == 1)
+            #expect(fixture.provider.verify(hookScriptPath: script) == .satisfied)
+        }
+    }
+
+    @Test("verify needs repair when timeout or type drifts")
+    func verifyNeedsRepairForEntryShapeDrift() throws {
+        try withFixture { fixture in
+            let script = "/tmp/muxy-copilot-hook.sh"
+            try fixture.provider.install(hookScriptPath: script)
+
+            var hooks = try #require(try fixture.settings()["hooks"] as? [String: Any])
+            var stop = try #require(hooks["agentStop"] as? [[String: Any]])
+            stop[0]["timeoutSec"] = 99
+            hooks["agentStop"] = stop
+            try fixture.writeHooks(hooks)
+            #expect(fixture.provider.verify(hookScriptPath: script) == .needsRepair)
+
+            try fixture.provider.install(hookScriptPath: script)
+            #expect(fixture.provider.verify(hookScriptPath: script) == .satisfied)
+            let repaired = try #require(
+                try fixture.settings()["hooks"] as? [String: Any]
+            )
+            let repairedStop = try #require(repaired["agentStop"] as? [[String: Any]])
+            #expect(repairedStop.first?["timeoutSec"] as? Int == 10)
+            #expect(repairedStop.first?["type"] as? String == "command")
+        }
+    }
+
     @Test("uninstall removes Muxy hooks while preserving foreign hooks")
     func uninstallPreservesForeignHooks() throws {
         try withFixture { fixture in
@@ -176,8 +218,13 @@ struct CopilotProviderTests {
         init() throws {
             rootURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("CopilotProviderTests-\(UUID().uuidString)", isDirectory: true)
-            hooksURL = rootURL.appendingPathComponent(".copilot/hooks/muxy-notify.json")
-            provider = CopilotProvider(homeDirectory: rootURL.path, pathEnvironment: "")
+            let copilotHome = rootURL.appendingPathComponent(".copilot")
+            hooksURL = copilotHome.appendingPathComponent("hooks/muxy-notify.json")
+            provider = CopilotProvider(
+                homeDirectory: rootURL.path,
+                pathEnvironment: "",
+                copilotHome: copilotHome.path
+            )
             try FileManager.default.createDirectory(
                 at: hooksURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true
@@ -193,8 +240,12 @@ struct CopilotProviderTests {
         }
 
         func writeHooks(_ hooks: [String: Any]) throws {
+            try writeSettings(["version": 1, "hooks": hooks])
+        }
+
+        func writeSettings(_ settings: [String: Any]) throws {
             let data = try JSONSerialization.data(
-                withJSONObject: ["version": 1, "hooks": hooks],
+                withJSONObject: settings,
                 options: [.prettyPrinted, .sortedKeys]
             )
             try data.write(to: hooksURL)

--- a/Tests/MuxyTests/Services/Providers/CopilotProviderTests.swift
+++ b/Tests/MuxyTests/Services/Providers/CopilotProviderTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("CopilotProvider hooks")
+struct CopilotProviderTests {
+    @Test("provider identity matches expected wire and settings ids")
+    func providerIdentity() {
+        let provider = CopilotProvider()
+        #expect(provider.id == "copilot")
+        #expect(provider.displayName == "GitHub Copilot")
+        #expect(provider.socketTypeKey == "copilot_hook")
+        #expect(provider.iconName == "copilot")
+        #expect(provider.executableNames == ["copilot"])
+        #expect(provider.hookScriptName == "muxy-copilot-hook")
+        #expect(provider.hookScriptExtension == "sh")
+    }
+
+    @Test("hook command embeds the event argument and muxy marker")
+    func hookCommandFormat() {
+        let command = CopilotProvider.hookCommand(hookScript: "/tmp/muxy-copilot-hook.sh", argument: "stop")
+        #expect(command == "'/tmp/muxy-copilot-hook.sh' stop # muxy-notification-hook")
+    }
+
+    @Test("install writes version and managed lifecycle hooks into empty settings")
+    func installWritesHooksFile() throws {
+        try withFixture { fixture in
+            try fixture.provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
+
+            let settings = try fixture.settings()
+            #expect(settings["version"] as? Int == 1)
+            let hooks = try #require(settings["hooks"] as? [String: Any])
+
+            for binding in CopilotProvider.bindings {
+                let bash = fixture.bash(in: hooks, event: binding.settingsKey)
+                #expect(bash?.contains(binding.argument) == true)
+                #expect(bash?.contains("muxy-notification-hook") == true)
+                let entries = try #require(hooks[binding.settingsKey] as? [[String: Any]])
+                #expect(entries.count == 1)
+                #expect(entries.first?["type"] as? String == "command")
+                #expect(entries.first?["timeoutSec"] as? Int == 10)
+            }
+        }
+    }
+
+    @Test("install is idempotent")
+    func installIsIdempotent() throws {
+        try withFixture { fixture in
+            try fixture.provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
+            let first = try Data(contentsOf: fixture.hooksURL)
+
+            try fixture.provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
+
+            #expect(try Data(contentsOf: fixture.hooksURL) == first)
+        }
+    }
+
+    @Test("install preserves foreign hooks and replaces stale Muxy entries")
+    func installPreservesForeignAndReplacesStale() throws {
+        try withFixture { fixture in
+            try fixture.writeHooks([
+                "agentStop": [
+                    fixture.muxyEntry("stop", script: "/old/muxy-copilot-hook.sh"),
+                    fixture.foreignEntry,
+                ],
+            ])
+
+            try fixture.provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
+
+            let hooks = try #require(try fixture.settings()["hooks"] as? [String: Any])
+            let stopEntries = try #require(hooks["agentStop"] as? [[String: Any]])
+            #expect(stopEntries.count == 2)
+            let bashCommands = stopEntries.compactMap { $0["bash"] as? String }
+            #expect(bashCommands.contains("echo foreign"))
+            #expect(bashCommands.contains { $0.contains("/tmp/muxy-copilot-hook.sh") && $0.contains(" stop ") })
+            #expect(!bashCommands.contains { $0.contains("/old/muxy-copilot-hook.sh") })
+        }
+    }
+
+    @Test("verify is satisfied after install and needs repair when incomplete")
+    func verifyStates() throws {
+        try withFixture { fixture in
+            let script = "/tmp/muxy-copilot-hook.sh"
+            #expect(fixture.provider.verify(hookScriptPath: script) == .needsRepair)
+
+            try fixture.provider.install(hookScriptPath: script)
+            #expect(fixture.provider.verify(hookScriptPath: script) == .satisfied)
+
+            try fixture.writeHooks([
+                "agentStop": [fixture.muxyEntry("stop")],
+            ])
+            #expect(fixture.provider.verify(hookScriptPath: script) == .needsRepair)
+        }
+    }
+
+    @Test("uninstall removes Muxy hooks while preserving foreign hooks")
+    func uninstallPreservesForeignHooks() throws {
+        try withFixture { fixture in
+            try fixture.provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
+            var hooks = try #require(try fixture.settings()["hooks"] as? [String: Any])
+            var stop = try #require(hooks["agentStop"] as? [[String: Any]])
+            stop.append(fixture.foreignEntry)
+            hooks["agentStop"] = stop
+            try fixture.writeHooks(hooks)
+
+            try fixture.provider.uninstall()
+
+            let remaining = try #require(try fixture.settings()["hooks"] as? [String: Any])
+            #expect(remaining["userPromptSubmitted"] == nil)
+            #expect(remaining["preToolUse"] == nil)
+            #expect(remaining["permissionRequest"] == nil)
+            #expect(remaining["notification"] == nil)
+            #expect(remaining["sessionEnd"] == nil)
+            #expect(remaining["errorOccurred"] == nil)
+            let stopEntries = try #require(remaining["agentStop"] as? [[String: Any]])
+            #expect(stopEntries.count == 1)
+            #expect(stopEntries.first?["bash"] as? String == "echo foreign")
+        }
+    }
+
+    @Test("uninstall is a no-op without managed hooks")
+    func uninstallWithoutManagedHooksIsNoOp() throws {
+        try withFixture { fixture in
+            try fixture.writeHooks(["agentStop": [fixture.foreignEntry]])
+            let before = try Data(contentsOf: fixture.hooksURL)
+
+            try fixture.provider.uninstall()
+
+            #expect(try Data(contentsOf: fixture.hooksURL) == before)
+        }
+    }
+
+    @Test("respects injectable copilot home override")
+    func usesCopilotHomeOverride() throws {
+        try withFixture { fixture in
+            let customHome = fixture.rootURL.appendingPathComponent("custom-copilot")
+            let provider = CopilotProvider(
+                homeDirectory: fixture.rootURL.path,
+                pathEnvironment: "",
+                copilotHome: customHome.path
+            )
+            try provider.install(hookScriptPath: "/tmp/muxy-copilot-hook.sh")
+
+            let path = customHome.appendingPathComponent("hooks/muxy-notify.json").path
+            #expect(FileManager.default.fileExists(atPath: path))
+            #expect(provider.configPaths == [path])
+            #expect(provider.isHookInstalled())
+        }
+    }
+
+    @Test("registry exposes copilot provider socket type")
+    @MainActor
+    func registryIncludesCopilot() {
+        #expect(AIProviderRegistry.shared.providers.contains(where: {
+            $0.id == "copilot" && $0.socketTypeKey == "copilot_hook"
+        }))
+    }
+
+    private func withFixture(_ body: (Fixture) throws -> Void) throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        try body(fixture)
+    }
+
+    private struct Fixture {
+        let rootURL: URL
+        let hooksURL: URL
+        let provider: CopilotProvider
+        let foreignEntry: [String: Any] = [
+            "type": "command",
+            "bash": "echo foreign",
+            "timeoutSec": 5,
+        ]
+
+        init() throws {
+            rootURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("CopilotProviderTests-\(UUID().uuidString)", isDirectory: true)
+            hooksURL = rootURL.appendingPathComponent(".copilot/hooks/muxy-notify.json")
+            provider = CopilotProvider(homeDirectory: rootURL.path, pathEnvironment: "")
+            try FileManager.default.createDirectory(
+                at: hooksURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        }
+
+        func muxyEntry(_ argument: String, script: String = "/tmp/muxy-copilot-hook.sh") -> [String: Any] {
+            [
+                "type": "command",
+                "bash": "'\(script)' \(argument) # muxy-notification-hook",
+                "timeoutSec": 10,
+            ]
+        }
+
+        func writeHooks(_ hooks: [String: Any]) throws {
+            let data = try JSONSerialization.data(
+                withJSONObject: ["version": 1, "hooks": hooks],
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            try data.write(to: hooksURL)
+        }
+
+        func settings() throws -> [String: Any] {
+            let data = try Data(contentsOf: hooksURL)
+            return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+
+        func bash(in hooks: [String: Any], event: String) -> String? {
+            (hooks[event] as? [[String: Any]])?.first?["bash"] as? String
+        }
+
+        func cleanUp() {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+    }
+}

--- a/Tests/MuxyTests/Utilities/LoginShellPathTests.swift
+++ b/Tests/MuxyTests/Utilities/LoginShellPathTests.swift
@@ -27,9 +27,25 @@ struct LoginShellPathTests {
         #expect(path.value == LoginShellPath.defaultPath)
     }
 
+    @Test("environment hydration captures PATH and Copilot home together")
+    func hydrateCapturesLoginShellEnvironment() async {
+        let path = LoginShellPath()
+
+        await path.hydrateEnvironment {
+            LoginShellEnvironmentValues(
+                path: "/tmp/custom-bin:/usr/bin",
+                copilotHome: "/tmp/custom-copilot"
+            )
+        }
+
+        #expect(path.value == "/tmp/custom-bin:/usr/bin")
+        #expect(path.copilotHome == "/tmp/custom-copilot")
+    }
+
     @Test("login shell lookup loads interactive configuration")
     func loginShellLookupLoadsInteractiveConfiguration() {
         #expect(LoginShellPath.shellArguments.prefix(3) == ["-l", "-i", "-c"])
+        #expect(LoginShellPath.shellArguments.last?.contains("printenv COPILOT_HOME") == true)
     }
 
     @Test("login shell lookup extracts PATH without startup output")
@@ -43,10 +59,40 @@ struct LoginShellPathTests {
         #expect(LoginShellPath.extractPath(from: output) == "/custom/bin:/usr/bin")
     }
 
+    @Test("login shell lookup extracts the complete environment")
+    func loginShellLookupExtractsEnvironment() {
+        let output = """
+        shell startup output
+        __MUXY_PATH_START__/custom/bin:/usr/bin__MUXY_PATH_END__
+        __MUXY_COPILOT_HOME_START__/custom/copilot__MUXY_COPILOT_HOME_END__
+        """
+
+        #expect(LoginShellPath.extractEnvironment(from: output) == LoginShellEnvironmentValues(
+            path: "/custom/bin:/usr/bin",
+            copilotHome: "/custom/copilot"
+        ))
+    }
+
+    @Test("login shell lookup accepts an unset Copilot home")
+    func loginShellLookupAcceptsUnsetCopilotHome() {
+        let output = """
+        __MUXY_PATH_START__/custom/bin:/usr/bin__MUXY_PATH_END__
+        __MUXY_COPILOT_HOME_START____MUXY_COPILOT_HOME_END__
+        """
+
+        #expect(LoginShellPath.extractEnvironment(from: output) == LoginShellEnvironmentValues(
+            path: "/custom/bin:/usr/bin",
+            copilotHome: nil
+        ))
+    }
+
     @Test("login shell lookup rejects malformed output")
     func loginShellLookupRejectsMalformedOutput() {
         #expect(LoginShellPath.extractPath(from: "/custom/bin:/usr/bin") == nil)
         #expect(LoginShellPath.extractPath(from: "__MUXY_PATH_START____MUXY_PATH_END__") == nil)
+        #expect(LoginShellPath.extractEnvironment(
+            from: "__MUXY_PATH_START__/usr/bin__MUXY_PATH_END__"
+        ) == nil)
     }
 
     @Test("login shell lookup drains noisy startup output")

--- a/docs/features/ai-notifications.md
+++ b/docs/features/ai-notifications.md
@@ -1,6 +1,6 @@
 # AI notifications
 
-Muxy tracks the AI coding agents running inside its terminals — Claude Code, Codex, Cursor, Droid, Grok, OpenCode, and Pi — and surfaces their lifecycle as pane and worktree status, completion badges, and notifications when a turn finishes or an agent needs attention.
+Muxy tracks the AI coding agents running inside its terminals — Claude Code, Codex, Cursor, GitHub Copilot, Droid, Grok, OpenCode, and Pi — and surfaces their lifecycle as pane and worktree status, completion badges, and notifications when a turn finishes or an agent needs attention.
 
 There are two independent sources of truth, and hooks are authoritative.
 
@@ -43,7 +43,7 @@ The bridge retries an event when an ack does not arrive within its delivery budg
 The compiled hook bridge (`muxy-hook`) and the provider shims are staged into `~/Library/Application Support/Muxy/hooks` (`hooks-dev` for debug builds) with private permissions:
 
 - `muxy-hook` — the compiled bridge every hook invokes.
-- `muxy-claude-hook.sh`, `muxy-codex-hook.sh`, `muxy-cursor-hook.sh`, `muxy-droid-hook.sh`, `muxy-grok-hook.sh` — thin shell shims that exec the colocated `muxy-hook`.
+- `muxy-claude-hook.sh`, `muxy-codex-hook.sh`, `muxy-copilot-hook.sh`, `muxy-cursor-hook.sh`, `muxy-droid-hook.sh`, `muxy-grok-hook.sh` — thin shell shims that exec the colocated `muxy-hook`.
 - `opencode-muxy-plugin.js`, `muxy-pi-extension.ts` — plugin/extension entry points that spawn the staged `muxy-hook`. When the binary is missing they log a clear error to their own stderr and skip the event. That stderr never reaches Muxy, so nothing restages automatically — use **Refresh** in Settings to restage.
 
 Reconciliation starts only after the complete staged resource set is available. Each provider also verifies that the shared `muxy-hook` bridge exists and is executable, so a stale shim or plugin cannot report healthy while its bridge is missing.
@@ -56,7 +56,7 @@ Each provider integration is reconciled declaratively: Muxy **verifies** that ev
 
 Muxy records a hash of every config file it writes and ignores watcher events whose content matches its own last write, so a repair never re-triggers itself. A per-file rate limiter caps repairs within a rolling minute; when it trips — most commonly when a release and a debug build both manage the same config — Muxy stops rewriting and reports a `conflict` instead of spinning.
 
-Results are tracked per provider in the health store — install state, last verified/repaired time, last event time, and last error — and shown in **Settings → Notifications** as a status dot and line per provider. A `conflict` means Muxy found a non-Muxy hook it will not overwrite; the message names it.
+Results are tracked per provider in the health store — install state, last verified/repaired time, last event time, and last error — and shown in **Settings → Notifications** as a status dot and line per provider. A `conflict` means Muxy found a non-Muxy hook it will not overwrite; the message names it. Copilot CLI hooks live in `~/.copilot/hooks/muxy-notify.json` (or `$COPILOT_HOME/hooks/` when set); restart the CLI after Muxy repairs hooks so the new config is loaded.
 
 ## Test button
 


### PR DESCRIPTION
Register CopilotProvider in registry, stage muxy-copilot-hook script, update AgentHookEventMapper aliases, and add hook lifecycle tests.

<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

Provides support for GitHub Copilot CLI in the Notification system of Muxy by installing required hooks into the GitHub Copilot system.

<!-- What does this PR do and why? Write this yourself — no AI-generated text. -->

## Changes

<!-- List the key changes -->

- Add new hook for copilot
- Add Copilot Provider to register/unregister hook
- Extend Notification system with event types from GH Copilot CLI
- Add tests

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

<!-- If applicable, add screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub Copilot as a supported AI coding agent, including provider launch and Copilot-specific hook integration.
  * Added the Copilot hook shim (`muxy-copilot-hook.sh`) to staging, with automatic hook installation, verification/repair, and uninstall behavior.
  * Extended lifecycle/notification mapping with additional working, stop/error, completion, and idle aliases.
* **Documentation**
  * Updated AI notifications documentation to include Copilot and its staging/health-and-repair details.
* **Tests**
  * Added end-to-end and fixture-based Copilot provider tests and expanded lifecycle mapping coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->