### PR TITLE
Fix extension panel lifecycle

### DIFF
--- a/Muxy/Services/Extensions/ExtensionPanelRegistry.swift
+++ b/Muxy/Services/Extensions/ExtensionPanelRegistry.swift
@@ -53,19 +53,23 @@ final class ExtensionPanelRegistry {
 
     func close(hostPanelID: String) {
         guard let state = state(forHostPanelID: hostPanelID) else {
+            PanelFocusRestoration.shared.restoreAfterClosing(panelID: hostPanelID)
             PanelHost.shared.close(hostPanelID)
             return
         }
         let surfaceKey = LifecycleSurfaceKey(kind: .panel, instanceID: state.id.uuidString)
         Task { @MainActor in
             let verdict = await ExtensionSurfaceBridgeRegistry.shared.requestBeforeClose(surfaceKey)
-            guard verdict == .allow else { return }
+            guard verdict == .allow,
+                  self.state(forHostPanelID: hostPanelID)?.id == state.id
+            else { return }
             forceClose(hostPanelID: hostPanelID)
         }
     }
 
     func forceClose(hostPanelID: String) {
         let closed = openStates.filter { $0.hostPanelID == hostPanelID }
+        PanelFocusRestoration.shared.restoreAfterClosing(panelID: hostPanelID)
         PanelHost.shared.close(hostPanelID)
         openStates.removeAll { $0.hostPanelID == hostPanelID }
         for state in closed {
@@ -81,6 +85,7 @@ final class ExtensionPanelRegistry {
     func closeAll(extensionID: String) {
         let closed = openStates.filter { $0.extensionID == extensionID }
         for state in closed {
+            PanelFocusRestoration.shared.restoreAfterClosing(panelID: state.hostPanelID)
             PanelHost.shared.close(state.hostPanelID)
         }
         openStates.removeAll { $0.extensionID == extensionID }
@@ -91,6 +96,9 @@ final class ExtensionPanelRegistry {
 
     private func pruneClosed() {
         let closed = openStates.filter { !PanelHost.shared.isOpen($0.hostPanelID) }
+        for state in closed {
+            PanelFocusRestoration.shared.restoreAfterClosing(panelID: state.hostPanelID)
+        }
         openStates.removeAll { !PanelHost.shared.isOpen($0.hostPanelID) }
         for state in closed {
             ExtensionLifecycleEvents.panelClosed(extensionID: state.extensionID, panelID: state.panelID)

--- a/Muxy/Services/UIHosts/PanelFocusRestoration.swift
+++ b/Muxy/Services/UIHosts/PanelFocusRestoration.swift
@@ -8,11 +8,19 @@ final class PanelFocusRestoration {
         weak var window: NSWindow?
         weak var responder: NSResponder?
         weak var panelView: NSView?
+        weak var panelControlResponder: NSResponder?
+        var precedingPanelID: String?
 
-        init(window: NSWindow, responder: NSResponder, panelView: NSView) {
+        init(
+            window: NSWindow,
+            responder: NSResponder,
+            panelView: NSView,
+            precedingPanelID: String?
+        ) {
             self.window = window
             self.responder = responder
             self.panelView = panelView
+            self.precedingPanelID = precedingPanelID
         }
     }
 
@@ -21,37 +29,68 @@ final class PanelFocusRestoration {
     func captureBeforeClaim(panelID: String, panelView: NSView) {
         if let snapshot = snapshots[panelID] {
             snapshot.panelView = panelView
+            snapshot.panelControlResponder = nil
+            retargetSnapshots(dependingOn: panelID, responder: panelView)
             return
         }
         guard let window = panelView.window,
               let responder = window.firstResponder,
               !Self.contains(responder, in: panelView)
         else { return }
+        let precedingPanelID = snapshots.first { _, snapshot in
+            Self.owns(responder, snapshot: snapshot)
+        }?.key
         snapshots[panelID] = Snapshot(
             window: window,
             responder: responder,
-            panelView: panelView
+            panelView: panelView,
+            precedingPanelID: precedingPanelID
         )
+    }
+
+    func setPanelControlFocused(panelID: String, focused: Bool) {
+        guard let snapshot = snapshots[panelID] else { return }
+        guard focused, let window = snapshot.window else {
+            snapshot.panelControlResponder = nil
+            return
+        }
+        snapshot.panelControlResponder = window.firstResponder
     }
 
     func restoreAfterClosing(panelID: String) {
         guard let snapshot = snapshots.removeValue(forKey: panelID) else { return }
-        rebaseSnapshots(dependingOn: snapshot)
+        rebaseSnapshots(dependingOn: panelID, closedSnapshot: snapshot)
         guard let window = snapshot.window,
               let responder = snapshot.responder,
-              let panelView = snapshot.panelView,
-              Self.contains(window.firstResponder, in: panelView)
+              Self.owns(window.firstResponder, snapshot: snapshot)
         else { return }
         window.makeFirstResponder(responder)
     }
 
-    private func rebaseSnapshots(dependingOn closedSnapshot: Snapshot) {
-        guard let panelView = closedSnapshot.panelView,
-              let responder = closedSnapshot.responder
-        else { return }
-        for snapshot in snapshots.values where Self.contains(snapshot.responder, in: panelView) {
+    private func rebaseSnapshots(
+        dependingOn closedPanelID: String,
+        closedSnapshot: Snapshot
+    ) {
+        guard let responder = closedSnapshot.responder else { return }
+        for snapshot in snapshots.values where snapshot.precedingPanelID == closedPanelID {
+            snapshot.responder = responder
+            snapshot.precedingPanelID = closedSnapshot.precedingPanelID
+        }
+    }
+
+    private func retargetSnapshots(dependingOn panelID: String, responder: NSResponder) {
+        for snapshot in snapshots.values where snapshot.precedingPanelID == panelID {
             snapshot.responder = responder
         }
+    }
+
+    private static func owns(_ responder: NSResponder?, snapshot: Snapshot) -> Bool {
+        guard let responder else { return false }
+        if responder === snapshot.panelControlResponder {
+            return true
+        }
+        guard let panelView = snapshot.panelView else { return false }
+        return contains(responder, in: panelView)
     }
 
     private static func contains(_ responder: NSResponder?, in view: NSView) -> Bool {

--- a/Muxy/Services/UIHosts/PanelFocusRestoration.swift
+++ b/Muxy/Services/UIHosts/PanelFocusRestoration.swift
@@ -1,0 +1,65 @@
+import AppKit
+
+@MainActor
+final class PanelFocusRestoration {
+    static let shared = PanelFocusRestoration()
+
+    private final class Snapshot {
+        weak var window: NSWindow?
+        weak var responder: NSResponder?
+        weak var panelView: NSView?
+
+        init(window: NSWindow, responder: NSResponder, panelView: NSView) {
+            self.window = window
+            self.responder = responder
+            self.panelView = panelView
+        }
+    }
+
+    private var snapshots: [String: Snapshot] = [:]
+
+    func captureBeforeClaim(panelID: String, panelView: NSView) {
+        if let snapshot = snapshots[panelID] {
+            snapshot.panelView = panelView
+            return
+        }
+        guard let window = panelView.window,
+              let responder = window.firstResponder,
+              !Self.contains(responder, in: panelView)
+        else { return }
+        snapshots[panelID] = Snapshot(
+            window: window,
+            responder: responder,
+            panelView: panelView
+        )
+    }
+
+    func restoreAfterClosing(panelID: String) {
+        guard let snapshot = snapshots.removeValue(forKey: panelID) else { return }
+        rebaseSnapshots(dependingOn: snapshot)
+        guard let window = snapshot.window,
+              let responder = snapshot.responder,
+              let panelView = snapshot.panelView,
+              Self.contains(window.firstResponder, in: panelView)
+        else { return }
+        window.makeFirstResponder(responder)
+    }
+
+    private func rebaseSnapshots(dependingOn closedSnapshot: Snapshot) {
+        guard let panelView = closedSnapshot.panelView,
+              let responder = closedSnapshot.responder
+        else { return }
+        for snapshot in snapshots.values where Self.contains(snapshot.responder, in: panelView) {
+            snapshot.responder = responder
+        }
+    }
+
+    private static func contains(_ responder: NSResponder?, in view: NSView) -> Bool {
+        guard let responder else { return false }
+        if responder === view {
+            return true
+        }
+        guard let responderView = responder as? NSView else { return false }
+        return responderView.isDescendant(of: view)
+    }
+}

--- a/Muxy/Services/UIHosts/PanelHost.swift
+++ b/Muxy/Services/UIHosts/PanelHost.swift
@@ -23,12 +23,16 @@ final class PanelHost {
         placement(for: panelID) != nil
     }
 
+    func panel(at position: PanelPosition, mode: PanelMode) -> PanelPlacement? {
+        placements.first { $0.position == position && $0.mode == mode }
+    }
+
     func pinnedPanel(at position: PanelPosition) -> String? {
-        placements.first { $0.position == position && $0.mode == .pinned }?.panelID
+        panel(at: position, mode: .pinned)?.panelID
     }
 
     func floatingPanel(at position: PanelPosition) -> String? {
-        placements.first { $0.position == position && $0.mode == .floating }?.panelID
+        panel(at: position, mode: .floating)?.panelID
     }
 
     func open(_ panelID: String, at position: PanelPosition, mode: PanelMode) {

--- a/Muxy/Views/Extensions/ExtensionWebView.swift
+++ b/Muxy/Views/Extensions/ExtensionWebView.swift
@@ -12,6 +12,7 @@ struct ExtensionWebView: NSViewRepresentable {
     let worktreeStore: WorktreeStore?
     let projectGroupStore: ProjectGroupStore?
     let focused: Bool
+    var focusRestorationID: String?
     var surfaceStore: ExtensionTabSurfaceStore?
 
     @Environment(BrowserProfileStore.self) private var browserProfileStore: BrowserProfileStore?
@@ -98,7 +99,10 @@ struct ExtensionWebView: NSViewRepresentable {
     }
 
     private func makeSurface() -> Surface {
-        let surfaceCoordinator = SurfaceCoordinator(surfaceKind: surfaceKind)
+        let surfaceCoordinator = SurfaceCoordinator(
+            surfaceKind: surfaceKind,
+            focusRestorationID: focusRestorationID
+        )
         guard let muxyExtension = ExtensionStore.shared.loadedExtension(id: extensionID) else {
             return Surface(
                 identity: identity,
@@ -240,6 +244,8 @@ struct ExtensionWebView: NSViewRepresentable {
         var consoleHandler: ExtensionConsoleHandler?
         var surfaceKey: LifecycleSurfaceKey?
         private let surfaceKind: LifecycleSurfaceKind
+        private let focusRestorationID: String?
+        private let focusRestoration: PanelFocusRestoration
         private weak var webView: WKWebView?
         private var themeObserver: NSObjectProtocol?
         private var extensionID: String = ""
@@ -249,8 +255,14 @@ struct ExtensionWebView: NSViewRepresentable {
         private var overlayActive = false
         private var activeClaimID: UUID?
 
-        init(surfaceKind: LifecycleSurfaceKind) {
+        init(
+            surfaceKind: LifecycleSurfaceKind,
+            focusRestorationID: String? = nil,
+            focusRestoration: PanelFocusRestoration = .shared
+        ) {
             self.surfaceKind = surfaceKind
+            self.focusRestorationID = focusRestorationID
+            self.focusRestoration = focusRestoration
         }
 
         func configureScriptInjection(
@@ -324,6 +336,12 @@ struct ExtensionWebView: NSViewRepresentable {
             DispatchQueue.main.async { [weak webView] in
                 guard let webView, let window = webView.window else { return }
                 if self.focused, !self.overlayActive {
+                    if let focusRestorationID = self.focusRestorationID {
+                        self.focusRestoration.captureBeforeClaim(
+                            panelID: focusRestorationID,
+                            panelView: webView
+                        )
+                    }
                     window.makeFirstResponder(webView)
                 } else if window.firstResponder === webView {
                     window.makeFirstResponder(nil)

--- a/Muxy/Views/MainWindow+Panels.swift
+++ b/Muxy/Views/MainWindow+Panels.swift
@@ -14,6 +14,19 @@ enum PanelLayoutMetrics {
     static let extensionDefaultHeight: Double = 240
 }
 
+struct PanelHostSlot<Content: View>: View {
+    let panelHost: PanelHost
+    let position: PanelPosition
+    let mode: PanelMode
+    @ViewBuilder let content: (PanelPlacement) -> Content
+
+    var body: some View {
+        if let placement = panelHost.panel(at: position, mode: mode) {
+            content(placement)
+        }
+    }
+}
+
 struct PanelFrame: ViewModifier {
     let position: PanelPosition
     let size: Binding<Double>

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1611,6 +1611,7 @@ struct MainWindow: View {
             ),
             mode: mode,
             position: position,
+            focusRestorationID: nil,
             onClose: { panelHost.close(BuiltinPanel.extensionConsole) },
             onTogglePin: nil,
             onTogglePosition: nil,

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1571,18 +1571,24 @@ struct MainWindow: View {
         )
     }
 
-    @ViewBuilder
     func pinnedPanelSlot(at position: PanelPosition) -> some View {
-        if let panelID = panelHost.pinnedPanel(at: position) {
-            panelContent(for: panelID, position: position, mode: .pinned)
+        PanelHostSlot(panelHost: panelHost, position: position, mode: .pinned) { placement in
+            panelContent(
+                for: placement.panelID,
+                position: placement.position,
+                mode: placement.mode
+            )
         }
     }
 
-    @ViewBuilder
     func floatingPanelOverlay(at position: PanelPosition) -> some View {
-        if let panelID = panelHost.floatingPanel(at: position) {
-            panelContent(for: panelID, position: position, mode: .floating)
-                .background(MuxyTheme.bg)
+        PanelHostSlot(panelHost: panelHost, position: position, mode: .floating) { placement in
+            panelContent(
+                for: placement.panelID,
+                position: placement.position,
+                mode: placement.mode
+            )
+            .background(MuxyTheme.bg)
         }
     }
 

--- a/Muxy/Views/Panels/ExtensionPanelView.swift
+++ b/Muxy/Views/Panels/ExtensionPanelView.swift
@@ -19,6 +19,7 @@ struct ExtensionPanelView: View {
                 chrome: chrome(for: panel, in: muxyExtension),
                 mode: placement.mode,
                 position: placement.position,
+                focusRestorationID: state.hostPanelID,
                 onClose: { ExtensionPanelRegistry.shared.close(hostPanelID: state.hostPanelID) },
                 onTogglePin: { togglePin() },
                 onTogglePosition: { togglePosition() },

--- a/Muxy/Views/Panels/ExtensionPanelView.swift
+++ b/Muxy/Views/Panels/ExtensionPanelView.swift
@@ -33,7 +33,8 @@ struct ExtensionPanelView: View {
                         projectStore: projectStore,
                         worktreeStore: worktreeStore,
                         projectGroupStore: projectGroupStore,
-                        focused: true
+                        focused: true,
+                        focusRestorationID: state.hostPanelID
                     )
                 }
             )

--- a/Muxy/Views/Panels/PanelContainer.swift
+++ b/Muxy/Views/Panels/PanelContainer.swift
@@ -4,10 +4,19 @@ struct PanelContainer<Content: View>: View {
     let chrome: PanelChrome
     let mode: PanelMode
     let position: PanelPosition
+    let focusRestorationID: String?
     let onClose: (() -> Void)?
     let onTogglePin: (() -> Void)?
     let onTogglePosition: (() -> Void)?
     @ViewBuilder let content: () -> Content
+    @FocusState private var focusedHeaderControl: HeaderFocus?
+
+    private enum HeaderFocus: Hashable {
+        case custom(String)
+        case position
+        case pin
+        case close
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -19,6 +28,13 @@ struct PanelContainer<Content: View>: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(MuxyTheme.bg)
+        .onChange(of: focusedHeaderControl) { _, focusedControl in
+            guard let focusRestorationID else { return }
+            PanelFocusRestoration.shared.setPanelControlFocused(
+                panelID: focusRestorationID,
+                focused: focusedControl != nil
+            )
+        }
     }
 
     private var header: some View {
@@ -43,6 +59,7 @@ struct PanelContainer<Content: View>: View {
                     control(
                         symbol: positionSymbol,
                         label: positionLabel,
+                        focus: .position,
                         action: onTogglePosition
                     )
                 }
@@ -50,11 +67,17 @@ struct PanelContainer<Content: View>: View {
                     control(
                         symbol: mode == .floating ? "pin" : "pin.slash",
                         label: mode == .floating ? "Dock Panel" : "Float Panel",
+                        focus: .pin,
                         action: onTogglePin
                     )
                 }
                 if chrome.shows(.close), let onClose {
-                    control(symbol: "xmark", label: "Close", action: onClose)
+                    control(
+                        symbol: "xmark",
+                        label: "Close",
+                        focus: .close,
+                        action: onClose
+                    )
                 }
             }
         }
@@ -76,6 +99,7 @@ struct PanelContainer<Content: View>: View {
                 action: button.action
             )
             .help(button.label)
+            .focused($focusedHeaderControl, equals: .custom(button.id))
         case let .extensionIcon(icon, muxyExtension):
             ExtensionIconButton(
                 icon: icon,
@@ -86,12 +110,19 @@ struct PanelContainer<Content: View>: View {
                 action: button.action
             )
             .help(button.label)
+            .focused($focusedHeaderControl, equals: .custom(button.id))
         }
     }
 
-    private func control(symbol: String, label: String, action: @escaping () -> Void) -> some View {
+    private func control(
+        symbol: String,
+        label: String,
+        focus: HeaderFocus,
+        action: @escaping () -> Void
+    ) -> some View {
         IconButton(symbol: symbol, accessibilityLabel: label, action: action)
             .help(label)
+            .focused($focusedHeaderControl, equals: focus)
     }
 
     private var positionSymbol: String {

--- a/Tests/MuxyTests/Services/UIHosts/PanelSharedStateTests.swift
+++ b/Tests/MuxyTests/Services/UIHosts/PanelSharedStateTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import Muxy
@@ -129,8 +131,121 @@ struct PanelSharedStateTests {
             #expect(!collector.closedPanelIDs(extensionID: "ext-b").contains("second"))
         }
 
-        private func panel(id: String) -> ExtensionPanel {
-            ExtensionPanel(id: id, entry: "index.html", position: .right, mode: .pinned)
+        @Test("closing a focused extension panel restores its previous responder")
+        func closeRestoresPreviousResponder() {
+            let extensionID = "focus-restoration-\(UUID().uuidString)"
+            let registry = ExtensionPanelRegistry.shared
+            let state = registry.open(
+                extensionID: extensionID,
+                panel: panel(id: "files"),
+                data: nil
+            )
+            defer { registry.closeAll(extensionID: extensionID) }
+            let window = focusTestWindow()
+            let previousResponder = FocusTestView()
+            let panelView = FocusTestView()
+            window.contentView?.addSubview(previousResponder)
+            window.contentView?.addSubview(panelView)
+            #expect(window.makeFirstResponder(previousResponder))
+
+            PanelFocusRestoration.shared.captureBeforeClaim(
+                panelID: state.hostPanelID,
+                panelView: panelView
+            )
+            #expect(window.makeFirstResponder(panelView))
+
+            registry.forceClose(hostPanelID: state.hostPanelID)
+
+            #expect(window.firstResponder === previousResponder)
+        }
+
+        @Test("closing all panels restores focus through out-of-order snapshots")
+        func closeAllRestoresOriginalResponder() {
+            let extensionID = "focus-restoration-\(UUID().uuidString)"
+            let registry = ExtensionPanelRegistry.shared
+            let firstState = registry.open(
+                extensionID: extensionID,
+                panel: panel(id: "first"),
+                data: nil
+            )
+            let secondState = registry.open(
+                extensionID: extensionID,
+                panel: panel(id: "second", position: .bottom),
+                data: nil
+            )
+            defer { registry.closeAll(extensionID: extensionID) }
+            let window = focusTestWindow()
+            let previousResponder = FocusTestView()
+            let firstPanelView = FocusTestView()
+            let secondPanelView = FocusTestView()
+            window.contentView?.addSubview(previousResponder)
+            window.contentView?.addSubview(firstPanelView)
+            window.contentView?.addSubview(secondPanelView)
+            #expect(window.makeFirstResponder(previousResponder))
+
+            PanelFocusRestoration.shared.captureBeforeClaim(
+                panelID: firstState.hostPanelID,
+                panelView: firstPanelView
+            )
+            #expect(window.makeFirstResponder(firstPanelView))
+            PanelFocusRestoration.shared.captureBeforeClaim(
+                panelID: secondState.hostPanelID,
+                panelView: secondPanelView
+            )
+            #expect(window.makeFirstResponder(secondPanelView))
+
+            registry.closeAll(extensionID: extensionID)
+
+            #expect(window.firstResponder === previousResponder)
+        }
+
+        @Test("an allowed stale close verdict preserves a replacement panel")
+        func staleCloseVerdictPreservesReplacement() async throws {
+            let extensionID = "stale-close-\(UUID().uuidString)"
+            let registry = ExtensionPanelRegistry.shared
+            let originalState = registry.open(
+                extensionID: extensionID,
+                panel: panel(id: "files"),
+                data: nil
+            )
+            let surfaceKey = LifecycleSurfaceKey(
+                kind: .panel,
+                instanceID: originalState.id.uuidString
+            )
+            let bridge = DeferredPanelBeforeCloseAsking()
+            ExtensionSurfaceBridgeRegistry.shared.register(bridge, for: surfaceKey)
+            defer {
+                ExtensionSurfaceBridgeRegistry.shared.unregister(surfaceKey, ifMatches: bridge)
+                registry.closeAll(extensionID: extensionID)
+            }
+
+            registry.close(hostPanelID: originalState.hostPanelID)
+            let requested = await waitFor(timeout: 1) {
+                bridge.askCount == 1
+            }
+            #expect(requested)
+
+            let replacementState = registry.open(
+                extensionID: extensionID,
+                panel: panel(id: "files"),
+                data: nil
+            )
+            bridge.resolve(.allow)
+            let completed = await waitFor(timeout: 1) {
+                bridge.completedRequestCount == 1
+            }
+            #expect(completed)
+
+            let currentState = try #require(registry.state(forHostPanelID: originalState.hostPanelID))
+            #expect(currentState.id == replacementState.id)
+            #expect(PanelHost.shared.isOpen(replacementState.hostPanelID))
+        }
+
+        private func panel(
+            id: String,
+            position: PanelPosition = .right
+        ) -> ExtensionPanel {
+            ExtensionPanel(id: id, entry: "index.html", position: position, mode: .pinned)
         }
 
         private func waitFor(timeout: TimeInterval, condition: () -> Bool) async -> Bool {
@@ -142,6 +257,154 @@ struct PanelSharedStateTests {
             return condition()
         }
     }
+
+    @Suite("PanelFocusRestoration")
+    @MainActor
+    struct PanelFocusRestorationTests {
+        @Test("replacement panel views preserve the original responder")
+        func replacementViewsPreserveOriginalResponder() {
+            let restoration = PanelFocusRestoration()
+            let window = focusTestWindow()
+            let previousResponder = FocusTestView()
+            let firstPanelView = FocusTestView()
+            let replacementPanelView = FocusTestView()
+            window.contentView?.addSubview(previousResponder)
+            window.contentView?.addSubview(firstPanelView)
+            window.contentView?.addSubview(replacementPanelView)
+            #expect(window.makeFirstResponder(previousResponder))
+
+            restoration.captureBeforeClaim(panelID: "files", panelView: firstPanelView)
+            #expect(window.makeFirstResponder(firstPanelView))
+            restoration.captureBeforeClaim(panelID: "files", panelView: replacementPanelView)
+            #expect(window.makeFirstResponder(replacementPanelView))
+
+            restoration.restoreAfterClosing(panelID: "files")
+
+            #expect(window.firstResponder === previousResponder)
+        }
+
+        @Test("closing a panel does not override focus moved elsewhere")
+        func newerFocusIsPreserved() {
+            let restoration = PanelFocusRestoration()
+            let window = focusTestWindow()
+            let previousResponder = FocusTestView()
+            let panelView = FocusTestView()
+            let newerResponder = FocusTestView()
+            window.contentView?.addSubview(previousResponder)
+            window.contentView?.addSubview(panelView)
+            window.contentView?.addSubview(newerResponder)
+            #expect(window.makeFirstResponder(previousResponder))
+
+            restoration.captureBeforeClaim(panelID: "files", panelView: panelView)
+            #expect(window.makeFirstResponder(panelView))
+            #expect(window.makeFirstResponder(newerResponder))
+
+            restoration.restoreAfterClosing(panelID: "files")
+
+            #expect(window.firstResponder === newerResponder)
+        }
+
+        @Test("closing an earlier panel rebases a later panel snapshot")
+        func outOfOrderCloseRestoresOriginalResponder() {
+            let restoration = PanelFocusRestoration()
+            let window = focusTestWindow()
+            let previousResponder = FocusTestView()
+            let firstPanelView = FocusTestView()
+            let secondPanelView = FocusTestView()
+            window.contentView?.addSubview(previousResponder)
+            window.contentView?.addSubview(firstPanelView)
+            window.contentView?.addSubview(secondPanelView)
+            #expect(window.makeFirstResponder(previousResponder))
+
+            restoration.captureBeforeClaim(panelID: "first", panelView: firstPanelView)
+            #expect(window.makeFirstResponder(firstPanelView))
+            restoration.captureBeforeClaim(panelID: "second", panelView: secondPanelView)
+            #expect(window.makeFirstResponder(secondPanelView))
+
+            restoration.restoreAfterClosing(panelID: "first")
+            #expect(window.firstResponder === secondPanelView)
+            restoration.restoreAfterClosing(panelID: "second")
+
+            #expect(window.firstResponder === previousResponder)
+        }
+    }
+
+    @Suite("PanelHostSlot")
+    @MainActor
+    struct PanelHostSlotTests {
+        @Test("panel placement changes do not update the workspace subtree")
+        func placementChangesDoNotUpdateWorkspace() async {
+            let host = PanelHost.shared
+            host.closeAll()
+            defer { host.closeAll() }
+            let workspaceRecorder = WorkspaceLifecycleRecorder()
+            let panelRecorder = PanelContentLifecycleRecorder()
+            let hostingView = NSHostingView(rootView: PanelHostSlotHarness(
+                panelHost: host,
+                workspaceRecorder: workspaceRecorder,
+                panelRecorder: panelRecorder
+            ))
+            hostingView.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+            hostingView.layoutSubtreeIfNeeded()
+            await settle(hostingView)
+
+            let initialMakeCount = workspaceRecorder.makeCount
+            let initialUpdateCount = workspaceRecorder.updateCount
+            #expect(panelRecorder.makeCount == 0)
+
+            host.open("ext:files:browser", at: .right, mode: .pinned)
+            let panelAppeared = await waitFor(hostingView) {
+                panelRecorder.makeCount == 1
+            }
+            #expect(panelAppeared)
+
+            host.close("ext:files:browser")
+            let panelDisappeared = await waitFor(hostingView) {
+                panelRecorder.dismantleCount == 1
+            }
+            #expect(panelDisappeared)
+
+            #expect(initialMakeCount == 1)
+            #expect(workspaceRecorder.makeCount == initialMakeCount)
+            #expect(workspaceRecorder.updateCount == initialUpdateCount)
+            #expect(workspaceRecorder.dismantleCount == 0)
+        }
+
+        private func waitFor(
+            _ hostingView: NSHostingView<PanelHostSlotHarness>,
+            condition: () -> Bool
+        ) async -> Bool {
+            let deadline = Date().addingTimeInterval(1)
+            while Date() < deadline {
+                if condition() { return true }
+                await settle(hostingView)
+            }
+            return condition()
+        }
+
+        private func settle(_ hostingView: NSHostingView<PanelHostSlotHarness>) async {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(20))
+            hostingView.layoutSubtreeIfNeeded()
+        }
+    }
+}
+
+@MainActor
+private func focusTestWindow() -> NSWindow {
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+        styleMask: [.titled],
+        backing: .buffered,
+        defer: false
+    )
+    window.contentView = NSView(frame: window.contentLayoutRect)
+    return window
+}
+
+@MainActor
+private final class FocusTestView: NSView {
+    override var acceptsFirstResponder: Bool { true }
 }
 
 private final class EventCollector: @unchecked Sendable {
@@ -160,5 +423,98 @@ private final class EventCollector: @unchecked Sendable {
         return events
             .filter { $0.name == ExtensionEventName.panelClosed && $0.payload["extensionID"] == extensionID }
             .compactMap { $0.payload["panelID"] }
+    }
+}
+
+@MainActor
+private final class DeferredPanelBeforeCloseAsking: BeforeCloseAsking {
+    private(set) var askCount = 0
+    private(set) var completedRequestCount = 0
+    private var continuation: CheckedContinuation<LifecycleVerdict, Never>?
+
+    func requestBeforeClose(reason _: LifecycleSurfaceKind, instanceID _: String) async -> LifecycleVerdict {
+        askCount += 1
+        let verdict = await withCheckedContinuation { continuation = $0 }
+        completedRequestCount += 1
+        return verdict
+    }
+
+    func resolve(_ verdict: LifecycleVerdict) {
+        let continuation = continuation
+        self.continuation = nil
+        continuation?.resume(returning: verdict)
+    }
+
+    func failPendingLifecycle() {
+        resolve(.allow)
+    }
+}
+
+@MainActor
+private final class WorkspaceLifecycleRecorder {
+    var makeCount = 0
+    var updateCount = 0
+    var dismantleCount = 0
+}
+
+@MainActor
+private final class PanelContentLifecycleRecorder {
+    var makeCount = 0
+    var dismantleCount = 0
+}
+
+private struct PanelHostSlotHarness: View {
+    let panelHost: PanelHost
+    let workspaceRecorder: WorkspaceLifecycleRecorder
+    let panelRecorder: PanelContentLifecycleRecorder
+
+    var body: some View {
+        HStack(spacing: 0) {
+            WorkspaceLifecycleProbe(recorder: workspaceRecorder)
+            PanelHostSlot(panelHost: panelHost, position: .right, mode: .pinned) { _ in
+                PanelContentLifecycleProbe(recorder: panelRecorder)
+                    .frame(width: 240)
+            }
+        }
+    }
+}
+
+private struct WorkspaceLifecycleProbe: NSViewRepresentable {
+    let recorder: WorkspaceLifecycleRecorder
+
+    func makeCoordinator() -> WorkspaceLifecycleRecorder {
+        recorder
+    }
+
+    func makeNSView(context _: Context) -> NSView {
+        recorder.makeCount += 1
+        return NSView()
+    }
+
+    func updateNSView(_: NSView, context _: Context) {
+        recorder.updateCount += 1
+    }
+
+    static func dismantleNSView(_: NSView, coordinator: WorkspaceLifecycleRecorder) {
+        coordinator.dismantleCount += 1
+    }
+}
+
+private struct PanelContentLifecycleProbe: NSViewRepresentable {
+    let recorder: PanelContentLifecycleRecorder
+
+    func makeCoordinator() -> PanelContentLifecycleRecorder {
+        recorder
+    }
+
+    func makeNSView(context _: Context) -> NSView {
+        recorder.makeCount += 1
+        return NSView()
+    }
+
+    func updateNSView(_: NSView, context _: Context) {}
+
+    static func dismantleNSView(_: NSView, coordinator: PanelContentLifecycleRecorder) {
+        coordinator.dismantleCount += 1
     }
 }

--- a/Tests/MuxyTests/Services/UIHosts/PanelSharedStateTests.swift
+++ b/Tests/MuxyTests/Services/UIHosts/PanelSharedStateTests.swift
@@ -289,19 +289,46 @@ struct PanelSharedStateTests {
             let window = focusTestWindow()
             let previousResponder = FocusTestView()
             let panelView = FocusTestView()
+            let panelControl = FocusTestView()
             let newerResponder = FocusTestView()
             window.contentView?.addSubview(previousResponder)
             window.contentView?.addSubview(panelView)
+            window.contentView?.addSubview(panelControl)
             window.contentView?.addSubview(newerResponder)
             #expect(window.makeFirstResponder(previousResponder))
 
             restoration.captureBeforeClaim(panelID: "files", panelView: panelView)
             #expect(window.makeFirstResponder(panelView))
+            #expect(window.makeFirstResponder(panelControl))
+            restoration.setPanelControlFocused(panelID: "files", focused: true)
             #expect(window.makeFirstResponder(newerResponder))
+            restoration.setPanelControlFocused(panelID: "files", focused: false)
 
             restoration.restoreAfterClosing(panelID: "files")
 
             #expect(window.firstResponder === newerResponder)
+        }
+
+        @Test("closing from a focused panel control restores the original responder")
+        func focusedPanelControlRestoresOriginalResponder() {
+            let restoration = PanelFocusRestoration()
+            let window = focusTestWindow()
+            let previousResponder = FocusTestView()
+            let panelView = FocusTestView()
+            let panelControl = FocusTestView()
+            window.contentView?.addSubview(previousResponder)
+            window.contentView?.addSubview(panelView)
+            window.contentView?.addSubview(panelControl)
+            #expect(window.makeFirstResponder(previousResponder))
+
+            restoration.captureBeforeClaim(panelID: "files", panelView: panelView)
+            #expect(window.makeFirstResponder(panelView))
+            #expect(window.makeFirstResponder(panelControl))
+            restoration.setPanelControlFocused(panelID: "files", focused: true)
+
+            restoration.restoreAfterClosing(panelID: "files")
+
+            #expect(window.firstResponder === previousResponder)
         }
 
         @Test("closing an earlier panel rebases a later panel snapshot")
@@ -324,6 +351,50 @@ struct PanelSharedStateTests {
             restoration.restoreAfterClosing(panelID: "first")
             #expect(window.firstResponder === secondPanelView)
             restoration.restoreAfterClosing(panelID: "second")
+
+            #expect(window.firstResponder === previousResponder)
+        }
+
+        @Test("replacement survives dependent closure after the old view is released")
+        func replacementSurvivesDependentClosureAfterOldViewRelease() {
+            let restoration = PanelFocusRestoration()
+            let window = focusTestWindow()
+            window.autorecalculatesKeyViewLoop = false
+            let previousResponder = FocusTestView()
+            let secondPanelView = FocusTestView()
+            let thirdPanelView = FocusTestView()
+            window.contentView?.addSubview(previousResponder)
+            window.contentView?.addSubview(secondPanelView)
+            window.contentView?.addSubview(thirdPanelView)
+            #expect(window.makeFirstResponder(previousResponder))
+
+            weak var releasedFirstPanelView: FocusTestView?
+            autoreleasepool {
+                let firstPanelView = FocusTestView()
+                let movedFirstPanelView = FocusTestView()
+                releasedFirstPanelView = firstPanelView
+                window.contentView?.addSubview(firstPanelView)
+                window.contentView?.addSubview(movedFirstPanelView)
+
+                restoration.captureBeforeClaim(panelID: "first", panelView: firstPanelView)
+                #expect(window.makeFirstResponder(firstPanelView))
+                restoration.captureBeforeClaim(panelID: "second", panelView: secondPanelView)
+                #expect(window.makeFirstResponder(secondPanelView))
+                restoration.captureBeforeClaim(panelID: "third", panelView: thirdPanelView)
+                #expect(window.makeFirstResponder(thirdPanelView))
+                restoration.captureBeforeClaim(panelID: "first", panelView: movedFirstPanelView)
+                #expect(window.makeFirstResponder(movedFirstPanelView))
+
+                firstPanelView.removeFromSuperview()
+            }
+            #expect(releasedFirstPanelView == nil)
+
+            #expect(window.makeFirstResponder(thirdPanelView))
+            restoration.restoreAfterClosing(panelID: "second")
+            #expect(window.firstResponder === thirdPanelView)
+            restoration.restoreAfterClosing(panelID: "first")
+            #expect(window.firstResponder === thirdPanelView)
+            restoration.restoreAfterClosing(panelID: "third")
 
             #expect(window.firstResponder === previousResponder)
         }

--- a/Tests/MuxyTests/Views/Extensions/ExtensionWebViewTests.swift
+++ b/Tests/MuxyTests/Views/Extensions/ExtensionWebViewTests.swift
@@ -117,6 +117,59 @@ struct ExtensionWebViewTests {
         #expect(webView.scripts.count == 2)
         #expect(webView.scripts.last?.contains("__muxyApplyFocus(false)") == true)
     }
+
+    @Test("focused panel webview captures the previous responder")
+    func focusedPanelCapturesPreviousResponder() async {
+        let restoration = PanelFocusRestoration()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: window.contentLayoutRect)
+        let previousResponder = ExtensionWebViewFocusTestView()
+        let webView = WKWebView(frame: contentView.bounds)
+        contentView.addSubview(previousResponder)
+        contentView.addSubview(webView)
+        window.contentView = contentView
+        #expect(window.makeFirstResponder(previousResponder))
+        let coordinator = ExtensionWebView.SurfaceCoordinator(
+            surfaceKind: .panel,
+            focusRestorationID: "files",
+            focusRestoration: restoration
+        )
+
+        coordinator.applyFocusIfChanged(
+            true,
+            overlayActive: false,
+            in: webView,
+            claimID: UUID()
+        )
+        let panelFocused = await waitFor {
+            window.firstResponder === webView
+        }
+        #expect(panelFocused)
+
+        restoration.restoreAfterClosing(panelID: "files")
+
+        #expect(window.firstResponder === previousResponder)
+    }
+
+    private func waitFor(condition: () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(1)
+        while Date() < deadline {
+            if condition() { return true }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
+    }
+}
+
+@MainActor
+private final class ExtensionWebViewFocusTestView: NSView {
+    override var acceptsFirstResponder: Bool { true }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

- isolate extension-panel placement observation from the workspace subtree so toggling a panel does not recreate or reload a remote terminal
- restore the previously focused responder after an extension WebView panel closes while preserving a newer focus choice
- preserve focus chains across panel movement, displacement, out-of-order closure, and extension shutdown
- bind asynchronous lifecycle close approvals to the exact panel instance so stale verdicts cannot close a replacement
- add SwiftUI/AppKit/WebKit regression coverage for terminal lifecycle and focus restoration

## Root cause

`MainWindow` directly observed shared panel placement state, so changing an extension panel invalidated the surrounding workspace hierarchy that owns the terminal view. Extension panel WebViews also claimed first-responder status without retaining the responder they displaced, and panel close requests used a stable host ID after an asynchronous lifecycle verdict.

The fix moves panel observation into a dedicated slot boundary and introduces weak, panel-scoped focus snapshots that are restored only when the closing panel still owns focus. Dependent snapshots are rebased when panels close out of order, and lifecycle approvals are revalidated against the original panel instance.

## Validation

- `scripts/checks.sh --fix`
- strict SwiftLint and SwiftFormat checks
- full build and test suite
- focused `PanelSharedStateTests` (17/17)
- focused extension WebView focus tests
- independent implementation review with verified follow-up fixes
- manual verification of remote terminal continuity and focus restoration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened stale-close safety to ensure the correct panel instance is closed.
  * Restored keyboard focus to the prior responder when closing single or multiple extension panels (including out-of-order scenarios).
* **UI Improvements**
  * Refactored panel slot rendering to use a dedicated slot wrapper for pinned and floating panels.
  * Extended focus handling across panel headers and extension web views.
* **Tests**
  * Added/expanded focus restoration, stale-close, and panel-slot lifecycle coverage (including SwiftUI and window first-responder assertions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->