### PR TITLE
fix: prevent SF Symbol 0×0 rasterization crash on macOS 27

### DIFF
--- a/Muxy/Services/ProjectPicker/ProjectPickerDefaultLocationSettingsModel.swift
+++ b/Muxy/Services/ProjectPicker/ProjectPickerDefaultLocationSettingsModel.swift
@@ -132,8 +132,8 @@ struct ProjectPickerDefaultLocationSettingsView: View {
 
     private var display: some View {
         HStack(spacing: 7) {
-            Image(systemName: "folder")
-                .font(.system(size: 11, weight: .medium))
+            Image(systemName: "folder").resizable().scaledToFit()
+                .frame(width: 11, height: 11)
                 .foregroundStyle(.secondary)
                 .frame(width: 15)
 

--- a/Muxy/Views/Browser/BrowserErrorView.swift
+++ b/Muxy/Views/Browser/BrowserErrorView.swift
@@ -6,8 +6,8 @@ struct BrowserErrorView: View {
 
     var body: some View {
         VStack(spacing: UIMetrics.spacing6) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: UIMetrics.iconXXL, weight: .regular))
+            Image(systemName: "exclamationmark.triangle").resizable().scaledToFit()
+                .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
                 .foregroundStyle(MuxyTheme.fgMuted)
 
             VStack(spacing: UIMetrics.spacing3) {

--- a/Muxy/Views/Browser/BrowserFindBar.swift
+++ b/Muxy/Views/Browser/BrowserFindBar.swift
@@ -10,8 +10,8 @@ struct BrowserFindBar: View {
 
     var body: some View {
         HStack(spacing: UIMetrics.spacing3) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+            Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(MuxyTheme.fgMuted)
 
             TextField("Find on page", text: $query)

--- a/Muxy/Views/Browser/BrowserStartPage.swift
+++ b/Muxy/Views/Browser/BrowserStartPage.swift
@@ -7,8 +7,8 @@ struct BrowserStartPage: View {
     var body: some View {
         VStack(spacing: UIMetrics.spacing7) {
             Spacer()
-            Image(systemName: "globe")
-                .font(.system(size: UIMetrics.fontMega, weight: .light))
+            Image(systemName: "globe").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontMega, height: UIMetrics.fontMega)
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text("New Tab")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
@@ -20,8 +20,8 @@ struct BrowserStartPage: View {
                 .frame(maxWidth: UIMetrics.scaled(360))
             Button(action: onFocusAddress) {
                 HStack(spacing: UIMetrics.spacing3) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                    Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     Text("Search or enter address")
                         .font(.system(size: UIMetrics.fontBody))
                     Spacer(minLength: 0)

--- a/Muxy/Views/Browser/BrowserSuggestionList.swift
+++ b/Muxy/Views/Browser/BrowserSuggestionList.swift
@@ -74,8 +74,8 @@ struct BrowserSuggestionList: View {
                 .resizable()
                 .interpolation(.high)
         } else {
-            Image(systemName: "clock.arrow.circlepath")
-                .font(.system(size: UIMetrics.fontCaption))
+            Image(systemName: "clock.arrow.circlepath").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(MuxyTheme.fgDim)
         }
     }

--- a/Muxy/Views/Browser/BrowserToolbar.swift
+++ b/Muxy/Views/Browser/BrowserToolbar.swift
@@ -81,8 +81,8 @@ struct BrowserToolbar: View {
                 }
             }
         } label: {
-            Image(systemName: "arrow.up.forward.app")
-                .font(.system(size: UIMetrics.fontBody, weight: .medium))
+            Image(systemName: "arrow.up.forward.app").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .contentShape(Rectangle())
@@ -129,8 +129,8 @@ struct BrowserToolbar: View {
             }
         } label: {
             HStack(spacing: UIMetrics.spacing1) {
-                Image(systemName: "person.crop.circle")
-                    .font(.system(size: UIMetrics.fontBody, weight: .medium))
+                Image(systemName: "person.crop.circle").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 Text(currentProfileName)
                     .font(.system(size: UIMetrics.fontCaption, weight: .medium))
                     .lineLimit(1)

--- a/Muxy/Views/Components/Badges/UpdateBadge.swift
+++ b/Muxy/Views/Components/Badges/UpdateBadge.swift
@@ -8,8 +8,8 @@ struct UpdateBadge: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: UIMetrics.spacing2) {
-                Image(systemName: "arrow.down.circle.fill")
-                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                Image(systemName: "arrow.down.circle.fill").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                 Text("Update \(version)")
                     .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
                     .lineLimit(1)

--- a/Muxy/Views/Components/Buttons/DebugButton.swift
+++ b/Muxy/Views/Components/Buttons/DebugButton.swift
@@ -9,8 +9,8 @@ struct DebugButton: View {
         Button {
             showingPopover.toggle()
         } label: {
-            Image(systemName: "ladybug.fill")
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: "ladybug.fill").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 .foregroundStyle(hovered ? MuxyTheme.warning : MuxyTheme.warning.opacity(0.75))
                 .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
                 .contentShape(Rectangle())
@@ -32,8 +32,8 @@ private struct DebugInfoPopover: View {
     var body: some View {
         VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
             HStack(spacing: UIMetrics.spacing3) {
-                Image(systemName: "ladybug.fill")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                Image(systemName: "ladybug.fill").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                     .foregroundStyle(MuxyTheme.warning)
                 Text("Debug")
                     .font(.system(size: UIMetrics.fontBody, weight: .semibold))
@@ -64,8 +64,8 @@ private struct DebugInfoPopover: View {
 
     private func metricRow(_ label: String, value: String, icon: String) -> some View {
         HStack(spacing: UIMetrics.spacing4) {
-            Image(systemName: icon)
-                .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+            Image(systemName: icon).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.iconMD)
             Text(label)

--- a/Muxy/Views/Components/Buttons/IconButton.swift
+++ b/Muxy/Views/Components/Buttons/IconButton.swift
@@ -16,8 +16,8 @@ struct IconButton: View {
             accessibilityLabel: accessibilityLabel,
             action: action
         ) {
-            Image(systemName: symbol)
-                .font(.system(size: UIMetrics.scaled(size), weight: .semibold))
+            Image(systemName: symbol).resizable().scaledToFit()
+                .frame(width: UIMetrics.scaled(size), height: UIMetrics.scaled(size))
                 .overlay(alignment: .topTrailing) {
                     if showsBadge {
                         IconButtonBadge()

--- a/Muxy/Views/Components/Buttons/OpenProjectControl.swift
+++ b/Muxy/Views/Components/Buttons/OpenProjectControl.swift
@@ -60,8 +60,8 @@ struct OpenProjectControl: View {
                 size: UIMetrics.iconMD
             )
         } else {
-            Image(systemName: "chevron.left.forwardslash.chevron.right")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            Image(systemName: "chevron.left.forwardslash.chevron.right").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
         }
     }
@@ -71,8 +71,8 @@ struct OpenProjectControl: View {
             guard projectPath != nil else { return }
             showingMenu.toggle()
         } label: {
-            Image(systemName: "chevron.down")
-                .font(.system(size: UIMetrics.fontMicro, weight: .semibold))
+            Image(systemName: "chevron.down").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontMicro, height: UIMetrics.fontMicro)
                 .foregroundStyle(menuForeground)
                 .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlSmall)
                 .contentShape(Rectangle())

--- a/Muxy/Views/Components/Buttons/ResourceUsageButton.swift
+++ b/Muxy/Views/Components/Buttons/ResourceUsageButton.swift
@@ -9,8 +9,8 @@ struct ResourceUsageButton: View {
         Button {
             showingPopover.toggle()
         } label: {
-            Image(systemName: "cpu")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            Image(systemName: "cpu").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
                 .padding(.horizontal, 4)
                 .frame(maxHeight: .infinity)
@@ -60,8 +60,8 @@ private struct ResourceUsagePopover: View {
             onClose()
         } label: {
             HStack(spacing: UIMetrics.spacing3) {
-                Image(systemName: "eye.slash")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                Image(systemName: "eye.slash").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 Text("Hide from status bar")
                     .font(.system(size: UIMetrics.fontFootnote))
                 Spacer(minLength: 0)
@@ -75,8 +75,8 @@ private struct ResourceUsagePopover: View {
 
     private var header: some View {
         HStack(spacing: UIMetrics.spacing3) {
-            Image(systemName: "cpu")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            Image(systemName: "cpu").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(MuxyTheme.accent)
             Text("Resources")
                 .font(.system(size: UIMetrics.fontBody, weight: .semibold))

--- a/Muxy/Views/Components/Icons/AppBundleIconView.swift
+++ b/Muxy/Views/Components/Icons/AppBundleIconView.swift
@@ -13,8 +13,8 @@ struct AppBundleIconView: View {
                 .interpolation(.high)
                 .antialiased(true)
         } else {
-            Image(systemName: fallbackSystemName)
-                .font(.system(size: size * 0.85, weight: .semibold))
+            Image(systemName: fallbackSystemName).resizable().scaledToFit()
+                .frame(width: size * 0.85, height: size * 0.85)
                 .foregroundStyle(.secondary)
                 .frame(width: size, height: size)
         }

--- a/Muxy/Views/Components/Icons/ExtensionIconView.swift
+++ b/Muxy/Views/Components/Icons/ExtensionIconView.swift
@@ -10,8 +10,8 @@ struct ExtensionIconView: View {
     var body: some View {
         switch icon {
         case let .symbol(name):
-            Image(systemName: name)
-                .font(.system(size: UIMetrics.scaled(size), weight: weight))
+            Image(systemName: name).resizable().scaledToFit()
+                .frame(width: UIMetrics.scaled(size), height: UIMetrics.scaled(size))
         case let .svg(path):
             svgImage(path: path)
         }
@@ -28,8 +28,8 @@ struct ExtensionIconView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: UIMetrics.scaled(size), height: UIMetrics.scaled(size))
         } else {
-            Image(systemName: "puzzlepiece.extension")
-                .font(.system(size: UIMetrics.scaled(size), weight: weight))
+            Image(systemName: "puzzlepiece.extension").resizable().scaledToFit()
+                .frame(width: UIMetrics.scaled(size), height: UIMetrics.scaled(size))
         }
     }
 }

--- a/Muxy/Views/Components/Icons/ExtensionRemoteIconView.swift
+++ b/Muxy/Views/Components/Icons/ExtensionRemoteIconView.swift
@@ -23,8 +23,8 @@ struct ExtensionRemoteIconView: View {
     }
 
     private var placeholder: some View {
-        Image(systemName: "puzzlepiece.extension")
-            .font(.system(size: placeholderSize))
+        Image(systemName: "puzzlepiece.extension").resizable().scaledToFit()
+            .frame(width: placeholderSize, height: placeholderSize)
             .foregroundStyle(MuxyTheme.fgDim)
     }
 

--- a/Muxy/Views/Components/Icons/ProviderIconView.swift
+++ b/Muxy/Views/Components/Icons/ProviderIconView.swift
@@ -34,8 +34,8 @@ struct ProviderIconView: View {
     }
 
     private var fallbackSymbol: some View {
-        Image(systemName: "sparkles")
-            .font(.system(size: size * 0.85, weight: .semibold))
+        Image(systemName: "sparkles").resizable().scaledToFit()
+            .frame(width: size * 0.85, height: size * 0.85)
             .frame(width: size, height: size)
     }
 

--- a/Muxy/Views/Components/Overlays/ProjectPickerOverlay.swift
+++ b/Muxy/Views/Components/Overlays/ProjectPickerOverlay.swift
@@ -55,8 +55,8 @@ struct ProjectPickerOverlay: View {
 
     private var pathBar: some View {
         HStack(spacing: UIMetrics.spacing4) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 .foregroundStyle(MuxyTheme.fgMuted)
 
             ZStack(alignment: .leading) {
@@ -87,8 +87,8 @@ struct ProjectPickerOverlay: View {
                 action: { handleCommand(.confirmTypedPath) },
                 label: {
                     HStack(spacing: UIMetrics.spacing2) {
-                        Image(systemName: "plus")
-                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        Image(systemName: "plus").resizable().scaledToFit()
+                            .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                         Text(workflow.session.topRightActionTitle)
                             .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
                     }
@@ -123,8 +123,8 @@ struct ProjectPickerOverlay: View {
                         }
                     }
                 } label: {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+                    Image(systemName: "chevron.down").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                         .padding(.horizontal, UIMetrics.spacing3)
                         .padding(.vertical, UIMetrics.spacing2)
                         .contentShape(Rectangle())
@@ -436,8 +436,8 @@ private struct ProjectPickerDirectoryRowView: View {
             ZStack(alignment: .bottomTrailing) {
                 Image(systemName: "folder")
                     .foregroundStyle(MuxyTheme.fgMuted)
-                Image(systemName: "arrow.up.forward")
-                    .font(.system(size: UIMetrics.scaled(7), weight: .bold))
+                Image(systemName: "arrow.up.forward").resizable().scaledToFit()
+                    .frame(width: UIMetrics.scaled(7), height: UIMetrics.scaled(7))
                     .foregroundStyle(MuxyTheme.fg)
                     .padding(1)
                     .background(MuxyTheme.surface, in: Circle())

--- a/Muxy/Views/Components/Overlays/TerminalOmniboxOverlay.swift
+++ b/Muxy/Views/Components/Overlays/TerminalOmniboxOverlay.swift
@@ -79,8 +79,8 @@ struct TerminalOmniboxOverlay: View {
 
     private var searchField: some View {
         HStack(spacing: UIMetrics.spacing4) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
+            Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontEmphasis, height: UIMetrics.fontEmphasis)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .accessibilityHidden(true)
             PaletteSearchField(
@@ -292,8 +292,8 @@ private struct TerminalOmniboxRow: View {
 
     var body: some View {
         HStack(spacing: UIMetrics.spacing5) {
-            Image(systemName: item.symbol)
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            Image(systemName: item.symbol).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.iconLG, alignment: .center)
             VStack(alignment: .leading, spacing: UIMetrics.scaled(1)) {
@@ -331,8 +331,8 @@ private struct TerminalOmniboxHint: View {
         HStack(spacing: UIMetrics.scaled(4)) {
             HStack(spacing: UIMetrics.scaled(3)) {
                 if let symbol {
-                    Image(systemName: symbol)
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    Image(systemName: symbol).resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                         .foregroundStyle(MuxyTheme.fgMuted)
                 }
                 if let text {

--- a/Muxy/Views/Components/Pickers/PopoverPicker.swift
+++ b/Muxy/Views/Components/Pickers/PopoverPicker.swift
@@ -90,8 +90,8 @@ struct PopoverPicker<Item: Identifiable, RowContent: View>: View {
         Button(action: action) {
             HStack(spacing: UIMetrics.spacing4) {
                 if let icon {
-                    Image(systemName: icon)
-                        .font(.system(size: UIMetrics.fontBody))
+                    Image(systemName: icon).resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 }
                 Text(title)
                     .font(.system(size: UIMetrics.fontBody, weight: .medium))

--- a/Muxy/Views/Components/Pickers/ProjectPickerShortcutHint.swift
+++ b/Muxy/Views/Components/Pickers/ProjectPickerShortcutHint.swift
@@ -29,8 +29,8 @@ struct ProjectPickerShortcutHint: View {
     private func keycapPart(_ part: ProjectPickerShortcutKeycapPart) -> some View {
         switch part {
         case let .symbol(name):
-            Image(systemName: name)
-                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+            Image(systemName: name).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(MuxyTheme.fgMuted)
         case let .text(text):
             Text(text)

--- a/Muxy/Views/Extensions/CreateExtensionSheet.swift
+++ b/Muxy/Views/Extensions/CreateExtensionSheet.swift
@@ -132,8 +132,8 @@ struct CreateExtensionSheet: View {
 
     private func guideRow(symbol: String, text: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
-            Image(systemName: symbol)
-                .font(.system(size: 11))
+            Image(systemName: symbol).resizable().scaledToFit()
+                .frame(width: 11, height: 11)
                 .foregroundStyle(MuxyTheme.accent)
                 .frame(width: 14, alignment: .center)
             Text(text)

--- a/Muxy/Views/Extensions/ExtensionConsentDialog.swift
+++ b/Muxy/Views/Extensions/ExtensionConsentDialog.swift
@@ -222,8 +222,8 @@ struct ExtensionConsentDialog: View {
 
     private var header: some View {
         HStack(alignment: .top, spacing: 12) {
-            Image(systemName: iconName)
-                .font(.system(size: 28, weight: .light))
+            Image(systemName: iconName).resizable().scaledToFit()
+                .frame(width: 28, height: 28)
                 .foregroundStyle(MuxyTheme.accent)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Allow \(request.extensionDisplayName)?")
@@ -263,8 +263,8 @@ struct ExtensionConsentDialog: View {
             }
             .toggleStyle(.checkbox)
             HStack(spacing: 6) {
-                Image(systemName: "info.circle")
-                    .font(.system(size: UIMetrics.fontCaption))
+                Image(systemName: "info.circle").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.fgMuted)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("\"Remember\" saves rule")

--- a/Muxy/Views/Extensions/ExtensionInstallPage.swift
+++ b/Muxy/Views/Extensions/ExtensionInstallPage.swift
@@ -57,8 +57,8 @@ struct ExtensionInstallPage: View {
 
     private func failedState(_ message: String) -> some View {
         VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 28))
+            Image(systemName: "exclamationmark.triangle").resizable().scaledToFit()
+                .frame(width: 28, height: 28)
                 .foregroundStyle(MuxyTheme.fgDim)
             Text(message)
                 .font(.system(size: 12))
@@ -146,8 +146,8 @@ struct ExtensionInstallPage: View {
 
     private var safetyNotice: some View {
         HStack(alignment: .top, spacing: 10) {
-            Image(systemName: "lock.shield")
-                .font(.system(size: 14, weight: .semibold))
+            Image(systemName: "lock.shield").resizable().scaledToFit()
+                .frame(width: 14, height: 14)
                 .foregroundStyle(MuxyTheme.accent)
             Text("No extension can run a command on your computer without you approving each command first.")
                 .font(.system(size: 12))

--- a/Muxy/Views/Extensions/ExtensionOutputPanel.swift
+++ b/Muxy/Views/Extensions/ExtensionOutputPanel.swift
@@ -42,8 +42,8 @@ struct ExtensionOutputPanel: View {
                 HStack(spacing: 4) {
                     Text(activeLabel)
                         .lineLimit(1)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: UIMetrics.fontCaption))
+                    Image(systemName: "chevron.down").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 }
                 .foregroundStyle(MuxyTheme.fg)
                 .padding(.horizontal, 6)

--- a/Muxy/Views/Extensions/ExtensionStorePage.swift
+++ b/Muxy/Views/Extensions/ExtensionStorePage.swift
@@ -73,8 +73,8 @@ struct ExtensionStorePage: View {
 
     private var searchField: some View {
         HStack(spacing: 6) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 11))
+            Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                .frame(width: 11, height: 11)
                 .foregroundStyle(MuxyTheme.fgDim)
             TextField("Search extensions", text: $query)
                 .textFieldStyle(.plain)
@@ -83,8 +83,8 @@ struct ExtensionStorePage: View {
                 Button {
                     query = ""
                 } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 11))
+                    Image(systemName: "xmark.circle.fill").resizable().scaledToFit()
+                        .frame(width: 11, height: 11)
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
                 .buttonStyle(.plain)
@@ -211,8 +211,8 @@ struct ExtensionStorePage: View {
 
     private var emptyState: some View {
         VStack(spacing: 10) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 32))
+            Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                .frame(width: 32, height: 32)
                 .foregroundStyle(MuxyTheme.fgDim)
             Text("No extensions found")
                 .font(.system(size: 13, weight: .semibold))
@@ -226,8 +226,8 @@ struct ExtensionStorePage: View {
 
     private func failedState(_ message: String) -> some View {
         VStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 28))
+            Image(systemName: "exclamationmark.triangle").resizable().scaledToFit()
+                .frame(width: 28, height: 28)
                 .foregroundStyle(MuxyTheme.fgDim)
             Text(message)
                 .font(.system(size: 12))
@@ -323,12 +323,12 @@ private struct ExtensionStoreMenuLabel: View {
 
     var body: some View {
         HStack(spacing: 5) {
-            Image(systemName: icon)
-                .font(.system(size: 10, weight: .medium))
+            Image(systemName: icon).resizable().scaledToFit()
+                .frame(width: 10, height: 10)
             Text(title)
                 .font(.system(size: 12))
-            Image(systemName: "chevron.down")
-                .font(.system(size: 9, weight: .semibold))
+            Image(systemName: "chevron.down").resizable().scaledToFit()
+                .frame(width: 9, height: 9)
         }
         .foregroundStyle(MuxyTheme.fgMuted)
         .padding(.horizontal, 10)

--- a/Muxy/Views/Extensions/ExtensionWebViewPane.swift
+++ b/Muxy/Views/Extensions/ExtensionWebViewPane.swift
@@ -40,8 +40,8 @@ struct ExtensionWebViewPane: View {
 
     private var placeholder: some View {
         VStack(spacing: 8) {
-            Image(systemName: "puzzlepiece.extension")
-                .font(.system(size: 32, weight: .light))
+            Image(systemName: "puzzlepiece.extension").resizable().scaledToFit()
+                .frame(width: 32, height: 32)
             Text("Extension \(state.extensionID) is not loaded")
                 .font(.headline)
             Text("Tab type: \(state.tabTypeID)")

--- a/Muxy/Views/Extensions/ExtensionsView.swift
+++ b/Muxy/Views/Extensions/ExtensionsView.swift
@@ -101,8 +101,8 @@ struct ExtensionsView: View {
                     activeInstallName = nil
                 } label: {
                     HStack(spacing: 4) {
-                        Image(systemName: "chevron.left")
-                            .font(.system(size: 11, weight: .semibold))
+                        Image(systemName: "chevron.left").resizable().scaledToFit()
+                            .frame(width: 11, height: 11)
                         Text("Extensions")
                             .font(.system(size: 12, weight: .medium))
                     }
@@ -115,8 +115,8 @@ struct ExtensionsView: View {
                 .help("Back to Extensions")
             } else {
                 HStack(spacing: 8) {
-                    Image(systemName: "puzzlepiece.extension")
-                        .font(.system(size: 13, weight: .medium))
+                    Image(systemName: "puzzlepiece.extension").resizable().scaledToFit()
+                        .frame(width: 13, height: 13)
                         .foregroundStyle(MuxyTheme.fgMuted)
                     Text("Extensions")
                         .font(.system(size: 15, weight: .semibold))
@@ -170,8 +170,8 @@ struct ExtensionsView: View {
             Button {
                 NSApp.keyWindow?.close()
             } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 12, weight: .semibold))
+                Image(systemName: "xmark").resizable().scaledToFit()
+                    .frame(width: 12, height: 12)
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .frame(width: 28, height: 28)
                     .contentShape(Rectangle())
@@ -327,8 +327,8 @@ private struct ExtensionsListPage: View {
 
     private var emptyState: some View {
         VStack(spacing: 10) {
-            Image(systemName: "puzzlepiece.extension")
-                .font(.system(size: 32))
+            Image(systemName: "puzzlepiece.extension").resizable().scaledToFit()
+                .frame(width: 32, height: 32)
                 .foregroundStyle(MuxyTheme.fgDim)
             Text("No extensions installed")
                 .font(.system(size: 13, weight: .semibold))
@@ -424,8 +424,8 @@ private struct ExtensionRow: View {
 
     private var rowContent: some View {
         HStack(spacing: 12) {
-            Image(systemName: "puzzlepiece.extension.fill")
-                .font(.system(size: 16))
+            Image(systemName: "puzzlepiece.extension.fill").resizable().scaledToFit()
+                .frame(width: 16, height: 16)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: 22)
             VStack(alignment: .leading, spacing: 3) {
@@ -452,8 +452,8 @@ private struct ExtensionRow: View {
             }
             Spacer(minLength: 12)
             ExtensionPermissionSummary(permissions: ext.manifest.permissions)
-            Image(systemName: "chevron.right")
-                .font(.system(size: 11, weight: .semibold))
+            Image(systemName: "chevron.right").resizable().scaledToFit()
+                .frame(width: 11, height: 11)
                 .foregroundStyle(MuxyTheme.fgDim)
         }
         .padding(.leading, 14)
@@ -474,8 +474,8 @@ private struct ExtensionUpdateButton: View {
                 if isUpdating {
                     ProgressView().controlSize(.small)
                 } else {
-                    Image(systemName: "arrow.down.circle.fill")
-                        .font(.system(size: 11))
+                    Image(systemName: "arrow.down.circle.fill").resizable().scaledToFit()
+                        .frame(width: 11, height: 11)
                 }
                 Text(isUpdating ? "Updating…" : "Update v\(version)")
                     .font(.system(size: 11, weight: .semibold))

--- a/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
@@ -256,8 +256,8 @@ struct ExpandedProjectRow: View {
                 worktreesExpanded.toggle()
             }
         } label: {
-            Image(systemName: "chevron.right")
-                .font(.system(size: UIMetrics.fontXS, weight: .semibold))
+            Image(systemName: "chevron.right").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                 .foregroundStyle(MuxyTheme.fg)
                 .rotationEffect(.degrees(worktreesExpanded ? 90 : 0))
                 .animation(.easeInOut(duration: 0.15), value: worktreesExpanded)
@@ -269,8 +269,8 @@ struct ExpandedProjectRow: View {
     }
 
     private var remoteIndicator: some View {
-        Image(systemName: "network")
-            .font(.system(size: UIMetrics.fontXS, weight: .semibold))
+        Image(systemName: "network").resizable().scaledToFit()
+            .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
             .foregroundStyle(MuxyTheme.fgMuted)
             .frame(width: UIMetrics.scaled(18), height: UIMetrics.scaled(18))
             .help(remoteDeviceName ?? "Remote project")
@@ -326,8 +326,8 @@ struct ExpandedProjectRow: View {
                 .fill(iconBackground(hasLogo: logo != nil))
 
             if project.isHome {
-                Image(systemName: Project.homeIcon)
-                    .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))
+                Image(systemName: Project.homeIcon).resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontTitleLarge, height: UIMetrics.fontTitleLarge)
                     .foregroundStyle(MuxyTheme.accentForeground)
             } else if let logo {
                 Image(nsImage: logo)
@@ -336,8 +336,8 @@ struct ExpandedProjectRow: View {
                     .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
                     .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous))
             } else if let iconName = project.icon {
-                Image(systemName: iconName)
-                    .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))
+                Image(systemName: iconName).resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontTitleLarge, height: UIMetrics.fontTitleLarge)
                     .foregroundStyle(letterForeground)
             } else {
                 Text(displayLetter)
@@ -743,8 +743,8 @@ private struct ExpandedNewWorktreeButton: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: UIMetrics.spacing3) {
-                Image(systemName: "plus")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                Image(systemName: "plus").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fg)
                     .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
                 Text("New Worktree")

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
@@ -566,8 +566,8 @@ private struct AddProjectButton: View {
             ZStack {
                 RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                     .fill(MuxyTheme.hover)
-                Image(systemName: "plus")
-                    .font(.system(size: UIMetrics.fontEmphasis, weight: .bold))
+                Image(systemName: "plus").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontEmphasis, height: UIMetrics.fontEmphasis)
                     .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
             }
             .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
@@ -579,8 +579,8 @@ private struct AddProjectButton: View {
                 ZStack {
                     RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
                         .fill(MuxyTheme.surface)
-                    Image(systemName: "plus")
-                        .font(.system(size: UIMetrics.fontEmphasis, weight: .bold))
+                    Image(systemName: "plus").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontEmphasis, height: UIMetrics.fontEmphasis)
                         .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
                 }
                 .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
@@ -603,8 +603,8 @@ private enum SortMenuButton {
         @State private var hovered = false
 
         var body: some View {
-            Image(systemName: "arrow.up.arrow.down")
-                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+            Image(systemName: "arrow.up.arrow.down").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .background(

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
@@ -253,8 +253,8 @@ struct ProjectRow: View {
                 .fill(iconBackground(hasLogo: logo != nil))
 
             if project.isHome {
-                Image(systemName: Project.homeIcon)
-                    .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))
+                Image(systemName: Project.homeIcon).resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontTitleLarge, height: UIMetrics.fontTitleLarge)
                     .foregroundStyle(MuxyTheme.accentForeground)
             } else if let logo {
                 Image(nsImage: logo)
@@ -263,8 +263,8 @@ struct ProjectRow: View {
                     .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
                     .clipShape(RoundedRectangle(cornerRadius: UIMetrics.radiusMD, style: .continuous))
             } else if let iconName = project.icon {
-                Image(systemName: iconName)
-                    .font(.system(size: UIMetrics.fontTitleLarge, weight: .medium))
+                Image(systemName: iconName).resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontTitleLarge, height: UIMetrics.fontTitleLarge)
                     .foregroundStyle(letterForeground)
             } else {
                 Text(displayLetter)

--- a/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
@@ -78,8 +78,8 @@ struct WorkspaceSwitcher: View {
         } label: {
             HStack(spacing: UIMetrics.spacing2) {
                 if activeGroup?.type == .ssh {
-                    Image(systemName: "network")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    Image(systemName: "network").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                         .foregroundStyle(MuxyTheme.accent)
                 }
                 Text(activeLabel)
@@ -87,8 +87,8 @@ struct WorkspaceSwitcher: View {
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .lineLimit(1)
                 Spacer()
-                Image(systemName: "chevron.down")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                Image(systemName: "chevron.down").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.fgMuted)
             }
             .padding(.horizontal, UIMetrics.spacing4)
@@ -110,8 +110,8 @@ struct WorkspaceSwitcher: View {
         Button {
             isShowingPopover.toggle()
         } label: {
-            Image(systemName: "chevron.down")
-                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+            Image(systemName: "chevron.down").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.iconXXL, height: UIMetrics.iconXXL)
                 .background(
@@ -168,12 +168,12 @@ struct WorkspaceSwitcher: View {
             isShowingPopover = false
         } label: {
             HStack(spacing: UIMetrics.spacing2) {
-                Image(systemName: projectGroupStore.activeGroupID == nil ? "checkmark" : "")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                Image(systemName: projectGroupStore.activeGroupID == nil ? "checkmark" : "").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.accent)
                     .frame(width: UIMetrics.fontCaption)
-                Image(systemName: "square.grid.2x2")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                Image(systemName: "square.grid.2x2").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .frame(width: UIMetrics.fontBody)
                 Text("All Projects")
@@ -204,8 +204,8 @@ struct WorkspaceSwitcher: View {
             }
         } label: {
             HStack(spacing: UIMetrics.spacing2) {
-                Image(systemName: "plus")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                Image(systemName: "plus").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.accent)
                     .frame(width: UIMetrics.fontCaption)
                 Text("New Workspace")
@@ -415,12 +415,12 @@ private struct WorkspaceRow: View {
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: UIMetrics.spacing2) {
-                Image(systemName: isActive ? "checkmark" : "")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                Image(systemName: isActive ? "checkmark" : "").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.accent)
                     .frame(width: UIMetrics.fontCaption)
-                Image(systemName: group.type == .ssh ? "network" : "square.stack.3d.up")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                Image(systemName: group.type == .ssh ? "network" : "square.stack.3d.up").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .frame(width: UIMetrics.fontBody)
                 Text(group.name)
@@ -458,8 +458,8 @@ private struct WorkspaceRow: View {
         case .connected:
             Circle().fill(.green).frame(width: UIMetrics.spacing2, height: UIMetrics.spacing2)
         case .failed:
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: UIMetrics.fontCaption))
+            Image(systemName: "exclamationmark.triangle.fill").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(.orange)
         case .disconnected,
              .none:

--- a/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
@@ -203,8 +203,8 @@ struct CreateWorktreeSheet: View {
     private var setupCommandsSection: some View {
         VStack(alignment: .leading, spacing: UIMetrics.spacing4) {
             HStack(spacing: UIMetrics.spacing3) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: UIMetrics.fontCaption))
+                Image(systemName: "exclamationmark.triangle.fill").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
                 Text("Setup commands from .muxy/worktree.json")
                     .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
@@ -235,8 +235,8 @@ struct CreateWorktreeSheet: View {
     private var setupCommandsGuideSection: some View {
         VStack(alignment: .leading, spacing: UIMetrics.spacing4) {
             HStack(spacing: UIMetrics.spacing3) {
-                Image(systemName: "info.circle")
-                    .font(.system(size: UIMetrics.fontCaption))
+                Image(systemName: "info.circle").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.fgDim)
                 Text("Optional setup commands")
                     .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))

--- a/Muxy/Views/Layouts/Shared/ProjectIconColorPicker.swift
+++ b/Muxy/Views/Layouts/Shared/ProjectIconColorPicker.swift
@@ -41,8 +41,8 @@ struct ProjectIconColorPicker: View {
                 onSelect(nil)
             } label: {
                 HStack(spacing: UIMetrics.spacing3) {
-                    Image(systemName: "arrow.uturn.backward")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                    Image(systemName: "arrow.uturn.backward").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     Text("Reset to Default")
                         .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 }

--- a/Muxy/Views/Layouts/Shared/SFSymbolPicker.swift
+++ b/Muxy/Views/Layouts/Shared/SFSymbolPicker.swift
@@ -240,8 +240,8 @@ struct SFSymbolPicker: View {
                 onSelect(nil)
             } label: {
                 HStack(spacing: UIMetrics.spacing3) {
-                    Image(systemName: "xmark.circle")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                    Image(systemName: "xmark.circle").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     Text("Remove Icon")
                         .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                 }
@@ -265,8 +265,8 @@ struct SFSymbolPicker: View {
                     .fill(isSelected ? MuxyTheme.accent.opacity(0.2) : Color.clear)
                     .frame(width: UIMetrics.controlLarge, height: UIMetrics.controlLarge)
 
-                Image(systemName: symbol.systemName)
-                    .font(.system(size: UIMetrics.fontTitleLarge, weight: .regular))
+                Image(systemName: symbol.systemName).resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontTitleLarge, height: UIMetrics.fontTitleLarge)
                     .foregroundStyle(isSelected ? MuxyTheme.accent : MuxyTheme.fg)
             }
             .frame(width: UIMetrics.controlLarge, height: UIMetrics.controlLarge)

--- a/Muxy/Views/Layouts/TabFocused/RepositoryAIActionSplitButton.swift
+++ b/Muxy/Views/Layouts/TabFocused/RepositoryAIActionSplitButton.swift
@@ -58,8 +58,8 @@ struct RepositoryAIActionSplitButton: View {
     private var primaryButton: some View {
         Button(action: onRun) {
             HStack(spacing: UIMetrics.spacing2) {
-                Image(systemName: action.symbolName)
-                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                Image(systemName: action.symbolName).resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                 Text(isRunning ? action.runningTitle : action.title)
                     .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
             }
@@ -84,8 +84,8 @@ struct RepositoryAIActionSplitButton: View {
         Button {
             showingMenu.toggle()
         } label: {
-            Image(systemName: "chevron.down")
-                .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+            Image(systemName: "chevron.down").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontMicro, height: UIMetrics.fontMicro)
                 .foregroundStyle(menuForeground)
                 .frame(width: UIMetrics.scaled(16), height: UIMetrics.controlSmall)
                 .contentShape(Rectangle())
@@ -143,8 +143,8 @@ struct RepositoryAIActionSplitButton: View {
             editingProjectPrompt = true
         } label: {
             HStack(spacing: UIMetrics.spacing3) {
-                Image(systemName: "text.quote")
-                    .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                Image(systemName: "text.quote").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                     .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                     Text("Edit Project Prompt…")
@@ -234,16 +234,16 @@ struct RepositoryAIActionSplitButton: View {
                 if let iconName {
                     ProviderIconView(iconName: iconName, size: UIMetrics.iconMD)
                 } else {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                    Image(systemName: "sparkles").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                         .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 }
                 Text(title)
                     .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fg)
                 Spacer(minLength: UIMetrics.spacing6)
-                Image(systemName: "checkmark")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .bold))
+                Image(systemName: "checkmark").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                     .foregroundStyle(MuxyTheme.accent)
                     .opacity(configuredProviderID == id ? 1 : 0)
             }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedBranchPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedBranchPopover.swift
@@ -105,8 +105,8 @@ struct TabFocusedBranchPopover: View {
         if isCreatingBranch {
             VStack(alignment: .leading, spacing: UIMetrics.spacing3) {
                 HStack(spacing: UIMetrics.spacing2) {
-                    Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    Image(systemName: "arrow.triangle.branch").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                         .foregroundStyle(MuxyTheme.accent)
                     Text("New branch")
                         .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
@@ -152,8 +152,8 @@ struct TabFocusedBranchPopover: View {
         } else {
             Button(action: beginBranchCreation) {
                 HStack(spacing: UIMetrics.spacing3) {
-                    Image(systemName: "plus")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+                    Image(systemName: "plus").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                         .frame(width: UIMetrics.iconSM)
                     Text("New branch")
                         .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
@@ -285,8 +285,8 @@ private struct BranchPopoverRow: View {
         HStack(spacing: UIMetrics.spacing2) {
             Button(action: onSelect) {
                 HStack(spacing: UIMetrics.spacing3) {
-                    Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                    Image(systemName: "arrow.triangle.branch").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                         .foregroundStyle(isSelected ? MuxyTheme.accent : MuxyTheme.fgMuted)
                         .frame(width: UIMetrics.iconSM)
                     Text(name)
@@ -314,15 +314,15 @@ private struct BranchPopoverRow: View {
     @ViewBuilder
     private var trailingAccessory: some View {
         if isSelected {
-            Image(systemName: "checkmark")
-                .font(.system(size: UIMetrics.fontXS, weight: .semibold))
+            Image(systemName: "checkmark").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                 .foregroundStyle(MuxyTheme.accent)
                 .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
                 .accessibilityHidden(true)
         } else {
             Button(action: onRequestDelete) {
-                Image(systemName: "trash")
-                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
+                Image(systemName: "trash").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                     .foregroundStyle(MuxyTheme.diffRemoveFg)
                     .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
                     .contentShape(Rectangle())

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
@@ -57,8 +57,8 @@ struct TabFocusedChangesPopover: View {
 
     private var header: some View {
         HStack(spacing: UIMetrics.spacing4) {
-            Image(systemName: "arrow.left.arrow.right")
-                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+            Image(systemName: "arrow.left.arrow.right").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontHeadline, height: UIMetrics.fontHeadline)
                 .foregroundStyle(summary.isDirty ? MuxyTheme.warning : MuxyTheme.diffAddFg)
             VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                 Text("Changes")
@@ -77,8 +77,8 @@ struct TabFocusedChangesPopover: View {
                     if isLoading {
                         ProgressView().controlSize(.mini)
                     } else {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        Image(systemName: "arrow.clockwise").resizable().scaledToFit()
+                            .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                     }
                 }
                 .foregroundStyle(MuxyTheme.fgMuted)
@@ -286,8 +286,8 @@ struct TabFocusedChangesPopover: View {
 
     private var cleanState: some View {
         VStack(spacing: UIMetrics.spacing3) {
-            Image(systemName: "checkmark.circle")
-                .font(.system(size: UIMetrics.fontDisplay, weight: .medium))
+            Image(systemName: "checkmark.circle").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontDisplay, height: UIMetrics.fontDisplay)
                 .foregroundStyle(MuxyTheme.diffAddFg)
             Text("Working tree is clean")
                 .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
@@ -298,8 +298,8 @@ struct TabFocusedChangesPopover: View {
 
     private func errorState(_ error: String) -> some View {
         VStack(spacing: UIMetrics.spacing3) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: UIMetrics.fontDisplay, weight: .medium))
+            Image(systemName: "exclamationmark.triangle").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontDisplay, height: UIMetrics.fontDisplay)
                 .foregroundStyle(MuxyTheme.warning)
             Text("Changes unavailable")
                 .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
@@ -325,8 +325,8 @@ struct TabFocusedChangesPopover: View {
             Divider().overlay(MuxyTheme.border)
             Button(role: .destructive, action: onRemoveWorktree) {
                 HStack(spacing: UIMetrics.spacing3) {
-                    Image(systemName: "trash")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    Image(systemName: "trash").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                         .frame(width: UIMetrics.iconSM)
                     Text(worktreeRemovalLabel)
                         .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
@@ -429,8 +429,8 @@ private struct ChangesPopoverActionButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: symbol)
-                .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+            Image(systemName: symbol).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(foreground)
                 .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
                 .background(isHovered && !isDisabled ? MuxyTheme.hover : .clear, in: RoundedRectangle(

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -115,8 +115,8 @@ struct TabFocusedProjectRow: View {
             Spacer(minLength: UIMetrics.spacing2)
             trailingControls
             if !isWorktreeRow, project.isPinned {
-                Image(systemName: "pin.fill")
-                    .font(.system(size: UIMetrics.fontXS, weight: .semibold))
+                Image(systemName: "pin.fill").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                     .foregroundStyle(MuxyTheme.fgMuted)
                     .frame(width: TabFocusedSidebarMetrics.controlSlot, height: TabFocusedSidebarMetrics.controlSlot)
                     .help("Pinned")
@@ -371,8 +371,8 @@ struct TabFocusedProjectRow: View {
     }
 
     private var rowIcon: some View {
-        Image(systemName: isExpanded ? "folder.fill" : "folder")
-            .font(.system(size: UIMetrics.fontHeadline, weight: .regular))
+        Image(systemName: isExpanded ? "folder.fill" : "folder").resizable().scaledToFit()
+            .frame(width: UIMetrics.fontHeadline, height: UIMetrics.fontHeadline)
             .foregroundStyle(projectTitleColor)
             .frame(width: TabFocusedSidebarMetrics.folderIconSize, height: TabFocusedSidebarMetrics.folderIconSize)
             .accessibilityHidden(true)
@@ -384,8 +384,8 @@ struct TabFocusedProjectRow: View {
             TerminalActivityIndicator(activity: rowActivity)
                 .frame(width: TabFocusedSidebarMetrics.controlSlot, height: TabFocusedSidebarMetrics.controlSlot)
         } else {
-            Image(systemName: "arrow.triangle.branch")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            Image(systemName: "arrow.triangle.branch").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: TabFocusedSidebarMetrics.controlSlot, height: TabFocusedSidebarMetrics.controlSlot)
                 .help("Worktree")

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedPullRequestPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedPullRequestPopover.swift
@@ -60,8 +60,8 @@ struct TabFocusedPullRequestPopover: View {
 
     private var header: some View {
         HStack(spacing: UIMetrics.spacing4) {
-            Image(systemName: PullRequestPresentation.symbol(for: info))
-                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+            Image(systemName: PullRequestPresentation.symbol(for: info)).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontHeadline, height: UIMetrics.fontHeadline)
                 .foregroundStyle(PullRequestPresentation.color(for: info))
             VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                 Text("Pull Request #\(info.number)")
@@ -77,8 +77,8 @@ struct TabFocusedPullRequestPopover: View {
                     if isRefreshing {
                         ProgressView().controlSize(.mini)
                     } else {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        Image(systemName: "arrow.clockwise").resizable().scaledToFit()
+                            .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                     }
                 }
                 .foregroundStyle(MuxyTheme.fgMuted)
@@ -186,8 +186,8 @@ struct TabFocusedPullRequestPopover: View {
                     if isBusy {
                         ProgressView().controlSize(.mini)
                     } else {
-                        Image(systemName: symbol)
-                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                        Image(systemName: symbol).resizable().scaledToFit()
+                            .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                     }
                     Text(label)
                         .font(.system(size: UIMetrics.fontFootnote, weight: isConfirming ? .semibold : .medium))
@@ -223,8 +223,8 @@ struct TabFocusedPullRequestPopover: View {
 
     private var confirmationCancelButton: some View {
         Button(action: cancelConfirmation) {
-            Image(systemName: "xmark")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            Image(systemName: "xmark").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .padding(.horizontal, UIMetrics.spacing4)
                 .padding(.vertical, UIMetrics.spacing3)

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -193,8 +193,8 @@ private struct TabFocusedAddProjectRow: View {
 
     private var label: some View {
         HStack(spacing: TabFocusedSidebarMetrics.iconTitleGap) {
-            Image(systemName: "plus")
-                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+            Image(systemName: "plus").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontHeadline, height: UIMetrics.fontHeadline)
                 .foregroundStyle(hovered ? MuxyTheme.accent : MuxyTheme.fgMuted)
                 .frame(
                     width: TabFocusedSidebarMetrics.folderIconSize,

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebarRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebarRow.swift
@@ -10,8 +10,8 @@ struct SidebarActionButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: symbol)
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: symbol).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 .foregroundStyle(foreground)
                 .frame(width: TabFocusedSidebarMetrics.controlSlot, height: TabFocusedSidebarMetrics.controlSlot)
                 .background {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -456,8 +456,8 @@ private struct TabFocusedTabRow: View {
     @ViewBuilder
     private var trailingContent: some View {
         if !tab.isPinned, closeButtonVisible {
-            Image(systemName: "xmark")
-                .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+            Image(systemName: "xmark").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 .contentShape(Rectangle())
@@ -472,8 +472,8 @@ private struct TabFocusedTabRow: View {
     @ViewBuilder
     private var statusAccessory: some View {
         if tab.isPinned {
-            Image(systemName: "pin.fill")
-                .font(.system(size: UIMetrics.fontXS, weight: .semibold))
+            Image(systemName: "pin.fill").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
         } else if let shortcutNumber, let combo = shortcutHint {
@@ -489,8 +489,8 @@ private struct TabFocusedTabRow: View {
                 .frame(width: UIMetrics.scaled(7), height: UIMetrics.scaled(7))
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
         } else if isIdle, !active {
-            Image(systemName: "moon.zzz")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+            Image(systemName: "moon.zzz").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 .help("Idle — terminal freed to save memory. Reopens when selected.")
@@ -510,8 +510,8 @@ private struct TabFocusedTabRow: View {
             if let agentIconName {
                 ProviderIconView(iconName: agentIconName, size: UIMetrics.iconMD)
             } else {
-                Image(systemName: "terminal")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                Image(systemName: "terminal").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
             }
         case .browser:
             if let favicon = tab.content.browserState?.faviconImage {
@@ -520,8 +520,8 @@ private struct TabFocusedTabRow: View {
                     .interpolation(.high)
                     .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
             } else {
-                Image(systemName: "globe")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                Image(systemName: "globe").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
             }
         case .extensionWebView:
             extensionIcon
@@ -536,8 +536,8 @@ private struct TabFocusedTabRow: View {
         {
             ExtensionIconView(icon: customIcon, muxyExtension: muxyExtension, size: 12)
         } else {
-            Image(systemName: "puzzlepiece.extension")
-                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+            Image(systemName: "puzzlepiece.extension").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
         }
     }
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1806,8 +1806,8 @@ private struct NavigationArrowButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: symbol)
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: symbol).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 .foregroundStyle(foregroundColor)
                 .frame(width: UIMetrics.scaled(22), height: UIMetrics.scaled(22))
                 .contentShape(Rectangle())
@@ -2009,8 +2009,8 @@ private struct MainWindowToast: View {
 
     var body: some View {
         HStack(alignment: toast.body == nil ? .center : .top, spacing: UIMetrics.spacing3) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: "checkmark.circle.fill").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 .foregroundStyle(MuxyTheme.diffAddFg)
             VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
                 Text(toast.title)

--- a/Muxy/Views/Panels/NotificationPanel.swift
+++ b/Muxy/Views/Panels/NotificationPanel.swift
@@ -108,8 +108,8 @@ struct NotificationPanel: View {
 
             VStack(spacing: UIMetrics.spacing4) {
                 Spacer()
-                Image(systemName: "bell.slash")
-                    .font(.system(size: UIMetrics.fontHero, weight: .light))
+                Image(systemName: "bell.slash").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontHero, height: UIMetrics.fontHero)
                     .foregroundStyle(MuxyTheme.fgMuted)
                 Text("No notifications")
                     .font(.system(size: UIMetrics.fontBody, weight: .medium))
@@ -163,8 +163,8 @@ private struct NotificationRow: View {
                     if item.isProviderIcon {
                         ProviderIconView(iconName: item.sourceIcon, size: UIMetrics.fontCaption, monochromeTint: MuxyTheme.fgMuted)
                     } else {
-                        Image(systemName: item.sourceIcon)
-                            .font(.system(size: UIMetrics.fontCaption))
+                        Image(systemName: item.sourceIcon).resizable().scaledToFit()
+                            .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                             .foregroundStyle(MuxyTheme.fgMuted)
                     }
                     Text(item.title)
@@ -198,8 +198,8 @@ private struct NotificationRow: View {
         Button {
             onRemove()
         } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+            Image(systemName: "xmark").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontMicro, height: UIMetrics.fontMicro)
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 .background(MuxyTheme.surface, in: Circle())

--- a/Muxy/Views/Panels/PanelContainer.swift
+++ b/Muxy/Views/Panels/PanelContainer.swift
@@ -24,8 +24,8 @@ struct PanelContainer<Content: View>: View {
     private var header: some View {
         HStack(spacing: UIMetrics.spacing2) {
             if chrome.showsIcon, let symbol = chrome.iconSymbol {
-                Image(systemName: symbol)
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                Image(systemName: symbol).resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                     .foregroundStyle(MuxyTheme.fgMuted)
             }
             if chrome.showsTitle, let title = chrome.title {

--- a/Muxy/Views/Panels/VoiceRecordingPanel.swift
+++ b/Muxy/Views/Panels/VoiceRecordingPanel.swift
@@ -200,8 +200,8 @@ struct VoiceRecordingPanel: View {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+            Image(systemName: systemName).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 .foregroundStyle(tint)
                 .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                 .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))

--- a/Muxy/Views/Settings/BrowserImportSheet.swift
+++ b/Muxy/Views/Settings/BrowserImportSheet.swift
@@ -57,8 +57,8 @@ struct BrowserImportSheet: View {
 
     private func importRow(_ profile: ImportableProfile) -> some View {
         HStack(spacing: UIMetrics.spacing3) {
-            Image(systemName: "person.crop.circle")
-                .font(.system(size: SettingsMetrics.labelFontSize))
+            Image(systemName: "person.crop.circle").resizable().scaledToFit()
+                .frame(width: SettingsMetrics.labelFontSize, height: SettingsMetrics.labelFontSize)
                 .foregroundStyle(SettingsStyle.mutedForeground)
             Text(profile.name)
                 .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))

--- a/Muxy/Views/Settings/BrowserSettingsView.swift
+++ b/Muxy/Views/Settings/BrowserSettingsView.swift
@@ -151,8 +151,8 @@ struct BrowserSettingsView: View {
             editorMode = .create
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .semibold))
+                Image(systemName: "plus").resizable().scaledToFit()
+                    .frame(width: 11, height: 11)
                 Text("Add Profile")
                     .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
             }
@@ -234,8 +234,8 @@ private struct BrowserProfileRow: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: "person.crop.circle")
-                .font(.system(size: SettingsMetrics.labelFontSize))
+            Image(systemName: "person.crop.circle").resizable().scaledToFit()
+                .frame(width: SettingsMetrics.labelFontSize, height: SettingsMetrics.labelFontSize)
                 .foregroundStyle(SettingsStyle.mutedForeground)
                 .frame(width: 16)
             Text(profile.name)
@@ -277,8 +277,8 @@ private struct BrowserProfileRow: View {
                 Button("Delete", role: .destructive, action: onDelete)
             }
         } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: SettingsMetrics.labelFontSize, weight: .semibold))
+            Image(systemName: "ellipsis").resizable().scaledToFit()
+                .frame(width: SettingsMetrics.labelFontSize, height: SettingsMetrics.labelFontSize)
                 .foregroundStyle(SettingsStyle.mutedForeground)
                 .frame(height: 20)
                 .contentShape(Rectangle())

--- a/Muxy/Views/Settings/CommandsSettingsView.swift
+++ b/Muxy/Views/Settings/CommandsSettingsView.swift
@@ -43,8 +43,8 @@ struct CommandsSettingsView: View {
                 recordingCommandPrefix = false
                 recordingCommandShortcutID = shortcut.id
             } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: SettingsMetrics.footnoteFontSize, weight: .semibold))
+                Image(systemName: "plus").resizable().scaledToFit()
+                    .frame(width: SettingsMetrics.footnoteFontSize, height: SettingsMetrics.footnoteFontSize)
             }
             .buttonStyle(.plain)
             .help("Add Command")
@@ -290,8 +290,8 @@ private struct CommandPrefixRow: View {
         HStack(spacing: 6) {
             if hovered {
                 Button(action: onReset) {
-                    Image(systemName: "arrow.counterclockwise")
-                        .font(.system(size: 10))
+                    Image(systemName: "arrow.counterclockwise").resizable().scaledToFit()
+                        .frame(width: 10, height: 10)
                         .foregroundStyle(SettingsStyle.mutedForeground)
                 }
                 .buttonStyle(.plain)
@@ -386,8 +386,8 @@ private struct CommandShortcutRow: View {
             .buttonStyle(.plain)
 
             Button(action: onDelete) {
-                Image(systemName: "trash")
-                    .font(.system(size: 10))
+                Image(systemName: "trash").resizable().scaledToFit()
+                    .frame(width: 10, height: 10)
                     .foregroundStyle(
                         deleteButtonHovered ? AnyShapeStyle(SettingsStyle.destructive) : AnyShapeStyle(SettingsStyle.mutedForeground)
                     )

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -195,8 +195,8 @@ struct InterfaceSettingsView: View {
                 Text(title)
                     .font(.system(size: SettingsMetrics.labelFontSize))
                     .lineLimit(1)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 10))
+                Image(systemName: "chevron.up.chevron.down").resizable().scaledToFit()
+                    .frame(width: 10, height: 10)
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 5)

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -248,8 +248,8 @@ private struct ShortcutRow: View {
         HStack(spacing: 6) {
             if hovered {
                 Button(action: onUnassign) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 10))
+                    Image(systemName: "xmark").resizable().scaledToFit()
+                        .frame(width: 10, height: 10)
                         .foregroundStyle(SettingsStyle.mutedForeground)
                 }
                 .buttonStyle(.plain)
@@ -257,8 +257,8 @@ private struct ShortcutRow: View {
                 .accessibilityLabel("Unassign Shortcut")
 
                 Button(action: onReset) {
-                    Image(systemName: "arrow.counterclockwise")
-                        .font(.system(size: 10))
+                    Image(systemName: "arrow.counterclockwise").resizable().scaledToFit()
+                        .frame(width: 10, height: 10)
                         .foregroundStyle(SettingsStyle.mutedForeground)
                 }
                 .buttonStyle(.plain)

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -357,8 +357,8 @@ struct MobileSettingsView: View {
     private func deviceRow(_ device: ApprovedDevice) -> some View {
         HStack {
             if isSelecting {
-                Image(systemName: selectedDeviceIDs.contains(device.id) ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: SettingsMetrics.labelFontSize))
+                Image(systemName: selectedDeviceIDs.contains(device.id) ? "checkmark.circle.fill" : "circle").resizable().scaledToFit()
+                    .frame(width: SettingsMetrics.labelFontSize, height: SettingsMetrics.labelFontSize)
                     .foregroundStyle(
                         selectedDeviceIDs.contains(device.id) ? MuxyTheme.accent : SettingsStyle.mutedForeground
                     )

--- a/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
+++ b/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
@@ -77,8 +77,8 @@ struct RemoteDevicesSettingsView: View {
             editorMode = .create
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .semibold))
+                Image(systemName: "plus").resizable().scaledToFit()
+                    .frame(width: 11, height: 11)
                 Text("Add Remote Device")
                     .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
             }
@@ -155,8 +155,8 @@ private struct RemoteDeviceRow: View {
             Button {
                 onDelete()
             } label: {
-                Image(systemName: "trash")
-                    .font(.system(size: SettingsMetrics.footnoteFontSize))
+                Image(systemName: "trash").resizable().scaledToFit()
+                    .frame(width: SettingsMetrics.footnoteFontSize, height: SettingsMetrics.footnoteFontSize)
                     .foregroundStyle(SettingsStyle.destructive)
             }
             .buttonStyle(.plain)

--- a/Muxy/Views/Settings/RichInputSettingsView.swift
+++ b/Muxy/Views/Settings/RichInputSettingsView.swift
@@ -79,8 +79,8 @@ struct RichInputSettingsView: View {
                             settings.richInputLineHeightMultiplier - EditorSettings.lineHeightMultiplierStep
                         )
                     } label: {
-                        Image(systemName: "minus")
-                            .font(.system(size: 10, weight: .medium))
+                        Image(systemName: "minus").resizable().scaledToFit()
+                            .frame(width: 10, height: 10)
                             .frame(width: 20, height: 20)
                     }
                     .buttonStyle(.borderless)
@@ -99,8 +99,8 @@ struct RichInputSettingsView: View {
                             settings.richInputLineHeightMultiplier + EditorSettings.lineHeightMultiplierStep
                         )
                     } label: {
-                        Image(systemName: "plus")
-                            .font(.system(size: 10, weight: .medium))
+                        Image(systemName: "plus").resizable().scaledToFit()
+                            .frame(width: 10, height: 10)
                             .frame(width: 20, height: 20)
                     }
                     .buttonStyle(.borderless)

--- a/Muxy/Views/Settings/SettingsJSONEditorView.swift
+++ b/Muxy/Views/Settings/SettingsJSONEditorView.swift
@@ -76,8 +76,8 @@ struct SettingsJSONEditorView: View {
 
     private var searchBar: some View {
         HStack(spacing: 8) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 11, weight: .medium))
+            Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                .frame(width: 11, height: 11)
                 .foregroundStyle(SettingsStyle.mutedForeground)
 
             TextField("Search JSON", text: $searchText)

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -174,8 +174,8 @@ private struct SettingsHeader: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack(spacing: 12) {
-                Image(systemName: "slider.horizontal.3")
-                    .font(.system(size: 13, weight: .medium))
+                Image(systemName: "slider.horizontal.3").resizable().scaledToFit()
+                    .frame(width: 13, height: 13)
                     .foregroundStyle(SettingsStyle.mutedForeground)
 
                 Text("Settings")
@@ -190,8 +190,8 @@ private struct SettingsHeader: View {
                 .frame(width: 1, height: 56)
 
             HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 12))
+                Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                    .frame(width: 12, height: 12)
                     .foregroundStyle(SettingsStyle.mutedForeground)
                 TextField("Search settings", text: $searchText)
                     .textFieldStyle(.plain)
@@ -201,8 +201,8 @@ private struct SettingsHeader: View {
                     Button {
                         searchText = ""
                     } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 12))
+                        Image(systemName: "xmark.circle.fill").resizable().scaledToFit()
+                            .frame(width: 12, height: 12)
                             .foregroundStyle(SettingsStyle.mutedForeground)
                     }
                     .buttonStyle(.plain)
@@ -222,8 +222,8 @@ private struct SettingsHeader: View {
             Button {
                 NSApp.keyWindow?.close()
             } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 12, weight: .semibold))
+                Image(systemName: "xmark").resizable().scaledToFit()
+                    .frame(width: 12, height: 12)
                     .foregroundStyle(SettingsStyle.mutedForeground)
                     .frame(width: 28, height: 28)
                     .contentShape(Rectangle())
@@ -288,8 +288,8 @@ private struct SettingsSidebar: View {
             selectedRoute = route
         } label: {
             HStack(spacing: 8) {
-                Image(systemName: symbol)
-                    .font(.system(size: 12, weight: .medium))
+                Image(systemName: symbol).resizable().scaledToFit()
+                    .frame(width: 12, height: 12)
                     .frame(width: 16)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)

--- a/Muxy/Views/Settings/ThemePicker.swift
+++ b/Muxy/Views/Settings/ThemePicker.swift
@@ -75,8 +75,8 @@ private struct ThemeRow: View {
                 Spacer(minLength: 0)
 
                 if isActive {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                    Image(systemName: "checkmark").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                         .foregroundStyle(Color.accentColor)
                 }
             }

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -121,8 +121,8 @@ struct ProjectStatusBar: View {
             }
         } label: {
             HStack(spacing: 4) {
-                Image(systemName: remote ? "network" : "folder")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                Image(systemName: remote ? "network" : "folder").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 Text(truncated)
                     .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
                     .lineLimit(1)
@@ -186,8 +186,8 @@ struct ProjectStatusBar: View {
         Button {
             extensionOutputVisible.toggle()
         } label: {
-            Image(systemName: "ladybug")
-                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+            Image(systemName: "ladybug").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 .foregroundStyle(extensionOutputVisible ? MuxyTheme.accent : MuxyTheme.fgMuted)
         }
         .buttonStyle(.plain)
@@ -198,8 +198,8 @@ struct ProjectStatusBar: View {
     private var richInputToggleButton: some View {
         Button(action: handleToggleRichInput) {
             HStack(spacing: 4) {
-                Image(systemName: "keyboard")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                Image(systemName: "keyboard").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 Text(richInputShortcutLabel)
                     .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                     .foregroundStyle(MuxyTheme.fgDim)
@@ -214,8 +214,8 @@ struct ProjectStatusBar: View {
     private var voiceRecordingButton: some View {
         Button(action: handleToggleVoiceRecording) {
             HStack(spacing: 4) {
-                Image(systemName: "mic")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                Image(systemName: "mic").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                 Text(voiceShortcutLabel)
                     .font(.system(size: UIMetrics.fontCaption, weight: .medium, design: .rounded))
                     .foregroundStyle(MuxyTheme.fgDim)
@@ -230,8 +230,8 @@ struct ProjectStatusBar: View {
     private var zoomControls: some View {
         HStack(spacing: 2) {
             Button(action: decreaseFontSize) {
-                Image(systemName: "textformat.size.smaller")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                Image(systemName: "textformat.size.smaller").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
             }
             .buttonStyle(RichInputToolbarButtonStyle())
             .disabled(richInputFontSize <= RichInputPreferences.minFontSize)
@@ -245,8 +245,8 @@ struct ProjectStatusBar: View {
                 .accessibilityLabel("Editor font size \(Int(clampedFontSize))")
 
             Button(action: increaseFontSize) {
-                Image(systemName: "textformat.size.larger")
-                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                Image(systemName: "textformat.size.larger").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
             }
             .buttonStyle(RichInputToolbarButtonStyle())
             .disabled(richInputFontSize >= RichInputPreferences.maxFontSize)

--- a/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
+++ b/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
@@ -146,8 +146,8 @@ struct RepositoryStatusBarItems: View {
             },
             content: {
                 HStack(spacing: UIMetrics.spacing2) {
-                    Image(systemName: "exclamationmark.triangle")
-                        .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                    Image(systemName: "exclamationmark.triangle").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                         .foregroundStyle(MuxyTheme.warning)
                     Text("Repository unavailable")
                         .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
@@ -169,8 +169,8 @@ struct RepositoryStatusBarItems: View {
             },
             content: {
                 HStack(spacing: UIMetrics.spacing2) {
-                    Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                    Image(systemName: "arrow.triangle.branch").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                         .foregroundStyle(MuxyTheme.accent)
                     Text(RepositoryToolbarPresentation.branchLabel(summary: summary, worktree: activeWorktree))
                         .font(.system(size: UIMetrics.fontCaption, weight: .semibold, design: .monospaced))
@@ -182,8 +182,8 @@ struct RepositoryStatusBarItems: View {
                     if let summary {
                         upstreamTelemetry(summary.aheadBehind)
                     }
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+                    Image(systemName: "chevron.down").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontMicro, height: UIMetrics.fontMicro)
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
             }
@@ -237,8 +237,8 @@ struct RepositoryStatusBarItems: View {
                     Text(summary.map(RepositoryChangesPresentation.chipLabel) ?? "Changes")
                         .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
                         .foregroundStyle(summary?.isDirty == true ? MuxyTheme.warning : MuxyTheme.fgMuted)
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+                    Image(systemName: "chevron.down").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontMicro, height: UIMetrics.fontMicro)
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
             }
@@ -312,8 +312,8 @@ struct RepositoryStatusBarItems: View {
                 Task { await repositoryState.refreshPullRequest(forceFresh: true) }
             },
             content: {
-                Image(systemName: "arrow.triangle.pull")
-                    .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                Image(systemName: "arrow.triangle.pull").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                     .foregroundStyle(MuxyTheme.fgMuted)
             }
         )
@@ -335,8 +335,8 @@ struct RepositoryStatusBarItems: View {
             action: { showPullRequestPopover = true },
             content: {
                 HStack(spacing: UIMetrics.spacing2) {
-                    Image(systemName: PullRequestPresentation.symbol(for: info))
-                        .font(.system(size: UIMetrics.fontXS, weight: .bold))
+                    Image(systemName: PullRequestPresentation.symbol(for: info)).resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontXS, height: UIMetrics.fontXS)
                         .foregroundStyle(color)
                     Text("PR #\(info.number)")
                         .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
@@ -346,8 +346,8 @@ struct RepositoryStatusBarItems: View {
                             .font(.system(size: UIMetrics.fontXS, weight: .bold, design: .rounded))
                             .foregroundStyle(color)
                     }
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: UIMetrics.fontMicro, weight: .bold))
+                    Image(systemName: "chevron.down").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontMicro, height: UIMetrics.fontMicro)
                         .foregroundStyle(MuxyTheme.fgDim)
                 }
             }

--- a/Muxy/Views/Terminal/RichInputSidePanel.swift
+++ b/Muxy/Views/Terminal/RichInputSidePanel.swift
@@ -174,8 +174,8 @@ private struct AttachmentChip: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Image(systemName: isImage ? "photo" : "doc")
-                .font(.system(size: 10))
+            Image(systemName: isImage ? "photo" : "doc").resizable().scaledToFit()
+                .frame(width: 10, height: 10)
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text(url.lastPathComponent)
                 .font(.system(size: 11))
@@ -183,8 +183,8 @@ private struct AttachmentChip: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
             Button(action: onRemove) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .semibold))
+                Image(systemName: "xmark").resizable().scaledToFit()
+                    .frame(width: 9, height: 9)
                     .foregroundStyle(MuxyTheme.fgMuted)
             }
             .buttonStyle(.plain)

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -108,8 +108,8 @@ struct SleepingTabPlaceholder: View {
     var body: some View {
         VStack(spacing: UIMetrics.spacing7) {
             Spacer()
-            Image(systemName: "moon.zzz")
-                .font(.system(size: UIMetrics.fontMega))
+            Image(systemName: "moon.zzz").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontMega, height: UIMetrics.fontMega)
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text("Tab is asleep")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
@@ -151,8 +151,8 @@ struct RemoteControlledPlaceholder: View {
     var body: some View {
         VStack(spacing: UIMetrics.spacing7) {
             Spacer()
-            Image(systemName: "iphone.gen3")
-                .font(.system(size: UIMetrics.fontMega))
+            Image(systemName: "iphone.gen3").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontMega, height: UIMetrics.fontMega)
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text("Controlled by \(deviceName)")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))

--- a/Muxy/Views/Terminal/TerminalSearchBar.swift
+++ b/Muxy/Views/Terminal/TerminalSearchBar.swift
@@ -12,8 +12,8 @@ struct TerminalSearchBar: View {
         VStack(spacing: 0) {
             HStack(spacing: UIMetrics.spacing3) {
                 HStack(spacing: UIMetrics.spacing2) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: UIMetrics.fontFootnote))
+                    Image(systemName: "magnifyingglass").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontFootnote, height: UIMetrics.fontFootnote)
                         .foregroundStyle(MuxyTheme.fgMuted)
                         .accessibilityHidden(true)
 
@@ -46,22 +46,22 @@ struct TerminalSearchBar: View {
                 )
 
                 Button(action: onNavigatePrevious) {
-                    Image(systemName: "chevron.up")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    Image(systemName: "chevron.up").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 }
                 .buttonStyle(SearchBarButtonStyle())
                 .accessibilityLabel("Previous Match")
 
                 Button(action: onNavigateNext) {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    Image(systemName: "chevron.down").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 }
                 .buttonStyle(SearchBarButtonStyle())
                 .accessibilityLabel("Next Match")
 
                 Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                    Image(systemName: "xmark").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                 }
                 .buttonStyle(SearchBarButtonStyle())
                 .accessibilityLabel("Close Search")

--- a/Muxy/Views/WhatsNew/WhatsNewView.swift
+++ b/Muxy/Views/WhatsNew/WhatsNewView.swift
@@ -32,8 +32,8 @@ struct WhatsNewView: View {
 
     private var header: some View {
         HStack(spacing: 12) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 13, weight: .medium))
+            Image(systemName: "sparkles").resizable().scaledToFit()
+                .frame(width: 13, height: 13)
                 .foregroundStyle(SettingsStyle.accent)
 
             Text("What's New")
@@ -59,8 +59,8 @@ struct WhatsNewView: View {
             Button {
                 NSApp.keyWindow?.close()
             } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 12, weight: .semibold))
+                Image(systemName: "xmark").resizable().scaledToFit()
+                    .frame(width: 12, height: 12)
                     .foregroundStyle(SettingsStyle.mutedForeground)
                     .frame(width: 28, height: 28)
                     .contentShape(Rectangle())

--- a/Muxy/Views/Workspace/EmptyProjectPlaceholder.swift
+++ b/Muxy/Views/Workspace/EmptyProjectPlaceholder.swift
@@ -7,8 +7,8 @@ struct EmptyProjectPlaceholder: View {
     var body: some View {
         VStack(spacing: UIMetrics.spacing7) {
             Spacer()
-            Image(systemName: "macwindow.badge.plus")
-                .font(.system(size: UIMetrics.fontMega))
+            Image(systemName: "macwindow.badge.plus").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontMega, height: UIMetrics.fontMega)
                 .foregroundStyle(MuxyTheme.fgMuted)
             Text("No tabs in \(project.name)")
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))

--- a/Muxy/Views/Workspace/LayoutPickerMenu.swift
+++ b/Muxy/Views/Workspace/LayoutPickerMenu.swift
@@ -15,8 +15,8 @@ struct LayoutPickerMenu: View {
                     }
                 }
             } label: {
-                Image(systemName: "rectangle.split.2x2")
-                    .font(.system(size: UIMetrics.fontEmphasis, weight: .semibold))
+                Image(systemName: "rectangle.split.2x2").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontEmphasis, height: UIMetrics.fontEmphasis)
                     .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlMedium)
                     .contentShape(Rectangle())
             }

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -196,8 +196,8 @@ private struct TabContentView: View {
 private struct BrowserDisabledPlaceholder: View {
     var body: some View {
         VStack(spacing: 8) {
-            Image(systemName: "globe.badge.chevron.backward")
-                .font(.system(size: 32, weight: .light))
+            Image(systemName: "globe.badge.chevron.backward").resizable().scaledToFit()
+                .frame(width: 32, height: 32)
             Text("Built-in browser is disabled")
                 .font(.headline)
             Text("Enable it in Settings → Browser.")

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -629,8 +629,8 @@ private struct TabCell: View {
     private var trailingAccessory: some View {
         ZStack {
             if !tab.isPinned {
-                Image(systemName: "xmark")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+                Image(systemName: "xmark").resizable().scaledToFit()
+                    .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
                     .foregroundStyle(MuxyTheme.fgDim)
                     .opacity(closeButtonVisible ? 1 : 0)
                     .allowsHitTesting(closeButtonVisible)
@@ -714,23 +714,23 @@ private struct TabCell: View {
                 .frame(width: UIMetrics.iconSM, height: UIMetrics.iconSM)
                 .transition(.opacity)
         } else if tab.isPinned {
-            Image(systemName: "pin.fill")
-                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+            Image(systemName: "pin.fill").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontCaption, height: UIMetrics.fontCaption)
         } else if tab.isOffline, !active {
-            Image(systemName: "moon.zzz")
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: "moon.zzz").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 .help("Idle — terminal freed to save memory. Reopens when selected.")
         } else if let customIconSymbol = tab.customIconSymbol {
-            Image(systemName: customIconSymbol)
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: customIconSymbol).resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
         } else {
             switch tab.kind {
             case .terminal:
                 if let agentIconName = tab.detectedAgentIconName {
                     ProviderIconView(iconName: agentIconName, size: UIMetrics.iconMD)
                 } else {
-                    Image(systemName: "terminal")
-                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                    Image(systemName: "terminal").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 }
             case .extensionWebView:
                 extensionIconView
@@ -741,8 +741,8 @@ private struct TabCell: View {
                         .interpolation(.high)
                         .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
                 } else {
-                    Image(systemName: "globe")
-                        .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                    Image(systemName: "globe").resizable().scaledToFit()
+                        .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
                 }
             }
         }
@@ -756,8 +756,8 @@ private struct TabCell: View {
         {
             ExtensionIconView(icon: icon, muxyExtension: muxyExtension, size: 12)
         } else {
-            Image(systemName: "puzzlepiece.extension")
-                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+            Image(systemName: "puzzlepiece.extension").resizable().scaledToFit()
+                .frame(width: UIMetrics.fontBody, height: UIMetrics.fontBody)
         }
     }
 }


### PR DESCRIPTION
Sizes launch-path SF Symbols with explicit frames instead of font metrics, which collapse to 0×0 during the pre-visible layout pass and trigger the CoreUI recursive rendition-lock crash on macOS 27.0.

Fixes #941. Same root cause/fix as manaflow-ai/cmux#5670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved consistency and sizing of system icons across browser, terminal, project, extension, workspace, settings, and notification interfaces.
  * Updated icons to scale and fit more reliably within their designated UI areas.
  * Preserved existing interactions, labels, colors, and accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->