### PR TITLE
Fix wrong bundle ID in Homebrew cask zap paths

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -99,8 +99,13 @@ jobs:
 
             zap trash: [
               "~/Library/Application Support/Muxy",
-              "~/Library/Preferences/app.muxy.Muxy.plist",
-              "~/Library/Saved Application State/app.muxy.Muxy.savedState",
+              "~/Library/Caches/com.muxy.app",
+              "~/Library/HTTPStorages/com.muxy.app",
+              "~/Library/HTTPStorages/com.muxy.app.binarycookies",
+              "~/Library/Logs/Muxy",
+              "~/Library/Preferences/com.muxy.app.plist",
+              "~/Library/Saved Application State/com.muxy.app.savedState",
+              "~/Library/WebKit/com.muxy.app",
             ]
           end
           EOF


### PR DESCRIPTION
Fixes #972

## Problem

`.github/workflows/update-homebrew-tap.yml` generates the Homebrew cask with zap paths keyed to `app.muxy.Muxy`, but the app ships as `com.muxy.app` (`Muxy/Info.plist:6`), and no build step rewrites it — `scripts/build-release.sh` only touches version, Sentry and Sparkle keys.

`app.muxy` exists in the codebase only as the `os_log` subsystem string; `app.muxy.Muxy` appears nowhere else. So `brew uninstall --zap muxy` has been silently leaving preferences and saved state behind.

Verified on a machine running Muxy 1.3.0: `~/Library/Preferences/app.muxy.Muxy.plist` and `~/Library/Saved Application State/app.muxy.Muxy.savedState` do not exist, while `~/Library/Preferences/com.muxy.app.plist` does.

## Change

Corrects the bundle ID and adds the remaining per-bundle-ID locations the app actually leaves behind:

| Path | Written by |
| --- | --- |
| `~/Library/Caches/com.muxy.app` | Sparkle download cache, Sentry envelopes, WebKit cache |
| `~/Library/HTTPStorages/com.muxy.app`<br>`~/Library/HTTPStorages/com.muxy.app.binarycookies` | `URLSession` / `WKWebsiteDataStore` cookie + storage |
| `~/Library/Logs/Muxy` | `MemoryDiagnostics.ensureLogDirectory()` — `diagnostics.log`, `last-session.txt` |
| `~/Library/WebKit/com.muxy.app` | Persistent `WKWebsiteDataStore` (browser tabs, extension webviews) |

`~/.config/muxy/extensions` and the `muxy` CLI wrapper (`/usr/local/bin/muxy`, `~/bin/muxy`, `~/.local/bin/muxy`) were deliberately left out — the former is user-authored content, and the latter can be root-owned and would need a separate `zap delete:` stanza.

## Verification

- Rendered the heredoc with dummy version/SHAs and confirmed `ruby -c` passes.
- Ran `brew style --cask` against the real tap before and after: **5 offenses both times, byte-identical**. This change adds no new style offenses. (The 5 pre-existing ones are unrelated — see below.)
- Confirmed the generated zap block is byte-identical to the one in the companion tap PR, so the next release regeneration produces no diff churn.
- `~/Library/Logs/Muxy` is not `#if DEBUG` gated, so it is created in release builds.
- Workflow YAML re-parses cleanly.

The workflow only regenerates the cask on the next stable release, so muxy-app/homebrew-tap#1 applies the same block to the live v1.3.0 cask.

## Unrelated pre-existing issues found while reviewing

Not fixed here, since they're outside the scope of #972:

- `Cask/StanzaGrouping` (x3) — blank lines inside the `on_arm` / `on_intel` blocks.
- `Cask/Desc` — `desc "Terminal multiplexer for macOS"` shouldn't name the platform.
- `Homebrew/OSDependsOn` — the cask is missing `depends_on macos:`.

Happy to open a follow-up for these if you want the cask style-clean.

---

Implemented with Claude Opus 5 via Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew uninstall cleanup for the macOS app.
  * Uninstallation now removes additional app-related caches, logs, preferences, saved state, web data, and HTTP storage files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->