### PR TITLE
Add Terminal Settings to the terminal context menu

### DIFF
--- a/Muxy/Extensions/Notification+Names.swift
+++ b/Muxy/Extensions/Notification+Names.swift
@@ -19,6 +19,7 @@ extension Notification.Name {
     static let focusProjectPickerDefaultLocation = Notification.Name("MuxyFocusProjectPickerDefaultLocation")
     static let focusRemoteDevicesSettings = Notification.Name("MuxyFocusRemoteDevicesSettings")
     static let focusBrowserSettings = Notification.Name("MuxyFocusBrowserSettings")
+    static let focusTerminalSettings = Notification.Name("MuxyFocusTerminalSettings")
     static let focusQuickTerminalShortcut = Notification.Name("MuxyFocusQuickTerminalShortcut")
     static let quickTerminalEnabledDidChange = Notification.Name("MuxyQuickTerminalEnabledDidChange")
     static let windowFullScreenDidChange = Notification.Name("MuxyWindowFullScreenDidChange")

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -1067,6 +1067,7 @@
 "Terminal Omnibox Projects" = "Terminal Omnibox Projects";
 "Terminal Omnibox Workspaces" = "Terminal Omnibox Workspaces";
 "Terminal Omnibox Worktrees" = "Terminal Omnibox Worktrees";
+"Terminal Settings…" = "Terminal Settings…";
 "Terminal file links use this opener. Built-in and unmatched extension files use the project target selected separately in the top bar." = "Terminal file links use this opener. Built-in and unmatched extension files use the project target selected separately in the top bar.";
 "Terminal size" = "Terminal size";
 "Terminal transparency" = "Terminal transparency";

--- a/Muxy/Services/UIHosts/SettingsFocusCoordinator.swift
+++ b/Muxy/Services/UIHosts/SettingsFocusCoordinator.swift
@@ -16,6 +16,11 @@ final class SettingsFocusCoordinator {
         notificationCenter.post(name: request.notificationName, object: nil)
     }
 
+    func openSettings(focusedOn request: SettingsFocusRequest) {
+        self.request(request)
+        notificationCenter.post(name: .openSettingsModal, object: nil)
+    }
+
     func consume(_ request: SettingsFocusRequest) -> Bool {
         pendingRequests.remove(request) != nil
     }
@@ -25,6 +30,7 @@ enum SettingsFocusRequest: Hashable {
     case projectPickerDefaultLocation
     case remoteDevices
     case browser
+    case terminal
     case quickTerminalShortcut
 
     var notificationName: Notification.Name {
@@ -35,6 +41,8 @@ enum SettingsFocusRequest: Hashable {
             .focusRemoteDevicesSettings
         case .browser:
             .focusBrowserSettings
+        case .terminal:
+            .focusTerminalSettings
         case .quickTerminalShortcut:
             .focusQuickTerminalShortcut
         }

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -57,6 +57,10 @@ struct SettingsView: View {
         .resetsSettingsFocusOnOutsideClick()
         .onAppear {
             selectedRoute = validatedRoute(selectedRoute)
+            if SettingsFocusCoordinator.shared.consume(.terminal) {
+                searchText = ""
+                selectedRoute = .builtin(.terminal)
+            }
             if SettingsFocusCoordinator.shared.consume(.quickTerminalShortcut) {
                 searchText = ""
                 selectedRoute = .builtin(.quickTerminal)
@@ -80,6 +84,11 @@ struct SettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .focusBrowserSettings)) { _ in
             searchText = ""
             selectedRoute = .builtin(.browser)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .focusTerminalSettings)) { _ in
+            _ = SettingsFocusCoordinator.shared.consume(.terminal)
+            searchText = ""
+            selectedRoute = .builtin(.terminal)
         }
         .onReceive(NotificationCenter.default.publisher(for: .focusQuickTerminalShortcut)) { _ in
             _ = SettingsFocusCoordinator.shared.consume(.quickTerminalShortcut)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1366,6 +1366,13 @@ final class GhosttyTerminalNSView: NSView,
     }
 
     private func presentContextMenu(with event: NSEvent) {
+        let menu = makeContextMenu()
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    func makeContextMenu(
+        settingsFocusCoordinator: SettingsFocusCoordinator = .shared
+    ) -> NSMenu {
         let menu = NSMenu(title: L10n.string("Terminal"))
 
         let paste = ClosureMenuItem(title: L10n.string("Paste")) { [weak self] in
@@ -1381,7 +1388,14 @@ final class GhosttyTerminalNSView: NSView,
         menu.addItem(contextSplitMenuItem(title: L10n.string("Split Down"), direction: .vertical, position: .second))
         menu.addItem(contextSplitMenuItem(title: L10n.string("Split Up"), direction: .vertical, position: .first))
 
-        NSMenu.popUpContextMenu(menu, with: event, for: self)
+        menu.addItem(.separator())
+
+        let settings = ClosureMenuItem(title: L10n.string("Terminal Settings…")) {
+            settingsFocusCoordinator.openSettings(focusedOn: .terminal)
+        }
+        menu.addItem(settings)
+
+        return menu
     }
 
     private func contextSplitMenuItem(title: String, direction: SplitDirection, position: SplitPosition) -> NSMenuItem {

--- a/Tests/MuxyTests/Services/UIHosts/SettingsFocusCoordinatorTests.swift
+++ b/Tests/MuxyTests/Services/UIHosts/SettingsFocusCoordinatorTests.swift
@@ -47,8 +47,45 @@ struct SettingsFocusCoordinatorTests {
         #expect(coordinator.consume(.quickTerminalShortcut))
         #expect(!coordinator.consume(.quickTerminalShortcut))
     }
+
+    @Test("opening terminal settings retains focus and emits both notifications")
+    func terminalSettingsOpenRoutesToTerminalSettings() {
+        let notificationCenter = NotificationCenter()
+        let coordinator = SettingsFocusCoordinator(notificationCenter: notificationCenter)
+        let flag = SettingsOpenNotificationFlag()
+        let focusObserver = notificationCenter.addObserver(
+            forName: .focusTerminalSettings,
+            object: nil,
+            queue: nil
+        ) { _ in
+            flag.didPostFocus = true
+        }
+        let openObserver = notificationCenter.addObserver(
+            forName: .openSettingsModal,
+            object: nil,
+            queue: nil
+        ) { _ in
+            flag.didPostOpen = true
+        }
+        defer {
+            notificationCenter.removeObserver(focusObserver)
+            notificationCenter.removeObserver(openObserver)
+        }
+
+        coordinator.openSettings(focusedOn: .terminal)
+
+        #expect(flag.didPostFocus)
+        #expect(flag.didPostOpen)
+        #expect(coordinator.consume(.terminal))
+        #expect(!coordinator.consume(.terminal))
+    }
 }
 
 private final class SettingsFocusNotificationFlag: @unchecked Sendable {
     var didPost = false
+}
+
+private final class SettingsOpenNotificationFlag: @unchecked Sendable {
+    var didPostFocus = false
+    var didPostOpen = false
 }

--- a/Tests/MuxyTests/Views/Terminal/TerminalContextMenuTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalContextMenuTests.swift
@@ -1,0 +1,42 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+@Suite("Terminal context menu")
+@MainActor
+struct TerminalContextMenuTests {
+    @Test("terminal settings item opens settings focused on Terminal")
+    func terminalSettingsItemOpensTerminalSettings() throws {
+        let notificationCenter = NotificationCenter()
+        let coordinator = SettingsFocusCoordinator(notificationCenter: notificationCenter)
+        let flag = TerminalSettingsOpenFlag()
+        let observer = notificationCenter.addObserver(
+            forName: .openSettingsModal,
+            object: nil,
+            queue: nil
+        ) { _ in
+            flag.didPost = true
+        }
+        defer { notificationCenter.removeObserver(observer) }
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+
+        let menu = view.makeContextMenu(settingsFocusCoordinator: coordinator)
+        let settingsIndex = try #require(menu.items.firstIndex {
+            $0.title == L10n.string("Terminal Settings…")
+        })
+        let settingsItem = menu.items[settingsIndex]
+
+        #expect(settingsIndex > 0)
+        #expect(menu.items[settingsIndex - 1].isSeparatorItem)
+
+        _ = settingsItem.target?.perform(settingsItem.action, with: settingsItem)
+
+        #expect(flag.didPost)
+        #expect(coordinator.consume(.terminal))
+    }
+}
+
+private final class TerminalSettingsOpenFlag: @unchecked Sendable {
+    var didPost = false
+}

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -112,7 +112,7 @@ the control that was focused before recording and can optionally press Return af
 
 ## Right-click menu
 
-Inside a terminal pane: **Paste**, **Split Right**, **Split Down**, **Close Pane**.
+Inside a terminal pane: **Paste**, **Split Right**, **Split Left**, **Split Down**, **Split Up**, and **Terminal Settings…**. Terminal Settings opens Muxy's settings directly on the Terminal section.
 
 Splitting creates a child pane inside the current top-level tab. Each pane keeps its own terminal, browser, source-control, or extension surface, while a one-pixel divider replaces the old per-pane tab strip. Child panes do not appear as separate entries in the window tab strip or the Tab Focused sidebar. An agent running in a child pane does appear as its own entry in the Agents Focused sidebar, and selecting it activates both the child pane and its parent top-level tab.
 


### PR DESCRIPTION
Adds a Terminal Settings… context-menu action that opens Settings directly to the Terminal section, with localized text, focus coordination, tests, and updated terminal documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Terminal Settings…** option to the terminal pane’s right-click menu.
  * Selecting it opens Muxy directly to the Terminal settings section.
* **Documentation**
  * Updated terminal context-menu documentation to reflect the available options.
* **Tests**
  * Added coverage for the new menu item and direct navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->