### PR TITLE
Add bounded subprocess runner

### DIFF
--- a/Muxy/Services/AI/ProviderDiscoveryService.swift
+++ b/Muxy/Services/AI/ProviderDiscoveryService.swift
@@ -2,13 +2,6 @@ import Foundation
 import os
 
 private let providerDiscoveryLogger = Logger(subsystem: "app.muxy", category: "ProviderDiscovery")
-private let providerDiscoveryOutputByteLimit = 64 * 1024
-private let providerDiscoveryProcessQueue = DispatchQueue(
-    label: "app.muxy.provider-discovery",
-    qos: .utility,
-    attributes: .concurrent
-)
-
 enum ProviderDiscoveryState: Equatable {
     case ready
     case warning(String)
@@ -51,19 +44,20 @@ enum ProviderDiscoveryError: LocalizedError {
 }
 
 @MainActor
-struct ProviderDiscoveryService {
+final class ProviderDiscoveryService {
     typealias Runner = @Sendable (
         _ executablePath: String,
         _ arguments: [String],
         _ workingDirectory: String,
         _ timeout: TimeInterval
-    ) async throws -> GitProcessResult
+    ) async throws -> SubprocessResult
 
     static let defaultTimeout: TimeInterval = 5
 
     private let health: HookHealthStore
     private let timeout: TimeInterval
     private let runner: Runner
+    private var generations: [String: Int] = [:]
 
     init(
         health: HookHealthStore = .shared,
@@ -81,9 +75,12 @@ struct ProviderDiscoveryService {
               let discoveryProvider = provider as? any AIProviderDiscoveryIntegration
         else { return }
 
+        let generation = nextGeneration(for: provider.id)
+
         guard let executablePath = launchProvider.agentCLIExecutablePath() else {
             record(
                 provider: provider,
+                generation: generation,
                 snapshot: ProviderDiscoverySnapshot(
                     executablePath: nil,
                     version: nil,
@@ -110,6 +107,7 @@ struct ProviderDiscoveryService {
             let details = discoveryProvider.discoveryDetails(from: result.stdout)
             record(
                 provider: provider,
+                generation: generation,
                 snapshot: ProviderDiscoverySnapshot(
                     executablePath: executablePath,
                     version: details.version,
@@ -119,6 +117,7 @@ struct ProviderDiscoveryService {
         } catch {
             record(
                 provider: provider,
+                generation: generation,
                 snapshot: ProviderDiscoverySnapshot(
                     executablePath: executablePath,
                     version: nil,
@@ -128,7 +127,18 @@ struct ProviderDiscoveryService {
         }
     }
 
-    private func record(provider: AIProviderIntegration, snapshot: ProviderDiscoverySnapshot) {
+    private func nextGeneration(for providerID: String) -> Int {
+        let generation = generations[providerID, default: 0] + 1
+        generations[providerID] = generation
+        return generation
+    }
+
+    private func record(
+        provider: AIProviderIntegration,
+        generation: Int,
+        snapshot: ProviderDiscoverySnapshot
+    ) {
+        guard generations[provider.id] == generation else { return }
         health.noteDiscovery(providerID: provider.id, snapshot: snapshot)
         let path = snapshot.executablePath ?? "not found"
         let version = snapshot.version ?? "unknown"
@@ -156,149 +166,12 @@ struct ProviderDiscoveryService {
         arguments: [String],
         workingDirectory: String,
         timeout: TimeInterval
-    ) async throws -> GitProcessResult {
-        try await withCheckedThrowingContinuation { continuation in
-            providerDiscoveryProcessQueue.async {
-                do {
-                    try continuation.resume(returning: runProcessSynchronously(
-                        executablePath: executablePath,
-                        arguments: arguments,
-                        workingDirectory: workingDirectory,
-                        timeout: timeout
-                    ))
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
-
-    nonisolated private static func runProcessSynchronously(
-        executablePath: String,
-        arguments: [String],
-        workingDirectory: String,
-        timeout: TimeInterval
-    ) throws -> GitProcessResult {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executablePath)
-        process.arguments = arguments
-        process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
-        process.environment = ProcessInfo.processInfo.environment
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        let stdout = ProviderDiscoveryOutputCollector(byteLimit: providerDiscoveryOutputByteLimit)
-        let stderr = ProviderDiscoveryOutputCollector(byteLimit: providerDiscoveryOutputByteLimit)
-        stdout.start(reading: stdoutPipe.fileHandleForReading)
-        stderr.start(reading: stderrPipe.fileHandleForReading)
-
-        let exited = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in exited.signal() }
-
-        do {
-            try process.run()
-        } catch {
-            stdout.stop(reading: stdoutPipe.fileHandleForReading)
-            stderr.stop(reading: stderrPipe.fileHandleForReading)
-            throw error
-        }
-
-        let timedOut = exited.wait(timeout: .now() + timeout) == .timedOut
-        if timedOut {
-            terminate(process, exited: exited)
-        }
-        process.waitUntilExit()
-
-        if !timedOut {
-            let drainDeadline = DispatchTime.now() + 0.5
-            stdout.waitForCompletion(until: drainDeadline)
-            stderr.waitForCompletion(until: drainDeadline)
-        }
-        stdout.stop(reading: stdoutPipe.fileHandleForReading)
-        stderr.stop(reading: stderrPipe.fileHandleForReading)
-
-        if timedOut {
-            throw ProviderDiscoveryError.timedOut(timeout)
-        }
-        let stdoutData = stdout.data
-        return GitProcessResult(
-            status: process.terminationStatus,
-            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
-            stdoutData: stdoutData,
-            stderr: String(data: stderr.data, encoding: .utf8) ?? "",
-            truncated: stdout.truncated || stderr.truncated
-        )
-    }
-
-    nonisolated private static func terminate(_ process: Process, exited: DispatchSemaphore) {
-        guard process.isRunning else { return }
-        process.terminate()
-        guard exited.wait(timeout: .now() + 0.5) == .timedOut, process.isRunning else { return }
-        kill(process.processIdentifier, SIGKILL)
-    }
-}
-
-private final class ProviderDiscoveryOutputCollector: @unchecked Sendable {
-    private let lock = NSLock()
-    private let completed = DispatchSemaphore(value: 0)
-    private let byteLimit: Int
-    private var storage = Data()
-    private var didTruncate = false
-    private var didComplete = false
-
-    init(byteLimit: Int) {
-        self.byteLimit = byteLimit
-    }
-
-    var data: Data {
-        lock.withLock { storage }
-    }
-
-    var truncated: Bool {
-        lock.withLock { didTruncate }
-    }
-
-    func start(reading handle: FileHandle) {
-        handle.readabilityHandler = { [weak self] handle in
-            guard let self else { return }
-            let chunk = handle.availableData
-            guard !chunk.isEmpty else {
-                complete()
-                return
-            }
-            lock.withLock {
-                let remaining = byteLimit - storage.count
-                if remaining > 0 {
-                    storage.append(chunk.prefix(remaining))
-                }
-                if chunk.count > remaining {
-                    didTruncate = true
-                }
-            }
-        }
-    }
-
-    func waitForCompletion(until deadline: DispatchTime) {
-        _ = completed.wait(timeout: deadline)
-    }
-
-    func stop(reading handle: FileHandle) {
-        handle.readabilityHandler = nil
-        try? handle.close()
-        complete()
-    }
-
-    private func complete() {
-        let shouldSignal = lock.withLock {
-            guard !didComplete else { return false }
-            didComplete = true
-            return true
-        }
-        if shouldSignal {
-            completed.signal()
-        }
+    ) async throws -> SubprocessResult {
+        try await SubprocessRunner.run(SubprocessRequest(
+            executablePath: executablePath,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            timeout: timeout
+        ))
     }
 }

--- a/Muxy/Services/AI/ProviderDiscoveryService.swift
+++ b/Muxy/Services/AI/ProviderDiscoveryService.swift
@@ -114,6 +114,10 @@ final class ProviderDiscoveryService {
                     state: details.state
                 )
             )
+        } catch SubprocessRunnerError.cancelled {
+            return
+        } catch is CancellationError {
+            return
         } catch {
             record(
                 provider: provider,

--- a/Muxy/Services/Extensions/ExtensionCommandProcess.swift
+++ b/Muxy/Services/Extensions/ExtensionCommandProcess.swift
@@ -340,8 +340,13 @@ final class OutputReader: @unchecked Sendable {
 
 final class OutputBox: @unchecked Sendable {
     private let lock = NSLock()
+    private let maximumBytes: Int
     private var data = Data()
     private(set) var overflow = false
+
+    init(maximumBytes: Int = ExtensionCommandExecutor.maxOutputBytes) {
+        self.maximumBytes = maximumBytes
+    }
 
     func append(_ chunk: Data) {
         lock.lock()
@@ -349,7 +354,7 @@ final class OutputBox: @unchecked Sendable {
         if overflow {
             return
         }
-        let remaining = ExtensionCommandExecutor.maxOutputBytes - data.count
+        let remaining = maximumBytes - data.count
         if chunk.count <= remaining {
             data.append(chunk)
             return
@@ -364,5 +369,11 @@ final class OutputBox: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    func value() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
     }
 }

--- a/Muxy/Services/Process/SubprocessRunner.swift
+++ b/Muxy/Services/Process/SubprocessRunner.swift
@@ -1,0 +1,209 @@
+import Darwin
+import Foundation
+
+struct SubprocessRequest: Sendable {
+    let executablePath: String
+    let arguments: [String]
+    let workingDirectory: String?
+    let environment: [String: String]
+    let standardInput: Data?
+    let timeout: TimeInterval?
+    let outputByteLimit: Int
+
+    init(
+        executablePath: String,
+        arguments: [String] = [],
+        workingDirectory: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        standardInput: Data? = nil,
+        timeout: TimeInterval? = nil,
+        outputByteLimit: Int = 64 * 1024
+    ) {
+        self.executablePath = executablePath
+        self.arguments = arguments
+        self.workingDirectory = workingDirectory
+        self.environment = environment
+        self.standardInput = standardInput
+        self.timeout = timeout
+        self.outputByteLimit = outputByteLimit
+    }
+}
+
+struct SubprocessResult: Sendable {
+    let status: Int32
+    let stdoutData: Data
+    let stderrData: Data
+    let truncated: Bool
+    var stdout: String { String(data: stdoutData, encoding: .utf8) ?? "" }
+    var stderr: String { String(data: stderrData, encoding: .utf8) ?? "" }
+}
+
+enum SubprocessRunnerError: LocalizedError {
+    case timedOut(TimeInterval)
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case let .timedOut(value): "Process timed out after \(Int(value))s"
+        case .cancelled: "Process cancelled"
+        }
+    }
+}
+
+enum SubprocessRunner {
+    static func run(_ request: SubprocessRequest) async throws -> SubprocessResult {
+        let job = SubprocessJob(request: request)
+        return try await withTaskCancellationHandler { try await job.run() } onCancel: { job.cancel() }
+    }
+}
+
+private final class SubprocessJob: @unchecked Sendable {
+    private let request: SubprocessRequest
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<SubprocessResult, Error>?
+    private var process: CancellableProcess?
+    private var stdoutReader: OutputReader?
+    private var stderrReader: OutputReader?
+    private var stdout: OutputBox?
+    private var stderr: OutputBox?
+    private var timedOut = false
+    private var cancelled = false
+    private var finished = false
+
+    init(request: SubprocessRequest) {
+        self.request = request
+    }
+
+    func run() async throws -> SubprocessResult {
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            self.continuation = continuation
+            let wasCancelled = cancelled
+            lock.unlock()
+            guard !wasCancelled else {
+                finish(.failure(SubprocessRunnerError.cancelled))
+                return
+            }
+            launch()
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        guard !finished else { lock.unlock()
+            return
+        }
+        cancelled = true
+        let process = process
+        lock.unlock()
+        guard let process else { finish(.failure(SubprocessRunnerError.cancelled))
+            return
+        }
+        _ = process.terminate()
+    }
+
+    private func launch() {
+        let configured = Process()
+        configured.executableURL = URL(fileURLWithPath: request.executablePath)
+        configured.arguments = request.arguments
+        configured.environment = request.environment
+        if let workingDirectory = request.workingDirectory {
+            configured.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
+        }
+        let stdin = Pipe(), stdoutPipe = Pipe(), stderrPipe = Pipe()
+        configured.standardInput = stdin
+        configured.standardOutput = stdoutPipe
+        configured.standardError = stderrPipe
+        let stdout = OutputBox(maximumBytes: request.outputByteLimit), stderr = OutputBox(maximumBytes: request.outputByteLimit)
+        let stdoutReader = OutputReader(pipe: stdoutPipe, box: stdout), stderrReader = OutputReader(pipe: stderrPipe, box: stderr)
+        stdoutReader.start()
+        stderrReader.start()
+        lock.lock()
+        guard !cancelled else { lock.unlock()
+            stdoutReader.finish()
+            stderrReader.finish()
+            finish(.failure(SubprocessRunnerError.cancelled))
+            return
+        }
+        self.stdout = stdout
+        self.stderr = stderr
+        self.stdoutReader = stdoutReader
+        self.stderrReader = stderrReader
+        do { self.process = try CancellableProcess.launch(
+            configuredProcess: configured,
+            stdinPipe: stdin,
+            stdoutPipe: stdoutPipe,
+            stderrPipe: stderrPipe
+        ) { [weak self] in self?.didTerminate() } } catch { lock.unlock()
+            stdoutReader.finish()
+            stderrReader.finish()
+            finish(.failure(error))
+            return
+        }
+        lock.unlock()
+        DispatchQueue.global(qos: .utility).async { [input = request.standardInput] in let handle = stdin.fileHandleForWriting
+            defer { try? handle.close() }
+            if let input {
+                try? handle.write(contentsOf: input)
+            }
+        }
+        if let timeout = request
+            .timeout
+        {
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) { [weak self] in self?.timeout() }
+        }
+    }
+
+    private func timeout() {
+        lock.lock()
+        guard !finished, !cancelled, let process else { lock.unlock()
+            return
+        }
+        timedOut = true
+        lock.unlock()
+        _ = process.terminate()
+    }
+
+    private func didTerminate() {
+        lock.lock()
+        let wasCancelled = cancelled
+        let didTimeOut = timedOut
+        let status = process?.terminationStatus ?? -1
+        let readers = (stdoutReader, stderrReader)
+        let output = (stdout, stderr)
+        lock.unlock()
+        readers.0?.finish()
+        readers.1?.finish()
+        if wasCancelled {
+            finish(.failure(SubprocessRunnerError.cancelled))
+            return
+        }
+        if didTimeOut, let timeout = request.timeout {
+            finish(.failure(SubprocessRunnerError.timedOut(timeout)))
+            return
+        }
+        finish(.success(SubprocessResult(
+            status: status,
+            stdoutData: output.0?.value() ?? Data(),
+            stderrData: output.1?.value() ?? Data(),
+            truncated: (output.0?.overflow ?? false) || (output.1?.overflow ?? false)
+        )))
+    }
+
+    private func finish(_ result: Result<SubprocessResult, Error>) {
+        lock.lock()
+        guard !finished else { lock.unlock()
+            return
+        }
+        finished = true
+        let continuation = continuation
+        self.continuation = nil
+        process = nil
+        stdoutReader = nil
+        stderrReader = nil
+        stdout = nil
+        stderr = nil
+        lock.unlock()
+        continuation?.resume(with: result)
+    }
+}

--- a/Muxy/Services/Process/SubprocessRunner.swift
+++ b/Muxy/Services/Process/SubprocessRunner.swift
@@ -38,12 +38,14 @@ struct SubprocessResult: Sendable {
     var stderr: String { String(data: stderrData, encoding: .utf8) ?? "" }
 }
 
-enum SubprocessRunnerError: LocalizedError {
+enum SubprocessRunnerError: LocalizedError, Equatable {
+    case launchFailed(String)
     case timedOut(TimeInterval)
     case cancelled
 
     var errorDescription: String? {
         switch self {
+        case let .launchFailed(detail): "Process failed to launch: \(detail)"
         case let .timedOut(value): "Process timed out after \(Int(value))s"
         case .cancelled: "Process cancelled"
         }
@@ -137,7 +139,7 @@ private final class SubprocessJob: @unchecked Sendable {
         ) { [weak self] in self?.didTerminate() } } catch { lock.unlock()
             stdoutReader.finish()
             stderrReader.finish()
-            finish(.failure(error))
+            finish(.failure(SubprocessRunnerError.launchFailed(error.localizedDescription)))
             return
         }
         lock.unlock()
@@ -192,11 +194,10 @@ private final class SubprocessJob: @unchecked Sendable {
 
     private func finish(_ result: Result<SubprocessResult, Error>) {
         lock.lock()
-        guard !finished else { lock.unlock()
+        guard !finished, let continuation else { lock.unlock()
             return
         }
         finished = true
-        let continuation = continuation
         self.continuation = nil
         process = nil
         stdoutReader = nil
@@ -204,6 +205,6 @@ private final class SubprocessJob: @unchecked Sendable {
         stdout = nil
         stderr = nil
         lock.unlock()
-        continuation?.resume(with: result)
+        continuation.resume(with: result)
     }
 }

--- a/Muxy/Services/Process/SubprocessRunner.swift
+++ b/Muxy/Services/Process/SubprocessRunner.swift
@@ -146,6 +146,7 @@ private final class SubprocessJob: @unchecked Sendable {
         DispatchQueue.global(qos: .utility).async { [input = request.standardInput] in let handle = stdin.fileHandleForWriting
             defer { try? handle.close() }
             if let input {
+                _ = fcntl(handle.fileDescriptor, F_SETNOSIGPIPE, 1)
                 try? handle.write(contentsOf: input)
             }
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "066ab307b4a0e89ca1cb729d2423eb57ebcd8a19de8762c00940d2cb612c1569",
+  "originHash" : "38de32c9070a3d810830af38e8a8a5722befb33ed6276eb5862dce40b752fe80",
   "pins" : [
     {
       "identity" : "sentry-cocoa",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "38de32c9070a3d810830af38e8a8a5722befb33ed6276eb5862dce40b752fe80",
+  "originHash" : "066ab307b4a0e89ca1cb729d2423eb57ebcd8a19de8762c00940d2cb612c1569",
   "pins" : [
     {
       "identity" : "sentry-cocoa",

--- a/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
+++ b/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
@@ -102,7 +102,7 @@ struct ProviderDiscoveryServiceTests {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let completionMarker = directory.appendingPathComponent("completed").path
 
-        await #expect(throws: ProviderDiscoveryError.self) {
+        await #expect(throws: SubprocessRunnerError.self) {
             try await ProviderDiscoveryService.runProcess(
                 executablePath: "/bin/sh",
                 arguments: ["-c", "/bin/sleep 1; /usr/bin/touch '\(completionMarker)'"],
@@ -160,18 +160,72 @@ struct ProviderDiscoveryServiceTests {
         #expect(results.0.status == 0)
         #expect(results.1.status == 0)
     }
+
+    @Test("process runner reports launch failures")
+    func processRunnerReportsLaunchFailure() async {
+        await #expect(throws: Error.self) {
+            try await SubprocessRunner.run(SubprocessRequest(executablePath: "/missing/muxy-probe"))
+        }
+    }
+
+    @Test("process runner cancels the process group")
+    func processRunnerCancelsProcessGroup() async throws {
+        let task = Task {
+            try await SubprocessRunner.run(SubprocessRequest(
+                executablePath: "/bin/sh",
+                arguments: ["-c", "(/bin/sleep 10) & wait"]
+            ))
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        await #expect(throws: Error.self) {
+            try await task.value
+        }
+    }
+
+    @Test("newer discovery results replace older probes")
+    func newerDiscoveryResultWins() async {
+        let provider = DiscoveryProvider(
+            executablePath: "/tmp/opencode",
+            details: ProviderDiscoveryDetails(version: nil, state: .ready),
+            usesOutputAsVersion: true
+        )
+        defer { provider.resetSettings() }
+        let health = HookHealthStore()
+        let sequence = ProbeSequence()
+        let service = ProviderDiscoveryService(health: health) { _, _, _, _ in
+            let invocation = await sequence.next()
+            if invocation == 1 {
+                try await Task.sleep(for: .milliseconds(100))
+                return providerDiscoveryProcessResult(stdout: "old")
+            }
+            return providerDiscoveryProcessResult(stdout: "new")
+        }
+
+        let first = Task { @MainActor in
+            await service.discover(provider)
+        }
+        try? await Task.sleep(for: .milliseconds(10))
+        let second = Task { @MainActor in
+            await service.discover(provider)
+        }
+        await first.value
+        await second.value
+
+        #expect(health.health(for: provider.id).discovery?.version == "new")
+    }
 }
 
 private func providerDiscoveryProcessResult(
     status: Int32 = 0,
     stdout: String = "",
     stderr: String = ""
-) -> GitProcessResult {
-    GitProcessResult(
+) -> SubprocessResult {
+    SubprocessResult(
         status: status,
-        stdout: stdout,
         stdoutData: Data(stdout.utf8),
-        stderr: stderr,
+        stderrData: Data(stderr.utf8),
         truncated: false
     )
 }
@@ -190,20 +244,38 @@ private final class DiscoveryProvider: AIProviderIntegration, AIAgentLaunchProvi
     let discoveryWorkingDirectory = "/tmp"
     private let executablePath: String?
     private let details: ProviderDiscoveryDetails
+    private let usesOutputAsVersion: Bool
 
-    init(executablePath: String?, details: ProviderDiscoveryDetails) {
+    init(
+        executablePath: String?,
+        details: ProviderDiscoveryDetails,
+        usesOutputAsVersion: Bool = false
+    ) {
         self.executablePath = executablePath
         self.details = details
+        self.usesOutputAsVersion = usesOutputAsVersion
     }
 
     func isToolInstalled() -> Bool { executablePath != nil }
     func agentCLIExecutablePath() -> String? { executablePath }
     func install(hookScriptPath _: String) throws {}
     func uninstall() throws {}
-    func discoveryDetails(from _: String) -> ProviderDiscoveryDetails { details }
+    func discoveryDetails(from output: String) -> ProviderDiscoveryDetails {
+        guard usesOutputAsVersion else { return details }
+        return ProviderDiscoveryDetails(version: output, state: details.state)
+    }
 
     func resetSettings() {
         UserDefaults.standard.removeObject(forKey: settingsKey)
+    }
+}
+
+private actor ProbeSequence {
+    private var value = 0
+
+    func next() -> Int {
+        value += 1
+        return value
     }
 }
 

--- a/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
+++ b/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
@@ -355,6 +355,8 @@ private actor ProbeGate {
     }
 }
 
+private struct ProbeMarkerTimeoutError: Error {}
+
 private func waitForFile(at url: URL) async throws {
     for _ in 0 ..< 250 {
         if FileManager.default.fileExists(atPath: url.path) {
@@ -363,6 +365,7 @@ private func waitForFile(at url: URL) async throws {
         try await Task.sleep(for: .milliseconds(20))
     }
     Issue.record("expected marker file at \(url.path)")
+    throw ProbeMarkerTimeoutError()
 }
 
 private func waitForProcessExit(_ pid: pid_t) async -> Bool {

--- a/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
+++ b/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Muxy
 
-@Suite("ProviderDiscoveryService")
+@Suite("ProviderDiscoveryService", .serialized)
 @MainActor
 struct ProviderDiscoveryServiceTests {
     @Test("discovery records executable version and ready state")
@@ -356,7 +356,7 @@ private actor ProbeGate {
 }
 
 private func waitForFile(at url: URL) async throws {
-    for _ in 0 ..< 100 {
+    for _ in 0 ..< 250 {
         if FileManager.default.fileExists(atPath: url.path) {
             return
         }

--- a/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
+++ b/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
@@ -225,7 +225,8 @@ struct ProviderDiscoveryServiceTests {
         let task = Task {
             try await SubprocessRunner.run(SubprocessRequest(
                 executablePath: "/bin/sh",
-                arguments: ["-c", "/bin/sleep 10 & child=$!; echo $child > '\(pidFile.path)'; wait"]
+                arguments: ["-c", "/bin/sleep 10 & child=$!; echo $child > '\(pidFile.path)'; wait"],
+                standardInput: Data(repeating: 0, count: 1024 * 1024)
             ))
         }
         try await waitForFile(at: pidFile)

--- a/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
+++ b/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
@@ -79,6 +79,29 @@ struct ProviderDiscoveryServiceTests {
         ))
     }
 
+    @Test("cancelled discovery preserves the previous result")
+    func cancelledDiscoveryPreservesPreviousResult() async {
+        let provider = DiscoveryProvider(
+            executablePath: "/tmp/opencode",
+            details: ProviderDiscoveryDetails(version: nil, state: .ready)
+        )
+        defer { provider.resetSettings() }
+        let health = HookHealthStore()
+        let previous = ProviderDiscoverySnapshot(
+            executablePath: "/tmp/opencode",
+            version: "1.18.5",
+            state: .ready
+        )
+        health.noteDiscovery(providerID: provider.id, snapshot: previous)
+        let service = ProviderDiscoveryService(health: health) { _, _, _, _ in
+            throw SubprocessRunnerError.cancelled
+        }
+
+        await service.discover(provider)
+
+        #expect(health.health(for: provider.id).discovery == previous)
+    }
+
     @Test("process runner captures bounded standard output and error")
     func processRunnerCapturesOutput() async throws {
         let result = try await ProviderDiscoveryService.runProcess(
@@ -102,7 +125,7 @@ struct ProviderDiscoveryServiceTests {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let completionMarker = directory.appendingPathComponent("completed").path
 
-        await #expect(throws: SubprocessRunnerError.self) {
+        await #expect(throws: SubprocessRunnerError.timedOut(0.05)) {
             try await ProviderDiscoveryService.runProcess(
                 executablePath: "/bin/sh",
                 arguments: ["-c", "/bin/sleep 1; /usr/bin/touch '\(completionMarker)'"],
@@ -163,25 +186,57 @@ struct ProviderDiscoveryServiceTests {
 
     @Test("process runner reports launch failures")
     func processRunnerReportsLaunchFailure() async {
-        await #expect(throws: Error.self) {
-            try await SubprocessRunner.run(SubprocessRequest(executablePath: "/missing/muxy-probe"))
+        do {
+            _ = try await SubprocessRunner.run(SubprocessRequest(executablePath: "/missing/muxy-probe"))
+            Issue.record("Expected the process launch to fail")
+        } catch let error as SubprocessRunnerError {
+            guard case .launchFailed = error else {
+                Issue.record("Expected a launch failure, received \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected SubprocessRunnerError, received \(error)")
+        }
+    }
+
+    @Test("process runner finishes when cancellation precedes execution")
+    func processRunnerHandlesPreCancelledTask() async {
+        let gate = ProbeGate()
+        let task = Task {
+            await gate.wait()
+            return try await SubprocessRunner.run(SubprocessRequest(executablePath: "/usr/bin/true"))
+        }
+        await gate.waitUntilReady()
+        task.cancel()
+        await gate.open()
+
+        await #expect(throws: SubprocessRunnerError.cancelled) {
+            try await task.value
         }
     }
 
     @Test("process runner cancels the process group")
     func processRunnerCancelsProcessGroup() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SubprocessCancellationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let pidFile = directory.appendingPathComponent("child-pid")
         let task = Task {
             try await SubprocessRunner.run(SubprocessRequest(
                 executablePath: "/bin/sh",
-                arguments: ["-c", "(/bin/sleep 10) & wait"]
+                arguments: ["-c", "/bin/sleep 10 & child=$!; echo $child > '\(pidFile.path)'; wait"]
             ))
         }
-        try await Task.sleep(for: .milliseconds(50))
+        try await waitForFile(at: pidFile)
+        let pidContents = try String(contentsOf: pidFile, encoding: .utf8)
+        let childPID = try #require(pid_t(pidContents.trimmingCharacters(in: .whitespacesAndNewlines)))
         task.cancel()
 
-        await #expect(throws: Error.self) {
+        await #expect(throws: SubprocessRunnerError.cancelled) {
             try await task.value
         }
+        #expect(await waitForProcessExit(childPID))
     }
 
     @Test("newer discovery results replace older probes")
@@ -277,6 +332,47 @@ private actor ProbeSequence {
         value += 1
         return value
     }
+}
+
+private actor ProbeGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var ready = false
+
+    func wait() async {
+        ready = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilReady() async {
+        while !ready {
+            await Task.yield()
+        }
+    }
+
+    func open() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private func waitForFile(at url: URL) async throws {
+    for _ in 0 ..< 100 {
+        if FileManager.default.fileExists(atPath: url.path) {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    Issue.record("expected marker file at \(url.path)")
+}
+
+private func waitForProcessExit(_ pid: pid_t) async -> Bool {
+    for _ in 0 ..< 100 {
+        if kill(pid, 0) == -1, errno == ESRCH {
+            return true
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+    }
+    return false
 }
 
 private final class InvocationRecorder: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- add a shared bounded subprocess runner with process-group teardown for timeout and cancellation
- migrate provider discovery to the shared runner and prevent stale or cancelled probes from replacing health state
- add typed lifecycle errors and focused concurrency, cancellation, timeout, output, and ordering coverage

## Changes
- run subprocesses with structured arguments, working directory, environment, optional stdin, bounded stdout/stderr, and timeout support
- terminate and reap isolated process groups on timeout or task cancellation
- keep completion continuations resumable when cancellation precedes execution
- preserve existing OpenCode discovery behavior for the current managed plugin, legacy plugin, and missing plugin states from `opencode debug info`
- keep executable paths private in provider discovery logs

## Testing
- [x] `scripts/checks.sh --fix`
- [x] `swift test --filter ProviderDiscoveryServiceTests`
- [x] verify cancellation reports `SubprocessRunnerError.cancelled` and reaps the descendant process
- [x] verify timeout and launch failures report their exact typed errors
- [x] verify newer discovery generations win and cancellation preserves the previous snapshot

## Screenshots
Not applicable; this is a non-visual infrastructure change.

Closes #958

AI contribution: OpenAI GPT-5.6-sol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared subprocess execution with cancellation, timeouts, standard input, and bounded output capture.
  * Added configurable command output limits with truncation reporting.

* **Bug Fixes**
  * Prevented outdated provider discovery results from replacing newer results.
  * Improved handling of launch failures, cancellations, timeouts, and process termination.
  * Preserved previous discovery results when a newer probe is cancelled.

* **Tests**
  * Expanded coverage for subprocess failures, cancellation, timeouts, output handling, and overlapping discovery requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->