### PR TITLE
Add install-on-quit updates

### DIFF
--- a/Muxy/Info.plist
+++ b/Muxy/Info.plist
@@ -32,6 +32,8 @@
 	<string>public.app-category.developer-tools</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
 	<key>SentryDSN</key>
 	<string>__MUXY_SENTRY_DSN__</string>
 	<key>NSAppleEventsUsageDescription</key>

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -249,6 +249,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private weak var whatsNewWindow: NSWindow?
     private let terminalTerminationCleanup = TerminalTerminationCleanup()
     private static let terminalCleanupTimeout: Duration = .seconds(5)
+    private var didPersistUserStateForTermination = false
 
     @MainActor
     func handleOpenProjectPath(_ path: String) {
@@ -513,6 +514,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         let reply = AppRelaunch.isRelaunching ? NSApplication.TerminateReply.terminateNow : confirmQuitIfNeeded()
         guard reply == .terminateNow else { return reply }
+        persistUserStateForTermination()
         guard !terminalTerminationCleanup.isComplete else { return .terminateNow }
         terminalTerminationCleanup.start(
             timeout: Self.terminalCleanupTimeout,
@@ -592,7 +594,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func persistUserStateForTermination() {
-        guard !AppRelaunch.isRelaunching else { return }
+        guard !AppRelaunch.isRelaunching, !didPersistUserStateForTermination else { return }
+        didPersistUserStateForTermination = true
         onTerminate?()
         RichInputDraftStore.shared.flush()
     }

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -247,9 +247,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private weak var settingsWindow: NSWindow?
     private weak var extensionsWindow: NSWindow?
     private weak var whatsNewWindow: NSWindow?
-    private let terminalTerminationCleanup = TerminalTerminationCleanup()
+    private let terminalTerminationCleanup: TerminalTerminationCleanup
+    private let prepareTerminalsForTermination: TerminalTerminationCleanup.Cleanup
+    private let replyToApplicationShouldTerminate: @MainActor (NSApplication) -> Void
     private static let terminalCleanupTimeout: Duration = .seconds(5)
     private var didPersistUserStateForTermination = false
+
+    override convenience init() {
+        self.init(
+            terminalTerminationCleanup: TerminalTerminationCleanup(),
+            prepareTerminalsForTermination: {
+                await TerminalViewRegistry.shared.prepareForTermination()
+            },
+            replyToApplicationShouldTerminate: {
+                $0.reply(toApplicationShouldTerminate: true)
+            }
+        )
+    }
+
+    init(
+        terminalTerminationCleanup: TerminalTerminationCleanup,
+        prepareTerminalsForTermination: @escaping TerminalTerminationCleanup.Cleanup,
+        replyToApplicationShouldTerminate: @escaping @MainActor (NSApplication) -> Void
+    ) {
+        self.terminalTerminationCleanup = terminalTerminationCleanup
+        self.prepareTerminalsForTermination = prepareTerminalsForTermination
+        self.replyToApplicationShouldTerminate = replyToApplicationShouldTerminate
+        super.init()
+    }
 
     @MainActor
     func handleOpenProjectPath(_ path: String) {
@@ -518,11 +543,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         guard !terminalTerminationCleanup.isComplete else { return .terminateNow }
         terminalTerminationCleanup.start(
             timeout: Self.terminalCleanupTimeout,
-            cleanup: {
-                await TerminalViewRegistry.shared.prepareForTermination()
-            },
-            completion: {
-                sender.reply(toApplicationShouldTerminate: true)
+            cleanup: prepareTerminalsForTermination,
+            completion: { [replyToApplicationShouldTerminate] in
+                replyToApplicationShouldTerminate(sender)
             }
         )
         return .terminateLater

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "Allow %@?" = "Allow %@?";
 "Allow & remember" = "Allow & remember";
 "Allow mobile device connections" = "Allow mobile device connections";
+"Automatic updates are unavailable for this configuration." = "Automatic updates are unavailable for this configuration.";
 "Anonymous crash reports help us fix bugs. Reports never include project paths, file contents, or personal data." = "Anonymous crash reports help us fix bugs. Reports never include project paths, file contents, or personal data.";
 "App" = "App";
 "App & subprocess resource usage" = "App & subprocess resource usage";
@@ -302,6 +303,7 @@
 "Draft · Open" = "Draft · Open";
 "Drag to reposition, scroll to zoom" = "Drag to reposition, scroll to zoom";
 "Drop an extension into the extensions folder to get started." = "Drop an extension into the extensions folder to get started.";
+"Downloads updates in the background and installs them when Muxy quits." = "Downloads updates in the background and installs them when Muxy quits.";
 "Each profile keeps its own cookies, cache, and logins. Pick a profile per tab from the browser toolbar. Import brings an existing browser's cookies so tabs start signed in." = "Each profile keeps its own cookies, cache, and logins. Pick a profile per tab from the browser toolbar. Import brings an existing browser's cookies so tabs start signed in.";
 "Edit" = "Edit";
 "Edit Connection" = "Edit Connection";
@@ -407,6 +409,7 @@
 "Inspect Element" = "Inspect Element";
 "Install" = "Install";
 "Install CLI" = "Install CLI";
+"Install Downloaded Updates on Quit" = "Install Downloaded Updates on Quit";
 "Install Muxy CLI?" = "Install Muxy CLI?";
 "Install a supported AI provider CLI or choose a provider." = "Install a supported AI provider CLI or choose a provider.";
 "Installed" = "Installed";

--- a/Muxy/Services/App/UpdateService.swift
+++ b/Muxy/Services/App/UpdateService.swift
@@ -41,12 +41,15 @@ enum UpdateChannel: String, CaseIterable, Identifiable {
 @MainActor @Observable
 final class UpdateService: NSObject {
     static let shared = UpdateService()
+    static let automaticallyUpdatesKey = "SUAutomaticallyUpdate"
 
     @ObservationIgnored private let controller: SPUStandardUpdaterController
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     @ObservationIgnored private let feedDelegate: FeedDelegate
 
     private(set) var canCheckForUpdates = false
+    private(set) var allowsAutomaticUpdates = false
+    private(set) var automaticallyDownloadsUpdates = false
     private(set) var availableUpdateVersion: String?
 
     var channel: UpdateChannel {
@@ -78,6 +81,12 @@ final class UpdateService: NSObject {
         controller.updater.publisher(for: \.canCheckForUpdates)
             .assign(to: \.canCheckForUpdates, on: self)
             .store(in: &cancellables)
+        controller.updater.publisher(for: \.allowsAutomaticUpdates)
+            .assign(to: \.allowsAutomaticUpdates, on: self)
+            .store(in: &cancellables)
+        controller.updater.publisher(for: \.automaticallyDownloadsUpdates)
+            .assign(to: \.automaticallyDownloadsUpdates, on: self)
+            .store(in: &cancellables)
         observeUpdateNotifications()
         applyFeatureFlags()
     }
@@ -92,6 +101,11 @@ final class UpdateService: NSObject {
 
     func checkForUpdates() {
         controller.checkForUpdates(nil)
+    }
+
+    func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {
+        guard enabled != automaticallyDownloadsUpdates else { return }
+        updater.automaticallyDownloadsUpdates = enabled
     }
 
     private func applyFeatureFlags() {
@@ -121,6 +135,8 @@ final class UpdateService: NSObject {
 }
 
 private final class FeedDelegate: NSObject, SPUUpdaterDelegate {
+    private static let noUpdateErrorCode = 1001
+
     var channel: UpdateChannel
 
     init(channel: UpdateChannel) {
@@ -137,5 +153,30 @@ private final class FeedDelegate: NSObject, SPUUpdaterDelegate {
         case .stable: []
         case .beta: [channel.rawValue]
         }
+    }
+
+    func updater(_: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
+        logger.info("Downloaded update \(item.displayVersionString, privacy: .public)")
+    }
+
+    func updater(_: SPUUpdater, failedToDownloadUpdate item: SUAppcastItem, error: Error) {
+        logger
+            .error(
+                "Failed to download update \(item.displayVersionString, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+    }
+
+    func updater(_: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        logger.info("Installing update \(item.displayVersionString, privacy: .public)")
+    }
+
+    func updater(_: SPUUpdater, willInstallUpdateOnQuit item: SUAppcastItem, immediateInstallationBlock _: @escaping () -> Void) -> Bool {
+        logger.info("Scheduling update \(item.displayVersionString, privacy: .public) for installation on quit")
+        return false
+    }
+
+    func updater(_: SPUUpdater, didAbortWithError error: Error) {
+        guard (error as NSError).code != Self.noUpdateErrorCode else { return }
+        logger.error("Update cycle aborted: \(error.localizedDescription, privacy: .public)")
     }
 }

--- a/Muxy/Services/App/UpdateService.swift
+++ b/Muxy/Services/App/UpdateService.swift
@@ -108,6 +108,11 @@ final class UpdateService: NSObject {
         updater.automaticallyDownloadsUpdates = enabled
     }
 
+    func resetAutomaticallyDownloadsUpdates() {
+        UserDefaults.standard.removeObject(forKey: Self.automaticallyUpdatesKey)
+        automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
+    }
+
     private func applyFeatureFlags() {
         #if DEBUG
         if ProcessInfo.processInfo.environment["FF_UPDATE_AVAILABLE"] != nil {
@@ -135,7 +140,7 @@ final class UpdateService: NSObject {
 }
 
 private final class FeedDelegate: NSObject, SPUUpdaterDelegate {
-    private static let noUpdateErrorCode = 1001
+    private static let noUpdateErrorCode = Int(SUError.noUpdateError.rawValue)
 
     var channel: UpdateChannel
 
@@ -176,7 +181,8 @@ private final class FeedDelegate: NSObject, SPUUpdaterDelegate {
     }
 
     func updater(_: SPUUpdater, didAbortWithError error: Error) {
-        guard (error as NSError).code != Self.noUpdateErrorCode else { return }
+        let error = error as NSError
+        guard error.domain != SUSparkleErrorDomain || error.code != Self.noUpdateErrorCode else { return }
         logger.error("Update cycle aborted: \(error.localizedDescription, privacy: .public)")
     }
 }

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -8,6 +8,7 @@ enum SettingsJSONStore {
     typealias QuickTerminalShortcutUpdater = @MainActor (QuickTerminalShortcut) throws -> Void
     typealias QuickTerminalEnabledUpdater = @MainActor (Bool) -> Void
     typealias QuickTerminalEnabledResetter = @MainActor () -> Void
+    typealias AutomaticUpdatesUpdater = @MainActor (Bool) -> Void
 
     private static var defaultsObserver: NSObjectProtocol?
     private static var isApplyingSettings = false
@@ -37,6 +38,9 @@ enum SettingsJSONStore {
         },
         quickTerminalEnabledResetter: QuickTerminalEnabledResetter = {
             QuickTerminalPreferences.resetEnabled()
+        },
+        automaticUpdatesUpdater: AutomaticUpdatesUpdater = {
+            UpdateService.shared.setAutomaticallyDownloadsUpdates($0)
         }
     ) throws {
         let data = Data(text.utf8)
@@ -57,7 +61,8 @@ enum SettingsJSONStore {
                 settings,
                 quickTerminalShortcutUpdater: quickTerminalShortcutUpdater,
                 quickTerminalEnabledUpdater: quickTerminalEnabledUpdater,
-                quickTerminalEnabledResetter: quickTerminalEnabledResetter
+                quickTerminalEnabledResetter: quickTerminalEnabledResetter,
+                automaticUpdatesUpdater: automaticUpdatesUpdater
             )
             isApplyingSettings = false
         } catch {
@@ -213,7 +218,8 @@ enum SettingsJSONStore {
         _ dictionary: [String: Any],
         quickTerminalShortcutUpdater: QuickTerminalShortcutUpdater,
         quickTerminalEnabledUpdater: QuickTerminalEnabledUpdater,
-        quickTerminalEnabledResetter: QuickTerminalEnabledResetter
+        quickTerminalEnabledResetter: QuickTerminalEnabledResetter,
+        automaticUpdatesUpdater: AutomaticUpdatesUpdater
     ) throws {
         if let quickTerminalShortcut = dictionary["shortcuts.quickTerminal"] {
             _ = try applySpecialSetting(
@@ -227,8 +233,12 @@ enum SettingsJSONStore {
         } else if dictionary[QuickTerminalPreferences.enabledKey] is NSNull {
             quickTerminalEnabledResetter()
         }
+        if let enabled = dictionary[UpdateService.automaticallyUpdatesKey] as? Bool {
+            automaticUpdatesUpdater(enabled)
+        }
         for (key, value) in dictionary where key != "shortcuts.quickTerminal"
             && key != QuickTerminalPreferences.enabledKey
+            && key != UpdateService.automaticallyUpdatesKey
         {
             if try applySpecialSetting(
                 key: key,

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -9,6 +9,7 @@ enum SettingsJSONStore {
     typealias QuickTerminalEnabledUpdater = @MainActor (Bool) -> Void
     typealias QuickTerminalEnabledResetter = @MainActor () -> Void
     typealias AutomaticUpdatesUpdater = @MainActor (Bool) -> Void
+    typealias AutomaticUpdatesResetter = @MainActor () -> Void
 
     private static var defaultsObserver: NSObjectProtocol?
     private static var isApplyingSettings = false
@@ -41,6 +42,9 @@ enum SettingsJSONStore {
         },
         automaticUpdatesUpdater: AutomaticUpdatesUpdater = {
             UpdateService.shared.setAutomaticallyDownloadsUpdates($0)
+        },
+        automaticUpdatesResetter: AutomaticUpdatesResetter = {
+            UpdateService.shared.resetAutomaticallyDownloadsUpdates()
         }
     ) throws {
         let data = Data(text.utf8)
@@ -64,6 +68,9 @@ enum SettingsJSONStore {
                 quickTerminalEnabledResetter: quickTerminalEnabledResetter,
                 automaticUpdatesUpdater: automaticUpdatesUpdater
             )
+            if settings[UpdateService.automaticallyUpdatesKey] is NSNull {
+                automaticUpdatesResetter()
+            }
             isApplyingSettings = false
         } catch {
             isApplyingSettings = false

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -11,6 +11,11 @@ enum SettingsJSONStore {
     typealias AutomaticUpdatesUpdater = @MainActor (Bool) -> Void
     typealias AutomaticUpdatesResetter = @MainActor () -> Void
 
+    private struct AutomaticUpdatesActions {
+        let update: AutomaticUpdatesUpdater
+        let reset: AutomaticUpdatesResetter
+    }
+
     private static var defaultsObserver: NSObjectProtocol?
     private static var isApplyingSettings = false
     private static var isSyncingFile = false
@@ -40,10 +45,10 @@ enum SettingsJSONStore {
         quickTerminalEnabledResetter: QuickTerminalEnabledResetter = {
             QuickTerminalPreferences.resetEnabled()
         },
-        automaticUpdatesUpdater: AutomaticUpdatesUpdater = {
+        automaticUpdatesUpdater: @escaping AutomaticUpdatesUpdater = {
             UpdateService.shared.setAutomaticallyDownloadsUpdates($0)
         },
-        automaticUpdatesResetter: AutomaticUpdatesResetter = {
+        automaticUpdatesResetter: @escaping AutomaticUpdatesResetter = {
             UpdateService.shared.resetAutomaticallyDownloadsUpdates()
         }
     ) throws {
@@ -61,16 +66,17 @@ enum SettingsJSONStore {
                 ofItemAtPath: userSettingsURL.path
             )
             isApplyingSettings = true
+            let automaticUpdatesActions = AutomaticUpdatesActions(
+                update: automaticUpdatesUpdater,
+                reset: automaticUpdatesResetter
+            )
             try apply(
                 settings,
                 quickTerminalShortcutUpdater: quickTerminalShortcutUpdater,
                 quickTerminalEnabledUpdater: quickTerminalEnabledUpdater,
                 quickTerminalEnabledResetter: quickTerminalEnabledResetter,
-                automaticUpdatesUpdater: automaticUpdatesUpdater
+                automaticUpdatesActions: automaticUpdatesActions
             )
-            if settings[UpdateService.automaticallyUpdatesKey] is NSNull {
-                automaticUpdatesResetter()
-            }
             isApplyingSettings = false
         } catch {
             isApplyingSettings = false
@@ -226,7 +232,7 @@ enum SettingsJSONStore {
         quickTerminalShortcutUpdater: QuickTerminalShortcutUpdater,
         quickTerminalEnabledUpdater: QuickTerminalEnabledUpdater,
         quickTerminalEnabledResetter: QuickTerminalEnabledResetter,
-        automaticUpdatesUpdater: AutomaticUpdatesUpdater
+        automaticUpdatesActions: AutomaticUpdatesActions
     ) throws {
         if let quickTerminalShortcut = dictionary["shortcuts.quickTerminal"] {
             _ = try applySpecialSetting(
@@ -241,7 +247,9 @@ enum SettingsJSONStore {
             quickTerminalEnabledResetter()
         }
         if let enabled = dictionary[UpdateService.automaticallyUpdatesKey] as? Bool {
-            automaticUpdatesUpdater(enabled)
+            automaticUpdatesActions.update(enabled)
+        } else if dictionary[UpdateService.automaticallyUpdatesKey] is NSNull {
+            automaticUpdatesActions.reset()
         }
         for (key, value) in dictionary where key != "shortcuts.quickTerminal"
             && key != QuickTerminalPreferences.enabledKey

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -6,6 +6,7 @@ struct GeneralSettingsView: View {
     @AppStorage(QuitConfirmationPreferences.confirmQuitKey)
     private var confirmQuit = true
     @State private var sentry = SentryService.shared
+    @State private var updateService = UpdateService.shared
 
     var body: some View {
         SettingsContainer {
@@ -25,6 +26,12 @@ struct GeneralSettingsView: View {
                     .labelsHidden()
                     .settingsControl()
                 }
+                SettingsToggleRow(
+                    label: L10n.resource("Install Downloaded Updates on Quit"),
+                    isOn: automaticUpdatesBinding
+                )
+                .disabled(!updateService.allowsAutomaticUpdates)
+                .help(L10n.string("Automatic updates are unavailable for this configuration."))
             }
 
             SettingsSection("Quit", showsDivider: sentry.hasDSN) {
@@ -66,6 +73,13 @@ struct GeneralSettingsView: View {
                 updateChannelRaw = newValue.rawValue
                 UpdateService.shared.channel = newValue
             }
+        )
+    }
+
+    private var automaticUpdatesBinding: Binding<Bool> {
+        Binding(
+            get: { updateService.automaticallyDownloadsUpdates },
+            set: { updateService.setAutomaticallyDownloadsUpdates($0) }
         )
     }
 }

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -321,6 +321,14 @@ enum SettingsCatalog {
             defaultValue: true
         ),
         SettingsCatalogItem(
+            key: UpdateService.automaticallyUpdatesKey,
+            title: "Install Downloaded Updates on Quit",
+            description: "Downloads updates in the background and installs them when Muxy quits.",
+            category: .general,
+            section: "Updates",
+            defaultValue: true
+        ),
+        SettingsCatalogItem(
             key: "muxy.sentry.consent",
             title: "Crash Reports",
             description: "Controls anonymous crash report consent when diagnostics are available.",

--- a/Tests/MuxyTests/Services/App/AppRelaunchTests.swift
+++ b/Tests/MuxyTests/Services/App/AppRelaunchTests.swift
@@ -57,6 +57,20 @@ struct AppRelaunchTests {
         #expect(!didPersist)
     }
 
+    @Test("termination persists user state only once")
+    func terminationPersistsUserStateOnlyOnce() {
+        let delegate = AppDelegate()
+        var persistCount = 0
+        delegate.onTerminate = {
+            persistCount += 1
+        }
+
+        delegate.persistUserStateForTermination()
+        delegate.persistUserStateForTermination()
+
+        #expect(persistCount == 1)
+    }
+
     @Test("dismisses attached sheets so termination is not blocked")
     func dismissesAttachedSheetsBeforeTermination() {
         let parent = NSWindow(

--- a/Tests/MuxyTests/Services/App/AppRelaunchTests.swift
+++ b/Tests/MuxyTests/Services/App/AppRelaunchTests.swift
@@ -71,6 +71,48 @@ struct AppRelaunchTests {
         #expect(persistCount == 1)
     }
 
+    @Test("termination persists user state before terminal cleanup")
+    func terminationPersistsUserStateBeforeTerminalCleanup() async {
+        let storedConfirmQuit = UserDefaults.standard.object(forKey: QuitConfirmationPreferences.confirmQuitKey)
+        defer {
+            if let storedConfirmQuit {
+                UserDefaults.standard.set(storedConfirmQuit, forKey: QuitConfirmationPreferences.confirmQuitKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: QuitConfirmationPreferences.confirmQuitKey)
+            }
+        }
+        QuitConfirmationPreferences.confirmQuit = false
+        let terminationCleanup = TerminalTerminationCleanup()
+        let (cleanupReleases, cleanupReleaseContinuation) = AsyncStream<Void>.makeStream()
+        var events: [String] = []
+        let delegate = AppDelegate(
+            terminalTerminationCleanup: terminationCleanup,
+            prepareTerminalsForTermination: {
+                events.append("cleanup")
+                for await _ in cleanupReleases {
+                    break
+                }
+            },
+            replyToApplicationShouldTerminate: { _ in }
+        )
+        delegate.onTerminate = {
+            events.append("persist")
+        }
+
+        let reply = delegate.applicationShouldTerminate(NSApplication.shared)
+        while events.count < 2 {
+            await Task.yield()
+        }
+
+        #expect(reply == .terminateLater)
+        #expect(events == ["persist", "cleanup"])
+        cleanupReleaseContinuation.yield()
+        cleanupReleaseContinuation.finish()
+        while !terminationCleanup.isComplete {
+            await Task.yield()
+        }
+    }
+
     @Test("dismisses attached sheets so termination is not blocked")
     func dismissesAttachedSheetsBeforeTermination() {
         let parent = NSWindow(

--- a/Tests/MuxyTests/Services/App/AppRelaunchTests.swift
+++ b/Tests/MuxyTests/Services/App/AppRelaunchTests.swift
@@ -100,17 +100,21 @@ struct AppRelaunchTests {
         }
 
         let reply = delegate.applicationShouldTerminate(NSApplication.shared)
-        while events.count < 2 {
+        let cleanupStartDeadline = Date().addingTimeInterval(2)
+        while events.count < 2, Date() < cleanupStartDeadline {
             await Task.yield()
         }
 
         #expect(reply == .terminateLater)
+        #expect(events.count == 2, "Terminal cleanup did not start before the deadline")
         #expect(events == ["persist", "cleanup"])
         cleanupReleaseContinuation.yield()
         cleanupReleaseContinuation.finish()
-        while !terminationCleanup.isComplete {
+        let cleanupCompletionDeadline = Date().addingTimeInterval(2)
+        while !terminationCleanup.isComplete, Date() < cleanupCompletionDeadline {
             await Task.yield()
         }
+        #expect(terminationCleanup.isComplete, "Terminal cleanup did not complete before the deadline")
     }
 
     @Test("dismisses attached sheets so termination is not blocked")

--- a/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
@@ -822,6 +822,25 @@ struct SettingsJSONStoreTests {
     }
 
     @Test
+    func saveAppliesAutomaticUpdatesThroughUpdater() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [UpdateService.automaticallyUpdatesKey])
+        defer { snapshot.restore() }
+        var receivedValue: Bool?
+        UserDefaults.standard.removeObject(forKey: UpdateService.automaticallyUpdatesKey)
+
+        try SettingsJSONStore.saveUserSettingsText(
+            "{\"\(UpdateService.automaticallyUpdatesKey)\":false}",
+            automaticUpdatesUpdater: {
+                receivedValue = $0
+                UserDefaults.standard.set($0, forKey: UpdateService.automaticallyUpdatesKey)
+            }
+        )
+
+        #expect(receivedValue == false)
+        #expect(UserDefaults.standard.bool(forKey: UpdateService.automaticallyUpdatesKey) == false)
+    }
+
+    @Test
     func systemSettingsIncludeAllBackedSettings() throws {
         let data = Data(SettingsJSONStore.systemSettingsText.utf8)
         let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])

--- a/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
@@ -841,6 +841,25 @@ struct SettingsJSONStoreTests {
     }
 
     @Test
+    func nullAutomaticUpdatesValueResetsToDefault() throws {
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [UpdateService.automaticallyUpdatesKey])
+        defer { snapshot.restore() }
+        var didReset = false
+        UserDefaults.standard.set(false, forKey: UpdateService.automaticallyUpdatesKey)
+
+        try SettingsJSONStore.saveUserSettingsText(
+            "{\"\(UpdateService.automaticallyUpdatesKey)\":null}",
+            automaticUpdatesResetter: {
+                didReset = true
+                UserDefaults.standard.removeObject(forKey: UpdateService.automaticallyUpdatesKey)
+            }
+        )
+
+        #expect(didReset)
+        #expect(UserDefaults.standard.object(forKey: UpdateService.automaticallyUpdatesKey) == nil)
+    }
+
+    @Test
     func systemSettingsIncludeAllBackedSettings() throws {
         let data = Data(SettingsJSONStore.systemSettingsText.utf8)
         let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -155,6 +155,7 @@ struct SettingsCatalogTests {
     func settingsUseWorkflowCategories() {
         #expect(SettingsCatalog.items.contains { $0.key == ProjectPickerPreferences.storageKey && $0.category == .projects })
         #expect(SettingsCatalog.items.contains { $0.key == GeneralSettingsKeys.autoCopyTerminalSelection && $0.category == .terminal })
+        #expect(SettingsCatalog.items.contains { $0.key == UpdateService.automaticallyUpdatesKey && $0.category == .general })
         #expect(SettingsCatalog.items.contains { $0.key == RecordingPreferences.languageKey && $0.category == .voice })
     }
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -13,6 +13,16 @@ until that provider becomes available again.
 Translation providers contain resource-only catalogs and cannot add executable code through the language feature.
 Extension authors can follow the [localization provider guide](../extensions/localizations.md).
 
+## Updates
+
+Muxy checks for updates automatically and downloads available releases in the background. Sparkle can offer
+**Install on Quit** for a downloaded release, applying it the next time Muxy quits without interrupting current work.
+Choose **Install and Relaunch** to apply the update immediately when that option is presented.
+
+Use **Install downloaded updates on quit** to control this behavior. Muxy saves workspace and draft state before the
+terminal shutdown cleanup begins, so a normal update-driven restart restores the last saved workspace.
+The same setting is available as `SUAutomaticallyUpdate` in `settings.json`.
+
 ## Worktree path templates
 
 Set the default under **Projects -> Worktrees** and choose **Template**. Every template must include `{branch}` and can


### PR DESCRIPTION
## Summary
- add a Sparkle-backed setting to download updates and install them when Muxy quits
- persist workspace and draft state before update-driven termination cleanup
- support the setting in settings.json and document its behavior

## Testing
- `scripts/checks.sh --fix` (formatting, linting, build, and 2,882 tests)
- `swift test --filter AppRelaunchTests` (6 tests)
- `swift test --filter SettingsJSONStoreTests` (44 tests)
- `swift test --filter SettingsCatalogTests` (19 tests)

## AI assistance
- OpenAI GPT-5.6-terra and GPT-5.6-sol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Install Downloaded Updates on Quit** to Settings.
  * Updates can download in the background and install when Muxy closes.
  * Automatic updates are enabled by default where supported.
  * The option is disabled when automatic updates aren’t available.
  * Automatic update preferences now sync when importing settings.
* **Bug Fixes**
  * User state is persisted reliably and only once during termination.
* **Documentation**
  * Updated the settings guide with the new update behavior and configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->