### PR TITLE
Fix clipped Home activity badge

### DIFF
--- a/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
@@ -75,6 +75,14 @@ enum SidebarLayout {
         }
         return collapsedStyle == .icons
     }
+
+    static func projectActivityIndicatorOffset(isUnread: Bool) -> CGFloat {
+        isUnread ? UIMetrics.spacing2 : UIMetrics.spacing1
+    }
+
+    static func projectListTopInset(isWide: Bool) -> CGFloat {
+        isWide ? 0 : projectActivityIndicatorOffset(isUnread: true)
+    }
 }
 
 struct ProjectFocusedSidebar: View {
@@ -445,6 +453,7 @@ struct ProjectFocusedSidebar: View {
 
                 addButton
             }
+            .padding(.top, SidebarLayout.projectListTopInset(isWide: isWide))
             .padding(.horizontal, isWide ? UIMetrics.spacing3 : UIMetrics.spacing4)
             .padding(.bottom, UIMetrics.spacing2)
             .onPreferenceChange(UUIDFramePreferenceKey<SidebarFrameTag>.self) { frames in

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
@@ -282,11 +282,9 @@ struct ProjectRow: View {
         .padding(UIMetrics.scaled(3))
         .overlay(alignment: .topTrailing) {
             if let projectActivity {
+                let offset = SidebarLayout.projectActivityIndicatorOffset(isUnread: projectActivity.isUnread)
                 TerminalActivityIndicator(activity: projectActivity)
-                    .offset(
-                        x: projectActivity.isUnread ? UIMetrics.spacing2 : UIMetrics.spacing1,
-                        y: projectActivity.isUnread ? -UIMetrics.spacing2 : -UIMetrics.spacing1
-                    )
+                    .offset(x: offset, y: -offset)
             }
         }
         .overlay {

--- a/Tests/MuxyTests/Views/Layouts/ProjectFocused/SidebarLayoutTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/ProjectFocused/SidebarLayoutTests.swift
@@ -50,6 +50,21 @@ struct SidebarLayoutTests {
         #expect(SidebarLayout.isWide(expanded: true, expandedStyle: .wide))
     }
 
+    @Test("collapsed project list reserves the maximum activity indicator offset")
+    func collapsedProjectListReservesActivityIndicatorOffset() {
+        let topInset = SidebarLayout.projectListTopInset(isWide: false)
+        let unreadOffset = SidebarLayout.projectActivityIndicatorOffset(isUnread: true)
+        let otherOffset = SidebarLayout.projectActivityIndicatorOffset(isUnread: false)
+
+        #expect(topInset == unreadOffset)
+        #expect(topInset >= otherOffset)
+    }
+
+    @Test("wide project list does not reserve collapsed activity indicator space")
+    func wideProjectListDoesNotReserveActivityIndicatorSpace() {
+        #expect(SidebarLayout.projectListTopInset(isWide: true) == 0)
+    }
+
     @Test("clampExpandedWidth clamps below the minimum")
     func clampExpandedBelowMin() {
         #expect(SidebarLayout.clampExpandedWidth(10) == SidebarLayout.minExpandedWidth)


### PR DESCRIPTION
## Summary

- reserve space above collapsed project rows for activity indicator overflow
- centralize project activity indicator geometry so the badge offset and scroll inset stay aligned
- add regression coverage for collapsed and wide sidebar layouts

## Testing

- `swift test --filter SidebarLayoutTests`
- `scripts/checks.sh --fix`

Closes #966

AI contribution: OpenAI GPT-5.6 Sol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project sidebar spacing when collapsed or expanded.
  * Aligned project activity indicators consistently for read and unread projects.

* **Tests**
  * Added coverage for collapsed sidebar insets and wide sidebar spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->