### PR TITLE
Prevent App Layout picker clipping

### DIFF
--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -98,14 +98,7 @@ struct InterfaceSettingsView: View {
 
             SettingsSection("Layout") {
                 SettingsRow("App Layout") {
-                    Picker("", selection: layoutSelection) {
-                        ForEach(AppLayout.allCases) { layout in
-                            Text(L10n.resource(key: layout.title)).tag(layout)
-                        }
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .settingsControl(.intrinsic)
+                    AppLayoutPicker(selection: layoutSelection)
                 }
             }
 
@@ -285,6 +278,21 @@ struct InterfaceSettingsView: View {
     private func refreshThemeNames() {
         currentLightTheme = themeService.currentLightThemeName()
         currentDarkTheme = themeService.currentDarkThemeName()
+    }
+}
+
+struct AppLayoutPicker: View {
+    @Binding var selection: AppLayout
+
+    var body: some View {
+        Picker("", selection: $selection) {
+            ForEach(AppLayout.allCases) { layout in
+                Text(L10n.resource(key: layout.title)).tag(layout)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .settingsControl(.intrinsic)
     }
 }
 

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -42,14 +42,14 @@ struct SettingsView: View {
                 )
                 Rectangle()
                     .fill(SettingsStyle.border)
-                    .frame(width: 1)
+                    .frame(width: SettingsMetrics.dividerThickness)
                 settingsContent
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .environment(\.settingsSearchQuery, searchText)
                     .environment(\.settingsCategory, selectedBuiltinCategory)
             }
         }
-        .frame(minWidth: 860, minHeight: 620)
+        .frame(minWidth: SettingsMetrics.minimumWindowWidth, minHeight: 620)
         .background(SettingsStyle.background)
         .foregroundStyle(SettingsStyle.foreground)
         .tint(SettingsStyle.accent)

--- a/Muxy/Views/Settings/Shared/SettingsComponents.swift
+++ b/Muxy/Views/Settings/Shared/SettingsComponents.swift
@@ -8,7 +8,10 @@ extension EnvironmentValues {
 }
 
 enum SettingsMetrics {
+    static let minimumWindowWidth: CGFloat = 860
     static let sidebarWidth: CGFloat = 210
+    static let dividerThickness: CGFloat = 1
+    static let minimumContentWidth = minimumWindowWidth - sidebarWidth - dividerThickness
     static let horizontalPadding: CGFloat = 12
     static let verticalPadding: CGFloat = 12
     static let rowVerticalPadding: CGFloat = 6
@@ -54,7 +57,7 @@ struct SettingsDivider: View {
     var body: some View {
         Rectangle()
             .fill(SettingsStyle.border)
-            .frame(height: 1)
+            .frame(height: SettingsMetrics.dividerThickness)
     }
 }
 

--- a/Tests/MuxyTests/Views/Settings/InterfaceSettingsViewTests.swift
+++ b/Tests/MuxyTests/Views/Settings/InterfaceSettingsViewTests.swift
@@ -1,0 +1,44 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("Interface settings view")
+struct InterfaceSettingsViewTests {
+    @Test("App Layout picker fits minimum settings content width")
+    func appLayoutPickerFitsMinimumSettingsContentWidth() throws {
+        let contentSize = NSSize(width: SettingsMetrics.minimumContentWidth, height: 40)
+        let hostingView = NSHostingView(
+            rootView: SettingsRow("App Layout") {
+                AppLayoutPicker(selection: .constant(.projectFocused))
+            }
+                .frame(width: contentSize.width, height: contentSize.height)
+        )
+        hostingView.frame = NSRect(origin: .zero, size: contentSize)
+        hostingView.layoutSubtreeIfNeeded()
+
+        let picker = try #require(appLayoutPicker(in: hostingView))
+        let pickerFrame = picker.convert(picker.bounds, to: hostingView)
+
+        #expect(pickerFrame.minX >= hostingView.bounds.minX)
+        #expect(pickerFrame.maxX <= hostingView.bounds.maxX)
+        #expect(picker.bounds.width >= picker.intrinsicContentSize.width)
+    }
+
+    private func appLayoutPicker(in view: NSView) -> NSSegmentedControl? {
+        if let control = view as? NSSegmentedControl,
+           control.segmentCount == AppLayout.allCases.count,
+           control.label(forSegment: control.segmentCount - 1) == L10n.string(key: AppLayout.agentsFocused.title)
+        {
+            return control
+        }
+        for subview in view.subviews {
+            if let control = appLayoutPicker(in: subview) {
+                return control
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

- isolate the intrinsically sized App Layout picker so its native control can be tested directly
- centralize minimum settings geometry shared by the production layout and regression test
- verify the segmented control stays within the minimum content width without truncating intrinsic content

## Testing

- `swift test --filter InterfaceSettingsViewTests`
- `scripts/checks.sh --fix` (formatting, linting, and build passed; the test phase hit a `ProjectPickerWorkflowTests` timing flake)
- `swift test --filter ProjectPickerWorkflowTests` (passed in isolation)

Closes #962

AI contribution: OpenAI GPT-5.6 Sol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an App Layout picker to Interface settings for selecting the preferred layout.
* **Improvements**
  * Standardized settings window sizing and divider spacing for a more consistent appearance.
  * Ensured the App Layout picker remains usable at the minimum settings window width.
* **Tests**
  * Added coverage to verify the layout picker fits correctly and preserves its intrinsic size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->