### PR TITLE
Add persistent background terminal sessions

### DIFF
--- a/Muxy/Models/Preferences/TerminalPersistentSessionPreferences.swift
+++ b/Muxy/Models/Preferences/TerminalPersistentSessionPreferences.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum TerminalPersistentSessionPreferences {
+    static let enabledKey = "muxy.terminalPersistentSession.enabled"
+
+    static let defaultIsEnabled = false
+
+    static var isEnabled: Bool {
+        get {
+            let defaults = UserDefaults.standard
+            guard defaults.object(forKey: enabledKey) != nil else { return defaultIsEnabled }
+            return defaults.bool(forKey: enabledKey)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: enabledKey) }
+    }
+}

--- a/Muxy/Models/Terminal/TerminalPaneState.swift
+++ b/Muxy/Models/Terminal/TerminalPaneState.swift
@@ -12,6 +12,7 @@ final class TerminalPaneState: Identifiable {
     nonisolated static let defaultTitle = "Terminal"
 
     let id: UUID
+    var sessionID: UUID
     let projectPath: String
     var title: String
     private(set) var usesDefaultTitle: Bool
@@ -26,6 +27,7 @@ final class TerminalPaneState: Identifiable {
 
     init(
         id: UUID = UUID(),
+        sessionID: UUID? = nil,
         projectPath: String,
         title: String? = nil,
         usesDefaultTitle: Bool? = nil,
@@ -36,6 +38,7 @@ final class TerminalPaneState: Identifiable {
         externalEditorFilePath: String? = nil
     ) {
         self.id = id
+        self.sessionID = sessionID ?? id
         self.projectPath = projectPath
         self.title = title ?? Self.defaultTitle
         self.usesDefaultTitle = usesDefaultTitle ?? (title == nil)

--- a/Muxy/Models/Terminal/TerminalTab.swift
+++ b/Muxy/Models/Terminal/TerminalTab.swift
@@ -142,6 +142,7 @@ final class TerminalTab: Identifiable {
             )
             content = .terminal(TerminalPaneState(
                 id: snapshot.paneID ?? UUID(),
+                sessionID: snapshot.paneSessionID,
                 projectPath: snapshot.projectPath,
                 title: snapshot.paneTitle,
                 usesDefaultTitle: snapshot.paneUsesDefaultTitle,
@@ -189,6 +190,7 @@ final class TerminalTab: Identifiable {
             paneTitle: extensionTabDefaultTitle ?? content.pane?.title,
             paneUsesDefaultTitle: content.pane?.usesDefaultTitle,
             paneID: content.pane?.id,
+            paneSessionID: content.pane?.sessionID,
             currentWorkingDirectory: content.pane?.currentWorkingDirectory,
             extensionID: content.extensionState?.extensionID,
             extensionTabTypeID: content.extensionState?.tabTypeID,

--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -40,6 +40,7 @@ final class AppState {
         case createExtensionTab(projectID: UUID, areaID: UUID?, request: CreateExtensionTabRequest)
         case createBrowserTab(projectID: UUID, areaID: UUID?, url: URL?, profileID: UUID)
         case createTabInWorktree(key: WorktreeKey, areaID: UUID?)
+        case createSessionTab(key: WorktreeKey, areaID: UUID?, sessionID: UUID, title: String?)
         case createBrowserTabInWorktree(key: WorktreeKey, areaID: UUID?, url: URL?, profileID: UUID)
         case createBrowserSplit(projectID: UUID, areaID: UUID, url: URL?, profileID: UUID)
         case createBrowserSplitInWorktree(key: WorktreeKey, areaID: UUID, url: URL?, profileID: UUID)
@@ -396,6 +397,21 @@ final class AppState {
 
     func hasTabs(for key: WorktreeKey) -> Bool {
         areas(for: key).contains { !$0.tabs.isEmpty }
+    }
+
+    var allTerminalPanes: [TerminalPaneState] {
+        workspaceRoots.values.flatMap { root in
+            root.allAreas().flatMap { area in
+                area.tabs.compactMap(\.content.pane)
+            }
+        }
+    }
+
+    func panes(inWorktree key: WorktreeKey) -> [TerminalPaneState] {
+        guard let root = workspaceRoots[key] else { return [] }
+        return root.allAreas().flatMap { area in
+            area.tabs.compactMap(\.content.pane)
+        }
     }
 
     func locatePane(paneID: UUID) -> (worktreeKey: WorktreeKey, pane: TerminalPaneState)? {

--- a/Muxy/Models/Workspace/Reducer/TabReducer.swift
+++ b/Muxy/Models/Workspace/Reducer/TabReducer.swift
@@ -23,6 +23,28 @@ enum TabReducer {
         return tabID
     }
 
+    static func createSessionTab(
+        key: WorktreeKey,
+        areaID: UUID?,
+        sessionID: UUID,
+        title: String?,
+        state: inout WorkspaceState
+    ) -> UUID? {
+        guard let area = WorkspaceReducerShared.resolveArea(key: key, areaID: areaID, state: state) else { return nil }
+        FocusReducer.focusArea(area.id, key: key, state: &state)
+        let alongsideTabID = area.activeTab.map { $0.parentTabID ?? $0.id }
+        let order = normalizedTopLevelOrder(key: key, state: state)
+        let tabID = area.createSessionTab(sessionID: sessionID, title: title)
+        state.topLevelTabOrder[key] = order + [tabID]
+        TopLevelTabReducer.registerTopLevelTab(
+            tabID,
+            alongside: alongsideTabID,
+            key: key,
+            state: &state
+        )
+        return tabID
+    }
+
     static func createTabAdjacent(
         projectID: UUID,
         areaID: UUID,

--- a/Muxy/Models/Workspace/TabArea.swift
+++ b/Muxy/Models/Workspace/TabArea.swift
@@ -77,6 +77,19 @@ final class TabArea: Identifiable {
     }
 
     @discardableResult
+    func createSessionTab(sessionID: UUID, title: String?) -> UUID {
+        let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pane = TerminalPaneState(
+            sessionID: sessionID,
+            projectPath: projectPath,
+            title: trimmedTitle?.isEmpty == false ? trimmedTitle : nil
+        )
+        let tab = TerminalTab(pane: pane)
+        insertTab(tab)
+        return tab.id
+    }
+
+    @discardableResult
     func createTab(inDirectory directory: String) -> UUID {
         let tab = TerminalTab(pane: TerminalPaneState(projectPath: directory))
         insertTab(tab)

--- a/Muxy/Models/Workspace/WorkspaceReducer.swift
+++ b/Muxy/Models/Workspace/WorkspaceReducer.swift
@@ -126,6 +126,16 @@ enum WorkspaceReducer {
             guard state.workspaceRoots[key] != nil else { break }
             effects.createdTabID = TabReducer.createTab(key: key, areaID: areaID, state: &state)
 
+        case let .createSessionTab(key, areaID, sessionID, title):
+            guard state.workspaceRoots[key] != nil else { break }
+            effects.createdTabID = TabReducer.createSessionTab(
+                key: key,
+                areaID: areaID,
+                sessionID: sessionID,
+                title: title,
+                state: &state
+            )
+
         case let .createBrowserTabInWorktree(key, areaID, url, profileID):
             guard state.workspaceRoots[key] != nil else { break }
             effects.createdTabID = TabReducer.createBrowserTab(
@@ -345,7 +355,8 @@ enum WorkspaceReducer {
             }
             return [key]
 
-        case let .createTabInWorktree(key, _),
+        case let .createSessionTab(key, _, _, _),
+             let .createTabInWorktree(key, _),
              let .createBrowserTabInWorktree(key, _, _, _),
              let .createBrowserSplitInWorktree(key, _, _, _),
              let .closeTabInWorktree(key, _, _),

--- a/Muxy/Models/Workspace/WorkspaceSnapshot.swift
+++ b/Muxy/Models/Workspace/WorkspaceSnapshot.swift
@@ -169,6 +169,7 @@ struct TerminalTabSnapshot: Codable {
     let paneTitle: String
     let paneUsesDefaultTitle: Bool
     let paneID: UUID?
+    let paneSessionID: UUID?
     let filePath: String?
     let currentWorkingDirectory: String?
     let extensionID: String?
@@ -189,6 +190,7 @@ struct TerminalTabSnapshot: Codable {
         paneTitle: String?,
         paneUsesDefaultTitle: Bool? = nil,
         paneID: UUID? = nil,
+        paneSessionID: UUID? = nil,
         filePath: String? = nil,
         currentWorkingDirectory: String? = nil,
         extensionID: String? = nil,
@@ -208,6 +210,7 @@ struct TerminalTabSnapshot: Codable {
         self.paneTitle = paneTitle ?? TerminalPaneState.defaultTitle
         self.paneUsesDefaultTitle = paneUsesDefaultTitle ?? (paneTitle == nil)
         self.paneID = paneID
+        self.paneSessionID = paneSessionID
         self.filePath = filePath
         self.currentWorkingDirectory = currentWorkingDirectory
         self.extensionID = extensionID
@@ -229,6 +232,7 @@ struct TerminalTabSnapshot: Codable {
         case paneTitle
         case paneUsesDefaultTitle
         case paneID
+        case paneSessionID
         case filePath
         case currentWorkingDirectory
         case extensionID
@@ -252,6 +256,7 @@ struct TerminalTabSnapshot: Codable {
         paneTitle = try container.decodeIfPresent(String.self, forKey: .paneTitle) ?? TerminalPaneState.defaultTitle
         paneUsesDefaultTitle = try container.decodeIfPresent(Bool.self, forKey: .paneUsesDefaultTitle) ?? false
         paneID = try container.decodeIfPresent(UUID.self, forKey: .paneID)
+        paneSessionID = try container.decodeIfPresent(UUID.self, forKey: .paneSessionID)
         filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
         currentWorkingDirectory = try container.decodeIfPresent(String.self, forKey: .currentWorkingDirectory)
         extensionID = try container.decodeIfPresent(String.self, forKey: .extensionID)

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -87,6 +87,7 @@ struct MuxyApp: App {
                         NotificationStore.shared.appState = appState
                         NotificationStore.shared.worktreeStore = worktreeStore
                         NotificationStore.shared.markAllAsRead()
+                        PersistentSessionRecovery.shared.recoverRestoredPanes(appState: appState)
                         DesktopNotificationService.shared.start(appState: appState)
                         MemoryDiagnostics.shared.configure(appState: appState)
                         TerminalProgressStore.shared.appState = appState

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -98,13 +98,17 @@
 "Approved Devices" = "Approved Devices";
 "Are you sure you want to quit Muxy?" = "Are you sure you want to quit Muxy?";
 "Attach File" = "Attach File";
+"Active tab" = "Active tab";
 "Auto" = "Auto";
+"Detached background terminals" = "Detached background terminals";
+"Detached terminals" = "Detached terminals";
 "Auto-copy selected text" = "Auto-copy selected text";
 "Auto-expand worktrees on project switch" = "Auto-expand worktrees on project switch";
 "Autocomplete" = "Autocomplete";
 "Back" = "Back";
 "Back (%@)" = "Back (%@)";
 "Back to Extensions" = "Back to Extensions";
+"Background sessions" = "Background sessions";
 "Background vibrancy" = "Background vibrancy";
 "Backup" = "Backup";
 "Base" = "Base";
@@ -321,6 +325,7 @@
 "Environment" = "Environment";
 "Expand Worktrees" = "Expand Worktrees";
 "Expanded Style" = "Expanded Style";
+"Every background terminal in this worktree is open in a tab." = "Every background terminal in this worktree is open in a tab.";
 "Export" = "Export";
 "Export Diagnostics..." = "Export Diagnostics...";
 "Export Muxy" = "Export Muxy";
@@ -499,6 +504,7 @@
 "New Terminal Tab" = "New Terminal Tab";
 "New Workspace" = "New Workspace";
 "New Worktree" = "New Worktree";
+"New tab" = "New tab";
 "New Worktree…" = "New Worktree…";
 "New branch" = "New branch";
 "New browser tabs open to a blank page. Turn on the toggle to open them to a website instead." = "New browser tabs open to a blank page. Turn on the toggle to open them to a website instead.";
@@ -708,7 +714,11 @@
 "Revoke Selected (%lld)" = "Revoke Selected (%lld)";
 "Revoking removes the device's access. It will need to request approval again to reconnect." = "Revoking removes the device's access. It will need to request approval again to reconnect.";
 "Right" = "Right";
+"Run New Terminals in the Background" = "Run New Terminals in the Background";
+"Run new terminals in the background" = "Run new terminals in the background";
 "Run these commands after creating the worktree" = "Run these commands after creating the worktree";
+"Runs each new terminal in a separate background process, the way tmux does. Quitting Muxy leaves those terminals running and reopening reconnects them with their recent output. Closing a tab still ends its session. Terminals that are already open keep their current behaviour." = "Runs each new terminal in a separate background process, the way tmux does. Quitting Muxy leaves those terminals running and reopening reconnects them with their recent output. Closing a tab still ends its session. Terminals that are already open keep their current behaviour.";
+"Runs new terminals in a background process so they survive quitting Muxy." = "Runs new terminals in a background process so they survive quitting Muxy.";
 "Runtime Error" = "Runtime Error";
 "SSH Host" = "SSH Host";
 "Save" = "Save";
@@ -1037,7 +1047,9 @@
 "Tab Types" = "Tab Types";
 "letters, digits, dash, underscore, dot" = "letters, digits, dash, underscore, dot";
 "Status bar" = "Status bar";
+"Stop background terminals?" = "Stop background terminals?";
 "Stop loading this dev extension. Your folder is left untouched." = "Stop loading this dev extension. Your folder is left untouched.";
+"Terminals are still running in the background. Turning this off stops them and ends whatever they are running." = "Terminals are still running in the background. Turning this off stops them and ends whatever they are running.";
 "Submarine" = "Submarine";
 "Switch Worktree…" = "Switch Worktree…";
 "Switch to a branch before committing and pushing." = "Switch to a branch before committing and pushing.";

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -10,8 +10,6 @@
 #   muxy close-pane --pane <id>                Close a pane
 #   muxy rename-pane --pane <id> <title>       Rename a pane tab
 #   muxy list-panes                            List all panes (tab-separated)
-#   muxy list-sessions                         List background terminal sessions (tab-separated)
-#   muxy kill-session --session <id>           Stop a background terminal session
 #   muxy list-projects                         List projects
 #   muxy switch-project <name|id|path>         Switch active project
 #   muxy list-worktrees [project]              List worktrees

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -10,6 +10,8 @@
 #   muxy close-pane --pane <id>                Close a pane
 #   muxy rename-pane --pane <id> <title>       Rename a pane tab
 #   muxy list-panes                            List all panes (tab-separated)
+#   muxy list-sessions                         List background terminal sessions (tab-separated)
+#   muxy kill-session --session <id>           Stop a background terminal session
 #   muxy list-projects                         List projects
 #   muxy switch-project <name|id|path>         Switch active project
 #   muxy list-worktrees [project]              List worktrees
@@ -58,6 +60,8 @@ usage_for() {
         close-pane)        echo "muxy close-pane --pane <id>" ;;
         rename-pane)       echo "muxy rename-pane --pane <id> <title>" ;;
         list-panes)        echo "muxy list-panes" ;;
+        list-sessions)     echo "muxy list-sessions" ;;
+        kill-session)      echo "muxy kill-session --session <id>" ;;
         list-projects)     echo "muxy list-projects" ;;
         switch-project)    echo "muxy switch-project <name|id|path>" ;;
         list-worktrees)    echo "muxy list-worktrees [project]" ;;
@@ -108,6 +112,8 @@ usage() {
     echo "  muxy close-pane --pane <id>              Close a pane"
     echo "  muxy rename-pane --pane <id> <title>     Rename a pane tab"
     echo "  muxy list-panes                          List all panes"
+    echo "  muxy list-sessions                       List background terminal sessions"
+    echo "  muxy kill-session --session <id>         Stop a background terminal session"
     echo "  muxy list-projects                       List projects"
     echo "  muxy switch-project <name|id|path>       Switch active project"
     echo "  muxy list-worktrees [project]            List worktrees"
@@ -441,6 +447,25 @@ case "$COMMAND" in
     list-panes)
         wants_help "$2" && print_command_help list-panes
         send_command "list-panes"
+        ;;
+    list-sessions)
+        wants_help "$2" && print_command_help list-sessions
+        send_command "list-sessions"
+        ;;
+    kill-session)
+        shift
+        SESSION_ID=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                -h|--help) print_command_help kill-session ;;
+                --session) SESSION_ID="$2"; shift 2 ;;
+                *) SESSION_ID="$1"; shift ;;
+            esac
+        done
+        if [ -z "$SESSION_ID" ]; then
+            die_usage kill-session
+        fi
+        send_command "kill-session|$SESSION_ID"
         ;;
     list-projects)
         wants_help "$2" && print_command_help list-projects
@@ -1006,6 +1031,7 @@ esac
 if [ -n "$COMMAND" ] && [ "$COMMAND" != "split-right" ] && [ "$COMMAND" != "split-down" ] && \
    [ "$COMMAND" != "send" ] && [ "$COMMAND" != "send-keys" ] && [ "$COMMAND" != "read-screen" ] && \
    [ "$COMMAND" != "close-pane" ] && [ "$COMMAND" != "rename-pane" ] && [ "$COMMAND" != "list-panes" ] && \
+   [ "$COMMAND" != "list-sessions" ] && [ "$COMMAND" != "kill-session" ] && \
    [ "$COMMAND" != "list-projects" ] && [ "$COMMAND" != "switch-project" ] && \
     [ "$COMMAND" != "list-worktrees" ] && [ "$COMMAND" != "create-worktree" ] && \
     [ "$COMMAND" != "switch-worktree" ] && \

--- a/Muxy/Resources/skills/muxy-cli/SKILL.md
+++ b/Muxy/Resources/skills/muxy-cli/SKILL.md
@@ -54,6 +54,7 @@ For the other surfaces, list and parse the **tab-separated** output (the first c
 | `muxy list-worktrees [project]` | `<worktree-id>  <name>  <path>  <branch>  <active>` |
 | `muxy list-workspaces` | `<workspace-id>  <name>  <project-count>  <active>` |
 | `muxy list-tabs` | `<index>  <tab-id>  <kind>  <title>  <active>` |
+| `muxy list-sessions` | `<session-id>  <shell-pid>  <cwd>  <attached>  <title>  <project-id>  <worktree-id>  <tab-id>` |
 
 ```bash
 PANE=$(muxy list-panes | awk -F'\t' '$2=="Tests"{print $1; exit}')
@@ -83,6 +84,16 @@ muxy read-screen --pane "$WEB" --lines 20
 ```
 
 If you need more history than is on screen, that is a sign the work should write to a file you can read directly, not be scraped from a terminal.
+
+## Background sessions
+
+If the user has **Settings → Terminal → Background sessions** on, terminals keep running after Muxy quits. `muxy list-sessions` shows them, along with the tab, project, and worktree each one belongs to, and `muxy kill-session --session <id>` stops one plus everything running inside it:
+
+```bash
+muxy kill-session --session "$SESSION"
+```
+
+Take the ID from the first column: it matches the pane ID only until a tab adopts another session. Closing a session's tab already ends it, so reach for `kill-session` only for a session that outlived its tab. Never kill a session you did not create — it is someone's running work, and it is gone for good.
 
 ## Worktrees and projects
 

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MuxySessionProtocol
 import MuxyShared
 import WebKit
 
@@ -396,6 +397,8 @@ enum MuxyAPI {
             "close-pane": "panes.close",
             "rename-pane": "panes.rename",
             "list-panes": "panes.list",
+            "list-sessions": "sessions.list",
+            "kill-session": "sessions.kill",
             "list-projects": "projects.list",
             "switch-project": "projects.switch",
             "list-worktrees": "worktrees.list",
@@ -433,6 +436,8 @@ enum MuxyAPI {
             "panes.readScreen": .panesRead,
             "panes.close": .panesWrite,
             "panes.rename": .panesWrite,
+            "sessions.list": .panesRead,
+            "sessions.kill": .panesWrite,
             "tabs.list": .tabsRead,
             "tabs.switch": .tabsWrite,
             "tabs.new": .tabsWrite,
@@ -1418,6 +1423,47 @@ enum MuxyAPI {
                     status: entry.status
                 )
             }
+        }
+    }
+
+    @MainActor
+    enum Sessions {
+        struct Info: Equatable, Sendable {
+            let sessionID: String
+            let shellProcessID: Int32
+            let workingDirectory: String
+            let isAttached: Bool
+            let title: String
+            let projectID: String
+            let worktreeID: String
+            let tabID: String
+        }
+
+        static func list() async -> [Info] {
+            await PersistentSessionService.shared.liveSessions().map(Self.info(from:))
+        }
+
+        static func info(from descriptor: SessionDescriptor) -> Info {
+            Info(
+                sessionID: descriptor.identifier.uuidString,
+                shellProcessID: descriptor.shellProcessID,
+                workingDirectory: descriptor.workingDirectory,
+                isAttached: descriptor.isAttached,
+                title: descriptor.value(forMetadataKey: SessionMetadataKey.title) ?? "",
+                projectID: descriptor.value(forMetadataKey: SessionMetadataKey.project) ?? "",
+                worktreeID: descriptor.value(forMetadataKey: SessionMetadataKey.worktree) ?? "",
+                tabID: descriptor.value(forMetadataKey: SessionMetadataKey.tab) ?? ""
+            )
+        }
+
+        static func kill(sessionIDString: String) async -> Result<Void, APIError> {
+            guard let sessionID = UUID(uuidString: sessionIDString) else { return .failure(.invalidPaneID) }
+            let sessions = await list()
+            guard sessions.contains(where: { $0.sessionID.caseInsensitiveCompare(sessionIDString) == .orderedSame }) else {
+                return .failure(.paneNotFound(sessionIDString))
+            }
+            PersistentSessionService.shared.endSession(sessionID: sessionID)
+            return .success(())
         }
     }
 

--- a/Muxy/Services/Socket/SocketCommandHandler.swift
+++ b/Muxy/Services/Socket/SocketCommandHandler.swift
@@ -90,6 +90,23 @@ enum SocketCommandHandler {
             return panes.map { pane in
                 "\(pane.id.uuidString)\t\(pane.title)\t\(pane.workingDirectory)\t\(pane.isFocused)"
             }.joined(separator: "\n")
+        case "list-sessions":
+            let sessions = await MuxyAPI.Sessions.list()
+            return sessions.map { session in
+                [
+                    session.sessionID,
+                    String(session.shellProcessID),
+                    session.workingDirectory,
+                    String(session.isAttached),
+                    session.title,
+                    session.projectID,
+                    session.worktreeID,
+                    session.tabID,
+                ].joined(separator: "\t")
+            }.joined(separator: "\n")
+        case "kill-session":
+            guard parts.count >= 2 else { return "error:usage kill-session|sessionID" }
+            return await serialize(MuxyAPI.Sessions.kill(sessionIDString: parts[1]), ok: "ok")
         case "list-projects":
             guard let projectStore else { return "error:project store unavailable" }
             let projects = MuxyAPI.Projects.list(appState: appState, projectStore: projectStore)

--- a/Muxy/Services/Terminal/PersistentSessionControlClient.swift
+++ b/Muxy/Services/Terminal/PersistentSessionControlClient.swift
@@ -1,0 +1,147 @@
+import Darwin
+import Foundation
+import MuxySessionProtocol
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "PersistentSession")
+
+struct PersistentSessionControlClient: Sendable {
+    static let defaultTimeout: TimeInterval = 2
+
+    let socketPath: String
+
+    func list(timeout: TimeInterval = defaultTimeout) -> [SessionDescriptor] {
+        descriptors(for: SessionFrame(kind: .list), timeout: timeout)
+    }
+
+    func info(identifier: SessionIdentifier, timeout: TimeInterval = defaultTimeout) -> SessionDescriptor? {
+        descriptors(
+            for: SessionFrame(kind: .info, payload: SessionIdentifierPayload.encode(identifier)),
+            timeout: timeout
+        ).first
+    }
+
+    @discardableResult
+    func kill(identifier: SessionIdentifier, timeout: TimeInterval = defaultTimeout) -> Bool {
+        exchange(
+            SessionFrame(kind: .kill, payload: SessionIdentifierPayload.encode(identifier)),
+            expecting: .acknowledged,
+            timeout: timeout
+        ) != nil
+    }
+
+    @discardableResult
+    func killAll(timeout: TimeInterval = defaultTimeout) -> Bool {
+        exchange(SessionFrame(kind: .killAll), expecting: .acknowledged, timeout: timeout) != nil
+    }
+
+    private func descriptors(for frame: SessionFrame, timeout: TimeInterval) -> [SessionDescriptor] {
+        guard let response = exchange(frame, expecting: .sessions, timeout: timeout) else { return [] }
+        do {
+            return try SessionDescriptor.decodeList(response.payload)
+        } catch {
+            logger.error("failed to decode the session list: \(String(describing: error))")
+            return []
+        }
+    }
+
+    private func exchange(
+        _ frame: SessionFrame,
+        expecting kind: SessionFrameKind,
+        timeout: TimeInterval
+    ) -> SessionFrame? {
+        guard let descriptor = PersistentSessionSocket.connect(path: socketPath) else { return nil }
+        defer { close(descriptor) }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        guard PersistentSessionSocket.write(descriptor, bytes: frame.encoded(), deadline: deadline) else { return nil }
+
+        var decoder = SessionFrameDecoder()
+        while Date() < deadline {
+            guard let bytes = PersistentSessionSocket.read(descriptor, deadline: deadline) else { return nil }
+            decoder.push(bytes)
+            while true {
+                let next: SessionFrame?
+                do {
+                    next = try decoder.next()
+                } catch {
+                    logger.error("session daemon sent a malformed frame")
+                    return nil
+                }
+                guard let next else { break }
+                if next.kind == kind {
+                    return next
+                }
+            }
+        }
+        return nil
+    }
+}
+
+enum PersistentSessionSocket {
+    static func connect(path: String) -> Int32? {
+        guard PersistentSessionPaths.fits(path) else { return nil }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        let bytes = Array(path.utf8)
+        guard bytes.count < capacity else { return nil }
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+                for (index, byte) in bytes.enumerated() {
+                    destination[index] = CChar(bitPattern: byte)
+                }
+                destination[bytes.count] = 0
+            }
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return nil }
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { casted in
+                Darwin.connect(descriptor, casted, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+
+    static func write(_ descriptor: Int32, bytes: [UInt8], deadline: Date) -> Bool {
+        var offset = 0
+        while offset < bytes.count {
+            guard wait(descriptor, for: Int16(POLLOUT), deadline: deadline) else { return false }
+            let written = bytes.withUnsafeBytes { pointer -> Int in
+                guard let base = pointer.baseAddress else { return -1 }
+                return Darwin.write(descriptor, base.advanced(by: offset), bytes.count - offset)
+            }
+            if written > 0 {
+                offset += written
+                continue
+            }
+            guard written < 0, errno == EINTR || errno == EAGAIN else { return false }
+        }
+        return true
+    }
+
+    static func read(_ descriptor: Int32, deadline: Date) -> [UInt8]? {
+        guard wait(descriptor, for: Int16(POLLIN), deadline: deadline) else { return nil }
+        let capacity = 64 * 1024
+        var buffer = [UInt8](repeating: 0, count: capacity)
+        let received = buffer.withUnsafeMutableBytes { pointer in
+            Darwin.read(descriptor, pointer.baseAddress, capacity)
+        }
+        guard received > 0 else { return nil }
+        return Array(buffer[0 ..< received])
+    }
+
+    private static func wait(_ descriptor: Int32, for events: Int16, deadline: Date) -> Bool {
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { return false }
+        var descriptors = [pollfd(fd: descriptor, events: events, revents: 0)]
+        return poll(&descriptors, 1, Int32(remaining * 1000)) > 0
+    }
+}

--- a/Muxy/Services/Terminal/PersistentSessionPaths.swift
+++ b/Muxy/Services/Terminal/PersistentSessionPaths.swift
@@ -1,0 +1,87 @@
+import Darwin
+import Foundation
+
+enum PersistentSessionPathError: Error, Equatable {
+    case pathTooLong
+    case insecureFallbackDirectory
+    case directoryUnavailable
+}
+
+enum PersistentSessionPaths {
+    static let sunPathCapacity = 104
+    static let directoryName = "sessions"
+    static let socketFileName = "control.sock"
+    static let binaryName = "muxy-session"
+
+    static func fits(_ path: String) -> Bool {
+        path.utf8.count < sunPathCapacity
+    }
+
+    static func preferredSocketPath(appSupportDirectory: URL) -> String {
+        appSupportDirectory
+            .appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent(socketFileName)
+            .path
+    }
+
+    static func fallbackSocketPath(userID: uid_t, root: String = "/tmp") -> String {
+        "\(root)/muxy-\(userID)/\(socketFileName)"
+    }
+
+    static func resolveSocketPath(
+        appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory(),
+        userID: uid_t = getuid(),
+        fallbackRoot: String = "/tmp",
+        fileManager: FileManager = .default
+    ) throws -> String {
+        let preferred = preferredSocketPath(appSupportDirectory: appSupportDirectory)
+        if fits(preferred) {
+            try prepareDirectory(at: URL(fileURLWithPath: preferred).deletingLastPathComponent(), fileManager: fileManager)
+            return preferred
+        }
+
+        let fallback = fallbackSocketPath(userID: userID, root: fallbackRoot)
+        guard fits(fallback) else { throw PersistentSessionPathError.pathTooLong }
+        let directory = URL(fileURLWithPath: fallback).deletingLastPathComponent()
+        try prepareDirectory(at: directory, fileManager: fileManager)
+        try secureFallbackDirectory(at: directory, userID: userID, fileManager: fileManager)
+        return fallback
+    }
+
+    static func binaryURL(executableURL: URL? = Bundle.main.executableURL, fileManager: FileManager = .default) -> URL? {
+        guard let executableURL else { return nil }
+        let sibling = executableURL.deletingLastPathComponent().appendingPathComponent(binaryName)
+        guard fileManager.isExecutableFile(atPath: sibling.path) else { return nil }
+        return sibling
+    }
+
+    private static func prepareDirectory(at url: URL, fileManager: FileManager) throws {
+        do {
+            try fileManager.createDirectory(
+                at: url,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: FilePermissions.privateDirectory]
+            )
+        } catch {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+                throw PersistentSessionPathError.directoryUnavailable
+            }
+        }
+    }
+
+    private static func secureFallbackDirectory(at url: URL, userID: uid_t, fileManager: FileManager) throws {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard let owner = attributes[.ownerAccountID] as? NSNumber, uid_t(owner.uint32Value) == userID else {
+            throw PersistentSessionPathError.insecureFallbackDirectory
+        }
+        guard let permissions = attributes[.posixPermissions] as? NSNumber else {
+            throw PersistentSessionPathError.insecureFallbackDirectory
+        }
+        guard permissions.int16Value & 0o077 != 0 else { return }
+        try fileManager.setAttributes(
+            [.posixPermissions: FilePermissions.privateDirectory],
+            ofItemAtPath: url.path
+        )
+    }
+}

--- a/Muxy/Services/Terminal/PersistentSessionRecovery.swift
+++ b/Muxy/Services/Terminal/PersistentSessionRecovery.swift
@@ -1,0 +1,38 @@
+import Foundation
+import MuxySessionProtocol
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "PersistentSession")
+
+@MainActor
+final class PersistentSessionRecovery {
+    static let shared = PersistentSessionRecovery()
+
+    private var hasRecovered = false
+
+    private init() {}
+
+    func recoverRestoredPanes(appState: AppState) {
+        guard !hasRecovered, TerminalPersistentSessionPreferences.isEnabled else { return }
+        hasRecovered = true
+        Task { @MainActor [weak self] in
+            let sessions = await PersistentSessionService.shared.liveSessions()
+            guard self != nil, !sessions.isEmpty else { return }
+            let recovered = Self.reattach(sessions: sessions, appState: appState)
+            guard recovered > 0 else { return }
+            logger.info("reattached \(recovered) background terminal session(s)")
+        }
+    }
+
+    @discardableResult
+    static func reattach(sessions: [SessionDescriptor], appState: AppState) -> Int {
+        let liveSessionIDs = Set(sessions.compactMap { UUID(uuidString: $0.identifier.uuidString) })
+        var recovered = 0
+        for pane in appState.allTerminalPanes where liveSessionIDs.contains(pane.sessionID) {
+            guard TerminalViewRegistry.shared.existingView(for: pane.id) == nil else { continue }
+            guard TerminalSurfaceMaterializer.materialize(paneID: pane.id, appState: appState) != nil else { continue }
+            recovered += 1
+        }
+        return recovered
+    }
+}

--- a/Muxy/Services/Terminal/PersistentSessionService.swift
+++ b/Muxy/Services/Terminal/PersistentSessionService.swift
@@ -1,0 +1,168 @@
+import Foundation
+import MuxySessionProtocol
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "PersistentSession")
+
+@MainActor
+final class PersistentSessionService {
+    static let shared = PersistentSessionService()
+
+    static let defaultShellIntegrationFeatures = "cursor,title"
+
+    private static let metadataVariables: [String: String] = [
+        SessionMetadataKey.project: "MUXY_SESSION_PROJECT",
+        SessionMetadataKey.worktree: "MUXY_SESSION_WORKTREE",
+        SessionMetadataKey.tab: "MUXY_SESSION_TAB",
+        SessionMetadataKey.title: "MUXY_SESSION_TITLE",
+    ]
+
+    private var resolvedSocketPath: String?
+    private var descriptors: [UUID: SessionDescriptor] = [:]
+    private var refreshingSessionIDs: Set<UUID> = []
+
+    private init() {}
+
+    var socketPath: String? {
+        if let resolvedSocketPath {
+            return resolvedSocketPath
+        }
+        do {
+            let path = try PersistentSessionPaths.resolveSocketPath()
+            resolvedSocketPath = path
+            return path
+        } catch {
+            logger.error("unable to resolve the session socket path: \(String(describing: error))")
+            return nil
+        }
+    }
+
+    var existingSocketPath: String? {
+        let candidates = [
+            PersistentSessionPaths.preferredSocketPath(
+                appSupportDirectory: MuxyFileStorage.appSupportDirectory(create: false)
+            ),
+            PersistentSessionPaths.fallbackSocketPath(userID: getuid()),
+        ]
+        return candidates.first { FileManager.default.fileExists(atPath: $0) }
+    }
+
+    var binaryPath: String? {
+        PersistentSessionPaths.binaryURL()?.path
+    }
+
+    var isAvailable: Bool {
+        socketPath != nil && binaryPath != nil
+    }
+
+    nonisolated static func sessionIdentifier(_ sessionID: UUID) -> SessionIdentifier? {
+        SessionIdentifier(uuidString: sessionID.uuidString)
+    }
+
+    func attachCommand() -> String? {
+        guard let binaryPath else { return nil }
+        return ShellEscaper.escape(binaryPath) + " attach"
+    }
+
+    func launchEnvironment(
+        sessionID: UUID,
+        workingDirectory: String,
+        command: String?,
+        metadata: [(key: String, value: String)] = [],
+        shell: String = UserShell.path(),
+        resourcesDirectory: String? = GhosttyService.bundledResourcesPath()
+    ) -> [(key: String, value: String)] {
+        guard let socketPath, let binaryPath else { return [] }
+        var entries: [(key: String, value: String)] = [
+            (key: "MUXY_SESSION_ID", value: sessionID.uuidString),
+            (key: "MUXY_SESSION_SOCKET", value: socketPath),
+            (key: "MUXY_SESSION_BINARY", value: binaryPath),
+            (key: "MUXY_SESSION_SHELL", value: shell),
+            (key: "MUXY_SESSION_CWD", value: workingDirectory),
+            (key: "MUXY_SESSION_COMMAND", value: command ?? ""),
+            (key: "GHOSTTY_SHELL_FEATURES", value: shellIntegrationFeatures()),
+        ]
+        if let resourcesDirectory {
+            entries.append((key: "MUXY_SESSION_RESOURCES", value: resourcesDirectory))
+        }
+        for entry in metadata {
+            guard let variable = Self.metadataVariables[entry.key], !entry.value.isEmpty else { continue }
+            entries.append((key: variable, value: entry.value))
+        }
+        return entries
+    }
+
+    private func shellIntegrationFeatures() -> String {
+        let configured = MuxyConfig.shared.configValue(for: "shell-integration-features")
+        guard let configured, !configured.isEmpty else { return Self.defaultShellIntegrationFeatures }
+        return configured
+    }
+
+    func noteSurfaceMaterialized(sessionID: UUID) {
+        refreshDescriptor(sessionID: sessionID)
+    }
+
+    func foregroundProcessID(sessionID: UUID) -> Int32? {
+        guard let descriptor = descriptors[sessionID] else {
+            refreshDescriptor(sessionID: sessionID)
+            return nil
+        }
+        guard let processID = TerminalTTYForegroundProcess.processID(ttyDevice: descriptor.ttyDevice) else {
+            descriptors.removeValue(forKey: sessionID)
+            return nil
+        }
+        return processID
+    }
+
+    func isRunningCommand(sessionID: UUID) -> Bool {
+        guard let descriptor = descriptors[sessionID] else { return false }
+        return TerminalTTYForegroundProcess.isRunningCommand(
+            foregroundProcessID: TerminalTTYForegroundProcess.processID(ttyDevice: descriptor.ttyDevice),
+            shellProcessID: descriptor.shellProcessID
+        )
+    }
+
+    func endSession(sessionID: UUID) {
+        descriptors.removeValue(forKey: sessionID)
+        guard let socketPath = existingSocketPath, let identifier = Self.sessionIdentifier(sessionID) else { return }
+        let client = PersistentSessionControlClient(socketPath: socketPath)
+        Task.detached(priority: .utility) {
+            client.kill(identifier: identifier)
+        }
+    }
+
+    func endAllSessions() async {
+        descriptors.removeAll()
+        guard let socketPath = existingSocketPath else { return }
+        let client = PersistentSessionControlClient(socketPath: socketPath)
+        _ = await Task.detached(priority: .utility) {
+            client.killAll()
+        }.value
+    }
+
+    func liveSessions() async -> [SessionDescriptor] {
+        guard let socketPath = existingSocketPath else { return [] }
+        let client = PersistentSessionControlClient(socketPath: socketPath)
+        return await Task.detached(priority: .utility) {
+            client.list()
+        }.value
+    }
+
+    private func refreshDescriptor(sessionID: UUID) {
+        guard let socketPath = existingSocketPath,
+              let identifier = Self.sessionIdentifier(sessionID),
+              !refreshingSessionIDs.contains(sessionID)
+        else { return }
+        refreshingSessionIDs.insert(sessionID)
+        let client = PersistentSessionControlClient(socketPath: socketPath)
+        Task { [weak self] in
+            let descriptor = await Task.detached(priority: .utility) {
+                client.info(identifier: identifier)
+            }.value
+            guard let self else { return }
+            refreshingSessionIDs.remove(sessionID)
+            guard let descriptor else { return }
+            descriptors[sessionID] = descriptor
+        }
+    }
+}

--- a/Muxy/Services/Terminal/TerminalBackend.swift
+++ b/Muxy/Services/Terminal/TerminalBackend.swift
@@ -38,7 +38,8 @@ enum TerminalBackend: String, CaseIterable, Identifiable, Sendable {
                 command: launch.command,
                 commandInteractive: launch.commandInteractive,
                 closesOnCommandExit: launch.closesOnCommandExit,
-                workspaceContext: launch.workspaceContext
+                workspaceContext: launch.workspaceContext,
+                persistentSessionID: launch.persistentSessionID
             )
         }
         precondition(surface.backend == self)
@@ -62,4 +63,21 @@ struct TerminalLaunchRequest {
     let commandInteractive: Bool
     let closesOnCommandExit: Bool
     let workspaceContext: WorkspaceContext
+    let persistentSessionID: UUID?
+
+    init(
+        workingDirectory: String,
+        command: String?,
+        commandInteractive: Bool,
+        closesOnCommandExit: Bool,
+        workspaceContext: WorkspaceContext,
+        persistentSessionID: UUID? = nil
+    ) {
+        self.workingDirectory = workingDirectory
+        self.command = command
+        self.commandInteractive = commandInteractive
+        self.closesOnCommandExit = closesOnCommandExit
+        self.workspaceContext = workspaceContext
+        self.persistentSessionID = persistentSessionID
+    }
 }

--- a/Muxy/Services/Terminal/TerminalPersistentSessionPolicy.swift
+++ b/Muxy/Services/Terminal/TerminalPersistentSessionPolicy.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum TerminalPersistentSessionPolicy {
+    static func usesPersistentSession(
+        preferenceEnabled: Bool,
+        workspaceContext: WorkspaceContext,
+        isAvailable: Bool
+    ) -> Bool {
+        guard preferenceEnabled, isAvailable else { return false }
+        return !workspaceContext.isRemote
+    }
+
+    @MainActor
+    static func usesPersistentSession(workspaceContext: WorkspaceContext) -> Bool {
+        usesPersistentSession(
+            preferenceEnabled: TerminalPersistentSessionPreferences.isEnabled,
+            workspaceContext: workspaceContext,
+            isAvailable: PersistentSessionService.shared.isAvailable
+        )
+    }
+}

--- a/Muxy/Services/Terminal/TerminalSessionAttachment.swift
+++ b/Muxy/Services/Terminal/TerminalSessionAttachment.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+@MainActor
+enum TerminalSessionAttachment {
+    enum Outcome: Equatable {
+        case attached
+        case alreadyAttached
+        case unavailable
+    }
+
+    static func attachToActivePane(sessionID: UUID, appState: AppState) -> Outcome {
+        guard let paneID = NotificationNavigator.activePaneID(appState: appState),
+              let location = appState.locatePane(paneID: paneID)
+        else { return .unavailable }
+        releaseOwners(of: sessionID, excluding: paneID, in: appState.allTerminalPanes)
+        return attach(sessionID: sessionID, to: location.pane)
+    }
+
+    static func attach(sessionID: UUID, to pane: TerminalPaneState) -> Outcome {
+        guard pane.sessionID != sessionID else { return .alreadyAttached }
+        TerminalViewRegistry.shared.releaseView(for: pane.id)
+        pane.sessionID = sessionID
+        return .attached
+    }
+
+    @discardableResult
+    static func releaseOwners(
+        of sessionID: UUID,
+        excluding paneID: UUID,
+        in panes: [TerminalPaneState]
+    ) -> [TerminalPaneState] {
+        let owners = panes.filter { $0.id != paneID && $0.sessionID == sessionID }
+        for owner in owners {
+            TerminalViewRegistry.shared.releaseView(for: owner.id)
+            owner.sessionID = owner.id
+        }
+        return owners
+    }
+
+    @discardableResult
+    static func attachInNewTab(
+        sessionID: UUID,
+        title: String?,
+        key: WorktreeKey,
+        appState: AppState
+    ) -> Outcome {
+        guard let existing = appState.allTerminalPanes.first(where: { $0.sessionID == sessionID }) else {
+            appState.dispatch(.createSessionTab(key: key, areaID: nil, sessionID: sessionID, title: title))
+            return .attached
+        }
+        guard let location = appState.locateTab(forPane: existing.id) else { return .alreadyAttached }
+        appState.dispatch(.selectTabInWorktree(
+            key: location.worktreeKey,
+            areaID: location.areaID,
+            tabID: location.tab.id
+        ))
+        return .alreadyAttached
+    }
+}

--- a/Muxy/Services/Terminal/TerminalSessionMetadataBuilder.swift
+++ b/Muxy/Services/Terminal/TerminalSessionMetadataBuilder.swift
@@ -1,0 +1,24 @@
+import Foundation
+import MuxySessionProtocol
+
+@MainActor
+enum TerminalSessionMetadataBuilder {
+    static func build(
+        worktreeKey: WorktreeKey,
+        tabID: UUID?,
+        title: String
+    ) -> [(key: String, value: String)] {
+        var entries: [(key: String, value: String)] = [
+            (key: SessionMetadataKey.project, value: worktreeKey.projectID.uuidString),
+            (key: SessionMetadataKey.worktree, value: worktreeKey.worktreeID.uuidString),
+        ]
+        if let tabID {
+            entries.append((key: SessionMetadataKey.tab, value: tabID.uuidString))
+        }
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedTitle.isEmpty {
+            entries.append((key: SessionMetadataKey.title, value: trimmedTitle))
+        }
+        return entries
+    }
+}

--- a/Muxy/Services/Terminal/TerminalSessionsStore.swift
+++ b/Muxy/Services/Terminal/TerminalSessionsStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MuxySessionProtocol
+
+@MainActor
+@Observable
+final class TerminalSessionsStore {
+    static let shared = TerminalSessionsStore()
+
+    private(set) var sessions: [SessionDescriptor] = []
+
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
+
+    private init() {}
+
+    func refresh() {
+        guard TerminalPersistentSessionPreferences.isEnabled else {
+            sessions = []
+            return
+        }
+        guard refreshTask == nil else { return }
+        refreshTask = Task { [weak self] in
+            let latest = await PersistentSessionService.shared.liveSessions()
+            guard let self else { return }
+            refreshTask = nil
+            sessions = latest
+        }
+    }
+
+    func detachedSessions(inWorktree key: WorktreeKey, ownedSessionIDs: Set<UUID>) -> [SessionDescriptor] {
+        Self.detached(sessions, inWorktree: key, ownedSessionIDs: ownedSessionIDs)
+    }
+
+    nonisolated static func filter(_ sessions: [SessionDescriptor], inWorktree key: WorktreeKey) -> [SessionDescriptor] {
+        sessions.filter { descriptor in
+            descriptor.value(forMetadataKey: SessionMetadataKey.project) == key.projectID.uuidString
+                && descriptor.value(forMetadataKey: SessionMetadataKey.worktree) == key.worktreeID.uuidString
+        }
+    }
+
+    nonisolated static func detached(
+        _ sessions: [SessionDescriptor],
+        inWorktree key: WorktreeKey,
+        ownedSessionIDs: Set<UUID>
+    ) -> [SessionDescriptor] {
+        filter(sessions, inWorktree: key).filter { descriptor in
+            guard let sessionID = UUID(uuidString: descriptor.identifier.uuidString) else { return true }
+            return !ownedSessionIDs.contains(sessionID)
+        }
+    }
+
+    nonisolated static func displayTitle(for descriptor: SessionDescriptor) -> String {
+        let title = descriptor.value(forMetadataKey: SessionMetadataKey.title)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard title.isEmpty else { return title }
+        let directory = (descriptor.workingDirectory as NSString).lastPathComponent
+        guard !directory.isEmpty, directory != "/" else { return TerminalPaneState.defaultTitle }
+        return directory
+    }
+}

--- a/Muxy/Services/Terminal/TerminalSurface.swift
+++ b/Muxy/Services/Terminal/TerminalSurface.swift
@@ -106,6 +106,7 @@ protocol TerminalSurface: TerminalInputTransactionTarget {
     var terminalView: NSView { get }
     var backend: TerminalBackend { get }
     var envVars: [(key: String, value: String)] { get set }
+    var sessionMetadata: [(key: String, value: String)] { get set }
     var onTitleChange: ((String) -> Void)? { get set }
     var onWorkingDirectoryChange: ((String) -> Void)? { get set }
     var onFocus: (() -> Void)? { get set }
@@ -122,6 +123,7 @@ protocol TerminalSurface: TerminalInputTransactionTarget {
     var overlayActive: Bool { get set }
     var foregroundProcessID: Int32? { get }
     var hasLiveSurface: Bool { get }
+    var persistentSessionID: UUID? { get }
 
     func tearDown()
     func setVisible(_ visible: Bool)
@@ -144,6 +146,10 @@ protocol TerminalSurface: TerminalInputTransactionTarget {
 
 @MainActor
 extension TerminalSurface {
+    var persistentSessionID: UUID? { nil }
+
+    var usesPersistentSession: Bool { persistentSessionID != nil }
+
     var capabilities: TerminalCapabilities {
         var capabilities: TerminalCapabilities = []
         if self is any TerminalRawOutputSource {

--- a/Muxy/Services/Terminal/TerminalSurfaceMaterializer.swift
+++ b/Muxy/Services/Terminal/TerminalSurfaceMaterializer.swift
@@ -10,6 +10,7 @@ enum TerminalSurfaceMaterializer {
         let pane = location.pane
         let view = TerminalViewRegistry.shared.view(
             for: paneID,
+            sessionID: pane.sessionID,
             workingDirectory: pane.currentWorkingDirectory ?? pane.projectPath,
             command: pane.startupCommand,
             commandInteractive: pane.startupCommandInteractive,
@@ -18,6 +19,11 @@ enum TerminalSurfaceMaterializer {
         if view.envVars.isEmpty {
             view.envVars = TerminalEnvVarBuilder.build(paneID: paneID, worktreeKey: location.worktreeKey)
         }
+        view.sessionMetadata = TerminalSessionMetadataBuilder.build(
+            worktreeKey: location.worktreeKey,
+            tabID: appState.locateTab(forPane: paneID)?.tab.id,
+            title: pane.title
+        )
         view.materializeHeadless()
         return view.hasLiveSurface ? view : nil
     }

--- a/Muxy/Services/Terminal/TerminalTTYForegroundProcess.swift
+++ b/Muxy/Services/Terminal/TerminalTTYForegroundProcess.swift
@@ -1,0 +1,51 @@
+import Darwin
+import Foundation
+
+struct TTYProcessEntry: Equatable, Sendable {
+    let processID: Int32
+    let processGroupID: Int32
+    let foregroundGroupID: Int32
+}
+
+enum TerminalTTYForegroundProcess {
+    static func select(from entries: [TTYProcessEntry]) -> Int32? {
+        guard let group = entries.lazy.map(\.foregroundGroupID).first(where: { $0 > 0 }) else { return nil }
+        if entries.contains(where: { $0.processID == group }) {
+            return group
+        }
+        return entries.filter { $0.processGroupID == group }.map(\.processID).min()
+    }
+
+    static func isRunningCommand(foregroundProcessID: Int32?, shellProcessID: Int32) -> Bool {
+        guard let foregroundProcessID, foregroundProcessID > 0, shellProcessID > 0 else { return false }
+        return foregroundProcessID != shellProcessID
+    }
+
+    static func processID(ttyDevice: UInt64) -> Int32? {
+        select(from: entries(ttyDevice: ttyDevice))
+    }
+
+    static func entries(ttyDevice: UInt64) -> [TTYProcessEntry] {
+        guard ttyDevice != 0 else { return [] }
+        var name: [Int32] = [
+            CTL_KERN,
+            KERN_PROC,
+            KERN_PROC_TTY,
+            Int32(bitPattern: UInt32(truncatingIfNeeded: ttyDevice)),
+        ]
+        var size = 0
+        guard sysctl(&name, 4, nil, &size, nil, 0) == 0, size > 0 else { return [] }
+
+        let stride = MemoryLayout<kinfo_proc>.stride
+        var records = [kinfo_proc](repeating: kinfo_proc(), count: size / stride)
+        guard sysctl(&name, 4, &records, &size, nil, 0) == 0 else { return [] }
+
+        return records.prefix(size / stride).map { record in
+            TTYProcessEntry(
+                processID: record.kp_proc.p_pid,
+                processGroupID: record.kp_eproc.e_pgid,
+                foregroundGroupID: record.kp_eproc.e_tpgid
+            )
+        }
+    }
+}

--- a/Muxy/Services/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Services/Terminal/TerminalViewRegistry.swift
@@ -25,6 +25,7 @@ final class TerminalViewRegistry {
 
     func view(
         for paneID: UUID,
+        sessionID: UUID? = nil,
         workingDirectory: String,
         command: String? = nil,
         commandInteractive: Bool = false,
@@ -35,12 +36,16 @@ final class TerminalViewRegistry {
         if let existing = views[paneID] {
             return existing
         }
+        let usesPersistentSession = TerminalPersistentSessionPolicy.usesPersistentSession(
+            workspaceContext: workspaceContext
+        )
         let view = backend.makeSurface(launch: TerminalLaunchRequest(
             workingDirectory: workingDirectory,
             command: command,
             commandInteractive: commandInteractive,
             closesOnCommandExit: closesOnCommandExit,
-            workspaceContext: workspaceContext
+            workspaceContext: workspaceContext,
+            persistentSessionID: usesPersistentSession ? (sessionID ?? paneID) : nil
         ))
         views[paneID] = view
         paneIDs[ObjectIdentifier(view.terminalView)] = paneID
@@ -52,10 +57,19 @@ final class TerminalViewRegistry {
     }
 
     func removeView(for paneID: UUID) {
-        guard let view = views.removeValue(forKey: paneID) else { return }
+        guard let view = releaseView(for: paneID) else { return }
+        if let sessionID = view.persistentSessionID {
+            PersistentSessionService.shared.endSession(sessionID: sessionID)
+        }
+    }
+
+    @discardableResult
+    func releaseView(for paneID: UUID) -> (any TerminalSurface)? {
+        guard let view = views.removeValue(forKey: paneID) else { return nil }
         TerminalCommandTracker.shared.removePane(paneID)
         view.tearDown()
         paneIDs.removeValue(forKey: ObjectIdentifier(view.terminalView))
+        return view
     }
 
     func prepareForTermination() async {

--- a/Muxy/Views/Components/Buttons/TerminalSessionsButton.swift
+++ b/Muxy/Views/Components/Buttons/TerminalSessionsButton.swift
@@ -1,0 +1,180 @@
+import AppKit
+import MuxySessionProtocol
+import SwiftUI
+
+struct TerminalSessionsButton: View {
+    @Environment(AppState.self) private var appState
+    @State private var store = TerminalSessionsStore.shared
+    @State private var showingPopover = false
+    @State private var hovered = false
+
+    private var worktreeKey: WorktreeKey? {
+        guard let projectID = appState.activeProjectID else { return nil }
+        return appState.activeWorktreeKey(for: projectID)
+    }
+
+    private var sessions: [SessionDescriptor] {
+        guard let worktreeKey else { return [] }
+        return store.detachedSessions(
+            inWorktree: worktreeKey,
+            ownedSessionIDs: Set(appState.allTerminalPanes.map(\.sessionID))
+        )
+    }
+
+    var body: some View {
+        if sessions.isEmpty {
+            refreshTrigger
+        } else {
+            StatusBarSeparator()
+            button
+        }
+    }
+
+    private var refreshTrigger: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .onAppear { store.refresh() }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                store.refresh()
+            }
+    }
+
+    private var button: some View {
+        Button {
+            showingPopover.toggle()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "rectangle.stack")
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                Text(verbatim: "\(sessions.count)")
+                    .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                    .monospacedDigit()
+            }
+            .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
+            .padding(.horizontal, 4)
+            .frame(maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .help(L10n.string("Detached background terminals"))
+        .accessibilityLabel(L10n.string("Detached background terminals"))
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            store.refresh()
+        }
+        .popover(isPresented: $showingPopover, arrowEdge: .bottom) {
+            TerminalSessionsPopover(
+                sessions: sessions,
+                worktreeKey: worktreeKey,
+                onClose: { showingPopover = false }
+            )
+            .onAppear { store.refresh() }
+        }
+    }
+}
+
+private struct TerminalSessionsPopover: View {
+    let sessions: [SessionDescriptor]
+    let worktreeKey: WorktreeKey?
+    let onClose: () -> Void
+
+    @Environment(AppState.self) private var appState
+    @State private var store = TerminalSessionsStore.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+            header
+            if sessions.isEmpty {
+                Text(L10n.resource("Every background terminal in this worktree is open in a tab."))
+                    .font(.system(size: UIMetrics.fontFootnote))
+                    .foregroundStyle(MuxyTheme.fgMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing4) {
+                        ForEach(sessions, id: \.identifier.uuidString) { session in
+                            row(session)
+                        }
+                    }
+                }
+                .frame(maxHeight: UIMetrics.scaled(320))
+            }
+        }
+        .padding(UIMetrics.spacing6)
+        .frame(width: UIMetrics.scaled(320))
+        .background(MuxyTheme.bg)
+    }
+
+    private var header: some View {
+        HStack {
+            Text(L10n.resource("Detached terminals"))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+            Spacer()
+            Text(verbatim: "\(sessions.count)")
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .monospacedDigit()
+        }
+    }
+
+    private func row(_ session: SessionDescriptor) -> some View {
+        VStack(alignment: .leading, spacing: UIMetrics.spacing2) {
+            Text(TerminalSessionsStore.displayTitle(for: session))
+                .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+                .foregroundStyle(MuxyTheme.fg)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(session.workingDirectory)
+                .font(.system(size: UIMetrics.fontCaption))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .lineLimit(1)
+                .truncationMode(.head)
+            HStack(spacing: UIMetrics.spacing3) {
+                actionButton(L10n.resource("Active tab")) { attachToActiveTab(session) }
+                actionButton(L10n.resource("New tab")) { attachInNewTab(session) }
+                Spacer(minLength: 0)
+                actionButton(L10n.resource("Stop"), isDestructive: true) { stop(session) }
+            }
+        }
+        .padding(.vertical, UIMetrics.spacing2)
+    }
+
+    private func actionButton(
+        _ label: LocalizedStringResource,
+        isDestructive: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: UIMetrics.fontCaption, weight: .medium))
+                .foregroundStyle(isDestructive ? MuxyTheme.warning : MuxyTheme.accent)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func attachToActiveTab(_ session: SessionDescriptor) {
+        guard let sessionID = UUID(uuidString: session.identifier.uuidString) else { return }
+        _ = TerminalSessionAttachment.attachToActivePane(sessionID: sessionID, appState: appState)
+        store.refresh()
+        onClose()
+    }
+
+    private func attachInNewTab(_ session: SessionDescriptor) {
+        guard let sessionID = UUID(uuidString: session.identifier.uuidString), let worktreeKey else { return }
+        TerminalSessionAttachment.attachInNewTab(
+            sessionID: sessionID,
+            title: session.value(forMetadataKey: SessionMetadataKey.title),
+            key: worktreeKey,
+            appState: appState
+        )
+        store.refresh()
+        onClose()
+    }
+
+    private func stop(_ session: SessionDescriptor) {
+        guard let sessionID = UUID(uuidString: session.identifier.uuidString) else { return }
+        PersistentSessionService.shared.endSession(sessionID: sessionID)
+        store.refresh()
+    }
+}

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -467,6 +467,14 @@ enum SettingsCatalog {
             defaultValue: TerminalOfflinePreferences.defaultIdleThreshold
         ),
         SettingsCatalogItem(
+            key: TerminalPersistentSessionPreferences.enabledKey,
+            title: "Run New Terminals in the Background",
+            description: "Runs new terminals in a background process so they survive quitting Muxy.",
+            category: .terminal,
+            section: "Background sessions",
+            defaultValue: TerminalPersistentSessionPreferences.defaultIsEnabled
+        ),
+        SettingsCatalogItem(
             key: "shortcuts.app",
             title: "App Shortcuts",
             description: "Configures Muxy keyboard shortcuts.",

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct TerminalSettingsView: View {
@@ -5,10 +6,35 @@ struct TerminalSettingsView: View {
     private var autoCopyTerminalSelection = false
     @AppStorage(TabCloseConfirmationPreferences.confirmRunningProcessKey)
     private var confirmRunningProcess = true
+    @AppStorage(TerminalPersistentSessionPreferences.enabledKey)
+    private var backgroundSessionsEnabled = TerminalPersistentSessionPreferences.defaultIsEnabled
     @AppStorage(TerminalOfflinePreferences.enabledKey)
     private var freeIdleTerminalsEnabled = TerminalOfflinePreferences.defaultIsEnabled
     @AppStorage(TerminalOfflinePreferences.idleThresholdKey)
     private var idleThresholdSeconds = TerminalOfflinePreferences.defaultIdleThreshold
+
+    private func confirmStoppingBackgroundSessions() {
+        Task { @MainActor in
+            let sessions = await PersistentSessionService.shared.liveSessions()
+            guard !sessions.isEmpty else { return }
+
+            let alert = NSAlert()
+            alert.messageText = L10n.string("Stop background terminals?")
+            alert.informativeText = L10n.string(
+                "Terminals are still running in the background. Turning this off stops them and ends whatever they are running."
+            )
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: L10n.string("Stop"))
+            alert.addButton(withTitle: L10n.string("Cancel"))
+            alert.buttons[1].keyEquivalent = "\u{1b}"
+
+            guard alert.runModal() == .alertFirstButtonReturn else {
+                backgroundSessionsEnabled = true
+                return
+            }
+            await PersistentSessionService.shared.endAllSessions()
+        }
+    }
 
     private var idleTimeoutSelection: Binding<String> {
         Binding(
@@ -38,6 +64,25 @@ struct TerminalSettingsView: View {
                     label: L10n.resource("Confirm before closing a tab with a running process"),
                     isOn: $confirmRunningProcess
                 )
+            }
+
+            SettingsSection(
+                "Background sessions",
+                footer: """
+                Runs each new terminal in a separate background process, the way tmux does. Quitting Muxy leaves \
+                those terminals running and reopening reconnects them with their recent output. Closing a tab still \
+                ends its session. Terminals that are already open keep their current behaviour.
+                """
+            ) {
+                SettingsToggleRow(
+                    label: L10n.resource("Run new terminals in the background"),
+                    isOn: $backgroundSessionsEnabled
+                )
+                .disabled(!PersistentSessionService.shared.isAvailable)
+                .onChange(of: backgroundSessionsEnabled) { _, isEnabled in
+                    guard !isEnabled else { return }
+                    confirmStoppingBackgroundSessions()
+                }
             }
 
             SettingsSection(

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -22,7 +22,9 @@ final class GhosttyTerminalNSView: NSView,
     private let commandInteractive: Bool
     private let commandClosesOnExit: Bool
     private let workspaceContext: WorkspaceContext
+    let persistentSessionID: UUID?
     var envVars: [(key: String, value: String)] = []
+    var sessionMetadata: [(key: String, value: String)] = []
     var onTitleChange: ((String) -> Void)?
     var onWorkingDirectoryChange: ((String) -> Void)?
     var onFocus: (() -> Void)?
@@ -74,6 +76,9 @@ final class GhosttyTerminalNSView: NSView,
 
     var foregroundProcessID: Int32? {
         guard let surface else { return nil }
+        if let persistentSessionID {
+            return PersistentSessionService.shared.foregroundProcessID(sessionID: persistentSessionID)
+        }
         let processID = ghostty_surface_foreground_pid(surface)
         guard processID > 0, processID <= UInt64(Int32.max) else { return nil }
         return Int32(processID)
@@ -103,13 +108,15 @@ final class GhosttyTerminalNSView: NSView,
         command: String? = nil,
         commandInteractive: Bool = false,
         closesOnCommandExit: Bool = true,
-        workspaceContext: WorkspaceContext = .local
+        workspaceContext: WorkspaceContext = .local,
+        persistentSessionID: UUID? = nil
     ) {
         self.workingDirectory = workingDirectory
         self.command = command
         self.commandInteractive = commandInteractive
         commandClosesOnExit = closesOnCommandExit
         self.workspaceContext = workspaceContext
+        self.persistentSessionID = persistentSessionID
         super.init(frame: .zero)
         wantsLayer = true
         setupTrackingArea()
@@ -181,6 +188,15 @@ final class GhosttyTerminalNSView: NSView,
         surfaceCStringPointers.append(workingDirectoryPointer)
         config.working_directory = UnsafePointer(workingDirectoryPointer)
 
+        let startedPersistentSession = workspaceContext.sshDestination == nil
+            && persistentSessionID != nil
+            && applyPersistentSessionConfiguration(
+                &config,
+                environment: &cEnvVars,
+                launchCommand: launchCommand,
+                workingDirectory: localWorkingDirectory
+            )
+
         if let destination = workspaceContext.sshDestination {
             if let remoteWrapped = strdup(TerminalLaunchCommand.remoteShellCommand(
                 destination: destination,
@@ -193,7 +209,8 @@ final class GhosttyTerminalNSView: NSView,
                 config.command = UnsafePointer(remoteWrapped)
                 config.wait_after_command = false
             }
-        } else if let command = launchCommand,
+        } else if !startedPersistentSession,
+                  let command = launchCommand,
                   let loginWrapped = strdup(TerminalLaunchCommand.shellCommand(
                       interactive: commandInteractive,
                       keepsShellOpen: !commandClosesOnExit
@@ -260,7 +277,48 @@ final class GhosttyTerminalNSView: NSView,
         }
 
         applyOcclusionState()
+        if let persistentSessionID {
+            PersistentSessionService.shared.noteSurfaceMaterialized(sessionID: persistentSessionID)
+        }
         startAgentDetection()
+    }
+
+    private func applyPersistentSessionConfiguration(
+        _ config: inout ghostty_surface_config_s,
+        environment: inout [ghostty_env_var_s],
+        launchCommand: String?,
+        workingDirectory: String
+    ) -> Bool {
+        guard let persistentSessionID,
+              let attachCommand = PersistentSessionService.shared.attachCommand(),
+              let attachPointer = strdup(attachCommand)
+        else { return false }
+
+        surfaceCStringPointers.append(attachPointer)
+        config.command = UnsafePointer(attachPointer)
+        config.wait_after_command = false
+
+        let sessionCommand = launchCommand.map { _ in
+            TerminalLaunchCommand.shellCommand(
+                interactive: commandInteractive,
+                keepsShellOpen: !commandClosesOnExit
+            )
+        }
+        var entries = PersistentSessionService.shared.launchEnvironment(
+            sessionID: persistentSessionID,
+            workingDirectory: workingDirectory,
+            command: sessionCommand,
+            metadata: sessionMetadata
+        )
+        if let launchCommand {
+            entries.append((key: TerminalLaunchCommand.environmentKey, value: launchCommand))
+        }
+        for entry in entries {
+            guard let key = strdup(entry.key), let value = strdup(entry.value) else { continue }
+            surfaceCStringPointers.append(contentsOf: [key, value])
+            environment.append(ghostty_env_var_s(key: key, value: value))
+        }
+        return true
     }
 
     func destroySurface() {
@@ -683,6 +741,9 @@ final class GhosttyTerminalNSView: NSView,
 
     func needsConfirmQuit() -> Bool {
         guard let surface else { return false }
+        if let persistentSessionID {
+            return PersistentSessionService.shared.isRunningCommand(sessionID: persistentSessionID)
+        }
         return ghostty_surface_needs_confirm_quit(surface)
     }
 
@@ -2091,7 +2152,9 @@ final class GhosttyTerminalNSView: NSView,
 
     private func detectAgentNow() {
         guard let surface else { return }
-        let foregroundPID = ghostty_surface_foreground_pid(surface)
+        let foregroundPID = persistentSessionID == nil
+            ? ghostty_surface_foreground_pid(surface)
+            : UInt64(max(foregroundProcessID ?? 0, 0))
         let candidateNames = ForegroundProcessInspector.executableNameCandidates(pid: foregroundPID)
         let providerID = AIAgentDetector.providerID(forCandidateNames: candidateNames, executables: agentExecutables)
         watchAgentProcess(providerID: providerID, processID: foregroundPID)

--- a/Muxy/Views/Terminal/ProjectStatusBar.swift
+++ b/Muxy/Views/Terminal/ProjectStatusBar.swift
@@ -16,6 +16,8 @@ struct ProjectStatusBar: View {
     @Environment(ExtensionStore.self) private var extensionStore
     @State private var popoverHost = PopoverHost.shared
     @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
+    @AppStorage(TerminalPersistentSessionPreferences.enabledKey)
+    private var backgroundSessionsEnabled = TerminalPersistentSessionPreferences.defaultIsEnabled
 
     var body: some View {
         HStack(spacing: 8) {
@@ -62,6 +64,9 @@ struct ProjectStatusBar: View {
             if activePane != nil {
                 separator
                 voiceRecordingButton
+            }
+            if backgroundSessionsEnabled, !isRemoteWorkspace {
+                TerminalSessionsButton()
             }
             if showResourceUsage {
                 separator

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -367,8 +367,15 @@ struct TerminalBridge: NSViewRepresentable {
     }
 
     private func configure(_ surface: any TerminalSurface) {
-        if surface.envVars.isEmpty, !surface.hasLiveSurface, let key = worktreeKey {
-            surface.envVars = TerminalEnvVarBuilder.build(paneID: state.id, worktreeKey: key)
+        if let key = worktreeKey {
+            if surface.envVars.isEmpty, !surface.hasLiveSurface {
+                surface.envVars = TerminalEnvVarBuilder.build(paneID: state.id, worktreeKey: key)
+            }
+            surface.sessionMetadata = TerminalSessionMetadataBuilder.build(
+                worktreeKey: key,
+                tabID: appState.locateTab(forPane: state.id)?.tab.id,
+                title: state.title
+            )
         }
         surface.isFocused = focused
         surface.overlayActive = overlayActive
@@ -425,6 +432,7 @@ struct TerminalBridge: NSViewRepresentable {
         let launch = state.consumeRestoredLaunch()
         return TerminalViewRegistry.shared.view(
             for: state.id,
+            sessionID: state.sessionID,
             workingDirectory: state.currentWorkingDirectory ?? state.projectPath,
             command: launch.command,
             commandInteractive: launch.interactive,

--- a/MuxySession/SessionAttachClient.swift
+++ b/MuxySession/SessionAttachClient.swift
@@ -1,0 +1,242 @@
+import Darwin
+import MachO
+import MuxySessionProtocol
+
+enum SessionAttachClient {
+    static let connectAttempts = 150
+    static let connectRetryMicroseconds: useconds_t = 20000
+    static let inputBacklogLimit = 4 * 1024 * 1024
+
+    struct Configuration {
+        let identifier: SessionIdentifier
+        let socketPath: String
+        let command: String
+        let shell: String
+        let resourcesDirectory: String
+        let workingDirectory: String
+        let metadata: [SessionEnvironmentEntry]
+    }
+
+    static func run(configuration: Configuration) -> Int32 {
+        signal(SIGPIPE, SIG_IGN)
+
+        guard let socket = connect(socketPath: configuration.socketPath) else {
+            SessionLog.write("muxy-session: could not reach the session daemon")
+            return 1
+        }
+        SessionIO.setNonBlocking(socket)
+
+        guard let signalPipe = SessionSignalPipe(signals: [SIGWINCH]) else {
+            SessionIO.close(socket)
+            return 1
+        }
+
+        let originalTerminal = enterRawMode()
+        defer {
+            if var originalTerminal {
+                tcsetattr(STDIN_FILENO, TCSANOW, &originalTerminal)
+            }
+        }
+
+        let connection = SessionConnection(descriptor: socket)
+        connection.enqueue(SessionFrame(kind: .attach, payload: makeRequest(configuration).encoded()))
+
+        return loop(connection: connection, signalPipe: signalPipe)
+    }
+
+    private static func loop(connection: SessionConnection, signalPipe: SessionSignalPipe) -> Int32 {
+        while true {
+            guard connection.flush() else { return 1 }
+
+            var descriptors = [
+                pollfd(fd: signalPipe.readDescriptor, events: Int16(POLLIN), revents: 0),
+                pollfd(
+                    fd: connection.descriptor,
+                    events: Int16(connection.hasPendingOutput ? Int32(POLLIN) | Int32(POLLOUT) : Int32(POLLIN)),
+                    revents: 0
+                ),
+            ]
+            if connection.pendingByteCount < inputBacklogLimit {
+                descriptors.append(pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0))
+            }
+
+            let ready = poll(&descriptors, nfds_t(descriptors.count), -1)
+            if ready < 0 {
+                guard errno == EINTR else { return 1 }
+                continue
+            }
+
+            for entry in descriptors where entry.revents != 0 {
+                if entry.fd == signalPipe.readDescriptor {
+                    signalPipe.drain()
+                    sendResize(connection)
+                } else if entry.fd == STDIN_FILENO {
+                    guard forwardInput(connection) else { return 0 }
+                } else if let status = receive(connection, revents: entry.revents) {
+                    _ = connection.flush()
+                    return status
+                }
+            }
+        }
+    }
+
+    private static func forwardInput(_ connection: SessionConnection) -> Bool {
+        switch SessionIO.read(STDIN_FILENO) {
+        case let .bytes(bytes):
+            connection.enqueue(SessionFrame(kind: .input, payload: bytes))
+            return true
+        case .wouldBlock:
+            return true
+        case .endOfFile,
+             .failed:
+            return false
+        }
+    }
+
+    private static func receive(_ connection: SessionConnection, revents: Int16) -> Int32? {
+        if revents & Int16(POLLOUT) != 0, !connection.flush() {
+            return 1
+        }
+        guard revents & Int16(POLLIN) != 0 || revents & Int16(POLLHUP) != 0 else { return nil }
+
+        var reachedEnd = false
+        readLoop: while true {
+            switch SessionIO.read(connection.descriptor) {
+            case let .bytes(bytes):
+                connection.decoder.push(bytes)
+            case .wouldBlock:
+                break readLoop
+            case .endOfFile,
+                 .failed:
+                reachedEnd = true
+                break readLoop
+            }
+        }
+
+        while true {
+            let frame: SessionFrame?
+            do {
+                frame = try connection.decoder.next()
+            } catch {
+                return 1
+            }
+            guard let frame else { break }
+            switch frame.kind {
+            case .output:
+                guard SessionIO.writeAll(STDOUT_FILENO, frame.payload) else { return 1 }
+            case .exited:
+                return (try? SessionExitPayload.decode(frame.payload)) ?? 0
+            case .failure:
+                let message = (try? SessionTextPayload.decode(frame.payload)) ?? "session failed"
+                SessionLog.write("muxy-session: " + message)
+                return 1
+            case .attached,
+                 .attach,
+                 .input,
+                 .resize,
+                 .list,
+                 .info,
+                 .kill,
+                 .killAll,
+                 .sessions,
+                 .acknowledged:
+                break
+            }
+        }
+
+        return reachedEnd ? 1 : nil
+    }
+
+    private static func sendResize(_ connection: SessionConnection) {
+        guard let size = SessionPTY.windowSize(descriptor: STDIN_FILENO) else { return }
+        connection.enqueue(SessionFrame(
+            kind: .resize,
+            payload: SessionResizePayload.encode(columns: size.columns, rows: size.rows)
+        ))
+    }
+
+    private static func makeRequest(_ configuration: Configuration) -> SessionAttachRequest {
+        let size = SessionPTY.windowSize(descriptor: STDIN_FILENO) ?? (columns: 80, rows: 24)
+        let environment = SessionProcessEnvironment.current()
+            .filter { !$0.key.hasPrefix("MUXY_SESSION_") }
+            .map { SessionEnvironmentEntry(key: $0.key, value: $0.value) }
+        return SessionAttachRequest(
+            identifier: configuration.identifier,
+            columns: size.columns,
+            rows: size.rows,
+            workingDirectory: configuration.workingDirectory,
+            command: configuration.command,
+            shell: configuration.shell,
+            resourcesDirectory: configuration.resourcesDirectory,
+            environment: environment,
+            metadata: configuration.metadata
+        )
+    }
+
+    private static func enterRawMode() -> termios? {
+        var original = termios()
+        guard tcgetattr(STDIN_FILENO, &original) == 0 else { return nil }
+        var raw = original
+        cfmakeraw(&raw)
+        guard tcsetattr(STDIN_FILENO, TCSANOW, &raw) == 0 else { return nil }
+        return original
+    }
+
+    private static func connect(socketPath: String) -> Int32? {
+        if let descriptor = SessionSocket.connect(path: socketPath) {
+            return descriptor
+        }
+        launchDaemon(socketPath: socketPath)
+        for _ in 0 ..< connectAttempts {
+            usleep(connectRetryMicroseconds)
+            if let descriptor = SessionSocket.connect(path: socketPath) {
+                return descriptor
+            }
+        }
+        return nil
+    }
+
+    private static func launchDaemon(socketPath: String) {
+        guard let binaryPath = executablePath() else {
+            SessionLog.write("muxy-session: unable to locate the session daemon binary")
+            return
+        }
+        let arguments = SessionCStringArray([binaryPath, "daemon", "--socket", socketPath])
+
+        var fileActions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&fileActions)
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        posix_spawn_file_actions_addopen(&fileActions, STDIN_FILENO, "/dev/null", O_RDWR, 0)
+        posix_spawn_file_actions_addopen(&fileActions, STDOUT_FILENO, "/dev/null", O_RDWR, 0)
+        posix_spawn_file_actions_addopen(
+            &fileActions,
+            STDERR_FILENO,
+            socketPath + ".log",
+            O_WRONLY | O_CREAT | O_TRUNC,
+            0o600
+        )
+
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETSID))
+
+        var processID: pid_t = 0
+        let result = posix_spawn(&processID, binaryPath, &fileActions, &attributes, arguments.pointer, environ)
+        guard result != 0 else { return }
+        SessionLog.write("muxy-session: could not start the session daemon (\(result))")
+    }
+
+    static func executablePath() -> String? {
+        if let provided = SessionProcessEnvironment.value("MUXY_SESSION_BINARY") {
+            return provided
+        }
+        var size = UInt32(PATH_MAX)
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard _NSGetExecutablePath(&buffer, &size) == 0 else { return nil }
+        return buffer.withUnsafeBufferPointer { pointer in
+            guard let base = pointer.baseAddress else { return nil }
+            return String(cString: base)
+        }
+    }
+}

--- a/MuxySession/SessionConnection.swift
+++ b/MuxySession/SessionConnection.swift
@@ -1,0 +1,127 @@
+import Darwin
+import MuxySessionProtocol
+
+final class SessionConnection {
+    let descriptor: Int32
+    var decoder = SessionFrameDecoder()
+    var attachedSession: SessionIdentifier?
+    var closesAfterFlush = false
+
+    private var outbox: [UInt8] = []
+    private var offset = 0
+
+    init(descriptor: Int32) {
+        self.descriptor = descriptor
+    }
+
+    var pendingByteCount: Int { outbox.count - offset }
+    var hasPendingOutput: Bool { pendingByteCount > 0 }
+
+    func enqueue(_ frame: SessionFrame) {
+        outbox.append(contentsOf: frame.encoded())
+    }
+
+    func flush() -> Bool {
+        while offset < outbox.count {
+            switch SessionIO.write(descriptor, outbox, from: offset) {
+            case let .wrote(count):
+                offset += count
+            case .wouldBlock:
+                compact()
+                return true
+            case .failed:
+                return false
+            }
+        }
+        outbox.removeAll(keepingCapacity: true)
+        offset = 0
+        return true
+    }
+
+    private func compact() {
+        guard offset > 0 else { return }
+        if offset == outbox.count {
+            outbox.removeAll(keepingCapacity: true)
+            offset = 0
+        } else if offset >= 1 << 16 {
+            outbox.removeFirst(offset)
+            offset = 0
+        }
+    }
+}
+
+final class PTYSession {
+    let identifier: SessionIdentifier
+    let processID: pid_t
+    let ttyDevice: UInt64
+    let workingDirectory: String
+
+    var masterDescriptor: Int32
+    var replay: SessionReplayBuffer
+    var clientDescriptor: Int32?
+    var isEnding = false
+    var metadata: [SessionEnvironmentEntry] = []
+
+    private var pendingInput: [UInt8] = []
+    private var inputOffset = 0
+
+    init(
+        identifier: SessionIdentifier,
+        process: SessionProcess,
+        workingDirectory: String,
+        replayCapacity: Int
+    ) {
+        self.identifier = identifier
+        processID = process.processID
+        ttyDevice = process.ttyDevice
+        masterDescriptor = process.masterDescriptor
+        self.workingDirectory = workingDirectory
+        replay = SessionReplayBuffer(capacity: replayCapacity)
+    }
+
+    var hasPendingInput: Bool { inputOffset < pendingInput.count }
+
+    var descriptor: SessionDescriptor {
+        SessionDescriptor(
+            identifier: identifier,
+            shellProcessID: processID,
+            ttyDevice: ttyDevice,
+            workingDirectory: workingDirectory,
+            isAttached: clientDescriptor != nil,
+            metadata: metadata
+        )
+    }
+
+    func appendInput(_ bytes: [UInt8], limit: Int) {
+        guard pendingInput.count - inputOffset + bytes.count <= limit else {
+            SessionLog.write("dropped \(bytes.count) input byte(s): the session is not draining its terminal")
+            return
+        }
+        pendingInput.append(contentsOf: bytes)
+    }
+
+    func flushInput() {
+        guard masterDescriptor >= 0 else { return }
+        while inputOffset < pendingInput.count {
+            switch SessionIO.write(masterDescriptor, pendingInput, from: inputOffset) {
+            case let .wrote(count):
+                inputOffset += count
+            case .wouldBlock:
+                compactInput()
+                return
+            case .failed:
+                pendingInput.removeAll(keepingCapacity: true)
+                inputOffset = 0
+                return
+            }
+        }
+        pendingInput.removeAll(keepingCapacity: true)
+        inputOffset = 0
+    }
+
+    private func compactInput() {
+        guard inputOffset >= 1 << 16 else { return }
+        pendingInput.removeFirst(inputOffset)
+        inputOffset = 0
+    }
+}

--- a/MuxySession/SessionDaemon.swift
+++ b/MuxySession/SessionDaemon.swift
@@ -198,15 +198,16 @@ final class SessionDaemon {
             let matches = sessions[identifier].map { [$0.descriptor] } ?? []
             connection.enqueue(SessionFrame(kind: .sessions, payload: SessionDescriptor.encodeList(matches)))
         case .kill:
-            if let identifier = try? SessionIdentifierPayload.decode(frame.payload), let session = sessions[identifier] {
-                endSession(session, status: 0)
+            let stopped = if let identifier = try? SessionIdentifierPayload.decode(frame.payload),
+                             let session = sessions[identifier]
+            {
+                endSession(session, status: 0, force: true)
+            } else {
+                true
             }
-            connection.enqueue(SessionFrame(kind: .acknowledged))
+            enqueueStopResult(stopped, connection: connection)
         case .killAll:
-            for session in Array(sessions.values) {
-                endSession(session, status: 0)
-            }
-            connection.enqueue(SessionFrame(kind: .acknowledged))
+            enqueueStopResult(endSessions(Array(sessions.values), status: 0), connection: connection)
         case .attached,
              .output,
              .exited,
@@ -359,14 +360,45 @@ final class SessionDaemon {
         SessionPTY.terminate(processID: session.processID)
     }
 
-    private func endSession(_ session: PTYSession, status: Int32) {
+    @discardableResult
+    private func endSession(_ session: PTYSession, status: Int32, force: Bool = false) -> Bool {
         closeMaster(session)
+        guard !force || SessionPTY.forceTerminate(processID: session.processID) else {
+            SessionLog.write("failed to stop session \(session.identifier.uuidString)")
+            return false
+        }
+        finishSession(session, status: status)
+        return true
+    }
+
+    private func endSessions(_ endingSessions: [PTYSession], status: Int32) -> Bool {
+        for session in endingSessions {
+            closeMaster(session)
+        }
+        let failedProcessIDs = SessionPTY.forceTerminate(processIDs: endingSessions.map(\.processID))
+        for session in endingSessions where !failedProcessIDs.contains(session.processID) {
+            finishSession(session, status: status)
+        }
+        for session in endingSessions where failedProcessIDs.contains(session.processID) {
+            SessionLog.write("failed to stop session \(session.identifier.uuidString)")
+        }
+        return failedProcessIDs.isEmpty
+    }
+
+    private func finishSession(_ session: PTYSession, status: Int32) {
         sessions.removeValue(forKey: session.identifier)
         guard let descriptor = session.clientDescriptor, let connection = connections[descriptor] else { return }
         connection.enqueue(SessionFrame(kind: .exited, payload: SessionExitPayload.encode(status: status)))
         connection.attachedSession = nil
         connection.closesAfterFlush = true
         session.clientDescriptor = nil
+    }
+
+    private func enqueueStopResult(_ stopped: Bool, connection: SessionConnection) {
+        let frame = stopped
+            ? SessionFrame(kind: .acknowledged)
+            : SessionFrame(kind: .failure, payload: SessionTextPayload.encode("failed to stop one or more sessions"))
+        connection.enqueue(frame)
     }
 
     private func reapChildren() {

--- a/MuxySession/SessionDaemon.swift
+++ b/MuxySession/SessionDaemon.swift
@@ -1,0 +1,424 @@
+import Darwin
+import MuxySessionProtocol
+
+final class SessionDaemon {
+    static let replayCapacity = 256 * 1024
+    static let clientOutputLimit = 4 * 1024 * 1024
+    static let sessionInputLimit = 1024 * 1024
+    static let maximumConnections = 64
+    static let idleTimeoutMilliseconds: Int32 = 10000
+    static let replayChunkSize = 32 * 1024
+
+    private let socketPath: String
+    private let listener: Int32
+    private let lockDescriptor: Int32
+    private let signalPipe: SessionSignalPipe
+
+    private var sessions: [SessionIdentifier: PTYSession] = [:]
+    private var sessionsByMaster: [Int32: SessionIdentifier] = [:]
+    private var connections: [Int32: SessionConnection] = [:]
+    private var closingDescriptors: [Int32] = []
+
+    init?(socketPath: String) {
+        self.socketPath = socketPath
+        signal(SIGPIPE, SIG_IGN)
+        signal(SIGHUP, SIG_IGN)
+
+        guard let lock = SessionSocket.acquireLock(path: socketPath + ".lock") else {
+            return nil
+        }
+        lockDescriptor = lock
+
+        guard let signalPipe = SessionSignalPipe(signals: [SIGCHLD]) else {
+            SessionIO.close(lock)
+            return nil
+        }
+        self.signalPipe = signalPipe
+
+        guard let listener = SessionSocket.makeListener(path: socketPath) else {
+            SessionIO.close(lock)
+            return nil
+        }
+        self.listener = listener
+    }
+
+    func run() {
+        while true {
+            let isIdle = sessions.isEmpty && connections.isEmpty
+            var descriptors = buildPollDescriptors()
+            let ready = poll(&descriptors, nfds_t(descriptors.count), isIdle ? Self.idleTimeoutMilliseconds : -1)
+            if ready == 0 {
+                guard sessions.isEmpty, connections.isEmpty else { continue }
+                break
+            }
+            if ready < 0 {
+                guard errno == EINTR else { break }
+                continue
+            }
+            handle(descriptors)
+            reapChildren()
+            flushConnections()
+            closeMarkedConnections()
+        }
+        shutdown()
+    }
+
+    private func shutdown() {
+        for session in Array(sessions.values) {
+            closeMaster(session)
+        }
+        for descriptor in connections.keys {
+            SessionIO.close(descriptor)
+        }
+        SessionIO.close(listener)
+        unlink(socketPath)
+        SessionIO.close(lockDescriptor)
+        unlink(socketPath + ".lock")
+    }
+
+    private func buildPollDescriptors() -> [pollfd] {
+        var descriptors: [pollfd] = [
+            pollfd(fd: listener, events: Int16(POLLIN), revents: 0),
+            pollfd(fd: signalPipe.readDescriptor, events: Int16(POLLIN), revents: 0),
+        ]
+        for connection in connections.values {
+            var events = Int32(POLLIN)
+            if connection.hasPendingOutput {
+                events |= Int32(POLLOUT)
+            }
+            descriptors.append(pollfd(fd: connection.descriptor, events: Int16(events), revents: 0))
+        }
+        for session in sessions.values where session.masterDescriptor >= 0 {
+            var events: Int32 = 0
+            if !isClientBackedUp(session) {
+                events |= Int32(POLLIN)
+            }
+            if session.hasPendingInput {
+                events |= Int32(POLLOUT)
+            }
+            guard events != 0 else { continue }
+            descriptors.append(pollfd(fd: session.masterDescriptor, events: Int16(events), revents: 0))
+        }
+        return descriptors
+    }
+
+    private func isClientBackedUp(_ session: PTYSession) -> Bool {
+        guard let descriptor = session.clientDescriptor, let connection = connections[descriptor] else { return false }
+        return connection.pendingByteCount >= Self.clientOutputLimit
+    }
+
+    private func handle(_ descriptors: [pollfd]) {
+        for entry in descriptors where entry.revents != 0 {
+            if entry.fd == listener {
+                acceptConnections()
+            } else if entry.fd == signalPipe.readDescriptor {
+                signalPipe.drain()
+            } else if connections[entry.fd] != nil {
+                handleConnection(entry)
+            } else if let identifier = sessionsByMaster[entry.fd] {
+                handleMaster(entry, identifier: identifier)
+            }
+        }
+    }
+
+    private func acceptConnections() {
+        while let descriptor = SessionSocket.accept(listener) {
+            guard connections.count < Self.maximumConnections else {
+                SessionIO.close(descriptor)
+                continue
+            }
+            guard SessionSocket.peerUserID(descriptor) == getuid() else {
+                SessionLog.write("rejected connection from another user")
+                SessionIO.close(descriptor)
+                continue
+            }
+            connections[descriptor] = SessionConnection(descriptor: descriptor)
+        }
+    }
+
+    private func handleConnection(_ entry: pollfd) {
+        guard let connection = connections[entry.fd] else { return }
+        if entry.revents & Int16(POLLOUT) != 0, !connection.flush() {
+            markForClose(entry.fd)
+            return
+        }
+        guard entry.revents & Int16(POLLIN) != 0 || entry.revents & Int16(POLLHUP) != 0 else { return }
+
+        var reachedEnd = false
+        readLoop: while true {
+            switch SessionIO.read(entry.fd) {
+            case let .bytes(bytes):
+                connection.decoder.push(bytes)
+            case .wouldBlock:
+                break readLoop
+            case .endOfFile,
+                 .failed:
+                reachedEnd = true
+                break readLoop
+            }
+        }
+
+        while true {
+            do {
+                guard let frame = try connection.decoder.next() else { break }
+                handle(frame: frame, connection: connection)
+            } catch {
+                SessionLog.write("dropping connection with a malformed frame")
+                markForClose(entry.fd)
+                return
+            }
+        }
+
+        if reachedEnd {
+            markForClose(entry.fd)
+        }
+    }
+
+    private func handle(frame: SessionFrame, connection: SessionConnection) {
+        switch frame.kind {
+        case .attach:
+            handleAttach(payload: frame.payload, connection: connection)
+        case .input:
+            guard let identifier = connection.attachedSession, let session = sessions[identifier] else { return }
+            session.appendInput(frame.payload, limit: Self.sessionInputLimit)
+            session.flushInput()
+        case .resize:
+            guard let identifier = connection.attachedSession,
+                  let session = sessions[identifier],
+                  let size = try? SessionResizePayload.decode(frame.payload)
+            else { return }
+            SessionPTY.resize(masterDescriptor: session.masterDescriptor, columns: size.columns, rows: size.rows)
+        case .list:
+            connection.enqueue(SessionFrame(
+                kind: .sessions,
+                payload: SessionDescriptor.encodeList(sessions.values.map(\.descriptor))
+            ))
+        case .info:
+            guard let identifier = try? SessionIdentifierPayload.decode(frame.payload) else { return }
+            let matches = sessions[identifier].map { [$0.descriptor] } ?? []
+            connection.enqueue(SessionFrame(kind: .sessions, payload: SessionDescriptor.encodeList(matches)))
+        case .kill:
+            if let identifier = try? SessionIdentifierPayload.decode(frame.payload), let session = sessions[identifier] {
+                endSession(session, status: 0)
+            }
+            connection.enqueue(SessionFrame(kind: .acknowledged))
+        case .killAll:
+            for session in Array(sessions.values) {
+                endSession(session, status: 0)
+            }
+            connection.enqueue(SessionFrame(kind: .acknowledged))
+        case .attached,
+             .output,
+             .exited,
+             .failure,
+             .sessions,
+             .acknowledged:
+            break
+        }
+    }
+
+    private func handleAttach(payload: [UInt8], connection: SessionConnection) {
+        guard let request = try? SessionAttachRequest.decode(payload) else {
+            connection.enqueue(SessionFrame(kind: .failure, payload: SessionTextPayload.encode("malformed attach request")))
+            connection.closesAfterFlush = true
+            return
+        }
+        guard request.version == SessionProtocolVersion.current else {
+            connection.enqueue(SessionFrame(
+                kind: .failure,
+                payload: SessionTextPayload.encode(
+                    "this background session is owned by a different version of Muxy; stop it to start a new one"
+                )
+            ))
+            connection.closesAfterFlush = true
+            return
+        }
+        guard connection.attachedSession == nil else { return }
+
+        if let session = sessions[request.identifier] {
+            attach(session: session, request: request, connection: connection)
+            return
+        }
+        create(request: request, connection: connection)
+    }
+
+    private func attach(session: PTYSession, request: SessionAttachRequest, connection: SessionConnection) {
+        if let previous = session.clientDescriptor, previous != connection.descriptor {
+            connections[previous]?.attachedSession = nil
+            markForClose(previous)
+        }
+        session.clientDescriptor = connection.descriptor
+        session.metadata = request.metadata
+        connection.attachedSession = session.identifier
+
+        SessionPTY.resize(
+            masterDescriptor: session.masterDescriptor,
+            columns: request.columns,
+            rows: request.rows
+        )
+        connection.enqueue(SessionFrame(
+            kind: .attached,
+            payload: SessionAttachAccepted(
+                created: false,
+                shellProcessID: session.processID,
+                ttyDevice: session.ttyDevice
+            ).encoded()
+        ))
+        enqueueReplay(session: session, connection: connection)
+        SessionPTY.requestRedraw(masterDescriptor: session.masterDescriptor, fallbackProcessID: session.processID)
+    }
+
+    private func enqueueReplay(session: PTYSession, connection: SessionConnection) {
+        let bytes = session.replay.bytes
+        guard !bytes.isEmpty else { return }
+        var index = 0
+        while index < bytes.count {
+            let end = min(index + Self.replayChunkSize, bytes.count)
+            connection.enqueue(SessionFrame(kind: .output, payload: Array(bytes[index ..< end])))
+            index = end
+        }
+    }
+
+    private func create(request: SessionAttachRequest, connection: SessionConnection) {
+        let invocation = SessionShellIntegration.invocation(
+            command: request.command,
+            shell: request.shell,
+            resourcesDirectory: request.resourcesDirectory,
+            environment: request.environment
+        )
+        guard let process = SessionPTY.spawn(
+            invocation: invocation,
+            workingDirectory: request.workingDirectory,
+            columns: request.columns,
+            rows: request.rows
+        )
+        else {
+            connection.enqueue(SessionFrame(kind: .failure, payload: SessionTextPayload.encode("failed to start the session")))
+            connection.closesAfterFlush = true
+            return
+        }
+
+        let session = PTYSession(
+            identifier: request.identifier,
+            process: process,
+            workingDirectory: request.workingDirectory,
+            replayCapacity: Self.replayCapacity
+        )
+        session.clientDescriptor = connection.descriptor
+        session.metadata = request.metadata
+        sessions[request.identifier] = session
+        sessionsByMaster[process.masterDescriptor] = request.identifier
+        connection.attachedSession = request.identifier
+
+        connection.enqueue(SessionFrame(
+            kind: .attached,
+            payload: SessionAttachAccepted(
+                created: true,
+                shellProcessID: process.processID,
+                ttyDevice: process.ttyDevice
+            ).encoded()
+        ))
+    }
+
+    private func handleMaster(_ entry: pollfd, identifier: SessionIdentifier) {
+        guard let session = sessions[identifier] else { return }
+        if entry.revents & Int16(POLLOUT) != 0 {
+            session.flushInput()
+        }
+        guard entry.revents & Int16(POLLIN) != 0
+            || entry.revents & Int16(POLLHUP) != 0
+            || entry.revents & Int16(POLLNVAL) != 0
+        else { return }
+
+        readLoop: while true {
+            switch SessionIO.read(session.masterDescriptor) {
+            case let .bytes(bytes):
+                session.replay.append(bytes)
+                if let descriptor = session.clientDescriptor, let connection = connections[descriptor] {
+                    connection.enqueue(SessionFrame(kind: .output, payload: bytes))
+                }
+                if isClientBackedUp(session) {
+                    break readLoop
+                }
+            case .wouldBlock:
+                break readLoop
+            case .endOfFile,
+                 .failed:
+                closeMaster(session)
+                return
+            }
+        }
+    }
+
+    private func closeMaster(_ session: PTYSession) {
+        guard session.masterDescriptor >= 0 else { return }
+        sessionsByMaster.removeValue(forKey: session.masterDescriptor)
+        SessionIO.close(session.masterDescriptor)
+        session.masterDescriptor = -1
+        session.isEnding = true
+        SessionPTY.terminate(processID: session.processID)
+    }
+
+    private func endSession(_ session: PTYSession, status: Int32) {
+        closeMaster(session)
+        sessions.removeValue(forKey: session.identifier)
+        guard let descriptor = session.clientDescriptor, let connection = connections[descriptor] else { return }
+        connection.enqueue(SessionFrame(kind: .exited, payload: SessionExitPayload.encode(status: status)))
+        connection.attachedSession = nil
+        connection.closesAfterFlush = true
+        session.clientDescriptor = nil
+    }
+
+    private func reapChildren() {
+        while true {
+            var status: Int32 = 0
+            let processID = waitpid(-1, &status, WNOHANG)
+            guard processID > 0 else { return }
+            guard let session = sessions.values.first(where: { $0.processID == processID }) else { continue }
+            endSession(session, status: Self.exitCode(status))
+        }
+    }
+
+    static func exitCode(_ status: Int32) -> Int32 {
+        let terminationSignal = status & 0o177
+        if terminationSignal == 0 {
+            return (status >> 8) & 0xFF
+        }
+        if terminationSignal == 0o177 {
+            return 0
+        }
+        return 128 + terminationSignal
+    }
+
+    private func flushConnections() {
+        for connection in connections.values {
+            if !connection.flush() {
+                markForClose(connection.descriptor)
+                continue
+            }
+            if connection.closesAfterFlush, !connection.hasPendingOutput {
+                markForClose(connection.descriptor)
+            }
+        }
+    }
+
+    private func markForClose(_ descriptor: Int32) {
+        guard !closingDescriptors.contains(descriptor) else { return }
+        closingDescriptors.append(descriptor)
+    }
+
+    private func closeMarkedConnections() {
+        let descriptors = closingDescriptors
+        closingDescriptors.removeAll(keepingCapacity: true)
+        for descriptor in descriptors {
+            guard let connection = connections.removeValue(forKey: descriptor) else { continue }
+            if let identifier = connection.attachedSession,
+               let session = sessions[identifier],
+               session.clientDescriptor == descriptor
+            {
+                session.clientDescriptor = nil
+            }
+            SessionIO.close(descriptor)
+        }
+    }
+}

--- a/MuxySession/SessionPTY.swift
+++ b/MuxySession/SessionPTY.swift
@@ -1,0 +1,106 @@
+import Darwin
+import MuxySessionProtocol
+
+struct SessionProcess {
+    let masterDescriptor: Int32
+    let processID: pid_t
+    let ttyDevice: UInt64
+}
+
+enum SessionPTY {
+    private static let resetSignals: [Int32] = [SIGPIPE, SIGCHLD, SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGTSTP, SIGTTIN, SIGTTOU]
+
+    static func spawn(
+        invocation: SessionShellInvocation,
+        workingDirectory: String,
+        columns: UInt16,
+        rows: UInt16
+    ) -> SessionProcess? {
+        let argumentList = SessionCStringArray(invocation.arguments)
+        let environmentList = SessionCStringArray(invocation.environment.map { "\($0.key)=\($0.value)" })
+        guard let executable = strdup(invocation.executable) else { return nil }
+        let directory = strdup(workingDirectory)
+        defer {
+            free(executable)
+            free(directory)
+        }
+
+        var size = winsize(
+            ws_row: rows == 0 ? 24 : rows,
+            ws_col: columns == 0 ? 80 : columns,
+            ws_xpixel: 0,
+            ws_ypixel: 0
+        )
+        var master: Int32 = -1
+        var name = [CChar](repeating: 0, count: Int(PATH_MAX))
+
+        let processID = forkpty(&master, &name, nil, &size)
+        if processID < 0 {
+            SessionLog.write("forkpty failed: \(String(cString: strerror(errno)))")
+            return nil
+        }
+
+        if processID == 0 {
+            var empty = sigset_t()
+            sigemptyset(&empty)
+            sigprocmask(SIG_SETMASK, &empty, nil)
+            for number in resetSignals {
+                signal(number, SIG_DFL)
+            }
+            if let directory, chdir(directory) != 0 {
+                if let home = getenv("HOME") {
+                    _ = chdir(home)
+                } else {
+                    _ = chdir("/")
+                }
+            }
+            execve(executable, argumentList.pointer, environmentList.pointer)
+            _exit(127)
+        }
+
+        SessionIO.setNonBlocking(master)
+        SessionIO.setCloseOnExec(master)
+
+        var status = stat()
+        let device: UInt64 = stat(&name, &status) == 0
+            ? UInt64(UInt32(bitPattern: status.st_rdev))
+            : 0
+
+        return SessionProcess(masterDescriptor: master, processID: processID, ttyDevice: device)
+    }
+
+    static func resize(masterDescriptor: Int32, columns: UInt16, rows: UInt16) {
+        var size = winsize(
+            ws_row: rows == 0 ? 24 : rows,
+            ws_col: columns == 0 ? 80 : columns,
+            ws_xpixel: 0,
+            ws_ypixel: 0
+        )
+        _ = ioctl(masterDescriptor, TIOCSWINSZ, &size)
+    }
+
+    static func windowSize(descriptor: Int32) -> (columns: UInt16, rows: UInt16)? {
+        var size = winsize()
+        guard ioctl(descriptor, TIOCGWINSZ, &size) == 0 else { return nil }
+        return (size.ws_col, size.ws_row)
+    }
+
+    static func foregroundProcessGroup(masterDescriptor: Int32) -> pid_t? {
+        let group = tcgetpgrp(masterDescriptor)
+        return group > 0 ? group : nil
+    }
+
+    static func requestRedraw(masterDescriptor: Int32, fallbackProcessID: pid_t) {
+        let group = foregroundProcessGroup(masterDescriptor: masterDescriptor) ?? fallbackProcessID
+        guard group > 0 else { return }
+        _ = killpg(group, SIGWINCH)
+    }
+
+    static func terminate(processID: pid_t) {
+        guard processID > 0 else { return }
+        if killpg(processID, SIGHUP) != 0 {
+            _ = kill(processID, SIGHUP)
+        }
+        _ = killpg(processID, SIGCONT)
+    }
+}

--- a/MuxySession/SessionPTY.swift
+++ b/MuxySession/SessionPTY.swift
@@ -9,6 +9,9 @@ struct SessionProcess {
 
 enum SessionPTY {
     private static let resetSignals: [Int32] = [SIGPIPE, SIGCHLD, SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGTSTP, SIGTTIN, SIGTTOU]
+    private static let terminationPollMicroseconds: useconds_t = 10000
+    private static let gracefulTerminationAttempts = 20
+    private static let forcedTerminationAttempts = 50
 
     static func spawn(
         invocation: SessionShellInvocation,
@@ -102,5 +105,113 @@ enum SessionPTY {
             _ = kill(processID, SIGHUP)
         }
         _ = killpg(processID, SIGCONT)
+    }
+
+    static func forceTerminate(processID: pid_t) -> Bool {
+        forceTerminate(processIDs: [processID]).isEmpty
+    }
+
+    static func forceTerminate(processIDs: [pid_t]) -> Set<pid_t> {
+        let targets = Set(processIDs.filter { $0 > 0 })
+        guard !targets.isEmpty else { return [] }
+
+        signalSessions(targets, signal: SIGTERM)
+        let resistant = waitForSessionsExit(targets, attempts: gracefulTerminationAttempts)
+        guard !resistant.isEmpty else { return [] }
+
+        signalSessions(resistant, signal: SIGKILL)
+        return waitForSessionsExit(resistant, attempts: forcedTerminationAttempts, repeatedSignal: SIGKILL)
+    }
+
+    private static func signalSessions(_ sessionIDs: Set<pid_t>, signal: Int32) {
+        guard let members = sessionProcessIDs(sessionIDs: sessionIDs) else {
+            for sessionID in sessionIDs {
+                _ = killpg(sessionID, signal)
+                _ = kill(sessionID, signal)
+            }
+            return
+        }
+        signalSessions(sessionIDs, members: members, signal: signal)
+    }
+
+    private static func signalSessions(_ sessionIDs: Set<pid_t>, members: [pid_t: [pid_t]], signal: Int32) {
+        for sessionID in sessionIDs {
+            let memberProcessIDs = members[sessionID] ?? []
+            if memberProcessIDs.isEmpty {
+                _ = kill(sessionID, signal)
+                continue
+            }
+            for memberProcessID in memberProcessIDs {
+                _ = kill(memberProcessID, signal)
+            }
+        }
+    }
+
+    private static func waitForSessionsExit(
+        _ sessionIDs: Set<pid_t>,
+        attempts: Int,
+        repeatedSignal: Int32? = nil
+    ) -> Set<pid_t> {
+        var remaining = sessionIDs
+        for _ in 0 ..< attempts {
+            reap(processIDs: remaining)
+            guard let members = sessionProcessIDs(sessionIDs: remaining) else {
+                usleep(terminationPollMicroseconds)
+                continue
+            }
+            remaining = activeSessionIDs(remaining, members: members)
+            guard !remaining.isEmpty else { return [] }
+            if let repeatedSignal {
+                signalSessions(remaining, members: members, signal: repeatedSignal)
+            }
+            usleep(terminationPollMicroseconds)
+        }
+
+        reap(processIDs: remaining)
+        guard let members = sessionProcessIDs(sessionIDs: remaining) else { return remaining }
+        return activeSessionIDs(remaining, members: members)
+    }
+
+    private static func activeSessionIDs(_ sessionIDs: Set<pid_t>, members: [pid_t: [pid_t]]) -> Set<pid_t> {
+        sessionIDs.filter { processExists($0) || !(members[$0] ?? []).isEmpty }
+    }
+
+    private static func reap(processIDs: Set<pid_t>) {
+        for processID in processIDs {
+            var status: Int32 = 0
+            while waitpid(processID, &status, WNOHANG) < 0, errno == EINTR {}
+        }
+    }
+
+    private static func processExists(_ processID: pid_t) -> Bool {
+        guard kill(processID, 0) != 0 else { return true }
+        return errno == EPERM
+    }
+
+    private static func sessionProcessIDs(sessionIDs: Set<pid_t>) -> [pid_t: [pid_t]]? {
+        let stride = MemoryLayout<kinfo_proc>.stride
+        for _ in 0 ..< 3 {
+            var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL]
+            var size = 0
+            guard sysctl(&name, 3, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+
+            var records = [kinfo_proc](repeating: kinfo_proc(), count: size / stride + 16)
+            size = records.count * stride
+            if sysctl(&name, 3, &records, &size, nil, 0) != 0 {
+                guard errno == ENOMEM else { return nil }
+                continue
+            }
+
+            var members: [pid_t: [pid_t]] = [:]
+            for record in records.prefix(size / stride) {
+                let processID = record.kp_proc.p_pid
+                guard processID > 0 else { continue }
+                let sessionID = getsid(processID)
+                guard sessionIDs.contains(sessionID) else { continue }
+                members[sessionID, default: []].append(processID)
+            }
+            return members
+        }
+        return nil
     }
 }

--- a/MuxySession/SessionSocket.swift
+++ b/MuxySession/SessionSocket.swift
@@ -1,0 +1,104 @@
+import Darwin
+
+enum SessionSocket {
+    static let backlog: Int32 = 16
+
+    static func makeListener(path: String) -> Int32? {
+        guard let address = makeAddress(path: path) else {
+            SessionLog.write("socket path too long: \(path)")
+            return nil
+        }
+        unlink(path)
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return nil }
+        SessionIO.setCloseOnExec(descriptor)
+
+        var storage = address
+        let previousMask = umask(0o077)
+        let bound = withUnsafePointer(to: &storage) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { casted in
+                bind(descriptor, casted, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        umask(previousMask)
+        guard bound == 0 else {
+            SessionLog.write("bind failed: \(String(cString: strerror(errno)))")
+            SessionIO.close(descriptor)
+            return nil
+        }
+        chmod(path, 0o600)
+        guard listen(descriptor, backlog) == 0 else {
+            SessionLog.write("listen failed: \(String(cString: strerror(errno)))")
+            SessionIO.close(descriptor)
+            return nil
+        }
+        SessionIO.setNonBlocking(descriptor)
+        return descriptor
+    }
+
+    static func connect(path: String) -> Int32? {
+        guard let address = makeAddress(path: path) else { return nil }
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return nil }
+        SessionIO.setCloseOnExec(descriptor)
+
+        var storage = address
+        let connected = withUnsafePointer(to: &storage) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { casted in
+                Darwin.connect(descriptor, casted, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            SessionIO.close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+
+    static func accept(_ listener: Int32) -> Int32? {
+        let descriptor = Darwin.accept(listener, nil, nil)
+        guard descriptor >= 0 else { return nil }
+        SessionIO.setCloseOnExec(descriptor)
+        SessionIO.setNonBlocking(descriptor)
+        return descriptor
+    }
+
+    static func peerUserID(_ descriptor: Int32) -> uid_t? {
+        var credentials = xucred()
+        var length = socklen_t(MemoryLayout<xucred>.size)
+        let result = withUnsafeMutablePointer(to: &credentials) { pointer in
+            getsockopt(descriptor, SOL_LOCAL, LOCAL_PEERCRED, pointer, &length)
+        }
+        guard result == 0, credentials.cr_version == XUCRED_VERSION else { return nil }
+        return credentials.cr_uid
+    }
+
+    static func acquireLock(path: String) -> Int32? {
+        let descriptor = open(path, O_CREAT | O_RDWR, 0o600)
+        guard descriptor >= 0 else { return nil }
+        SessionIO.setCloseOnExec(descriptor)
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            SessionIO.close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+
+    private static func makeAddress(path: String) -> sockaddr_un? {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        let bytes = Array(path.utf8)
+        guard bytes.count < capacity else { return nil }
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+                for (index, byte) in bytes.enumerated() {
+                    destination[index] = CChar(bitPattern: byte)
+                }
+                destination[bytes.count] = 0
+            }
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        return address
+    }
+}

--- a/MuxySession/SessionSupport.swift
+++ b/MuxySession/SessionSupport.swift
@@ -1,0 +1,168 @@
+import Darwin
+
+enum SessionReadOutcome {
+    case bytes([UInt8])
+    case wouldBlock
+    case endOfFile
+    case failed
+}
+
+enum SessionWriteOutcome {
+    case wrote(Int)
+    case wouldBlock
+    case failed
+}
+
+enum SessionIO {
+    static let chunkSize = 64 * 1024
+
+    static func setNonBlocking(_ descriptor: Int32) {
+        let flags = fcntl(descriptor, F_GETFL, 0)
+        guard flags >= 0 else { return }
+        _ = fcntl(descriptor, F_SETFL, flags | O_NONBLOCK)
+    }
+
+    static func setCloseOnExec(_ descriptor: Int32) {
+        let flags = fcntl(descriptor, F_GETFD, 0)
+        guard flags >= 0 else { return }
+        _ = fcntl(descriptor, F_SETFD, flags | FD_CLOEXEC)
+    }
+
+    static func read(_ descriptor: Int32, limit: Int = chunkSize) -> SessionReadOutcome {
+        var buffer = [UInt8](repeating: 0, count: limit)
+        let count = buffer.withUnsafeMutableBytes { pointer in
+            Darwin.read(descriptor, pointer.baseAddress, limit)
+        }
+        if count > 0 {
+            return .bytes(Array(buffer[0 ..< count]))
+        }
+        if count == 0 {
+            return .endOfFile
+        }
+        switch errno {
+        case EINTR,
+             EAGAIN:
+            return .wouldBlock
+        default:
+            return .failed
+        }
+    }
+
+    static func write(_ descriptor: Int32, _ bytes: [UInt8], from offset: Int) -> SessionWriteOutcome {
+        guard offset < bytes.count else { return .wrote(0) }
+        let count = bytes.withUnsafeBytes { pointer -> Int in
+            guard let base = pointer.baseAddress else { return -1 }
+            return Darwin.write(descriptor, base.advanced(by: offset), bytes.count - offset)
+        }
+        if count >= 0 {
+            return .wrote(count)
+        }
+        switch errno {
+        case EINTR,
+             EAGAIN:
+            return .wouldBlock
+        default:
+            return .failed
+        }
+    }
+
+    @discardableResult
+    static func writeAll(_ descriptor: Int32, _ bytes: [UInt8]) -> Bool {
+        var offset = 0
+        while offset < bytes.count {
+            switch write(descriptor, bytes, from: offset) {
+            case let .wrote(count):
+                offset += count
+            case .wouldBlock:
+                continue
+            case .failed:
+                return false
+            }
+        }
+        return true
+    }
+
+    static func close(_ descriptor: Int32) {
+        guard descriptor >= 0 else { return }
+        _ = Darwin.close(descriptor)
+    }
+}
+
+final class SessionSignalPipe {
+    nonisolated(unsafe) private static var writeDescriptor: Int32 = -1
+
+    let readDescriptor: Int32
+
+    init?(signals: [Int32]) {
+        var descriptors: [Int32] = [0, 0]
+        guard pipe(&descriptors) == 0 else { return nil }
+        readDescriptor = descriptors[0]
+        Self.writeDescriptor = descriptors[1]
+        SessionIO.setNonBlocking(readDescriptor)
+        SessionIO.setNonBlocking(Self.writeDescriptor)
+        SessionIO.setCloseOnExec(readDescriptor)
+        SessionIO.setCloseOnExec(Self.writeDescriptor)
+        for number in signals {
+            signal(number) { _ in
+                var token: UInt8 = 1
+                _ = Darwin.write(SessionSignalPipe.writeDescriptor, &token, 1)
+            }
+        }
+    }
+
+    func drain() {
+        while case .bytes = SessionIO.read(readDescriptor, limit: 64) {}
+    }
+}
+
+final class SessionCStringArray {
+    private let storage: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+    private let count: Int
+
+    init(_ values: [String]) {
+        count = values.count
+        storage = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>.allocate(capacity: count + 1)
+        for (index, value) in values.enumerated() {
+            storage[index] = strdup(value)
+        }
+        storage[count] = nil
+    }
+
+    var pointer: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> { storage }
+
+    deinit {
+        for index in 0 ..< count {
+            free(storage[index])
+        }
+        storage.deallocate()
+    }
+}
+
+enum SessionLog {
+    static func write(_ message: String) {
+        SessionIO.writeAll(STDERR_FILENO, Array((message + "\n").utf8))
+    }
+}
+
+enum SessionProcessEnvironment {
+    static func current() -> [(key: String, value: String)] {
+        var result: [(key: String, value: String)] = []
+        var cursor = environ
+        while let entry = cursor.pointee {
+            let text = String(cString: entry)
+            if let separator = text.firstIndex(of: "=") {
+                let key = String(text[text.startIndex ..< separator])
+                let value = String(text[text.index(after: separator)...])
+                result.append((key: key, value: value))
+            }
+            cursor = cursor.advanced(by: 1)
+        }
+        return result
+    }
+
+    static func value(_ key: String) -> String? {
+        guard let raw = getenv(key) else { return nil }
+        let value = String(cString: raw)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/MuxySession/main.swift
+++ b/MuxySession/main.swift
@@ -1,0 +1,76 @@
+import Darwin
+import MuxySessionProtocol
+
+func argumentValue(_ name: String, in arguments: [String]) -> String? {
+    guard let index = arguments.firstIndex(of: name), index + 1 < arguments.count else { return nil }
+    return arguments[index + 1]
+}
+
+func currentDirectory() -> String {
+    guard let raw = getcwd(nil, 0) else { return "/" }
+    defer { free(raw) }
+    return String(cString: raw)
+}
+
+func attachConfiguration() -> SessionAttachClient.Configuration? {
+    guard let rawIdentifier = SessionProcessEnvironment.value("MUXY_SESSION_ID"),
+          let identifier = SessionIdentifier(uuidString: rawIdentifier),
+          let socketPath = SessionProcessEnvironment.value("MUXY_SESSION_SOCKET")
+    else { return nil }
+
+    return SessionAttachClient.Configuration(
+        identifier: identifier,
+        socketPath: socketPath,
+        command: SessionProcessEnvironment.value("MUXY_SESSION_COMMAND") ?? "",
+        shell: SessionProcessEnvironment.value("MUXY_SESSION_SHELL")
+            ?? SessionProcessEnvironment.value("SHELL")
+            ?? SessionShellIntegration.defaultShell,
+        resourcesDirectory: SessionProcessEnvironment.value("MUXY_SESSION_RESOURCES")
+            ?? SessionProcessEnvironment.value("GHOSTTY_RESOURCES_DIR")
+            ?? "",
+        workingDirectory: SessionProcessEnvironment.value("MUXY_SESSION_CWD") ?? currentDirectory(),
+        metadata: attachMetadata()
+    )
+}
+
+func attachMetadata() -> [SessionEnvironmentEntry] {
+    let sources = [
+        (SessionMetadataKey.project, "MUXY_SESSION_PROJECT"),
+        (SessionMetadataKey.worktree, "MUXY_SESSION_WORKTREE"),
+        (SessionMetadataKey.tab, "MUXY_SESSION_TAB"),
+        (SessionMetadataKey.title, "MUXY_SESSION_TITLE"),
+    ]
+    return sources.compactMap { key, variable in
+        guard let value = SessionProcessEnvironment.value(variable) else { return nil }
+        return SessionEnvironmentEntry(key: key, value: value)
+    }
+}
+
+func fail(_ message: String) -> Never {
+    SessionLog.write(message)
+    exit(2)
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count > 1 else {
+    fail("usage: muxy-session daemon --socket <path> | muxy-session attach")
+}
+
+switch arguments[1] {
+case "daemon":
+    guard let socketPath = argumentValue("--socket", in: arguments) else {
+        fail("usage: muxy-session daemon --socket <path>")
+    }
+    guard let daemon = SessionDaemon(socketPath: socketPath) else {
+        exit(0)
+    }
+    daemon.run()
+    exit(0)
+case "attach":
+    guard let configuration = attachConfiguration() else {
+        fail("muxy-session: MUXY_SESSION_ID and MUXY_SESSION_SOCKET are required")
+    }
+    exit(SessionAttachClient.run(configuration: configuration))
+default:
+    fail("muxy-session: unknown command \(arguments[1])")
+}

--- a/MuxySessionProtocol/SessionBytes.swift
+++ b/MuxySessionProtocol/SessionBytes.swift
@@ -1,0 +1,148 @@
+public struct SessionByteWriter: Sendable {
+    public private(set) var bytes: [UInt8] = []
+
+    public init() {}
+
+    public mutating func writeUInt8(_ value: UInt8) {
+        bytes.append(value)
+    }
+
+    public mutating func writeUInt16(_ value: UInt16) {
+        bytes.append(UInt8(truncatingIfNeeded: value >> 8))
+        bytes.append(UInt8(truncatingIfNeeded: value))
+    }
+
+    public mutating func writeUInt32(_ value: UInt32) {
+        for shift in stride(from: 24, through: 0, by: -8) {
+            bytes.append(UInt8(truncatingIfNeeded: value >> UInt32(shift)))
+        }
+    }
+
+    public mutating func writeUInt64(_ value: UInt64) {
+        for shift in stride(from: 56, through: 0, by: -8) {
+            bytes.append(UInt8(truncatingIfNeeded: value >> UInt64(shift)))
+        }
+    }
+
+    public mutating func writeInt32(_ value: Int32) {
+        writeUInt32(UInt32(bitPattern: value))
+    }
+
+    public mutating func writeRaw(_ value: [UInt8]) {
+        bytes.append(contentsOf: value)
+    }
+
+    public mutating func writeString(_ value: String) {
+        let encoded = Array(value.utf8)
+        writeUInt32(UInt32(encoded.count))
+        bytes.append(contentsOf: encoded)
+    }
+
+    public mutating func writeIdentifier(_ value: SessionIdentifier) {
+        bytes.append(contentsOf: value.bytes)
+    }
+
+    public mutating func writeEntries(_ entries: [SessionEnvironmentEntry]) {
+        writeUInt32(UInt32(entries.count))
+        for entry in entries {
+            writeString(entry.key)
+            writeString(entry.value)
+        }
+    }
+}
+
+public struct SessionByteReader {
+    private let bytes: [UInt8]
+    private var offset: Int
+
+    public init(_ bytes: [UInt8]) {
+        self.bytes = bytes
+        offset = 0
+    }
+
+    public var isAtEnd: Bool { offset >= bytes.count }
+
+    public mutating func readUInt8() throws -> UInt8 {
+        try requireRemaining(1)
+        defer { offset += 1 }
+        return bytes[offset]
+    }
+
+    public mutating func readUInt16() throws -> UInt16 {
+        try requireRemaining(2)
+        defer { offset += 2 }
+        return UInt16(bytes[offset]) << 8 | UInt16(bytes[offset + 1])
+    }
+
+    public mutating func readUInt32() throws -> UInt32 {
+        try requireRemaining(4)
+        defer { offset += 4 }
+        var value: UInt32 = 0
+        for index in 0 ..< 4 {
+            value = value << 8 | UInt32(bytes[offset + index])
+        }
+        return value
+    }
+
+    public mutating func readUInt64() throws -> UInt64 {
+        try requireRemaining(8)
+        defer { offset += 8 }
+        var value: UInt64 = 0
+        for index in 0 ..< 8 {
+            value = value << 8 | UInt64(bytes[offset + index])
+        }
+        return value
+    }
+
+    public mutating func readInt32() throws -> Int32 {
+        try Int32(bitPattern: readUInt32())
+    }
+
+    public mutating func readRaw(_ count: Int) throws -> [UInt8] {
+        try requireRemaining(count)
+        defer { offset += count }
+        return Array(bytes[offset ..< offset + count])
+    }
+
+    public mutating func readString() throws -> String {
+        let length = try Int(readUInt32())
+        let raw = try readRaw(length)
+        return String(decoding: raw, as: UTF8.self)
+    }
+
+    public mutating func readIdentifier() throws -> SessionIdentifier {
+        let raw = try readRaw(SessionIdentifier.byteCount)
+        guard let identifier = SessionIdentifier(bytes: raw) else {
+            throw SessionProtocolError.malformedPayload
+        }
+        return identifier
+    }
+
+    public mutating func readEntries() throws -> [SessionEnvironmentEntry] {
+        let count = try Int(readUInt32())
+        guard count >= 0, count <= bytes.count else { throw SessionProtocolError.malformedPayload }
+        var entries: [SessionEnvironmentEntry] = []
+        entries.reserveCapacity(count)
+        for _ in 0 ..< count {
+            try entries.append(SessionEnvironmentEntry(key: readString(), value: readString()))
+        }
+        return entries
+    }
+
+    public mutating func readRemaining() -> [UInt8] {
+        defer { offset = bytes.count }
+        return Array(bytes[offset...])
+    }
+
+    private func requireRemaining(_ count: Int) throws {
+        guard count >= 0, bytes.count - offset >= count else {
+            throw SessionProtocolError.malformedPayload
+        }
+    }
+}
+
+public enum SessionProtocolError: Error, Equatable, Sendable {
+    case malformedPayload
+    case unknownFrameKind(UInt8)
+    case frameTooLarge(Int)
+}

--- a/MuxySessionProtocol/SessionFrame.swift
+++ b/MuxySessionProtocol/SessionFrame.swift
@@ -1,0 +1,95 @@
+public enum SessionFrameKind: UInt8, Sendable, CaseIterable {
+    case attach = 0x01
+    case input = 0x02
+    case resize = 0x03
+
+    case attached = 0x11
+    case output = 0x12
+    case exited = 0x13
+    case failure = 0x14
+
+    case list = 0x21
+    case info = 0x22
+    case kill = 0x23
+    case killAll = 0x24
+
+    case sessions = 0x31
+    case acknowledged = 0x32
+}
+
+public struct SessionFrame: Equatable, Sendable {
+    public static let headerSize = 5
+    public static let maximumPayloadSize = 1 << 20
+
+    public let kind: SessionFrameKind
+    public let payload: [UInt8]
+
+    public init(kind: SessionFrameKind, payload: [UInt8] = []) {
+        self.kind = kind
+        self.payload = payload
+    }
+
+    public func encoded() -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeUInt8(kind.rawValue)
+        writer.writeUInt32(UInt32(payload.count))
+        writer.writeRaw(payload)
+        return writer.bytes
+    }
+}
+
+public struct SessionFrameDecoder: Sendable {
+    private var buffer: [UInt8] = []
+    private var consumed = 0
+
+    public init() {}
+
+    public var bufferedByteCount: Int { buffer.count - consumed }
+
+    public mutating func push(_ bytes: [UInt8]) {
+        buffer.append(contentsOf: bytes)
+    }
+
+    public mutating func push(_ bytes: UnsafeBufferPointer<UInt8>) {
+        buffer.append(contentsOf: bytes)
+    }
+
+    public mutating func next() throws -> SessionFrame? {
+        guard buffer.count - consumed >= SessionFrame.headerSize else {
+            compact()
+            return nil
+        }
+        let rawKind = buffer[consumed]
+        var length = 0
+        for index in 1 ..< SessionFrame.headerSize {
+            length = length << 8 | Int(buffer[consumed + index])
+        }
+        guard length <= SessionFrame.maximumPayloadSize else {
+            throw SessionProtocolError.frameTooLarge(length)
+        }
+        guard buffer.count - consumed - SessionFrame.headerSize >= length else {
+            compact()
+            return nil
+        }
+        guard let kind = SessionFrameKind(rawValue: rawKind) else {
+            throw SessionProtocolError.unknownFrameKind(rawKind)
+        }
+        let start = consumed + SessionFrame.headerSize
+        let payload = Array(buffer[start ..< start + length])
+        consumed = start + length
+        compact()
+        return SessionFrame(kind: kind, payload: payload)
+    }
+
+    private mutating func compact() {
+        guard consumed > 0 else { return }
+        if consumed == buffer.count {
+            buffer.removeAll(keepingCapacity: true)
+        } else if consumed >= 1 << 16 {
+            buffer.removeFirst(consumed)
+        } else {
+            return
+        }
+        consumed = 0
+    }
+}

--- a/MuxySessionProtocol/SessionIdentifier.swift
+++ b/MuxySessionProtocol/SessionIdentifier.swift
@@ -1,0 +1,62 @@
+public struct SessionIdentifier: Hashable, Sendable {
+    public static let byteCount = 16
+
+    public let bytes: [UInt8]
+
+    public init?(bytes: [UInt8]) {
+        guard bytes.count == Self.byteCount else { return nil }
+        self.bytes = bytes
+    }
+
+    public init?(uuidString: String) {
+        var parsed: [UInt8] = []
+        parsed.reserveCapacity(Self.byteCount)
+        var pendingHighNibble: UInt8?
+        for character in uuidString {
+            if character == "-" {
+                continue
+            }
+            guard let nibble = Self.nibble(character) else { return nil }
+            guard let high = pendingHighNibble else {
+                pendingHighNibble = nibble
+                continue
+            }
+            guard parsed.count < Self.byteCount else { return nil }
+            parsed.append(high << 4 | nibble)
+            pendingHighNibble = nil
+        }
+        guard pendingHighNibble == nil, parsed.count == Self.byteCount else { return nil }
+        bytes = parsed
+    }
+
+    public var uuidString: String {
+        var result = ""
+        result.reserveCapacity(36)
+        for (index, byte) in bytes.enumerated() {
+            if index == 4 || index == 6 || index == 8 || index == 10 {
+                result.append("-")
+            }
+            result.append(Self.hexDigit(byte >> 4))
+            result.append(Self.hexDigit(byte & 0x0F))
+        }
+        return result
+    }
+
+    private static func nibble(_ character: Character) -> UInt8? {
+        switch character {
+        case "0" ... "9":
+            UInt8(character.asciiValue ?? 0) - UInt8(ascii: "0")
+        case "a" ... "f":
+            UInt8(character.asciiValue ?? 0) - UInt8(ascii: "a") + 10
+        case "A" ... "F":
+            UInt8(character.asciiValue ?? 0) - UInt8(ascii: "A") + 10
+        default:
+            nil
+        }
+    }
+
+    private static func hexDigit(_ value: UInt8) -> Character {
+        let digits: [Character] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"]
+        return digits[Int(value & 0x0F)]
+    }
+}

--- a/MuxySessionProtocol/SessionMessages.swift
+++ b/MuxySessionProtocol/SessionMessages.swift
@@ -1,0 +1,232 @@
+public enum SessionProtocolVersion {
+    public static let current: UInt16 = 1
+}
+
+public struct SessionAttachRequest: Equatable, Sendable {
+    public let version: UInt16
+    public let identifier: SessionIdentifier
+    public let columns: UInt16
+    public let rows: UInt16
+    public let workingDirectory: String
+    public let command: String
+    public let shell: String
+    public let resourcesDirectory: String
+    public let environment: [SessionEnvironmentEntry]
+    public let metadata: [SessionEnvironmentEntry]
+
+    public init(
+        version: UInt16 = SessionProtocolVersion.current,
+        identifier: SessionIdentifier,
+        columns: UInt16,
+        rows: UInt16,
+        workingDirectory: String,
+        command: String,
+        shell: String,
+        resourcesDirectory: String,
+        environment: [SessionEnvironmentEntry],
+        metadata: [SessionEnvironmentEntry] = []
+    ) {
+        self.version = version
+        self.identifier = identifier
+        self.columns = columns
+        self.rows = rows
+        self.workingDirectory = workingDirectory
+        self.command = command
+        self.shell = shell
+        self.resourcesDirectory = resourcesDirectory
+        self.environment = environment
+        self.metadata = metadata
+    }
+
+    public func encoded() -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeUInt16(version)
+        writer.writeIdentifier(identifier)
+        writer.writeUInt16(columns)
+        writer.writeUInt16(rows)
+        writer.writeString(workingDirectory)
+        writer.writeString(command)
+        writer.writeString(shell)
+        writer.writeString(resourcesDirectory)
+        writer.writeEntries(environment)
+        writer.writeEntries(metadata)
+        return writer.bytes
+    }
+
+    public static func decode(_ payload: [UInt8]) throws -> SessionAttachRequest {
+        var reader = SessionByteReader(payload)
+        return try SessionAttachRequest(
+            version: reader.readUInt16(),
+            identifier: reader.readIdentifier(),
+            columns: reader.readUInt16(),
+            rows: reader.readUInt16(),
+            workingDirectory: reader.readString(),
+            command: reader.readString(),
+            shell: reader.readString(),
+            resourcesDirectory: reader.readString(),
+            environment: reader.readEntries(),
+            metadata: reader.readEntries()
+        )
+    }
+}
+
+public struct SessionEnvironmentEntry: Equatable, Sendable {
+    public let key: String
+    public let value: String
+
+    public init(key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+}
+
+public struct SessionAttachAccepted: Equatable, Sendable {
+    public let created: Bool
+    public let shellProcessID: Int32
+    public let ttyDevice: UInt64
+
+    public init(created: Bool, shellProcessID: Int32, ttyDevice: UInt64) {
+        self.created = created
+        self.shellProcessID = shellProcessID
+        self.ttyDevice = ttyDevice
+    }
+
+    public func encoded() -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeUInt8(created ? 1 : 0)
+        writer.writeInt32(shellProcessID)
+        writer.writeUInt64(ttyDevice)
+        return writer.bytes
+    }
+
+    public static func decode(_ payload: [UInt8]) throws -> SessionAttachAccepted {
+        var reader = SessionByteReader(payload)
+        return try SessionAttachAccepted(
+            created: reader.readUInt8() == 1,
+            shellProcessID: reader.readInt32(),
+            ttyDevice: reader.readUInt64()
+        )
+    }
+}
+
+public struct SessionDescriptor: Equatable, Sendable {
+    public let identifier: SessionIdentifier
+    public let shellProcessID: Int32
+    public let ttyDevice: UInt64
+    public let workingDirectory: String
+    public let isAttached: Bool
+    public let metadata: [SessionEnvironmentEntry]
+
+    public init(
+        identifier: SessionIdentifier,
+        shellProcessID: Int32,
+        ttyDevice: UInt64,
+        workingDirectory: String,
+        isAttached: Bool,
+        metadata: [SessionEnvironmentEntry] = []
+    ) {
+        self.identifier = identifier
+        self.shellProcessID = shellProcessID
+        self.ttyDevice = ttyDevice
+        self.workingDirectory = workingDirectory
+        self.isAttached = isAttached
+        self.metadata = metadata
+    }
+
+    public func value(forMetadataKey key: String) -> String? {
+        metadata.first { $0.key == key }?.value
+    }
+
+    public func encode(into writer: inout SessionByteWriter) {
+        writer.writeIdentifier(identifier)
+        writer.writeInt32(shellProcessID)
+        writer.writeUInt64(ttyDevice)
+        writer.writeString(workingDirectory)
+        writer.writeUInt8(isAttached ? 1 : 0)
+        writer.writeEntries(metadata)
+    }
+
+    public static func decode(from reader: inout SessionByteReader) throws -> SessionDescriptor {
+        try SessionDescriptor(
+            identifier: reader.readIdentifier(),
+            shellProcessID: reader.readInt32(),
+            ttyDevice: reader.readUInt64(),
+            workingDirectory: reader.readString(),
+            isAttached: reader.readUInt8() == 1,
+            metadata: reader.readEntries()
+        )
+    }
+
+    public static func encodeList(_ descriptors: [SessionDescriptor]) -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeUInt32(UInt32(descriptors.count))
+        for descriptor in descriptors {
+            descriptor.encode(into: &writer)
+        }
+        return writer.bytes
+    }
+
+    public static func decodeList(_ payload: [UInt8]) throws -> [SessionDescriptor] {
+        var reader = SessionByteReader(payload)
+        let count = try Int(reader.readUInt32())
+        var descriptors: [SessionDescriptor] = []
+        descriptors.reserveCapacity(count)
+        for _ in 0 ..< count {
+            try descriptors.append(SessionDescriptor.decode(from: &reader))
+        }
+        return descriptors
+    }
+}
+
+public enum SessionResizePayload {
+    public static func encode(columns: UInt16, rows: UInt16) -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeUInt16(columns)
+        writer.writeUInt16(rows)
+        return writer.bytes
+    }
+
+    public static func decode(_ payload: [UInt8]) throws -> (columns: UInt16, rows: UInt16) {
+        var reader = SessionByteReader(payload)
+        return try (reader.readUInt16(), reader.readUInt16())
+    }
+}
+
+public enum SessionExitPayload {
+    public static func encode(status: Int32) -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeInt32(status)
+        return writer.bytes
+    }
+
+    public static func decode(_ payload: [UInt8]) throws -> Int32 {
+        var reader = SessionByteReader(payload)
+        return try reader.readInt32()
+    }
+}
+
+public enum SessionTextPayload {
+    public static func encode(_ text: String) -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeString(text)
+        return writer.bytes
+    }
+
+    public static func decode(_ payload: [UInt8]) throws -> String {
+        var reader = SessionByteReader(payload)
+        return try reader.readString()
+    }
+}
+
+public enum SessionIdentifierPayload {
+    public static func encode(_ identifier: SessionIdentifier) -> [UInt8] {
+        var writer = SessionByteWriter()
+        writer.writeIdentifier(identifier)
+        return writer.bytes
+    }
+
+    public static func decode(_ payload: [UInt8]) throws -> SessionIdentifier {
+        var reader = SessionByteReader(payload)
+        return try reader.readIdentifier()
+    }
+}

--- a/MuxySessionProtocol/SessionMetadataKey.swift
+++ b/MuxySessionProtocol/SessionMetadataKey.swift
@@ -1,0 +1,6 @@
+public enum SessionMetadataKey {
+    public static let project = "project"
+    public static let worktree = "worktree"
+    public static let tab = "tab"
+    public static let title = "title"
+}

--- a/MuxySessionProtocol/SessionReplayBuffer.swift
+++ b/MuxySessionProtocol/SessionReplayBuffer.swift
@@ -1,0 +1,55 @@
+public struct SessionReplayBuffer: Sendable {
+    public let capacity: Int
+
+    private var storage: [UInt8]
+    private var start = 0
+    private var count = 0
+
+    public init(capacity: Int) {
+        self.capacity = max(capacity, 0)
+        storage = [UInt8](repeating: 0, count: self.capacity)
+    }
+
+    public var isEmpty: Bool { count == 0 }
+    public var byteCount: Int { count }
+
+    public mutating func append(_ bytes: [UInt8]) {
+        bytes.withUnsafeBufferPointer { append($0) }
+    }
+
+    public mutating func append(_ bytes: UnsafeBufferPointer<UInt8>) {
+        guard capacity > 0, !bytes.isEmpty else { return }
+        guard bytes.count < capacity else {
+            let tail = bytes.suffix(capacity)
+            for (offset, byte) in tail.enumerated() {
+                storage[offset] = byte
+            }
+            start = 0
+            count = capacity
+            return
+        }
+        for byte in bytes {
+            storage[(start + count) % capacity] = byte
+            if count < capacity {
+                count += 1
+            } else {
+                start = (start + 1) % capacity
+            }
+        }
+    }
+
+    public var bytes: [UInt8] {
+        guard count > 0 else { return [] }
+        var result = [UInt8]()
+        result.reserveCapacity(count)
+        for offset in 0 ..< count {
+            result.append(storage[(start + offset) % capacity])
+        }
+        return result
+    }
+
+    public mutating func removeAll() {
+        start = 0
+        count = 0
+    }
+}

--- a/MuxySessionProtocol/SessionShellIntegration.swift
+++ b/MuxySessionProtocol/SessionShellIntegration.swift
@@ -1,0 +1,135 @@
+public struct SessionShellInvocation: Equatable, Sendable {
+    public let executable: String
+    public let arguments: [String]
+    public let environment: [SessionEnvironmentEntry]
+
+    public init(executable: String, arguments: [String], environment: [SessionEnvironmentEntry]) {
+        self.executable = executable
+        self.arguments = arguments
+        self.environment = environment
+    }
+}
+
+public struct SessionEnvironment: Equatable, Sendable {
+    private var keys: [String]
+    private var values: [String: String]
+
+    public init(_ entries: [SessionEnvironmentEntry]) {
+        keys = []
+        values = [:]
+        for entry in entries {
+            if values[entry.key] == nil {
+                keys.append(entry.key)
+            }
+            values[entry.key] = entry.value
+        }
+    }
+
+    public subscript(key: String) -> String? {
+        get { values[key] }
+        set {
+            guard let newValue else {
+                keys.removeAll { $0 == key }
+                values.removeValue(forKey: key)
+                return
+            }
+            if values[key] == nil {
+                keys.append(key)
+            }
+            values[key] = newValue
+        }
+    }
+
+    public var entries: [SessionEnvironmentEntry] {
+        keys.compactMap { key in
+            guard let value = values[key] else { return nil }
+            return SessionEnvironmentEntry(key: key, value: value)
+        }
+    }
+}
+
+public enum SessionShellIntegration {
+    public static let defaultShell = "/bin/zsh"
+    private static let posixShell = "/bin/sh"
+    private static let xdgFallbackDataDirectories = "/usr/local/share:/usr/share"
+
+    public static func invocation(
+        command: String,
+        shell: String,
+        resourcesDirectory: String,
+        environment: [SessionEnvironmentEntry]
+    ) -> SessionShellInvocation {
+        let resolvedShell = shell.isEmpty ? defaultShell : shell
+        let name = shellName(resolvedShell)
+        var environment = SessionEnvironment(environment)
+        var arguments = ["-" + name]
+
+        if !resourcesDirectory.isEmpty {
+            environment["GHOSTTY_RESOURCES_DIR"] = resourcesDirectory
+            let root = resourcesDirectory + "/shell-integration"
+            switch name {
+            case "zsh":
+                applyZshIntegration(root: root, environment: &environment)
+            case "bash":
+                if command.isEmpty {
+                    applyBashIntegration(root: root, environment: &environment)
+                    arguments.append("--posix")
+                }
+            case "fish",
+                 "elvish",
+                 "nu":
+                applyXDGIntegration(root: root, environment: &environment)
+            default:
+                break
+            }
+        }
+
+        guard command.isEmpty else {
+            return SessionShellInvocation(
+                executable: posixShell,
+                arguments: [posixShell, "-c", "exec " + command],
+                environment: environment.entries
+            )
+        }
+
+        return SessionShellInvocation(
+            executable: resolvedShell,
+            arguments: arguments,
+            environment: environment.entries
+        )
+    }
+
+    public static func shellName(_ shell: String) -> String {
+        guard let separator = shell.lastIndex(of: "/") else { return shell }
+        return String(shell[shell.index(after: separator)...])
+    }
+
+    private static func applyZshIntegration(root: String, environment: inout SessionEnvironment) {
+        if let existing = environment["ZDOTDIR"] {
+            environment["GHOSTTY_ZSH_ZDOTDIR"] = existing
+        }
+        environment["ZDOTDIR"] = root + "/zsh"
+    }
+
+    private static func applyBashIntegration(root: String, environment: inout SessionEnvironment) {
+        if let existing = environment["ENV"] {
+            environment["GHOSTTY_BASH_ENV"] = existing
+        }
+        environment["ENV"] = root + "/bash/ghostty.bash"
+        environment["GHOSTTY_BASH_INJECT"] = "1"
+        if environment["HISTFILE"] == nil, let home = environment["HOME"], !home.isEmpty {
+            environment["HISTFILE"] = home + "/.bash_history"
+            environment["GHOSTTY_BASH_UNEXPORT_HISTFILE"] = "1"
+        }
+    }
+
+    private static func applyXDGIntegration(root: String, environment: inout SessionEnvironment) {
+        environment["GHOSTTY_SHELL_INTEGRATION_XDG_DIR"] = root
+        guard let existing = environment["XDG_DATA_DIRS"], !existing.isEmpty else {
+            environment["XDG_DATA_DIRS"] = root + ":" + xdgFallbackDataDirectories
+            return
+        }
+        guard !existing.split(separator: ":").contains(where: { $0 == root }) else { return }
+        environment["XDG_DATA_DIRS"] = root + ":" + existing
+    }
+}

--- a/MuxySessionProtocol/SessionShellIntegration.swift
+++ b/MuxySessionProtocol/SessionShellIntegration.swift
@@ -71,8 +71,8 @@ public enum SessionShellIntegration {
             case "zsh":
                 applyZshIntegration(root: root, environment: &environment)
             case "bash":
+                applyBashIntegration(root: root, environment: &environment)
                 if command.isEmpty {
-                    applyBashIntegration(root: root, environment: &environment)
                     arguments.append("--posix")
                 }
             case "fish",

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     products: [
         .library(name: "MuxyShared", targets: ["MuxyShared"]),
         .executable(name: "muxy-hook", targets: ["MuxyHookBridge"]),
+        .executable(name: "muxy-session", targets: ["MuxySession"]),
     ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.1"),
@@ -53,6 +54,17 @@ let package = Package(
             publicHeadersPath: "."
         ),
         .target(
+            name: "MuxySessionProtocol",
+            path: "MuxySessionProtocol"
+        ),
+        .executableTarget(
+            name: "MuxySession",
+            dependencies: [
+                "MuxySessionProtocol",
+            ],
+            path: "MuxySession"
+        ),
+        .target(
             name: "MuxyServer",
             dependencies: [
                 "MuxyShared",
@@ -65,6 +77,7 @@ let package = Package(
                 "GhosttyKit",
                 "MuxyShared",
                 "MuxyServer",
+                "MuxySessionProtocol",
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "Sentry", package: "sentry-cocoa"),
@@ -109,6 +122,7 @@ let package = Package(
                 "Muxy",
                 "MuxyShared",
                 "MuxyServer",
+                "MuxySessionProtocol",
                 "MuxyExtensionHost",
                 "MuxyHookKit",
                 .product(name: "Yams", package: "Yams"),

--- a/Tests/MuxyTests/Services/Session/PersistentSessionIntegrationTests.swift
+++ b/Tests/MuxyTests/Services/Session/PersistentSessionIntegrationTests.swift
@@ -1,0 +1,282 @@
+import Foundation
+import MuxySessionProtocol
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalPersistentSessionPolicy")
+struct TerminalPersistentSessionPolicyTests {
+    @Test("uses a background session for local panes when enabled and available")
+    func enablesForLocalPanes() {
+        #expect(TerminalPersistentSessionPolicy.usesPersistentSession(
+            preferenceEnabled: true,
+            workspaceContext: .local,
+            isAvailable: true
+        ))
+    }
+
+    @Test("stays off when the preference is disabled")
+    func respectsPreference() {
+        #expect(!TerminalPersistentSessionPolicy.usesPersistentSession(
+            preferenceEnabled: false,
+            workspaceContext: .local,
+            isAvailable: true
+        ))
+    }
+
+    @Test("stays off when the helper binary is unavailable")
+    func requiresAvailability() {
+        #expect(!TerminalPersistentSessionPolicy.usesPersistentSession(
+            preferenceEnabled: true,
+            workspaceContext: .local,
+            isAvailable: false
+        ))
+    }
+
+    @Test("never applies to remote panes")
+    func excludesRemotePanes() {
+        let destination = SSHDestination(host: "example.com", user: "test")
+        #expect(!TerminalPersistentSessionPolicy.usesPersistentSession(
+            preferenceEnabled: true,
+            workspaceContext: .ssh(destination),
+            isAvailable: true
+        ))
+    }
+}
+
+@Suite("TerminalTTYForegroundProcess")
+struct TerminalTTYForegroundProcessTests {
+    @Test("returns nothing when the tty has no processes")
+    func handlesEmptyTTY() {
+        #expect(TerminalTTYForegroundProcess.select(from: []) == nil)
+    }
+
+    @Test("returns nothing when no foreground group is set")
+    func handlesMissingForegroundGroup() {
+        let entries = [TTYProcessEntry(processID: 10, processGroupID: 10, foregroundGroupID: 0)]
+        #expect(TerminalTTYForegroundProcess.select(from: entries) == nil)
+    }
+
+    @Test("returns the foreground group leader")
+    func returnsGroupLeader() {
+        let entries = [
+            TTYProcessEntry(processID: 10, processGroupID: 10, foregroundGroupID: 42),
+            TTYProcessEntry(processID: 42, processGroupID: 42, foregroundGroupID: 42),
+            TTYProcessEntry(processID: 43, processGroupID: 42, foregroundGroupID: 42),
+        ]
+        #expect(TerminalTTYForegroundProcess.select(from: entries) == 42)
+    }
+
+    @Test("falls back to the lowest member when the group leader has gone")
+    func fallsBackToGroupMember() {
+        let entries = [
+            TTYProcessEntry(processID: 10, processGroupID: 10, foregroundGroupID: 42),
+            TTYProcessEntry(processID: 44, processGroupID: 42, foregroundGroupID: 42),
+            TTYProcessEntry(processID: 43, processGroupID: 42, foregroundGroupID: 42),
+        ]
+        #expect(TerminalTTYForegroundProcess.select(from: entries) == 43)
+    }
+
+    @Test("returns nothing when the foreground group has no surviving members")
+    func handlesVanishedGroup() {
+        let entries = [TTYProcessEntry(processID: 10, processGroupID: 10, foregroundGroupID: 42)]
+        #expect(TerminalTTYForegroundProcess.select(from: entries) == nil)
+    }
+
+    @Test("treats the shell itself as no running command")
+    func detectsIdleShell() {
+        #expect(!TerminalTTYForegroundProcess.isRunningCommand(foregroundProcessID: 900, shellProcessID: 900))
+    }
+
+    @Test("treats any other foreground process as a running command")
+    func detectsRunningCommand() {
+        #expect(TerminalTTYForegroundProcess.isRunningCommand(foregroundProcessID: 950, shellProcessID: 900))
+    }
+
+    @Test("reports no running command without a resolvable foreground process")
+    func handlesUnknownForeground() {
+        #expect(!TerminalTTYForegroundProcess.isRunningCommand(foregroundProcessID: nil, shellProcessID: 900))
+        #expect(!TerminalTTYForegroundProcess.isRunningCommand(foregroundProcessID: 0, shellProcessID: 900))
+    }
+
+    @Test("returns nothing for an unknown tty device")
+    func handlesUnknownDevice() {
+        #expect(TerminalTTYForegroundProcess.entries(ttyDevice: 0).isEmpty)
+        #expect(TerminalTTYForegroundProcess.processID(ttyDevice: 0) == nil)
+    }
+}
+
+@Suite("PersistentSessionPaths")
+struct PersistentSessionPathsTests {
+    @Test("accepts paths that fit a unix socket address")
+    func acceptsShortPaths() {
+        #expect(PersistentSessionPaths.fits("/tmp/muxy/control.sock"))
+        #expect(PersistentSessionPaths.fits(String(repeating: "a", count: 103)))
+    }
+
+    @Test("rejects paths at or beyond the sun_path limit")
+    func rejectsLongPaths() {
+        #expect(!PersistentSessionPaths.fits(String(repeating: "a", count: 104)))
+        #expect(!PersistentSessionPaths.fits(String(repeating: "a", count: 400)))
+    }
+
+    @Test("builds the socket path inside the app support directory")
+    func buildsPreferredPath() {
+        let directory = URL(fileURLWithPath: "/Users/test/Library/Application Support/Muxy", isDirectory: true)
+        let path = PersistentSessionPaths.preferredSocketPath(appSupportDirectory: directory)
+        #expect(path == "/Users/test/Library/Application Support/Muxy/sessions/control.sock")
+    }
+
+    @Test("scopes the fallback path to the user")
+    func buildsFallbackPath() {
+        #expect(PersistentSessionPaths.fallbackSocketPath(userID: 501) == "/tmp/muxy-501/control.sock")
+        #expect(PersistentSessionPaths.fits(PersistentSessionPaths.fallbackSocketPath(userID: 4_294_967_295)))
+    }
+
+    private func makeFallbackRoot() throws -> URL {
+        let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("mxf-\(UUID().uuidString.prefix(6))", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private var overlongAppSupportDirectory: URL {
+        URL(fileURLWithPath: "/" + String(repeating: "d", count: 120), isDirectory: true)
+    }
+
+    @Test("uses the app support directory when the path fits")
+    func resolvesPreferredPath() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("mx-\(UUID().uuidString.prefix(6))")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolved = try PersistentSessionPaths.resolveSocketPath(appSupportDirectory: root, userID: getuid())
+        #expect(resolved == PersistentSessionPaths.preferredSocketPath(appSupportDirectory: root))
+        #expect(FileManager.default.fileExists(atPath: URL(fileURLWithPath: resolved).deletingLastPathComponent().path))
+    }
+
+    @Test("falls back to a user-scoped directory when the app support path is too long")
+    func resolvesFallbackPath() throws {
+        let root = try makeFallbackRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = try PersistentSessionPaths.resolveSocketPath(
+            appSupportDirectory: overlongAppSupportDirectory,
+            userID: getuid(),
+            fallbackRoot: root.path
+        )
+        #expect(resolved == PersistentSessionPaths.fallbackSocketPath(userID: getuid(), root: root.path))
+        #expect(FileManager.default.fileExists(atPath: URL(fileURLWithPath: resolved).deletingLastPathComponent().path))
+    }
+
+    @Test("tightens a fallback directory we own but that is too permissive")
+    func tightensLoosePermissions() throws {
+        let root = try makeFallbackRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let directory = URL(fileURLWithPath: PersistentSessionPaths.fallbackSocketPath(userID: getuid(), root: root.path))
+            .deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o777]
+        )
+
+        _ = try PersistentSessionPaths.resolveSocketPath(
+            appSupportDirectory: overlongAppSupportDirectory,
+            userID: getuid(),
+            fallbackRoot: root.path
+        )
+
+        let permissions = try #require(
+            FileManager.default.attributesOfItem(atPath: directory.path)[.posixPermissions] as? NSNumber
+        )
+        #expect(permissions.int16Value & 0o077 == 0)
+    }
+
+    @Test("refuses a fallback directory owned by another user")
+    func rejectsForeignFallback() throws {
+        let root = try makeFallbackRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let foreignUserID = getuid() &+ 1
+        let directory = URL(fileURLWithPath: PersistentSessionPaths.fallbackSocketPath(userID: foreignUserID, root: root.path))
+            .deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        #expect(throws: PersistentSessionPathError.insecureFallbackDirectory) {
+            try PersistentSessionPaths.resolveSocketPath(
+                appSupportDirectory: overlongAppSupportDirectory,
+                userID: foreignUserID,
+                fallbackRoot: root.path
+            )
+        }
+    }
+
+    @Test("locates the helper binary next to the app executable")
+    func locatesBinary() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("mx-\(UUID().uuidString.prefix(6))")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let executable = root.appendingPathComponent("Muxy")
+        let helper = root.appendingPathComponent(PersistentSessionPaths.binaryName)
+        #expect(PersistentSessionPaths.binaryURL(executableURL: executable) == nil)
+
+        try Data("#!/bin/sh\n".utf8).write(to: helper)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+        #expect(PersistentSessionPaths.binaryURL(executableURL: executable)?.path == helper.path)
+        #expect(PersistentSessionPaths.binaryURL(executableURL: nil) == nil)
+    }
+}
+
+@Suite("TerminalPersistentSessionPreferences")
+struct TerminalPersistentSessionPreferencesTests {
+    @Test("defaults to off")
+    func defaultsToOff() {
+        #expect(!TerminalPersistentSessionPreferences.defaultIsEnabled)
+    }
+
+    @Test("round-trips through user defaults")
+    func roundTripsPreference() {
+        let original = TerminalPersistentSessionPreferences.isEnabled
+        defer { TerminalPersistentSessionPreferences.isEnabled = original }
+
+        TerminalPersistentSessionPreferences.isEnabled = true
+        #expect(TerminalPersistentSessionPreferences.isEnabled)
+        TerminalPersistentSessionPreferences.isEnabled = false
+        #expect(!TerminalPersistentSessionPreferences.isEnabled)
+    }
+}
+
+@Suite("PersistentSessionControlClient", .enabled(if: SessionDaemonHarness.binaryURL != nil))
+struct PersistentSessionControlClientTests {
+    @Test("returns nothing when no daemon is listening")
+    func toleratesMissingDaemon() throws {
+        let client = PersistentSessionControlClient(socketPath: "/tmp/muxy-missing-\(UUID().uuidString.prefix(8)).sock")
+        let identifier = try #require(SessionIdentifier(uuidString: UUID().uuidString))
+        #expect(client.list().isEmpty)
+        #expect(client.info(identifier: identifier) == nil)
+        #expect(!client.killAll())
+    }
+
+    @Test("lists and kills sessions through the control socket")
+    func listsAndKillsSessions() throws {
+        let harness = try SessionDaemonHarness()
+        try harness.start()
+        defer { harness.stop() }
+
+        let identifier = try #require(SessionIdentifier(uuidString: UUID().uuidString))
+        let attached = try #require(SessionTestConnection(socketPath: harness.socketPath))
+        defer { attached.close() }
+        attached.send(harness.attachRequest(identifier: identifier, command: "sh -c 'sleep 30'"))
+        _ = try #require(attached.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+        let client = PersistentSessionControlClient(socketPath: harness.socketPath)
+        let listed = client.list()
+        #expect(listed.count == 1)
+        #expect(listed.first?.identifier == identifier)
+        #expect(client.info(identifier: identifier)?.shellProcessID == listed.first?.shellProcessID)
+
+        #expect(client.kill(identifier: identifier))
+        #expect(client.list().isEmpty)
+    }
+}

--- a/Tests/MuxyTests/Services/Session/SessionDaemonEndToEndTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionDaemonEndToEndTests.swift
@@ -1,0 +1,368 @@
+import Foundation
+import MuxySessionProtocol
+import Testing
+
+@testable import Muxy
+
+@Suite("SessionDaemon end to end", .serialized, .enabled(if: SessionDaemonHarness.binaryURL != nil))
+struct SessionDaemonEndToEndTests {
+    private func makeIdentifier() throws -> SessionIdentifier {
+        try #require(SessionIdentifier(uuidString: UUID().uuidString))
+    }
+
+    private func withHarness(_ body: (SessionDaemonHarness) throws -> Void) throws {
+        let harness = try SessionDaemonHarness()
+        try harness.start()
+        defer { harness.stop() }
+        try body(harness)
+    }
+
+    @Test("creates a session and streams its output")
+    func createsSessionAndStreamsOutput() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            connection.send(harness.attachRequest(identifier: identifier, command: "sh -c 'echo READY; sleep 30'"))
+
+            let attached = try #require(connection.waitForFrame(timeout: 5) { $0.kind == .attached })
+            let acceptance = try SessionAttachAccepted.decode(attached.payload)
+            #expect(acceptance.created)
+            #expect(acceptance.shellProcessID > 0)
+            #expect(acceptance.ttyDevice != 0)
+
+            let output = connection.collectOutput(timeout: 5) { $0.contains("READY") }
+            #expect(output.contains("READY"))
+        }
+    }
+
+    @Test("keeps the session alive after the client disconnects and replays on reattach")
+    func replaysAfterReattach() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let first = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            first.send(harness.attachRequest(identifier: identifier, command: "sh -c 'echo MARKER; sleep 30'"))
+            _ = first.collectOutput(timeout: 5) { $0.contains("MARKER") }
+            first.close()
+
+            let second = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { second.close() }
+            second.send(harness.attachRequest(identifier: identifier, command: "sh -c 'echo SHOULD_NOT_RUN; sleep 30'"))
+
+            let attached = try #require(second.waitForFrame(timeout: 5) { $0.kind == .attached })
+            let acceptance = try SessionAttachAccepted.decode(attached.payload)
+            #expect(!acceptance.created)
+
+            let replayed = second.collectOutput(timeout: 5) { $0.contains("MARKER") }
+            #expect(replayed.contains("MARKER"))
+            #expect(!replayed.contains("SHOULD_NOT_RUN"))
+        }
+    }
+
+    @Test("forwards input to the session")
+    func forwardsInput() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            connection.send(harness.attachRequest(
+                identifier: identifier,
+                command: "sh -c 'while read line; do echo GOT:$line; done'"
+            ))
+            _ = try #require(connection.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            connection.send(SessionFrame(kind: .input, payload: Array("ping\n".utf8)))
+            let output = connection.collectOutput(timeout: 5) { $0.contains("GOT:ping") }
+            #expect(output.contains("GOT:ping"))
+        }
+    }
+
+    @Test("runs a pane startup command through the shell wrapper the app builds")
+    func runsStartupCommandWrapper() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            let wrapper = TerminalLaunchCommand.shellCommand(
+                interactive: false,
+                keepsShellOpen: true,
+                shell: "/bin/sh"
+            )
+            connection.send(harness.attachRequest(
+                identifier: identifier,
+                command: wrapper,
+                environment: [
+                    SessionEnvironmentEntry(
+                        key: TerminalLaunchCommand.environmentKey,
+                        value: "echo STARTUP_RAN"
+                    ),
+                ]
+            ))
+
+            let output = connection.collectOutput(timeout: 5) { $0.contains("STARTUP_RAN") }
+            #expect(output.contains("STARTUP_RAN"))
+        }
+    }
+
+    @Test("keeps the shell open after a startup command that is meant to persist")
+    func keepsShellOpenAfterStartupCommand() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            connection.send(harness.attachRequest(
+                identifier: identifier,
+                command: TerminalLaunchCommand.shellCommand(
+                    interactive: false,
+                    keepsShellOpen: true,
+                    shell: "/bin/sh"
+                ),
+                environment: [
+                    SessionEnvironmentEntry(key: TerminalLaunchCommand.environmentKey, value: "true"),
+                ]
+            ))
+            _ = try #require(connection.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .list))
+            let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            #expect(try SessionDescriptor.decodeList(listed.payload).count == 1)
+        }
+    }
+
+    @Test("reports the exit status when the session ends")
+    func reportsExitStatus() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            connection.send(harness.attachRequest(identifier: identifier, command: "sh -c 'exit 7'"))
+            let exited = try #require(connection.waitForFrame(timeout: 5) { $0.kind == .exited })
+            #expect(try SessionExitPayload.decode(exited.payload) == 7)
+        }
+    }
+
+    @Test("lists live sessions with their tty and shell process")
+    func listsSessions() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let attached = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { attached.close() }
+            attached.send(harness.attachRequest(identifier: identifier, command: "sh -c 'sleep 30'"))
+            _ = try #require(attached.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .list))
+            let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            let descriptors = try SessionDescriptor.decodeList(listed.payload)
+
+            #expect(descriptors.count == 1)
+            let descriptor = try #require(descriptors.first)
+            #expect(descriptor.identifier == identifier)
+            #expect(descriptor.shellProcessID > 0)
+            #expect(descriptor.ttyDevice != 0)
+            #expect(descriptor.workingDirectory == "/tmp")
+            #expect(descriptor.isAttached)
+        }
+    }
+
+    @Test("reports a session as detached once its client goes away")
+    func reportsDetachedSessions() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let attached = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            attached.send(harness.attachRequest(identifier: identifier, command: "sh -c 'sleep 30'"))
+            _ = try #require(attached.waitForFrame(timeout: 5) { $0.kind == .attached })
+            attached.close()
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+
+            var descriptors: [SessionDescriptor] = []
+            let deadline = Date().addingTimeInterval(5)
+            while Date() < deadline {
+                control.send(SessionFrame(kind: .list))
+                let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+                descriptors = try SessionDescriptor.decodeList(listed.payload)
+                if descriptors.first?.isAttached == false { break }
+                usleep(50_000)
+            }
+            #expect(descriptors.count == 1)
+            #expect(descriptors.first?.isAttached == false)
+        }
+    }
+
+    @Test("kills a session on request")
+    func killsSession() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let attached = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { attached.close() }
+            attached.send(harness.attachRequest(identifier: identifier, command: "sh -c 'sleep 30'"))
+            _ = try #require(attached.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .kill, payload: SessionIdentifierPayload.encode(identifier)))
+            _ = try #require(control.waitForFrame(timeout: 5) { $0.kind == .acknowledged })
+
+            _ = try #require(attached.waitForFrame(timeout: 5) { $0.kind == .exited })
+
+            control.send(SessionFrame(kind: .list))
+            let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            #expect(try SessionDescriptor.decodeList(listed.payload).isEmpty)
+        }
+    }
+
+    @Test("returns session details for a single identifier")
+    func returnsSessionInfo() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let other = try makeIdentifier()
+            let attached = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { attached.close() }
+            attached.send(harness.attachRequest(identifier: identifier, command: "sh -c 'sleep 30'"))
+            _ = try #require(attached.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+
+            control.send(SessionFrame(kind: .info, payload: SessionIdentifierPayload.encode(identifier)))
+            let found = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            #expect(try SessionDescriptor.decodeList(found.payload).count == 1)
+
+            control.send(SessionFrame(kind: .info, payload: SessionIdentifierPayload.encode(other)))
+            let missing = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            #expect(try SessionDescriptor.decodeList(missing.payload).isEmpty)
+        }
+    }
+
+    @Test("reports which tab, project and worktree a session belongs to")
+    func reportsSessionOwnership() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let projectID = UUID().uuidString
+            let worktreeID = UUID().uuidString
+            let tabID = UUID().uuidString
+
+            let attached = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { attached.close() }
+            attached.send(harness.attachRequest(
+                identifier: identifier,
+                command: "sh -c 'sleep 30'",
+                metadata: [
+                    SessionEnvironmentEntry(key: SessionMetadataKey.project, value: projectID),
+                    SessionEnvironmentEntry(key: SessionMetadataKey.worktree, value: worktreeID),
+                    SessionEnvironmentEntry(key: SessionMetadataKey.tab, value: tabID),
+                    SessionEnvironmentEntry(key: SessionMetadataKey.title, value: "Dev Server"),
+                ]
+            ))
+            _ = try #require(attached.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .list))
+            let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            let descriptor = try #require(try SessionDescriptor.decodeList(listed.payload).first)
+
+            #expect(descriptor.value(forMetadataKey: SessionMetadataKey.project) == projectID)
+            #expect(descriptor.value(forMetadataKey: SessionMetadataKey.worktree) == worktreeID)
+            #expect(descriptor.value(forMetadataKey: SessionMetadataKey.tab) == tabID)
+            #expect(descriptor.value(forMetadataKey: SessionMetadataKey.title) == "Dev Server")
+        }
+    }
+
+    @Test("refreshes ownership when a session is reattached from another tab")
+    func refreshesOwnershipOnReattach() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let first = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            first.send(harness.attachRequest(
+                identifier: identifier,
+                command: "sh -c 'sleep 30'",
+                metadata: [SessionEnvironmentEntry(key: SessionMetadataKey.tab, value: "first-tab")]
+            ))
+            _ = try #require(first.waitForFrame(timeout: 5) { $0.kind == .attached })
+            first.close()
+
+            let second = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { second.close() }
+            second.send(harness.attachRequest(
+                identifier: identifier,
+                command: "",
+                metadata: [SessionEnvironmentEntry(key: SessionMetadataKey.tab, value: "second-tab")]
+            ))
+            _ = try #require(second.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .info, payload: SessionIdentifierPayload.encode(identifier)))
+            let found = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            let descriptor = try #require(try SessionDescriptor.decodeList(found.payload).first)
+            #expect(descriptor.value(forMetadataKey: SessionMetadataKey.tab) == "second-tab")
+        }
+    }
+
+    @Test("refuses an attach from a different protocol version")
+    func refusesVersionMismatch() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+            connection.send(harness.attachRequest(
+                identifier: identifier,
+                command: "sh -c 'sleep 30'",
+                version: SessionProtocolVersion.current &+ 1
+            ))
+            let failure = try #require(connection.waitForFrame(timeout: 5) { $0.kind == .failure })
+            #expect(try SessionTextPayload.decode(failure.payload).contains("different version"))
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .list))
+            let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            #expect(try SessionDescriptor.decodeList(listed.payload).isEmpty)
+        }
+    }
+
+    @Test("reports a failure for a malformed attach request")
+    func reportsMalformedAttach() throws {
+        try withHarness { harness in
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+            connection.send(SessionFrame(kind: .attach, payload: [1, 2, 3]))
+            let failure = try #require(connection.waitForFrame(timeout: 5) { $0.kind == .failure })
+            #expect(try SessionTextPayload.decode(failure.payload).isEmpty == false)
+        }
+    }
+
+    @Test("hands a reattaching client the session and drops the previous one")
+    func replacesPreviousClient() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let first = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { first.close() }
+            first.send(harness.attachRequest(identifier: identifier, command: "sh -c 'sleep 30'"))
+            _ = try #require(first.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+            let second = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { second.close() }
+            second.send(harness.attachRequest(identifier: identifier, command: "sh -c 'sleep 30'"))
+            let attached = try #require(second.waitForFrame(timeout: 5) { $0.kind == .attached })
+            #expect(try SessionAttachAccepted.decode(attached.payload).created == false)
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .list))
+            let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
+            #expect(try SessionDescriptor.decodeList(listed.payload).count == 1)
+        }
+    }
+}

--- a/Tests/MuxyTests/Services/Session/SessionDaemonEndToEndTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionDaemonEndToEndTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import MuxySessionProtocol
 import Testing
@@ -6,6 +7,12 @@ import Testing
 
 @Suite("SessionDaemon end to end", .serialized, .enabled(if: SessionDaemonHarness.binaryURL != nil))
 struct SessionDaemonEndToEndTests {
+    private struct SignalResistantSession {
+        let identifier: SessionIdentifier
+        let connection: SessionTestConnection
+        let processIDs: [pid_t]
+    }
+
     private func makeIdentifier() throws -> SessionIdentifier {
         try #require(SessionIdentifier(uuidString: UUID().uuidString))
     }
@@ -221,6 +228,48 @@ struct SessionDaemonEndToEndTests {
         }
     }
 
+    @Test("kills an entire session whose processes ignore hangup and termination")
+    func killsSignalResistantSession() throws {
+        try withHarness { harness in
+            let resistantSession = try makeSignalResistantSession(harness: harness)
+            defer { resistantSession.connection.close() }
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(
+                kind: .kill,
+                payload: SessionIdentifierPayload.encode(resistantSession.identifier)
+            ))
+            _ = try #require(control.waitForFrame(timeout: 5) { $0.kind == .acknowledged })
+
+            for processID in resistantSession.processIDs {
+                #expect(!processExists(processID))
+            }
+        }
+    }
+
+    @Test("kills signal-resistant sessions together within the control timeout")
+    func killsAllSignalResistantSessionsWithinControlTimeout() throws {
+        try withHarness { harness in
+            var resistantSessions: [SignalResistantSession] = []
+            defer { resistantSessions.forEach { $0.connection.close() } }
+            for _ in 0 ..< 12 {
+                resistantSessions.append(try makeSignalResistantSession(harness: harness))
+            }
+
+            let control = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { control.close() }
+            control.send(SessionFrame(kind: .killAll))
+            _ = try #require(control.waitForFrame(timeout: PersistentSessionControlClient.defaultTimeout) {
+                $0.kind == .acknowledged
+            })
+
+            for processID in resistantSessions.flatMap(\.processIDs) {
+                #expect(!processExists(processID))
+            }
+        }
+    }
+
     @Test("returns session details for a single identifier")
     func returnsSessionInfo() throws {
         try withHarness { harness in
@@ -364,5 +413,35 @@ struct SessionDaemonEndToEndTests {
             let listed = try #require(control.waitForFrame(timeout: 5) { $0.kind == .sessions })
             #expect(try SessionDescriptor.decodeList(listed.payload).count == 1)
         }
+    }
+
+    private func processExists(_ processID: pid_t) -> Bool {
+        guard kill(processID, 0) != 0 else { return true }
+        return errno == EPERM
+    }
+
+    private func makeSignalResistantSession(harness: SessionDaemonHarness) throws -> SignalResistantSession {
+        let identifier = try makeIdentifier()
+        let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+        connection.send(harness.attachRequest(
+            identifier: identifier,
+            command: "sh -c 'trap \"\" HUP TERM; sh -c \"trap \\\"\\\" HUP TERM; echo CHILD=\\$\\$; while :; do sleep 1; done\" & echo READY; wait'"
+        ))
+
+        let acceptedFrame = try #require(connection.waitForFrame(timeout: 5) { $0.kind == .attached })
+        let accepted = try SessionAttachAccepted.decode(acceptedFrame.payload)
+        let output = connection.collectOutput(timeout: 5) { $0.contains("READY") && $0.contains("CHILD=") }
+        let childProcessID = output
+            .split(whereSeparator: \.isNewline)
+            .lazy
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { $0.hasPrefix("CHILD=") }
+            .flatMap { pid_t(String($0.dropFirst("CHILD=".count))) }
+
+        return try SignalResistantSession(
+            identifier: identifier,
+            connection: connection,
+            processIDs: [accepted.shellProcessID, #require(childProcessID)]
+        )
     }
 }

--- a/Tests/MuxyTests/Services/Session/SessionFrameTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionFrameTests.swift
@@ -1,0 +1,232 @@
+import MuxySessionProtocol
+import Testing
+
+@Suite("SessionFrame")
+struct SessionFrameTests {
+    @Test("encodes a header of kind and big-endian length")
+    func encodesHeader() {
+        let frame = SessionFrame(kind: .input, payload: [0xAA, 0xBB, 0xCC])
+        #expect(frame.encoded() == [0x02, 0x00, 0x00, 0x00, 0x03, 0xAA, 0xBB, 0xCC])
+    }
+
+    @Test("decodes frames pushed in a single chunk")
+    func decodesSingleChunk() throws {
+        var decoder = SessionFrameDecoder()
+        decoder.push(SessionFrame(kind: .list).encoded())
+        decoder.push(SessionFrame(kind: .output, payload: [1, 2, 3]).encoded())
+
+        #expect(try decoder.next() == SessionFrame(kind: .list))
+        #expect(try decoder.next() == SessionFrame(kind: .output, payload: [1, 2, 3]))
+        #expect(try decoder.next() == nil)
+    }
+
+    @Test("decodes a frame split across arbitrary byte boundaries")
+    func decodesSplitFrames() throws {
+        let encoded = SessionFrame(kind: .output, payload: Array(repeating: 0x7F, count: 300)).encoded()
+        var decoder = SessionFrameDecoder()
+        for byte in encoded.dropLast() {
+            decoder.push([byte])
+            #expect(try decoder.next() == nil)
+        }
+        decoder.push([encoded[encoded.count - 1]])
+        let frame = try decoder.next()
+        #expect(frame?.kind == .output)
+        #expect(frame?.payload.count == 300)
+    }
+
+    @Test("reports an empty payload frame as complete once the header arrives")
+    func decodesEmptyPayload() throws {
+        var decoder = SessionFrameDecoder()
+        decoder.push([SessionFrameKind.acknowledged.rawValue, 0, 0, 0, 0])
+        #expect(try decoder.next() == SessionFrame(kind: .acknowledged))
+    }
+
+    @Test("rejects an unknown frame kind")
+    func rejectsUnknownKind() {
+        var decoder = SessionFrameDecoder()
+        decoder.push([0xF0, 0, 0, 0, 0])
+        #expect(throws: SessionProtocolError.unknownFrameKind(0xF0)) {
+            try decoder.next()
+        }
+    }
+
+    @Test("rejects a frame larger than the maximum payload size")
+    func rejectsOversizedFrame() {
+        var decoder = SessionFrameDecoder()
+        let length = SessionFrame.maximumPayloadSize + 1
+        decoder.push([
+            SessionFrameKind.input.rawValue,
+            UInt8(truncatingIfNeeded: length >> 24),
+            UInt8(truncatingIfNeeded: length >> 16),
+            UInt8(truncatingIfNeeded: length >> 8),
+            UInt8(truncatingIfNeeded: length),
+        ])
+        #expect(throws: SessionProtocolError.frameTooLarge(length)) {
+            try decoder.next()
+        }
+    }
+
+    @Test("checks the length before the kind so a hostile peer cannot force a large buffer")
+    func checksLengthBeforeKind() {
+        var decoder = SessionFrameDecoder()
+        let length = SessionFrame.maximumPayloadSize + 1
+        decoder.push([
+            0xF0,
+            UInt8(truncatingIfNeeded: length >> 24),
+            UInt8(truncatingIfNeeded: length >> 16),
+            UInt8(truncatingIfNeeded: length >> 8),
+            UInt8(truncatingIfNeeded: length),
+        ])
+        #expect(throws: SessionProtocolError.frameTooLarge(length)) {
+            try decoder.next()
+        }
+    }
+
+    @Test("drains buffered bytes as frames are consumed")
+    func drainsBuffer() throws {
+        var decoder = SessionFrameDecoder()
+        decoder.push(SessionFrame(kind: .input, payload: [9]).encoded())
+        #expect(decoder.bufferedByteCount == 6)
+        _ = try decoder.next()
+        #expect(decoder.bufferedByteCount == 0)
+    }
+}
+
+@Suite("SessionIdentifier")
+struct SessionIdentifierTests {
+    @Test("round-trips a canonical uuid string")
+    func roundTripsUUIDString() throws {
+        let text = "3F2504E0-4F89-11D3-9A0C-0305E82C3301"
+        let identifier = try #require(SessionIdentifier(uuidString: text))
+        #expect(identifier.bytes.count == 16)
+        #expect(identifier.uuidString == text.lowercased())
+    }
+
+    @Test("parses lowercase and uppercase equivalently")
+    func parsesEitherCase() {
+        let upper = SessionIdentifier(uuidString: "3F2504E0-4F89-11D3-9A0C-0305E82C3301")
+        let lower = SessionIdentifier(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c3301")
+        #expect(upper == lower)
+    }
+
+    @Test("rejects malformed input")
+    func rejectsMalformedInput() {
+        #expect(SessionIdentifier(uuidString: "") == nil)
+        #expect(SessionIdentifier(uuidString: "not-a-uuid") == nil)
+        #expect(SessionIdentifier(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c33") == nil)
+        #expect(SessionIdentifier(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c3301ff") == nil)
+        #expect(SessionIdentifier(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c330g") == nil)
+        #expect(SessionIdentifier(bytes: [1, 2, 3]) == nil)
+    }
+}
+
+@Suite("SessionMessages")
+struct SessionMessagesTests {
+    private var identifier: SessionIdentifier {
+        // swiftlint:disable:next force_unwrapping
+        SessionIdentifier(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c3301")!
+    }
+
+    @Test("round-trips an attach request including its environment")
+    func roundTripsAttachRequest() throws {
+        let request = SessionAttachRequest(
+            identifier: identifier,
+            columns: 120,
+            rows: 40,
+            workingDirectory: "/Users/test/project",
+            command: "/bin/zsh -l -c 'echo hi' /bin/zsh",
+            shell: "/bin/zsh",
+            resourcesDirectory: "/Applications/Muxy.app/Contents/Resources/ghostty",
+            environment: [
+                SessionEnvironmentEntry(key: "TERM", value: "xterm-ghostty"),
+                SessionEnvironmentEntry(key: "MUXY_PANE_ID", value: identifier.uuidString),
+            ]
+        )
+        #expect(try SessionAttachRequest.decode(request.encoded()) == request)
+    }
+
+    @Test("round-trips an attach request with no environment")
+    func roundTripsEmptyEnvironment() throws {
+        let request = SessionAttachRequest(
+            identifier: identifier,
+            columns: 80,
+            rows: 24,
+            workingDirectory: "/",
+            command: "",
+            shell: "/bin/zsh",
+            resourcesDirectory: "",
+            environment: []
+        )
+        #expect(try SessionAttachRequest.decode(request.encoded()) == request)
+    }
+
+    @Test("preserves non-ascii payloads")
+    func preservesNonASCII() throws {
+        let request = SessionAttachRequest(
+            identifier: identifier,
+            columns: 80,
+            rows: 24,
+            workingDirectory: "/Users/test/проект/日本語",
+            command: "",
+            shell: "/bin/zsh",
+            resourcesDirectory: "",
+            environment: [SessionEnvironmentEntry(key: "GREETING", value: "héllo 👋")]
+        )
+        #expect(try SessionAttachRequest.decode(request.encoded()) == request)
+    }
+
+    @Test("round-trips an attach acceptance")
+    func roundTripsAttachAccepted() throws {
+        let accepted = SessionAttachAccepted(created: true, shellProcessID: 4321, ttyDevice: 268_435_460)
+        #expect(try SessionAttachAccepted.decode(accepted.encoded()) == accepted)
+    }
+
+    @Test("round-trips a descriptor list")
+    func roundTripsDescriptorList() throws {
+        let descriptors = [
+            SessionDescriptor(
+                identifier: identifier,
+                shellProcessID: 900,
+                ttyDevice: 42,
+                workingDirectory: "/tmp",
+                isAttached: true
+            ),
+            SessionDescriptor(
+                identifier: identifier,
+                shellProcessID: 901,
+                ttyDevice: 43,
+                workingDirectory: "/var",
+                isAttached: false
+            ),
+        ]
+        #expect(try SessionDescriptor.decodeList(SessionDescriptor.encodeList(descriptors)) == descriptors)
+    }
+
+    @Test("round-trips an empty descriptor list")
+    func roundTripsEmptyDescriptorList() throws {
+        #expect(try SessionDescriptor.decodeList(SessionDescriptor.encodeList([])).isEmpty)
+    }
+
+    @Test("round-trips resize, exit, text and identifier payloads")
+    func roundTripsScalarPayloads() throws {
+        let resize = try SessionResizePayload.decode(SessionResizePayload.encode(columns: 200, rows: 60))
+        #expect(resize.columns == 200)
+        #expect(resize.rows == 60)
+        #expect(try SessionExitPayload.decode(SessionExitPayload.encode(status: -1)) == -1)
+        #expect(try SessionTextPayload.decode(SessionTextPayload.encode("failed")) == "failed")
+        #expect(try SessionIdentifierPayload.decode(SessionIdentifierPayload.encode(identifier)) == identifier)
+    }
+
+    @Test("rejects truncated payloads instead of trapping")
+    func rejectsTruncatedPayloads() {
+        #expect(throws: SessionProtocolError.malformedPayload) {
+            try SessionAttachAccepted.decode([1, 2])
+        }
+        #expect(throws: SessionProtocolError.malformedPayload) {
+            try SessionIdentifierPayload.decode([1, 2, 3])
+        }
+        #expect(throws: SessionProtocolError.malformedPayload) {
+            try SessionTextPayload.decode([0, 0, 0, 8, 1, 2])
+        }
+    }
+}

--- a/Tests/MuxyTests/Services/Session/SessionFrameTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionFrameTests.swift
@@ -122,13 +122,13 @@ struct SessionIdentifierTests {
 
 @Suite("SessionMessages")
 struct SessionMessagesTests {
-    private var identifier: SessionIdentifier {
-        // swiftlint:disable:next force_unwrapping
-        SessionIdentifier(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c3301")!
+    private func makeIdentifier() throws -> SessionIdentifier {
+        try #require(SessionIdentifier(uuidString: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"))
     }
 
     @Test("round-trips an attach request including its environment")
     func roundTripsAttachRequest() throws {
+        let identifier = try makeIdentifier()
         let request = SessionAttachRequest(
             identifier: identifier,
             columns: 120,
@@ -147,6 +147,7 @@ struct SessionMessagesTests {
 
     @Test("round-trips an attach request with no environment")
     func roundTripsEmptyEnvironment() throws {
+        let identifier = try makeIdentifier()
         let request = SessionAttachRequest(
             identifier: identifier,
             columns: 80,
@@ -162,6 +163,7 @@ struct SessionMessagesTests {
 
     @Test("preserves non-ascii payloads")
     func preservesNonASCII() throws {
+        let identifier = try makeIdentifier()
         let request = SessionAttachRequest(
             identifier: identifier,
             columns: 80,
@@ -183,6 +185,7 @@ struct SessionMessagesTests {
 
     @Test("round-trips a descriptor list")
     func roundTripsDescriptorList() throws {
+        let identifier = try makeIdentifier()
         let descriptors = [
             SessionDescriptor(
                 identifier: identifier,
@@ -209,6 +212,7 @@ struct SessionMessagesTests {
 
     @Test("round-trips resize, exit, text and identifier payloads")
     func roundTripsScalarPayloads() throws {
+        let identifier = try makeIdentifier()
         let resize = try SessionResizePayload.decode(SessionResizePayload.encode(columns: 200, rows: 60))
         #expect(resize.columns == 200)
         #expect(resize.rows == 60)

--- a/Tests/MuxyTests/Services/Session/SessionReplayBufferTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionReplayBufferTests.swift
@@ -1,0 +1,92 @@
+import MuxySessionProtocol
+import Testing
+
+@Suite("SessionReplayBuffer")
+struct SessionReplayBufferTests {
+    @Test("starts empty")
+    func startsEmpty() {
+        let buffer = SessionReplayBuffer(capacity: 8)
+        #expect(buffer.isEmpty)
+        #expect(buffer.bytes.isEmpty)
+        #expect(buffer.byteCount == 0)
+    }
+
+    @Test("keeps everything while below capacity")
+    func keepsEverythingBelowCapacity() {
+        var buffer = SessionReplayBuffer(capacity: 8)
+        buffer.append([1, 2, 3])
+        #expect(buffer.bytes == [1, 2, 3])
+        buffer.append([4, 5])
+        #expect(buffer.bytes == [1, 2, 3, 4, 5])
+        #expect(buffer.byteCount == 5)
+    }
+
+    @Test("fills exactly to capacity without dropping")
+    func fillsExactly() {
+        var buffer = SessionReplayBuffer(capacity: 4)
+        buffer.append([1, 2, 3, 4])
+        #expect(buffer.bytes == [1, 2, 3, 4])
+    }
+
+    @Test("drops the oldest bytes once full")
+    func dropsOldest() {
+        var buffer = SessionReplayBuffer(capacity: 4)
+        buffer.append([1, 2, 3, 4])
+        buffer.append([5])
+        #expect(buffer.bytes == [2, 3, 4, 5])
+        buffer.append([6, 7])
+        #expect(buffer.bytes == [4, 5, 6, 7])
+    }
+
+    @Test("keeps only the tail of a write larger than capacity")
+    func keepsTailOfOversizedWrite() {
+        var buffer = SessionReplayBuffer(capacity: 3)
+        buffer.append([1, 2, 3, 4, 5, 6, 7])
+        #expect(buffer.bytes == [5, 6, 7])
+    }
+
+    @Test("keeps only the tail of a write exactly one over capacity")
+    func keepsTailOfBoundaryWrite() {
+        var buffer = SessionReplayBuffer(capacity: 3)
+        buffer.append([1, 2, 3, 4])
+        #expect(buffer.bytes == [2, 3, 4])
+    }
+
+    @Test("stays correct across many wraparounds")
+    func staysCorrectAcrossWraparounds() {
+        var buffer = SessionReplayBuffer(capacity: 5)
+        for value in UInt8(1) ... UInt8(50) {
+            buffer.append([value])
+        }
+        #expect(buffer.bytes == [46, 47, 48, 49, 50])
+    }
+
+    @Test("wraps correctly when an oversized write follows a partial fill")
+    func wrapsAfterPartialFill() {
+        var buffer = SessionReplayBuffer(capacity: 4)
+        buffer.append([1, 2, 3])
+        buffer.append([4, 5, 6, 7, 8])
+        #expect(buffer.bytes == [5, 6, 7, 8])
+    }
+
+    @Test("ignores empty writes and tolerates zero capacity")
+    func toleratesDegenerateInput() {
+        var buffer = SessionReplayBuffer(capacity: 4)
+        buffer.append([])
+        #expect(buffer.isEmpty)
+
+        var zero = SessionReplayBuffer(capacity: 0)
+        zero.append([1, 2, 3])
+        #expect(zero.bytes.isEmpty)
+    }
+
+    @Test("clears back to empty")
+    func clears() {
+        var buffer = SessionReplayBuffer(capacity: 4)
+        buffer.append([1, 2, 3, 4, 5])
+        buffer.removeAll()
+        #expect(buffer.isEmpty)
+        buffer.append([9])
+        #expect(buffer.bytes == [9])
+    }
+}

--- a/Tests/MuxyTests/Services/Session/SessionShellIntegrationTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionShellIntegrationTests.swift
@@ -1,0 +1,156 @@
+import MuxySessionProtocol
+import Testing
+
+@Suite("SessionShellIntegration")
+struct SessionShellIntegrationTests {
+    private let resources = "/Applications/Muxy.app/Contents/Resources/ghostty"
+    private var integrationRoot: String { resources + "/shell-integration" }
+
+    private func invocation(
+        shell: String,
+        command: String = "",
+        resourcesDirectory: String? = nil,
+        environment: [String: String] = [:]
+    ) -> SessionShellInvocation {
+        SessionShellIntegration.invocation(
+            command: command,
+            shell: shell,
+            resourcesDirectory: resourcesDirectory ?? resources,
+            environment: environment.map { SessionEnvironmentEntry(key: $0.key, value: $0.value) }
+        )
+    }
+
+    private func value(_ key: String, in invocation: SessionShellInvocation) -> String? {
+        invocation.environment.first { $0.key == key }?.value
+    }
+
+    @Test("runs the shell as a login shell")
+    func runsLoginShell() {
+        let result = invocation(shell: "/bin/zsh")
+        #expect(result.executable == "/bin/zsh")
+        #expect(result.arguments.first == "-zsh")
+    }
+
+    @Test("points zsh at the bundled ZDOTDIR")
+    func injectsZsh() {
+        let result = invocation(shell: "/bin/zsh")
+        #expect(value("ZDOTDIR", in: result) == integrationRoot + "/zsh")
+        #expect(value("GHOSTTY_RESOURCES_DIR", in: result) == resources)
+        #expect(value("GHOSTTY_ZSH_ZDOTDIR", in: result) == nil)
+    }
+
+    @Test("preserves an existing ZDOTDIR so the integration can restore it")
+    func preservesExistingZDOTDIR() {
+        let result = invocation(shell: "/opt/homebrew/bin/zsh", environment: ["ZDOTDIR": "/Users/test/.config/zsh"])
+        #expect(value("GHOSTTY_ZSH_ZDOTDIR", in: result) == "/Users/test/.config/zsh")
+        #expect(value("ZDOTDIR", in: result) == integrationRoot + "/zsh")
+    }
+
+    @Test("starts bash in posix mode with ENV pointing at the integration")
+    func injectsBash() {
+        let result = invocation(shell: "/bin/bash", environment: ["HOME": "/Users/test"])
+        #expect(result.arguments == ["-bash", "--posix"])
+        #expect(value("ENV", in: result) == integrationRoot + "/bash/ghostty.bash")
+        #expect(value("GHOSTTY_BASH_INJECT", in: result) == "1")
+        #expect(value("HISTFILE", in: result) == "/Users/test/.bash_history")
+        #expect(value("GHOSTTY_BASH_UNEXPORT_HISTFILE", in: result) == "1")
+    }
+
+    @Test("preserves an existing bash ENV and HISTFILE")
+    func preservesExistingBashState() {
+        let result = invocation(
+            shell: "/bin/bash",
+            environment: ["ENV": "/Users/test/.env", "HISTFILE": "/Users/test/.history", "HOME": "/Users/test"]
+        )
+        #expect(value("GHOSTTY_BASH_ENV", in: result) == "/Users/test/.env")
+        #expect(value("ENV", in: result) == integrationRoot + "/bash/ghostty.bash")
+        #expect(value("HISTFILE", in: result) == "/Users/test/.history")
+        #expect(value("GHOSTTY_BASH_UNEXPORT_HISTFILE", in: result) == nil)
+    }
+
+    @Test("leaves HISTFILE alone when HOME is unknown")
+    func skipsHistfileWithoutHome() {
+        let result = invocation(shell: "/bin/bash")
+        #expect(value("HISTFILE", in: result) == nil)
+        #expect(value("GHOSTTY_BASH_UNEXPORT_HISTFILE", in: result) == nil)
+    }
+
+    @Test("prepends the integration root to XDG_DATA_DIRS for fish, elvish and nushell")
+    func injectsXDGShells() {
+        for shell in ["/opt/homebrew/bin/fish", "/usr/local/bin/elvish", "/opt/homebrew/bin/nu"] {
+            let result = invocation(shell: shell, environment: ["XDG_DATA_DIRS": "/usr/share"])
+            #expect(value("XDG_DATA_DIRS", in: result) == integrationRoot + ":/usr/share")
+            #expect(value("GHOSTTY_SHELL_INTEGRATION_XDG_DIR", in: result) == integrationRoot)
+        }
+    }
+
+    @Test("keeps the XDG defaults when the variable is unset")
+    func usesXDGDefaults() {
+        let result = invocation(shell: "/opt/homebrew/bin/fish")
+        #expect(value("XDG_DATA_DIRS", in: result) == integrationRoot + ":/usr/local/share:/usr/share")
+    }
+
+    @Test("does not add the integration root to XDG_DATA_DIRS twice")
+    func doesNotDuplicateXDGEntry() {
+        let result = invocation(
+            shell: "/opt/homebrew/bin/fish",
+            environment: ["XDG_DATA_DIRS": integrationRoot + ":/usr/share"]
+        )
+        #expect(value("XDG_DATA_DIRS", in: result) == integrationRoot + ":/usr/share")
+    }
+
+    @Test("leaves unknown shells untouched apart from the resources directory")
+    func leavesUnknownShellsAlone() {
+        let result = invocation(shell: "/usr/local/bin/xonsh")
+        #expect(result.arguments == ["-xonsh"])
+        #expect(value("ZDOTDIR", in: result) == nil)
+        #expect(value("XDG_DATA_DIRS", in: result) == nil)
+        #expect(value("ENV", in: result) == nil)
+    }
+
+    @Test("skips every injection when no resources directory is known")
+    func skipsWithoutResources() {
+        let result = invocation(shell: "/bin/zsh", resourcesDirectory: "")
+        #expect(result.arguments == ["-zsh"])
+        #expect(value("ZDOTDIR", in: result) == nil)
+        #expect(value("GHOSTTY_RESOURCES_DIR", in: result) == nil)
+    }
+
+    @Test("runs a startup command through sh -c so the wrapper keeps its shell syntax")
+    func runsStartupCommand() {
+        let command = "/bin/zsh -l -c 'eval \"$MUXY_STARTUP_COMMAND\"' /bin/zsh"
+        let result = invocation(shell: "/bin/zsh", command: command)
+        #expect(result.executable == "/bin/sh")
+        #expect(result.arguments == ["/bin/sh", "-c", "exec " + command])
+        #expect(value("ZDOTDIR", in: result) == integrationRoot + "/zsh")
+    }
+
+    @Test("does not force bash into posix mode when running a startup command")
+    func skipsBashInjectionForCommands() {
+        let result = invocation(shell: "/bin/bash", command: "echo hi", environment: ["HOME": "/Users/test"])
+        #expect(result.executable == "/bin/sh")
+        #expect(value("ENV", in: result) == nil)
+        #expect(value("GHOSTTY_BASH_INJECT", in: result) == nil)
+    }
+
+    @Test("falls back to zsh when the shell is unknown")
+    func fallsBackToDefaultShell() {
+        let result = invocation(shell: "")
+        #expect(result.executable == SessionShellIntegration.defaultShell)
+        #expect(result.arguments == ["-zsh"])
+    }
+
+    @Test("derives the shell name from the last path component")
+    func derivesShellName() {
+        #expect(SessionShellIntegration.shellName("/bin/zsh") == "zsh")
+        #expect(SessionShellIntegration.shellName("zsh") == "zsh")
+        #expect(SessionShellIntegration.shellName("/opt/homebrew/bin/fish") == "fish")
+    }
+
+    @Test("keeps the inherited environment")
+    func keepsInheritedEnvironment() {
+        let result = invocation(shell: "/bin/zsh", environment: ["TERM": "xterm-ghostty", "MUXY_PANE_ID": "abc"])
+        #expect(value("TERM", in: result) == "xterm-ghostty")
+        #expect(value("MUXY_PANE_ID", in: result) == "abc")
+    }
+}

--- a/Tests/MuxyTests/Services/Session/SessionShellIntegrationTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionShellIntegrationTests.swift
@@ -125,12 +125,13 @@ struct SessionShellIntegrationTests {
         #expect(value("ZDOTDIR", in: result) == integrationRoot + "/zsh")
     }
 
-    @Test("does not force bash into posix mode when running a startup command")
-    func skipsBashInjectionForCommands() {
+    @Test("injects bash integration for startup commands without changing the outer shell")
+    func injectsBashForCommands() {
         let result = invocation(shell: "/bin/bash", command: "echo hi", environment: ["HOME": "/Users/test"])
         #expect(result.executable == "/bin/sh")
-        #expect(value("ENV", in: result) == nil)
-        #expect(value("GHOSTTY_BASH_INJECT", in: result) == nil)
+        #expect(result.arguments == ["/bin/sh", "-c", "exec echo hi"])
+        #expect(value("ENV", in: result) == integrationRoot + "/bash/ghostty.bash")
+        #expect(value("GHOSTTY_BASH_INJECT", in: result) == "1")
     }
 
     @Test("falls back to zsh when the shell is unknown")

--- a/Tests/MuxyTests/Services/Session/TerminalSessionsStoreTests.swift
+++ b/Tests/MuxyTests/Services/Session/TerminalSessionsStoreTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import MuxySessionProtocol
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalSessionsStore")
+struct TerminalSessionsStoreTests {
+    private func descriptor(
+        projectID: String? = nil,
+        worktreeID: String? = nil,
+        title: String? = nil,
+        workingDirectory: String = "/Users/test/project",
+        isAttached: Bool = false
+    ) throws -> SessionDescriptor {
+        var metadata: [SessionEnvironmentEntry] = []
+        if let projectID {
+            metadata.append(SessionEnvironmentEntry(key: SessionMetadataKey.project, value: projectID))
+        }
+        if let worktreeID {
+            metadata.append(SessionEnvironmentEntry(key: SessionMetadataKey.worktree, value: worktreeID))
+        }
+        if let title {
+            metadata.append(SessionEnvironmentEntry(key: SessionMetadataKey.title, value: title))
+        }
+        return SessionDescriptor(
+            identifier: try #require(SessionIdentifier(uuidString: UUID().uuidString)),
+            shellProcessID: 900,
+            ttyDevice: 42,
+            workingDirectory: workingDirectory,
+            isAttached: isAttached,
+            metadata: metadata
+        )
+    }
+
+    @Test("keeps only sessions belonging to the given worktree")
+    func filtersByWorktree() throws {
+        let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+        let other = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+
+        let matching = try descriptor(projectID: key.projectID.uuidString, worktreeID: key.worktreeID.uuidString)
+        let otherWorktree = try descriptor(projectID: key.projectID.uuidString, worktreeID: other.worktreeID.uuidString)
+        let otherProject = try descriptor(projectID: other.projectID.uuidString, worktreeID: key.worktreeID.uuidString)
+        let untagged = try descriptor()
+
+        let filtered = TerminalSessionsStore.filter(
+            [matching, otherWorktree, otherProject, untagged],
+            inWorktree: key
+        )
+        #expect(filtered == [matching])
+    }
+
+    @Test("returns nothing when no session carries metadata")
+    func filtersOutUntaggedSessions() throws {
+        let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+        #expect(TerminalSessionsStore.filter([try descriptor()], inWorktree: key).isEmpty)
+    }
+
+    @Test("hides sessions a pane already owns")
+    func hidesOwnedSessions() throws {
+        let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+        let owned = try descriptor(projectID: key.projectID.uuidString, worktreeID: key.worktreeID.uuidString)
+        let detached = try descriptor(projectID: key.projectID.uuidString, worktreeID: key.worktreeID.uuidString)
+        let ownedID = try #require(UUID(uuidString: owned.identifier.uuidString))
+
+        let result = TerminalSessionsStore.detached(
+            [owned, detached],
+            inWorktree: key,
+            ownedSessionIDs: [ownedID]
+        )
+        #expect(result == [detached])
+    }
+
+    @Test("matches ownership across the lowercase daemon identifier and uppercase pane UUID")
+    func matchesOwnershipRegardlessOfCase() throws {
+        let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+        let session = try descriptor(projectID: key.projectID.uuidString, worktreeID: key.worktreeID.uuidString)
+        let identifierText = session.identifier.uuidString
+        #expect(identifierText == identifierText.lowercased())
+
+        let paneSessionID = try #require(UUID(uuidString: identifierText))
+        #expect(paneSessionID.uuidString == paneSessionID.uuidString.uppercased())
+
+        let result = TerminalSessionsStore.detached([session], inWorktree: key, ownedSessionIDs: [paneSessionID])
+        #expect(result.isEmpty)
+    }
+
+    @Test("keeps a session still marked attached by the daemon when no pane owns it")
+    func keepsUnownedSessionRegardlessOfDaemonFlag() throws {
+        let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+        let session = try descriptor(
+            projectID: key.projectID.uuidString,
+            worktreeID: key.worktreeID.uuidString,
+            isAttached: true
+        )
+        let result = TerminalSessionsStore.detached([session], inWorktree: key, ownedSessionIDs: [])
+        #expect(result == [session])
+    }
+
+    @Test("keeps a session whose pane was freed to save memory out of the list")
+    func hidesIdleFreedPane() throws {
+        let key = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+        let session = try descriptor(
+            projectID: key.projectID.uuidString,
+            worktreeID: key.worktreeID.uuidString,
+            isAttached: false
+        )
+        let ownedID = try #require(UUID(uuidString: session.identifier.uuidString))
+        #expect(TerminalSessionsStore.detached([session], inWorktree: key, ownedSessionIDs: [ownedID]).isEmpty)
+    }
+
+    @Test("prefers the recorded title for display")
+    func prefersRecordedTitle() throws {
+        let session = try descriptor(title: "Dev Server")
+        #expect(TerminalSessionsStore.displayTitle(for: session) == "Dev Server")
+    }
+
+    @Test("falls back to the working directory name without a title")
+    func fallsBackToDirectoryName() throws {
+        let session = try descriptor(workingDirectory: "/Users/test/my-app")
+        #expect(TerminalSessionsStore.displayTitle(for: session) == "my-app")
+    }
+
+    @Test("falls back to the default terminal title for a blank title and root directory")
+    func fallsBackToDefaultTitle() throws {
+        let session = try descriptor(title: "   ", workingDirectory: "/")
+        #expect(TerminalSessionsStore.displayTitle(for: session) == TerminalPaneState.defaultTitle)
+    }
+}
+
+@Suite("TerminalSessionAttachment")
+@MainActor
+struct TerminalSessionAttachmentTests {
+    @Test("points a pane at another session")
+    func repointsPane() {
+        let pane = TerminalPaneState(projectPath: "/tmp")
+        #expect(pane.sessionID == pane.id)
+
+        let target = UUID()
+        #expect(TerminalSessionAttachment.attach(sessionID: target, to: pane) == .attached)
+        #expect(pane.sessionID == target)
+    }
+
+    @Test("reports an unchanged pane when it already owns the session")
+    func detectsUnchangedPane() {
+        let pane = TerminalPaneState(projectPath: "/tmp")
+        #expect(TerminalSessionAttachment.attach(sessionID: pane.sessionID, to: pane) == .alreadyAttached)
+        #expect(pane.sessionID == pane.id)
+    }
+
+    @Test("hands a previous owner back its own session so two panes never share one")
+    func releasesPreviousOwner() {
+        let shared = UUID()
+        let previousOwner = TerminalPaneState(sessionID: shared, projectPath: "/tmp")
+        let bystander = TerminalPaneState(projectPath: "/tmp")
+        let adopting = TerminalPaneState(projectPath: "/tmp")
+
+        let released = TerminalSessionAttachment.releaseOwners(
+            of: shared,
+            excluding: adopting.id,
+            in: [previousOwner, bystander, adopting]
+        )
+
+        #expect(released.map(\.id) == [previousOwner.id])
+        #expect(previousOwner.sessionID == previousOwner.id)
+        #expect(bystander.sessionID == bystander.id)
+    }
+
+    @Test("leaves the adopting pane alone when it already owns the session")
+    func skipsTheAdoptingPane() {
+        let pane = TerminalPaneState(projectPath: "/tmp")
+        let released = TerminalSessionAttachment.releaseOwners(
+            of: pane.sessionID,
+            excluding: pane.id,
+            in: [pane]
+        )
+        #expect(released.isEmpty)
+        #expect(pane.sessionID == pane.id)
+    }
+}
+
+@Suite("TerminalPaneState session identity")
+@MainActor
+struct TerminalPaneSessionIdentityTests {
+    @Test("defaults the session to the pane itself")
+    func defaultsToPaneID() {
+        let pane = TerminalPaneState(projectPath: "/tmp")
+        #expect(pane.sessionID == pane.id)
+    }
+
+    @Test("keeps an adopted session distinct from the pane")
+    func keepsAdoptedSession() {
+        let adopted = UUID()
+        let pane = TerminalPaneState(sessionID: adopted, projectPath: "/tmp")
+        #expect(pane.sessionID == adopted)
+        #expect(pane.id != adopted)
+    }
+
+    @Test("round-trips the session through a tab snapshot")
+    func roundTripsThroughSnapshot() {
+        let adopted = UUID()
+        let tab = TerminalTab(pane: TerminalPaneState(sessionID: adopted, projectPath: "/tmp"))
+        let restored = TerminalTab(restoring: tab.snapshot())
+        #expect(restored.content.pane?.sessionID == adopted)
+    }
+
+    @Test("restores a legacy snapshot with the pane as its own session")
+    func restoresLegacySnapshot() {
+        let paneID = UUID()
+        let snapshot = TerminalTabSnapshot(
+            kind: .terminal,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: "/tmp",
+            paneTitle: nil,
+            paneID: paneID
+        )
+        let restored = TerminalTab(restoring: snapshot)
+        #expect(restored.content.pane?.sessionID == paneID)
+    }
+}

--- a/Tests/MuxyTests/Support/SessionDaemonHarness.swift
+++ b/Tests/MuxyTests/Support/SessionDaemonHarness.swift
@@ -1,0 +1,185 @@
+import Darwin
+import Foundation
+import MuxySessionProtocol
+
+final class SessionDaemonHarness {
+    static let binaryURL: URL? = {
+        let root = RepositoryRoot.find()
+        let candidates = [
+            ProcessInfo.processInfo.environment["MUXY_SESSION_BINARY"].map { URL(fileURLWithPath: $0) },
+            root.appendingPathComponent(".build/debug/muxy-session"),
+            root.appendingPathComponent(".build/release/muxy-session"),
+        ].compactMap(\.self)
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0.path) }
+    }()
+
+    let directory: URL
+    let socketPath: String
+
+    private var daemon: Process?
+
+    init() throws {
+        let name = "mxs-" + UUID().uuidString.prefix(8)
+        directory = URL(fileURLWithPath: "/tmp", isDirectory: true).appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        socketPath = directory.appendingPathComponent("c.sock").path
+    }
+
+    func start() throws {
+        guard let binaryURL = Self.binaryURL else { return }
+        let process = Process()
+        process.executableURL = binaryURL
+        process.arguments = ["daemon", "--socket", socketPath]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        daemon = process
+
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: socketPath), let probe = SessionTestConnection(socketPath: socketPath) {
+                probe.close()
+                return
+            }
+            usleep(20_000)
+        }
+    }
+
+    func stop() {
+        if let connection = SessionTestConnection(socketPath: socketPath) {
+            connection.send(SessionFrame(kind: .killAll))
+            _ = connection.waitForFrame(timeout: 2) { $0.kind == .acknowledged }
+            connection.close()
+        }
+        daemon?.terminate()
+        daemon?.waitUntilExit()
+        daemon = nil
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func attachRequest(
+        identifier: SessionIdentifier,
+        command: String,
+        shell: String = "/bin/sh",
+        columns: UInt16 = 80,
+        rows: UInt16 = 24,
+        environment: [SessionEnvironmentEntry] = [],
+        metadata: [SessionEnvironmentEntry] = [],
+        version: UInt16 = SessionProtocolVersion.current
+    ) -> SessionFrame {
+        SessionFrame(
+            kind: .attach,
+            payload: SessionAttachRequest(
+                version: version,
+                identifier: identifier,
+                columns: columns,
+                rows: rows,
+                workingDirectory: "/tmp",
+                command: command,
+                shell: shell,
+                resourcesDirectory: "",
+                environment: [SessionEnvironmentEntry(key: "PATH", value: "/usr/bin:/bin")] + environment,
+                metadata: metadata
+            ).encoded()
+        )
+    }
+}
+
+final class SessionTestConnection {
+    private let descriptor: Int32
+    private var decoder = SessionFrameDecoder()
+    private var pending: [SessionFrame] = []
+
+    init?(socketPath: String) {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        let bytes = Array(socketPath.utf8)
+        guard bytes.count < capacity else { return nil }
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+                for (index, byte) in bytes.enumerated() {
+                    destination[index] = CChar(bitPattern: byte)
+                }
+                destination[bytes.count] = 0
+            }
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        let socketDescriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard socketDescriptor >= 0 else { return nil }
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { casted in
+                Darwin.connect(socketDescriptor, casted, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connected == 0 else {
+            Darwin.close(socketDescriptor)
+            return nil
+        }
+        descriptor = socketDescriptor
+    }
+
+    func send(_ frame: SessionFrame) {
+        let bytes = frame.encoded()
+        var offset = 0
+        bytes.withUnsafeBytes { pointer in
+            guard let base = pointer.baseAddress else { return }
+            while offset < bytes.count {
+                let written = Darwin.write(descriptor, base.advanced(by: offset), bytes.count - offset)
+                guard written > 0 else { return }
+                offset += written
+            }
+        }
+    }
+
+    func waitForFrame(timeout: TimeInterval, matching predicate: (SessionFrame) -> Bool) -> SessionFrame? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            if let index = pending.firstIndex(where: predicate) {
+                return pending.remove(at: index)
+            }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0, readMore(timeout: remaining) else { return nil }
+        }
+    }
+
+    func collectOutput(timeout: TimeInterval, until predicate: (String) -> Bool) -> String {
+        var text = ""
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            while let index = pending.firstIndex(where: { $0.kind == .output }) {
+                let frame = pending.remove(at: index)
+                text += String(decoding: frame.payload, as: UTF8.self)
+            }
+            if predicate(text) { return text }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0, readMore(timeout: remaining) else { return text }
+        }
+    }
+
+    private func readMore(timeout: TimeInterval) -> Bool {
+        var descriptors = [pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)]
+        let ready = poll(&descriptors, 1, Int32(timeout * 1000))
+        guard ready > 0 else { return false }
+
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        let count = buffer.withUnsafeMutableBytes { pointer in
+            Darwin.read(descriptor, pointer.baseAddress, 64 * 1024)
+        }
+        guard count > 0 else { return false }
+        decoder.push(Array(buffer[0 ..< count]))
+        while let frame = try? decoder.next() {
+            pending.append(frame)
+        }
+        return true
+    }
+
+    func close() {
+        Darwin.close(descriptor)
+    }
+}

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -11,8 +11,8 @@ Permissions apply only to identified callers. The host identifies itself on beha
 
 | Permission | Grants |
 | --- | --- |
-| `panes:read` | `read-screen`, `list-panes` |
-| `panes:write` | `split-right`, `split-down`, `send`, `send-keys`, `close-pane`, `rename-pane`. Split requests with a startup command also require `commands:exec`. |
+| `panes:read` | `read-screen`, `list-panes`, `list-sessions` |
+| `panes:write` | `split-right`, `split-down`, `send`, `send-keys`, `close-pane`, `rename-pane`, `kill-session`. Split requests with a startup command also require `commands:exec`. `kill-session` stops a background terminal session and everything running inside it. |
 | `tabs:read` | `list-tabs` |
 | `tabs:write` | `switch-tab`, `new-tab`, `next-tab`, `previous-tab`, `open-tab`. Opening a terminal tab with a startup `command` also prompts for runtime consent. |
 | `browser:read` | Read-only browser calls: `browser.list`, `browser.read`, `browser.waitFor`, `browser.waitForNavigation`, `browser.wait` (without `{ function }`), `browser.screenshot`, `browser.getText`, `browser.getHTML`, `browser.getValue`, `browser.getAttribute`, `browser.getCount`, `browser.is`, `browser.find`, `browser.snapshot`, `browser.storage.get`, `browser.cookies.get` — see [Browser](browser.md). |

--- a/docs/features/muxy-cli.md
+++ b/docs/features/muxy-cli.md
@@ -296,6 +296,32 @@ Close a pane:
 muxy close-pane --pane "$PANE"
 ```
 
+### Background sessions
+
+When **Settings → Terminal → Background sessions** is on, terminals keep running after Muxy quits. List them:
+
+```bash
+muxy list-sessions
+```
+
+Output is tab-separated:
+
+```text
+<session-id>  <shell-pid>  <working-directory>  <attached>  <title>  <project-id>  <worktree-id>  <tab-id>
+```
+
+`<attached>` is `true` while a terminal pane is connected to the session and `false` while it runs unattended. The last four columns identify which tab, project, and worktree the session belongs to, and are empty for a session that has never been attached from a worktree.
+
+A session ID matches its pane ID until a tab adopts someone else's session, so always take the ID from the first column rather than assuming it is a pane ID.
+
+Stop a session and everything running inside it:
+
+```bash
+muxy kill-session --session "$SESSION"
+```
+
+Closing the session's tab in the app stops it too, so this is mainly for sessions that outlived their tab or that you want to end from a script.
+
 ## Tab control
 
 Tab commands talk to the running Muxy app through a local Unix socket. Muxy must be open.
@@ -443,6 +469,7 @@ The socket is private to your user. It does not grant extra privileges, but any 
 - send text or supported control keys
 - rename or close panes
 - create new splits
+- list and stop background terminal sessions
 
 Avoid exposing sensitive terminal output if you are running untrusted local software.
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -6,6 +6,42 @@ Muxy's terminals are powered by [libghostty](https://github.com/ghostty-org/ghos
 
 Muxy currently ships Ghostty as its terminal backend. Pane hosting, remote control, quick terminal creation, search, rich input, process detection, and offline lifecycle depend on Muxy's backend-neutral terminal surface contract. Optional integrations use dedicated capability protocols, so unsupported search, remote snapshots, client themes, offline lifecycle, raw output, and image paste behavior is never invoked. Image attachments fall back to escaped file paths when a backend does not support clipboard image paste. Ghostty-specific handles and callbacks stay inside the Ghostty implementation boundary. There is no user-facing backend selector until another implementation satisfies the capabilities required by these integrations.
 
+## Background sessions
+
+**Settings → Terminal → Background sessions** runs each new terminal in a detached process so it survives quitting Muxy, the way tmux does. It is off by default and only affects terminals opened after it is switched on; terminals that are already open keep their current behavior.
+
+libghostty owns the PTY of every surface it creates and offers no way to hand a surface an existing PTY, so a background terminal cannot simply be adopted. Muxy uses the same split tmux does. A `muxy-session` daemon owns the real PTY of every background session and lives in its own session (`setsid`), which is what lets it outlive the app. The surface runs `muxy-session attach`, a small client that proxies bytes, window size, and the final exit status over a unix socket. Quitting Muxy kills the clients and leaves the daemon and its shells running.
+
+Each pane carries a session ID that defaults to its own pane ID and is persisted in workspace snapshots, so reopening Muxy reattaches each restored pane to its own session. Because the two IDs are separate, a pane can also adopt a session that started somewhere else. On reattach the daemon replays a capped 256 KB buffer of recent output and sends `SIGWINCH` to the foreground process group so full-screen programs repaint. The daemon exits on its own once it has been idle with no sessions.
+
+Every attach carries metadata identifying the project, worktree, tab, and title the session belongs to, and the daemon refreshes it each time a client reattaches. That is what lets Muxy group sessions by worktree and show which tab owns one. The attach also carries a protocol version; a session started by a different version of Muxy is refused with a clear message rather than being misread.
+
+### Recovering sessions
+
+Reopening Muxy reattaches every restored pane whose session is still running, without waiting for you to click the tab, so output keeps flowing and scrollback keeps building from the moment the window appears.
+
+Closing a tab ends its session. Sessions are never killed behind your back otherwise: one whose tab is gone keeps running and shows up in the status bar as detached, where you can reattach or stop it.
+
+The status bar lists only the sessions in the current project and worktree that **no tab currently owns**, since a session already open in a tab is not something you need to recover. Ownership is decided by the pane pointing at the session, not by whether a client happens to be connected, so a tab whose terminal was freed by the idle-memory setting still counts as owning its session. When every session in the worktree is open in a tab, the status bar item disappears entirely.
+
+Each row shows the session's title and working directory with three actions:
+
+- **Active tab** points the focused terminal tab at that session. The session the tab was showing keeps running and becomes detached, so it takes the vacated slot in the list.
+- **New tab** opens a tab in the current worktree attached to that session.
+- **Stop** ends the session and everything running inside it.
+
+A session can only ever be owned by one tab, because the daemon accepts a single attached client. Adopting a session hands its previous owner back a fresh session of its own rather than leaving that tab looking at a dead terminal.
+
+Ghostty only injects its shell integration into shells it spawns itself, so the daemon reproduces that injection using the contract the bundled scripts document: `ZDOTDIR` plus `GHOSTTY_ZSH_ZDOTDIR` for zsh, `ENV` plus `GHOSTTY_BASH_INJECT` and POSIX mode for bash, and `XDG_DATA_DIRS` plus `GHOSTTY_SHELL_INTEGRATION_XDG_DIR` for fish, elvish, and nushell. Background terminals in those shells keep working-directory tracking, tab titles, prompt marks, and AI progress. Other shells run normally but lose those integrations, exactly as they do under tmux.
+
+Because the surface's own foreground process is the attach client, Muxy resolves the real foreground process from the session's tty through `sysctl(KERN_PROC_TTY)`. Agent detection, the running-process close confirmation, and AI hook to pane mapping behave the same as in a normal terminal.
+
+The control socket lives in Muxy's Application Support directory with `0700` on the directory and `0600` on the socket, falling back to a user-scoped `/tmp/muxy-<uid>` only when the primary path exceeds the 104-byte `sun_path` limit. The daemon verifies the peer's uid with `LOCAL_PEERCRED` and refuses connections from other users.
+
+Remote SSH panes and the quick terminal are never backed by a background session.
+
+`muxy list-sessions` and `muxy kill-session --session <id>` manage sessions from a shell. See [Muxy CLI](muxy-cli.md).
+
 ## Quick terminal
 
 Assign Double Shift or a conventional global shortcut to open the quick terminal from anywhere. On a display with a camera cutout, it expands out of the cutout like a dynamic island. It always starts in your home directory and keeps the same shell, working directory, and history while hidden.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -36,6 +36,23 @@ In **Appearance → Sidebar**, select **Tab Focused** or **Agents Focused** to s
 It is off by default. Turn it on to nest all worktrees under their project; turn it off to keep worktrees as top-level rows. Tab
 Focused shows top-level worktrees only when they have open tabs, while Agents Focused shows every secondary worktree.
 
+## Background sessions
+
+Open **Settings → Terminal → Background sessions** to keep terminals running after Muxy quits:
+
+- **Run new terminals in the background** starts each new terminal in a separate background process, like tmux. Quitting Muxy leaves those terminals running, and reopening it reconnects them along with their recent output.
+- Only terminals opened after the setting is switched on are affected. Terminals that are already open keep their current behavior.
+- Reopening Muxy reattaches every restored tab whose session is still running, without waiting for you to click the tab.
+- Closing a tab ends its session. A session whose tab is gone keeps running and stays available from the status bar.
+- Turning the setting off asks for confirmation and then stops every terminal still running in the background.
+- Remote SSH terminals and the quick terminal are never run this way.
+
+The status bar shows how many background terminals in the current project and worktree are **not** open in a tab. Its popover lists those and can point the focused tab at one, open a new tab attached to one, or stop one. It disappears when nothing is waiting, so it only appears when you have something to recover.
+
+Background terminals keep working-directory tracking, tab titles, and AI progress in zsh, bash, fish, elvish, and nushell. Other shells run normally but lose those integrations, the same limitation tmux has.
+
+The setting is stored as `muxy.terminalPersistentSession.enabled` in `settings.json`. Use `muxy list-sessions` and `muxy kill-session --session <id>` to inspect and stop sessions from a shell.
+
 ## Quick terminal
 
 The assigned shortcut is the only way to open the quick terminal. On a display with a camera cutout, the terminal expands out of it like a dynamic island. Open **Quick Terminal** in Settings to configure its shortcut, size, and appearance:

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -111,6 +111,9 @@ strip -Sx "$APP_BUNDLE/Contents/MacOS/MuxyExtensionHost"
 cp "$SPM_BUILD_DIR/muxy-hook" "$APP_BUNDLE/Contents/MacOS/muxy-hook"
 strip -Sx "$APP_BUNDLE/Contents/MacOS/muxy-hook"
 
+cp "$SPM_BUILD_DIR/muxy-session" "$APP_BUNDLE/Contents/MacOS/muxy-session"
+strip -Sx "$APP_BUNDLE/Contents/MacOS/muxy-session"
+
 echo "==> Generating dSYM"
 xcrun dsymutil "$APP_BUNDLE/Contents/MacOS/Muxy" -o "$DSYM_BUNDLE"
 
@@ -198,6 +201,11 @@ if [[ -n "$SIGN_IDENTITY" ]]; then
     /usr/bin/codesign --force --options runtime --timestamp \
         --sign "$SIGN_IDENTITY" \
         "$APP_BUNDLE/Contents/MacOS/muxy-hook"
+
+    echo "==> Signing terminal session helper"
+    /usr/bin/codesign --force --options runtime --timestamp \
+        --sign "$SIGN_IDENTITY" \
+        "$APP_BUNDLE/Contents/MacOS/muxy-session"
 
     echo "==> Signing app bundle"
     /usr/bin/codesign --force --options runtime --timestamp \

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 root="${0:A:h:h}"
 binary="$root/.build/debug/Muxy"
 hook_binary="$root/.build/debug/muxy-hook"
+session_binary="$root/.build/debug/muxy-session"
 
 args=()
 for arg in "$@"; do
@@ -30,6 +31,7 @@ else
     "$root/Muxy"/**/*(.) \
     "$root/MuxyShared"/**/*(.) \
     "$root/MuxyServer"/**/*(.) \
+    "$root/MuxySessionProtocol"/**/*(.) \
     "$root/GhosttyKit"/**/*(.); do
     if [[ "$path" -nt "$binary" ]]; then
       needs_build=true
@@ -56,12 +58,33 @@ else
   done
 fi
 
+needs_session_build=false
+
+if [[ ! -x "$session_binary" ]]; then
+  needs_session_build=true
+else
+  for path in \
+    "$root/Package.swift" \
+    "$root/Package.resolved" \
+    "$root/MuxySession"/**/*(.) \
+    "$root/MuxySessionProtocol"/**/*(.); do
+    if [[ "$path" -nt "$session_binary" ]]; then
+      needs_session_build=true
+      break
+    fi
+  done
+fi
+
 if [[ "$needs_build" == true ]]; then
   swift build --product Muxy --skip-update
 fi
 
 if [[ "$needs_hook_build" == true ]]; then
   swift build --product muxy-hook --skip-update
+fi
+
+if [[ "$needs_session_build" == true ]]; then
+  swift build --product muxy-session --skip-update
 fi
 
 exec "$binary" "${args[@]}"


### PR DESCRIPTION
Add an opt-in session daemon that keeps local terminals running after Muxy quits and restores or reattaches them on relaunch. Includes detached-session controls, CLI commands, secure socket handling, session metadata and recovery, settings, documentation, build integration, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background terminal sessions that continue running after Muxy quits and can be restored automatically.
  * Added controls to attach, open, refresh, and stop detached sessions from the status bar.
  * Added settings to enable or disable background sessions, with confirmation before stopping active sessions.
  * Added `list-sessions` and `kill-session` CLI commands.
* **Documentation**
  * Documented background sessions, session management, permissions, and limitations.
* **Tests**
  * Added coverage for session persistence, recovery, protocol behavior, and terminal integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->