### PR TITLE
Add Send to Background for persistent terminal sessions

### DIFF
--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -46,6 +46,7 @@ final class AppState {
         case createBrowserSplitInWorktree(key: WorktreeKey, areaID: UUID, url: URL?, profileID: UUID)
         case closeTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case closeTabInWorktree(key: WorktreeKey, areaID: UUID, tabID: UUID)
+        case sendTabToBackground(key: WorktreeKey, tabID: UUID)
         case selectTab(projectID: UUID, areaID: UUID, tabID: UUID)
         case selectTabInWorktree(key: WorktreeKey, areaID: UUID, tabID: UUID)
         case selectTabByIndex(projectID: UUID, index: Int)
@@ -578,10 +579,43 @@ final class AppState {
         }
     }
 
+    func canSendTabToBackground(paneID: UUID) -> Bool {
+        backgroundableTab(for: paneID) != nil
+    }
+
+    @discardableResult
+    func sendTabToBackground(paneID: UUID) -> Bool {
+        guard let target = backgroundableTab(for: paneID) else { return false }
+        dispatch(.sendTabToBackground(key: target.key, tabID: target.tabID))
+        TerminalSessionsStore.shared.refresh()
+        return true
+    }
+
     func closeTabs(_ tabIDs: [UUID], areaID: UUID, projectID: UUID) {
         for tabID in tabIDs {
             closeTab(tabID, areaID: areaID, projectID: projectID)
         }
+    }
+
+    private func backgroundableTab(for paneID: UUID) -> (key: WorktreeKey, tabID: UUID)? {
+        guard let location = locateTab(forPane: paneID),
+              let root = workspaceRoots[location.worktreeKey]
+        else { return nil }
+        let topLevelTabID = location.tab.parentTabID ?? location.tab.id
+        guard let topLevelTab = root.locateTab(id: topLevelTabID)?.tab,
+              !topLevelTab.isPinned
+        else { return nil }
+        let ownedTabs = root.allTabs().filter {
+            $0.id == topLevelTabID || $0.parentTabID == topLevelTabID
+        }
+        let panes = ownedTabs.compactMap(\.content.pane)
+        guard !panes.isEmpty,
+              panes.count == ownedTabs.count,
+              panes.allSatisfy({ pane in
+                  terminalViews.hasPersistentSession(for: pane.id, sessionID: pane.sessionID)
+              })
+        else { return nil }
+        return (location.worktreeKey, topLevelTabID)
     }
 
     func closeTabs(_ tabIDs: [UUID], areaID: UUID, key: WorktreeKey) {
@@ -900,6 +934,12 @@ final class AppState {
 
         for paneID in effects.paneIDsToRemove {
             terminalViews.removeView(for: paneID)
+            TerminalProgressStore.shared.resetPane(paneID)
+            DetectedAgentStore.shared.resetPane(paneID)
+        }
+
+        for paneID in effects.paneIDsToRelease {
+            terminalViews.releaseViewPreservingSession(for: paneID)
             TerminalProgressStore.shared.resetPane(paneID)
             DetectedAgentStore.shared.resetPane(paneID)
         }

--- a/Muxy/Models/Workspace/Reducer/TabReducer.swift
+++ b/Muxy/Models/Workspace/Reducer/TabReducer.swift
@@ -2,6 +2,19 @@ import Foundation
 
 @MainActor
 enum TabReducer {
+    private enum PaneDisposition {
+        case terminate
+        case release
+    }
+
+    private struct TopLevelTabCloseRequest {
+        let tab: TerminalTab
+        let areaID: UUID
+        let key: WorktreeKey
+        let paneDisposition: PaneDisposition
+        let preservesFinalWorkspace: Bool
+    }
+
     static func createTab(projectID: UUID, areaID: UUID?, state: inout WorkspaceState) -> UUID? {
         guard let key = WorkspaceReducerShared.activeKey(projectID: projectID, state: state) else { return nil }
         return createTab(key: key, areaID: areaID, state: &state)
@@ -252,7 +265,17 @@ enum TabReducer {
               !tab.isPinned
         else { return }
         if tab.parentTabID == nil {
-            closeTopLevelTab(tab, areaID: areaID, key: key, state: &state, effects: &effects)
+            closeTopLevelTab(
+                TopLevelTabCloseRequest(
+                    tab: tab,
+                    areaID: areaID,
+                    key: key,
+                    paneDisposition: .terminate,
+                    preservesFinalWorkspace: false
+                ),
+                state: &state,
+                effects: &effects
+            )
             return
         }
 
@@ -262,6 +285,32 @@ enum TabReducer {
 
         guard area.tabs.isEmpty else { return }
         SplitReducer.closeArea(areaID, key: key, state: &state, effects: &effects)
+    }
+
+    static func sendTabToBackground(
+        _ tabID: UUID,
+        key: WorktreeKey,
+        state: inout WorkspaceState,
+        effects: inout WorkspaceSideEffects
+    ) {
+        guard let root = state.workspaceRoots[key],
+              let located = root.locateTab(id: tabID),
+              located.tab.parentTabID == nil,
+              !located.tab.isPinned
+        else { return }
+        let ownedTabs = root.allTabs().filter { $0.id == tabID || $0.parentTabID == tabID }
+        guard !ownedTabs.isEmpty, ownedTabs.allSatisfy({ $0.content.pane != nil }) else { return }
+        closeTopLevelTab(
+            TopLevelTabCloseRequest(
+                tab: located.tab,
+                areaID: located.area.id,
+                key: key,
+                paneDisposition: .release,
+                preservesFinalWorkspace: true
+            ),
+            state: &state,
+            effects: &effects
+        )
     }
 
     static func selectRelativeFlatTab(key: WorktreeKey, offset: Int, state: inout WorkspaceState) {
@@ -299,12 +348,13 @@ enum TabReducer {
     }
 
     private static func closeTopLevelTab(
-        _ tab: TerminalTab,
-        areaID: UUID,
-        key: WorktreeKey,
+        _ request: TopLevelTabCloseRequest,
         state: inout WorkspaceState,
         effects: inout WorkspaceSideEffects
     ) {
+        let tab = request.tab
+        let areaID = request.areaID
+        let key = request.key
         guard var root = state.workspaceRoots[key] else { return }
         let originalOrder = normalizedTopLevelOrder(key: key, state: state)
         let closedIndex = originalOrder.firstIndex(of: tab.id) ?? 0
@@ -313,7 +363,7 @@ enum TabReducer {
             .tabIDs
             ?? originalOrder
         let sourceGroupClosedIndex = sourceGroupOrder.firstIndex(of: tab.id) ?? 0
-        let preservesEmptyWorkspace = state.keepProjectOpenWhenEmpty
+        let preservesEmptyWorkspace = (request.preservesFinalWorkspace || state.keepProjectOpenWhenEmpty)
             && root.allTabs().count(where: { $0.parentTabID == nil }) == 1
         let ownedIDs = Set(root.allTabs().filter { $0.parentTabID == tab.id }.map(\.id) + [tab.id])
         let closedTabWasFocused = state.focusedAreaID[key]
@@ -328,7 +378,12 @@ enum TabReducer {
             let ownedTabs = affectedArea.tabs.filter { ownedIDs.contains($0.id) }
             for ownedTab in ownedTabs {
                 if let paneID = ownedTab.content.pane?.id {
-                    effects.paneIDsToRemove.append(paneID)
+                    switch request.paneDisposition {
+                    case .terminate:
+                        effects.paneIDsToRemove.append(paneID)
+                    case .release:
+                        effects.paneIDsToRelease.append(paneID)
+                    }
                 }
                 _ = affectedArea.extractTabForMove(ownedTab.id)
             }

--- a/Muxy/Models/Workspace/WorkspaceReducer.swift
+++ b/Muxy/Models/Workspace/WorkspaceReducer.swift
@@ -20,6 +20,7 @@ struct WorkspaceSideEffects {
     }
 
     var paneIDsToRemove: [UUID] = []
+    var paneIDsToRelease: [UUID] = []
     var projectIDsToRemove: [UUID] = []
     var deferredAreaCollapses: [DeferredAreaCollapse] = []
     var createdTabID: UUID?
@@ -172,6 +173,10 @@ enum WorkspaceReducer {
         case let .closeTabInWorktree(key, areaID, tabID):
             guard state.workspaceRoots[key] != nil else { break }
             TabReducer.closeTab(tabID, areaID: areaID, key: key, state: &state, effects: &effects)
+
+        case let .sendTabToBackground(key, tabID):
+            guard state.workspaceRoots[key] != nil else { break }
+            TabReducer.sendTabToBackground(tabID, key: key, state: &state, effects: &effects)
 
         case let .selectTab(projectID, areaID, tabID):
             TabReducer.selectTab(projectID: projectID, areaID: areaID, tabID: tabID, state: &state)
@@ -360,6 +365,7 @@ enum WorkspaceReducer {
              let .createBrowserTabInWorktree(key, _, _, _),
              let .createBrowserSplitInWorktree(key, _, _, _),
              let .closeTabInWorktree(key, _, _),
+             let .sendTabToBackground(key, _),
              let .selectTabInWorktree(key, _, _),
              let .selectNextTabInWorktree(key),
              let .selectPreviousTabInWorktree(key),

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -756,6 +756,7 @@
 "Selected" = "Selected";
 "Selection" = "Selection";
 "Send" = "Send";
+"Send to Background" = "Send to Background";
 "Send Without Enter" = "Send Without Enter";
 "Send anonymous crash reports" = "Send anonymous crash reports";
 "Send to Active Pane" = "Send to Active Pane";

--- a/Muxy/Services/App/AppStateDependencies.swift
+++ b/Muxy/Services/App/AppStateDependencies.swift
@@ -54,5 +54,17 @@ final class UserDefaultsActiveProjectSelectionStore: ActiveProjectSelectionStori
 @MainActor
 protocol TerminalViewRemoving {
     func removeView(for paneID: UUID)
+    func releaseViewPreservingSession(for paneID: UUID)
+    func hasPersistentSession(for paneID: UUID, sessionID: UUID) -> Bool
     func needsConfirmQuit(for paneID: UUID) -> Bool
+}
+
+extension TerminalViewRemoving {
+    func releaseViewPreservingSession(for paneID: UUID) {
+        removeView(for: paneID)
+    }
+
+    func hasPersistentSession(for _: UUID, sessionID _: UUID) -> Bool {
+        false
+    }
 }

--- a/Muxy/Services/App/AppStateDependencies.swift
+++ b/Muxy/Services/App/AppStateDependencies.swift
@@ -58,13 +58,3 @@ protocol TerminalViewRemoving {
     func hasPersistentSession(for paneID: UUID, sessionID: UUID) -> Bool
     func needsConfirmQuit(for paneID: UUID) -> Bool
 }
-
-extension TerminalViewRemoving {
-    func releaseViewPreservingSession(for paneID: UUID) {
-        removeView(for: paneID)
-    }
-
-    func hasPersistentSession(for _: UUID, sessionID _: UUID) -> Bool {
-        false
-    }
-}

--- a/Muxy/Services/Terminal/TerminalSurface.swift
+++ b/Muxy/Services/Terminal/TerminalSurface.swift
@@ -88,6 +88,11 @@ protocol TerminalImagePasteSurface: AnyObject {
 }
 
 @MainActor
+protocol TerminalBackgroundingSurface: AnyObject {
+    var onSendToBackground: (() -> Void)? { get set }
+}
+
+@MainActor
 protocol TerminalInputSubmissionTarget: AnyObject {
     func sendRemoteBytes(_ bytes: Data)
     func submitRichInput(text: String)

--- a/Muxy/Services/Terminal/TerminalSurface.swift
+++ b/Muxy/Services/Terminal/TerminalSurface.swift
@@ -89,6 +89,7 @@ protocol TerminalImagePasteSurface: AnyObject {
 
 @MainActor
 protocol TerminalBackgroundingSurface: AnyObject {
+    var canSendToBackground: (() -> Bool)? { get set }
     var onSendToBackground: (() -> Void)? { get set }
 }
 

--- a/Muxy/Services/Terminal/TerminalViewRegistry.swift
+++ b/Muxy/Services/Terminal/TerminalViewRegistry.swift
@@ -72,6 +72,14 @@ final class TerminalViewRegistry {
         return view
     }
 
+    func hasPersistentSession(for paneID: UUID, sessionID: UUID) -> Bool {
+        views[paneID]?.persistentSessionID == sessionID
+    }
+
+    func releaseViewPreservingSession(for paneID: UUID) {
+        releaseView(for: paneID)
+    }
+
     func prepareForTermination() async {
         for view in views.values {
             view.scheduleTerminationCleanup()

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -71,7 +71,8 @@ struct TerminalSettingsView: View {
                 footer: """
                 Runs each new terminal in a separate background process, the way tmux does. Quitting Muxy leaves \
                 those terminals running and reopening reconnects them with their recent output. Closing a tab still \
-                ends its session. Terminals that are already open keep their current behaviour.
+                ends its session. Use Send to Background from a terminal's context menu to close an eligible tab \
+                without stopping its processes. Terminals that are already open keep their current behaviour.
                 """
             ) {
                 SettingsToggleRow(

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -32,6 +32,7 @@ final class GhosttyTerminalNSView: NSView,
     var onExternalDragHoverChange: ((Bool) -> Void)?
     var onProcessExit: (() -> Void)?
     var onSplitRequest: ((SplitDirection, SplitPosition) -> Void)?
+    var canSendToBackground: (() -> Bool)?
     var onSendToBackground: (() -> Void)?
     var onSearchStart: ((String?) -> Void)?
     var onSearchEnd: (() -> Void)?
@@ -375,6 +376,7 @@ final class GhosttyTerminalNSView: NSView,
         onExternalDragHoverChange = nil
         onProcessExit = nil
         onSplitRequest = nil
+        canSendToBackground = nil
         onSendToBackground = nil
         onSearchStart = nil
         onSearchEnd = nil
@@ -1452,6 +1454,7 @@ final class GhosttyTerminalNSView: NSView,
         settingsFocusCoordinator: SettingsFocusCoordinator = .shared
     ) -> NSMenu {
         let menu = NSMenu(title: L10n.string("Terminal"))
+        menu.autoenablesItems = false
 
         let paste = ClosureMenuItem(title: L10n.string("Paste")) { [weak self] in
             self?.performContextPaste()
@@ -1464,7 +1467,7 @@ final class GhosttyTerminalNSView: NSView,
         let sendToBackground = ClosureMenuItem(title: L10n.string("Send to Background")) { [weak self] in
             self?.onSendToBackground?()
         }
-        sendToBackground.isEnabled = persistentSessionID != nil && onSendToBackground != nil
+        sendToBackground.isEnabled = persistentSessionID != nil && canSendToBackground?() == true
         menu.addItem(sendToBackground)
 
         menu.addItem(.separator())

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -10,7 +10,8 @@ final class GhosttyTerminalNSView: NSView,
     TerminalClientThemeSurface,
     TerminalOfflineSurface,
     TerminalSearchSurface,
-    TerminalImagePasteSurface
+    TerminalImagePasteSurface,
+    TerminalBackgroundingSurface
 {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
     var terminalView: NSView { self }
@@ -31,6 +32,7 @@ final class GhosttyTerminalNSView: NSView,
     var onExternalDragHoverChange: ((Bool) -> Void)?
     var onProcessExit: (() -> Void)?
     var onSplitRequest: ((SplitDirection, SplitPosition) -> Void)?
+    var onSendToBackground: (() -> Void)?
     var onSearchStart: ((String?) -> Void)?
     var onSearchEnd: (() -> Void)?
     var onSearchTotal: ((Int?) -> Void)?
@@ -373,6 +375,7 @@ final class GhosttyTerminalNSView: NSView,
         onExternalDragHoverChange = nil
         onProcessExit = nil
         onSplitRequest = nil
+        onSendToBackground = nil
         onSearchStart = nil
         onSearchEnd = nil
         onSearchTotal = nil
@@ -1455,6 +1458,14 @@ final class GhosttyTerminalNSView: NSView,
         }
         paste.isEnabled = NSPasteboard.general.string(forType: .string).map { !$0.isEmpty } ?? pasteboardHasImage()
         menu.addItem(paste)
+
+        menu.addItem(.separator())
+
+        let sendToBackground = ClosureMenuItem(title: L10n.string("Send to Background")) { [weak self] in
+            self?.onSendToBackground?()
+        }
+        sendToBackground.isEnabled = persistentSessionID != nil && onSendToBackground != nil
+        menu.addItem(sendToBackground)
 
         menu.addItem(.separator())
 

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -385,6 +385,15 @@ struct TerminalBridge: NSViewRepresentable {
         surface.onFocus = onFocus
         surface.onProcessExit = onProcessExit
         surface.onSplitRequest = onSplitRequest
+        if let backgroundingSurface = surface as? any TerminalBackgroundingSurface {
+            if appState.canSendTabToBackground(paneID: state.id) {
+                backgroundingSurface.onSendToBackground = { [weak appState] in
+                    appState?.sendTabToBackground(paneID: state.id)
+                }
+            } else {
+                backgroundingSurface.onSendToBackground = nil
+            }
+        }
         surface.onExternalDragHoverChange = makeExternalDragHoverHandler(areaID: areaID)
         surface.onTitleChange = { [weak state] title in
             DispatchQueue.main.async {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -386,12 +386,12 @@ struct TerminalBridge: NSViewRepresentable {
         surface.onProcessExit = onProcessExit
         surface.onSplitRequest = onSplitRequest
         if let backgroundingSurface = surface as? any TerminalBackgroundingSurface {
-            if appState.canSendTabToBackground(paneID: state.id) {
-                backgroundingSurface.onSendToBackground = { [weak appState] in
-                    appState?.sendTabToBackground(paneID: state.id)
-                }
-            } else {
-                backgroundingSurface.onSendToBackground = nil
+            let paneID = state.id
+            backgroundingSurface.canSendToBackground = { [weak appState] in
+                appState?.canSendTabToBackground(paneID: paneID) ?? false
+            }
+            backgroundingSurface.onSendToBackground = { [weak appState] in
+                appState?.sendTabToBackground(paneID: paneID)
             }
         }
         surface.onExternalDragHoverChange = makeExternalDragHoverHandler(areaID: areaID)

--- a/Tests/MuxyTests/Models/Workspace/AppStateBackgroundSessionTests.swift
+++ b/Tests/MuxyTests/Models/Workspace/AppStateBackgroundSessionTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("AppState background sessions", .serialized)
+@MainActor
+struct AppStateBackgroundSessionTests {
+    @Test("sending the final tab to the background releases its session and keeps the workspace")
+    func backgroundFinalTab() throws {
+        let context = makeContext()
+        let pane = try #require(context.area.activeTab?.content.pane)
+        context.terminalViews.persistentSessions[pane.id] = pane.sessionID
+
+        #expect(context.appState.canSendTabToBackground(paneID: pane.id))
+        #expect(context.appState.sendTabToBackground(paneID: pane.id))
+        #expect(context.terminalViews.releasedPaneIDs == [pane.id])
+        #expect(context.terminalViews.removedPaneIDs.isEmpty)
+        #expect(context.appState.workspaceRoots[context.key] != nil)
+        #expect(context.appState.workspaceRoots[context.key]?.allTabs().isEmpty == true)
+        #expect(context.appState.activeProjectID == context.key.projectID)
+    }
+
+    @Test("sending a split tab to the background releases every terminal session")
+    func backgroundSplitTab() throws {
+        let context = makeContext()
+        let rootTab = try #require(context.area.activeTab)
+        let rootPane = try #require(rootTab.content.pane)
+        let childPane = TerminalPaneState(projectPath: context.area.projectPath)
+        let childTab = TerminalTab(pane: childPane, parentTabID: rootTab.id)
+        let childArea = TabArea(projectPath: context.area.projectPath, existingTab: childTab)
+        context.appState.workspaceRoots[context.key] = .split(SplitBranch(
+            direction: .horizontal,
+            first: .tabArea(context.area),
+            second: .tabArea(childArea)
+        ))
+        context.terminalViews.persistentSessions = [
+            rootPane.id: rootPane.sessionID,
+            childPane.id: childPane.sessionID,
+        ]
+
+        #expect(context.appState.canSendTabToBackground(paneID: childPane.id))
+        #expect(context.appState.sendTabToBackground(paneID: childPane.id))
+        #expect(Set(context.terminalViews.releasedPaneIDs) == Set([rootPane.id, childPane.id]))
+        #expect(context.appState.workspaceRoots[context.key]?.allTabs().isEmpty == true)
+    }
+
+    @Test("ordinary, pinned, and mixed-content tabs cannot be sent to the background")
+    func rejectsIneligibleTabs() throws {
+        let context = makeContext()
+        let rootTab = try #require(context.area.activeTab)
+        let rootPane = try #require(rootTab.content.pane)
+
+        #expect(!context.appState.canSendTabToBackground(paneID: rootPane.id))
+
+        context.terminalViews.persistentSessions[rootPane.id] = rootPane.sessionID
+        context.area.togglePin(rootTab.id)
+        #expect(!context.appState.canSendTabToBackground(paneID: rootPane.id))
+
+        context.area.togglePin(rootTab.id)
+        let extensionState = ExtensionTabState(
+            extensionID: "editor",
+            tabTypeID: "document",
+            projectPath: context.area.projectPath,
+            defaultTitle: "Document"
+        )
+        let extensionTab = TerminalTab(extensionState: extensionState, parentTabID: rootTab.id)
+        let childArea = TabArea(projectPath: context.area.projectPath, existingTab: extensionTab)
+        context.appState.workspaceRoots[context.key] = .split(SplitBranch(
+            direction: .horizontal,
+            first: .tabArea(context.area),
+            second: .tabArea(childArea)
+        ))
+
+        #expect(!context.appState.canSendTabToBackground(paneID: rootPane.id))
+        #expect(!context.appState.sendTabToBackground(paneID: rootPane.id))
+        #expect(context.terminalViews.releasedPaneIDs.isEmpty)
+    }
+
+    private func makeContext() -> BackgroundSessionTestContext {
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let terminalViews = BackgroundSessionTerminalViews()
+        let appState = AppState(
+            selectionStore: BackgroundSessionSelectionStore(),
+            terminalViews: terminalViews,
+            workspacePersistence: BackgroundSessionWorkspacePersistence()
+        )
+        let area = TabArea(projectPath: "/tmp/test")
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+        return BackgroundSessionTestContext(
+            appState: appState,
+            terminalViews: terminalViews,
+            key: key,
+            area: area
+        )
+    }
+}
+
+@MainActor
+private struct BackgroundSessionTestContext {
+    let appState: AppState
+    let terminalViews: BackgroundSessionTerminalViews
+    let key: WorktreeKey
+    let area: TabArea
+}
+
+@MainActor
+private final class BackgroundSessionTerminalViews: TerminalViewRemoving {
+    var persistentSessions: [UUID: UUID] = [:]
+    private(set) var removedPaneIDs: [UUID] = []
+    private(set) var releasedPaneIDs: [UUID] = []
+
+    func removeView(for paneID: UUID) {
+        removedPaneIDs.append(paneID)
+    }
+
+    func releaseViewPreservingSession(for paneID: UUID) {
+        releasedPaneIDs.append(paneID)
+    }
+
+    func hasPersistentSession(for paneID: UUID, sessionID: UUID) -> Bool {
+        persistentSessions[paneID] == sessionID
+    }
+
+    func needsConfirmQuit(for _: UUID) -> Bool {
+        false
+    }
+}
+
+@MainActor
+private final class BackgroundSessionSelectionStore: ActiveProjectSelectionStoring {
+    private var projectID: UUID?
+    private var worktreeIDs: [UUID: UUID] = [:]
+
+    func loadActiveProjectID() -> UUID? { projectID }
+    func saveActiveProjectID(_ id: UUID?) { projectID = id }
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { worktreeIDs }
+    func saveActiveWorktreeIDs(_ ids: [UUID: UUID]) { worktreeIDs = ids }
+}
+
+private final class BackgroundSessionWorkspacePersistence: WorkspacePersisting {
+    private var snapshots: [WorkspaceSnapshot] = []
+
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { snapshots }
+    func saveWorkspaces(_ workspaces: [WorkspaceSnapshot]) throws { snapshots = workspaces }
+}

--- a/Tests/MuxyTests/Support/TerminalViewRemovingTestDefaults.swift
+++ b/Tests/MuxyTests/Support/TerminalViewRemovingTestDefaults.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@testable import Muxy
+
+extension TerminalViewRemoving {
+    func releaseViewPreservingSession(for _: UUID) {}
+
+    func hasPersistentSession(for _: UUID, sessionID _: UUID) -> Bool {
+        false
+    }
+}

--- a/Tests/MuxyTests/Views/Terminal/TerminalContextMenuTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalContextMenuTests.swift
@@ -6,6 +6,42 @@ import Testing
 @Suite("Terminal context menu")
 @MainActor
 struct TerminalContextMenuTests {
+    @Test("send to background invokes its action for a persistent terminal")
+    func sendToBackgroundInvokesAction() throws {
+        let flag = TerminalBackgroundActionFlag()
+        let view = GhosttyTerminalNSView(
+            workingDirectory: "/tmp",
+            persistentSessionID: UUID()
+        )
+        view.onSendToBackground = {
+            flag.didInvoke = true
+        }
+
+        let menu = view.makeContextMenu()
+        let item = try #require(menu.items.first {
+            $0.title == L10n.string("Send to Background")
+        })
+
+        #expect(item.isEnabled)
+
+        _ = item.target?.perform(item.action, with: item)
+
+        #expect(flag.didInvoke)
+    }
+
+    @Test("send to background is disabled without a persistent session")
+    func sendToBackgroundRequiresPersistentSession() throws {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+        view.onSendToBackground = {}
+
+        let menu = view.makeContextMenu()
+        let item = try #require(menu.items.first {
+            $0.title == L10n.string("Send to Background")
+        })
+
+        #expect(!item.isEnabled)
+    }
+
     @Test("terminal settings item opens settings focused on Terminal")
     func terminalSettingsItemOpensTerminalSettings() throws {
         let notificationCenter = NotificationCenter()
@@ -39,4 +75,8 @@ struct TerminalContextMenuTests {
 
 private final class TerminalSettingsOpenFlag: @unchecked Sendable {
     var didPost = false
+}
+
+private final class TerminalBackgroundActionFlag {
+    var didInvoke = false
 }

--- a/Tests/MuxyTests/Views/Terminal/TerminalContextMenuTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalContextMenuTests.swift
@@ -6,21 +6,19 @@ import Testing
 @Suite("Terminal context menu")
 @MainActor
 struct TerminalContextMenuTests {
-    @Test("send to background invokes its action for a persistent terminal")
+    @Test("send to background invokes its action for an eligible persistent terminal")
     func sendToBackgroundInvokesAction() throws {
         let flag = TerminalBackgroundActionFlag()
         let view = GhosttyTerminalNSView(
             workingDirectory: "/tmp",
             persistentSessionID: UUID()
         )
+        view.canSendToBackground = { true }
         view.onSendToBackground = {
             flag.didInvoke = true
         }
 
-        let menu = view.makeContextMenu()
-        let item = try #require(menu.items.first {
-            $0.title == L10n.string("Send to Background")
-        })
+        let item = try sendToBackgroundItem(in: view.makeContextMenu())
 
         #expect(item.isEnabled)
 
@@ -32,14 +30,33 @@ struct TerminalContextMenuTests {
     @Test("send to background is disabled without a persistent session")
     func sendToBackgroundRequiresPersistentSession() throws {
         let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+        view.canSendToBackground = { true }
         view.onSendToBackground = {}
 
-        let menu = view.makeContextMenu()
-        let item = try #require(menu.items.first {
-            $0.title == L10n.string("Send to Background")
-        })
+        let item = try sendToBackgroundItem(in: view.makeContextMenu())
 
         #expect(!item.isEnabled)
+    }
+
+    @Test("send to background is disabled for an ineligible tab")
+    func sendToBackgroundRequiresEligibleTab() throws {
+        let view = GhosttyTerminalNSView(
+            workingDirectory: "/tmp",
+            persistentSessionID: UUID()
+        )
+        view.canSendToBackground = { false }
+        view.onSendToBackground = {}
+
+        let item = try sendToBackgroundItem(in: view.makeContextMenu())
+
+        #expect(!item.isEnabled)
+    }
+
+    @Test("the context menu keeps the enabled state it was built with")
+    func contextMenuDoesNotAutoenableItems() {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+
+        #expect(!view.makeContextMenu().autoenablesItems)
     }
 
     @Test("terminal settings item opens settings focused on Terminal")
@@ -70,6 +87,13 @@ struct TerminalContextMenuTests {
 
         #expect(flag.didPost)
         #expect(coordinator.consume(.terminal))
+    }
+
+    private func sendToBackgroundItem(in menu: NSMenu) throws -> NSMenuItem {
+        menu.update()
+        return try #require(menu.items.first {
+            $0.title == L10n.string("Send to Background")
+        })
     }
 }
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -20,7 +20,9 @@ Every attach carries metadata identifying the project, worktree, tab, and title 
 
 Reopening Muxy reattaches every restored pane whose session is still running, without waiting for you to click the tab, so output keeps flowing and scrollback keeps building from the moment the window appears.
 
-Closing a tab ends its session. Sessions are never killed behind your back otherwise: one whose tab is gone keeps running and shows up in the status bar as detached, where you can reattach or stop it.
+Closing a tab ends its session. To keep a local background-backed tab running without its visible terminal, right-click inside the terminal and choose **Send to Background**. The tab closes without stopping its processes and its sessions appear in the status bar as detached. A split tab moves all of its terminal sessions together. The action is unavailable for pinned tabs, mixed-content splits, remote terminals, and terminals opened without background sessions enabled.
+
+Sessions are never killed behind your back otherwise: one whose tab is gone keeps running and shows up in the status bar as detached, where you can reattach or stop it. Sending the final visible tab to the background keeps its project and worktree open so the status-bar entry remains accessible.
 
 The status bar lists only the sessions in the current project and worktree that **no tab currently owns**, since a session already open in a tab is not something you need to recover. Ownership is decided by the pane pointing at the session, not by whether a client happens to be connected, so a tab whose terminal was freed by the idle-memory setting still counts as owning its session. When every session in the worktree is open in a tab, the status bar item disappears entirely.
 
@@ -154,7 +156,7 @@ the control that was focused before recording and can optionally press Return af
 
 ## Right-click menu
 
-Inside a terminal pane: **Paste**, **Split Right**, **Split Left**, **Split Down**, **Split Up**, and **Terminal Settings…**. Terminal Settings opens Muxy's settings directly on the Terminal section.
+Inside a terminal pane: **Paste**, **Send to Background**, **Split Right**, **Split Left**, **Split Down**, **Split Up**, and **Terminal Settings…**. Terminal Settings opens Muxy's settings directly on the Terminal section. Send to Background closes an eligible local background-backed tab while leaving its processes running.
 
 Splitting creates a child pane inside the current top-level tab. Each pane keeps its own terminal, browser, source-control, or extension surface, while a one-pixel divider replaces the old per-pane tab strip. Child panes do not appear as separate entries in the window tab strip or the Tab Focused sidebar. An agent running in a child pane does appear as its own entry in the Agents Focused sidebar, and selecting it activates both the child pane and its parent top-level tab.
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -53,7 +53,7 @@ Open **Settings → Terminal → Background sessions** to keep terminals running
 - **Run new terminals in the background** starts each new terminal in a separate background process, like tmux. Quitting Muxy leaves those terminals running, and reopening it reconnects them along with their recent output.
 - Only terminals opened after the setting is switched on are affected. Terminals that are already open keep their current behavior.
 - Reopening Muxy reattaches every restored tab whose session is still running, without waiting for you to click the tab.
-- Closing a tab ends its session. A session whose tab is gone keeps running and stays available from the status bar.
+- Closing a tab ends its session. Right-click an eligible local terminal and choose **Send to Background** to close its tab without stopping its processes; the session then stays available from the status bar.
 - Turning the setting off asks for confirmation and then stops every terminal still running in the background.
 - Remote SSH terminals and the quick terminal are never run this way.
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -8,6 +8,18 @@
       "skillPath": "skills/build/SKILL.md",
       "computedHash": "44aeeb7946fcc486135f115c7358b9f056e4c9d7aadbf00d170d8621c39bb6e2"
     },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "f361db4e15e6bfd562a9282b1dccda513910a50061f9e838ce017be9c69dde3f"
+    },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "368d3dd7251247c69f3656d93dc83c8f1577792eacac2111f1e7981db2ece49b"
+    },
     "swiftui-expert-skill": {
       "source": "avdlee/swiftui-agent-skill",
       "sourceType": "github",


### PR DESCRIPTION
Add a terminal context-menu action that closes eligible tabs while preserving their background sessions, including split-tab and final-workspace handling. Update settings and documentation, and add coverage for session eligibility, release behavior, and menu state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Send to Background” for eligible local terminal tabs, including split tabs.
  * Closing a backgrounded tab preserves its persistent terminal session and project/worktree context.
  * Added the action to the terminal context menu, with availability based on session eligibility.

* **Documentation**
  * Updated terminal and settings guidance for background sessions, restrictions, and recovery.

* **Tests**
  * Added coverage for backgrounding behavior, session preservation, workspace handling, and menu availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->