### PR TITLE
Improve persistent terminal session recovery

### DIFF
--- a/Muxy/Models/Terminal/TerminalPaneState.swift
+++ b/Muxy/Models/Terminal/TerminalPaneState.swift
@@ -22,6 +22,7 @@ final class TerminalPaneState: Identifiable {
     let closesOnStartupCommandExit: Bool
     let externalEditorFilePath: String?
     var isOffline = false
+    var sessionRecoveryFailed = false
     let searchState = TerminalSearchState()
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
 

--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -936,12 +936,14 @@ final class AppState {
             terminalViews.removeView(for: paneID)
             TerminalProgressStore.shared.resetPane(paneID)
             DetectedAgentStore.shared.resetPane(paneID)
+            PersistentSessionExitHandler.shared.resetPane(paneID)
         }
 
         for paneID in effects.paneIDsToRelease {
             terminalViews.releaseViewPreservingSession(for: paneID)
             TerminalProgressStore.shared.resetPane(paneID)
             DetectedAgentStore.shared.resetPane(paneID)
+            PersistentSessionExitHandler.shared.resetPane(paneID)
         }
 
         if case let .removeProject(projectID) = action {

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "Back" = "Back";
 "Back (%@)" = "Back (%@)";
 "Back to Extensions" = "Back to Extensions";
+"Background session unreachable" = "Background session unreachable";
 "Background sessions" = "Background sessions";
 "Background vibrancy" = "Background vibrancy";
 "Backup" = "Backup";
@@ -478,6 +479,7 @@
 "Muxy Picker can use Finder or Muxy's picker. Projects can stay in the sidebar after closing their last tab." = "Muxy Picker can use Finder or Muxy's picker. Projects can stay in the sidebar after closing their last tab.";
 "Muxy Picker searches this location by folder name. Use App Default to search your home folder. Projects can stay in the sidebar after closing their last tab." = "Muxy Picker searches this location by folder name. Use App Default to search your home folder. Projects can stay in the sidebar after closing their last tab.";
 "Muxy can only add folders as projects. Choose a folder or type a new folder path." = "Muxy can only add folders as projects. Choose a folder or type a new folder path.";
+"Muxy could not reconnect to this terminal. The session was left running." = "Muxy could not reconnect to this terminal. The session was left running.";
 "Muxy can send anonymous crash and error reports so we can fix bugs faster. No personal data, no project contents, no file paths are sent — only crash details and an anonymous installation ID.\n\nYou can change this anytime in Settings → General → Diagnostics." = "Muxy can send anonymous crash and error reports so we can fix bugs faster. No personal data, no project contents, no file paths are sent — only crash details and an anonymous installation ID.\n\nYou can change this anytime in Settings → General → Diagnostics.";
 "Muxy couldn't add \"%@\". Check that the folder exists and you have permission to use it." = "Muxy couldn't add \"%@\". Check that the folder exists and you have permission to use it.";
 "Muxy couldn't create and add \"%@\". Check that you have permission to use this location." = "Muxy couldn't create and add \"%@\". Check that you have permission to use this location.";
@@ -688,6 +690,8 @@
 "Report an Issue..." = "Report an Issue...";
 "Repository unavailable" = "Repository unavailable";
 "Repository unavailable. Click to retry." = "Repository unavailable. Click to retry.";
+"Reconnect" = "Reconnect";
+"Reconnect to the background terminal session" = "Reconnect to the background terminal session";
 "Reset" = "Reset";
 "Reset All" = "Reset All";
 "Reset Icon Color" = "Reset Icon Color";

--- a/Muxy/Services/App/AppEnvironment.swift
+++ b/Muxy/Services/App/AppEnvironment.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 struct AppEnvironment {
-    static let isDevelopment: Bool = {
+    nonisolated static let isDevelopment: Bool = {
         #if DEBUG
         true
         #else

--- a/Muxy/Services/Terminal/PersistentSessionControlClient.swift
+++ b/Muxy/Services/Terminal/PersistentSessionControlClient.swift
@@ -5,6 +5,12 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "PersistentSession")
 
+enum PersistentSessionLookup: Equatable, Sendable {
+    case found(SessionDescriptor)
+    case absent
+    case unreachable
+}
+
 struct PersistentSessionControlClient: Sendable {
     static let defaultTimeout: TimeInterval = 2
 
@@ -15,28 +21,46 @@ struct PersistentSessionControlClient: Sendable {
     }
 
     func info(identifier: SessionIdentifier, timeout: TimeInterval = defaultTimeout) -> SessionDescriptor? {
-        descriptors(
-            for: SessionFrame(kind: .info, payload: SessionIdentifierPayload.encode(identifier)),
+        guard case let .found(descriptor) = lookup(identifier: identifier, timeout: timeout) else { return nil }
+        return descriptor
+    }
+
+    func lookup(identifier: SessionIdentifier, timeout: TimeInterval = defaultTimeout) -> PersistentSessionLookup {
+        let response = exchange(
+            SessionFrame(kind: .info, payload: SessionIdentifierPayload.encode(identifier)),
+            expecting: .sessions,
             timeout: timeout
-        ).first
+        )
+        guard case let .frame(frame) = response else { return .unreachable }
+        do {
+            guard let descriptor = try SessionDescriptor.decodeList(frame.payload).first else { return .absent }
+            return .found(descriptor)
+        } catch {
+            logger.error("failed to decode the session lookup: \(String(describing: error))")
+            return .unreachable
+        }
     }
 
     @discardableResult
     func kill(identifier: SessionIdentifier, timeout: TimeInterval = defaultTimeout) -> Bool {
-        exchange(
+        acknowledged(
             SessionFrame(kind: .kill, payload: SessionIdentifierPayload.encode(identifier)),
-            expecting: .acknowledged,
             timeout: timeout
-        ) != nil
+        )
     }
 
     @discardableResult
     func killAll(timeout: TimeInterval = defaultTimeout) -> Bool {
-        exchange(SessionFrame(kind: .killAll), expecting: .acknowledged, timeout: timeout) != nil
+        acknowledged(SessionFrame(kind: .killAll), timeout: timeout)
+    }
+
+    private enum ExchangeResult {
+        case frame(SessionFrame)
+        case unreachable
     }
 
     private func descriptors(for frame: SessionFrame, timeout: TimeInterval) -> [SessionDescriptor] {
-        guard let response = exchange(frame, expecting: .sessions, timeout: timeout) else { return [] }
+        guard case let .frame(response) = exchange(frame, expecting: .sessions, timeout: timeout) else { return [] }
         do {
             return try SessionDescriptor.decodeList(response.payload)
         } catch {
@@ -45,20 +69,27 @@ struct PersistentSessionControlClient: Sendable {
         }
     }
 
+    private func acknowledged(_ frame: SessionFrame, timeout: TimeInterval) -> Bool {
+        guard case .frame = exchange(frame, expecting: .acknowledged, timeout: timeout) else { return false }
+        return true
+    }
+
     private func exchange(
         _ frame: SessionFrame,
         expecting kind: SessionFrameKind,
         timeout: TimeInterval
-    ) -> SessionFrame? {
-        guard let descriptor = PersistentSessionSocket.connect(path: socketPath) else { return nil }
+    ) -> ExchangeResult {
+        guard let descriptor = PersistentSessionSocket.connect(path: socketPath) else { return .unreachable }
         defer { close(descriptor) }
 
         let deadline = Date().addingTimeInterval(timeout)
-        guard PersistentSessionSocket.write(descriptor, bytes: frame.encoded(), deadline: deadline) else { return nil }
+        guard PersistentSessionSocket.write(descriptor, bytes: frame.encoded(), deadline: deadline) else {
+            return .unreachable
+        }
 
         var decoder = SessionFrameDecoder()
         while Date() < deadline {
-            guard let bytes = PersistentSessionSocket.read(descriptor, deadline: deadline) else { return nil }
+            guard let bytes = PersistentSessionSocket.read(descriptor, deadline: deadline) else { return .unreachable }
             decoder.push(bytes)
             while true {
                 let next: SessionFrame?
@@ -66,15 +97,15 @@ struct PersistentSessionControlClient: Sendable {
                     next = try decoder.next()
                 } catch {
                     logger.error("session daemon sent a malformed frame")
-                    return nil
+                    return .unreachable
                 }
                 guard let next else { break }
                 if next.kind == kind {
-                    return next
+                    return .frame(next)
                 }
             }
         }
-        return nil
+        return .unreachable
     }
 }
 

--- a/Muxy/Services/Terminal/PersistentSessionExitHandler.swift
+++ b/Muxy/Services/Terminal/PersistentSessionExitHandler.swift
@@ -1,0 +1,92 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "PersistentSession")
+
+@MainActor
+final class PersistentSessionExitHandler {
+    static let shared = PersistentSessionExitHandler()
+
+    enum Decision: Equatable {
+        case closePane
+        case reattach
+        case reportFailure
+    }
+
+    static let attemptLimit = 3
+    static let attemptResetInterval: TimeInterval = 60
+
+    private struct Recovery {
+        var attempt: Int
+        var updatedAt: Date
+    }
+
+    private var recoveries: [UUID: Recovery] = [:]
+    private var handlingPaneIDs: Set<UUID> = []
+
+    private init() {}
+
+    func handleExit(paneID: UUID, sessionID: UUID, closePane: @escaping () -> Void) {
+        guard !handlingPaneIDs.contains(paneID) else { return }
+        handlingPaneIDs.insert(paneID)
+        let attempt = nextAttempt(paneID: paneID)
+
+        Task { @MainActor [weak self] in
+            let lookup = await PersistentSessionService.shared.lookup(sessionID: sessionID)
+            guard let self else { return }
+            defer { handlingPaneIDs.remove(paneID) }
+
+            let decision = Self.decision(lookup: lookup, attempt: attempt, limit: Self.attemptLimit)
+            guard TerminalViewRegistry.shared.hasPersistentSession(for: paneID, sessionID: sessionID) else { return }
+
+            switch decision {
+            case .closePane:
+                recoveries.removeValue(forKey: paneID)
+                closePane()
+            case .reattach:
+                logger.info("reattaching background session after attempt \(attempt)")
+                try? await Task.sleep(for: Self.backoff(attempt: attempt))
+                guard TerminalViewRegistry.shared.hasPersistentSession(for: paneID, sessionID: sessionID) else { return }
+                recoverySurface(paneID: paneID)?.reattachPersistentSession()
+            case .reportFailure:
+                logger.error("giving up on reattaching a background session after \(attempt - 1) attempt(s)")
+                recoveries.removeValue(forKey: paneID)
+                recoverySurface(paneID: paneID)?.reportSessionRecoveryFailure()
+            }
+        }
+    }
+
+    func resetPane(_ paneID: UUID) {
+        recoveries.removeValue(forKey: paneID)
+        handlingPaneIDs.remove(paneID)
+    }
+
+    private func recoverySurface(paneID: UUID) -> (any TerminalSessionRecoverySurface)? {
+        TerminalViewRegistry.shared.existingView(for: paneID) as? any TerminalSessionRecoverySurface
+    }
+
+    private func nextAttempt(paneID: UUID, now: Date = Date()) -> Int {
+        let previous = recoveries[paneID]
+        let attempt = Self.attempt(
+            previous: previous?.attempt ?? 0,
+            elapsed: previous.map { now.timeIntervalSince($0.updatedAt) },
+            resetAfter: Self.attemptResetInterval
+        )
+        recoveries[paneID] = Recovery(attempt: attempt, updatedAt: now)
+        return attempt
+    }
+
+    nonisolated static func attempt(previous: Int, elapsed: TimeInterval?, resetAfter: TimeInterval) -> Int {
+        guard let elapsed, elapsed < resetAfter else { return 1 }
+        return previous + 1
+    }
+
+    nonisolated static func decision(lookup: PersistentSessionLookup, attempt: Int, limit: Int) -> Decision {
+        guard lookup != .absent else { return .closePane }
+        return attempt <= limit ? .reattach : .reportFailure
+    }
+
+    nonisolated static func backoff(attempt: Int) -> Duration {
+        .milliseconds(300 * max(attempt, 1))
+    }
+}

--- a/Muxy/Services/Terminal/PersistentSessionPaths.swift
+++ b/Muxy/Services/Terminal/PersistentSessionPaths.swift
@@ -9,7 +9,6 @@ enum PersistentSessionPathError: Error, Equatable {
 
 enum PersistentSessionPaths {
     static let sunPathCapacity = 104
-    static let directoryName = "sessions"
     static let socketFileName = "control.sock"
     static let binaryName = "muxy-session"
 
@@ -17,30 +16,43 @@ enum PersistentSessionPaths {
         path.utf8.count < sunPathCapacity
     }
 
-    static func preferredSocketPath(appSupportDirectory: URL) -> String {
+    static func directoryName(isDevelopment: Bool = AppEnvironment.isDevelopment) -> String {
+        isDevelopment ? "sessions-dev" : "sessions"
+    }
+
+    static func preferredSocketPath(
+        appSupportDirectory: URL,
+        isDevelopment: Bool = AppEnvironment.isDevelopment
+    ) -> String {
         appSupportDirectory
-            .appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent(directoryName(isDevelopment: isDevelopment), isDirectory: true)
             .appendingPathComponent(socketFileName)
             .path
     }
 
-    static func fallbackSocketPath(userID: uid_t, root: String = "/tmp") -> String {
-        "\(root)/muxy-\(userID)/\(socketFileName)"
+    static func fallbackSocketPath(
+        userID: uid_t,
+        root: String = "/tmp",
+        isDevelopment: Bool = AppEnvironment.isDevelopment
+    ) -> String {
+        let prefix = isDevelopment ? "muxy-dev" : "muxy"
+        return "\(root)/\(prefix)-\(userID)/\(socketFileName)"
     }
 
     static func resolveSocketPath(
         appSupportDirectory: URL = MuxyFileStorage.appSupportDirectory(),
         userID: uid_t = getuid(),
         fallbackRoot: String = "/tmp",
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        isDevelopment: Bool = AppEnvironment.isDevelopment
     ) throws -> String {
-        let preferred = preferredSocketPath(appSupportDirectory: appSupportDirectory)
+        let preferred = preferredSocketPath(appSupportDirectory: appSupportDirectory, isDevelopment: isDevelopment)
         if fits(preferred) {
             try prepareDirectory(at: URL(fileURLWithPath: preferred).deletingLastPathComponent(), fileManager: fileManager)
             return preferred
         }
 
-        let fallback = fallbackSocketPath(userID: userID, root: fallbackRoot)
+        let fallback = fallbackSocketPath(userID: userID, root: fallbackRoot, isDevelopment: isDevelopment)
         guard fits(fallback) else { throw PersistentSessionPathError.pathTooLong }
         let directory = URL(fileURLWithPath: fallback).deletingLastPathComponent()
         try prepareDirectory(at: directory, fileManager: fileManager)

--- a/Muxy/Services/Terminal/PersistentSessionService.swift
+++ b/Muxy/Services/Terminal/PersistentSessionService.swift
@@ -4,6 +4,11 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "PersistentSession")
 
+enum SessionCommandActivity: Equatable, Sendable {
+    case idle
+    case running
+}
+
 @MainActor
 final class PersistentSessionService {
     static let shared = PersistentSessionService()
@@ -115,11 +120,33 @@ final class PersistentSessionService {
     }
 
     func isRunningCommand(sessionID: UUID) -> Bool {
-        guard let descriptor = descriptors[sessionID] else { return false }
+        commandActivity(sessionID: sessionID) == .running
+    }
+
+    func commandActivity(sessionID: UUID) -> SessionCommandActivity? {
+        guard let descriptor = descriptors[sessionID] else {
+            refreshDescriptor(sessionID: sessionID)
+            return nil
+        }
+        guard let foregroundProcessID = TerminalTTYForegroundProcess.processID(ttyDevice: descriptor.ttyDevice) else {
+            descriptors.removeValue(forKey: sessionID)
+            refreshDescriptor(sessionID: sessionID)
+            return nil
+        }
         return TerminalTTYForegroundProcess.isRunningCommand(
-            foregroundProcessID: TerminalTTYForegroundProcess.processID(ttyDevice: descriptor.ttyDevice),
+            foregroundProcessID: foregroundProcessID,
             shellProcessID: descriptor.shellProcessID
-        )
+        ) ? .running : .idle
+    }
+
+    func lookup(sessionID: UUID) async -> PersistentSessionLookup {
+        guard let socketPath = existingSocketPath, let identifier = Self.sessionIdentifier(sessionID) else {
+            return .unreachable
+        }
+        let client = PersistentSessionControlClient(socketPath: socketPath)
+        return await Task.detached(priority: .utility) {
+            client.lookup(identifier: identifier)
+        }.value
     }
 
     func endSession(sessionID: UUID) {

--- a/Muxy/Services/Terminal/TerminalPersistentSessionPolicy.swift
+++ b/Muxy/Services/Terminal/TerminalPersistentSessionPolicy.swift
@@ -18,4 +18,16 @@ enum TerminalPersistentSessionPolicy {
             isAvailable: PersistentSessionService.shared.isAvailable
         )
     }
+
+    static func isIdle(
+        activity: SessionCommandActivity?,
+        isShellCommandRunning: Bool,
+        isAlternateScreen: Bool
+    ) -> Bool {
+        guard let activity else { return false }
+        return TerminalOfflinePolicy.isIdle(
+            hasRunningProcess: activity == .running || isShellCommandRunning,
+            isAlternateScreen: isAlternateScreen
+        )
+    }
 }

--- a/Muxy/Services/Terminal/TerminalSurface.swift
+++ b/Muxy/Services/Terminal/TerminalSurface.swift
@@ -94,6 +94,15 @@ protocol TerminalBackgroundingSurface: AnyObject {
 }
 
 @MainActor
+protocol TerminalSessionRecoverySurface: AnyObject {
+    var onSessionRecoveryFailed: ((Bool) -> Void)? { get set }
+    var isSessionRecoveryFailed: Bool { get }
+
+    func reattachPersistentSession()
+    func reportSessionRecoveryFailure()
+}
+
+@MainActor
 protocol TerminalInputSubmissionTarget: AnyObject {
     func sendRemoteBytes(_ bytes: Data)
     func submitRichInput(text: String)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -11,7 +11,8 @@ final class GhosttyTerminalNSView: NSView,
     TerminalOfflineSurface,
     TerminalSearchSurface,
     TerminalImagePasteSurface,
-    TerminalBackgroundingSurface
+    TerminalBackgroundingSurface,
+    TerminalSessionRecoverySurface
 {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
     var terminalView: NSView { self }
@@ -34,6 +35,8 @@ final class GhosttyTerminalNSView: NSView,
     var onSplitRequest: ((SplitDirection, SplitPosition) -> Void)?
     var canSendToBackground: (() -> Bool)?
     var onSendToBackground: (() -> Void)?
+    var onSessionRecoveryFailed: ((Bool) -> Void)?
+    private(set) var isSessionRecoveryFailed = false
     var onSearchStart: ((String?) -> Void)?
     var onSearchEnd: (() -> Void)?
     var onSearchTotal: ((Int?) -> Void)?
@@ -162,7 +165,7 @@ final class GhosttyTerminalNSView: NSView,
     private var pendingSurfaceCreation = false
 
     func createSurface() {
-        guard surface == nil, let app = GhosttyService.shared.app else { return }
+        guard surface == nil, !isSessionRecoveryFailed, let app = GhosttyService.shared.app else { return }
 
         guard let backingSize = backingPixelSize() else {
             pendingSurfaceCreation = true
@@ -378,6 +381,7 @@ final class GhosttyTerminalNSView: NSView,
         onSplitRequest = nil
         canSendToBackground = nil
         onSendToBackground = nil
+        onSessionRecoveryFailed = nil
         onSearchStart = nil
         onSearchEnd = nil
         onSearchTotal = nil
@@ -587,6 +591,13 @@ final class GhosttyTerminalNSView: NSView,
 
     func isTerminalIdle() -> Bool {
         guard let surface else { return true }
+        if let persistentSessionID {
+            return TerminalPersistentSessionPolicy.isIdle(
+                activity: PersistentSessionService.shared.commandActivity(sessionID: persistentSessionID),
+                isShellCommandRunning: shellActivityTracker.isCommandRunning,
+                isAlternateScreen: isAlternateScreenActive(surface: surface)
+            )
+        }
         if ghostty_surface_needs_confirm_quit(surface) {
             return false
         }
@@ -628,6 +639,23 @@ final class GhosttyTerminalNSView: NSView,
         destroySurface()
         isOfflinedState = true
         onOfflineChange?(true)
+    }
+
+    func reattachPersistentSession() {
+        guard persistentSessionID != nil else { return }
+        destroySurface()
+        isSessionRecoveryFailed = false
+        onSessionRecoveryFailed?(false)
+        processExitHandled = false
+        createSurface()
+        applyOcclusionState()
+    }
+
+    func reportSessionRecoveryFailure() {
+        guard persistentSessionID != nil, !isSessionRecoveryFailed else { return }
+        destroySurface()
+        isSessionRecoveryFailed = true
+        onSessionRecoveryFailed?(true)
     }
 
     func applyColorScheme(isDark: Bool) {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -30,9 +30,23 @@ struct TerminalPane: View {
         )
     }
 
+    private var showsUnreachableSessionPlaceholder: Bool {
+        SleepingTabPlaceholderPolicy.shouldPresent(
+            isVisible: visible,
+            isOffline: state.sessionRecoveryFailed,
+            isRemotelyOwned: remoteOwnerName != nil
+        )
+    }
+
     private func wakePane() {
         let surface = TerminalViewRegistry.shared.existingView(for: state.id)
         (surface as? any TerminalOfflineSurface)?.wake()
+        onFocus()
+    }
+
+    private func reconnectPane() {
+        let surface = TerminalViewRegistry.shared.existingView(for: state.id)
+        (surface as? any TerminalSessionRecoverySurface)?.reattachPersistentSession()
         onFocus()
     }
 
@@ -96,11 +110,57 @@ struct TerminalPane: View {
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
 
-            if showsSleepingPlaceholder {
+            if showsUnreachableSessionPlaceholder {
+                UnreachableSessionPlaceholder(isFocused: focused, onReconnect: reconnectPane)
+                    .transition(.opacity)
+            } else if showsSleepingPlaceholder {
                 SleepingTabPlaceholder(isFocused: focused, onWake: wakePane)
                     .transition(.opacity)
             }
         }
+    }
+}
+
+struct UnreachableSessionPlaceholder: View {
+    let isFocused: Bool
+    let onReconnect: () -> Void
+
+    var body: some View {
+        VStack(spacing: UIMetrics.spacing7) {
+            Spacer()
+            Image(systemName: "bolt.horizontal.circle")
+                .font(.system(size: UIMetrics.fontMega))
+                .foregroundStyle(MuxyTheme.fgMuted)
+            Text(L10n.resource("Background session unreachable"))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+            Text(L10n.resource("Muxy could not reconnect to this terminal. The session was left running."))
+                .font(.system(size: UIMetrics.fontBody))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: UIMetrics.scaled(360))
+            Button(action: onReconnect) {
+                HStack(spacing: UIMetrics.spacing4) {
+                    Text(L10n.resource("Reconnect"))
+                    if isFocused {
+                        Text(L10n.resource("⏎"))
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
+                            .opacity(0.72)
+                    }
+                }
+            }
+            .keyboardShortcut(isFocused ? KeyboardShortcut(.return, modifiers: []) : nil)
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(MuxyTheme.bg)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onReconnect)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(L10n.string("Background session unreachable"))
+        .accessibilityHint(L10n.string("Reconnect to the background terminal session"))
     }
 }
 
@@ -383,7 +443,7 @@ struct TerminalBridge: NSViewRepresentable {
         surface.setVisible(visible)
         surface.setFocused(focused)
         surface.onFocus = onFocus
-        surface.onProcessExit = onProcessExit
+        surface.onProcessExit = makeProcessExitHandler(surface)
         surface.onSplitRequest = onSplitRequest
         if let backgroundingSurface = surface as? any TerminalBackgroundingSurface {
             let paneID = state.id
@@ -406,6 +466,7 @@ struct TerminalBridge: NSViewRepresentable {
             }
         }
         configureOfflineCallback(surface)
+        configureSessionRecoveryCallback(surface)
         configureAgentDetectionCallback(surface)
         if let searchSurface = surface as? any TerminalSearchSurface {
             configureSearchCallbacks(searchSurface)
@@ -421,6 +482,30 @@ struct TerminalBridge: NSViewRepresentable {
         }
         offlineSurface.onOfflineChange = { [weak state] offline in
             state?.isOffline = offline
+        }
+    }
+
+    private func configureSessionRecoveryCallback(_ surface: any TerminalSurface) {
+        let recoverySurface = surface as? any TerminalSessionRecoverySurface
+        let hasFailed = recoverySurface?.isSessionRecoveryFailed ?? false
+        if state.sessionRecoveryFailed != hasFailed {
+            state.sessionRecoveryFailed = hasFailed
+        }
+        recoverySurface?.onSessionRecoveryFailed = { [weak state] failed in
+            state?.sessionRecoveryFailed = failed
+        }
+    }
+
+    private func makeProcessExitHandler(_ surface: any TerminalSurface) -> () -> Void {
+        guard let sessionID = surface.persistentSessionID else { return onProcessExit }
+        let paneID = state.id
+        let closePane = onProcessExit
+        return {
+            PersistentSessionExitHandler.shared.handleExit(
+                paneID: paneID,
+                sessionID: sessionID,
+                closePane: closePane
+            )
         }
     }
 

--- a/MuxySession/SessionAttachClient.swift
+++ b/MuxySession/SessionAttachClient.swift
@@ -2,9 +2,19 @@ import Darwin
 import MachO
 import MuxySessionProtocol
 
+enum SessionAttachExitCode {
+    static let transportFailure: Int32 = 90
+    static let protocolFailure: Int32 = 91
+    static let daemonUnavailable: Int32 = 92
+    static let startupFailure: Int32 = 93
+}
+
 enum SessionAttachClient {
-    static let connectAttempts = 150
+    static let connectCycles = 3
+    static let connectAttemptsPerCycle = 50
     static let connectRetryMicroseconds: useconds_t = 20000
+    static let handshakeAttempts = 3
+    static let handshakeRetryMicroseconds: useconds_t = 100_000
     static let inputBacklogLimit = 4 * 1024 * 1024
 
     struct Configuration {
@@ -17,18 +27,17 @@ enum SessionAttachClient {
         let metadata: [SessionEnvironmentEntry]
     }
 
+    private enum Outcome {
+        case finished(Int32)
+        case retry
+        case failed(Int32)
+    }
+
     static func run(configuration: Configuration) -> Int32 {
         signal(SIGPIPE, SIG_IGN)
 
-        guard let socket = connect(socketPath: configuration.socketPath) else {
-            SessionLog.write("muxy-session: could not reach the session daemon")
-            return 1
-        }
-        SessionIO.setNonBlocking(socket)
-
         guard let signalPipe = SessionSignalPipe(signals: [SIGWINCH]) else {
-            SessionIO.close(socket)
-            return 1
+            return SessionAttachExitCode.startupFailure
         }
 
         let originalTerminal = enterRawMode()
@@ -38,15 +47,36 @@ enum SessionAttachClient {
             }
         }
 
+        for attempt in 0 ..< handshakeAttempts {
+            switch attach(configuration: configuration, signalPipe: signalPipe) {
+            case let .finished(status),
+                 let .failed(status):
+                return status
+            case .retry:
+                if attempt + 1 < handshakeAttempts {
+                    usleep(handshakeRetryMicroseconds)
+                }
+            }
+        }
+
+        report("could not reach the session daemon")
+        return SessionAttachExitCode.daemonUnavailable
+    }
+
+    private static func attach(configuration: Configuration, signalPipe: SessionSignalPipe) -> Outcome {
+        guard let socket = connect(socketPath: configuration.socketPath) else { return .retry }
+        defer { SessionIO.close(socket) }
+        SessionIO.setNonBlocking(socket)
+
         let connection = SessionConnection(descriptor: socket)
         connection.enqueue(SessionFrame(kind: .attach, payload: makeRequest(configuration).encoded()))
-
         return loop(connection: connection, signalPipe: signalPipe)
     }
 
-    private static func loop(connection: SessionConnection, signalPipe: SessionSignalPipe) -> Int32 {
+    private static func loop(connection: SessionConnection, signalPipe: SessionSignalPipe) -> Outcome {
+        var isAttached = false
         while true {
-            guard connection.flush() else { return 1 }
+            guard connection.flush() else { return transportOutcome(isAttached: isAttached) }
 
             var descriptors = [
                 pollfd(fd: signalPipe.readDescriptor, events: Int16(POLLIN), revents: 0),
@@ -56,13 +86,13 @@ enum SessionAttachClient {
                     revents: 0
                 ),
             ]
-            if connection.pendingByteCount < inputBacklogLimit {
+            if isAttached, connection.pendingByteCount < inputBacklogLimit {
                 descriptors.append(pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0))
             }
 
             let ready = poll(&descriptors, nfds_t(descriptors.count), -1)
             if ready < 0 {
-                guard errno == EINTR else { return 1 }
+                guard errno == EINTR else { return transportOutcome(isAttached: isAttached) }
                 continue
             }
 
@@ -71,13 +101,17 @@ enum SessionAttachClient {
                     signalPipe.drain()
                     sendResize(connection)
                 } else if entry.fd == STDIN_FILENO {
-                    guard forwardInput(connection) else { return 0 }
-                } else if let status = receive(connection, revents: entry.revents) {
+                    guard forwardInput(connection) else { return .finished(0) }
+                } else if let outcome = receive(connection, revents: entry.revents, isAttached: &isAttached) {
                     _ = connection.flush()
-                    return status
+                    return outcome
                 }
             }
         }
+    }
+
+    private static func transportOutcome(isAttached: Bool) -> Outcome {
+        isAttached ? .failed(SessionAttachExitCode.transportFailure) : .retry
     }
 
     private static func forwardInput(_ connection: SessionConnection) -> Bool {
@@ -93,9 +127,13 @@ enum SessionAttachClient {
         }
     }
 
-    private static func receive(_ connection: SessionConnection, revents: Int16) -> Int32? {
+    private static func receive(
+        _ connection: SessionConnection,
+        revents: Int16,
+        isAttached: inout Bool
+    ) -> Outcome? {
         if revents & Int16(POLLOUT) != 0, !connection.flush() {
-            return 1
+            return transportOutcome(isAttached: isAttached)
         }
         guard revents & Int16(POLLIN) != 0 || revents & Int16(POLLHUP) != 0 else { return nil }
 
@@ -118,20 +156,22 @@ enum SessionAttachClient {
             do {
                 frame = try connection.decoder.next()
             } catch {
-                return 1
+                return .failed(SessionAttachExitCode.protocolFailure)
             }
             guard let frame else { break }
             switch frame.kind {
+            case .attached:
+                isAttached = true
             case .output:
-                guard SessionIO.writeAll(STDOUT_FILENO, frame.payload) else { return 1 }
+                guard SessionIO.writeAll(STDOUT_FILENO, frame.payload) else {
+                    return transportOutcome(isAttached: isAttached)
+                }
             case .exited:
-                return (try? SessionExitPayload.decode(frame.payload)) ?? 0
+                return .finished((try? SessionExitPayload.decode(frame.payload)) ?? 0)
             case .failure:
-                let message = (try? SessionTextPayload.decode(frame.payload)) ?? "session failed"
-                SessionLog.write("muxy-session: " + message)
-                return 1
-            case .attached,
-                 .attach,
+                report((try? SessionTextPayload.decode(frame.payload)) ?? "session failed")
+                return .failed(SessionAttachExitCode.protocolFailure)
+            case .attach,
                  .input,
                  .resize,
                  .list,
@@ -144,7 +184,11 @@ enum SessionAttachClient {
             }
         }
 
-        return reachedEnd ? 1 : nil
+        return reachedEnd ? transportOutcome(isAttached: isAttached) : nil
+    }
+
+    private static func report(_ message: String) {
+        SessionIO.writeAll(STDERR_FILENO, Array(("muxy-session: " + message + "\r\n").utf8))
     }
 
     private static func sendResize(_ connection: SessionConnection) {
@@ -183,14 +227,16 @@ enum SessionAttachClient {
     }
 
     private static func connect(socketPath: String) -> Int32? {
-        if let descriptor = SessionSocket.connect(path: socketPath) {
-            return descriptor
-        }
-        launchDaemon(socketPath: socketPath)
-        for _ in 0 ..< connectAttempts {
-            usleep(connectRetryMicroseconds)
+        for _ in 0 ..< connectCycles {
             if let descriptor = SessionSocket.connect(path: socketPath) {
                 return descriptor
+            }
+            launchDaemon(socketPath: socketPath)
+            for _ in 0 ..< connectAttemptsPerCycle {
+                usleep(connectRetryMicroseconds)
+                if let descriptor = SessionSocket.connect(path: socketPath) {
+                    return descriptor
+                }
             }
         }
         return nil
@@ -198,7 +244,7 @@ enum SessionAttachClient {
 
     private static func launchDaemon(socketPath: String) {
         guard let binaryPath = executablePath() else {
-            SessionLog.write("muxy-session: unable to locate the session daemon binary")
+            report("unable to locate the session daemon binary")
             return
         }
         let arguments = SessionCStringArray([binaryPath, "daemon", "--socket", socketPath])
@@ -212,7 +258,7 @@ enum SessionAttachClient {
             &fileActions,
             STDERR_FILENO,
             socketPath + ".log",
-            O_WRONLY | O_CREAT | O_TRUNC,
+            O_WRONLY | O_CREAT | O_APPEND,
             0o600
         )
 
@@ -224,7 +270,7 @@ enum SessionAttachClient {
         var processID: pid_t = 0
         let result = posix_spawn(&processID, binaryPath, &fileActions, &attributes, arguments.pointer, environ)
         guard result != 0 else { return }
-        SessionLog.write("muxy-session: could not start the session daemon (\(result))")
+        report("could not start the session daemon (\(result))")
     }
 
     static func executablePath() -> String? {

--- a/MuxySession/SessionAttachClient.swift
+++ b/MuxySession/SessionAttachClient.swift
@@ -33,6 +33,18 @@ enum SessionAttachClient {
         case failed(Int32)
     }
 
+    private enum ConnectionOutcome {
+        case connected(Int32)
+        case retry
+        case failed(Int32)
+    }
+
+    private enum DaemonLaunchOutcome {
+        case started
+        case retryableFailure
+        case fatalFailure
+    }
+
     static func run(configuration: Configuration) -> Int32 {
         signal(SIGPIPE, SIG_IGN)
 
@@ -64,7 +76,15 @@ enum SessionAttachClient {
     }
 
     private static func attach(configuration: Configuration, signalPipe: SessionSignalPipe) -> Outcome {
-        guard let socket = connect(socketPath: configuration.socketPath) else { return .retry }
+        let socket: Int32
+        switch connect(socketPath: configuration.socketPath) {
+        case let .connected(descriptor):
+            socket = descriptor
+        case .retry:
+            return .retry
+        case let .failed(status):
+            return .failed(status)
+        }
         defer { SessionIO.close(socket) }
         SessionIO.setNonBlocking(socket)
 
@@ -226,26 +246,32 @@ enum SessionAttachClient {
         return original
     }
 
-    private static func connect(socketPath: String) -> Int32? {
+    private static func connect(socketPath: String) -> ConnectionOutcome {
         for _ in 0 ..< connectCycles {
             if let descriptor = SessionSocket.connect(path: socketPath) {
-                return descriptor
+                return .connected(descriptor)
             }
-            launchDaemon(socketPath: socketPath)
+            switch launchDaemon(socketPath: socketPath) {
+            case .started,
+                 .retryableFailure:
+                break
+            case .fatalFailure:
+                return .failed(SessionAttachExitCode.startupFailure)
+            }
             for _ in 0 ..< connectAttemptsPerCycle {
                 usleep(connectRetryMicroseconds)
                 if let descriptor = SessionSocket.connect(path: socketPath) {
-                    return descriptor
+                    return .connected(descriptor)
                 }
             }
         }
-        return nil
+        return .retry
     }
 
-    private static func launchDaemon(socketPath: String) {
+    private static func launchDaemon(socketPath: String) -> DaemonLaunchOutcome {
         guard let binaryPath = executablePath() else {
             report("unable to locate the session daemon binary")
-            return
+            return .fatalFailure
         }
         let arguments = SessionCStringArray([binaryPath, "daemon", "--socket", socketPath])
 
@@ -269,8 +295,9 @@ enum SessionAttachClient {
 
         var processID: pid_t = 0
         let result = posix_spawn(&processID, binaryPath, &fileActions, &attributes, arguments.pointer, environ)
-        guard result != 0 else { return }
+        guard result != 0 else { return .started }
         report("could not start the session daemon (\(result))")
+        return result == EAGAIN || result == EINTR ? .retryableFailure : .fatalFailure
     }
 
     static func executablePath() -> String? {

--- a/MuxySession/SessionDaemon.swift
+++ b/MuxySession/SessionDaemon.swift
@@ -10,6 +10,7 @@ final class SessionDaemon {
     static let replayChunkSize = 32 * 1024
 
     private let socketPath: String
+    private let idleTimeout: Int32
     private let listener: Int32
     private let lockDescriptor: Int32
     private let signalPipe: SessionSignalPipe
@@ -19,8 +20,9 @@ final class SessionDaemon {
     private var connections: [Int32: SessionConnection] = [:]
     private var closingDescriptors: [Int32] = []
 
-    init?(socketPath: String) {
+    init?(socketPath: String, idleTimeoutMilliseconds: Int32 = SessionDaemon.idleTimeoutMilliseconds) {
         self.socketPath = socketPath
+        idleTimeout = idleTimeoutMilliseconds
         signal(SIGPIPE, SIG_IGN)
         signal(SIGHUP, SIG_IGN)
 
@@ -46,9 +48,11 @@ final class SessionDaemon {
         while true {
             let isIdle = sessions.isEmpty && connections.isEmpty
             var descriptors = buildPollDescriptors()
-            let ready = poll(&descriptors, nfds_t(descriptors.count), isIdle ? Self.idleTimeoutMilliseconds : -1)
+            let ready = poll(&descriptors, nfds_t(descriptors.count), isIdle ? idleTimeout : -1)
             if ready == 0 {
                 guard sessions.isEmpty, connections.isEmpty else { continue }
+                acceptConnections()
+                guard connections.isEmpty else { continue }
                 break
             }
             if ready < 0 {

--- a/MuxySession/main.swift
+++ b/MuxySession/main.swift
@@ -61,7 +61,9 @@ case "daemon":
     guard let socketPath = argumentValue("--socket", in: arguments) else {
         fail("usage: muxy-session daemon --socket <path>")
     }
-    guard let daemon = SessionDaemon(socketPath: socketPath) else {
+    let idleTimeout = argumentValue("--idle-timeout", in: arguments)
+        .flatMap(Int32.init) ?? SessionDaemon.idleTimeoutMilliseconds
+    guard let daemon = SessionDaemon(socketPath: socketPath, idleTimeoutMilliseconds: idleTimeout) else {
         exit(0)
     }
     daemon.run()

--- a/Tests/MuxyTests/Services/Session/PersistentSessionIntegrationTests.swift
+++ b/Tests/MuxyTests/Services/Session/PersistentSessionIntegrationTests.swift
@@ -123,14 +123,29 @@ struct PersistentSessionPathsTests {
     @Test("builds the socket path inside the app support directory")
     func buildsPreferredPath() {
         let directory = URL(fileURLWithPath: "/Users/test/Library/Application Support/Muxy", isDirectory: true)
-        let path = PersistentSessionPaths.preferredSocketPath(appSupportDirectory: directory)
-        #expect(path == "/Users/test/Library/Application Support/Muxy/sessions/control.sock")
+        let releasePath = PersistentSessionPaths.preferredSocketPath(appSupportDirectory: directory, isDevelopment: false)
+        let developmentPath = PersistentSessionPaths.preferredSocketPath(appSupportDirectory: directory, isDevelopment: true)
+        #expect(releasePath == "/Users/test/Library/Application Support/Muxy/sessions/control.sock")
+        #expect(developmentPath == "/Users/test/Library/Application Support/Muxy/sessions-dev/control.sock")
     }
 
     @Test("scopes the fallback path to the user")
     func buildsFallbackPath() {
-        #expect(PersistentSessionPaths.fallbackSocketPath(userID: 501) == "/tmp/muxy-501/control.sock")
-        #expect(PersistentSessionPaths.fits(PersistentSessionPaths.fallbackSocketPath(userID: 4_294_967_295)))
+        #expect(PersistentSessionPaths.fallbackSocketPath(userID: 501, isDevelopment: false) == "/tmp/muxy-501/control.sock")
+        #expect(PersistentSessionPaths.fallbackSocketPath(userID: 501, isDevelopment: true) == "/tmp/muxy-dev-501/control.sock")
+        #expect(PersistentSessionPaths.fits(PersistentSessionPaths.fallbackSocketPath(userID: 4_294_967_295, isDevelopment: false)))
+        #expect(PersistentSessionPaths.fits(PersistentSessionPaths.fallbackSocketPath(userID: 4_294_967_295, isDevelopment: true)))
+    }
+
+    @Test("keeps development and release paths separate")
+    func separatesDevelopmentAndReleasePaths() {
+        let directory = URL(fileURLWithPath: "/Users/test/Library/Application Support/Muxy", isDirectory: true)
+        let releasePreferred = PersistentSessionPaths.preferredSocketPath(appSupportDirectory: directory, isDevelopment: false)
+        let developmentPreferred = PersistentSessionPaths.preferredSocketPath(appSupportDirectory: directory, isDevelopment: true)
+        let releaseFallback = PersistentSessionPaths.fallbackSocketPath(userID: 501, isDevelopment: false)
+        let developmentFallback = PersistentSessionPaths.fallbackSocketPath(userID: 501, isDevelopment: true)
+        #expect(releasePreferred != developmentPreferred)
+        #expect(releaseFallback != developmentFallback)
     }
 
     private func makeFallbackRoot() throws -> URL {
@@ -148,8 +163,18 @@ struct PersistentSessionPathsTests {
     func resolvesPreferredPath() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("mx-\(UUID().uuidString.prefix(6))")
         defer { try? FileManager.default.removeItem(at: root) }
-        let resolved = try PersistentSessionPaths.resolveSocketPath(appSupportDirectory: root, userID: getuid())
-        #expect(resolved == PersistentSessionPaths.preferredSocketPath(appSupportDirectory: root))
+        let resolved = try PersistentSessionPaths.resolveSocketPath(appSupportDirectory: root, userID: getuid(), isDevelopment: false)
+        #expect(resolved == PersistentSessionPaths.preferredSocketPath(appSupportDirectory: root, isDevelopment: false))
+        #expect(FileManager.default.fileExists(atPath: URL(fileURLWithPath: resolved).deletingLastPathComponent().path))
+    }
+
+    @Test("resolves the development socket path into its own directory")
+    func resolvesDevelopmentPreferredPath() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("mx-\(UUID().uuidString.prefix(6))")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolved = try PersistentSessionPaths.resolveSocketPath(appSupportDirectory: root, userID: getuid(), isDevelopment: true)
+        #expect(resolved == PersistentSessionPaths.preferredSocketPath(appSupportDirectory: root, isDevelopment: true))
+        #expect(resolved.contains("sessions-dev"))
         #expect(FileManager.default.fileExists(atPath: URL(fileURLWithPath: resolved).deletingLastPathComponent().path))
     }
 
@@ -161,9 +186,10 @@ struct PersistentSessionPathsTests {
         let resolved = try PersistentSessionPaths.resolveSocketPath(
             appSupportDirectory: overlongAppSupportDirectory,
             userID: getuid(),
-            fallbackRoot: root.path
+            fallbackRoot: root.path,
+            isDevelopment: false
         )
-        #expect(resolved == PersistentSessionPaths.fallbackSocketPath(userID: getuid(), root: root.path))
+        #expect(resolved == PersistentSessionPaths.fallbackSocketPath(userID: getuid(), root: root.path, isDevelopment: false))
         #expect(FileManager.default.fileExists(atPath: URL(fileURLWithPath: resolved).deletingLastPathComponent().path))
     }
 
@@ -172,7 +198,7 @@ struct PersistentSessionPathsTests {
         let root = try makeFallbackRoot()
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let directory = URL(fileURLWithPath: PersistentSessionPaths.fallbackSocketPath(userID: getuid(), root: root.path))
+        let directory = URL(fileURLWithPath: PersistentSessionPaths.fallbackSocketPath(userID: getuid(), root: root.path, isDevelopment: false))
             .deletingLastPathComponent()
         try FileManager.default.createDirectory(
             at: directory,
@@ -183,7 +209,8 @@ struct PersistentSessionPathsTests {
         _ = try PersistentSessionPaths.resolveSocketPath(
             appSupportDirectory: overlongAppSupportDirectory,
             userID: getuid(),
-            fallbackRoot: root.path
+            fallbackRoot: root.path,
+            isDevelopment: false
         )
 
         let permissions = try #require(
@@ -198,7 +225,7 @@ struct PersistentSessionPathsTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let foreignUserID = getuid() &+ 1
-        let directory = URL(fileURLWithPath: PersistentSessionPaths.fallbackSocketPath(userID: foreignUserID, root: root.path))
+        let directory = URL(fileURLWithPath: PersistentSessionPaths.fallbackSocketPath(userID: foreignUserID, root: root.path, isDevelopment: false))
             .deletingLastPathComponent()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
@@ -206,7 +233,8 @@ struct PersistentSessionPathsTests {
             try PersistentSessionPaths.resolveSocketPath(
                 appSupportDirectory: overlongAppSupportDirectory,
                 userID: foreignUserID,
-                fallbackRoot: root.path
+                fallbackRoot: root.path,
+                isDevelopment: false
             )
         }
     }

--- a/Tests/MuxyTests/Services/Session/PersistentSessionRecoveryPolicyTests.swift
+++ b/Tests/MuxyTests/Services/Session/PersistentSessionRecoveryPolicyTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import MuxySessionProtocol
+import Testing
+
+@testable import Muxy
+
+@Suite("PersistentSessionExitHandler decisions")
+struct PersistentSessionExitHandlerTests {
+    private let descriptor = SessionDescriptor(
+        identifier: SessionIdentifier(uuidString: UUID().uuidString)!,
+        shellProcessID: 100,
+        ttyDevice: 1,
+        workingDirectory: "/tmp",
+        isAttached: false
+    )
+
+    @Test("closes the pane when the session really ended")
+    func closesPaneForEndedSession() {
+        #expect(PersistentSessionExitHandler.decision(lookup: .absent, attempt: 1, limit: 3) == .closePane)
+    }
+
+    @Test("closes the pane for an ended session regardless of earlier retries")
+    func closesPaneEvenAfterRetries() {
+        #expect(PersistentSessionExitHandler.decision(lookup: .absent, attempt: 9, limit: 3) == .closePane)
+    }
+
+    @Test("reattaches while the session is still alive")
+    func reattachesLiveSession() {
+        for attempt in 1 ... 3 {
+            #expect(PersistentSessionExitHandler.decision(
+                lookup: .found(descriptor),
+                attempt: attempt,
+                limit: 3
+            ) == .reattach)
+        }
+    }
+
+    @Test("reattaches when the daemon cannot be reached")
+    func reattachesUnreachableDaemon() {
+        #expect(PersistentSessionExitHandler.decision(lookup: .unreachable, attempt: 1, limit: 3) == .reattach)
+    }
+
+    @Test("reports a failure once the retry budget is spent")
+    func reportsFailureAfterBudget() {
+        #expect(PersistentSessionExitHandler.decision(
+            lookup: .found(descriptor),
+            attempt: 4,
+            limit: 3
+        ) == .reportFailure)
+        #expect(PersistentSessionExitHandler.decision(
+            lookup: .unreachable,
+            attempt: 4,
+            limit: 3
+        ) == .reportFailure)
+    }
+
+    @Test("counts the first exit as the first attempt")
+    func countsFirstAttempt() {
+        #expect(PersistentSessionExitHandler.attempt(previous: 0, elapsed: nil, resetAfter: 60) == 1)
+    }
+
+    @Test("keeps counting attempts inside the reset window")
+    func countsRepeatedAttempts() {
+        #expect(PersistentSessionExitHandler.attempt(previous: 2, elapsed: 5, resetAfter: 60) == 3)
+    }
+
+    @Test("starts over once the session has been healthy for a while")
+    func resetsAfterHealthyPeriod() {
+        #expect(PersistentSessionExitHandler.attempt(previous: 3, elapsed: 61, resetAfter: 60) == 1)
+    }
+
+    @Test("backs off further with every attempt")
+    func backsOffProgressively() {
+        #expect(PersistentSessionExitHandler.backoff(attempt: 1) == .milliseconds(300))
+        #expect(PersistentSessionExitHandler.backoff(attempt: 3) == .milliseconds(900))
+        #expect(PersistentSessionExitHandler.backoff(attempt: 0) == .milliseconds(300))
+    }
+}
+
+@Suite("TerminalPersistentSessionPolicy idleness")
+struct TerminalPersistentSessionIdlePolicyTests {
+    @Test("treats an idle session shell as idle")
+    func idleSessionIsIdle() {
+        #expect(TerminalPersistentSessionPolicy.isIdle(
+            activity: .idle,
+            isShellCommandRunning: false,
+            isAlternateScreen: false
+        ))
+    }
+
+    @Test("keeps a session running a command awake")
+    func runningCommandIsBusy() {
+        #expect(!TerminalPersistentSessionPolicy.isIdle(
+            activity: .running,
+            isShellCommandRunning: false,
+            isAlternateScreen: false
+        ))
+    }
+
+    @Test("keeps a session awake while shell integration reports a command")
+    func shellIntegrationCommandIsBusy() {
+        #expect(!TerminalPersistentSessionPolicy.isIdle(
+            activity: .idle,
+            isShellCommandRunning: true,
+            isAlternateScreen: false
+        ))
+    }
+
+    @Test("keeps a session showing a full screen program awake")
+    func alternateScreenIsBusy() {
+        #expect(!TerminalPersistentSessionPolicy.isIdle(
+            activity: .idle,
+            isShellCommandRunning: false,
+            isAlternateScreen: true
+        ))
+    }
+
+    @Test("never sleeps a session whose state is unknown")
+    func unknownActivityStaysAwake() {
+        #expect(!TerminalPersistentSessionPolicy.isIdle(
+            activity: nil,
+            isShellCommandRunning: false,
+            isAlternateScreen: false
+        ))
+    }
+}

--- a/Tests/MuxyTests/Services/Session/SessionDaemonLifecycleTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionDaemonLifecycleTests.swift
@@ -1,0 +1,118 @@
+import Darwin
+import Foundation
+import MuxySessionProtocol
+import Testing
+
+@testable import Muxy
+
+@Suite("SessionDaemon lifecycle", .serialized, .enabled(if: SessionDaemonHarness.binaryURL != nil))
+struct SessionDaemonLifecycleTests {
+    private static let idleTimeoutMilliseconds = 100
+
+    private func makeIdentifier() throws -> SessionIdentifier {
+        try #require(SessionIdentifier(uuidString: UUID().uuidString))
+    }
+
+    @Test("starts a fresh daemon after an idle one has exited")
+    func attachClientStartsDaemonAfterIdleExit() throws {
+        let harness = try SessionDaemonHarness()
+        defer { harness.stop() }
+        try harness.start(idleTimeoutMilliseconds: Self.idleTimeoutMilliseconds)
+
+        let deadline = Date().addingTimeInterval(5)
+        while FileManager.default.fileExists(atPath: harness.socketPath), Date() < deadline {
+            usleep(20_000)
+        }
+        #expect(!FileManager.default.fileExists(atPath: harness.socketPath))
+
+        let result = try harness.runAttachClient(
+            identifier: makeIdentifier(),
+            command: "echo RESTARTED",
+            timeout: 15
+        )
+        #expect(result.output.contains("RESTARTED"))
+        #expect(result.status == 0)
+    }
+
+    @Test("starts a daemon on demand and runs the session command")
+    func attachClientStartsDaemonOnDemand() throws {
+        let harness = try SessionDaemonHarness()
+        defer { harness.stop() }
+
+        let result = try harness.runAttachClient(
+            identifier: makeIdentifier(),
+            command: "echo CLIENT_READY",
+            timeout: 15
+        )
+        #expect(result.output.contains("CLIENT_READY"))
+        #expect(result.status == 0)
+    }
+
+    @Test("keeps trying after the first daemon loses the startup race")
+    func attachClientRetriesAfterLostStartupRace() throws {
+        let harness = try SessionDaemonHarness()
+        defer { harness.stop() }
+
+        let lock = open(harness.socketPath + ".lock", O_CREAT | O_RDWR, 0o600)
+        try #require(lock >= 0)
+        try #require(flock(lock, LOCK_EX | LOCK_NB) == 0)
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.2) {
+            flock(lock, LOCK_UN)
+            close(lock)
+        }
+
+        let result = try harness.runAttachClient(
+            identifier: makeIdentifier(),
+            command: "echo RACED",
+            timeout: 15
+        )
+        #expect(result.output.contains("RACED"))
+        #expect(result.status == 0)
+    }
+
+    @Test("keeps daemons on separate sockets fully isolated")
+    func isolatesDaemonsOnSeparateSockets() throws {
+        let first = try SessionDaemonHarness()
+        defer { first.stop() }
+        try first.start()
+        let second = try SessionDaemonHarness()
+        defer { second.stop() }
+        try second.start()
+
+        let firstAttached = try #require(SessionTestConnection(socketPath: first.socketPath))
+        defer { firstAttached.close() }
+        firstAttached.send(first.attachRequest(identifier: try makeIdentifier(), command: "sh -c 'sleep 30'"))
+        _ = try #require(firstAttached.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+        let secondAttached = try #require(SessionTestConnection(socketPath: second.socketPath))
+        defer { secondAttached.close() }
+        secondAttached.send(second.attachRequest(identifier: try makeIdentifier(), command: "sh -c 'sleep 30'"))
+        _ = try #require(secondAttached.waitForFrame(timeout: 5) { $0.kind == .attached })
+
+        let firstControl = try #require(SessionTestConnection(socketPath: first.socketPath))
+        defer { firstControl.close() }
+        firstControl.send(SessionFrame(kind: .killAll))
+        _ = try #require(firstControl.waitForFrame(timeout: 5) { $0.kind == .acknowledged })
+
+        let secondControl = try #require(SessionTestConnection(socketPath: second.socketPath))
+        defer { secondControl.close() }
+        secondControl.send(SessionFrame(kind: .list))
+        let listed = try #require(secondControl.waitForFrame(timeout: 5) { $0.kind == .sessions })
+        #expect(try SessionDescriptor.decodeList(listed.payload).count == 1)
+    }
+
+    @Test("recovers when the socket path holds a stale file")
+    func attachClientRecoversFromStaleSocketPath() throws {
+        let harness = try SessionDaemonHarness()
+        defer { harness.stop() }
+        try Data().write(to: URL(fileURLWithPath: harness.socketPath))
+
+        let result = try harness.runAttachClient(
+            identifier: makeIdentifier(),
+            command: "echo RECOVERED",
+            timeout: 15
+        )
+        #expect(result.output.contains("RECOVERED"))
+        #expect(result.status == 0)
+    }
+}

--- a/Tests/MuxyTests/Services/Session/SessionDaemonLifecycleTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionDaemonLifecycleTests.swift
@@ -48,6 +48,22 @@ struct SessionDaemonLifecycleTests {
         #expect(result.status == 0)
     }
 
+    @Test("fails immediately when the daemon binary cannot be launched")
+    func attachClientFailsFastForMissingDaemonBinary() throws {
+        let harness = try SessionDaemonHarness()
+        defer { harness.stop() }
+
+        let result = try harness.runAttachClient(
+            identifier: makeIdentifier(),
+            command: "",
+            timeout: 5,
+            daemonBinaryPath: harness.directory.appendingPathComponent("missing-muxy-session").path
+        )
+        let launchFailureCount = result.output.components(separatedBy: "could not start the session daemon").count - 1
+        #expect(result.status == 93)
+        #expect(launchFailureCount == 1)
+    }
+
     @Test("keeps trying after the first daemon loses the startup race")
     func attachClientRetriesAfterLostStartupRace() throws {
         let harness = try SessionDaemonHarness()

--- a/Tests/MuxyTests/Support/SessionDaemonHarness.swift
+++ b/Tests/MuxyTests/Support/SessionDaemonHarness.swift
@@ -70,7 +70,8 @@ final class SessionDaemonHarness {
     func runAttachClient(
         identifier: SessionIdentifier,
         command: String,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        daemonBinaryPath: String? = nil
     ) throws -> AttachClientResult {
         guard let binaryURL = Self.binaryURL else {
             return AttachClientResult(status: -1, output: "")
@@ -82,7 +83,7 @@ final class SessionDaemonHarness {
             "PATH": "/usr/bin:/bin",
             "MUXY_SESSION_ID": identifier.uuidString,
             "MUXY_SESSION_SOCKET": socketPath,
-            "MUXY_SESSION_BINARY": binaryURL.path,
+            "MUXY_SESSION_BINARY": daemonBinaryPath ?? binaryURL.path,
             "MUXY_SESSION_SHELL": "/bin/sh",
             "MUXY_SESSION_CWD": "/tmp",
             "MUXY_SESSION_COMMAND": command,

--- a/Tests/MuxyTests/Support/SessionDaemonHarness.swift
+++ b/Tests/MuxyTests/Support/SessionDaemonHarness.swift
@@ -29,11 +29,12 @@ final class SessionDaemonHarness {
         socketPath = directory.appendingPathComponent("c.sock").path
     }
 
-    func start() throws {
+    func start(idleTimeoutMilliseconds: Int? = nil) throws {
         guard let binaryURL = Self.binaryURL else { return }
         let process = Process()
         process.executableURL = binaryURL
         process.arguments = ["daemon", "--socket", socketPath]
+            + (idleTimeoutMilliseconds.map { ["--idle-timeout", String($0)] } ?? [])
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         try process.run()
@@ -59,6 +60,58 @@ final class SessionDaemonHarness {
         daemon?.waitUntilExit()
         daemon = nil
         try? FileManager.default.removeItem(at: directory)
+    }
+
+    struct AttachClientResult {
+        let status: Int32
+        let output: String
+    }
+
+    func runAttachClient(
+        identifier: SessionIdentifier,
+        command: String,
+        timeout: TimeInterval
+    ) throws -> AttachClientResult {
+        guard let binaryURL = Self.binaryURL else {
+            return AttachClientResult(status: -1, output: "")
+        }
+        let process = Process()
+        process.executableURL = binaryURL
+        process.arguments = ["attach"]
+        process.environment = [
+            "PATH": "/usr/bin:/bin",
+            "MUXY_SESSION_ID": identifier.uuidString,
+            "MUXY_SESSION_SOCKET": socketPath,
+            "MUXY_SESSION_BINARY": binaryURL.path,
+            "MUXY_SESSION_SHELL": "/bin/sh",
+            "MUXY_SESSION_CWD": "/tmp",
+            "MUXY_SESSION_COMMAND": command,
+        ]
+
+        let outputURL = directory.appendingPathComponent("attach-\(identifier.uuidString).log")
+        FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        let input = Pipe()
+        process.standardInput = input
+        process.standardOutput = outputHandle
+        process.standardError = outputHandle
+        try process.run()
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            usleep(20_000)
+        }
+        if process.isRunning {
+            process.terminate()
+        }
+        process.waitUntilExit()
+        input.fileHandleForWriting.closeFile()
+        try? outputHandle.close()
+
+        return AttachClientResult(
+            status: process.terminationStatus,
+            output: (try? String(contentsOf: outputURL, encoding: .utf8)) ?? ""
+        )
     }
 
     func attachRequest(

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -14,6 +14,8 @@ libghostty owns the PTY of every surface it creates and offers no way to hand a 
 
 Each pane carries a session ID that defaults to its own pane ID and is persisted in workspace snapshots, so reopening Muxy reattaches each restored pane to its own session. Because the two IDs are separate, a pane can also adopt a session that started somewhere else. On reattach the daemon replays a capped 256 KB buffer of recent output and sends `SIGWINCH` to the foreground process group so full-screen programs repaint. The daemon exits on its own once it has been idle with no sessions.
 
+The attach client starts a daemon on demand and keeps retrying the whole connect-and-launch cycle until it succeeds or its budget runs out, so a terminal opened while an idle daemon is shutting down does not fail. A connection that drops before the session is handed over is retried on a fresh socket rather than reported as an exit, and a daemon that is idling out accepts anything still waiting in its listen backlog before it closes.
+
 Every attach carries metadata identifying the project, worktree, tab, and title the session belongs to, and the daemon refreshes it each time a client reattaches. That is what lets Muxy group sessions by worktree and show which tab owns one. The attach also carries a protocol version; a session started by a different version of Muxy is refused with a clear message rather than being misread.
 
 ### Recovering sessions
@@ -23,6 +25,8 @@ Reopening Muxy reattaches every restored pane whose session is still running, wi
 Closing a tab ends its session. To keep a local background-backed tab running without its visible terminal, right-click inside the terminal and choose **Send to Background**. The tab closes without stopping its processes and its sessions appear in the status bar as detached. A split tab moves all of its terminal sessions together. The action is unavailable for pinned tabs, mixed-content splits, remote terminals, and terminals opened without background sessions enabled.
 
 Sessions are never killed behind your back otherwise: one whose tab is gone keeps running and shows up in the status bar as detached, where you can reattach or stop it. Sending the final visible tab to the background keeps its project and worktree open so the status-bar entry remains accessible.
+
+When an attach client goes away, Muxy asks the daemon what actually happened before touching the tab. Only a session the daemon reports as gone closes its tab; a session that is still running, or a daemon that cannot be reached, is treated as a dropped connection and reattached with a short backoff. If several attempts in a row fail, the tab stays open showing a **Reconnect** placeholder and the session keeps running, so a daemon crash or a version mismatch after an update can never close tabs or discard work. A tab that has been healthy for a while starts its retry budget over.
 
 The status bar lists only the sessions in the current project and worktree that **no tab currently owns**, since a session already open in a tab is not something you need to recover. Ownership is decided by the pane pointing at the session, not by whether a client happens to be connected, so a tab whose terminal was freed by the idle-memory setting still counts as owning its session. When every session in the worktree is open in a tab, the status bar item disappears entirely.
 
@@ -36,9 +40,9 @@ A session can only ever be owned by one tab, because the daemon accepts a single
 
 Ghostty only injects its shell integration into shells it spawns itself, so the daemon reproduces that injection using the contract the bundled scripts document: `ZDOTDIR` plus `GHOSTTY_ZSH_ZDOTDIR` for zsh, `ENV` plus `GHOSTTY_BASH_INJECT` and POSIX mode for bash, and `XDG_DATA_DIRS` plus `GHOSTTY_SHELL_INTEGRATION_XDG_DIR` for fish, elvish, and nushell. Background terminals in those shells keep working-directory tracking, tab titles, prompt marks, and AI progress. Other shells run normally but lose those integrations, exactly as they do under tmux.
 
-Because the surface's own foreground process is the attach client, Muxy resolves the real foreground process from the session's tty through `sysctl(KERN_PROC_TTY)`. Agent detection, the running-process close confirmation, and AI hook to pane mapping behave the same as in a normal terminal.
+Because the surface's own foreground process is the attach client, Muxy resolves the real foreground process from the session's tty through `sysctl(KERN_PROC_TTY)`. Agent detection, the running-process close confirmation, the idle-memory sweep, and AI hook to pane mapping behave the same as in a normal terminal. Idleness in particular has to come from the session rather than the surface: the attach client is not a shell, so judging it locally would keep every background terminal awake forever and disable the idle-memory setting app-wide. A session whose state cannot be resolved is treated as busy and left running.
 
-The control socket lives in Muxy's Application Support directory with `0700` on the directory and `0600` on the socket, falling back to a user-scoped `/tmp/muxy-<uid>` only when the primary path exceeds the 104-byte `sun_path` limit. The daemon verifies the peer's uid with `LOCAL_PEERCRED` and refuses connections from other users.
+The control socket lives in Muxy's Application Support directory with `0700` on the directory and `0600` on the socket, falling back to a user-scoped `/tmp/muxy-<uid>` only when the primary path exceeds the 104-byte `sun_path` limit. The daemon verifies the peer's uid with `LOCAL_PEERCRED` and refuses connections from other users. A development build uses its own `sessions-dev` directory and `/tmp/muxy-dev-<uid>` fallback, so running a dev build alongside the release app keeps two fully separate daemons — neither build can list, adopt, or stop the other's sessions.
 
 Remote SSH panes and the quick terminal are never backed by a background session.
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -54,6 +54,7 @@ Open **Settings → Terminal → Background sessions** to keep terminals running
 - Only terminals opened after the setting is switched on are affected. Terminals that are already open keep their current behavior.
 - Reopening Muxy reattaches every restored tab whose session is still running, without waiting for you to click the tab.
 - Closing a tab ends its session. Right-click an eligible local terminal and choose **Send to Background** to close its tab without stopping its processes; the session then stays available from the status bar.
+- If Muxy loses its connection to a still-running session, it reconnects on its own. A tab only closes when the session itself has ended; when reconnecting keeps failing the tab waits with a **Reconnect** button instead, and the session keeps running.
 - Turning the setting off asks for confirmation and then stops every terminal still running in the background.
 - Remote SSH terminals and the quick terminal are never run this way.
 


### PR DESCRIPTION
Make persistent terminals resilient to daemon startup races and dropped connections with automatic reattachment, bounded retries, and a manual reconnect state. Isolate development sockets, improve session idleness detection, and add lifecycle, recovery, path, documentation, and policy coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery for background terminal sessions, including retries for temporary connection and daemon failures.
  - Added a **Reconnect** action when recovery fails, while keeping the terminal tab open.
  - Improved session activity detection so active commands and alternate-screen programs remain protected from sleeping.
  - Added configurable daemon idle timeouts and isolated session paths for development builds.

- **Documentation**
  - Updated terminal and settings documentation to explain automatic reconnection and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->