### PR TITLE
Fix terminal mouse and pane drag routing

### DIFF
--- a/Muxy/Models/Workspace/TabDragCoordinator.swift
+++ b/Muxy/Models/Workspace/TabDragCoordinator.swift
@@ -8,10 +8,22 @@ enum DragCoordinateSpace {
 enum DragActivation {
     static let distance: CGFloat = 4
 
-    static func exceedsDistance(from origin: CGPoint, to point: CGPoint) -> Bool {
+    static func reachesDistance(from origin: CGPoint, to point: CGPoint) -> Bool {
         let dx = point.x - origin.x
         let dy = point.y - origin.y
-        return (dx * dx) + (dy * dy) > distance * distance
+        return (dx * dx) + (dy * dy) >= distance * distance
+    }
+}
+
+struct CommandDragActivation {
+    private(set) var startedWithCommand: Bool?
+
+    mutating func shouldActivate(commandHeld: Bool, from origin: CGPoint, to point: CGPoint) -> Bool {
+        if startedWithCommand == nil {
+            startedWithCommand = commandHeld
+        }
+        guard startedWithCommand == true else { return false }
+        return DragActivation.reachesDistance(from: origin, to: point)
     }
 }
 

--- a/Muxy/Models/Workspace/TabDragCoordinator.swift
+++ b/Muxy/Models/Workspace/TabDragCoordinator.swift
@@ -5,6 +5,16 @@ enum DragCoordinateSpace {
     static let mainWindow = "main-window-drag-space"
 }
 
+enum DragActivation {
+    static let distance: CGFloat = 4
+
+    static func exceedsDistance(from origin: CGPoint, to point: CGPoint) -> Bool {
+        let dx = point.x - origin.x
+        let dy = point.y - origin.y
+        return (dx * dx) + (dy * dy) > distance * distance
+    }
+}
+
 enum TabMoveRequest {
     case toArea(tabID: UUID, sourceAreaID: UUID, destinationAreaID: UUID)
     case toNewSplit(tabID: UUID, sourceAreaID: UUID, targetAreaID: UUID, split: SplitPlacement)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -49,6 +49,10 @@ final class GhosttyTerminalNSView: NSView,
     private var isShowingHandCursor = false
     private var fileHoverUnderlineLayer: CAShapeLayer?
     private var lastMouseTopDownPoint: CGPoint?
+    private var leftMousePressRouting: LeftMousePressRouting = .ignored
+    private var leftMouseDownWindowPoint: NSPoint?
+    private var didDragAfterLeftMouseDown = false
+    private var forwardedRightMousePress = false
     var hasOSC8LinkUnderCursor: Bool = false
     var isFocused: Bool = false
     var overlayActive: Bool = false
@@ -1073,14 +1077,45 @@ final class GhosttyTerminalNSView: NSView,
         }
     }
 
+    enum LeftMousePressRouting {
+        case ignored
+        case forwardedToSurface
+        case commandPending
+        case commandHandled
+    }
+
+    static func forwardsLeftMousePress(commandHeld: Bool) -> Bool {
+        !commandHeld
+    }
+
+    static func forwardsLeftMouseRelease(routing: LeftMousePressRouting, didDrag: Bool) -> Bool {
+        switch routing {
+        case .forwardedToSurface:
+            true
+        case .commandPending:
+            !didDrag
+        case .ignored,
+             .commandHandled:
+            false
+        }
+    }
+
+    static func reachesSurfaceWhileOverlayActive(routing: LeftMousePressRouting) -> Bool {
+        routing == .forwardedToSurface
+    }
+
     override func mouseDown(with event: NSEvent) {
+        leftMousePressRouting = .ignored
+        leftMouseDownWindowPoint = event.locationInWindow
+        didDragAfterLeftMouseDown = false
         if overlayActive {
             return
         }
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
-        let commandWord = event.modifierFlags.contains(.command) && !hasOSC8LinkUnderCursor
+        let commandHeld = event.modifierFlags.contains(.command)
+        let commandWord = commandHeld && !hasOSC8LinkUnderCursor
             ? readQuicklookWordUnderMouse()
             : nil
         let commandFileToken = commandWord.flatMap { resolvedCmdFileToken(for: $0)?.text }
@@ -1089,21 +1124,34 @@ final class GhosttyTerminalNSView: NSView,
             openCommandFile: { onCmdClickFile?($0) },
             focusTerminal: claimFocusForMouseDown
         ) {
+            leftMousePressRouting = .commandHandled
             return
         }
         if commandWord != nil {
+            leftMousePressRouting = .commandPending
             return
         }
+        guard Self.forwardsLeftMousePress(commandHeld: commandHeld) else {
+            leftMousePressRouting = .commandPending
+            return
+        }
+        leftMousePressRouting = .forwardedToSurface
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
     }
 
     override func mouseUp(with event: NSEvent) {
-        if overlayActive {
+        let routing = leftMousePressRouting
+        let didDrag = didDragAfterLeftMouseDown
+        leftMousePressRouting = .ignored
+        leftMouseDownWindowPoint = nil
+        didDragAfterLeftMouseDown = false
+        if overlayActive, !Self.reachesSurfaceWhileOverlayActive(routing: routing) {
             return
         }
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
+        guard Self.forwardsLeftMouseRelease(routing: routing, didDrag: didDrag) else { return }
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
         autoCopySelectionIfEnabled()
     }
@@ -1118,7 +1166,13 @@ final class GhosttyTerminalNSView: NSView,
     }
 
     override func mouseDragged(with event: NSEvent) {
+        updateLeftDragState(with: event)
         mouseMoved(with: event)
+    }
+
+    private func updateLeftDragState(with event: NSEvent) {
+        guard !didDragAfterLeftMouseDown, let origin = leftMouseDownWindowPoint else { return }
+        didDragAfterLeftMouseDown = DragActivation.exceedsDistance(from: origin, to: event.locationInWindow)
     }
 
     override func rightMouseDragged(with event: NSEvent) {
@@ -1447,26 +1501,47 @@ final class GhosttyTerminalNSView: NSView,
         return bounds.height / CGFloat(cells.rows)
     }
 
+    static func forwardsRightMouseButton(mouseCaptured: Bool, shiftHeld: Bool) -> Bool {
+        mouseCaptured && !shiftHeld
+    }
+
     override func rightMouseDown(with event: NSEvent) {
+        forwardedRightMousePress = false
         if overlayActive {
             return
         }
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
-        let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, modsFromEvent(event))
-        if !consumed {
+        guard Self.forwardsRightMouseButton(
+            mouseCaptured: ghostty_surface_mouse_captured(surface),
+            shiftHeld: event.modifierFlags.contains(.shift)
+        )
+        else {
             presentContextMenu(with: event)
+            return
         }
+        forwardedRightMousePress = true
+        let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, modsFromEvent(event))
+        guard !consumed else { return }
+        forwardedRightMousePress = false
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, modsFromEvent(event))
+        presentContextMenu(with: event)
     }
 
     override func rightMouseUp(with event: NSEvent) {
+        let forwardedPress = forwardedRightMousePress
+        forwardedRightMousePress = false
         if overlayActive {
             return
         }
         guard let surface else { return }
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
+        guard forwardedPress else {
+            super.rightMouseUp(with: event)
+            return
+        }
         let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, modsFromEvent(event))
         if !consumed {
             super.rightMouseUp(with: event)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1101,7 +1101,11 @@ final class GhosttyTerminalNSView: NSView,
     }
 
     static func reachesSurfaceWhileOverlayActive(routing: LeftMousePressRouting) -> Bool {
-        routing == .forwardedToSurface
+        reachesSurfaceWhileOverlayActive(forwardedPress: routing == .forwardedToSurface)
+    }
+
+    static func reachesSurfaceWhileOverlayActive(forwardedPress: Bool) -> Bool {
+        forwardedPress
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -1172,7 +1176,7 @@ final class GhosttyTerminalNSView: NSView,
 
     private func updateLeftDragState(with event: NSEvent) {
         guard !didDragAfterLeftMouseDown, let origin = leftMouseDownWindowPoint else { return }
-        didDragAfterLeftMouseDown = DragActivation.exceedsDistance(from: origin, to: event.locationInWindow)
+        didDragAfterLeftMouseDown = DragActivation.reachesDistance(from: origin, to: event.locationInWindow)
     }
 
     override func rightMouseDragged(with event: NSEvent) {
@@ -1532,7 +1536,7 @@ final class GhosttyTerminalNSView: NSView,
     override func rightMouseUp(with event: NSEvent) {
         let forwardedPress = forwardedRightMousePress
         forwardedRightMousePress = false
-        if overlayActive {
+        if overlayActive, !Self.reachesSurfaceWhileOverlayActive(forwardedPress: forwardedPress) {
             return
         }
         guard let surface else { return }

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -16,7 +16,7 @@ struct TabAreaView: View {
     @State private var isExternalDragHovering = false
     @State private var externalDragHideTask: Task<Void, any Error>?
     @State private var isCommandDragging = false
-    @State private var isCommandDragRejected = false
+    @State private var commandDragActivation = CommandDragActivation()
 
     private static let externalDragHideDebounce: Duration = .milliseconds(80)
 
@@ -58,7 +58,7 @@ struct TabAreaView: View {
             }
         }
         .simultaneousGesture(
-            DragGesture(minimumDistance: DragActivation.distance, coordinateSpace: .named(DragCoordinateSpace.mainWindow))
+            DragGesture(minimumDistance: 0, coordinateSpace: .named(DragCoordinateSpace.mainWindow))
                 .onChanged { value in
                     handleCommandDragChanged(value)
                 }
@@ -77,7 +77,7 @@ struct TabAreaView: View {
         }
         .onDisappear {
             externalDragHideTask?.cancel()
-            isCommandDragRejected = false
+            commandDragActivation = CommandDragActivation()
             if isCommandDragging {
                 dragCoordinator.cancelDrag()
                 isCommandDragging = false
@@ -105,20 +105,14 @@ struct TabAreaView: View {
         }
     }
 
-    static func startsCommandDrag(commandHeld: Bool, isRejected: Bool) -> Bool {
-        commandHeld && !isRejected
-    }
-
     private func handleCommandDragChanged(_ value: DragGesture.Value) {
         if !isCommandDragging {
-            guard Self.startsCommandDrag(
+            guard commandDragActivation.shouldActivate(
                 commandHeld: NSEvent.modifierFlags.contains(.command),
-                isRejected: isCommandDragRejected
+                from: value.startLocation,
+                to: value.location
             )
-            else {
-                isCommandDragRejected = true
-                return
-            }
+            else { return }
             isCommandDragging = true
             onFocus()
             dragCoordinator.beginDrag(tabID: tab.id, sourceAreaID: area.id, projectID: projectID)
@@ -127,7 +121,7 @@ struct TabAreaView: View {
     }
 
     private func handleCommandDragEnded() {
-        isCommandDragRejected = false
+        commandDragActivation = CommandDragActivation()
         guard isCommandDragging else { return }
         isCommandDragging = false
         guard let result = dragCoordinator.endDrag() else { return }

--- a/Muxy/Views/Workspace/TabAreaView.swift
+++ b/Muxy/Views/Workspace/TabAreaView.swift
@@ -16,6 +16,7 @@ struct TabAreaView: View {
     @State private var isExternalDragHovering = false
     @State private var externalDragHideTask: Task<Void, any Error>?
     @State private var isCommandDragging = false
+    @State private var isCommandDragRejected = false
 
     private static let externalDragHideDebounce: Duration = .milliseconds(80)
 
@@ -57,7 +58,7 @@ struct TabAreaView: View {
             }
         }
         .simultaneousGesture(
-            DragGesture(minimumDistance: 4, coordinateSpace: .named(DragCoordinateSpace.mainWindow))
+            DragGesture(minimumDistance: DragActivation.distance, coordinateSpace: .named(DragCoordinateSpace.mainWindow))
                 .onChanged { value in
                     handleCommandDragChanged(value)
                 }
@@ -76,6 +77,7 @@ struct TabAreaView: View {
         }
         .onDisappear {
             externalDragHideTask?.cancel()
+            isCommandDragRejected = false
             if isCommandDragging {
                 dragCoordinator.cancelDrag()
                 isCommandDragging = false
@@ -103,9 +105,20 @@ struct TabAreaView: View {
         }
     }
 
+    static func startsCommandDrag(commandHeld: Bool, isRejected: Bool) -> Bool {
+        commandHeld && !isRejected
+    }
+
     private func handleCommandDragChanged(_ value: DragGesture.Value) {
         if !isCommandDragging {
-            guard NSEvent.modifierFlags.contains(.command) else { return }
+            guard Self.startsCommandDrag(
+                commandHeld: NSEvent.modifierFlags.contains(.command),
+                isRejected: isCommandDragRejected
+            )
+            else {
+                isCommandDragRejected = true
+                return
+            }
             isCommandDragging = true
             onFocus()
             dragCoordinator.beginDrag(tabID: tab.id, sourceAreaID: area.id, projectID: projectID)
@@ -114,6 +127,7 @@ struct TabAreaView: View {
     }
 
     private func handleCommandDragEnded() {
+        isCommandDragRejected = false
         guard isCommandDragging else { return }
         isCommandDragging = false
         guard let result = dragCoordinator.endDrag() else { return }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -243,8 +243,6 @@ struct PaneTabStrip: View {
         DebugButton()
     }
 
-    private static let dragActivationDistance: CGFloat = 4
-
     private func handleDragChanged(
         tab: TabSnapshot,
         globalLocation: CGPoint,
@@ -255,12 +253,10 @@ struct PaneTabStrip: View {
             onSelectTab(tab.id)
         }
 
-        let dx = globalLocation.x - dragStartGlobalLocation.x
         let dy = globalLocation.y - dragStartGlobalLocation.y
-        let distance = (dx * dx + dy * dy).squareRoot()
 
         if dragState.draggedID == nil {
-            guard distance >= Self.dragActivationDistance else { return }
+            guard DragActivation.exceedsDistance(from: dragStartGlobalLocation, to: globalLocation) else { return }
             dragState.draggedID = tab.id
             dragState.lastReorderTargetID = nil
         }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -256,7 +256,7 @@ struct PaneTabStrip: View {
         let dy = globalLocation.y - dragStartGlobalLocation.y
 
         if dragState.draggedID == nil {
-            guard DragActivation.exceedsDistance(from: dragStartGlobalLocation, to: globalLocation) else { return }
+            guard DragActivation.reachesDistance(from: dragStartGlobalLocation, to: globalLocation) else { return }
             dragState.draggedID = tab.id
             dragState.lastReorderTargetID = nil
         }

--- a/Tests/MuxyTests/Views/Terminal/TerminalMouseRoutingTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalMouseRoutingTests.swift
@@ -1,0 +1,88 @@
+import AppKit
+import Testing
+@testable import Muxy
+
+@Suite("GhosttyTerminalNSView mouse routing")
+@MainActor
+struct TerminalMouseRoutingTests {
+    @Test func plainLeftPressReachesTheSurface() {
+        #expect(GhosttyTerminalNSView.forwardsLeftMousePress(commandHeld: false))
+    }
+
+    @Test func commandLeftPressNeverReachesTheSurface() {
+        #expect(GhosttyTerminalNSView.forwardsLeftMousePress(commandHeld: true) == false)
+    }
+
+    @Test func forwardedPressAlwaysReleases() {
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .forwardedToSurface, didDrag: false))
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .forwardedToSurface, didDrag: true))
+    }
+
+    @Test func commandClickReleasesSoLinksStillOpen() {
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .commandPending, didDrag: false))
+    }
+
+    @Test func commandDragDoesNotRelease() {
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .commandPending, didDrag: true) == false)
+    }
+
+    @Test func handledCommandClickDoesNotRelease() {
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .commandHandled, didDrag: false) == false)
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .commandHandled, didDrag: true) == false)
+    }
+
+    @Test func releaseWithoutPressIsDropped() {
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .ignored, didDrag: false) == false)
+        #expect(GhosttyTerminalNSView.forwardsLeftMouseRelease(routing: .ignored, didDrag: true) == false)
+    }
+
+    @Test func overlayOnlyLetsAForwardedPressRelease() {
+        #expect(GhosttyTerminalNSView.reachesSurfaceWhileOverlayActive(routing: .forwardedToSurface))
+        #expect(GhosttyTerminalNSView.reachesSurfaceWhileOverlayActive(routing: .commandPending) == false)
+        #expect(GhosttyTerminalNSView.reachesSurfaceWhileOverlayActive(routing: .commandHandled) == false)
+        #expect(GhosttyTerminalNSView.reachesSurfaceWhileOverlayActive(routing: .ignored) == false)
+    }
+
+    @Test func rightPressNeverReachesTheSurfaceWithoutMouseReporting() {
+        #expect(GhosttyTerminalNSView.forwardsRightMouseButton(mouseCaptured: false, shiftHeld: false) == false)
+    }
+
+    @Test func rightPressReachesMouseReportingPrograms() {
+        #expect(GhosttyTerminalNSView.forwardsRightMouseButton(mouseCaptured: true, shiftHeld: false))
+    }
+
+    @Test func shiftRightClickBypassesMouseReportingPrograms() {
+        #expect(GhosttyTerminalNSView.forwardsRightMouseButton(mouseCaptured: true, shiftHeld: true) == false)
+    }
+}
+
+@Suite("Drag activation")
+struct DragActivationTests {
+    @Test func jitterWithinTheThresholdIsNotADrag() {
+        #expect(DragActivation.exceedsDistance(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 102, y: 101)) == false)
+    }
+
+    @Test func movementAtExactlyTheThresholdIsNotADrag() {
+        #expect(DragActivation.exceedsDistance(
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100 + DragActivation.distance)
+        ) == false)
+    }
+
+    @Test func movementBeyondTheThresholdIsADrag() {
+        #expect(DragActivation.exceedsDistance(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 100, y: 106)))
+    }
+}
+
+@Suite("TabAreaView command drag")
+@MainActor
+struct TabAreaCommandDragTests {
+    @Test func commandHeldAtGestureStartBeginsThePaneDrag() {
+        #expect(TabAreaView.startsCommandDrag(commandHeld: true, isRejected: false))
+    }
+
+    @Test func gestureStartedWithoutCommandNeverBecomesAPaneDrag() {
+        #expect(TabAreaView.startsCommandDrag(commandHeld: false, isRejected: false) == false)
+        #expect(TabAreaView.startsCommandDrag(commandHeld: true, isRejected: true) == false)
+    }
+}

--- a/Tests/MuxyTests/Views/Terminal/TerminalMouseRoutingTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalMouseRoutingTests.swift
@@ -43,6 +43,11 @@ struct TerminalMouseRoutingTests {
         #expect(GhosttyTerminalNSView.reachesSurfaceWhileOverlayActive(routing: .ignored) == false)
     }
 
+    @Test func overlayBalancesAForwardedRightPress() {
+        #expect(GhosttyTerminalNSView.reachesSurfaceWhileOverlayActive(forwardedPress: true))
+        #expect(GhosttyTerminalNSView.reachesSurfaceWhileOverlayActive(forwardedPress: false) == false)
+    }
+
     @Test func rightPressNeverReachesTheSurfaceWithoutMouseReporting() {
         #expect(GhosttyTerminalNSView.forwardsRightMouseButton(mouseCaptured: false, shiftHeld: false) == false)
     }
@@ -59,30 +64,74 @@ struct TerminalMouseRoutingTests {
 @Suite("Drag activation")
 struct DragActivationTests {
     @Test func jitterWithinTheThresholdIsNotADrag() {
-        #expect(DragActivation.exceedsDistance(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 102, y: 101)) == false)
+        #expect(DragActivation.reachesDistance(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 102, y: 101)) == false)
     }
 
-    @Test func movementAtExactlyTheThresholdIsNotADrag() {
-        #expect(DragActivation.exceedsDistance(
+    @Test func movementAtExactlyTheThresholdIsADrag() {
+        #expect(DragActivation.reachesDistance(
             from: CGPoint(x: 100, y: 100),
             to: CGPoint(x: 100, y: 100 + DragActivation.distance)
-        ) == false)
+        ))
     }
 
     @Test func movementBeyondTheThresholdIsADrag() {
-        #expect(DragActivation.exceedsDistance(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 100, y: 106)))
+        #expect(DragActivation.reachesDistance(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 100, y: 106)))
     }
 }
 
 @Suite("TabAreaView command drag")
-@MainActor
 struct TabAreaCommandDragTests {
-    @Test func commandHeldAtGestureStartBeginsThePaneDrag() {
-        #expect(TabAreaView.startsCommandDrag(commandHeld: true, isRejected: false))
+    @Test func commandHeldAtGestureStartActivatesAtTheThreshold() {
+        var activation = CommandDragActivation()
+
+        let activatesAtStart = activation.shouldActivate(
+            commandHeld: true,
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100)
+        )
+        let activatesAtThreshold = activation.shouldActivate(
+            commandHeld: true,
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100 + DragActivation.distance)
+        )
+
+        #expect(activatesAtStart == false)
+        #expect(activatesAtThreshold)
     }
 
-    @Test func gestureStartedWithoutCommandNeverBecomesAPaneDrag() {
-        #expect(TabAreaView.startsCommandDrag(commandHeld: false, isRejected: false) == false)
-        #expect(TabAreaView.startsCommandDrag(commandHeld: true, isRejected: true) == false)
+    @Test func commandPressedAfterGestureStartNeverActivatesThePaneDrag() {
+        var activation = CommandDragActivation()
+
+        let activatesAtStart = activation.shouldActivate(
+            commandHeld: false,
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100)
+        )
+        let activatesAfterCommandPress = activation.shouldActivate(
+            commandHeld: true,
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100 + DragActivation.distance)
+        )
+
+        #expect(activatesAtStart == false)
+        #expect(activatesAfterCommandPress == false)
+    }
+
+    @Test func commandReleasedAfterGestureStartStillActivatesThePaneDrag() {
+        var activation = CommandDragActivation()
+
+        let activatesAtStart = activation.shouldActivate(
+            commandHeld: true,
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100)
+        )
+        let activatesAfterCommandRelease = activation.shouldActivate(
+            commandHeld: false,
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100 + DragActivation.distance)
+        )
+
+        #expect(activatesAtStart == false)
+        #expect(activatesAfterCommandRelease)
     }
 }

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -121,6 +121,23 @@ upload the image and inline its remote path, because a Mac file path does not re
 upload fails, Muxy withholds Return and clears every line it has already submitted, so a partial prompt is never
 left in the TUI.
 
+## Mouse
+
+Plain left-click and drag selects terminal text. `⌘` and right-click are reserved for Muxy, and neither starts
+nor changes a text selection:
+
+| Gesture | Result |
+| --- | --- |
+| `⌘` + left-click | Opens the file path or link under the pointer |
+| `⌘` + left-drag | Moves the pane to another area or split |
+| Right-click | Opens the [right-click menu](#right-click-menu) |
+
+A `⌘` + left-drag is decided when the gesture starts, so pressing or releasing `⌘` mid-drag never switches
+between moving the pane and selecting text.
+
+Programs that enable mouse reporting keep receiving right-click. Hold `Shift` while right-clicking such a program
+to get Muxy's menu instead.
+
 ## Working directory
 
 Muxy tracks the cwd via Ghostty's shell integration (OSC 7). The directory is persisted in workspace snapshots so newly recreated tabs land in the same folder when applicable.
@@ -161,6 +178,8 @@ the control that was focused before recording and can optionally press Return af
 ## Right-click menu
 
 Inside a terminal pane: **Paste**, **Send to Background**, **Split Right**, **Split Left**, **Split Down**, **Split Up**, and **Terminal Settings…**. Terminal Settings opens Muxy's settings directly on the Terminal section. Send to Background closes an eligible local background-backed tab while leaving its processes running.
+
+Opening the menu never selects terminal text. While a program has mouse reporting enabled the right button belongs to that program, so hold `Shift` to open the menu instead.
 
 Splitting creates a child pane inside the current top-level tab. Each pane keeps its own terminal, browser, source-control, or extension surface, while a one-pixel divider replaces the old per-pane tab strip. Child panes do not appear as separate entries in the window tab strip or the Tab Focused sidebar. An agent running in a child pane does appear as its own entry in the Agents Focused sidebar, and selecting it activates both the child pane and its parent top-level tab.
 


### PR DESCRIPTION
Prevent command-click and command-drag gestures from changing terminal selections, preserve balanced mouse events, and route right-clicks correctly between Muxy and mouse-reporting programs. Add focused tests and document the updated mouse behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal mouse handling for clicks, releases, dragging, right-click menus, and text selection.
  - Improved behavior when applications capture right-click input, including Shift-based menu access.
  - Improved Command-drag behavior when moving workspace panes or tabs.
  - Standardized drag activation thresholds for more predictable gestures.

- **Documentation**
  - Added guidance on terminal mouse interactions, selection, pane dragging, link and path opening, and context menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->