### PR TITLE
Add built-in sidebar tips

### DIFF
--- a/Muxy/Models/Preferences/TipsPreferences.swift
+++ b/Muxy/Models/Preferences/TipsPreferences.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum TipsPreferences {
+    static let visibleKey = "muxy.tips.visible"
+    static let defaultVisible = true
+
+    static func isVisible(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: visibleKey) != nil else { return defaultVisible }
+        return defaults.bool(forKey: visibleKey)
+    }
+}

--- a/Muxy/Models/UI/MuxyTip.swift
+++ b/Muxy/Models/UI/MuxyTip.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct MuxyTip: Decodable, Equatable, Sendable {
+    let description: String
+
+    init(description: String) throws {
+        let normalizedDescription = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedDescription.isEmpty else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: [],
+                debugDescription: "Tip descriptions cannot be empty"
+            ))
+        }
+        self.description = normalizedDescription
+    }
+
+    init(from decoder: any Decoder) throws {
+        let fields = try decoder.container(keyedBy: FieldKey.self)
+        guard Set(fields.allKeys.map(\.stringValue)) == [CodingKeys.description.rawValue] else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "Tips must contain exactly one description field"
+            ))
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(description: container.decode(String.self, forKey: .description))
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case description
+    }
+
+    private struct FieldKey: CodingKey {
+        let stringValue: String
+        let intValue: Int?
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            intValue = nil
+        }
+
+        init?(intValue: Int) {
+            stringValue = String(intValue)
+            self.intValue = intValue
+        }
+    }
+}

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "%lld%%" = "%lld%%";
 "%lld/%lld" = "%lld/%lld";
 "%lld/%lld passing" = "%lld/%lld passing";
+"%lld of %lld" = "%lld of %lld";
 "%u" = "%u";
 "+%lld" = "+%lld";
 "/path/to/worktrees" = "/path/to/worktrees";
@@ -388,6 +389,8 @@
 "Hero" = "Hero";
 "Hidden" = "Hidden";
 "Hide" = "Hide";
+"Hide Tips" = "Hide Tips";
+"Hide Tips?" = "Hide Tips?";
 "Hide Home" = "Hide Home";
 "Hide from status bar" = "Hide from status bar";
 "Hide resource usage. Re-enable it in Settings → Interface." = "Hide resource usage. Re-enable it in Settings → Interface.";
@@ -516,6 +519,7 @@
 "Next Match" = "Next Match";
 "Next Project" = "Next Project";
 "Next Tab" = "Next Tab";
+"Next Tip" = "Next Tip";
 "No Custom Commands" = "No Custom Commands";
 "No Shortcut" = "No Shortcut";
 "No branches" = "No branches";
@@ -607,6 +611,7 @@
 "Previous Match" = "Previous Match";
 "Previous Project" = "Previous Project";
 "Previous Tab" = "Previous Tab";
+"Previous Tip" = "Previous Tip";
 "Primary worktree" = "Primary worktree";
 "Profile name" = "Profile name";
 "Profiles" = "Profiles";
@@ -782,6 +787,8 @@
 "Shortcuts" = "Shortcuts";
 "Show" = "Show";
 "Show Home" = "Show Home";
+"Show Muxy Tip" = "Show Muxy Tip";
+"Show Tips" = "Show Tips";
 "Show Resource Usage in Status Bar" = "Show Resource Usage in Status Bar";
 "Show Status Bar" = "Show Status Bar";
 "Show unread notification indicator on worktrees" = "Show unread notification indicator on worktrees";
@@ -1007,6 +1014,7 @@
 "Wrench" = "Wrench";
 "Wrench Fill" = "Wrench Fill";
 "Yellow" = "Yellow";
+"You can show tips again in Settings → Interface → Sidebar by turning on Show Tips." = "You can show tips again in Settings → Interface → Sidebar by turning on Show Tips.";
 "(none)" = "(none)";
 "Adds CLAUDE.md and AGENTS.md and bundles the muxy-extension skill" = "Adds CLAUDE.md and AGENTS.md and bundles the muxy-extension skill";
 "Adds the directory to the Muxy sidebar as a project" = "Adds the directory to the Muxy sidebar as a project";
@@ -1112,6 +1120,7 @@
 "Theme" = "Theme";
 "Theme Picker" = "Theme Picker";
 "Theme Picker (%@)" = "Theme Picker (%@)";
+"Muxy Tip" = "Muxy Tip";
 "Transparency shows the desktop through terminal panes, the top bar, and the status bar. Vibrancy controls the native macOS material intensity and is required for the effect." = "Transparency shows the desktop through terminal panes, the top bar, and the status bar. Vibrancy controls the native macOS material intensity and is required for the effect.";
 "These commands will run in the new worktree's terminal. Only enable this if you trust this repository." = "These commands will run in the new worktree's terminal. Only enable this if you trust this repository.";
 "This PR has conflicts and cannot be merged." = "This PR has conflicts and cannot be merged.";
@@ -1392,6 +1401,7 @@
 "Shows or hides the status bar." = "Shows or hides the status bar.";
 "Shows the QR code used to pair a mobile device." = "Shows the QR code used to pair a mobile device.";
 "Shows the permanent Home project at the top of the sidebar." = "Shows the permanent Home project at the top of the sidebar.";
+"Shows Muxy tips at the bottom of the built-in sidebar." = "Shows Muxy tips at the bottom of the built-in sidebar.";
 "Shows toast notifications." = "Shows toast notifications.";
 "Sidebar Vibrancy" = "Sidebar Vibrancy";
 "Sorts the worktree switcher with the active worktree first, then by most-recently-used." = "Sorts the worktree switcher with the active worktree first, then by most-recently-used.";

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -288,6 +288,7 @@
 "Description" = "Description";
 "Deselect All" = "Deselect All";
 "Desktop notifications" = "Desktop notifications";
+"Develop extensions for Muxy to add the features you want. [Read the extension docs](https://muxy.app/docs/extensions/overview)." = "Develop extensions for Muxy to add the features you want. [Read the extension docs](https://muxy.app/docs/extensions/overview).";
 "Device" = "Device";
 "Diagnostics" = "Diagnostics";
 "Disable Periodic Logging" = "Disable Periodic Logging";
@@ -726,8 +727,10 @@
 "Revoke Selected (%lld)" = "Revoke Selected (%lld)";
 "Revoking removes the device's access. It will need to request approval again to reconnect." = "Revoking removes the device's access. It will need to request approval again to reconnect.";
 "Right" = "Right";
+"Right-click inside a terminal to send its tab to the background." = "Right-click inside a terminal to send its tab to the background.";
 "Run New Terminals in the Background" = "Run New Terminals in the Background";
 "Run new terminals in the background" = "Run new terminals in the background";
+"Run terminals as background sessions to preserve them after Muxy closes. Enable this in Settings → Terminal → Background Sessions." = "Run terminals as background sessions to preserve them after Muxy closes. Enable this in Settings → Terminal → Background Sessions.";
 "Run these commands after creating the worktree" = "Run these commands after creating the worktree";
 "Runs each new terminal in a separate background process, the way tmux does. Quitting Muxy leaves those terminals running and reopening reconnects them with their recent output. Closing a tab still ends its session. Terminals that are already open keep their current behaviour." = "Runs each new terminal in a separate background process, the way tmux does. Quitting Muxy leaves those terminals running and reopening reconnects them with their recent output. Closing a tab still ends its session. Terminals that are already open keep their current behaviour.";
 "Runs new terminals in a background process so they survive quitting Muxy." = "Runs new terminals in a background process so they survive quitting Muxy.";
@@ -1011,6 +1014,7 @@
 "Wand and Stars" = "Wand and Stars";
 "Waveform" = "Waveform";
 "Waveform Path" = "Waveform Path";
+"Write an extension to replace the Muxy sidebar entirely. [Read the sidebar extension docs](https://muxy.app/docs/extensions/sidebars)." = "Write an extension to replace the Muxy sidebar entirely. [Read the sidebar extension docs](https://muxy.app/docs/extensions/sidebars).";
 "Wrench" = "Wrench";
 "Wrench Fill" = "Wrench Fill";
 "Yellow" = "Yellow";

--- a/Muxy/Resources/tips.json
+++ b/Muxy/Resources/tips.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Run terminals as background sessions to preserve them after Muxy closes. Enable this in Settings → Terminal → Background Sessions."
+  },
+  {
+    "description": "Right-click inside a terminal to send its tab to the background."
+  },
+  {
+    "description": "Write an extension to replace the Muxy sidebar entirely. [Read the sidebar extension docs](https://muxy.app/docs/extensions/sidebars)."
+  },
+  {
+    "description": "Develop extensions for Muxy to add the features you want. [Read the extension docs](https://muxy.app/docs/extensions/overview)."
+  }
+]

--- a/Muxy/Services/App/TipsStore.swift
+++ b/Muxy/Services/App/TipsStore.swift
@@ -1,0 +1,71 @@
+import Foundation
+import os
+
+private let tipsLogger = Logger(subsystem: "app.muxy", category: "TipsStore")
+
+enum TipCatalog {
+    static func decode(_ data: Data) throws -> [MuxyTip] {
+        let tips = try JSONDecoder().decode([MuxyTip].self, from: data)
+        guard !tips.isEmpty else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: [],
+                debugDescription: "Tips catalog cannot be empty"
+            ))
+        }
+        return tips
+    }
+
+    static func load(bundle: Bundle = .appResources) -> [MuxyTip] {
+        guard let url = bundle.url(forResource: "tips", withExtension: "json") else {
+            tipsLogger.error("Bundled tips.json not found")
+            return []
+        }
+        do {
+            return try decode(Data(contentsOf: url))
+        } catch {
+            tipsLogger.error("Failed to load tips.json: \(error.localizedDescription)")
+            return []
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class TipsStore {
+    static let shared = TipsStore()
+
+    let tips: [MuxyTip]
+    private(set) var currentIndex: Int
+
+    init(
+        tips: [MuxyTip] = TipCatalog.load(),
+        startingIndex: (Int) -> Int = { Int.random(in: 0 ..< $0) }
+    ) {
+        self.tips = tips
+        currentIndex = tips.isEmpty ? 0 : Self.validIndex(startingIndex(tips.count), count: tips.count)
+    }
+
+    var currentTip: MuxyTip? {
+        guard tips.indices.contains(currentIndex) else { return nil }
+        return tips[currentIndex]
+    }
+
+    var position: Int {
+        guard currentTip != nil else { return 0 }
+        return currentIndex + 1
+    }
+
+    func showNext() {
+        guard !tips.isEmpty else { return }
+        currentIndex = (currentIndex + 1) % tips.count
+    }
+
+    func showPrevious() {
+        guard !tips.isEmpty else { return }
+        currentIndex = (currentIndex - 1 + tips.count) % tips.count
+    }
+
+    private static func validIndex(_ index: Int, count: Int) -> Int {
+        min(max(index, 0), count - 1)
+    }
+}

--- a/Muxy/Views/Layouts/Shared/SidebarFooter.swift
+++ b/Muxy/Views/Layouts/Shared/SidebarFooter.swift
@@ -6,13 +6,19 @@ struct SidebarFooter: View {
 
     @State private var showThemePicker = false
     @State private var showNotifications = false
+    @State private var showTipsPopover = false
     @State private var extensionStore = ExtensionStore.shared
+    @State private var tipsStore = TipsStore.shared
+    @AppStorage(TipsPreferences.visibleKey) private var showTips = TipsPreferences.defaultVisible
 
     private var notificationStore: NotificationStore { NotificationStore.shared }
 
     var body: some View {
         VStack(spacing: 0) {
             if isWide {
+                if showTips, tipsStore.currentTip != nil {
+                    SidebarTipCard(store: tipsStore, onHide: hideTips)
+                }
                 expandedFooter
             } else {
                 collapsedFooter
@@ -23,6 +29,10 @@ struct SidebarFooter: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .toggleNotificationPanel)) { _ in
             showNotifications.toggle()
+        }
+        .onChange(of: showTips) { _, isVisible in
+            guard !isVisible else { return }
+            showTipsPopover = false
         }
     }
 
@@ -58,6 +68,9 @@ struct SidebarFooter: View {
 
     private var collapsedFooter: some View {
         VStack(spacing: UIMetrics.spacing2) {
+            if showTips, tipsStore.currentTip != nil {
+                tipsButton
+            }
             notificationsButton
             extensionsButton
             themeButton
@@ -81,6 +94,21 @@ struct SidebarFooter: View {
     private var sidebarToggleButton: some View {
         IconButton(symbol: "sidebar.left", accessibilityLabel: sidebarToggleLabel) { postToggleSidebar() }
             .help(L10n.string("\(sidebarToggleLabel) (\(KeyBindingStore.shared.combo(for: .toggleSidebar).displayString))"))
+    }
+
+    private var tipsButton: some View {
+        IconButton(symbol: "lightbulb", accessibilityLabel: L10n.string("Show Muxy Tip")) {
+            showTipsPopover.toggle()
+        }
+        .help(L10n.string("Show Muxy Tip"))
+        .popover(isPresented: $showTipsPopover) {
+            SidebarTipPopover(store: tipsStore, onHide: hideTips)
+        }
+    }
+
+    private func hideTips() {
+        showTipsPopover = false
+        showTips = false
     }
 
     private var notificationsButton: some View {

--- a/Muxy/Views/Layouts/Shared/SidebarTipView.swift
+++ b/Muxy/Views/Layouts/Shared/SidebarTipView.swift
@@ -42,7 +42,7 @@ private struct SidebarTipContent: View {
             VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
                 header
 
-                Text(attributedDescription(tip.description))
+                Text(TipDescriptionPresentation.attributedDescription(tip.description))
                     .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fg)
                     .fixedSize(horizontal: false, vertical: true)
@@ -137,11 +137,20 @@ private struct SidebarTipContent: View {
         .accessibilityLabel(label)
         .help(label)
     }
+}
 
-    private func attributedDescription(_ description: String) -> AttributedString {
-        (try? AttributedString(
-            markdown: description,
+@MainActor
+enum TipDescriptionPresentation {
+    static func attributedDescription(
+        _ description: String,
+        localization: LocalizationService = .shared
+    ) -> AttributedString {
+        let localizedDescription = localization.string(
+            LocalizedStringResource(String.LocalizationValue(description))
+        )
+        return (try? AttributedString(
+            markdown: localizedDescription,
             options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )) ?? AttributedString(description)
+        )) ?? AttributedString(localizedDescription)
     }
 }

--- a/Muxy/Views/Layouts/Shared/SidebarTipView.swift
+++ b/Muxy/Views/Layouts/Shared/SidebarTipView.swift
@@ -1,0 +1,147 @@
+import Foundation
+import SwiftUI
+
+struct SidebarTipCard: View {
+    let store: TipsStore
+    let onHide: () -> Void
+
+    var body: some View {
+        if store.currentTip != nil {
+            SidebarTipContent(store: store, onHide: onHide)
+                .padding(UIMetrics.spacing6)
+                .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusLG))
+                .overlay {
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusLG)
+                        .stroke(MuxyTheme.border, lineWidth: 1)
+                }
+                .padding(.horizontal, UIMetrics.spacing4)
+                .padding(.bottom, UIMetrics.spacing3)
+        }
+    }
+}
+
+struct SidebarTipPopover: View {
+    let store: TipsStore
+    let onHide: () -> Void
+
+    var body: some View {
+        SidebarTipContent(store: store, onHide: onHide)
+            .padding(UIMetrics.spacing7)
+            .frame(width: UIMetrics.scaled(300))
+            .background(MuxyTheme.bg)
+    }
+}
+
+private struct SidebarTipContent: View {
+    let store: TipsStore
+    let onHide: () -> Void
+    @State private var showHideConfirmation = false
+
+    var body: some View {
+        if let tip = store.currentTip {
+            VStack(alignment: .leading, spacing: UIMetrics.spacing5) {
+                header
+
+                Text(attributedDescription(tip.description))
+                    .font(.system(size: UIMetrics.fontBody))
+                    .foregroundStyle(MuxyTheme.fg)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .tint(MuxyTheme.accent)
+
+                controls
+            }
+            .accessibilityElement(children: .contain)
+            .alert(L10n.string("Hide Tips?"), isPresented: $showHideConfirmation) {
+                Button(L10n.string("Hide Tips"), role: .destructive, action: onHide)
+                    .keyboardShortcut(.defaultAction)
+                Button(L10n.string("Cancel"), role: .cancel) {}
+                    .keyboardShortcut(.cancelAction)
+            } message: {
+                Text(L10n.resource(
+                    "You can show tips again in Settings → Interface → Sidebar by turning on Show Tips."
+                ))
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: UIMetrics.spacing3) {
+            Image(systemName: "lightbulb.fill")
+                .font(.system(size: UIMetrics.iconXS, weight: .semibold))
+                .foregroundStyle(MuxyTheme.accent)
+                .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
+                .background(MuxyTheme.accentSoft, in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD))
+
+            Text(L10n.resource("Muxy Tip"))
+                .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+                .tracking(UIMetrics.scaled(0.7))
+                .foregroundStyle(MuxyTheme.accent)
+                .textCase(.uppercase)
+
+            Spacer(minLength: UIMetrics.spacing2)
+
+            Button {
+                showHideConfirmation = true
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: UIMetrics.iconXS, weight: .semibold))
+                    .foregroundStyle(MuxyTheme.fgDim)
+                    .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(L10n.string("Hide Tips"))
+            .help(L10n.string("Hide Tips"))
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: UIMetrics.spacing2) {
+            Text(L10n.resource("\(store.position) of \(store.tips.count)"))
+                .font(.system(size: UIMetrics.fontCaption).monospacedDigit())
+                .foregroundStyle(MuxyTheme.fgDim)
+
+            Spacer(minLength: UIMetrics.spacing3)
+
+            navigationButton(
+                symbol: "chevron.left",
+                label: L10n.string("Previous Tip"),
+                action: store.showPrevious
+            )
+            navigationButton(
+                symbol: "chevron.right",
+                label: L10n.string("Next Tip"),
+                action: store.showNext
+            )
+        }
+    }
+
+    private func navigationButton(
+        symbol: String,
+        label: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: UIMetrics.iconXS, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .frame(width: UIMetrics.controlMedium, height: UIMetrics.controlSmall)
+                .background(MuxyTheme.hover, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+                .overlay {
+                    RoundedRectangle(cornerRadius: UIMetrics.radiusSM)
+                        .stroke(MuxyTheme.border, lineWidth: 1)
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .help(label)
+    }
+
+    private func attributedDescription(_ description: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: description,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(description)
+    }
+}

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -113,7 +113,7 @@ struct TabFocusedSidebar: View {
             }
             .scrollIndicators(.never)
 
-            SidebarFooter()
+            SidebarFooter(isWide: isWide, sidebarExpanded: sidebarExpanded)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -22,6 +22,7 @@ struct InterfaceSettingsView: View {
     @AppStorage(SidebarCollapsedStyle.storageKey) private var sidebarCollapsedStyle = SidebarCollapsedStyle.defaultValue.rawValue
     @AppStorage(SidebarExpandedStyle.storageKey) private var sidebarExpandedStyle = SidebarExpandedStyle.defaultValue.rawValue
     @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
+    @AppStorage(TipsPreferences.visibleKey) private var showTips = TipsPreferences.defaultVisible
     @AppStorage(SidebarSelection.storageKey) private var activeSidebar = SidebarSelection.builtinValue
     @AppStorage(LocalizationSelection.storageKey)
     private var selectedLocalization = LocalizationSelection.builtinValue
@@ -193,6 +194,8 @@ struct InterfaceSettingsView: View {
             SettingsToggleRow(label: L10n.resource("Vibrancy"), isOn: sidebarVibrancyEnabled)
 
             SettingsToggleRow(label: L10n.resource("Show Home"), isOn: $showHomeProject)
+
+            SettingsToggleRow(label: L10n.resource("Show Tips"), isOn: $showTips)
 
             SettingsToggleRow(
                 label: L10n.resource("Auto-expand worktrees on project switch"),

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -183,6 +183,15 @@ enum SettingsCatalog {
             defaultValue: HomeProjectPreferences.defaultVisible
         ),
         SettingsCatalogItem(
+            key: TipsPreferences.visibleKey,
+            title: "Show Tips",
+            description: "Shows Muxy tips at the bottom of the built-in sidebar.",
+            category: .appearance,
+            section: "Sidebar",
+            defaultValue: TipsPreferences.defaultVisible,
+            aliases: ["hints", "help", "sidebar card", "lightbulb"]
+        ),
+        SettingsCatalogItem(
             key: SidebarSelection.storageKey,
             title: "Active Sidebar",
             description: "Chooses the built-in sidebar or one provided by an extension.",

--- a/Package.swift
+++ b/Package.swift
@@ -94,6 +94,7 @@ let package = Package(
                 .copy("Resources/skills"),
                 .copy("Resources/starter-kits"),
                 .copy("Resources/terminfo"),
+                .copy("Resources/tips.json"),
             ],
             linkerSettings: [
                 .unsafeFlags([

--- a/Tests/MuxyTests/Models/Preferences/TipsPreferencesTests.swift
+++ b/Tests/MuxyTests/Models/Preferences/TipsPreferencesTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TipsPreferences")
+struct TipsPreferencesTests {
+    @Test("tips are visible by default")
+    func visibleByDefault() throws {
+        let suiteName = "muxy.tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(TipsPreferences.isVisible(defaults: defaults))
+    }
+
+    @Test("stored visibility overrides the default")
+    func storedVisibility() throws {
+        let suiteName = "muxy.tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: TipsPreferences.visibleKey)
+
+        #expect(!TipsPreferences.isVisible(defaults: defaults))
+    }
+}

--- a/Tests/MuxyTests/Services/App/TipsStoreTests.swift
+++ b/Tests/MuxyTests/Services/App/TipsStoreTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TipsStore")
+@MainActor
+struct TipsStoreTests {
+    @Test("catalog decodes description-only tips")
+    func catalogDecodesDescriptions() throws {
+        let tips = try TipCatalog.decode(Data(#"[{"description":" First tip "},{"description":"Second tip"}]"#.utf8))
+
+        #expect(tips == [try MuxyTip(description: "First tip"), try MuxyTip(description: "Second tip")])
+    }
+
+    @Test("catalog rejects empty collections")
+    func catalogRejectsEmptyCollection() {
+        #expect(throws: DecodingError.self) {
+            try TipCatalog.decode(Data("[]".utf8))
+        }
+    }
+
+    @Test("catalog rejects blank descriptions")
+    func catalogRejectsBlankDescription() {
+        #expect(throws: DecodingError.self) {
+            try TipCatalog.decode(Data(#"[{"description":"   "}]"#.utf8))
+        }
+    }
+
+    @Test("catalog rejects fields other than description")
+    func catalogRejectsUnknownFields() {
+        #expect(throws: DecodingError.self) {
+            try TipCatalog.decode(Data(#"[{"description":"Tip","name":"Extra"}]"#.utf8))
+        }
+    }
+
+    @Test("bundled catalog contains only description fields")
+    func bundledCatalogSchema() throws {
+        let url = RepositoryRoot.find().appendingPathComponent("Muxy/Resources/tips.json")
+        let data = try Data(contentsOf: url)
+        let objects = try #require(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+
+        #expect(!objects.isEmpty)
+        #expect(objects.allSatisfy { Set($0.keys) == ["description"] })
+        #expect(try TipCatalog.decode(data).count == objects.count)
+    }
+
+    @Test("module resource bundle contains the tips catalog")
+    func moduleBundleContainsCatalog() {
+        #expect(!TipCatalog.load(bundle: .module).isEmpty)
+    }
+
+    @Test("starting tip is selected once during initialization")
+    func startingTipIsStable() throws {
+        var selections = 0
+        let store = TipsStore(tips: try tips()) { count in
+            selections += 1
+            #expect(count == 3)
+            return 1
+        }
+
+        #expect(store.currentTip?.description == "Second")
+        #expect(store.currentTip?.description == "Second")
+        #expect(selections == 1)
+    }
+
+    @Test("navigation wraps in catalog order")
+    func navigationWraps() throws {
+        let store = TipsStore(tips: try tips()) { _ in 0 }
+
+        store.showPrevious()
+        #expect(store.currentTip?.description == "Third")
+        #expect(store.position == 3)
+
+        store.showNext()
+        #expect(store.currentTip?.description == "First")
+        #expect(store.position == 1)
+    }
+
+    @Test("empty stores ignore navigation")
+    func emptyStoreIgnoresNavigation() {
+        let store = TipsStore(tips: []) { _ in
+            Issue.record("Empty stores must not request a starting index")
+            return 0
+        }
+
+        store.showNext()
+        store.showPrevious()
+
+        #expect(store.currentTip == nil)
+        #expect(store.position == 0)
+    }
+
+    private func tips() throws -> [MuxyTip] {
+        [
+            try MuxyTip(description: "First"),
+            try MuxyTip(description: "Second"),
+            try MuxyTip(description: "Third"),
+        ]
+    }
+}

--- a/Tests/MuxyTests/Views/Layouts/Shared/SidebarTipViewTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/SidebarTipViewTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("SidebarTipView")
+@MainActor
+struct SidebarTipViewTests {
+    @Test("tip descriptions are localized before Markdown parsing")
+    func descriptionLocalizationPreservesMarkdownLinks() throws {
+        let description = "Read [tips](https://muxy.app/docs)."
+        let fixture = try LocalizationTestSupport.makeService(
+            translations: #"""
+            "Read [tips](https://muxy.app/docs)." = "Lies [Tipps](https://muxy.app/docs).";
+            """#
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let attributedDescription = TipDescriptionPresentation.attributedDescription(
+            description,
+            localization: fixture.service
+        )
+
+        #expect(String(attributedDescription.characters) == "Lies Tipps.")
+        #expect(attributedDescription.runs.contains { $0.link == URL(string: "https://muxy.app/docs") })
+    }
+}

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -201,6 +201,17 @@ struct SettingsCatalogTests {
     }
 
     @Test
+    func tipsSettingIsRegisteredAndSearchable() {
+        let item = SettingsCatalog.items.first { $0.key == TipsPreferences.visibleKey }
+
+        #expect(item?.category == .appearance)
+        #expect(item?.section == "Sidebar")
+        #expect(item?.defaultValue as? Bool == TipsPreferences.defaultVisible)
+        #expect(SettingsCatalog.matchingItems(query: "lightbulb").contains { $0.key == TipsPreferences.visibleKey })
+        #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == TipsPreferences.visibleKey })
+    }
+
+    @Test
     func worktreePathTemplateIsRegisteredAndSearchable() {
         #expect(SettingsCatalog.jsonEditableItems.contains {
             $0.key == GeneralSettingsKeys.defaultWorktreePathTemplate

--- a/docs/features/tips.md
+++ b/docs/features/tips.md
@@ -1,0 +1,22 @@
+# Tips
+
+Muxy's built-in sidebar tips are stored in `Muxy/Resources/tips.json`. The file is bundled with the app, decoded once
+per process, and never fetched from a remote service.
+
+Each entry has exactly one field:
+
+```json
+{
+  "description": "A concise, actionable tip."
+}
+```
+
+Descriptions must contain non-whitespace text. They may contain inline Markdown links when a tip needs to reference
+Muxy documentation. Do not add names, identifiers, categories, links, display rules, or other fields. Keep the JSON
+order intentional because the previous and next buttons follow it.
+
+Muxy chooses a random starting entry once per app launch. It does not rotate tips automatically. Missing, malformed,
+empty, or invalid catalogs are logged and leave the tip interface hidden.
+
+Closing a tip asks for confirmation before hiding the interface. Tips can be restored from
+**Settings → Interface → Sidebar → Show Tips**.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -46,6 +46,16 @@ In **Appearance → Sidebar**, select **Tab Focused** or **Agents Focused** to s
 It is off by default. Turn it on to nest all worktrees under their project; turn it off to keep worktrees as top-level rows. Tab
 Focused shows top-level worktrees only when they have open tabs, while Agents Focused shows every secondary worktree.
 
+## Sidebar tips
+
+Muxy shows one tip at the bottom of the built-in sidebar. The starting tip is selected when Muxy launches and stays
+stable until you use the previous or next button. In an icon-only sidebar, select the lightbulb button to open the same
+tip in a popover.
+
+Select the close button on a tip, then confirm **Hide Tips** to hide tips. Turn on
+**Settings → Interface → Sidebar → Show Tips** to show them again. The preference is stored as `muxy.tips.visible` in
+`settings.json`. Extension-provided sidebars control their own content and do not show the built-in tip card.
+
 ## Background sessions
 
 Open **Settings → Terminal → Background sessions** to keep terminals running after Muxy quits:


### PR DESCRIPTION
Add bundled, navigable tips to the built-in sidebar with wide and collapsed layouts, persistent visibility settings, localization, validation tests, and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rotating sidebar tips with navigation, Markdown descriptions, accessibility support, and hide/show controls.
  * Added four built-in tips covering terminal sessions and extensions.
  * Added a persistent “Show Tips” setting in Sidebar preferences.
  * Tips start at a varied position and support circular navigation.
  * Added confirmation when hiding tips, with an option to restore them later.

* **Documentation**
  * Documented tip behavior, customization, storage, and restoration in the user and feature guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->