### PR TITLE
Add resizable and expandable Composer layout

### DIFF
--- a/Muxy/Models/Preferences/ComposerLayoutPreferences.swift
+++ b/Muxy/Models/Preferences/ComposerLayoutPreferences.swift
@@ -1,0 +1,67 @@
+import CoreGraphics
+import Foundation
+
+enum ComposerLayoutPreferences {
+    static let widthKey = "muxy.composer.width"
+    static let heightKey = "muxy.composer.height"
+    static let expandedKey = "muxy.composer.expanded"
+
+    static let defaultWidth: Double = 570
+    static let defaultHeight: Double = 236
+    static let defaultExpanded = false
+    static let minWidth: CGFloat = 360
+    static let minHeight: CGFloat = 180
+    static let expandedWidth: CGFloat = 880
+    static let expandedHeight: CGFloat = 620
+    static let edgeMargin: CGFloat = 20
+    static let centeredResizeGain: Double = 2
+
+    static func size(width: Double, height: Double, isExpanded: Bool, available: CGSize) -> CGSize {
+        let maximum = maximumSize(available: available)
+        guard !isExpanded else {
+            return CGSize(
+                width: min(maximum.width, expandedWidth),
+                height: min(maximum.height, expandedHeight)
+            )
+        }
+        return CGSize(
+            width: clamped(sanitized(width, fallback: defaultWidth), minimum: minWidth, maximum: maximum.width),
+            height: clamped(sanitized(height, fallback: defaultHeight), minimum: minHeight, maximum: maximum.height)
+        )
+    }
+
+    static func clampedWidth(_ width: CGFloat, available: CGSize) -> CGFloat {
+        clamped(width, minimum: minWidth, maximum: maximumSize(available: available).width)
+    }
+
+    static func clampedHeight(_ height: CGFloat, available: CGSize) -> CGFloat {
+        clamped(height, minimum: minHeight, maximum: maximumSize(available: available).height)
+    }
+
+    static func resizedLength(anchor: CGFloat, translation: CGFloat, isLeadingEdge: Bool) -> CGFloat {
+        guard anchor.isFinite, translation.isFinite else { return anchor }
+        let signed = isLeadingEdge ? -translation : translation
+        return anchor + signed * CGFloat(centeredResizeGain)
+    }
+
+    static func maximumSize(available: CGSize) -> CGSize {
+        CGSize(
+            width: maximumLength(available: available.width, fallback: CGFloat(defaultWidth)),
+            height: maximumLength(available: available.height, fallback: CGFloat(defaultHeight))
+        )
+    }
+
+    private static func maximumLength(available: CGFloat, fallback: CGFloat) -> CGFloat {
+        guard available.isFinite, available > 0 else { return fallback }
+        return max(0, available - edgeMargin * 2)
+    }
+
+    private static func sanitized(_ value: Double, fallback: Double) -> CGFloat {
+        guard value.isFinite, value > 0 else { return CGFloat(fallback) }
+        return CGFloat(value)
+    }
+
+    private static func clamped(_ value: CGFloat, minimum: CGFloat, maximum: CGFloat) -> CGFloat {
+        min(maximum, max(minimum, value))
+    }
+}

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -197,6 +197,7 @@
 "Closed" = "Closed";
 "Closed PR #%lld" = "Closed PR #%lld";
 "Closing…" = "Closing…";
+"Collapse Composer" = "Collapse Composer";
 "Collapse Worktrees" = "Collapse Worktrees";
 "Collapsed Style" = "Collapsed Style";
 "Command" = "Command";
@@ -328,6 +329,7 @@
 "English is built in. Additional languages can be provided by enabled extensions." = "English is built in. Additional languages can be provided by enabled extensions.";
 "Enter a port between %u and %u." = "Enter a port between %u and %u.";
 "Environment" = "Environment";
+"Expand Composer" = "Expand Composer";
 "Expand Worktrees" = "Expand Worktrees";
 "Expanded Style" = "Expanded Style";
 "Every background terminal in this worktree is open in a tab." = "Every background terminal in this worktree is open in a tab.";
@@ -700,6 +702,7 @@
 "Reconnect to the background terminal session" = "Reconnect to the background terminal session";
 "Reset" = "Reset";
 "Reset All" = "Reset All";
+"Reset Composer Size" = "Reset Composer Size";
 "Reset Icon Color" = "Reset Icon Color";
 "Reset Shortcut" = "Reset Shortcut";
 "Reset Tab Color" = "Reset Tab Color";

--- a/Muxy/Theme/UIMetrics.swift
+++ b/Muxy/Theme/UIMetrics.swift
@@ -57,4 +57,10 @@ enum UIMetrics {
     static func scaled(_ value: CGFloat) -> CGFloat {
         value * UIScale.shared.multiplier
     }
+
+    static func unscaled(_ value: CGFloat) -> CGFloat {
+        let multiplier = UIScale.shared.multiplier
+        guard multiplier > 0 else { return value }
+        return value / multiplier
+    }
 }

--- a/Muxy/Views/Components/Interaction/ResizeHandle.swift
+++ b/Muxy/Views/Components/Interaction/ResizeHandle.swift
@@ -17,13 +17,38 @@ struct ResizeHandle: View {
         case trailing
     }
 
+    enum Edge {
+        case leading
+        case trailing
+        case top
+        case bottom
+
+        var axis: Axis {
+            switch self {
+            case .leading,
+                 .trailing:
+                .horizontal
+            case .top,
+                 .bottom:
+                .vertical
+            }
+        }
+
+        var isLeading: Bool {
+            self == .leading || self == .top
+        }
+
+        var hitAreaBias: HitAreaBias {
+            isLeading ? .leading : .trailing
+        }
+    }
+
     let axis: Axis
     var hitAreaBias: HitAreaBias = .centered
     var onEnd: (() -> Void)?
     let onDrag: (DragGesture.Value) -> Void
     @State private var hovering = false
-    @State private var dragCursorPushed = false
-    @GestureState private var dragging = false
+    @State private var dragging = false
 
     private var active: Bool { hovering || dragging }
 
@@ -32,37 +57,15 @@ struct ResizeHandle: View {
             .fill(active ? MuxyTheme.accent : MuxyTheme.border)
             .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
             .overlay(alignment: handleAlignment) {
-                Rectangle()
-                    .fill(Color.black.opacity(0.001))
-                    .frame(
-                        width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
-                        height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
-                    )
-                    .background {
-                        ResizeCursorRegion(axis: axis) { hovering = $0 }
-                    }
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 1, coordinateSpace: .global)
-                            .updating($dragging) { _, state, _ in state = true }
-                            .onChanged { value in
-                                activateDragCursor()
-                                onDrag(value)
-                            }
-                            .onEnded { _ in
-                                onEnd?()
-                                releaseDragCursor()
-                            }
-                    )
+                ResizeDragArea(
+                    axis: axis,
+                    onHoverChange: { hovering = $0 },
+                    onDraggingChange: { dragging = $0 },
+                    onEnd: onEnd,
+                    onDrag: onDrag
+                )
             }
             .zIndex(1)
-            .onChange(of: dragging) { _, isDragging in
-                guard !isDragging else { return }
-                releaseDragCursor()
-            }
-            .onDisappear {
-                releaseDragCursor()
-            }
     }
 
     private var handleAlignment: Alignment {
@@ -74,6 +77,49 @@ struct ResizeHandle: View {
         case .trailing:
             axis == .horizontal ? .trailing : .bottom
         }
+    }
+}
+
+struct ResizeDragArea: View {
+    let axis: ResizeHandle.Axis
+    var onHoverChange: ((Bool) -> Void)?
+    var onDraggingChange: ((Bool) -> Void)?
+    var onEnd: (() -> Void)?
+    let onDrag: (DragGesture.Value) -> Void
+    @State private var dragCursorPushed = false
+    @GestureState private var dragging = false
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.black.opacity(0.001))
+            .frame(
+                width: axis == .horizontal ? UIMetrics.resizeHandleHitArea : nil,
+                height: axis == .vertical ? UIMetrics.resizeHandleHitArea : nil
+            )
+            .background {
+                ResizeCursorRegion(axis: axis) { onHoverChange?($0) }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 1, coordinateSpace: .global)
+                    .updating($dragging) { _, state, _ in state = true }
+                    .onChanged { value in
+                        activateDragCursor()
+                        onDrag(value)
+                    }
+                    .onEnded { _ in
+                        onEnd?()
+                        releaseDragCursor()
+                    }
+            )
+            .onChange(of: dragging) { _, isDragging in
+                onDraggingChange?(isDragging)
+                guard !isDragging else { return }
+                releaseDragCursor()
+            }
+            .onDisappear {
+                releaseDragCursor()
+            }
     }
 
     private func activateDragCursor() {
@@ -185,26 +231,8 @@ struct AnchoredResizeHandle<Anchor>: View {
 }
 
 struct PanelResizeHandle: View {
-    enum Edge {
-        case leading
-        case trailing
-        case top
-        case bottom
-
-        var hitAreaBias: ResizeHandle.HitAreaBias {
-            switch self {
-            case .leading,
-                 .top:
-                .leading
-            case .trailing,
-                 .bottom:
-                .trailing
-            }
-        }
-    }
-
     let axis: ResizeHandle.Axis
-    var edge: Edge = .leading
+    var edge: ResizeHandle.Edge = .leading
     let current: () -> CGFloat
     let apply: (CGFloat) -> Void
 
@@ -214,8 +242,7 @@ struct PanelResizeHandle: View {
             hitAreaBias: edge.hitAreaBias,
             captureAnchor: current,
             onTranslate: { start, delta in
-                let signed = (edge == .leading || edge == .top) ? -delta : delta
-                apply(start + signed)
+                apply(start + (edge.isLeading ? -delta : delta))
             }
         )
         .accessibilityHidden(true)

--- a/Muxy/Views/Composer/ComposerResizeEdge.swift
+++ b/Muxy/Views/Composer/ComposerResizeEdge.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct ComposerResizeEdge: View {
+    let edge: ResizeHandle.Edge
+    let captureAnchor: () -> CGFloat
+    let apply: (CGFloat) -> Void
+
+    @State private var anchor: CGFloat?
+    @State private var hovering = false
+    @State private var dragging = false
+
+    var body: some View {
+        ResizeDragArea(
+            axis: edge.axis,
+            onHoverChange: { hovering = $0 },
+            onDraggingChange: { dragging = $0 },
+            onEnd: { anchor = nil },
+            onDrag: resize
+        )
+        .overlay(grip.allowsHitTesting(false))
+        .accessibilityHidden(true)
+    }
+
+    private var isActive: Bool {
+        hovering || dragging
+    }
+
+    private var grip: some View {
+        Capsule()
+            .fill(MuxyTheme.fgMuted)
+            .frame(
+                width: edge.axis == .horizontal ? UIMetrics.scaled(3) : UIMetrics.scaled(28),
+                height: edge.axis == .horizontal ? UIMetrics.scaled(28) : UIMetrics.scaled(3)
+            )
+            .opacity(isActive ? 0.8 : 0)
+            .animation(.easeOut(duration: 0.12), value: isActive)
+    }
+
+    private func resize(_ value: DragGesture.Value) {
+        let start = anchor ?? captureAnchor()
+        anchor = start
+        let translation = edge.axis == .horizontal ? value.translation.width : value.translation.height
+        apply(ComposerLayoutPreferences.resizedLength(
+            anchor: start,
+            translation: UIMetrics.unscaled(translation),
+            isLeadingEdge: edge.isLeading
+        ))
+    }
+}

--- a/Muxy/Views/Composer/FocusedComposerView.swift
+++ b/Muxy/Views/Composer/FocusedComposerView.swift
@@ -9,12 +9,16 @@ struct FocusedComposerView: View {
     let projectName: String
     let worktreeName: String
     let languageIdentifier: String
+    let availableSize: CGSize
     @Binding var broadcasts: Bool
     let onSubmit: (_ appendReturn: Bool, _ selectedText: String?) -> Void
     let onClose: () -> Void
 
     @State private var editorSettings = EditorSettings.shared
     @AppStorage(RichInputPreferences.fontSizeKey) private var fontSize = RichInputPreferences.defaultFontSize
+    @AppStorage(ComposerLayoutPreferences.widthKey) private var storedWidth = ComposerLayoutPreferences.defaultWidth
+    @AppStorage(ComposerLayoutPreferences.heightKey) private var storedHeight = ComposerLayoutPreferences.defaultHeight
+    @AppStorage(ComposerLayoutPreferences.expandedKey) private var isExpanded = ComposerLayoutPreferences.defaultExpanded
     @State private var insertion: RichInputTextEditor.Insertion?
     @State private var submission: RichInputTextEditor.Submission?
 
@@ -34,6 +38,8 @@ struct FocusedComposerView: View {
                         .fill(MuxyTheme.surface)
                 }
         }
+        .overlay(resizeEdges)
+        .frame(width: UIMetrics.scaled(layoutSize.width), height: UIMetrics.scaled(layoutSize.height))
         .shadow(color: .black.opacity(0.45), radius: UIMetrics.scaled(36), y: UIMetrics.scaled(18))
         .onDrop(of: [UTType.fileURL, UTType.image], isTargeted: nil, perform: handleDrop)
         .onChange(of: state.text) { persistDraft() }
@@ -56,6 +62,18 @@ struct FocusedComposerView: View {
                 .font(.system(size: UIMetrics.fontCaption))
                 .foregroundStyle(MuxyTheme.fgDim)
             Spacer(minLength: UIMetrics.spacing3)
+            Button(action: toggleExpanded) {
+                Image(systemName: isExpanded
+                    ? "arrow.down.right.and.arrow.up.left"
+                    : "arrow.up.left.and.arrow.down.right"
+                )
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(MuxyTheme.fgDim)
+            .accessibilityLabel(expandLabel)
+            .help(expandLabel)
             Button(action: onClose) {
                 Image(systemName: "xmark")
                     .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
@@ -66,6 +84,36 @@ struct FocusedComposerView: View {
             .accessibilityLabel(L10n.string("Close Composer"))
         }
         .frame(height: UIMetrics.scaled(22))
+    }
+
+    private var expandLabel: String {
+        isExpanded ? L10n.string("Collapse Composer") : L10n.string("Expand Composer")
+    }
+
+    private var resizeEdges: some View {
+        ZStack {
+            HStack(spacing: 0) {
+                widthEdge(.leading)
+                Spacer(minLength: 0)
+                widthEdge(.trailing)
+            }
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                ComposerResizeEdge(
+                    edge: .bottom,
+                    captureAnchor: { layoutSize.height },
+                    apply: applyHeight
+                )
+            }
+        }
+    }
+
+    private func widthEdge(_ edge: ResizeHandle.Edge) -> some View {
+        ComposerResizeEdge(
+            edge: edge,
+            captureAnchor: { layoutSize.width },
+            apply: applyWidth
+        )
     }
 
     private var editor: some View {
@@ -80,7 +128,7 @@ struct FocusedComposerView: View {
             callbacks: editorCallbacks
         )
         .padding(.bottom, voice.showsFeedback ? UIMetrics.scaled(30) : 0)
-        .frame(height: UIMetrics.scaled(146))
+        .frame(maxHeight: .infinity)
         .background(MuxyTheme.bg.opacity(0.001))
         .overlay(alignment: .topLeading) {
             if state.text.isEmpty {
@@ -204,6 +252,8 @@ struct FocusedComposerView: View {
                     requestSubmission(appendReturn: false)
                 }
                 .disabled(!voice.canSubmit)
+                Divider()
+                Button(L10n.string("Reset Composer Size"), action: resetSize)
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
@@ -268,6 +318,54 @@ struct FocusedComposerView: View {
             },
             onPasteFileURL: addAttachment
         )
+    }
+
+    private var layoutSize: CGSize {
+        ComposerLayoutPreferences.size(
+            width: storedWidth,
+            height: storedHeight,
+            isExpanded: isExpanded,
+            available: logicalAvailableSize
+        )
+    }
+
+    private var logicalAvailableSize: CGSize {
+        CGSize(
+            width: UIMetrics.unscaled(availableSize.width),
+            height: UIMetrics.unscaled(availableSize.height)
+        )
+    }
+
+    private func applyWidth(_ width: CGFloat) {
+        detachFromExpanded()
+        storedWidth = Double(ComposerLayoutPreferences.clampedWidth(width, available: logicalAvailableSize))
+    }
+
+    private func applyHeight(_ height: CGFloat) {
+        detachFromExpanded()
+        storedHeight = Double(ComposerLayoutPreferences.clampedHeight(height, available: logicalAvailableSize))
+    }
+
+    private func detachFromExpanded() {
+        guard isExpanded else { return }
+        let current = layoutSize
+        storedWidth = Double(current.width)
+        storedHeight = Double(current.height)
+        isExpanded = false
+    }
+
+    private func toggleExpanded() {
+        withAnimation(.easeOut(duration: 0.14)) {
+            isExpanded.toggle()
+        }
+    }
+
+    private func resetSize() {
+        withAnimation(.easeOut(duration: 0.14)) {
+            isExpanded = ComposerLayoutPreferences.defaultExpanded
+            storedWidth = ComposerLayoutPreferences.defaultWidth
+            storedHeight = ComposerLayoutPreferences.defaultHeight
+        }
     }
 
     private var clampedFontSize: CGFloat {

--- a/Muxy/Views/MainWindow+Panels.swift
+++ b/Muxy/Views/MainWindow+Panels.swift
@@ -47,7 +47,7 @@ struct PanelFrame: ViewModifier {
         }
     }
 
-    private func handle(axis: ResizeHandle.Axis, edge: PanelResizeHandle.Edge) -> some View {
+    private func handle(axis: ResizeHandle.Axis, edge: ResizeHandle.Edge) -> some View {
         PanelResizeHandle(
             axis: axis,
             edge: edge,

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -831,6 +831,7 @@ struct MainWindow: View {
                         projectName: project.localizedDisplayName,
                         worktreeName: worktree.branch ?? worktree.name,
                         languageIdentifier: recordingLanguage,
+                        availableSize: geometry.size,
                         broadcasts: $richInputBroadcast,
                         onSubmit: { appendReturn, selectedText in
                             submitRichInput(state, appendReturn: appendReturn, selectedText: selectedText)
@@ -838,7 +839,6 @@ struct MainWindow: View {
                         },
                         onClose: closeComposer
                     )
-                    .frame(width: min(UIMetrics.scaled(570), max(0, geometry.size.width - UIMetrics.spacing8 * 2)))
                     .transition(.opacity.combined(with: .scale(scale: 0.98)))
                 }
             }
@@ -1673,7 +1673,7 @@ struct MainWindow: View {
 
     private func panelResize<V: BinaryFloatingPoint>(
         axis: ResizeHandle.Axis,
-        edge: PanelResizeHandle.Edge,
+        edge: ResizeHandle.Edge,
         value: Binding<V>,
         range: ClosedRange<CGFloat>
     ) -> some View {

--- a/Tests/MuxyTests/Models/Preferences/ComposerLayoutPreferencesTests.swift
+++ b/Tests/MuxyTests/Models/Preferences/ComposerLayoutPreferencesTests.swift
@@ -1,0 +1,183 @@
+import CoreGraphics
+import Testing
+
+@testable import Muxy
+
+@Suite("Composer layout preferences")
+struct ComposerLayoutPreferencesTests {
+    private let window = CGSize(width: 1400, height: 900)
+
+    @Test("stored size is used when it fits the window")
+    func usesStoredSize() {
+        let size = ComposerLayoutPreferences.size(
+            width: 800,
+            height: 500,
+            isExpanded: false,
+            available: window
+        )
+
+        #expect(size == CGSize(width: 800, height: 500))
+    }
+
+    @Test("size falls back to defaults for unusable stored values")
+    func fallsBackToDefaults() {
+        let size = ComposerLayoutPreferences.size(
+            width: 0,
+            height: .nan,
+            isExpanded: false,
+            available: window
+        )
+
+        #expect(size.width == CGFloat(ComposerLayoutPreferences.defaultWidth))
+        #expect(size.height == CGFloat(ComposerLayoutPreferences.defaultHeight))
+    }
+
+    @Test("size never drops below the minimums")
+    func clampsToMinimums() {
+        let size = ComposerLayoutPreferences.size(
+            width: 10,
+            height: 10,
+            isExpanded: false,
+            available: window
+        )
+
+        #expect(size.width == ComposerLayoutPreferences.minWidth)
+        #expect(size.height == ComposerLayoutPreferences.minHeight)
+    }
+
+    @Test("size is clamped to the window without changing the stored preference")
+    func clampsToAvailableSpace() {
+        let available = CGSize(width: 600, height: 400)
+        let margin = ComposerLayoutPreferences.edgeMargin * 2
+
+        let size = ComposerLayoutPreferences.size(
+            width: 5000,
+            height: 5000,
+            isExpanded: false,
+            available: available
+        )
+
+        #expect(size == CGSize(width: available.width - margin, height: available.height - margin))
+    }
+
+    @Test("a window smaller than the minimum wins over the minimum")
+    func availableSpaceWinsOverMinimums() {
+        let available = CGSize(width: 200, height: 120)
+
+        let size = ComposerLayoutPreferences.size(
+            width: ComposerLayoutPreferences.defaultWidth,
+            height: ComposerLayoutPreferences.defaultHeight,
+            isExpanded: false,
+            available: available
+        )
+
+        #expect(size.width < ComposerLayoutPreferences.minWidth)
+        #expect(size.height < ComposerLayoutPreferences.minHeight)
+        #expect(size.width == available.width - ComposerLayoutPreferences.edgeMargin * 2)
+    }
+
+    @Test("expanded size stops at the readable preset on a large window")
+    func expandedStopsAtThePreset() {
+        let size = ComposerLayoutPreferences.size(
+            width: ComposerLayoutPreferences.defaultWidth,
+            height: ComposerLayoutPreferences.defaultHeight,
+            isExpanded: true,
+            available: window
+        )
+
+        #expect(size == CGSize(
+            width: ComposerLayoutPreferences.expandedWidth,
+            height: ComposerLayoutPreferences.expandedHeight
+        ))
+        #expect(size.width < window.width)
+        #expect(size.height < window.height)
+    }
+
+    @Test("expanded size still fits a window smaller than the preset")
+    func expandedFitsSmallWindow() {
+        let available = CGSize(width: 600, height: 400)
+        let margin = ComposerLayoutPreferences.edgeMargin * 2
+
+        let size = ComposerLayoutPreferences.size(
+            width: ComposerLayoutPreferences.defaultWidth,
+            height: ComposerLayoutPreferences.defaultHeight,
+            isExpanded: true,
+            available: available
+        )
+
+        #expect(size == CGSize(width: available.width - margin, height: available.height - margin))
+    }
+
+    @Test("expanded size is larger than the default size")
+    func expandedIsLargerThanDefault() {
+        #expect(ComposerLayoutPreferences.expandedWidth > CGFloat(ComposerLayoutPreferences.defaultWidth))
+        #expect(ComposerLayoutPreferences.expandedHeight > CGFloat(ComposerLayoutPreferences.defaultHeight))
+    }
+
+    @Test("an unusable window falls back to a finite size")
+    func handlesUnusableWindow() {
+        let size = ComposerLayoutPreferences.size(
+            width: 5000,
+            height: 5000,
+            isExpanded: true,
+            available: CGSize(width: 0, height: CGFloat.nan)
+        )
+
+        #expect(size.width == CGFloat(ComposerLayoutPreferences.defaultWidth))
+        #expect(size.height == CGFloat(ComposerLayoutPreferences.defaultHeight))
+    }
+
+    @Test("dragging a trailing edge grows the centered box at twice the translation")
+    func trailingEdgeGrowsSymmetrically() {
+        let length = ComposerLayoutPreferences.resizedLength(
+            anchor: 400,
+            translation: 50,
+            isLeadingEdge: false
+        )
+
+        #expect(length == 500)
+    }
+
+    @Test("dragging a leading edge outward grows the centered box")
+    func leadingEdgeGrowsOutward() {
+        let length = ComposerLayoutPreferences.resizedLength(
+            anchor: 400,
+            translation: -50,
+            isLeadingEdge: true
+        )
+
+        #expect(length == 500)
+    }
+
+    @Test("dragging a leading edge inward shrinks the centered box")
+    func leadingEdgeShrinksInward() {
+        let length = ComposerLayoutPreferences.resizedLength(
+            anchor: 400,
+            translation: 50,
+            isLeadingEdge: true
+        )
+
+        #expect(length == 300)
+    }
+
+    @Test("an unusable translation keeps the anchor")
+    func ignoresUnusableTranslation() {
+        let length = ComposerLayoutPreferences.resizedLength(
+            anchor: 400,
+            translation: .nan,
+            isLeadingEdge: false
+        )
+
+        #expect(length == 400)
+    }
+
+    @Test("dragged lengths are clamped to the window and the minimums")
+    func clampsDraggedLengths() {
+        let available = CGSize(width: 700, height: 500)
+
+        #expect(ComposerLayoutPreferences.clampedWidth(50, available: available) == ComposerLayoutPreferences.minWidth)
+        #expect(ComposerLayoutPreferences.clampedHeight(50, available: available) == ComposerLayoutPreferences.minHeight)
+        #expect(ComposerLayoutPreferences.clampedWidth(5000, available: available) == 660)
+        #expect(ComposerLayoutPreferences.clampedHeight(5000, available: available) == 460)
+    }
+}

--- a/Tests/MuxyTests/Views/Components/Interaction/ResizeHandleTests.swift
+++ b/Tests/MuxyTests/Views/Components/Interaction/ResizeHandleTests.swift
@@ -21,9 +21,22 @@ struct ResizeHandleTests {
 
     @Test("panel resize hit areas stay inside their panel edge")
     func panelResizeHitAreasStayInsidePanelEdge() {
-        #expect(PanelResizeHandle.Edge.leading.hitAreaBias == .leading)
-        #expect(PanelResizeHandle.Edge.trailing.hitAreaBias == .trailing)
-        #expect(PanelResizeHandle.Edge.top.hitAreaBias == .leading)
-        #expect(PanelResizeHandle.Edge.bottom.hitAreaBias == .trailing)
+        #expect(ResizeHandle.Edge.leading.hitAreaBias == .leading)
+        #expect(ResizeHandle.Edge.trailing.hitAreaBias == .trailing)
+        #expect(ResizeHandle.Edge.top.hitAreaBias == .leading)
+        #expect(ResizeHandle.Edge.bottom.hitAreaBias == .trailing)
+    }
+
+    @Test("each resize edge drives its own axis and direction")
+    func resizeEdgesDriveTheirAxisAndDirection() {
+        #expect(ResizeHandle.Edge.leading.axis == .horizontal)
+        #expect(ResizeHandle.Edge.trailing.axis == .horizontal)
+        #expect(ResizeHandle.Edge.top.axis == .vertical)
+        #expect(ResizeHandle.Edge.bottom.axis == .vertical)
+
+        #expect(ResizeHandle.Edge.leading.isLeading)
+        #expect(ResizeHandle.Edge.top.isLeading)
+        #expect(!ResizeHandle.Edge.trailing.isLeading)
+        #expect(!ResizeHandle.Edge.bottom.isLeading)
     }
 }

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -164,6 +164,17 @@ already open. Stop Composer dictation to insert the transcript at the editor cur
 recording, then edit or send it normally. Composer dictation requires an installed on-device speech language plus
 microphone and speech recognition access.
 
+Long prompts can use a larger Composer. Drag its left, right, or bottom edge to resize it; because the Composer
+stays centered, a dragged edge grows the box symmetrically and follows the pointer. The expand button in the
+Composer header switches to a large preset instead, which is capped so it stays readable on big displays and
+shrinks to fit smaller windows; dragging an edge is what grows the Composer beyond that preset, and pressing the
+button again restores the size you dragged. Both the size and
+the expanded state are remembered across Composer sessions and app restarts, are stored independently of the UI
+Scale preset, and are always clamped to the current window, so a smaller window shrinks the Composer without
+losing your size. **Reset Composer Size** in the Composer's More menu returns it to the default size. The text
+editor takes whatever room the box has left, so attachments and the dictation status line reduce it while they
+are visible. `Cmd+=` and `Cmd+-` still change the Composer font size rather than the box.
+
 Each Composer submission is serialized with later keyboard input for its target terminal. Text, image paths, and
 the optional Return are submitted as one transaction, including when a Composer message is broadcast to several
 panes. Broadcast targets are processed one at a time, and each unique image attachment is normalized once into


### PR DESCRIPTION
Add persistent Composer sizing with draggable edges, an expandable preset, and a reset action. Reuse shared resize interactions, clamp dimensions to the available window across UI scales, and add localization, documentation, and layout tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resize the Composer by dragging any edge, with smooth hover and drag feedback.
  * Expand, collapse, or reset the Composer size from its controls and actions menu.
  * Composer dimensions and expanded state are now preserved between sessions.
  * The editor adapts to available window space and prevents unusable sizes.
  * Added localized labels for Composer resize actions.

* **Documentation**
  * Documented Composer resizing, expansion, persistence, and reset options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->