### PR TITLE
feat: add CLI commands for settings import and export

### DIFF
--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -47,6 +47,7 @@
 COMMAND="$1"
 SOCKET="${MUXY_SOCKET_PATH:-$HOME/Library/Application Support/Muxy/muxy.sock}"
 NC_TIMEOUT="${MUXY_CLI_TIMEOUT:-10}"
+BACKUP_TIMEOUT="${MUXY_BACKUP_TIMEOUT:-610}"
 
 usage_for() {
     case "$1" in
@@ -103,8 +104,8 @@ wants_help() {
 resolve_path() {
     case "$1" in
         /*) printf '%s\n' "$1" ;;
-        ~) printf '%s\n' "$HOME" ;;
-        ~/*) printf '%s\n' "$HOME/${1#\~/}" ;;
+        '~') printf '%s\n' "$HOME" ;;
+        '~'/*) printf '%s\n' "$HOME/${1#\~/}" ;;
         *)
             local dir
             dir=$(cd "$(dirname "$1")" 2>/dev/null && pwd) || {
@@ -699,12 +700,12 @@ case "$COMMAND" in
             export)
                 [ $# -eq 1 ] || die_usage config
                 CONFIG_PATH=$(resolve_path "$1") || exit 1
-                send_command "config-export|$CONFIG_PATH"
+                send_command "config-export|$CONFIG_PATH" "$BACKUP_TIMEOUT"
                 ;;
             import)
                 [ $# -eq 1 ] || die_usage config
                 CONFIG_PATH=$(resolve_path "$1") || exit 1
-                send_command "config-import|$CONFIG_PATH"
+                send_command "config-import|$CONFIG_PATH" "$BACKUP_TIMEOUT"
                 ;;
             *)
                 die_usage config

--- a/Muxy/Resources/scripts/muxy-cli
+++ b/Muxy/Resources/scripts/muxy-cli
@@ -74,6 +74,7 @@ usage_for() {
         create-project)    echo "muxy create-project <path> [--create] [--name <name>] [--workspace <workspace>]" ;;
         attach-project)    echo "muxy attach-project <project> --workspace <workspace>" ;;
         detach-project)    echo "muxy detach-project <project>" ;;
+        config)            echo "muxy config <export|import> <path>" ;;
         list-tabs)         echo "muxy list-tabs [--project <p>] [--worktree <w>]" ;;
         switch-tab)        echo "muxy switch-tab <index|id|title> [--project <p>] [--worktree <w>]" ;;
         new-tab)           echo "muxy new-tab [--project <p>] [--worktree <w>]" ;;
@@ -97,6 +98,22 @@ print_command_help() {
 
 wants_help() {
     [ "$1" = "-h" ] || [ "$1" = "--help" ]
+}
+
+resolve_path() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        ~) printf '%s\n' "$HOME" ;;
+        ~/*) printf '%s\n' "$HOME/${1#\~/}" ;;
+        *)
+            local dir
+            dir=$(cd "$(dirname "$1")" 2>/dev/null && pwd) || {
+                echo "Error: no such directory: $(dirname "$1")" >&2
+                exit 1
+            }
+            printf '%s/%s\n' "$dir" "$(basename "$1")"
+            ;;
+    esac
 }
 
 usage() {
@@ -126,6 +143,8 @@ usage() {
     echo "  muxy create-project <path> [--create]    Create or attach a project"
     echo "  muxy attach-project <project> --workspace <workspace>  Move a project into a workspace"
     echo "  muxy detach-project <project>            Remove a project from all workspaces"
+    echo "  muxy config export <path>                Export a full Muxy backup"
+    echo "  muxy config import <path>                Import a full Muxy backup and restart"
     echo "  muxy list-tabs                           List tabs"
     echo "  muxy switch-tab <index|id|title>         Switch active tab"
     echo "  muxy new-tab                             Create a terminal tab"
@@ -670,6 +689,28 @@ case "$COMMAND" in
             die_usage detach-project
         fi
         send_command "detach-project|$(b64_field "$*")"
+        ;;
+    config)
+        shift
+        wants_help "$1" && print_command_help config
+        SUB="${1:-}"
+        shift || true
+        case "$SUB" in
+            export)
+                [ $# -eq 1 ] || die_usage config
+                CONFIG_PATH=$(resolve_path "$1") || exit 1
+                send_command "config-export|$CONFIG_PATH"
+                ;;
+            import)
+                [ $# -eq 1 ] || die_usage config
+                CONFIG_PATH=$(resolve_path "$1") || exit 1
+                send_command "config-import|$CONFIG_PATH"
+                ;;
+            *)
+                die_usage config
+                ;;
+        esac
+        exit 0
         ;;
     list-tabs)
         shift

--- a/Muxy/Resources/skills/muxy-cli/SKILL.md
+++ b/Muxy/Resources/skills/muxy-cli/SKILL.md
@@ -233,7 +233,7 @@ muxy config export ~/Backups/muxy.muxy
 muxy config import ~/Backups/muxy.muxy
 ```
 
-`config export` writes a full Muxy backup (settings, projects, worktrees, workspaces, key bindings, shortcuts, and Ghostty config) with secrets such as SSH keys and paired devices stripped. `config import` replaces current Muxy data, creates a pre-import backup first, applies the imported settings, and restarts Muxy. Paths resolve relative to the calling shell's working directory. For extensions, both commands require the `files.read` and `files.write` permissions.
+`config export` writes a full Muxy backup (settings, projects, worktrees, workspaces, key bindings, shortcuts, and Ghostty config) with secrets such as SSH keys and paired devices stripped. `config import` replaces current Muxy data, creates a pre-import backup first, applies the imported settings, and restarts Muxy. Paths resolve relative to the calling shell's working directory. Backup commands wait up to 610 seconds by default; set `MUXY_BACKUP_TIMEOUT` to override the timeout.
 
 ## Install the skills into your AI harnesses
 

--- a/Muxy/Resources/skills/muxy-cli/SKILL.md
+++ b/Muxy/Resources/skills/muxy-cli/SKILL.md
@@ -226,6 +226,15 @@ muxy browser list --worktree feature/login
 
 Run `browser open` with no URL to open the configured home page (blank by default). Capture the tab ID from `browser open` (or `browser list`) and reuse it; never guess it. After navigating, give the page a moment to load (`wait-for`, `wait-for-navigation`, or a `wait` condition) before reading. Cookies are shared by all tabs on the same profile. If the built-in browser is disabled in Settings, browser actions return an error and `browser list` returns no tabs.
 
+## Backup configuration
+
+```bash
+muxy config export ~/Backups/muxy.muxy
+muxy config import ~/Backups/muxy.muxy
+```
+
+`config export` writes a full Muxy backup (settings, projects, worktrees, workspaces, key bindings, shortcuts, and Ghostty config) with secrets such as SSH keys and paired devices stripped. `config import` replaces current Muxy data, creates a pre-import backup first, applies the imported settings, and restarts Muxy. Paths resolve relative to the calling shell's working directory. For extensions, both commands require the `files.read` and `files.write` permissions.
+
 ## Install the skills into your AI harnesses
 
 `muxy install-skills` installs the Muxy agent skills (`muxy-cli` and `muxy-extension`) into every AI coding harness it detects on the machine — Claude Code, Codex, Cursor, Droid, Grok, OpenCode, and others — using each tool's own skill location. It wraps `npx skills add` with `--global` (all your projects) and `--yes` (non-interactive), and forwards any extra arguments, so you can scope it like `muxy install-skills -a codex`. Run it once so future sessions of those harnesses pick the skills up automatically; it needs `npx` (Node.js) on `PATH` and does not require Muxy to be running.

--- a/Muxy/Services/Backup/BackupService.swift
+++ b/Muxy/Services/Backup/BackupService.swift
@@ -3,7 +3,36 @@ import os
 
 private let logger = Logger(subsystem: "app.muxy", category: "BackupService")
 
+private actor BackupOperationLock {
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func withLock<T: Sendable>(_ operation: @MainActor @Sendable () async throws -> T) async rethrows -> T {
+        await acquire()
+        defer { release() }
+        return try await operation()
+    }
+
+    private func acquire() async {
+        guard isLocked else {
+            isLocked = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    private func release() {
+        guard !waiters.isEmpty else {
+            isLocked = false
+            return
+        }
+        waiters.removeFirst().resume()
+    }
+}
+
 struct BackupService {
+    private static let operationLock = BackupOperationLock()
+
     let baseDirectory: URL
 
     init(baseDirectory: URL = MuxyFileStorage.appSupportDirectory()) {
@@ -46,18 +75,30 @@ struct BackupService {
 
     @MainActor
     func exportCurrent(to archiveURL: URL, createdAt: Date = Date()) async throws {
-        SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
-        try await export(to: archiveURL, appVersion: currentAppVersion, createdAt: createdAt)
+        try await BackupService.operationLock.withLock {
+            switch SettingsJSONStore.syncUserSettingsFileWithCurrentSettings() {
+            case .updated,
+                 .unchanged:
+                break
+            case .failed:
+                throw SettingsJSONError.syncFailed
+            }
+            try await export(to: archiveURL, appVersion: currentAppVersion, createdAt: createdAt)
+        }
     }
 
     @MainActor
     func importAndApply(from archiveURL: URL) async throws {
-        let backupDirectory = try await importBackup(from: archiveURL, backupStamp: backupStamp())
-        do {
-            try SettingsJSONStore.applyUserSettingsFile()
-        } catch {
-            try await restoreFromPreImport(backupDirectory: backupDirectory)
-            throw error
+        try await BackupService.operationLock.withLock {
+            let backupDirectory = try await importBackup(from: archiveURL, backupStamp: backupStamp())
+            do {
+                try SettingsJSONStore.applyUserSettingsFile(
+                    from: baseDirectory.appendingPathComponent(SettingsCatalog.userSettingsFilename)
+                )
+            } catch {
+                try await restoreFromPreImport(backupDirectory: backupDirectory)
+                throw error
+            }
         }
     }
 
@@ -182,12 +223,12 @@ struct BackupService {
         let fileManager = FileManager.default
 
         for name in BackupArchive.exportableFiles + BackupArchive.exportableDirectories {
-            let source = backupDirectory.appendingPathComponent(name)
-            guard fileManager.fileExists(atPath: source.path) else { continue }
             let destination = baseDirectory.appendingPathComponent(name)
             if fileManager.fileExists(atPath: destination.path) {
                 try fileManager.removeItem(at: destination)
             }
+            let source = backupDirectory.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
             try fileManager.copyItem(at: source, to: destination)
         }
     }

--- a/Muxy/Services/Backup/BackupService.swift
+++ b/Muxy/Services/Backup/BackupService.swift
@@ -44,6 +44,29 @@ struct BackupService {
         }
     }
 
+    @MainActor
+    func exportCurrent(to archiveURL: URL, createdAt: Date = Date()) async throws {
+        SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
+        try await export(to: archiveURL, appVersion: currentAppVersion, createdAt: createdAt)
+    }
+
+    @MainActor
+    func importAndApply(from archiveURL: URL) async throws {
+        let backupDirectory = try await importBackup(from: archiveURL, backupStamp: backupStamp())
+        do {
+            try SettingsJSONStore.applyUserSettingsFile()
+        } catch {
+            try await restoreFromPreImport(backupDirectory: backupDirectory)
+            throw error
+        }
+    }
+
+    private func restoreFromPreImport(backupDirectory: URL) async throws {
+        try await GitProcessRunner.offMainThrowing {
+            try restoreCurrentData(from: backupDirectory)
+        }
+    }
+
     @discardableResult
     private func performImport(from archiveURL: URL, backupStamp: String) throws -> URL {
         let staging = try makeTemporaryDirectory()
@@ -213,5 +236,16 @@ struct BackupService {
             .appendingPathComponent("muxy-backup-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    private var currentAppVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    }
+
+    private func backupStamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: Date())
     }
 }

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -11,6 +11,12 @@ enum SettingsJSONStore {
     typealias AutomaticUpdatesUpdater = @MainActor (Bool) -> Void
     typealias AutomaticUpdatesResetter = @MainActor () -> Void
 
+    enum SyncResult: Equatable {
+        case updated
+        case unchanged
+        case failed
+    }
+
     private struct AutomaticUpdatesActions {
         let update: AutomaticUpdatesUpdater
         let reset: AutomaticUpdatesResetter
@@ -86,8 +92,8 @@ enum SettingsJSONStore {
         syncUserSettingsFileWithCurrentSettings()
     }
 
-    static func applyUserSettingsFile() throws {
-        let text = try String(contentsOf: userSettingsURL, encoding: .utf8)
+    static func applyUserSettingsFile(from fileURL: URL = userSettingsURL) throws {
+        let text = try String(contentsOf: fileURL, encoding: .utf8)
         try saveUserSettingsText(text)
     }
 
@@ -127,8 +133,8 @@ enum SettingsJSONStore {
     }
 
     @discardableResult
-    static func syncUserSettingsFileWithCurrentSettings() -> Bool {
-        guard !isApplyingSettings, !isSyncingFile else { return false }
+    static func syncUserSettingsFileWithCurrentSettings() -> SyncResult {
+        guard !isApplyingSettings, !isSyncingFile else { return .failed }
         isSyncingFile = true
         defer { isSyncingFile = false }
         var dictionary = existingUserSettingsDictionary()
@@ -137,15 +143,15 @@ enum SettingsJSONStore {
         }
         let data = Data(prettyJSONString(dictionary).utf8)
         if (try? Data(contentsOf: userSettingsURL)) == data {
-            return false
+            return .unchanged
         }
         do {
             try data.write(to: userSettingsURL, options: .atomic)
             try FileManager.default.setAttributes([.posixPermissions: FilePermissions.privateFile], ofItemAtPath: userSettingsURL.path)
-            return true
+            return .updated
         } catch {
             settingsJSONLogger.error("Failed to sync user settings file: \(error.localizedDescription)")
-            return false
+            return .failed
         }
     }
 
@@ -648,6 +654,7 @@ enum SettingsJSONError: LocalizedError {
     case topLevelObjectRequired
     case unsupportedValue(String)
     case invalidValue(String)
+    case syncFailed
 
     var errorDescription: String? {
         switch self {
@@ -657,6 +664,8 @@ enum SettingsJSONError: LocalizedError {
             "Unsupported JSON value for \"\(key)\"."
         case let .invalidValue(key):
             "Invalid JSON value for \"\(key)\"."
+        case .syncFailed:
+            "Failed to synchronize user settings file with current settings."
         }
     }
 }

--- a/Muxy/Services/Socket/SocketCommandHandler.swift
+++ b/Muxy/Services/Socket/SocketCommandHandler.swift
@@ -16,6 +16,12 @@ enum SocketCommandHandler {
             return "error:empty command"
         }
 
+        if clientContext.extensionID != nil,
+           cmd == "config-export" || cmd == "config-import"
+        {
+            return "error:config backup commands are unavailable to extensions"
+        }
+
         if let extensionID = clientContext.extensionID {
             for required in requiredPermissions(command: cmd, parts: parts)
                 where !ExtensionStore.shared.extensionHasPermission(id: extensionID, permission: required)
@@ -1061,9 +1067,6 @@ enum SocketCommandHandler {
     }
 
     static func requiredPermissions(command: String, parts: [String]) -> [ExtensionPermission] {
-        if command == "config-export" || command == "config-import" {
-            return [.filesRead, .filesWrite]
-        }
         if command.hasPrefix("browser."), parts.count >= 2 {
             let args = decodeJSONObject(parts[1]) ?? [:]
             return MuxyAPI.Permissions.required(for: command, args: args).map { [$0] } ?? []

--- a/Muxy/Services/Socket/SocketCommandHandler.swift
+++ b/Muxy/Services/Socket/SocketCommandHandler.swift
@@ -25,6 +25,23 @@ enum SocketCommandHandler {
         }
 
         switch cmd {
+        case "config-export":
+            guard let archiveURL = backupURL(from: parts) else { return "error:usage config-export|path" }
+            do {
+                try await BackupService().exportCurrent(to: archiveURL)
+                return "ok"
+            } catch {
+                return "error:\(error.localizedDescription)"
+            }
+        case "config-import":
+            guard let archiveURL = backupURL(from: parts) else { return "error:usage config-import|path" }
+            do {
+                try await BackupService().importAndApply(from: archiveURL)
+                try AppRelaunch.relaunch()
+                return "ok"
+            } catch {
+                return "error:\(error.localizedDescription)"
+            }
         case "split-right":
             return handleSplit(
                 direction: .horizontal,
@@ -967,6 +984,13 @@ enum SocketCommandHandler {
         return trimmed
     }
 
+    private static func backupURL(from parts: [String]) -> URL? {
+        guard parts.count >= 2 else { return nil }
+        let path = parts.dropFirst().joined(separator: "|")
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+    }
+
     @MainActor
     private static func handleSplit(
         direction: SplitDirection,
@@ -1037,6 +1061,9 @@ enum SocketCommandHandler {
     }
 
     static func requiredPermissions(command: String, parts: [String]) -> [ExtensionPermission] {
+        if command == "config-export" || command == "config-import" {
+            return [.filesRead, .filesWrite]
+        }
         if command.hasPrefix("browser."), parts.count >= 2 {
             let args = decodeJSONObject(parts[1]) ?? [:]
             return MuxyAPI.Permissions.required(for: command, args: args).map { [$0] } ?? []

--- a/Muxy/Views/Settings/BackupSettingsView.swift
+++ b/Muxy/Views/Settings/BackupSettingsView.swift
@@ -99,11 +99,9 @@ struct BackupSettingsView: View {
 
         errorMessage = nil
         isWorking = true
-        let version = appVersion
-        SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
         Task {
             do {
-                try await BackupService().export(to: url, appVersion: version, createdAt: Date())
+                try await BackupService().exportCurrent(to: url)
                 ToastState.shared.show(title: L10n.string("Export complete"), body: url.lastPathComponent)
             } catch {
                 errorMessage = error.localizedDescription
@@ -132,11 +130,9 @@ struct BackupSettingsView: View {
         guard let url = pendingImportURL else { return }
         pendingImportURL = nil
         isWorking = true
-        let stamp = backupStamp()
         Task {
             do {
-                try await BackupService().importBackup(from: url, backupStamp: stamp)
-                try SettingsJSONStore.applyUserSettingsFile()
+                try await BackupService().importAndApply(from: url)
                 isWorking = false
                 try AppRelaunch.relaunch()
             } catch {
@@ -152,16 +148,6 @@ struct BackupSettingsView: View {
             .filter { !$0.isEmpty }
             .joined(separator: "-")
         return "Muxy-Backup-\(sanitizedHost).\(BackupArchive.fileExtension)"
-    }
-
-    private func backupStamp() -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
-        return formatter.string(from: Date())
-    }
-
-    private var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
     }
 }
 

--- a/Tests/MuxyTests/Services/Backup/BackupServiceTests.swift
+++ b/Tests/MuxyTests/Services/Backup/BackupServiceTests.swift
@@ -178,6 +178,40 @@ struct BackupServiceTests {
         #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("settings.json").path))
     }
 
+    @Test("import and apply installs a valid settings file into the target")
+    func appliesValidImportedSettings() async throws {
+        let statusBarValue = UserDefaults.standard.object(forKey: "muxy.showStatusBar")
+        defer {
+            if let statusBarValue {
+                UserDefaults.standard.set(statusBarValue, forKey: "muxy.showStatusBar")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "muxy.showStatusBar")
+            }
+        }
+        try await withSettingsFileSnapshot {
+            let target = tempDirectory()
+            try write(Data(#"{"muxy.showStatusBar":true}"#.utf8), named: "settings.json", in: target)
+
+            let staging = tempDirectory()
+            try write(Data(#"{"muxy.showStatusBar":false}"#.utf8), named: "settings.json", in: staging)
+            let manifest = BackupManifest(
+                schemaVersion: BackupManifest.currentSchemaVersion,
+                appVersion: "1.0",
+                createdAt: Date(),
+                files: ["settings.json"]
+            )
+            try JSONEncoder.iso8601.encode(manifest).write(to: staging.appendingPathComponent(BackupManifest.filename))
+            let archive = tempDirectory().appendingPathComponent("valid.muxy")
+            try BackupArchive.zip(directory: staging, to: archive)
+
+            try await BackupService(baseDirectory: target).importAndApply(from: archive)
+
+            let data = try Data(contentsOf: target.appendingPathComponent("settings.json"))
+            let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            #expect(object?["muxy.showStatusBar"] as? Bool == false)
+        }
+    }
+
     @Test("import leaves active data in place when backup preparation fails")
     func leavesActiveDataWhenBackupPreparationFails() async throws {
         let source = try seedSource()

--- a/Tests/MuxyTests/Services/Backup/BackupServiceTests.swift
+++ b/Tests/MuxyTests/Services/Backup/BackupServiceTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Muxy
 
-@Suite("BackupService")
+@Suite("BackupService", .serialized)
 struct BackupServiceTests {
     private func tempDirectory() -> URL {
         let dir = FileManager.default.temporaryDirectory
@@ -14,6 +14,20 @@ struct BackupServiceTests {
 
     private func write(_ data: Data, named name: String, in directory: URL) throws {
         try data.write(to: directory.appendingPathComponent(name), options: .atomic)
+    }
+
+    private func withSettingsFileSnapshot(_ body: () async throws -> Void) async throws {
+        let url = await SettingsJSONStore.userSettingsURL
+        let snapshot = try? Data(contentsOf: url)
+        let existed = FileManager.default.fileExists(atPath: url.path)
+        defer {
+            if existed, let snapshot {
+                try? snapshot.write(to: url, options: .atomic)
+            } else if !existed {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+        try await body()
     }
 
     private func seedSource() throws -> URL {
@@ -97,6 +111,32 @@ struct BackupServiceTests {
         #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("approved-devices.json").path))
     }
 
+    @Test("export proceeds when the settings file is already in sync")
+    func exportProceedsWhenSettingsUnchanged() async throws {
+        try await withSettingsFileSnapshot {
+            await SettingsJSONStore.syncUserSettingsFileWithCurrentSettings()
+            let archive = tempDirectory().appendingPathComponent("backup.muxy")
+            try await BackupService(baseDirectory: tempDirectory()).exportCurrent(to: archive)
+            #expect(FileManager.default.fileExists(atPath: archive.path))
+        }
+    }
+
+    @Test("concurrent exportCurrent calls complete without interfering")
+    func concurrentExportsComplete() async throws {
+        try await withSettingsFileSnapshot {
+            let service = BackupService(baseDirectory: tempDirectory())
+            let first = tempDirectory().appendingPathComponent("first.muxy")
+            let second = tempDirectory().appendingPathComponent("second.muxy")
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { try await service.exportCurrent(to: first) }
+                group.addTask { try await service.exportCurrent(to: second) }
+                try await group.waitForAll()
+            }
+            #expect(FileManager.default.fileExists(atPath: first.path))
+            #expect(FileManager.default.fileExists(atPath: second.path))
+        }
+    }
+
     @Test("import backs up existing data before replacing")
     func backsUpExistingData() async throws {
         let source = try seedSource()
@@ -109,6 +149,33 @@ struct BackupServiceTests {
 
         let preserved = backupDirectory.appendingPathComponent("projects.json")
         #expect(try Data(contentsOf: preserved) == Data(#"["old"]"#.utf8))
+    }
+
+    @Test("failed settings application restores pre-import data and removes introduced files")
+    func failedApplyRestoresPreImportState() async throws {
+        let target = tempDirectory()
+        try write(Data(#"["old"]"#.utf8), named: "projects.json", in: target)
+
+        let staging = tempDirectory()
+        try write(Data("[]".utf8), named: "settings.json", in: staging)
+        try write(Data("[]".utf8), named: "remote-devices.json", in: staging)
+        let manifest = BackupManifest(
+            schemaVersion: BackupManifest.currentSchemaVersion,
+            appVersion: "1.0",
+            createdAt: Date(),
+            files: ["settings.json", "remote-devices.json"]
+        )
+        try JSONEncoder.iso8601.encode(manifest).write(to: staging.appendingPathComponent(BackupManifest.filename))
+        let archive = tempDirectory().appendingPathComponent("broken.muxy")
+        try BackupArchive.zip(directory: staging, to: archive)
+
+        await #expect(throws: SettingsJSONError.self) {
+            try await BackupService(baseDirectory: target).importAndApply(from: archive)
+        }
+
+        #expect(try Data(contentsOf: target.appendingPathComponent("projects.json")) == Data(#"["old"]"#.utf8))
+        #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("remote-devices.json").path))
+        #expect(!FileManager.default.fileExists(atPath: target.appendingPathComponent("settings.json").path))
     }
 
     @Test("import leaves active data in place when backup preparation fails")

--- a/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyURLOpenTests.swift
@@ -116,6 +116,62 @@ struct MuxyCLILaunchResourceTests {
         #expect(!accessor.contains("copyItem"))
     }
 
+    @Test("config commands expand a quoted home path and use the backup timeout", arguments: ["export", "import"])
+    func configCommandsExpandQuotedHomePathAndUseBackupTimeout(operation: String) throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-cli-config-\(UUID().uuidString)", isDirectory: true)
+        let home = directory.appendingPathComponent("home", isDirectory: true)
+        let bin = directory.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let argumentsURL = directory.appendingPathComponent("nc-arguments")
+        let inputURL = directory.appendingPathComponent("nc-input")
+        let socketURL = directory.appendingPathComponent("muxy.sock")
+        try Data().write(to: socketURL)
+
+        let netcatURL = bin.appendingPathComponent("nc")
+        try #"""
+        #!/bin/bash
+        printf '%s' "$*" > "$MUXY_TEST_NC_ARGUMENTS"
+        cat > "$MUXY_TEST_NC_INPUT"
+        printf 'ok\0'
+        """#.write(to: netcatURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: netcatURL.path)
+
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            Self.repositoryRoot.appendingPathComponent("Muxy/Resources/scripts/muxy-cli").path,
+            "config",
+            operation,
+            "~/My Backups/muxy.muxy",
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = home.path
+        environment["MUXY_SOCKET_PATH"] = socketURL.path
+        environment["MUXY_TEST_NC_ARGUMENTS"] = argumentsURL.path
+        environment["MUXY_TEST_NC_INPUT"] = inputURL.path
+        environment["PATH"] = "\(bin.path):/usr/bin:/bin"
+        environment.removeValue(forKey: "MUXY_BACKUP_TIMEOUT")
+        process.environment = environment
+        process.standardOutput = output
+        process.standardError = output
+
+        try process.run()
+        process.waitUntilExit()
+
+        let processOutput = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let netcatArguments = try String(contentsOf: argumentsURL, encoding: .utf8)
+        let netcatInput = try String(contentsOf: inputURL, encoding: .utf8)
+
+        #expect(process.terminationStatus == 0, Comment(rawValue: processOutput))
+        #expect(netcatArguments == "-w 610 -U \(socketURL.path)")
+        #expect(netcatInput == "config-\(operation)|\(home.path)/My Backups/muxy.muxy\n")
+    }
+
     @Test("app bundle prohibits multiple running instances")
     func appProhibitsMultipleInstances() throws {
         let plistData = try Data(

--- a/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
@@ -898,8 +898,8 @@ struct SettingsJSONStoreTests {
 
         try Data("{}".utf8).write(to: SettingsJSONStore.userSettingsURL, options: .atomic)
 
-        #expect(SettingsJSONStore.syncUserSettingsFileWithCurrentSettings())
-        #expect(!SettingsJSONStore.syncUserSettingsFileWithCurrentSettings())
+        #expect(SettingsJSONStore.syncUserSettingsFileWithCurrentSettings() == .updated)
+        #expect(SettingsJSONStore.syncUserSettingsFileWithCurrentSettings() == .unchanged)
     }
 }
 

--- a/Tests/MuxyTests/Services/Socket/NotificationSocketAcceptLoopTests.swift
+++ b/Tests/MuxyTests/Services/Socket/NotificationSocketAcceptLoopTests.swift
@@ -47,7 +47,7 @@ struct NotificationSocketAcceptLoopTests {
         return String(decoding: payload, as: UTF8.self)
     }
 
-    private static func readCommandReply(_ fd: Int32, deadline: TimeInterval = 5) throws -> Data {
+    private static func readCommandReply(_ fd: Int32, deadline: TimeInterval = 60) throws -> Data {
         var collected = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
         let end = Date().addingTimeInterval(deadline)

--- a/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
@@ -15,6 +15,42 @@ struct SocketCommandHandlerTests {
         #expect(result.hasPrefix("error:"))
     }
 
+    @Test("config-export requires a destination path")
+    func exportConfigRequiresPath() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("config-export", appState: appState)
+        #expect(result == "error:usage config-export|path")
+    }
+
+    @Test("config-import requires a source path")
+    func importConfigRequiresPath() async {
+        let appState = makeAppState()
+        let result = await SocketCommandHandler.handleRequest("config-import", appState: appState)
+        #expect(result == "error:usage config-import|path")
+    }
+
+    @Test("config-import rejects an invalid archive")
+    func importConfigRejectsInvalidArchive() async throws {
+        let appState = makeAppState()
+        let archive = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-invalid-\(UUID().uuidString).muxy")
+        try Data("invalid".utf8).write(to: archive)
+        defer { try? FileManager.default.removeItem(at: archive) }
+
+        let result = await SocketCommandHandler.handleRequest(
+            "config-import|\(archive.path)",
+            appState: appState
+        )
+
+        #expect(result.hasPrefix("error:"))
+    }
+
+    @Test("config backup commands require file permissions for extensions")
+    func configBackupRequiresFilePermissions() {
+        #expect(SocketCommandHandler.requiredPermissions(command: "config-export", parts: ["config-export", "/tmp/backup.muxy"]) == [.filesRead, .filesWrite])
+        #expect(SocketCommandHandler.requiredPermissions(command: "config-import", parts: ["config-import", "/tmp/backup.muxy"]) == [.filesRead, .filesWrite])
+    }
+
     @Test("split-right returns new pane ID")
     func splitReturnsNewPaneID() async {
         let appState = makeAppState()

--- a/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
+++ b/Tests/MuxyTests/Services/Socket/SocketCommandHandlerTests.swift
@@ -45,10 +45,24 @@ struct SocketCommandHandlerTests {
         #expect(result.hasPrefix("error:"))
     }
 
-    @Test("config backup commands require file permissions for extensions")
-    func configBackupRequiresFilePermissions() {
-        #expect(SocketCommandHandler.requiredPermissions(command: "config-export", parts: ["config-export", "/tmp/backup.muxy"]) == [.filesRead, .filesWrite])
-        #expect(SocketCommandHandler.requiredPermissions(command: "config-import", parts: ["config-import", "/tmp/backup.muxy"]) == [.filesRead, .filesWrite])
+    @Test("config backup commands reject extension clients")
+    func configBackupRejectsExtensionClients() async {
+        let appState = makeAppState()
+        let context = NotificationSocketServer.ClientContext(extensionID: "test.extension")
+
+        let exportResult = await SocketCommandHandler.handleRequest(
+            "config-export|/tmp/backup.muxy",
+            appState: appState,
+            clientContext: context
+        )
+        let importResult = await SocketCommandHandler.handleRequest(
+            "config-import|/tmp/backup.muxy",
+            appState: appState,
+            clientContext: context
+        )
+
+        #expect(exportResult == "error:config backup commands are unavailable to extensions")
+        #expect(importResult == "error:config backup commands are unavailable to extensions")
     }
 
     @Test("split-right returns new pane ID")

--- a/docs/features/muxy-cli.md
+++ b/docs/features/muxy-cli.md
@@ -22,6 +22,22 @@ Run `muxy <command> --help` (or `-h`) to see the options for a single command:
 muxy create-worktree --help
 ```
 
+## Backup Muxy configuration
+
+Export the full Muxy backup used by the Settings UI:
+
+```bash
+muxy config export ~/Backups/muxy.muxy
+```
+
+Import a backup:
+
+```bash
+muxy config import ~/Backups/muxy.muxy
+```
+
+Import replaces current Muxy data, creates the existing pre-import backup, and restarts Muxy after the restore completes.
+
 ## Open a project
 
 Open the current folder:

--- a/docs/features/muxy-cli.md
+++ b/docs/features/muxy-cli.md
@@ -38,6 +38,8 @@ muxy config import ~/Backups/muxy.muxy
 
 Import replaces current Muxy data, creates the existing pre-import backup, and restarts Muxy after the restore completes.
 
+Backup commands wait up to 610 seconds by default. Set `MUXY_BACKUP_TIMEOUT` to override the timeout for unusually large backups.
+
 ## Open a project
 
 Open the current folder:


### PR DESCRIPTION
## Summary

Adds `muxy config export <path>` and `muxy config import <path>` CLI commands, exposing the existing backup/restore flow to the CLI so this operations can be scriptable.

## Changes

<!-- List the key changes -->

- Socket handler cases for both commands with extension permission mapping (filesRead + filesWrite)
- Shared BackupService.exportCurrent / importAndApply
- import rolls back to the pre-import backup if settings-apply fails
- Timestamp helper pinned to en_US_POSIX so non-Gregorian calendars can't corrupt backup dir names
- Tests: usage errors, invalid archive rejection, permission mapping

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## Screenshots

No UI changes. CLI only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to export and import complete Muxy configuration backups.
  * Added support for absolute, home-relative, and relative backup paths.
  * Importing creates a safety backup, replaces current configuration, and restarts Muxy.
  * Added equivalent backup operations through supported integrations.
  * Added a configurable backup timeout, defaulting to 610 seconds.

* **Bug Fixes**
  * Failed imports now restore the previous configuration automatically.
  * Backup operations are serialized to improve reliability during concurrent requests.
  * Invalid paths and command arguments now return clear errors.

* **Documentation**
  * Documented backup contents, secret handling, permissions, path handling, timeout configuration, and import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->