### PR TITLE
Add persistent project search setting

### DIFF
--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -79,6 +79,7 @@
 "Allow %@?" = "Allow %@?";
 "Allow & remember" = "Allow & remember";
 "Allow mobile device connections" = "Allow mobile device connections";
+"Always Show Project Search" = "Always Show Project Search";
 "Automatic updates are unavailable for this configuration." = "Automatic updates are unavailable for this configuration.";
 "Anonymous crash reports help us fix bugs. Reports never include project paths, file contents, or personal data." = "Anonymous crash reports help us fix bugs. Reports never include project paths, file contents, or personal data.";
 "App" = "App";
@@ -172,6 +173,7 @@
 "Clear All" = "Clear All";
 "Clear Data" = "Clear Data";
 "Clear data for “%@”?" = "Clear data for “%@”?";
+"Clear project search" = "Clear project search";
 "Cleared browsing data for “%@”" = "Cleared browsing data for “%@”";
 "Click again to close now. Otherwise it will close automatically after five seconds." = "Click again to close now. Otherwise it will close automatically after five seconds.";
 "Click again to merge now. Otherwise it will merge automatically after five seconds." = "Click again to merge now. Otherwise it will merge automatically after five seconds.";
@@ -1406,6 +1408,7 @@
 "Shows a macOS notification when Muxy is not frontmost." = "Shows a macOS notification when Muxy is not frontmost.";
 "Shows app and subprocess CPU and memory usage in the status bar. Disabling it stops the sampling." = "Shows app and subprocess CPU and memory usage in the status bar. Disabling it stops the sampling.";
 "Shows or hides the status bar." = "Shows or hides the status bar.";
+"Shows the project search field whenever the project-focused sidebar is expanded." = "Shows the project search field whenever the project-focused sidebar is expanded.";
 "Shows the QR code used to pair a mobile device." = "Shows the QR code used to pair a mobile device.";
 "Shows the permanent Home project at the top of the sidebar." = "Shows the permanent Home project at the top of the sidebar.";
 "Shows Muxy tips at the bottom of the built-in sidebar." = "Shows Muxy tips at the bottom of the built-in sidebar.";

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
@@ -29,6 +29,65 @@ enum ProjectListSearch {
     }
 }
 
+struct ProjectSearchField: View {
+    @Binding var text: String
+    let isEnabled: Bool
+    let isWide: Bool
+
+    var body: some View {
+        Group {
+            if isEnabled, isWide {
+                searchField
+                    .padding(.horizontal, UIMetrics.spacing3)
+            }
+        }
+        .onChange(of: isEnabled) { _, isEnabled in
+            guard !isEnabled else { return }
+            text = ""
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: UIMetrics.spacing2) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: UIMetrics.fontFootnote))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .accessibilityHidden(true)
+
+            TextField(L10n.string("Search projects"), text: $text)
+                .textFieldStyle(.plain)
+                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+                .accessibilityLabel(L10n.string("Search projects"))
+
+            if !text.isEmpty {
+                Button {
+                    clear()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: UIMetrics.fontFootnote))
+                        .foregroundStyle(MuxyTheme.fgMuted)
+                        .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(L10n.string("Clear project search"))
+                .help(L10n.string("Clear project search"))
+            }
+        }
+        .padding(.horizontal, UIMetrics.spacing4)
+        .frame(height: UIMetrics.controlMedium)
+        .background(
+            MuxyTheme.surface,
+            in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
+        )
+    }
+
+    func clear() {
+        text = ""
+    }
+}
+
 @MainActor
 enum SidebarLayout {
     static var collapsedWidth: CGFloat { UIMetrics.sidebarCollapsedWidth }
@@ -95,7 +154,6 @@ struct ProjectFocusedSidebar: View {
     @State private var isExternalDropTargeted = false
     @State private var projectPendingRemoval: Project?
     @State private var projectSearchText = ""
-    @FocusState private var isProjectSearchFocused: Bool
     let expanded: Bool
     let expandedCustomWidth: CGFloat
     @AppStorage(SidebarCollapsedStyle.storageKey) private var collapsedStyleRaw = SidebarCollapsedStyle.defaultValue.rawValue
@@ -218,19 +276,6 @@ struct ProjectFocusedSidebar: View {
         .help(L10n.string("Sort Projects: \(L10n.string(key: sortMode.title))"))
     }
 
-    private var projectSearchToggle: some View {
-        Button(action: toggleProjectSearch) {
-            SidebarHeaderIconButtonLabel(
-                systemName: isProjectSearchVisible ? "xmark" : "magnifyingglass",
-                accessibilityLabel: isProjectSearchVisible
-                    ? L10n.string("Close Project Search")
-                    : L10n.string("Search Projects")
-            )
-        }
-        .buttonStyle(.plain)
-        .help(isProjectSearchVisible ? L10n.string("Close Project Search") : L10n.string("Search Projects"))
-    }
-
     private var remoteProjectMenu: some View {
         Menu {
             let devices = remoteDeviceStore.sshDevices()
@@ -348,7 +393,6 @@ struct ProjectFocusedSidebar: View {
                 if showSortMenu {
                     sortMenu
                 }
-                projectSearchToggle
             }
         } else {
             WorkspaceSwitcher(isWide: isWide)
@@ -365,53 +409,14 @@ struct ProjectFocusedSidebar: View {
                 .padding(.horizontal, isWide ? UIMetrics.spacing3 : UIMetrics.spacing4)
                 .padding(.top, UIMetrics.spacing2)
 
-            if isWide, isProjectSearchVisible {
-                projectSearchField
-                    .padding(.horizontal, UIMetrics.spacing3)
-            }
+            ProjectSearchField(
+                text: $projectSearchText,
+                isEnabled: isProjectSearchVisible,
+                isWide: isWide
+            )
 
             scrollableProjects
         }
-    }
-
-    private var projectSearchField: some View {
-        HStack(spacing: UIMetrics.spacing2) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: UIMetrics.fontFootnote))
-                .foregroundStyle(MuxyTheme.fgMuted)
-                .accessibilityHidden(true)
-
-            TextField(L10n.string("Search projects"), text: $projectSearchText)
-                .textFieldStyle(.plain)
-                .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
-                .foregroundStyle(MuxyTheme.fg)
-                .focused($isProjectSearchFocused)
-                .onExitCommand(perform: hideProjectSearch)
-                .accessibilityLabel(L10n.string("Search projects"))
-        }
-        .padding(.horizontal, UIMetrics.spacing4)
-        .frame(height: UIMetrics.controlMedium)
-        .background(
-            MuxyTheme.surface,
-            in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
-        )
-    }
-
-    private func toggleProjectSearch() {
-        guard isProjectSearchVisible else {
-            isProjectSearchVisible = true
-            DispatchQueue.main.async {
-                isProjectSearchFocused = true
-            }
-            return
-        }
-        hideProjectSearch()
-    }
-
-    private func hideProjectSearch() {
-        projectSearchText = ""
-        isProjectSearchFocused = false
-        isProjectSearchVisible = false
     }
 
     private var scrollableProjects: some View {

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -32,6 +32,8 @@ struct InterfaceSettingsView: View {
     private var orderWorktreesByMRU = WorktreeListPreferences.defaultOrderByMRU
     @AppStorage(WorktreeListPreferences.groupWorktreesKey)
     private var groupWorktrees = WorktreeListPreferences.defaultGroupWorktrees
+    @AppStorage(ProjectSearchPreferences.visibleKey)
+    private var showProjectSearch = ProjectSearchPreferences.defaultVisible
 
     private var layoutSelection: Binding<AppLayout> {
         Binding(get: { layoutStore.layout }, set: { layoutStore.set($0) })
@@ -203,6 +205,11 @@ struct InterfaceSettingsView: View {
             )
 
             if isProjectFocused {
+                SettingsToggleRow(
+                    label: L10n.resource("Always Show Project Search"),
+                    isOn: $showProjectSearch
+                )
+
                 SettingsRow("Collapsed Style") {
                     Picker("", selection: $sidebarCollapsedStyle) {
                         ForEach(SidebarCollapsedStyle.allCases) { style in

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -192,6 +192,15 @@ enum SettingsCatalog {
             aliases: ["hints", "help", "sidebar card", "lightbulb"]
         ),
         SettingsCatalogItem(
+            key: ProjectSearchPreferences.visibleKey,
+            title: "Always Show Project Search",
+            description: "Shows the project search field whenever the project-focused sidebar is expanded.",
+            category: .appearance,
+            section: "Sidebar",
+            defaultValue: ProjectSearchPreferences.defaultVisible,
+            aliases: ["find projects", "search bar", "search box"]
+        ),
+        SettingsCatalogItem(
             key: SidebarSelection.storageKey,
             title: "Active Sidebar",
             description: "Chooses the built-in sidebar or one provided by an extension.",

--- a/Tests/MuxyTests/Views/Layouts/ProjectFocused/ProjectListSearchTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/ProjectFocused/ProjectListSearchTests.swift
@@ -66,8 +66,8 @@ struct ProjectListSearchTests {
         #expect(ProjectListSearch.activeQuery("Alpha", isVisible: true, isWide: false).isEmpty)
     }
 
-    @Test("search field is hidden by default")
-    func searchFieldIsHiddenByDefault() {
+    @Test("always show search is disabled by default")
+    func alwaysShowSearchIsDisabledByDefault() {
         #expect(!ProjectSearchPreferences.defaultVisible)
     }
 

--- a/Tests/MuxyTests/Views/Layouts/ProjectFocused/ProjectSearchFieldTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/ProjectFocused/ProjectSearchFieldTests.swift
@@ -1,0 +1,125 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("ProjectSearchField")
+struct ProjectSearchFieldTests {
+    @Test("renders only when enabled in a wide sidebar")
+    func rendersOnlyWhenEnabledAndWide() {
+        #expect(textField(in: hostingView(isEnabled: true, isWide: true)) != nil)
+        #expect(textField(in: hostingView(isEnabled: false, isWide: true)) == nil)
+        #expect(textField(in: hostingView(isEnabled: true, isWide: false)) == nil)
+    }
+
+    @Test("clear action clears text")
+    func clearActionClearsText() {
+        let model = ProjectSearchFieldTestModel(text: "Muxy", isEnabled: true, isWide: true)
+        let field = ProjectSearchField(
+            text: Binding(
+                get: { model.text },
+                set: { model.text = $0 }
+            ),
+            isEnabled: true,
+            isWide: true
+        )
+
+        field.clear()
+
+        #expect(model.text.isEmpty)
+    }
+
+    @Test("disabling search clears the query")
+    func disablingSearchClearsQuery() async throws {
+        let model = ProjectSearchFieldTestModel(text: "Muxy", isEnabled: true, isWide: true)
+        let hostingView = hostingView(model: model)
+
+        model.isEnabled = false
+
+        try await waitUntil {
+            hostingView.layoutSubtreeIfNeeded()
+            return model.text.isEmpty && self.textField(in: hostingView) == nil
+        }
+    }
+
+    @Test("collapsing the sidebar preserves the query")
+    func collapsingSidebarPreservesQuery() async throws {
+        let model = ProjectSearchFieldTestModel(text: "Muxy", isEnabled: true, isWide: true)
+        let hostingView = hostingView(model: model)
+
+        model.isWide = false
+
+        try await waitUntil {
+            hostingView.layoutSubtreeIfNeeded()
+            return self.textField(in: hostingView) == nil
+        }
+        #expect(model.text == "Muxy")
+    }
+
+    private func hostingView(isEnabled: Bool, isWide: Bool) -> NSView {
+        let view = ProjectSearchField(text: .constant(""), isEnabled: isEnabled, isWide: isWide)
+            .frame(width: 220, height: UIMetrics.controlMedium)
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 220, height: UIMetrics.controlMedium)
+        hostingView.layoutSubtreeIfNeeded()
+        return hostingView
+    }
+
+    private func hostingView(model: ProjectSearchFieldTestModel) -> NSView {
+        let view = ProjectSearchFieldTestHarness(model: model)
+            .frame(width: 220, height: UIMetrics.controlMedium)
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 220, height: UIMetrics.controlMedium)
+        hostingView.layoutSubtreeIfNeeded()
+        return hostingView
+    }
+
+    private func textField(in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField {
+            return field
+        }
+        for subview in view.subviews {
+            if let field = textField(in: subview) {
+                return field
+            }
+        }
+        return nil
+    }
+
+    private func waitUntil(_ condition: @MainActor () -> Bool) async throws {
+        for _ in 0..<40 {
+            if condition() {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(condition())
+    }
+}
+
+@MainActor
+private final class ProjectSearchFieldTestModel: ObservableObject {
+    @Published var text: String
+    @Published var isEnabled: Bool
+    @Published var isWide: Bool
+
+    init(text: String, isEnabled: Bool, isWide: Bool) {
+        self.text = text
+        self.isEnabled = isEnabled
+        self.isWide = isWide
+    }
+}
+
+private struct ProjectSearchFieldTestHarness: View {
+    @ObservedObject var model: ProjectSearchFieldTestModel
+
+    var body: some View {
+        ProjectSearchField(
+            text: $model.text,
+            isEnabled: model.isEnabled,
+            isWide: model.isWide
+        )
+    }
+}

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -212,6 +212,19 @@ struct SettingsCatalogTests {
     }
 
     @Test
+    func projectSearchSettingIsRegisteredAndSearchable() {
+        let item = SettingsCatalog.items.first { $0.key == ProjectSearchPreferences.visibleKey }
+
+        #expect(item?.category == .appearance)
+        #expect(item?.section == "Sidebar")
+        #expect(item?.defaultValue as? Bool == ProjectSearchPreferences.defaultVisible)
+        #expect(SettingsCatalog.matchingItems(query: "search bar").contains {
+            $0.key == ProjectSearchPreferences.visibleKey
+        })
+        #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == ProjectSearchPreferences.visibleKey })
+    }
+
+    @Test
     func worktreePathTemplateIsRegisteredAndSearchable() {
         #expect(SettingsCatalog.jsonEditableItems.contains {
             $0.key == GeneralSettingsKeys.defaultWorktreePathTemplate

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -46,6 +46,13 @@ In **Appearance → Sidebar**, select **Tab Focused** or **Agents Focused** to s
 It is off by default. Turn it on to nest all worktrees under their project; turn it off to keep worktrees as top-level rows. Tab
 Focused shows top-level worktrees only when they have open tabs, while Agents Focused shows every secondary worktree.
 
+## Project search
+
+In the Project Focused layout, turn on **Settings → Interface → Sidebar → Always Show Project Search** to keep the
+project search field visible whenever the sidebar uses its expanded style. The setting is off by default, and the
+search field is unavailable while it is off or while the sidebar uses an icon-only style. The preference is stored as
+`muxy.showProjectSearch` in `settings.json`.
+
 ## Sidebar tips
 
 Muxy shows one tip at the bottom of the built-in sidebar. The starting tip is selected when Muxy launches and stays


### PR DESCRIPTION
## Summary

- Add an opt-in setting that keeps project search visible in the expanded Project Focused sidebar.
- Remove the transient search toggle and add an accessible inline clear control.
- Preserve search while collapsing the sidebar and clear it when the setting is disabled.

## Changes

- Register the disabled-by-default preference in Interface settings and the JSON settings catalog.
- Add localization and user-guide documentation for the preference and clear action.
- Add SwiftUI regression coverage for visibility, query lifecycle, and clearing.

## Verification

- `scripts/checks.sh --fix` (3,109 tests)

## AI Assistance

- OpenAI `gpt-5.6-sol`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to always show project search in the Project Focused sidebar.
  * Added a clear button and improved search-field behavior when visibility changes.
* **Documentation**
  * Documented the project-search visibility setting, default behavior, limitations, and configuration storage.
* **Tests**
  * Added coverage for search-field visibility, query clearing, persistence, and settings registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->