### PR TITLE
Resolve agent tab provider icons from hook state

### DIFF
--- a/Muxy/Services/AgentDetection/AgentPaneIdentity.swift
+++ b/Muxy/Services/AgentDetection/AgentPaneIdentity.swift
@@ -11,6 +11,15 @@ enum AgentPaneIdentity {
         return detectedAgentStore.agent(for: paneID) ?? agentStatusStore.activeProviderID(forPane: paneID)
     }
 
+    static func providerID(
+        forPanes paneIDs: [UUID],
+        detectedAgentStore: DetectedAgentStore = .shared,
+        agentStatusStore: AgentStatusStore = .shared
+    ) -> String? {
+        paneIDs.compactMap { detectedAgentStore.agent(for: $0) }.first
+            ?? paneIDs.compactMap { agentStatusStore.activeProviderID(forPane: $0) }.first
+    }
+
     static func iconName(
         forPane paneID: UUID?,
         detectedAgentStore: DetectedAgentStore = .shared,
@@ -19,6 +28,21 @@ enum AgentPaneIdentity {
     ) -> String? {
         guard let providerID = providerID(
             forPane: paneID,
+            detectedAgentStore: detectedAgentStore,
+            agentStatusStore: agentStatusStore
+        )
+        else { return nil }
+        return registry.iconName(forProviderID: providerID)
+    }
+
+    static func iconName(
+        forPanes paneIDs: [UUID],
+        detectedAgentStore: DetectedAgentStore = .shared,
+        agentStatusStore: AgentStatusStore = .shared,
+        registry: AIProviderRegistry = .shared
+    ) -> String? {
+        guard let providerID = providerID(
+            forPanes: paneIDs,
             detectedAgentStore: detectedAgentStore,
             agentStatusStore: agentStatusStore
         )

--- a/Muxy/Services/AgentDetection/AgentPaneIdentity.swift
+++ b/Muxy/Services/AgentDetection/AgentPaneIdentity.swift
@@ -16,8 +16,17 @@ enum AgentPaneIdentity {
         detectedAgentStore: DetectedAgentStore = .shared,
         agentStatusStore: AgentStatusStore = .shared
     ) -> String? {
-        paneIDs.compactMap { detectedAgentStore.agent(for: $0) }.first
-            ?? paneIDs.compactMap { agentStatusStore.activeProviderID(forPane: $0) }.first
+        for paneID in paneIDs {
+            if let providerID = detectedAgentStore.agent(for: paneID) {
+                return providerID
+            }
+        }
+        for paneID in paneIDs {
+            if let providerID = agentStatusStore.activeProviderID(forPane: paneID) {
+                return providerID
+            }
+        }
+        return nil
     }
 
     static func iconName(

--- a/Muxy/Services/AgentDetection/AgentPaneIdentity.swift
+++ b/Muxy/Services/AgentDetection/AgentPaneIdentity.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@MainActor
+enum AgentPaneIdentity {
+    static func providerID(
+        forPane paneID: UUID?,
+        detectedAgentStore: DetectedAgentStore = .shared,
+        agentStatusStore: AgentStatusStore = .shared
+    ) -> String? {
+        guard let paneID else { return nil }
+        return detectedAgentStore.agent(for: paneID) ?? agentStatusStore.activeProviderID(forPane: paneID)
+    }
+
+    static func iconName(
+        forPane paneID: UUID?,
+        detectedAgentStore: DetectedAgentStore = .shared,
+        agentStatusStore: AgentStatusStore = .shared,
+        registry: AIProviderRegistry = .shared
+    ) -> String? {
+        guard let providerID = providerID(
+            forPane: paneID,
+            detectedAgentStore: detectedAgentStore,
+            agentStatusStore: agentStatusStore
+        )
+        else { return nil }
+        return registry.iconName(forProviderID: providerID)
+    }
+}

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -660,9 +660,8 @@ struct TabFocusedTabRow: View {
     private var leadingIcon: some View {
         switch tab.kind {
         case .terminal:
-            let agentIconName = relatedTabs.compactMap {
-                AgentPaneIdentity.iconName(forPane: $0.content.pane?.id)
-            }.first
+            let paneIDs = relatedTabs.compactMap { $0.content.pane?.id }
+            let agentIconName = AgentPaneIdentity.iconName(forPanes: paneIDs)
             if let agentIconName {
                 ProviderIconView(iconName: agentIconName, size: UIMetrics.iconMD)
             } else {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -661,7 +661,7 @@ struct TabFocusedTabRow: View {
         switch tab.kind {
         case .terminal:
             let agentIconName = relatedTabs.compactMap {
-                DetectedAgentStore.shared.iconName(forPane: $0.content.pane?.id)
+                AgentPaneIdentity.iconName(forPane: $0.content.pane?.id)
             }.first
             if let agentIconName {
                 ProviderIconView(iconName: agentIconName, size: UIMetrics.iconMD)

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -85,7 +85,7 @@ struct PaneTabStrip: View {
                 isOffline: !panes.isEmpty && panes.allSatisfy(\.isOffline),
                 faviconImage: tab.content.browserState?.faviconImage,
                 detectedAgentIconName: paneIDs.compactMap {
-                    DetectedAgentStore.shared.iconName(forPane: $0)
+                    AgentPaneIdentity.iconName(forPane: $0)
                 }.first,
                 agentStatus: agentStatus,
                 hasUnread: relatedTabs.contains { NotificationStore.shared.hasUnread(tabID: $0.id) }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -84,9 +84,7 @@ struct PaneTabStrip: View {
                 customIcon: tab.content.extensionState?.customIcon,
                 isOffline: !panes.isEmpty && panes.allSatisfy(\.isOffline),
                 faviconImage: tab.content.browserState?.faviconImage,
-                detectedAgentIconName: paneIDs.compactMap {
-                    AgentPaneIdentity.iconName(forPane: $0)
-                }.first,
+                detectedAgentIconName: AgentPaneIdentity.iconName(forPanes: paneIDs),
                 agentStatus: agentStatus,
                 hasUnread: relatedTabs.contains { NotificationStore.shared.hasUnread(tabID: $0.id) }
             )

--- a/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
+++ b/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
@@ -318,6 +318,14 @@ struct AgentStatusStoreTests {
     private func makeContext(
         agentProcessAlive: Bool = false
     ) -> (AgentStatusStore, ManualGraceScheduler, UUID) {
+        let (store, scheduler, paneIDs) = makeContext(paneCount: 1, agentProcessAlive: agentProcessAlive)
+        return (store, scheduler, paneIDs[0])
+    }
+
+    private func makeContext(
+        paneCount: Int,
+        agentProcessAlive: Bool = false
+    ) -> (AgentStatusStore, ManualGraceScheduler, [UUID]) {
         let scheduler = ManualGraceScheduler()
         let store = AgentStatusStore(
             scheduler: scheduler,
@@ -332,18 +340,21 @@ struct AgentStatusStoreTests {
         )
         let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
         let area = TabArea(projectPath: "/tmp/project")
+        for _ in 1 ..< paneCount {
+            area.createTab()
+        }
         appState.activeProjectID = projectID
         appState.activeWorktreeID[projectID] = worktreeID
         appState.workspaceRoots[key] = .tabArea(area)
         appState.focusedAreaID[key] = area.id
-        let paneID = area.tabs.last!.content.pane!.id
+        let paneIDs = area.tabs.compactMap { $0.content.pane?.id }
 
         NotificationStore.shared.appState = appState
         NotificationStore.shared.worktreeStore = WorktreeStore(
             persistence: WorktreePersistenceStub(),
             projects: []
         )
-        return (store, scheduler, paneID)
+        return (store, scheduler, paneIDs)
     }
 
     private func send(
@@ -481,6 +492,18 @@ struct AgentStatusStoreTests {
         defer { DetectedAgentStore.shared.resetPane(paneID) }
 
         #expect(AgentPaneIdentity.iconName(forPane: paneID, agentStatusStore: store) == "claude")
+    }
+
+    @Test("pane identity icon prefers detected panes before hook panes")
+    func paneIdentityIconPrefersDetectedPanesBeforeHookPanes() {
+        let (store, _, paneIDs) = makeContext(paneCount: 2)
+        let hookPaneID = paneIDs[0]
+        let detectedPaneID = paneIDs[1]
+        send(store, hookPaneID, provider: "codex", .working, sequence: 1)
+        DetectedAgentStore.shared.setAgent("claude", for: detectedPaneID)
+        defer { DetectedAgentStore.shared.resetPane(detectedPaneID) }
+
+        #expect(AgentPaneIdentity.iconName(forPanes: paneIDs, agentStatusStore: store) == "claude")
     }
 
     @Test("ending a session cancels a pending grace transition")

--- a/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
+++ b/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
@@ -461,6 +461,28 @@ struct AgentStatusStoreTests {
         #expect(store.isCompletionPending(forPane: paneID))
     }
 
+    @Test("pane identity icon falls back to every active hook provider")
+    func paneIdentityIconFallsBackToEveryActiveHookProvider() {
+        let (store, _, paneID) = makeContext()
+
+        for (index, provider) in AIProviderRegistry.shared.agentLaunchProviders.enumerated() {
+            send(store, paneID, provider: provider.id, .working, sequence: UInt64(index + 1))
+
+            #expect(DetectedAgentStore.shared.agent(for: paneID) == nil)
+            #expect(AgentPaneIdentity.iconName(forPane: paneID, agentStatusStore: store) == provider.iconName)
+        }
+    }
+
+    @Test("detected pane identity wins over active hook provider")
+    func detectedPaneIdentityWinsOverActiveHookProvider() {
+        let (store, _, paneID) = makeContext()
+        send(store, paneID, provider: "codex", .working, sequence: 1)
+        DetectedAgentStore.shared.setAgent("claude", for: paneID)
+        defer { DetectedAgentStore.shared.resetPane(paneID) }
+
+        #expect(AgentPaneIdentity.iconName(forPane: paneID, agentStatusStore: store) == "claude")
+    }
+
     @Test("ending a session cancels a pending grace transition")
     func endSessionCancelsGrace() {
         let (store, scheduler, paneID) = makeContext()


### PR DESCRIPTION
## Summary
- Use a shared pane identity helper for tab agent icons so hook-reported sessions can show their provider icon when process detection is absent
- Apply the helper to the tab-focused list and top tab strip
- Keep detected/provisional agent identity preferred over hook status

## Testing
- scripts/checks.sh --fix

AI assistance: OpenAI GPT-5 Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent icon accuracy across tab lists and workspace tabs.
  * Added consistent icon handling for single-pane and multi-pane layouts.
  * Icons now fall back to the active provider when no detected agent is available.
  * Detected agent identities take precedence over active provider status.
  * Unified icon resolution for more consistent results across workspace views.

* **Tests**
  * Added coverage for fallback behavior and detected-agent precedence across multiple panes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->