### PR TITLE
Fix agent tab startup commands

### DIFF
--- a/Muxy/Models/Project/CommandTabRequest.swift
+++ b/Muxy/Models/Project/CommandTabRequest.swift
@@ -7,6 +7,7 @@ struct CommandTabRequest: Equatable {
     let command: String
     let closesOnCommandExit: Bool
     let directory: String?
+    let startupCommandRestoration: StartupCommandRestoration
 
     init(
         projectID: UUID,
@@ -14,7 +15,8 @@ struct CommandTabRequest: Equatable {
         name: String,
         command: String,
         closesOnCommandExit: Bool,
-        directory: String? = nil
+        directory: String? = nil,
+        startupCommandRestoration: StartupCommandRestoration = .restore
     ) {
         self.projectID = projectID
         self.areaID = areaID
@@ -22,5 +24,6 @@ struct CommandTabRequest: Equatable {
         self.command = command
         self.closesOnCommandExit = closesOnCommandExit
         self.directory = directory
+        self.startupCommandRestoration = startupCommandRestoration
     }
 }

--- a/Muxy/Models/Terminal/TerminalPaneState.swift
+++ b/Muxy/Models/Terminal/TerminalPaneState.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+enum StartupCommandRestoration: String, Codable, Equatable {
+    case restore
+    case initialLaunchOnly
+}
+
 struct TerminalPaneLaunch: Equatable {
     let command: String?
     let interactive: Bool
@@ -20,6 +25,7 @@ final class TerminalPaneState: Identifiable {
     let startupCommand: String?
     let startupCommandInteractive: Bool
     let closesOnStartupCommandExit: Bool
+    let startupCommandRestoration: StartupCommandRestoration
     let externalEditorFilePath: String?
     var isOffline = false
     var sessionRecoveryFailed = false
@@ -36,6 +42,7 @@ final class TerminalPaneState: Identifiable {
         startupCommand: String? = nil,
         startupCommandInteractive: Bool = false,
         closesOnStartupCommandExit: Bool = true,
+        startupCommandRestoration: StartupCommandRestoration = .restore,
         externalEditorFilePath: String? = nil
     ) {
         self.id = id
@@ -47,6 +54,7 @@ final class TerminalPaneState: Identifiable {
         self.startupCommand = startupCommand
         self.startupCommandInteractive = startupCommandInteractive
         self.closesOnStartupCommandExit = closesOnStartupCommandExit
+        self.startupCommandRestoration = startupCommandRestoration
         self.externalEditorFilePath = externalEditorFilePath
     }
 

--- a/Muxy/Models/Terminal/TerminalTab.swift
+++ b/Muxy/Models/Terminal/TerminalTab.swift
@@ -146,7 +146,10 @@ final class TerminalTab: Identifiable {
                 projectPath: snapshot.projectPath,
                 title: snapshot.paneTitle,
                 usesDefaultTitle: snapshot.paneUsesDefaultTitle,
-                initialWorkingDirectory: restoredWorkingDirectory
+                initialWorkingDirectory: restoredWorkingDirectory,
+                startupCommand: snapshot.startupCommand,
+                startupCommandInteractive: snapshot.startupCommandInteractive ?? false,
+                closesOnStartupCommandExit: snapshot.closesOnStartupCommandExit ?? true
             ))
         case .extensionWebView:
             if let extensionID = snapshot.extensionID,
@@ -178,7 +181,9 @@ final class TerminalTab: Identifiable {
     }
 
     func snapshot() -> TerminalTabSnapshot {
-        TerminalTabSnapshot(
+        let pane = content.pane
+        let startupCommand = pane?.startupCommand
+        return TerminalTabSnapshot(
             kind: content.kind,
             id: id,
             parentTabID: parentTabID,
@@ -187,11 +192,14 @@ final class TerminalTab: Identifiable {
             customIcon: customIcon,
             isPinned: isPinned,
             projectPath: content.projectPath,
-            paneTitle: extensionTabDefaultTitle ?? content.pane?.title,
-            paneUsesDefaultTitle: content.pane?.usesDefaultTitle,
-            paneID: content.pane?.id,
-            paneSessionID: content.pane?.sessionID,
-            currentWorkingDirectory: content.pane?.currentWorkingDirectory,
+            paneTitle: extensionTabDefaultTitle ?? pane?.title,
+            paneUsesDefaultTitle: pane?.usesDefaultTitle,
+            paneID: pane?.id,
+            paneSessionID: pane?.sessionID,
+            currentWorkingDirectory: pane?.currentWorkingDirectory,
+            startupCommand: startupCommand,
+            startupCommandInteractive: startupCommand == nil ? nil : pane?.startupCommandInteractive,
+            closesOnStartupCommandExit: startupCommand == nil ? nil : pane?.closesOnStartupCommandExit,
             extensionID: content.extensionState?.extensionID,
             extensionTabTypeID: content.extensionState?.tabTypeID,
             extensionTabData: content.extensionState?.data,

--- a/Muxy/Models/Terminal/TerminalTab.swift
+++ b/Muxy/Models/Terminal/TerminalTab.swift
@@ -140,6 +140,7 @@ final class TerminalTab: Identifiable {
                 snapshot.currentWorkingDirectory,
                 projectPath: snapshot.projectPath
             )
+            let restoresStartupCommand = snapshot.startupCommandRestoration == .restore
             content = .terminal(TerminalPaneState(
                 id: snapshot.paneID ?? UUID(),
                 sessionID: snapshot.paneSessionID,
@@ -147,9 +148,10 @@ final class TerminalTab: Identifiable {
                 title: snapshot.paneTitle,
                 usesDefaultTitle: snapshot.paneUsesDefaultTitle,
                 initialWorkingDirectory: restoredWorkingDirectory,
-                startupCommand: snapshot.startupCommand,
+                startupCommand: restoresStartupCommand ? snapshot.startupCommand : nil,
                 startupCommandInteractive: snapshot.startupCommandInteractive ?? false,
-                closesOnStartupCommandExit: snapshot.closesOnStartupCommandExit ?? true
+                closesOnStartupCommandExit: snapshot.closesOnStartupCommandExit ?? true,
+                startupCommandRestoration: restoresStartupCommand ? .restore : .initialLaunchOnly
             ))
         case .extensionWebView:
             if let extensionID = snapshot.extensionID,
@@ -183,6 +185,7 @@ final class TerminalTab: Identifiable {
     func snapshot() -> TerminalTabSnapshot {
         let pane = content.pane
         let startupCommand = pane?.startupCommand
+        let startupCommandRestoration = pane?.startupCommandRestoration
         return TerminalTabSnapshot(
             kind: content.kind,
             id: id,
@@ -200,6 +203,7 @@ final class TerminalTab: Identifiable {
             startupCommand: startupCommand,
             startupCommandInteractive: startupCommand == nil ? nil : pane?.startupCommandInteractive,
             closesOnStartupCommandExit: startupCommand == nil ? nil : pane?.closesOnStartupCommandExit,
+            startupCommandRestoration: startupCommand == nil ? nil : startupCommandRestoration,
             extensionID: content.extensionState?.extensionID,
             extensionTabTypeID: content.extensionState?.tabTypeID,
             extensionTabData: content.extensionState?.data,

--- a/Muxy/Models/Terminal/TerminalTab.swift
+++ b/Muxy/Models/Terminal/TerminalTab.swift
@@ -184,8 +184,10 @@ final class TerminalTab: Identifiable {
 
     func snapshot() -> TerminalTabSnapshot {
         let pane = content.pane
-        let startupCommand = pane?.startupCommand
-        let startupCommandRestoration = pane?.startupCommandRestoration
+        let restorableStartupCommand = pane?.startupCommandRestoration == .restore ? pane?.startupCommand : nil
+        let paneTitle = pane?.startupCommandRestoration == .initialLaunchOnly && pane?.title == pane?.startupCommand
+            ? nil
+            : pane?.title
         return TerminalTabSnapshot(
             kind: content.kind,
             id: id,
@@ -195,15 +197,15 @@ final class TerminalTab: Identifiable {
             customIcon: customIcon,
             isPinned: isPinned,
             projectPath: content.projectPath,
-            paneTitle: extensionTabDefaultTitle ?? pane?.title,
-            paneUsesDefaultTitle: pane?.usesDefaultTitle,
+            paneTitle: extensionTabDefaultTitle ?? paneTitle,
+            paneUsesDefaultTitle: paneTitle == nil ? nil : pane?.usesDefaultTitle,
             paneID: pane?.id,
             paneSessionID: pane?.sessionID,
             currentWorkingDirectory: pane?.currentWorkingDirectory,
-            startupCommand: startupCommand,
-            startupCommandInteractive: startupCommand == nil ? nil : pane?.startupCommandInteractive,
-            closesOnStartupCommandExit: startupCommand == nil ? nil : pane?.closesOnStartupCommandExit,
-            startupCommandRestoration: startupCommand == nil ? nil : startupCommandRestoration,
+            startupCommand: restorableStartupCommand,
+            startupCommandInteractive: restorableStartupCommand == nil ? nil : pane?.startupCommandInteractive,
+            closesOnStartupCommandExit: restorableStartupCommand == nil ? nil : pane?.closesOnStartupCommandExit,
+            startupCommandRestoration: restorableStartupCommand == nil ? nil : .restore,
             extensionID: content.extensionState?.extensionID,
             extensionTabTypeID: content.extensionState?.tabTypeID,
             extensionTabData: content.extensionState?.data,

--- a/Muxy/Models/Workspace/Reducer/TabReducer.swift
+++ b/Muxy/Models/Workspace/Reducer/TabReducer.swift
@@ -118,7 +118,8 @@ enum TabReducer {
             name: request.name,
             command: request.command,
             closesOnCommandExit: request.closesOnCommandExit,
-            directory: request.directory
+            directory: request.directory,
+            startupCommandRestoration: request.startupCommandRestoration
         )
         if let tabID {
             state.topLevelTabOrder[key] = order + [tabID]

--- a/Muxy/Models/Workspace/TabArea.swift
+++ b/Muxy/Models/Workspace/TabArea.swift
@@ -101,7 +101,8 @@ final class TabArea: Identifiable {
         name: String,
         command: String,
         closesOnCommandExit: Bool = true,
-        directory: String? = nil
+        directory: String? = nil,
+        startupCommandRestoration: StartupCommandRestoration = .restore
     ) -> UUID? {
         let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedCommand.isEmpty else { return nil }
@@ -112,7 +113,8 @@ final class TabArea: Identifiable {
             initialWorkingDirectory: directory,
             startupCommand: trimmedCommand,
             startupCommandInteractive: true,
-            closesOnStartupCommandExit: closesOnCommandExit
+            closesOnStartupCommandExit: closesOnCommandExit,
+            startupCommandRestoration: startupCommandRestoration
         )
         let tab = TerminalTab(pane: pane)
         insertTab(tab)

--- a/Muxy/Models/Workspace/WorkspaceSnapshot.swift
+++ b/Muxy/Models/Workspace/WorkspaceSnapshot.swift
@@ -172,6 +172,9 @@ struct TerminalTabSnapshot: Codable {
     let paneSessionID: UUID?
     let filePath: String?
     let currentWorkingDirectory: String?
+    let startupCommand: String?
+    let startupCommandInteractive: Bool?
+    let closesOnStartupCommandExit: Bool?
     let extensionID: String?
     let extensionTabTypeID: String?
     let extensionTabData: ExtensionJSON?
@@ -193,6 +196,9 @@ struct TerminalTabSnapshot: Codable {
         paneSessionID: UUID? = nil,
         filePath: String? = nil,
         currentWorkingDirectory: String? = nil,
+        startupCommand: String? = nil,
+        startupCommandInteractive: Bool? = nil,
+        closesOnStartupCommandExit: Bool? = nil,
         extensionID: String? = nil,
         extensionTabTypeID: String? = nil,
         extensionTabData: ExtensionJSON? = nil,
@@ -213,6 +219,9 @@ struct TerminalTabSnapshot: Codable {
         self.paneSessionID = paneSessionID
         self.filePath = filePath
         self.currentWorkingDirectory = currentWorkingDirectory
+        self.startupCommand = startupCommand
+        self.startupCommandInteractive = startupCommandInteractive
+        self.closesOnStartupCommandExit = closesOnStartupCommandExit
         self.extensionID = extensionID
         self.extensionTabTypeID = extensionTabTypeID
         self.extensionTabData = extensionTabData
@@ -235,6 +244,9 @@ struct TerminalTabSnapshot: Codable {
         case paneSessionID
         case filePath
         case currentWorkingDirectory
+        case startupCommand
+        case startupCommandInteractive
+        case closesOnStartupCommandExit
         case extensionID
         case extensionTabTypeID
         case extensionTabData
@@ -259,6 +271,9 @@ struct TerminalTabSnapshot: Codable {
         paneSessionID = try container.decodeIfPresent(UUID.self, forKey: .paneSessionID)
         filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
         currentWorkingDirectory = try container.decodeIfPresent(String.self, forKey: .currentWorkingDirectory)
+        startupCommand = try container.decodeIfPresent(String.self, forKey: .startupCommand)
+        startupCommandInteractive = try container.decodeIfPresent(Bool.self, forKey: .startupCommandInteractive)
+        closesOnStartupCommandExit = try container.decodeIfPresent(Bool.self, forKey: .closesOnStartupCommandExit)
         extensionID = try container.decodeIfPresent(String.self, forKey: .extensionID)
         extensionTabTypeID = try container.decodeIfPresent(String.self, forKey: .extensionTabTypeID)
         extensionTabData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .extensionTabData)

--- a/Muxy/Models/Workspace/WorkspaceSnapshot.swift
+++ b/Muxy/Models/Workspace/WorkspaceSnapshot.swift
@@ -175,6 +175,7 @@ struct TerminalTabSnapshot: Codable {
     let startupCommand: String?
     let startupCommandInteractive: Bool?
     let closesOnStartupCommandExit: Bool?
+    let startupCommandRestoration: StartupCommandRestoration?
     let extensionID: String?
     let extensionTabTypeID: String?
     let extensionTabData: ExtensionJSON?
@@ -199,6 +200,7 @@ struct TerminalTabSnapshot: Codable {
         startupCommand: String? = nil,
         startupCommandInteractive: Bool? = nil,
         closesOnStartupCommandExit: Bool? = nil,
+        startupCommandRestoration: StartupCommandRestoration? = nil,
         extensionID: String? = nil,
         extensionTabTypeID: String? = nil,
         extensionTabData: ExtensionJSON? = nil,
@@ -222,6 +224,7 @@ struct TerminalTabSnapshot: Codable {
         self.startupCommand = startupCommand
         self.startupCommandInteractive = startupCommandInteractive
         self.closesOnStartupCommandExit = closesOnStartupCommandExit
+        self.startupCommandRestoration = startupCommandRestoration
         self.extensionID = extensionID
         self.extensionTabTypeID = extensionTabTypeID
         self.extensionTabData = extensionTabData
@@ -247,6 +250,7 @@ struct TerminalTabSnapshot: Codable {
         case startupCommand
         case startupCommandInteractive
         case closesOnStartupCommandExit
+        case startupCommandRestoration
         case extensionID
         case extensionTabTypeID
         case extensionTabData
@@ -274,6 +278,7 @@ struct TerminalTabSnapshot: Codable {
         startupCommand = try container.decodeIfPresent(String.self, forKey: .startupCommand)
         startupCommandInteractive = try container.decodeIfPresent(Bool.self, forKey: .startupCommandInteractive)
         closesOnStartupCommandExit = try container.decodeIfPresent(Bool.self, forKey: .closesOnStartupCommandExit)
+        startupCommandRestoration = try container.decodeIfPresent(StartupCommandRestoration.self, forKey: .startupCommandRestoration)
         extensionID = try container.decodeIfPresent(String.self, forKey: .extensionID)
         extensionTabTypeID = try container.decodeIfPresent(String.self, forKey: .extensionTabTypeID)
         extensionTabData = try container.decodeIfPresent(ExtensionJSON.self, forKey: .extensionTabData)

--- a/Muxy/Services/AI/AIAgentLaunchProvider.swift
+++ b/Muxy/Services/AI/AIAgentLaunchProvider.swift
@@ -70,8 +70,8 @@ extension AIAgentLaunchProvider {
 }
 
 enum AgentTabLaunchCommand {
-    static func local(provider: any AIAgentLaunchProvider) -> String? {
-        guard provider.agentCLIExecutablePath() != nil else { return nil }
+    static func local(provider: any AIAgentLaunchProvider, availableExecutables: Set<String>) -> String? {
+        guard availableExecutables.contains(provider.agentLaunchConfiguration.executable) else { return nil }
 
         return ShellEscaper.escape(provider.agentLaunchConfiguration.executable)
     }
@@ -91,11 +91,21 @@ struct AgentTabLaunchOption: Identifiable {
         command == nil ? "\(provider.displayName) · Not installed" : provider.displayName
     }
 
-    static func resolveLocal(providers: [any AIAgentLaunchProvider]) -> [Self] {
-        providers.map { provider in
+    @MainActor
+    static func resolveLocal(
+        providers: [any AIAgentLaunchProvider],
+        resolveAvailableCommands: ([String]) async -> Set<String> = { await LoginShellPath.availableCommands($0) }
+    ) async -> [Self] {
+        let availableExecutables = await resolveAvailableCommands(
+            Array(Set(providers.map(\.agentLaunchConfiguration.executable))).sorted()
+        )
+        return providers.map { provider in
             Self(
                 provider: provider,
-                command: AgentTabLaunchCommand.local(provider: provider)
+                command: AgentTabLaunchCommand.local(
+                    provider: provider,
+                    availableExecutables: availableExecutables
+                )
             )
         }
     }
@@ -115,8 +125,8 @@ struct AgentTabLaunchOption: Identifiable {
     }
 
     @MainActor
-    static func resolveLocal() -> [Self] {
-        resolveLocal(providers: AIProviderRegistry.shared.agentLaunchProviders)
+    static func resolveLocal() async -> [Self] {
+        await resolveLocal(providers: AIProviderRegistry.shared.agentLaunchProviders)
     }
 
     @MainActor
@@ -132,19 +142,19 @@ struct AgentTabLaunchOption: Identifiable {
 
 @MainActor
 enum AgentTabLaunchOptionsLoader {
-    typealias LocalResolver = @MainActor () -> [AgentTabLaunchOption]
+    typealias LocalResolver = @MainActor () async -> [AgentTabLaunchOption]
     typealias RemoteResolver = @MainActor (SSHDestination) async throws -> [AgentTabLaunchOption]
 
     static func resolve(
         context: WorkspaceContext,
-        localResolver: LocalResolver = { AgentTabLaunchOption.resolveLocal() },
+        localResolver: LocalResolver = { await AgentTabLaunchOption.resolveLocal() },
         remoteResolver: RemoteResolver = { destination in
             try await AgentTabLaunchOption.resolveRemote(destination: destination)
         }
     ) async throws -> [AgentTabLaunchOption] {
         let options: [AgentTabLaunchOption] = switch context {
         case .local:
-            localResolver()
+            await localResolver()
         case let .ssh(destination):
             try await remoteResolver(destination)
         }

--- a/Muxy/Services/AI/AIAgentLaunchProvider.swift
+++ b/Muxy/Services/AI/AIAgentLaunchProvider.swift
@@ -71,7 +71,9 @@ extension AIAgentLaunchProvider {
 
 enum AgentTabLaunchCommand {
     static func local(provider: any AIAgentLaunchProvider) -> String? {
-        provider.agentCLIExecutablePath().map(ShellEscaper.escape)
+        guard provider.agentCLIExecutablePath() != nil else { return nil }
+
+        return ShellEscaper.escape(provider.agentLaunchConfiguration.executable)
     }
 
     static func remote(provider: any AIAgentLaunchProvider) -> String {

--- a/Muxy/Services/Extensions/ExtensionCommandProcess.swift
+++ b/Muxy/Services/Extensions/ExtensionCommandProcess.swift
@@ -127,7 +127,7 @@ final class CancellableProcess: @unchecked Sendable {
             self.source = nil
             lock.unlock()
             source?.cancel()
-            DispatchQueue.global(qos: .userInitiated).async { [self] in
+            monitoringQueue.async { [self] in
                 onTermination()
             }
             return false
@@ -135,7 +135,7 @@ final class CancellableProcess: @unchecked Sendable {
         state = .terminating
         lock.unlock()
         kill(-processIdentifier, SIGTERM)
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(200)) { [self] in
+        monitoringQueue.asyncAfter(deadline: .now() + .milliseconds(200)) { [self] in
             kill(-processIdentifier, SIGKILL)
             lock.lock()
             guard state == .terminating else {
@@ -219,7 +219,7 @@ final class CancellableProcess: @unchecked Sendable {
 
     private func processDidExit() {
         lock.lock()
-        guard state == .running else {
+        guard state == .running || state == .terminating else {
             lock.unlock()
             return
         }

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -1907,7 +1907,8 @@ enum MuxyAPI {
                 name: command,
                 command: command,
                 closesOnCommandExit: false,
-                directory: resolvedDirectory
+                directory: resolvedDirectory,
+                startupCommandRestoration: .initialLaunchOnly
             )))
             guard let tabID = effects.createdTabID else { return .failure(.tabCreateFailed) }
             return .success(tabID)

--- a/Muxy/Services/Process/SubprocessRunner.swift
+++ b/Muxy/Services/Process/SubprocessRunner.swift
@@ -60,6 +60,11 @@ enum SubprocessRunner {
 }
 
 private final class SubprocessJob: @unchecked Sendable {
+    private static let timeoutQueue = DispatchQueue(
+        label: "app.muxy.subprocess-timeout",
+        qos: .userInitiated
+    )
+
     private let request: SubprocessRequest
     private let lock = NSLock()
     private var continuation: CheckedContinuation<SubprocessResult, Error>?
@@ -153,7 +158,7 @@ private final class SubprocessJob: @unchecked Sendable {
         if let timeout = request
             .timeout
         {
-            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) { [weak self] in self?.timeout() }
+            Self.timeoutQueue.asyncAfter(deadline: .now() + timeout) { [weak self] in self?.timeout() }
         }
     }
 

--- a/Muxy/Services/Process/SubprocessRunner.swift
+++ b/Muxy/Services/Process/SubprocessRunner.swift
@@ -64,6 +64,10 @@ private final class SubprocessJob: @unchecked Sendable {
         label: "app.muxy.subprocess-timeout",
         qos: .userInitiated
     )
+    private static let monitoringQueue = DispatchQueue(
+        label: "app.muxy.subprocess-monitor",
+        qos: .userInitiated
+    )
 
     private let request: SubprocessRequest
     private let lock = NSLock()
@@ -140,7 +144,8 @@ private final class SubprocessJob: @unchecked Sendable {
             configuredProcess: configured,
             stdinPipe: stdin,
             stdoutPipe: stdoutPipe,
-            stderrPipe: stderrPipe
+            stderrPipe: stderrPipe,
+            monitoringQueue: Self.monitoringQueue
         ) { [weak self] in self?.didTerminate() } } catch { lock.unlock()
             stdoutReader.finish()
             stderrReader.finish()

--- a/Muxy/Services/Terminal/TerminalLaunchCommand.swift
+++ b/Muxy/Services/Terminal/TerminalLaunchCommand.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MuxySessionProtocol
 
 enum TerminalLaunchCommand {
     static let environmentKey = "MUXY_STARTUP_COMMAND"
@@ -8,9 +9,9 @@ enum TerminalLaunchCommand {
         keepsShellOpen: Bool = false,
         shell: String = UserShell.path()
     ) -> String {
-        let flags = interactive ? "-l -i" : "-l"
+        let flags = startupShellFlags(interactive: interactive, shell: shell)
         let escapedShell = ShellEscaper.escape(shell)
-        return "\(escapedShell) \(flags) -c '\(script(keepsShellOpen: keepsShellOpen))' \(escapedShell)"
+        return "\(escapedShell) \(flags) -c '\(script(shell: shell, keepsShellOpen: keepsShellOpen))' \(escapedShell)"
     }
 
     static func remoteShellCommand(
@@ -20,16 +21,49 @@ enum TerminalLaunchCommand {
         interactive: Bool,
         keepsShellOpen: Bool
     ) -> String {
-        let inner = remoteLoginShell(
+        let remoteCommand = remoteShellBootstrapCommand(
+            environment: destination.environment,
+            workingDirectory: workingDirectory,
             startupCommand: startupCommand,
             interactive: interactive,
             keepsShellOpen: keepsShellOpen
         )
-        let remoteCommand = RemoteCommandBuilder.changeDirectoryPrefix(workingDirectory) + inner
-        let command = RemoteCommandBuilder.environmentPrefix(destination.environment) + remoteCommand
         let options = SSHDestination.terminalOptions
-        let arguments = destination.connectionArguments + options + ["-tt", destination.target, "--", command]
+        let arguments = destination.connectionArguments + options + ["-tt", destination.target, "--", remoteCommand]
         return (["/usr/bin/ssh"] + arguments.map(ShellEscaper.escape)).joined(separator: " ")
+    }
+
+    static func remoteShellBootstrapCommand(
+        environment: [String: String],
+        workingDirectory: String,
+        startupCommand: String?,
+        interactive: Bool,
+        keepsShellOpen: Bool
+    ) -> String {
+        let script = remoteShellBootstrapScript(
+            environment: environment,
+            workingDirectory: workingDirectory,
+            startupCommand: startupCommand,
+            interactive: interactive,
+            keepsShellOpen: keepsShellOpen
+        )
+        return "exec /bin/sh -c \(ShellEscaper.escape(script))"
+    }
+
+    static func remoteShellBootstrapScript(
+        environment: [String: String],
+        workingDirectory: String,
+        startupCommand: String?,
+        interactive: Bool,
+        keepsShellOpen: Bool
+    ) -> String {
+        RemoteCommandBuilder.environmentPrefix(environment)
+            + RemoteCommandBuilder.changeDirectoryPrefix(workingDirectory)
+            + remoteLoginShell(
+                startupCommand: startupCommand,
+                interactive: interactive,
+                keepsShellOpen: keepsShellOpen
+            )
     }
 
     private static func remoteLoginShell(
@@ -37,16 +71,51 @@ enum TerminalLaunchCommand {
         interactive: Bool,
         keepsShellOpen: Bool
     ) -> String {
+        let shell = "\"${SHELL:-/bin/sh}\""
         let flags = interactive ? "-l -i" : "-l"
         guard let startupCommand, !startupCommand.isEmpty else {
-            return "exec \"${SHELL:-/bin/sh}\" \(flags)"
+            return "exec \(shell) \(flags)"
         }
-        let scriptText = ShellEscaper.escape(script(keepsShellOpen: keepsShellOpen))
         let assignment = "\(environmentKey)=\(ShellEscaper.escape(startupCommand))"
-        return "export \(assignment); exec \"${SHELL:-/bin/sh}\" \(flags) -c \(scriptText) \"${SHELL:-/bin/sh}\""
+        return [
+            "export \(assignment)",
+            "__muxy_shell=${SHELL:-/bin/sh}",
+            "__muxy_shell_name=${__muxy_shell##*/}",
+            remoteLoginShellCase(
+                interactive: interactive,
+                keepsShellOpen: keepsShellOpen
+            ),
+        ].joined(separator: "; ")
     }
 
-    private static func script(keepsShellOpen: Bool) -> String {
+    private static func remoteLoginShellCase(
+        interactive: Bool,
+        keepsShellOpen: Bool
+    ) -> String {
+        let posixFlags = interactive ? "-l -i" : "-l"
+        let fishFlags = startupShellFlags(interactive: interactive, shell: "fish")
+        let posixScriptText = ShellEscaper.escape(posixScript(keepsShellOpen: keepsShellOpen))
+        let fishScriptText = ShellEscaper.escape(fishScript(keepsShellOpen: keepsShellOpen))
+        let fishBranch = "fish) exec \"$__muxy_shell\" \(fishFlags) -c \(fishScriptText) \"$__muxy_shell\""
+        let posixBranch = "*) exec \"$__muxy_shell\" \(posixFlags) -c \(posixScriptText) \"$__muxy_shell\""
+        return "case \"$__muxy_shell_name\" in \(fishBranch) ;; \(posixBranch) ;; esac"
+    }
+
+    private static func script(shell: String, keepsShellOpen: Bool) -> String {
+        if SessionShellIntegration.shellName(shell) == "fish" {
+            return fishScript(keepsShellOpen: keepsShellOpen)
+        }
+        return posixScript(keepsShellOpen: keepsShellOpen)
+    }
+
+    private static func startupShellFlags(interactive: Bool, shell: String) -> String {
+        if interactive, SessionShellIntegration.shellName(shell) == "fish" {
+            return "-l"
+        }
+        return interactive ? "-l -i" : "-l"
+    }
+
+    private static func posixScript(keepsShellOpen: Bool) -> String {
         var segments = [
             "eval \"$\(environmentKey)\"",
             "muxy_status=$?",
@@ -55,6 +124,18 @@ enum TerminalLaunchCommand {
         ]
         segments.append(keepsShellOpen ? "else exec \"$0\" -l" : "else exit $muxy_status")
         segments.append("fi")
+        return segments.joined(separator: "; ")
+    }
+
+    private static func fishScript(keepsShellOpen: Bool) -> String {
+        var segments = [
+            "eval \"$\(environmentKey)\"",
+            "set muxy_status $status",
+            "if test $muxy_status -ne 0",
+            "exec \"$argv[1]\" -l",
+        ]
+        segments.append(keepsShellOpen ? "else exec \"$argv[1]\" -l" : "else exit $muxy_status")
+        segments.append("end")
         return segments.joined(separator: "; ")
     }
 }

--- a/Muxy/Utilities/LoginShellPath.swift
+++ b/Muxy/Utilities/LoginShellPath.swift
@@ -172,7 +172,7 @@ final class LoginShellPath: @unchecked Sendable {
     }
 
     static func extractAvailableCommands(from output: Data, expected: Set<String>) -> Set<String> {
-        guard let text = String(bytes: output, encoding: .utf8) else { return [] }
+        guard let text = decodedShellOutput(from: output) else { return [] }
         let startMarker = "__MUXY_COMMAND_AVAILABILITY_START__"
         let endMarker = "__MUXY_COMMAND_AVAILABILITY_END__"
         guard let startRange = text.range(of: startMarker),

--- a/Muxy/Utilities/LoginShellPath.swift
+++ b/Muxy/Utilities/LoginShellPath.swift
@@ -129,6 +129,61 @@ final class LoginShellPath: @unchecked Sendable {
         return extractEnvironment(from: output)
     }
 
+    static func availableCommands(_ commands: [String]) async -> Set<String> {
+        await Task.detached(priority: .utility) {
+            availableCommands(commands, shellPath: UserShell.path(), readShellOutput: Self.readShellOutput)
+        }.value
+    }
+
+    static func availableCommands(
+        _ commands: [String],
+        shellPath: String,
+        readShellOutput: (String, [String], DispatchTimeInterval) -> Data?
+    ) -> Set<String> {
+        guard !commands.isEmpty else { return [] }
+        guard let output = readShellOutput(
+            shellPath,
+            commandAvailabilityArguments(shellPath: shellPath, commands: commands),
+            .seconds(3)
+        )
+        else { return [] }
+        return extractAvailableCommands(from: output, expected: Set(commands))
+    }
+
+    static func commandAvailabilityArguments(shellPath: String, commands: [String]) -> [String] {
+        let startMarker = "__MUXY_COMMAND_AVAILABILITY_START__"
+        let endMarker = "__MUXY_COMMAND_AVAILABILITY_END__"
+        let checks = commands.map { command in
+            let escaped = ShellEscaper.escape(command)
+            if URL(fileURLWithPath: shellPath).lastPathComponent == "fish" {
+                return "type -q \(escaped); and printf '%s\\n' \(escaped)"
+            }
+            return "command -v \(escaped) >/dev/null 2>&1 && printf '%s\\n' \(escaped)"
+        }
+        let script = ([
+            "printf '%s\\n' \(ShellEscaper.escape(startMarker))",
+        ] + checks + [
+            "printf '%s\\n' \(ShellEscaper.escape(endMarker))",
+        ]).joined(separator: "; ")
+        if URL(fileURLWithPath: shellPath).lastPathComponent == "fish" {
+            return ["-l", "-c", script]
+        }
+        return ["-l", "-i", "-c", script]
+    }
+
+    static func extractAvailableCommands(from output: Data, expected: Set<String>) -> Set<String> {
+        guard let text = String(bytes: output, encoding: .utf8) else { return [] }
+        let startMarker = "__MUXY_COMMAND_AVAILABILITY_START__"
+        let endMarker = "__MUXY_COMMAND_AVAILABILITY_END__"
+        guard let startRange = text.range(of: startMarker),
+              let endRange = text.range(of: endMarker, range: startRange.upperBound ..< text.endIndex)
+        else { return [] }
+        return Set(text[startRange.upperBound ..< endRange.lowerBound]
+            .split(whereSeparator: \.isNewline)
+            .map(String.init))
+            .intersection(expected)
+    }
+
     private static func readShellOutput(
         shellPath: String,
         arguments: [String],

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -100,9 +100,15 @@ struct AgentsFocusedTabActions: View {
     private func presentProviders() {
         providerTask?.cancel()
         guard case let .ssh(destination) = workspaceContext else {
-            options = AgentTabLaunchOption.resolveLocal()
-            loadingProviders = false
+            options = []
+            loadingProviders = true
             showingProviders = true
+            providerTask = Task {
+                let resolved = await AgentTabLaunchOption.resolveLocal()
+                guard !Task.isCancelled else { return }
+                options = resolved
+                loadingProviders = false
+            }
             return
         }
 
@@ -169,7 +175,8 @@ enum AgentsFocusedTabLauncher {
             areaID: nil,
             name: request.name,
             command: request.command,
-            closesOnCommandExit: false
+            closesOnCommandExit: false,
+            startupCommandRestoration: .restore
         )))
         guard let tabID = effects.createdTabID,
               let key = appState.activeWorktreeKey(for: request.project.id),

--- a/Tests/MuxyTests/Models/Layout/AppLayoutTests.swift
+++ b/Tests/MuxyTests/Models/Layout/AppLayoutTests.swift
@@ -290,6 +290,8 @@ struct AgentsFocusedTabLauncherTests {
         #expect(appState.activeWorktreeID[targetProject.id] == targetWorktree.id)
         #expect(agentTabs.count == 1)
         #expect(agentTabs.first?.content.pane?.title == "Codex")
+        let restored = TerminalTab(restoring: try #require(agentTabs.first?.snapshot()))
+        #expect(restored.content.pane?.consumeRestoredLaunch().command == "codex")
         let paneID = try #require(agentTabs.first?.content.pane?.id)
         defer { DetectedAgentStore.shared.resetPane(paneID) }
         #expect(DetectedAgentStore.shared.agent(for: paneID) == "codex")

--- a/Tests/MuxyTests/Models/Workspace/TabAreaTests.swift
+++ b/Tests/MuxyTests/Models/Workspace/TabAreaTests.swift
@@ -89,10 +89,30 @@ struct TabAreaTests {
         #expect(snapshot.startupCommand == "claude")
         #expect(snapshot.startupCommandInteractive == true)
         #expect(snapshot.closesOnStartupCommandExit == false)
+        #expect(snapshot.startupCommandRestoration == .restore)
         #expect(restored.content.pane?.title == "Claude Code")
         #expect(launch.command == "claude")
         #expect(launch.interactive == true)
         #expect(launch.closesOnCommandExit == false)
+    }
+
+    @Test("legacy command snapshots do not restore startup commands")
+    func legacyCommandTabSnapshotDoesNotRestoreStartupLaunch() {
+        let snapshot = TerminalTabSnapshot(
+            kind: .terminal,
+            customTitle: nil,
+            colorID: nil,
+            isPinned: false,
+            projectPath: testPath,
+            paneTitle: "Extension Command",
+            startupCommand: "npm run dev",
+            startupCommandInteractive: true,
+            closesOnStartupCommandExit: false
+        )
+
+        let restored = TerminalTab(restoring: snapshot)
+
+        #expect(restored.content.pane?.consumeRestoredLaunch().command == nil)
     }
 
     @Test("createCommandTab ignores empty command")

--- a/Tests/MuxyTests/Models/Workspace/TabAreaTests.swift
+++ b/Tests/MuxyTests/Models/Workspace/TabAreaTests.swift
@@ -77,6 +77,24 @@ struct TabAreaTests {
         #expect(pane?.closesOnStartupCommandExit == false)
     }
 
+    @Test("command tab snapshot preserves startup launch")
+    func commandTabSnapshotPreservesStartupLaunch() throws {
+        let area = TabArea(projectPath: testPath)
+        area.createCommandTab(name: "Claude Code", command: "claude", closesOnCommandExit: false)
+
+        let snapshot = try #require(area.activeTab?.snapshot())
+        let restored = TerminalTab(restoring: snapshot)
+        let launch = try #require(restored.content.pane?.consumeRestoredLaunch())
+
+        #expect(snapshot.startupCommand == "claude")
+        #expect(snapshot.startupCommandInteractive == true)
+        #expect(snapshot.closesOnStartupCommandExit == false)
+        #expect(restored.content.pane?.title == "Claude Code")
+        #expect(launch.command == "claude")
+        #expect(launch.interactive == true)
+        #expect(launch.closesOnCommandExit == false)
+    }
+
     @Test("createCommandTab ignores empty command")
     func createCommandTabEmptyCommand() {
         let area = TabArea(projectPath: testPath)

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -110,11 +110,11 @@ struct AIAgentLaunchProviderTests {
         ])
     }
 
-    @Test("agent tabs launch installed local executables safely")
+    @Test("agent tabs launch installed local providers through the user shell")
     func localAgentTabCommand() {
         let provider = AgentTabLaunchTestProvider(executablePath: "/tmp/Agent Tools/codex")
 
-        #expect(AgentTabLaunchCommand.local(provider: provider) == "'/tmp/Agent Tools/codex'")
+        #expect(AgentTabLaunchCommand.local(provider: provider) == "test-agent")
     }
 
     @Test("agent tabs omit unavailable local providers")
@@ -138,7 +138,7 @@ struct AIAgentLaunchProviderTests {
         let options = AgentTabLaunchOption.resolveLocal(providers: [provider])
 
         #expect(provider.resolutionCount == 1)
-        #expect(options.first?.command == "/tmp/test-agent")
+        #expect(options.first?.command == "test-agent")
         #expect(options.first?.title == "Test Agent")
     }
 

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -114,14 +114,17 @@ struct AIAgentLaunchProviderTests {
     func localAgentTabCommand() {
         let provider = AgentTabLaunchTestProvider(executablePath: "/tmp/Agent Tools/codex")
 
-        #expect(AgentTabLaunchCommand.local(provider: provider) == "test-agent")
+        #expect(AgentTabLaunchCommand.local(
+            provider: provider,
+            availableExecutables: ["test-agent"]
+        ) == "test-agent")
     }
 
     @Test("agent tabs omit unavailable local providers")
     func unavailableLocalAgentTabCommand() {
         let provider = AgentTabLaunchTestProvider(executablePath: nil)
 
-        #expect(AgentTabLaunchCommand.local(provider: provider) == nil)
+        #expect(AgentTabLaunchCommand.local(provider: provider, availableExecutables: []) == nil)
     }
 
     @Test("agent tabs escape remote executable names")
@@ -131,15 +134,32 @@ struct AIAgentLaunchProviderTests {
         #expect(AgentTabLaunchCommand.remote(provider: provider) == "test-agent")
     }
 
-    @Test("agent launch options resolve each local executable once")
-    func launchOptionsSnapshotExecutableResolution() {
+    @Test("agent launch options resolve availability through the login shell once")
+    @MainActor
+    func launchOptionsResolveLoginShellAvailability() async {
         let provider = CountingAgentTabLaunchTestProvider()
+        var resolutionCount = 0
 
-        let options = AgentTabLaunchOption.resolveLocal(providers: [provider])
+        let options = await AgentTabLaunchOption.resolveLocal(providers: [provider]) { commands in
+            resolutionCount += 1
+            #expect(commands == ["test-agent"])
+            return ["test-agent"]
+        }
 
-        #expect(provider.resolutionCount == 1)
+        #expect(provider.resolutionCount == 0)
+        #expect(resolutionCount == 1)
         #expect(options.first?.command == "test-agent")
         #expect(options.first?.title == "Test Agent")
+    }
+
+    @Test("agent launch options do not trust filesystem resolution outside the login shell")
+    @MainActor
+    func launchOptionsRejectFilesystemOnlyAvailability() async {
+        let provider = AgentTabLaunchTestProvider(executablePath: "/tmp/test-agent")
+
+        let options = await AgentTabLaunchOption.resolveLocal(providers: [provider]) { _ in [] }
+
+        #expect(options.first?.command == nil)
     }
 
     @Test("remote launch options disable providers missing from the remote PATH")

--- a/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
+++ b/Tests/MuxyTests/Services/AI/ProviderDiscoveryServiceTests.swift
@@ -119,21 +119,25 @@ struct ProviderDiscoveryServiceTests {
 
     @Test("process runner terminates timed out probes")
     func processRunnerTerminatesTimeout() async throws {
+        let timeout: TimeInterval = 0.25
+        let clock = ContinuousClock()
+        let started = clock.now
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ProviderDiscoveryTimeoutTests-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: directory) }
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let completionMarker = directory.appendingPathComponent("completed").path
 
-        await #expect(throws: SubprocessRunnerError.timedOut(0.05)) {
+        await #expect(throws: SubprocessRunnerError.timedOut(timeout)) {
             try await ProviderDiscoveryService.runProcess(
                 executablePath: "/bin/sh",
-                arguments: ["-c", "/bin/sleep 1; /usr/bin/touch '\(completionMarker)'"],
+                arguments: ["-c", "/bin/sleep 5; /usr/bin/touch '\(completionMarker)'"],
                 workingDirectory: directory.path,
-                timeout: 0.05
+                timeout: timeout
             )
         }
 
+        #expect(clock.now - started < .seconds(1))
         #expect(!FileManager.default.fileExists(atPath: completionMarker))
     }
 

--- a/Tests/MuxyTests/Services/Extensions/ExtensionCommandExecutorTests.swift
+++ b/Tests/MuxyTests/Services/Extensions/ExtensionCommandExecutorTests.swift
@@ -328,11 +328,51 @@ struct ExtensionCommandExecutorTests {
 
         try await waitForUnreapedProcessExit(runningProcess.processIdentifier)
         #expect(!runningProcess.terminate())
-        #expect(await completion.wait())
         #expect(runningProcess.terminationStatus == 0)
 
         monitoringQueue.resume()
         monitoringQueueIsSuspended = false
+        #expect(await completion.wait())
+    }
+
+    @Test("terminated process completion uses monitoring queue")
+    func terminatedProcessCompletionUsesMonitoringQueue() async throws {
+        let monitoringQueue = DispatchQueue(label: "muxy.exec.test.terminate-monitor")
+        monitoringQueue.suspend()
+        var monitoringQueueIsSuspended = true
+        defer {
+            if monitoringQueueIsSuspended {
+                monitoringQueue.resume()
+            }
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["5"]
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let completion = ProcessCompletionBox()
+        let runningProcess = try CancellableProcess.launch(
+            configuredProcess: process,
+            stdinPipe: stdinPipe,
+            stdoutPipe: stdoutPipe,
+            stderrPipe: stderrPipe,
+            monitoringQueue: monitoringQueue
+        ) {
+            completion.complete()
+        }
+        try? stdinPipe.fileHandleForWriting.close()
+
+        #expect(runningProcess.terminate())
+
+        try await Task.sleep(for: .milliseconds(350))
+        #expect(!completion.isCompleted)
+
+        monitoringQueue.resume()
+        monitoringQueueIsSuspended = false
+
+        #expect(await completion.wait(milliseconds: 1000))
     }
 
     @Test("cancelled owner state prevents authorization and launch")
@@ -772,18 +812,18 @@ private final class ProcessCompletionBox: @unchecked Sendable {
         lock.unlock()
     }
 
-    func wait() async -> Bool {
-        for _ in 0 ..< 100 {
-            if isCompleted() { return true }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        return false
-    }
-
-    private func isCompleted() -> Bool {
+    var isCompleted: Bool {
         lock.lock()
         defer { lock.unlock() }
         return completed
+    }
+
+    func wait(milliseconds: Int = 2000) async -> Bool {
+        for _ in 0 ..< max(1, milliseconds / 20) {
+            if isCompleted { return true }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return false
     }
 }
 

--- a/Tests/MuxyTests/Services/MuxyAPI/MuxyAPITabsOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPI/MuxyAPITabsOpenTests.swift
@@ -222,10 +222,19 @@ struct MuxyAPITabsOpenTests {
         let pane = try #require(tab.content.pane)
         let snapshot = tab.snapshot()
         let restored = TerminalTab(restoring: snapshot)
+        let encodedSnapshot = try JSONEncoder().encode(snapshot)
+        let encodedSnapshotText = try #require(String(data: encodedSnapshot, encoding: .utf8))
 
         #expect(pane.startupCommand == "npm run dev")
         #expect(pane.startupCommandRestoration == .initialLaunchOnly)
-        #expect(snapshot.startupCommandRestoration == .initialLaunchOnly)
+        #expect(snapshot.paneTitle == TerminalPaneState.defaultTitle)
+        #expect(snapshot.paneUsesDefaultTitle)
+        #expect(snapshot.startupCommand == nil)
+        #expect(snapshot.startupCommandInteractive == nil)
+        #expect(snapshot.closesOnStartupCommandExit == nil)
+        #expect(snapshot.startupCommandRestoration == nil)
+        #expect(!encodedSnapshotText.contains("npm run dev"))
+        #expect(!encodedSnapshotText.contains("startupCommand"))
         #expect(restored.content.pane?.consumeRestoredLaunch().command == nil)
     }
 

--- a/Tests/MuxyTests/Services/MuxyAPI/MuxyAPITabsOpenTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPI/MuxyAPITabsOpenTests.swift
@@ -188,22 +188,45 @@ struct MuxyAPITabsOpenTests {
         #expect(paneCount(in: appState) == before)
     }
 
-    @Test("open(terminal) with a command runs after consent is granted")
-    func openTerminalWithCommandRequiresGrantedConsent() async throws {
+    @Test("extension command tabs run once and do not restore startup commands")
+    func extensionCommandTabDoesNotRestoreStartupCommand() async throws {
         let appState = makeAppState()
         let extensionID = "demo.session-restore"
-        let consent = makeConsent(extensionID: extensionID, command: "npm run dev", decision: .allow)
-        let result = await MuxyAPI.Tabs.open(
-            OpenTabRequest(kind: .terminal, command: "npm run dev"),
-            appState: appState,
-            callingExtensionID: extensionID,
-            consent: consent
+        let consent = ExtensionConsentService(
+            grantStore: ExtensionGrantStore(fileURL: temporaryGrantFileURL()),
+            auditLog: ExtensionAuditLog(fileURL: temporaryGrantFileURL())
         )
+        let opening = Task { @MainActor in
+            await MuxyAPI.Tabs.open(
+                OpenTabRequest(kind: .terminal, command: "npm run dev"),
+                appState: appState,
+                callingExtensionID: extensionID,
+                consent: consent
+            )
+        }
+        for _ in 0 ..< 100 where consent.pendingPrompt == nil {
+            await Task.yield()
+        }
+        guard let requestID = consent.pendingPrompt?.id else {
+            opening.cancel()
+            Issue.record("expected command consent prompt")
+            return
+        }
+        consent.respond(requestID: requestID, choice: .allowOnce)
+        let result = await opening.value
         guard case .success = result else {
             Issue.record("expected success")
             return
         }
-        #expect(openedPanes(in: appState).last?.startupCommand == "npm run dev")
+        let tab = try #require(openedTabs(in: appState).last)
+        let pane = try #require(tab.content.pane)
+        let snapshot = tab.snapshot()
+        let restored = TerminalTab(restoring: snapshot)
+
+        #expect(pane.startupCommand == "npm run dev")
+        #expect(pane.startupCommandRestoration == .initialLaunchOnly)
+        #expect(snapshot.startupCommandRestoration == .initialLaunchOnly)
+        #expect(restored.content.pane?.consumeRestoredLaunch().command == nil)
     }
 
     @Test("open(terminal) with a command is rejected when consent is denied")
@@ -314,6 +337,10 @@ struct MuxyAPITabsOpenTests {
                 area.tabs.compactMap { $0.content.pane }
             }
         }
+    }
+
+    private func openedTabs(in appState: AppState) -> [TerminalTab] {
+        appState.workspaceRoots.values.flatMap { $0.allTabs() }
     }
 
     private func openedTabIDs(in appState: AppState) -> [UUID] {

--- a/Tests/MuxyTests/Services/Session/SessionDaemonEndToEndTests.swift
+++ b/Tests/MuxyTests/Services/Session/SessionDaemonEndToEndTests.swift
@@ -13,6 +13,11 @@ struct SessionDaemonEndToEndTests {
         let processIDs: [pid_t]
     }
 
+    private static let fishPath = [
+        "/opt/homebrew/bin/fish",
+        "/usr/local/bin/fish",
+    ].first { FileManager.default.isExecutableFile(atPath: $0) }
+
     private func makeIdentifier() throws -> SessionIdentifier {
         try #require(SessionIdentifier(uuidString: UUID().uuidString))
     }
@@ -111,6 +116,97 @@ struct SessionDaemonEndToEndTests {
 
             let output = connection.collectOutput(timeout: 5) { $0.contains("STARTUP_RAN") }
             #expect(output.contains("STARTUP_RAN"))
+        }
+    }
+
+    @Test("runs a fish pane startup command through the persistent session wrapper", .enabled(if: SessionDaemonEndToEndTests.fishPath != nil))
+    func runsFishPaneStartupCommandWrapper() throws {
+        let fishPath = try #require(Self.fishPath)
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            let wrapper = TerminalLaunchCommand.shellCommand(
+                interactive: true,
+                keepsShellOpen: true,
+                shell: fishPath
+            )
+            connection.send(harness.attachRequest(
+                identifier: identifier,
+                command: wrapper,
+                shell: fishPath,
+                environment: [
+                    SessionEnvironmentEntry(
+                        key: TerminalLaunchCommand.environmentKey,
+                        value: "printf \"FISH_STARTUP_RAN\\n\""
+                    ),
+                ]
+            ))
+
+            let output = connection.collectOutput(timeout: 5) { $0.contains("FISH_STARTUP_RAN") }
+            #expect(output.contains("FISH_STARTUP_RAN"))
+        }
+    }
+
+    @Test("runs a zsh pane startup command through the persistent session wrapper")
+    func runsZshPaneStartupCommandWrapper() throws {
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            let wrapper = TerminalLaunchCommand.shellCommand(
+                interactive: true,
+                keepsShellOpen: true,
+                shell: "/bin/zsh"
+            )
+            connection.send(harness.attachRequest(
+                identifier: identifier,
+                command: wrapper,
+                shell: "/bin/zsh",
+                environment: [
+                    SessionEnvironmentEntry(
+                        key: TerminalLaunchCommand.environmentKey,
+                        value: "printf \"ZSH_STARTUP_RAN\\n\""
+                    ),
+                ]
+            ))
+
+            let output = connection.collectOutput(timeout: 5) { $0.contains("ZSH_STARTUP_RAN") }
+            #expect(output.contains("ZSH_STARTUP_RAN"))
+        }
+    }
+
+    @Test("runs a remote fish startup command through the bootstrap wrapper", .enabled(if: SessionDaemonEndToEndTests.fishPath != nil))
+    func runsRemoteFishStartupBootstrapWrapper() throws {
+        let fishPath = try #require(Self.fishPath)
+        try withHarness { harness in
+            let identifier = try makeIdentifier()
+            let connection = try #require(SessionTestConnection(socketPath: harness.socketPath))
+            defer { connection.close() }
+
+            let script = TerminalLaunchCommand.remoteShellBootstrapScript(
+                environment: [:],
+                workingDirectory: "",
+                startupCommand: "printf \"REMOTE_FISH_STARTUP_RAN\\n\"",
+                interactive: true,
+                keepsShellOpen: false
+            )
+            connection.send(harness.attachRequest(
+                identifier: identifier,
+                command: "/bin/sh -c \(ShellEscaper.escape(script))",
+                shell: "/bin/sh",
+                environment: [
+                    SessionEnvironmentEntry(
+                        key: "SHELL",
+                        value: fishPath
+                    ),
+                ]
+            ))
+
+            let output = connection.collectOutput(timeout: 5) { $0.contains("REMOTE_FISH_STARTUP_RAN") }
+            #expect(output.contains("REMOTE_FISH_STARTUP_RAN"))
         }
     }
 

--- a/Tests/MuxyTests/Services/Terminal/TerminalLaunchCommandTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/TerminalLaunchCommandTests.swift
@@ -33,6 +33,18 @@ struct TerminalLaunchCommandTests {
         #expect(!command.contains("else exit $muxy_status"))
     }
 
+    @Test("Builds fish-compatible login shell command")
+    func buildsFishCompatibleLoginShellCommand() {
+        let command = TerminalLaunchCommand.shellCommand(interactive: true, shell: "/opt/homebrew/bin/fish")
+
+        #expect(command.hasPrefix("/opt/homebrew/bin/fish -l -c 'eval \"$MUXY_STARTUP_COMMAND\"; set muxy_status $status;"))
+        #expect(command.contains("if test $muxy_status -ne 0"))
+        #expect(command.contains("then exec \"$0\" -l") == false)
+        #expect(command.contains("muxy_status=$?") == false)
+        #expect(command.contains("exec \"$argv[1]\" -l"))
+        #expect(command.hasSuffix("' /opt/homebrew/bin/fish"))
+    }
+
     @Test("Launch wrapper does not embed user command")
     func launchWrapperDoesNotEmbedUserCommand() {
         let command = TerminalLaunchCommand.shellCommand(interactive: true, shell: "/bin/zsh")
@@ -58,7 +70,8 @@ struct TerminalLaunchCommandTests {
         )
         #expect(command.hasPrefix("/usr/bin/ssh "))
         #expect(command.contains("-tt"))
-        #expect(command.contains("'export TERM=xterm-256color; cd ~/code/api && exec \"${SHELL:-/bin/sh}\" -l -i'"))
+        #expect(command.contains("exec /bin/sh -c"))
+        #expect(command.contains("export TERM=xterm-256color; cd ~/code/api && exec \"${SHELL:-/bin/sh}\" -l -i"))
     }
 
     @Test("Remote shell escapes an injected startup command so it cannot break out")
@@ -77,6 +90,35 @@ struct TerminalLaunchCommandTests {
         #expect(command.contains("'\\''"))
     }
 
+    @Test("Remote shell routes fish startup commands through fish syntax")
+    func remoteShellRoutesFishStartupCommand() {
+        let persistentCommand = TerminalLaunchCommand.remoteShellBootstrapCommand(
+            environment: [:],
+            workingDirectory: "",
+            startupCommand: "printf REMOTE_FISH",
+            interactive: true,
+            keepsShellOpen: true
+        )
+        let closingCommand = TerminalLaunchCommand.remoteShellBootstrapCommand(
+            environment: [:],
+            workingDirectory: "",
+            startupCommand: "printf REMOTE_FISH",
+            interactive: true,
+            keepsShellOpen: false
+        )
+
+        #expect(persistentCommand.hasPrefix("exec /bin/sh -c "))
+        #expect(persistentCommand.contains("__muxy_shell_name=${__muxy_shell##*/}"))
+        #expect(persistentCommand.contains("case \"$__muxy_shell_name\" in fish)"))
+        #expect(persistentCommand.contains("exec \"$__muxy_shell\" -l -c"))
+        #expect(persistentCommand.contains("set muxy_status $status"))
+        #expect(persistentCommand.contains("else exec \"$argv[1]\" -l"))
+        #expect(persistentCommand.contains("*) exec \"$__muxy_shell\" -l -i -c"))
+        #expect(persistentCommand.contains("muxy_status=$?"))
+        #expect(closingCommand.contains("set muxy_status $status"))
+        #expect(closingCommand.contains("else exit $muxy_status"))
+    }
+
     @Test("Remote shell uses configured environment")
     func remoteShellUsesConfiguredEnvironment() {
         let command = TerminalLaunchCommand.remoteShellCommand(
@@ -86,6 +128,6 @@ struct TerminalLaunchCommandTests {
             interactive: true,
             keepsShellOpen: false
         )
-        #expect(command.contains("'export LANG=C.UTF-8; export TERM=screen-256color; cd ~ && exec \"${SHELL:-/bin/sh}\" -l -i'"))
+        #expect(command.contains("export LANG=C.UTF-8; export TERM=screen-256color; cd ~ && exec \"${SHELL:-/bin/sh}\" -l -i"))
     }
 }

--- a/Tests/MuxyTests/Utilities/LoginShellPathTests.swift
+++ b/Tests/MuxyTests/Utilities/LoginShellPathTests.swift
@@ -48,6 +48,46 @@ struct LoginShellPathTests {
         #expect(LoginShellPath.shellArguments.last?.contains("printenv COPILOT_HOME") == true)
     }
 
+    @Test("agent command availability uses fish startup flags and function lookup")
+    func commandAvailabilityUsesFishSemantics() {
+        let arguments = LoginShellPath.commandAvailabilityArguments(
+            shellPath: "/opt/homebrew/bin/fish",
+            commands: ["codex"]
+        )
+
+        #expect(arguments.prefix(2) == ["-l", "-c"])
+        #expect(arguments.last?.contains("type -q codex") == true)
+    }
+
+    @Test("agent command availability preserves zsh interactive startup semantics")
+    func commandAvailabilityUsesZshSemantics() {
+        let arguments = LoginShellPath.commandAvailabilityArguments(
+            shellPath: "/bin/zsh",
+            commands: ["codex"]
+        )
+
+        #expect(arguments.prefix(3) == ["-l", "-i", "-c"])
+        #expect(arguments.last?.contains("command -v codex") == true)
+    }
+
+    @Test("agent command availability accepts only marked login shell results")
+    func commandAvailabilityAcceptsMarkedResults() {
+        let available = LoginShellPath.availableCommands(
+            ["codex", "claude"],
+            shellPath: "/bin/zsh"
+        ) { _, _, _ in
+            Data("""
+            startup noise
+            __MUXY_COMMAND_AVAILABILITY_START__
+            codex
+            unrelated
+            __MUXY_COMMAND_AVAILABILITY_END__
+            """.utf8)
+        }
+
+        #expect(available == ["codex"])
+    }
+
     @Test("login shell lookup extracts PATH without startup output")
     func loginShellLookupExtractsPathWithoutStartupOutput() {
         let output = """

--- a/Tests/MuxyTests/Utilities/LoginShellPathTests.swift
+++ b/Tests/MuxyTests/Utilities/LoginShellPathTests.swift
@@ -88,6 +88,22 @@ struct LoginShellPathTests {
         #expect(available == ["codex"])
     }
 
+    @Test("agent command availability tolerates a truncated UTF-8 scalar before results")
+    func commandAvailabilityToleratesTruncatedUTF8() {
+        let output = Data([0x80]) + Data("""
+        __MUXY_COMMAND_AVAILABILITY_START__
+        codex
+        __MUXY_COMMAND_AVAILABILITY_END__
+        """.utf8)
+
+        let available = LoginShellPath.extractAvailableCommands(
+            from: output,
+            expected: ["codex", "claude"]
+        )
+
+        #expect(available == ["codex"])
+    }
+
     @Test("login shell lookup extracts PATH without startup output")
     func loginShellLookupExtractsPathWithoutStartupOutput() {
         let output = """


### PR DESCRIPTION
## Summary
- Preserve pane startup commands across terminal tab snapshot and restore so command tabs run when materialized.
- Launch local agents through the user shell command name while keeping executable-path detection for availability.
- Preserve the existing POSIX-style startup wrapper for sh/bash/zsh-like shells and add fish-compatible local and remote startup wrappers.

## Shell compatibility
The existing POSIX-style startup script remains the default path for sh/bash/zsh-like shells. This PR adds fish-specific startup script generation because fish is not POSIX-compatible and does not reliably run the previous interactive `-i -c` startup path in the persistent session flow.

Remote terminal startup now enters a `/bin/sh` bootstrap before dispatching back to the remote `$SHELL`. This keeps the outer SSH command parseable when sshd invokes a fish login shell with `-c`, while still preserving the existing POSIX-style execution path for sh/bash/zsh-like shells.

This does not claim general support for every non-POSIX shell; it only covers the fish startup behavior validated here.

## Testing
- mise exec -- swift test --filter TerminalLaunchCommandTests
- mise exec -- swift test --filter SessionDaemonEndToEndTests
- mise exec -- scripts/checks.sh --fix

AI assistance: OpenAI GPT-5 Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal startup commands now preserve interactive mode, close-on-exit settings, and restoration preferences when tabs are restored.
  * Added Fish shell support for local and remote startup commands.
  * Agent launches now use available configured provider executables.

* **Bug Fixes**
  * Improved handling of unavailable agent executables and shell-specific startup behavior.

* **Tests**
  * Added coverage for startup restoration, one-time launches, and Fish/Zsh command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->