### PR TITLE
Open local terminal file links outside the project with the default app

### DIFF
--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -586,25 +586,45 @@ struct TerminalBridge: NSViewRepresentable {
         }
         view.onCmdClickFile = { token in
             guard let location = Self.resolveFileLocation(from: token, projectPath: projectPath) else { return }
-            if Self.openWithRegisteredFileOpener(
+            _ = Self.openFileLocation(
                 location,
                 projectPath: projectPath,
                 projectID: projectID,
                 areaID: areaID,
                 appState: appState
-            ) {
-                return
-            }
-            _ = IDEIntegrationService.shared.openProject(
-                at: projectPath,
-                highlightingFileAt: location.path,
-                line: location.line,
-                column: location.column
             )
         }
         view.onOpenURL = { url in
             if let location = Self.resolveFileLocation(from: url, projectPath: projectPath) {
-                if Self.openWithRegisteredFileOpener(
+                return Self.openFileLocation(
+                    location,
+                    projectPath: projectPath,
+                    projectID: projectID,
+                    areaID: areaID,
+                    appState: appState
+                )
+            }
+            guard Self.isExternalLink(url) else {
+                ToastState.shared.show(L10n.string("File not found"))
+                return false
+            }
+            return Self.openExternalLink(url, appState: appState)
+        }
+    }
+
+    @MainActor
+    private static func openFileLocation(
+        _ location: ResolvedFileLocation,
+        projectPath: String,
+        projectID: UUID?,
+        areaID: UUID,
+        appState: AppState
+    ) -> Bool {
+        openFileLocation(
+            location,
+            projectPath: projectPath,
+            projectFileOpener: { location in
+                if openWithRegisteredFileOpener(
                     location,
                     projectPath: projectPath,
                     projectID: projectID,
@@ -619,13 +639,21 @@ struct TerminalBridge: NSViewRepresentable {
                     line: location.line,
                     column: location.column
                 )
-            }
-            guard Self.isExternalLink(url) else {
-                ToastState.shared.show(L10n.string("File not found"))
-                return false
-            }
-            return Self.openExternalLink(url, appState: appState)
+            },
+            defaultApplicationOpener: { NSWorkspace.shared.open($0) }
+        )
+    }
+
+    static func openFileLocation(
+        _ location: ResolvedFileLocation,
+        projectPath: String,
+        projectFileOpener: (ResolvedFileLocation) -> Bool,
+        defaultApplicationOpener: (URL) -> Bool
+    ) -> Bool {
+        guard relativePath(location.path, inside: projectPath) != nil else {
+            return defaultApplicationOpener(URL(fileURLWithPath: location.path))
         }
+        return projectFileOpener(location)
     }
 
     @MainActor

--- a/Tests/MuxyTests/Views/Terminal/TerminalBridgeResolveFilePathTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalBridgeResolveFilePathTests.swift
@@ -379,6 +379,62 @@ struct TerminalBridgeResolveFilePathTests {
         #expect(TerminalBridge.relativePath(outside, inside: dir.path) == nil)
     }
 
+    @Test func routesFileOutsideProjectToDefaultApplication() throws {
+        let project = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: project) }
+        let outside = writeFile(
+            URL(fileURLWithPath: NSTemporaryDirectory()),
+            name: "outside-\(UUID().uuidString).png"
+        )
+        defer { try? FileManager.default.removeItem(atPath: outside) }
+        let location = TerminalBridge.ResolvedFileLocation(path: outside, line: nil, column: nil)
+        var openedURL: URL?
+        var openedProjectFile = false
+
+        let opened = TerminalBridge.openFileLocation(
+            location,
+            projectPath: project.path,
+            projectFileOpener: { _ in
+                openedProjectFile = true
+                return true
+            },
+            defaultApplicationOpener: {
+                openedURL = $0
+                return true
+            }
+        )
+
+        #expect(opened)
+        #expect(openedURL == URL(fileURLWithPath: outside))
+        #expect(!openedProjectFile)
+    }
+
+    @Test func routesFileInsideProjectToProjectOpener() throws {
+        let project = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: project) }
+        let file = writeFile(project, name: "inside.png")
+        let location = TerminalBridge.ResolvedFileLocation(path: file, line: nil, column: nil)
+        var openedProjectLocation: TerminalBridge.ResolvedFileLocation?
+        var openedURL: URL?
+
+        let opened = TerminalBridge.openFileLocation(
+            location,
+            projectPath: project.path,
+            projectFileOpener: {
+                openedProjectLocation = $0
+                return true
+            },
+            defaultApplicationOpener: {
+                openedURL = $0
+                return true
+            }
+        )
+
+        #expect(opened)
+        #expect(openedProjectLocation == location)
+        #expect(openedURL == nil)
+    }
+
     @Test func stripsLineSuffixOnlyWhenTrailingNumeric() {
         #expect(TerminalBridge.stripLineColumnSuffix(from: "a.txt:12") == .init(path: "a.txt", line: 12, column: nil))
         #expect(TerminalBridge.stripLineColumnSuffix(from: "a.txt:12:7") == .init(path: "a.txt", line: 12, column: 7))

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -132,6 +132,9 @@ nor changes a text selection:
 | `⌘` + left-drag | Moves the pane to another area or split |
 | Right-click | Opens the [right-click menu](#right-click-menu) |
 
+File paths inside the current project use its configured file opener. Local files outside the project open in
+their default macOS application.
+
 A `⌘` + left-drag is decided when the gesture starts, so pressing or releasing `⌘` mid-drag never switches
 between moving the pane and selecting text.
 


### PR DESCRIPTION
## What changed

Local file links opened from the terminal are now routed according to their location:

- Files inside the current project continue to use the configured project file opener, including Files (Editor).
- Files outside the current project open with the macOS default application.

This fixes an issue where clicking a temporary file such as `/var/folders/.../image.png` could fall back to Finder and open the project root instead of the selected file.

## Implementation

- Share the same local-file routing between command-click and OSC 8 URL callbacks.
- Preserve the existing project opener and IDE fallback for project files.
- Use NSWorkspace for project-external local files.
- Add regression coverage for both routing paths.
- Document the terminal file-link behavior.

## Screenshot

![Reproduction: temporary file link rendered in the terminal](https://github.com/user-attachments/assets/f22917d3-1fc5-413a-b2f1-d281413a70b2)

## Testing

- TerminalBridgeResolveFilePathTests: 39 tests passed.
- 3,101 remaining tests passed when excluding the unchanged timing-sensitive MuxyAPIPanesMaterializeTests suite.
- SwiftFormat passed.
- SwiftLint passed.
- Test build passed.

The complete local test run encountered three paneSurfaceNotReady timeouts in the unchanged MuxyAPIPanesMaterializeTests suite under Xcode 26.2. The repository pins Xcode 16.4, so CI will provide the authoritative result.

## AI assistance

GPT-5.6 Sol assisted with the implementation, tests, documentation, and review.
