### PR TITLE
Add panel presentation for Rich Input composer

### DIFF
--- a/Muxy/Models/Preferences/RichInputPreferences.swift
+++ b/Muxy/Models/Preferences/RichInputPreferences.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+enum RichInputPresentationMode: String, CaseIterable, Identifiable {
+    case panel
+    case floating
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .panel: "Panel"
+        case .floating: "Floating"
+        }
+    }
+}
+
 enum RichInputPreferences {
     static let fontSizeKey = "muxy.richInput.fontSize"
     static let defaultFontSize: Double = 13
@@ -9,4 +23,10 @@ enum RichInputPreferences {
 
     static let broadcastKey = "muxy.richInput.broadcast"
     static let defaultBroadcast = false
+
+    static let presentationModeKey = "muxy.richInput.presentationMode"
+    static let defaultPresentationMode: RichInputPresentationMode = .panel
+
+    static let positionKey = "muxy.richInput.position"
+    static let defaultPosition: PanelPosition = .right
 }

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -134,6 +134,8 @@
 "Browser Profile" = "Browser Profile";
 "Browse…" = "Browse…";
 "Browsing" = "Browsing";
+"Broadcast Off — Send to Active Pane" = "Broadcast Off — Send to Active Pane";
+"Broadcast On — Send to All Split Panes" = "Broadcast On — Send to All Split Panes";
 "Built-in" = "Built-in";
 "Built-in (Top Bar Project Target)" = "Built-in (Top Bar Project Target)";
 "Built-in browser is disabled" = "Built-in browser is disabled";
@@ -166,6 +168,7 @@
 "Choose the AI provider for %@" = "Choose the AI provider for %@";
 "Choose where to save the Muxy backup" = "Choose where to save the Muxy backup";
 "Choose…" = "Choose…";
+"Chooses whether the composer opens as a workspace panel or a floating modal." = "Chooses whether the composer opens as a workspace panel or a floating modal.";
 "Clean" = "Clean";
 "Clean working tree" = "Clean working tree";
 "Clear" = "Clear";
@@ -210,6 +213,7 @@
 "Committed and pushed" = "Committed and pushed";
 "Committing" = "Committing";
 "Composer" = "Composer";
+"Composer Presentation" = "Composer Presentation";
 "Composer Voice" = "Composer Voice";
 "Confirm Delete All (%lld)" = "Confirm Delete All (%lld)";
 "Confirm before closing a tab with a running process" = "Confirm before closing a tab with a running process";
@@ -365,6 +369,7 @@
 "Finder" = "Finder";
 "Finished" = "Finished";
 "Fix Search Location" = "Fix Search Location";
+"Floating" = "Floating";
 "Focus Pane Down" = "Focus Pane Down";
 "Focus Pane Left" = "Focus Pane Left";
 "Focus Pane Right" = "Focus Pane Right";
@@ -588,6 +593,7 @@
 "PRIMARY" = "PRIMARY";
 "Pair Mobile Device" = "Pair Mobile Device";
 "Pairing network" = "Pairing network";
+"Panel" = "Panel";
 "Panes" = "Panes";
 "Paste" = "Paste";
 "Path Is Not a Folder" = "Path Is Not a Folder";
@@ -605,6 +611,7 @@
 "Port %@" = "Port %@";
 "Port must be between 1 and 65535." = "Port must be between 1 and 65535.";
 "Position" = "Position";
+"Presentation" = "Presentation";
 "Press Return after inserting" = "Press Return after inserting";
 "Press a global shortcut, or Escape to cancel." = "Press a global shortcut, or Escape to cancel.";
 "Press key…" = "Press key…";
@@ -730,6 +737,7 @@
 "Revoke 1 device?" = "Revoke 1 device?";
 "Revoke Selected (%lld)" = "Revoke Selected (%lld)";
 "Revoking removes the device's access. It will need to request approval again to reconnect." = "Revoking removes the device's access. It will need to request approval again to reconnect.";
+"Rich Input" = "Rich Input";
 "Right" = "Right";
 "After enabling background sessions and opening a new local terminal, right-click inside its unpinned terminal-only tab and choose Send to Background to close the tab without stopping its processes." = "After enabling background sessions and opening a new local terminal, right-click inside its unpinned terminal-only tab and choose Send to Background to close the tab without stopping its processes.";
 "Run New Terminals in the Background" = "Run New Terminals in the Background";
@@ -1195,6 +1203,8 @@
 "Updates" = "Updates";
 "Updating…" = "Updating…";
 "Use App Default" = "Use App Default";
+"Use Composer Panel" = "Use Composer Panel";
+"Use Floating Composer" = "Use Floating Composer";
 "Use Global Prompt" = "Use Global Prompt";
 "Use Path" = "Use Path";
 "Use existing branch" = "Use existing branch";

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -363,6 +363,7 @@ enum SettingsJSONStore {
             AppBackgroundStyle.storageKey: Set(AppBackgroundStyle.allCases.map(\.rawValue)),
             SidebarCollapsedStyle.storageKey: Set(SidebarCollapsedStyle.allCases.map(\.rawValue)),
             SidebarExpandedStyle.storageKey: Set(SidebarExpandedStyle.allCases.map(\.rawValue)),
+            RichInputPreferences.presentationModeKey: Set(RichInputPresentationMode.allCases.map(\.rawValue)),
             "editor.richInputImageStrategy": Set(RichInputImageStrategy.allCases.map(\.rawValue)),
             NotificationSettings.Key.sound: Set(NotificationSound.allCases.map(\.rawValue)),
             NotificationSettings.Key.toastPosition: Set(ToastPosition.allCases.map(\.rawValue)),

--- a/Muxy/Services/RichInput/RichInputPresentationController.swift
+++ b/Muxy/Services/RichInput/RichInputPresentationController.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+struct RichInputPresentationTarget: Equatable {
+    let worktreeKey: WorktreeKey
+    let paneID: UUID
+}
+
+@MainActor
+@Observable
+final class RichInputPresentationController {
+    private(set) var isFloatingVisible = false
+    private(set) var target: RichInputPresentationTarget?
+    private let panelHost: PanelHost
+    private var panelWasVisible: Bool
+
+    init(panelHost: PanelHost = .shared) {
+        self.panelHost = panelHost
+        panelWasVisible = panelHost.isOpen(BuiltinPanel.richInput)
+    }
+
+    var isPanelVisible: Bool {
+        panelHost.isOpen(BuiltinPanel.richInput)
+    }
+
+    var isVisible: Bool {
+        isFloatingVisible || isPanelVisible
+    }
+
+    func present(
+        mode: RichInputPresentationMode,
+        position: PanelPosition,
+        target: RichInputPresentationTarget
+    ) {
+        self.target = target
+        isFloatingVisible = false
+        panelHost.close(BuiltinPanel.richInput)
+        switch mode {
+        case .panel:
+            panelHost.open(BuiltinPanel.richInput, at: position, mode: .pinned)
+        case .floating:
+            isFloatingVisible = true
+        }
+        panelWasVisible = isPanelVisible
+    }
+
+    @discardableResult
+    func close() -> Bool {
+        let wasVisible = isVisible
+        target = nil
+        isFloatingVisible = false
+        panelHost.close(BuiltinPanel.richInput)
+        panelWasVisible = false
+        return wasVisible
+    }
+
+    @discardableResult
+    func synchronize(mode: RichInputPresentationMode, position: PanelPosition) -> Bool {
+        guard isVisible, let target else { return false }
+        if mode == .panel, isPanelVisible, !isFloatingVisible {
+            return false
+        }
+        if mode == .floating, isFloatingVisible, !isPanelVisible {
+            return false
+        }
+        present(mode: mode, position: position, target: target)
+        return true
+    }
+
+    func movePanel(to position: PanelPosition) {
+        guard isPanelVisible else { return }
+        panelHost.move(BuiltinPanel.richInput, to: position)
+        panelWasVisible = isPanelVisible
+    }
+
+    func reconcilePanelHostChange(voice: ComposerVoiceState) {
+        let panelIsVisible = isPanelVisible
+        defer { panelWasVisible = panelIsVisible }
+        guard panelWasVisible, !panelIsVisible, !isFloatingVisible else { return }
+        target = nil
+        voice.cancel()
+    }
+
+    @discardableResult
+    func reconcileTargetChange(
+        _ currentTarget: RichInputPresentationTarget?,
+        voice: ComposerVoiceState
+    ) -> Bool {
+        guard isVisible else {
+            target = nil
+            return false
+        }
+        guard target != currentTarget else { return false }
+        voice.cancel()
+        guard isPanelVisible, let currentTarget else {
+            return close()
+        }
+        target = currentTarget
+        return false
+    }
+}

--- a/Muxy/Views/Composer/FocusedComposerView.swift
+++ b/Muxy/Views/Composer/FocusedComposerView.swift
@@ -10,8 +10,10 @@ struct FocusedComposerView: View {
     let worktreeName: String
     let languageIdentifier: String
     let availableSize: CGSize
+    let presentationMode: RichInputPresentationMode
     @Binding var broadcasts: Bool
     let onSubmit: (_ appendReturn: Bool, _ selectedText: String?) -> Void
+    let onChangePresentationMode: (RichInputPresentationMode) -> Void
     let onClose: () -> Void
 
     @State private var editorSettings = EditorSettings.shared
@@ -23,11 +25,26 @@ struct FocusedComposerView: View {
     @State private var submission: RichInputTextEditor.Submission?
 
     var body: some View {
+        Group {
+            switch presentationMode {
+            case .panel:
+                panelLayout
+            case .floating:
+                floatingLayout
+            }
+        }
+        .onDrop(of: [UTType.fileURL, UTType.image], isTargeted: nil, perform: handleDrop)
+        .onChange(of: state.text) { persistDraft() }
+        .onChange(of: state.fileAttachments) { persistDraft() }
+        .onChange(of: state.imageAttachments) { persistDraft() }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(L10n.string("Composer"))
+    }
+
+    private var floatingLayout: some View {
         VStack(spacing: 0) {
             metadata
-            editor
-            attachments
-            actions
+            inputContent
         }
         .padding(UIMetrics.scaled(14))
         .background {
@@ -41,12 +58,22 @@ struct FocusedComposerView: View {
         .overlay(resizeEdges)
         .frame(width: UIMetrics.scaled(layoutSize.width), height: UIMetrics.scaled(layoutSize.height))
         .shadow(color: .black.opacity(0.45), radius: UIMetrics.scaled(36), y: UIMetrics.scaled(18))
-        .onDrop(of: [UTType.fileURL, UTType.image], isTargeted: nil, perform: handleDrop)
-        .onChange(of: state.text) { persistDraft() }
-        .onChange(of: state.fileAttachments) { persistDraft() }
-        .onChange(of: state.imageAttachments) { persistDraft() }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(L10n.string("Composer"))
+    }
+
+    private var panelLayout: some View {
+        VStack(spacing: 0) {
+            inputContent
+        }
+        .padding(UIMetrics.scaled(14))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(MuxyTheme.bg)
+    }
+
+    @ViewBuilder
+    private var inputContent: some View {
+        editor
+        attachments
+        actions
     }
 
     private var metadata: some View {
@@ -253,7 +280,12 @@ struct FocusedComposerView: View {
                 }
                 .disabled(!voice.canSubmit)
                 Divider()
-                Button(L10n.string("Reset Composer Size"), action: resetSize)
+                Button(presentationModeSwitchLabel) {
+                    onChangePresentationMode(presentationMode == .panel ? .floating : .panel)
+                }
+                if presentationMode == .floating {
+                    Button(L10n.string("Reset Composer Size"), action: resetSize)
+                }
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
@@ -291,6 +323,13 @@ struct FocusedComposerView: View {
             .accessibilityLabel(L10n.string("Send"))
         }
         .padding(.top, UIMetrics.spacing4)
+    }
+
+    private var presentationModeSwitchLabel: String {
+        switch presentationMode {
+        case .panel: L10n.string("Use Floating Composer")
+        case .floating: L10n.string("Use Composer Panel")
+        }
     }
 
     private var editorConfiguration: RichInputTextEditor.Configuration {

--- a/Muxy/Views/MainWindow+Panels.swift
+++ b/Muxy/Views/MainWindow+Panels.swift
@@ -1,10 +1,16 @@
 import SwiftUI
 
 enum BuiltinPanel {
+    static let richInput = "builtin:richInput"
     static let extensionConsole = "builtin:extensionConsole"
 }
 
 enum PanelLayoutMetrics {
+    static let richInputWidthRange: ClosedRange<CGFloat> = 280 ... 800
+    static let richInputDefaultWidth: Double = 380
+    static let richInputHeightRange: ClosedRange<CGFloat> = 120 ... 600
+    static let richInputDefaultHeight: Double = 220
+
     static let consoleHeightRange: ClosedRange<CGFloat> = 120 ... 600
     static let consoleDefaultHeight: Double = 220
 

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -112,7 +112,7 @@ struct MainWindow: View {
     private var richInputPanelPosition = RichInputPreferences.defaultPosition
     @AppStorage(RichInputPreferences.broadcastKey) private var richInputBroadcast = RichInputPreferences.defaultBroadcast
     @State private var richInputStates: [WorktreeKey: RichInputState] = [:]
-    @State private var composerVisible = false
+    @State private var richInputPresentation = RichInputPresentationController()
     @State private var composerVoice = ComposerVoiceState()
     @State private var visitedWorktreeKeys: Set<WorktreeKey> = []
     @AppStorage(WorktreeListPreferences.orderByMRUKey)
@@ -189,6 +189,13 @@ struct MainWindow: View {
             .onChange(of: richInputPresentationMode) { _, mode in
                 synchronizeRichInputPresentationMode(mode)
             }
+            .onChange(of: panelHost.placements) {
+                richInputPresentation.reconcilePanelHostChange(voice: composerVoice)
+            }
+            .onChange(of: activeRichInputTarget) { _, target in
+                guard richInputPresentation.reconcileTargetChange(target, voice: composerVoice) else { return }
+                restoreActiveTerminalFocus()
+            }
     }
 
     private var windowColumns: some View {
@@ -209,7 +216,7 @@ struct MainWindow: View {
             overlayActive: overlayActive,
             toastAlignment: toastAlignment,
             isVoicePanelVisible: voiceRecording.isPanelVisible,
-            isComposerVisible: composerVisible,
+            isComposerVisible: richInputPresentation.isFloatingVisible,
             hasToast: ToastState.shared.message != nil
         )
     }
@@ -382,9 +389,6 @@ struct MainWindow: View {
     }
 
     private func refreshWorkspaceWatcherAndVisited() {
-        if composerVisible {
-            closeComposer()
-        }
         updateWorkspaceFileWatcher()
         recordVisitedActiveWorktree()
     }
@@ -778,7 +782,7 @@ struct MainWindow: View {
 
     private var activeModalOverlays: Set<MainWindowModalOverlay> {
         var overlays: Set<MainWindowModalOverlay> = []
-        if composerVisible {
+        if richInputPresentation.isFloatingVisible {
             overlays.insert(.composer)
         }
         if showTerminalOmnibox {
@@ -820,7 +824,7 @@ struct MainWindow: View {
 
     @ViewBuilder
     private var composerOverlay: some View {
-        if composerVisible,
+        if richInputPresentation.isFloatingVisible,
            let state = activeRichInputState,
            let worktreeKey = activeWorktreeKey,
            let project = activeProject,
@@ -1133,9 +1137,6 @@ struct MainWindow: View {
     }
 
     private func activateWorkspaceForActiveProject() {
-        if composerVisible {
-            closeComposer()
-        }
         guard let projectID = appState.activeProjectID, projectID != Project.homeID else { return }
         let candidates = projectStore.projects + projectGroupStore.remoteProjects
         guard let project = candidates.first(where: { $0.id == projectID }) else { return }
@@ -1808,17 +1809,24 @@ struct MainWindow: View {
         activeTerminalPane?.id
     }
 
+    private var activeRichInputTarget: RichInputPresentationTarget? {
+        guard let worktreeKey = activeWorktreeKey,
+              let paneID = activeRichInputPaneID
+        else { return nil }
+        return RichInputPresentationTarget(worktreeKey: worktreeKey, paneID: paneID)
+    }
+
     private var activeTerminalPane: TerminalPaneState? {
         guard let project = activeProject else { return nil }
         return appState.activeTab(for: project.id)?.content.pane
     }
 
     private var richInputPanelVisible: Bool {
-        panelHost.isOpen(BuiltinPanel.richInput)
+        richInputPresentation.isPanelVisible
     }
 
     private var richInputVisible: Bool {
-        composerVisible || richInputPanelVisible
+        richInputPresentation.isVisible
     }
 
     private func toggleRichInput() {
@@ -1831,17 +1839,18 @@ struct MainWindow: View {
 
     @discardableResult
     private func presentRichInput(startsVoice: Bool) -> Bool {
-        guard let richInputState = activeRichInputState, activeRichInputPaneID != nil else { return false }
+        guard let richInputState = activeRichInputState,
+              let target = activeRichInputTarget
+        else { return false }
         guard MainWindowModalPolicy.canPresent(.composer, active: activeModalOverlays) else { return false }
         if voiceRecording.isPanelVisible {
             voiceRecording.cancel()
         }
-        switch richInputPresentationMode {
-        case .panel:
-            panelHost.open(BuiltinPanel.richInput, at: richInputPanelPosition, mode: .pinned)
-        case .floating:
-            composerVisible = true
-        }
+        richInputPresentation.present(
+            mode: richInputPresentationMode,
+            position: richInputPanelPosition,
+            target: target
+        )
         richInputState.focusVersion += 1
         guard startsVoice else { return true }
         DispatchQueue.main.async {
@@ -1852,15 +1861,13 @@ struct MainWindow: View {
     }
 
     private func closeComposer() {
-        guard composerVisible else { return }
+        guard richInputPresentation.isFloatingVisible else { return }
         closeRichInput()
     }
 
     private func closeRichInput() {
-        guard richInputVisible else { return }
+        guard richInputPresentation.close() else { return }
         composerVoice.cancel()
-        composerVisible = false
-        panelHost.close(BuiltinPanel.richInput)
         restoreActiveTerminalFocus()
     }
 
@@ -1880,28 +1887,13 @@ struct MainWindow: View {
     }
 
     private func synchronizeRichInputPresentationMode(_ mode: RichInputPresentationMode) {
-        guard richInputVisible else { return }
-        if mode == .panel, richInputPanelVisible, !composerVisible {
-            return
-        }
-        if mode == .floating, composerVisible, !richInputPanelVisible {
-            return
-        }
-        composerVisible = false
-        panelHost.close(BuiltinPanel.richInput)
-        switch mode {
-        case .panel:
-            panelHost.open(BuiltinPanel.richInput, at: richInputPanelPosition, mode: .pinned)
-        case .floating:
-            composerVisible = true
-        }
+        guard richInputPresentation.synchronize(mode: mode, position: richInputPanelPosition) else { return }
         activeRichInputState?.focusVersion += 1
     }
 
     private func toggleRichInputPanelPosition() {
         richInputPanelPosition = richInputPanelPosition.opposite
-        guard richInputPanelVisible else { return }
-        panelHost.move(BuiltinPanel.richInput, to: richInputPanelPosition)
+        richInputPresentation.movePanel(to: richInputPanelPosition)
     }
 
     private func submitRichInput(_ richInput: RichInputState, appendReturn: Bool, selectedText: String?) {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -104,6 +104,12 @@ struct MainWindow: View {
     @State private var workspaceFileWatcher = WorkspaceFileWatcher()
     @AppStorage("muxy.extensionPanelWidth") private var extensionPanelWidth: Double = PanelLayoutMetrics.extensionDefaultWidth
     @AppStorage("muxy.extensionPanelHeight") private var extensionPanelHeight: Double = PanelLayoutMetrics.extensionDefaultHeight
+    @AppStorage("muxy.richInputPanelWidth") private var richInputPanelWidth = PanelLayoutMetrics.richInputDefaultWidth
+    @AppStorage("muxy.richInputPanelHeight") private var richInputPanelHeight = PanelLayoutMetrics.richInputDefaultHeight
+    @AppStorage(RichInputPreferences.presentationModeKey)
+    private var richInputPresentationMode = RichInputPreferences.defaultPresentationMode
+    @AppStorage(RichInputPreferences.positionKey)
+    private var richInputPanelPosition = RichInputPreferences.defaultPosition
     @AppStorage(RichInputPreferences.broadcastKey) private var richInputBroadcast = RichInputPreferences.defaultBroadcast
     @State private var richInputStates: [WorktreeKey: RichInputState] = [:]
     @State private var composerVisible = false
@@ -180,6 +186,9 @@ struct MainWindow: View {
             .modifier(windowOverlays)
             .modifier(windowChrome)
             .modifier(windowEventListeners)
+            .onChange(of: richInputPresentationMode) { _, mode in
+                synchronizeRichInputPresentationMode(mode)
+            }
     }
 
     private var windowColumns: some View {
@@ -262,8 +271,8 @@ struct MainWindow: View {
     private var windowEventListeners: MainWindowEventListeners {
         MainWindowEventListeners(
             inputListeners: InputNotificationListeners(
-                onToggleRichInput: { toggleComposer() },
-                onToggleComposerVoice: { _ = presentComposer(startsVoice: true) },
+                onToggleRichInput: { toggleRichInput() },
+                onToggleComposerVoice: { _ = presentRichInput(startsVoice: true) },
                 onToggleVoiceRecording: { _ = openVoiceRecorder() }
             ),
             tabCloseObserver: TabCloseConfirmationObserver(
@@ -832,11 +841,13 @@ struct MainWindow: View {
                         worktreeName: worktree.branch ?? worktree.name,
                         languageIdentifier: recordingLanguage,
                         availableSize: geometry.size,
+                        presentationMode: .floating,
                         broadcasts: $richInputBroadcast,
                         onSubmit: { appendReturn, selectedText in
                             submitRichInput(state, appendReturn: appendReturn, selectedText: selectedText)
                             closeComposer()
                         },
+                        onChangePresentationMode: changeRichInputPresentationMode,
                         onClose: closeComposer
                     )
                     .transition(.opacity.combined(with: .scale(scale: 0.98)))
@@ -1518,7 +1529,7 @@ struct MainWindow: View {
 
     private func handleShortcutAction(_ action: ShortcutAction) -> Bool {
         if action == .toggleComposerVoice {
-            return presentComposer(startsVoice: true)
+            return presentRichInput(startsVoice: true)
         }
         if action == .toggleVoiceRecording {
             return openVoiceRecorder()
@@ -1527,8 +1538,8 @@ struct MainWindow: View {
     }
 
     private func openVoiceRecorder() -> Bool {
-        if MainWindowVoiceInputPolicy.target(composerVisible: composerVisible) == .composer {
-            return presentComposer(startsVoice: true)
+        if MainWindowVoiceInputPolicy.target(composerVisible: richInputVisible) == .composer {
+            return presentRichInput(startsVoice: true)
         }
         if voiceRecording.isPanelVisible {
             voiceRecording.cancel()
@@ -1604,10 +1615,61 @@ struct MainWindow: View {
     @ViewBuilder
     private func panelContent(for panelID: String, position: PanelPosition, mode: PanelMode) -> some View {
         switch panelID {
+        case BuiltinPanel.richInput:
+            richInputPanelBody(position: position, mode: mode)
         case BuiltinPanel.extensionConsole:
             extensionConsolePanelBody(position: position, mode: mode)
         default:
             extensionPanelBody(panelID: panelID, position: position, mode: mode)
+        }
+    }
+
+    @ViewBuilder
+    private func richInputPanelBody(position: PanelPosition, mode: PanelMode) -> some View {
+        if let state = activeRichInputState,
+           let worktreeKey = activeWorktreeKey,
+           let project = activeProject,
+           let worktree = resolvedActiveWorktree(for: project)
+        {
+            PanelContainer(
+                chrome: PanelChrome(
+                    iconSymbol: "keyboard",
+                    title: L10n.string("Rich Input"),
+                    hiddenControls: [.pin],
+                    trailingButtons: [richInputBroadcastButton, useFloatingComposerButton]
+                ),
+                mode: mode,
+                position: position,
+                focusRestorationID: nil,
+                onClose: closeRichInput,
+                onTogglePin: nil,
+                onTogglePosition: toggleRichInputPanelPosition,
+                content: {
+                    FocusedComposerView(
+                        state: state,
+                        voice: composerVoice,
+                        worktreeKey: worktreeKey,
+                        projectName: project.localizedDisplayName,
+                        worktreeName: worktree.branch ?? worktree.name,
+                        languageIdentifier: recordingLanguage,
+                        availableSize: .zero,
+                        presentationMode: .panel,
+                        broadcasts: $richInputBroadcast,
+                        onSubmit: { appendReturn, selectedText in
+                            submitRichInput(state, appendReturn: appendReturn, selectedText: selectedText)
+                        },
+                        onChangePresentationMode: changeRichInputPresentationMode,
+                        onClose: closeRichInput
+                    )
+                }
+            )
+            .modifier(PanelFrame(
+                position: position,
+                size: position == .bottom ? $richInputPanelHeight : $richInputPanelWidth,
+                range: position == .bottom
+                    ? PanelLayoutMetrics.richInputHeightRange
+                    : PanelLayoutMetrics.richInputWidthRange
+            ))
         }
     }
 
@@ -1659,6 +1721,29 @@ struct MainWindow: View {
                     : PanelLayoutMetrics.extensionWidthRange
             ))
         }
+    }
+
+    private var richInputBroadcastButton: PanelHeaderButton {
+        PanelHeaderButton(
+            id: "richInput.broadcast",
+            icon: .symbol(richInputBroadcast
+                ? "dot.radiowaves.left.and.right"
+                : "antenna.radiowaves.left.and.right.slash"),
+            label: richInputBroadcast
+                ? L10n.string("Broadcast On — Send to All Split Panes")
+                : L10n.string("Broadcast Off — Send to Active Pane"),
+            isActive: richInputBroadcast,
+            action: { richInputBroadcast.toggle() }
+        )
+    }
+
+    private var useFloatingComposerButton: PanelHeaderButton {
+        PanelHeaderButton(
+            id: "richInput.presentationMode",
+            icon: .symbol("rectangle.on.rectangle"),
+            label: L10n.string("Use Floating Composer"),
+            action: { changeRichInputPresentationMode(.floating) }
+        )
     }
 
     private var sidebarResizeHandle: some View {
@@ -1728,28 +1813,39 @@ struct MainWindow: View {
         return appState.activeTab(for: project.id)?.content.pane
     }
 
-    private func toggleComposer() {
-        if composerVisible {
-            closeComposer()
+    private var richInputPanelVisible: Bool {
+        panelHost.isOpen(BuiltinPanel.richInput)
+    }
+
+    private var richInputVisible: Bool {
+        composerVisible || richInputPanelVisible
+    }
+
+    private func toggleRichInput() {
+        if richInputVisible {
+            closeRichInput()
         } else {
-            _ = presentComposer(startsVoice: false)
+            _ = presentRichInput(startsVoice: false)
         }
     }
 
     @discardableResult
-    private func presentComposer(startsVoice: Bool) -> Bool {
+    private func presentRichInput(startsVoice: Bool) -> Bool {
         guard let richInputState = activeRichInputState, activeRichInputPaneID != nil else { return false }
         guard MainWindowModalPolicy.canPresent(.composer, active: activeModalOverlays) else { return false }
         if voiceRecording.isPanelVisible {
             voiceRecording.cancel()
         }
-        if !composerVisible {
+        switch richInputPresentationMode {
+        case .panel:
+            panelHost.open(BuiltinPanel.richInput, at: richInputPanelPosition, mode: .pinned)
+        case .floating:
             composerVisible = true
         }
         richInputState.focusVersion += 1
         guard startsVoice else { return true }
         DispatchQueue.main.async {
-            guard composerVisible else { return }
+            guard richInputVisible else { return }
             composerVoice.start(languageIdentifier: recordingLanguage)
         }
         return true
@@ -1757,14 +1853,55 @@ struct MainWindow: View {
 
     private func closeComposer() {
         guard composerVisible else { return }
+        closeRichInput()
+    }
+
+    private func closeRichInput() {
+        guard richInputVisible else { return }
         composerVoice.cancel()
         composerVisible = false
+        panelHost.close(BuiltinPanel.richInput)
+        restoreActiveTerminalFocus()
+    }
+
+    private func restoreActiveTerminalFocus() {
         guard let paneID = activeRichInputPaneID,
               let view = TerminalViewRegistry.shared.existingView(for: paneID)
         else { return }
         DispatchQueue.main.async {
             view.terminalView.window?.makeFirstResponder(view.terminalView)
         }
+    }
+
+    private func changeRichInputPresentationMode(_ mode: RichInputPresentationMode) {
+        guard richInputPresentationMode != mode else { return }
+        richInputPresentationMode = mode
+        synchronizeRichInputPresentationMode(mode)
+    }
+
+    private func synchronizeRichInputPresentationMode(_ mode: RichInputPresentationMode) {
+        guard richInputVisible else { return }
+        if mode == .panel, richInputPanelVisible, !composerVisible {
+            return
+        }
+        if mode == .floating, composerVisible, !richInputPanelVisible {
+            return
+        }
+        composerVisible = false
+        panelHost.close(BuiltinPanel.richInput)
+        switch mode {
+        case .panel:
+            panelHost.open(BuiltinPanel.richInput, at: richInputPanelPosition, mode: .pinned)
+        case .floating:
+            composerVisible = true
+        }
+        activeRichInputState?.focusVersion += 1
+    }
+
+    private func toggleRichInputPanelPosition() {
+        richInputPanelPosition = richInputPanelPosition.opposite
+        guard richInputPanelVisible else { return }
+        panelHost.move(BuiltinPanel.richInput, to: richInputPanelPosition)
     }
 
     private func submitRichInput(_ richInput: RichInputState, appendReturn: Bool, selectedText: String?) {

--- a/Muxy/Views/Settings/RichInputSettingsView.swift
+++ b/Muxy/Views/Settings/RichInputSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct RichInputSettingsView: View {
     @State private var settings = EditorSettings.shared
     @State private var monoFonts: [String] = []
+    @AppStorage(RichInputPreferences.presentationModeKey)
+    private var presentationMode = RichInputPreferences.defaultPresentationMode
 
     var body: some View {
         VStack(spacing: 0) {
@@ -14,6 +16,7 @@ struct RichInputSettingsView: View {
                 Spacer()
                 Button(L10n.string("Reset to Defaults")) {
                     settings.resetToDefaults()
+                    presentationMode = RichInputPreferences.defaultPresentationMode
                 }
                 .font(.system(size: SettingsMetrics.footnoteFontSize))
                 .buttonStyle(.borderless)
@@ -37,6 +40,17 @@ struct RichInputSettingsView: View {
             """,
             showsDivider: false
         ) {
+            SettingsRow("Presentation") {
+                Picker("", selection: $presentationMode) {
+                    ForEach(RichInputPresentationMode.allCases) { mode in
+                        Text(L10n.resource(key: mode.displayName)).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .settingsControl(.intrinsic)
+            }
+
             SettingsRow("Image Submission") {
                 Picker("", selection: $settings.richInputImageStrategy) {
                     ForEach(RichInputImageStrategy.allCases) { strategy in

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -440,6 +440,15 @@ enum SettingsCatalog {
             defaultValue: SidebarExpandedStyle.defaultValue.rawValue
         ),
         SettingsCatalogItem(
+            key: RichInputPreferences.presentationModeKey,
+            title: "Composer Presentation",
+            description: "Chooses whether the composer opens as a workspace panel or a floating modal.",
+            category: .richInput,
+            section: "Composer",
+            defaultValue: RichInputPreferences.defaultPresentationMode.rawValue,
+            aliases: ["rich input", "panel", "floating"]
+        ),
+        SettingsCatalogItem(
             key: "editor.richInputImageStrategy",
             title: "Composer Image Submission",
             description: "Chooses how the composer submits images.",

--- a/Tests/MuxyTests/Models/Preferences/RichInputPreferencesTests.swift
+++ b/Tests/MuxyTests/Models/Preferences/RichInputPreferencesTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("Rich input preferences")
+struct RichInputPreferencesTests {
+    @Test("panel presentation is the default")
+    func panelPresentationIsDefault() {
+        #expect(RichInputPreferences.defaultPresentationMode == .panel)
+        #expect(RichInputPreferences.defaultPosition == .right)
+    }
+
+    @Test("presentation modes have stable persisted values")
+    func presentationModesHaveStablePersistedValues() {
+        #expect(RichInputPresentationMode.allCases.map(\.rawValue) == ["panel", "floating"])
+        #expect(RichInputPresentationMode.allCases.map(\.displayName) == ["Panel", "Floating"])
+        #expect(RichInputPresentationMode(rawValue: "panel") == .panel)
+        #expect(RichInputPresentationMode(rawValue: "floating") == .floating)
+    }
+}

--- a/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/SettingsJSONStoreTests.swift
@@ -822,6 +822,18 @@ struct SettingsJSONStoreTests {
     }
 
     @Test
+    func saveAppliesComposerPresentationMode() throws {
+        let key = RichInputPreferences.presentationModeKey
+        let snapshot = SettingsJSONStoreSnapshot.capture(keys: [key])
+        defer { snapshot.restore() }
+        UserDefaults.standard.removeObject(forKey: key)
+
+        try SettingsJSONStore.saveUserSettingsText("{\"\(key)\":\"floating\"}")
+
+        #expect(UserDefaults.standard.string(forKey: key) == RichInputPresentationMode.floating.rawValue)
+    }
+
+    @Test
     func saveAppliesAutomaticUpdatesThroughUpdater() throws {
         let snapshot = SettingsJSONStoreSnapshot.capture(keys: [UpdateService.automaticallyUpdatesKey])
         defer { snapshot.restore() }

--- a/Tests/MuxyTests/Services/RichInput/RichInputPresentationControllerTests.swift
+++ b/Tests/MuxyTests/Services/RichInput/RichInputPresentationControllerTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Rich input presentation controller")
+@MainActor
+struct RichInputPresentationControllerTests {
+    private let firstTarget = RichInputPresentationTarget(
+        worktreeKey: WorktreeKey(projectID: UUID(), worktreeID: UUID()),
+        paneID: UUID()
+    )
+
+    @Test("presents and closes the panel")
+    func presentsAndClosesPanel() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+
+        controller.present(mode: .panel, position: .right, target: firstTarget)
+
+        #expect(controller.isVisible)
+        #expect(controller.isPanelVisible)
+        #expect(!controller.isFloatingVisible)
+        #expect(host.placement(for: BuiltinPanel.richInput)?.position == .right)
+        #expect(controller.close())
+        #expect(!controller.isVisible)
+        #expect(controller.target == nil)
+    }
+
+    @Test("switches between panel and floating presentations")
+    func switchesPresentations() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+
+        controller.present(mode: .panel, position: .right, target: firstTarget)
+        controller.synchronize(mode: .floating, position: .right)
+
+        #expect(controller.isFloatingVisible)
+        #expect(!controller.isPanelVisible)
+        #expect(controller.target == firstTarget)
+
+        controller.synchronize(mode: .panel, position: .bottom)
+
+        #expect(!controller.isFloatingVisible)
+        #expect(controller.isPanelVisible)
+        #expect(host.placement(for: BuiltinPanel.richInput)?.position == .bottom)
+    }
+
+    @Test("moves an open panel without closing it")
+    func movesPanel() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+        controller.present(mode: .panel, position: .right, target: firstTarget)
+
+        controller.movePanel(to: .bottom)
+
+        #expect(controller.isPanelVisible)
+        #expect(host.placement(for: BuiltinPanel.richInput)?.position == .bottom)
+    }
+
+    @Test("reports unexpected panel displacement")
+    func reportsPanelDisplacement() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+        let recorder = RichInputPresentationVoiceRecorderStub()
+        recorder.isRecording = true
+        let voice = ComposerVoiceState(recorder: recorder)
+        controller.present(mode: .panel, position: .right, target: firstTarget)
+
+        host.open("extension:files", at: .right, mode: .pinned)
+        controller.reconcilePanelHostChange(voice: voice)
+
+        #expect(!controller.isVisible)
+        #expect(controller.target == nil)
+        #expect(recorder.cancelCount == 1)
+    }
+
+    @Test("presentation changes preserve rich input state")
+    func presentationChangesPreserveRichInputState() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+        let state = RichInputState()
+        state.text = "draft"
+        state.fileAttachments = [URL(fileURLWithPath: "/tmp/file.txt")]
+        state.imageAttachments = [URL(fileURLWithPath: "/tmp/image.png")]
+
+        controller.present(mode: .panel, position: .right, target: firstTarget)
+        controller.synchronize(mode: .floating, position: .right)
+        controller.synchronize(mode: .panel, position: .bottom)
+
+        #expect(state.text == "draft")
+        #expect(state.fileAttachments.map(\.path) == ["/tmp/file.txt"])
+        #expect(state.imageAttachments.map(\.path) == ["/tmp/image.png"])
+    }
+
+    @Test("target changes cancel dictation and rebind an open panel")
+    func targetChangesCancelDictationAndRebindPanel() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+        let recorder = RichInputPresentationVoiceRecorderStub()
+        recorder.isRecording = true
+        let voice = ComposerVoiceState(recorder: recorder)
+        let nextTarget = RichInputPresentationTarget(
+            worktreeKey: WorktreeKey(projectID: UUID(), worktreeID: UUID()),
+            paneID: UUID()
+        )
+        controller.present(mode: .panel, position: .right, target: firstTarget)
+
+        let didClose = controller.reconcileTargetChange(nextTarget, voice: voice)
+
+        #expect(!didClose)
+        #expect(controller.isPanelVisible)
+        #expect(controller.target == nextTarget)
+        #expect(recorder.cancelCount == 1)
+    }
+
+    @Test("losing the target closes the panel and cancels dictation")
+    func losingTargetClosesPanelAndCancelsDictation() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+        let recorder = RichInputPresentationVoiceRecorderStub()
+        recorder.isRecording = true
+        let voice = ComposerVoiceState(recorder: recorder)
+        controller.present(mode: .panel, position: .right, target: firstTarget)
+
+        let didClose = controller.reconcileTargetChange(nil, voice: voice)
+
+        #expect(didClose)
+        #expect(!controller.isVisible)
+        #expect(controller.target == nil)
+        #expect(recorder.cancelCount == 1)
+    }
+
+    @Test("changing a floating target closes the composer and cancels dictation")
+    func changingFloatingTargetClosesComposerAndCancelsDictation() {
+        let host = PanelHost()
+        let controller = RichInputPresentationController(panelHost: host)
+        let recorder = RichInputPresentationVoiceRecorderStub()
+        recorder.isRecording = true
+        let voice = ComposerVoiceState(recorder: recorder)
+        let nextTarget = RichInputPresentationTarget(
+            worktreeKey: WorktreeKey(projectID: UUID(), worktreeID: UUID()),
+            paneID: UUID()
+        )
+        controller.present(mode: .floating, position: .right, target: firstTarget)
+
+        let didClose = controller.reconcileTargetChange(nextTarget, voice: voice)
+
+        #expect(didClose)
+        #expect(!controller.isVisible)
+        #expect(controller.target == nil)
+        #expect(recorder.cancelCount == 1)
+    }
+}
+
+@MainActor
+private final class RichInputPresentationVoiceRecorderStub: VoiceRecording {
+    var isRecording = false
+    var isPaused = false
+    var elapsed: TimeInterval = 0
+    var level: Float = 0
+    var transcript = ""
+    var onFailure: (@MainActor (String) -> Void)?
+    private(set) var cancelCount = 0
+
+    func start(locale _: Locale) throws {
+        isRecording = true
+    }
+
+    func pause() {
+        isPaused = true
+    }
+
+    func resume() {
+        isPaused = false
+    }
+
+    func finish() -> String {
+        isRecording = false
+        return transcript
+    }
+
+    func cancel() {
+        cancelCount += 1
+        isRecording = false
+        isPaused = false
+    }
+}

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -148,6 +148,9 @@ struct SettingsCatalogTests {
     @Test
     func categoryMatchingUsesCatalogItems() {
         #expect(SettingsCatalog.categoryMatches(.richInput, query: "rich input"))
+        #expect(SettingsCatalog.matchingItems(query: "floating").contains {
+            $0.key == RichInputPreferences.presentationModeKey
+        })
         #expect(!SettingsCatalog.categoryMatches(.mobile, query: "rich input"))
     }
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -160,8 +160,8 @@ Define reusable shell command shortcuts in **Settings → Commands**:
 
 `Cmd+I` opens the composer for multiline prompts, files, images, and broadcast sends. The default **Panel**
 presentation docks it beside the workspace. Resize the panel from its workspace-facing edge or move it between
-the right and bottom positions from its header. Choose **Floating** under **Settings -> Terminal -> Composer ->
-Presentation**, use the panel header's floating button, or choose **Use Floating Composer** from its More menu to
+the right and bottom positions from its header. Choose **Floating** under **Settings -> Composer -> Presentation**,
+use the panel header's floating button, or choose **Use Floating Composer** from its More menu to
 open the centered modal instead. Choose **Use Composer Panel** from the floating Composer's More menu to switch
 back. The presentation choice, panel position, and both layouts' sizes persist across app restarts, and switching
 an open Composer preserves its draft and attachments.

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -158,22 +158,28 @@ Define reusable shell command shortcuts in **Settings → Commands**:
 
 ## Composer
 
-`Cmd+I` opens the focused composer for multiline prompts, files, images, and broadcast sends. `Cmd+Shift+I`
-opens the legacy voice recorder normally, or starts on-device dictation inside the focused composer when it is
-already open. Stop Composer dictation to insert the transcript at the editor cursor, or press Return while
-recording, then edit or send it normally. Composer dictation requires an installed on-device speech language plus
-microphone and speech recognition access.
+`Cmd+I` opens the composer for multiline prompts, files, images, and broadcast sends. The default **Panel**
+presentation docks it beside the workspace. Resize the panel from its workspace-facing edge or move it between
+the right and bottom positions from its header. Choose **Floating** under **Settings -> Terminal -> Composer ->
+Presentation**, use the panel header's floating button, or choose **Use Floating Composer** from its More menu to
+open the centered modal instead. Choose **Use Composer Panel** from the floating Composer's More menu to switch
+back. The presentation choice, panel position, and both layouts' sizes persist across app restarts, and switching
+an open Composer preserves its draft and attachments.
 
-Long prompts can use a larger Composer. Drag its left, right, or bottom edge to resize it; because the Composer
-stays centered, a dragged edge grows the box symmetrically and follows the pointer. The expand button in the
-Composer header switches to a large preset instead, which is capped so it stays readable on big displays and
-shrinks to fit smaller windows; dragging an edge is what grows the Composer beyond that preset, and pressing the
-button again restores the size you dragged. Both the size and
-the expanded state are remembered across Composer sessions and app restarts, are stored independently of the UI
-Scale preset, and are always clamped to the current window, so a smaller window shrinks the Composer without
-losing your size. **Reset Composer Size** in the Composer's More menu returns it to the default size. The text
-editor takes whatever room the box has left, so attachments and the dictation status line reduce it while they
-are visible. `Cmd+=` and `Cmd+-` still change the Composer font size rather than the box.
+`Cmd+Shift+I` opens the legacy voice recorder normally, or starts on-device dictation inside either Composer
+presentation when it is already open. Stop Composer dictation to insert the transcript at the editor cursor, or
+press Return while recording, then edit or send it normally. Composer dictation requires an installed on-device
+speech language plus microphone and speech recognition access.
+
+Long prompts in the floating presentation can use a larger Composer. Drag its left, right, or bottom edge to
+resize it; because the Composer stays centered, a dragged edge grows the box symmetrically and follows the
+pointer. The expand button in the Composer header switches to a large preset instead, which is capped so it stays
+readable on big displays and shrinks to fit smaller windows; dragging an edge is what grows the Composer beyond
+that preset, and pressing the button again restores the size you dragged. Both the size and the expanded state
+are stored independently of the UI Scale preset and always clamped to the current window, so a smaller window
+shrinks the Composer without losing your size. **Reset Composer Size** in the Composer's More menu returns it to
+the default size. The text editor takes whatever room the box has left, so attachments and the dictation status
+line reduce it while they are visible. `Cmd+=` and `Cmd+-` still change the Composer font size rather than the box.
 
 Each Composer submission is serialized with later keyboard input for its target terminal. Text, image paths, and
 the optional Return are submitted as one transaction, including when a Composer message is broadcast to several


### PR DESCRIPTION
Adds a docked Rich Input composer panel with persistent presentation, position, and sizing preferences, while retaining the floating composer option. Updates settings, localization, persistence validation, tests, and terminal documentation for switching between both presentations.

AI assistance: OpenAI GPT-5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Panel and Floating presentation options for the Composer.
  * Added configurable panel position, resizing, and size reset controls.
  * Preserved Composer drafts and attachments when switching presentation modes.
  * Added persisted presentation preferences and settings search support.
  * Improved dictation, focus restoration, shortcuts, and panel behavior across layouts.

* **Documentation**
  * Updated Composer documentation with presentation, resizing, persistence, and dictation details.

* **Tests**
  * Added coverage for preferences, persistence, settings search, mode switching, panel movement, and state recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->