### PR TITLE
Make the tab close button respond on the first click

### DIFF
--- a/Muxy/Views/Components/Buttons/TabCloseButton.swift
+++ b/Muxy/Views/Components/Buttons/TabCloseButton.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct TabCloseButton: View {
+    let action: () -> Void
+    @State private var hovered = false
+
+    var body: some View {
+        Image(systemName: "xmark")
+            .font(.system(size: UIMetrics.fontCaption, weight: .bold))
+            .foregroundStyle(hovered ? MuxyTheme.fg : MuxyTheme.fgMuted)
+            .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
+            .background {
+                RoundedRectangle(cornerRadius: UIMetrics.radiusSM, style: .continuous)
+                    .fill(hovered ? MuxyTheme.hover : Color.clear)
+            }
+            .contentShape(Rectangle())
+            .onHover { hovered = $0 }
+            .overlay {
+                LeftClickView(action: action)
+                    .accessibilityHidden(true)
+            }
+            .accessibilityLabel(L10n.string("Close Tab"))
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction { action() }
+    }
+}

--- a/Muxy/Views/Components/Interaction/LeftClickView.swift
+++ b/Muxy/Views/Components/Interaction/LeftClickView.swift
@@ -1,0 +1,38 @@
+import AppKit
+import SwiftUI
+
+struct LeftClickView: NSViewRepresentable {
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> LeftClickNSView {
+        let view = LeftClickNSView()
+        view.action = action
+        return view
+    }
+
+    func updateNSView(_ nsView: LeftClickNSView, context: Context) {
+        nsView.action = action
+    }
+}
+
+final class LeftClickNSView: NSView {
+    var action: (() -> Void)?
+
+    override func isAccessibilityElement() -> Bool {
+        false
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let currentEvent = NSApp.currentEvent,
+              currentEvent.type == .leftMouseDown
+        else { return nil }
+        return super.hitTest(point)
+    }
+
+    override func mouseDown(with event: NSEvent) {}
+
+    override func mouseUp(with event: NSEvent) {
+        guard bounds.contains(convert(event.locationInWindow, from: nil)) else { return }
+        action?()
+    }
+}

--- a/Muxy/Views/Components/Interaction/LeftClickView.swift
+++ b/Muxy/Views/Components/Interaction/LeftClickView.swift
@@ -17,6 +17,7 @@ struct LeftClickView: NSViewRepresentable {
 
 final class LeftClickNSView: NSView {
     var action: (() -> Void)?
+    private var isPressed = false
 
     override func isAccessibilityElement() -> Bool {
         false
@@ -24,15 +25,21 @@ final class LeftClickNSView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard let currentEvent = NSApp.currentEvent,
-              currentEvent.type == .leftMouseDown
+              currentEvent.type == .leftMouseDown || currentEvent.type == .leftMouseUp
         else { return nil }
         return super.hitTest(point)
     }
 
-    override func mouseDown(with event: NSEvent) {}
+    override func mouseDown(with event: NSEvent) {
+        isPressed = true
+    }
 
     override func mouseUp(with event: NSEvent) {
-        guard bounds.contains(convert(event.locationInWindow, from: nil)) else { return }
+        let wasPressed = isPressed
+        isPressed = false
+        guard wasPressed,
+              bounds.contains(convert(event.locationInWindow, from: nil))
+        else { return }
         action?()
     }
 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -612,14 +612,7 @@ struct TabFocusedTabRow: View {
     @ViewBuilder
     private var trailingContent: some View {
         if !tab.isPinned, closeButtonVisible {
-            Image(systemName: "xmark")
-                .font(.system(size: UIMetrics.fontCaption, weight: .bold))
-                .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
-                .contentShape(Rectangle())
-                .onTapGesture { close() }
-                .accessibilityLabel(L10n.string("Close Tab"))
-                .accessibilityAddTraits(.isButton)
+            TabCloseButton { close() }
         } else {
             statusAccessory
         }

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -632,15 +632,8 @@ private struct TabCell: View {
 
     private var trailingAccessory: some View {
         ZStack {
-            if !tab.isPinned {
-                Image(systemName: "xmark")
-                    .font(.system(size: UIMetrics.fontCaption, weight: .bold))
-                    .foregroundStyle(MuxyTheme.fgDim)
-                    .opacity(closeButtonVisible ? 1 : 0)
-                    .allowsHitTesting(closeButtonVisible)
-                    .onTapGesture(perform: onClose)
-                    .accessibilityLabel(L10n.string("Close Tab"))
-                    .accessibilityAddTraits(.isButton)
+            if closeButtonVisible {
+                TabCloseButton(action: onClose)
             }
         }
         .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)

--- a/Tests/MuxyTests/Views/Components/Interaction/LeftClickViewTests.swift
+++ b/Tests/MuxyTests/Views/Components/Interaction/LeftClickViewTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+@MainActor
+@Suite("LeftClickView")
+struct LeftClickViewTests {
+    @Test("stays transparent while no primary press is being routed")
+    func staysTransparentWithoutPrimaryPress() {
+        let view = LeftClickNSView()
+        view.frame = NSRect(x: 0, y: 0, width: 14, height: 14)
+
+        #expect(view.hitTest(NSPoint(x: 7, y: 7)) == nil)
+    }
+
+    @Test("fires once the primary press is released inside the control")
+    func firesWhenReleasedInsideControl() throws {
+        var closes = 0
+        let view = hostedView { closes += 1 }
+
+        view.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: 17, y: 17)))
+        view.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: 17, y: 17)))
+
+        #expect(closes == 1)
+    }
+
+    @Test("ignores a press released outside the control")
+    func ignoresReleaseOutsideControl() throws {
+        var closes = 0
+        let view = hostedView { closes += 1 }
+
+        view.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: 17, y: 17)))
+        view.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: 60, y: 60)))
+
+        #expect(closes == 0)
+    }
+
+    @Test("fires for every press of a rapid click sequence")
+    func firesForRapidClickSequence() throws {
+        var closes = 0
+        let view = hostedView { closes += 1 }
+
+        for clickCount in 1 ... 3 {
+            view.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: 17, y: 17), clickCount: clickCount))
+            view.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: 17, y: 17), clickCount: clickCount))
+        }
+
+        #expect(closes == 3)
+    }
+
+    private func hostedView(action: @escaping () -> Void) -> LeftClickNSView {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let view = LeftClickNSView()
+        view.frame = NSRect(x: 10, y: 10, width: 14, height: 14)
+        view.action = action
+        window.contentView?.addSubview(view)
+        return view
+    }
+
+    private func event(
+        _ type: NSEvent.EventType,
+        at location: NSPoint,
+        clickCount: Int = 1
+    ) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: clickCount,
+            pressure: 1
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

The tab close button (x) frequently failed to register clicks, or felt delayed. This fixes the responsiveness and adds a hover affordance so the control is clearly distinguishable.

## Problem

Three causes in the top tab strip (`Muxy/Views/Workspace/TabStrip.swift`), only one of which (`#1`) was the visible symptom for most users:

1. **Hit area was the glyph, not the slot.** The `xmark` had no `.frame`/`.contentShape`, so its tap target was the ~10pt glyph. A few pixels off and the click fell through to the cell — selecting the tab instead of closing it. (The sidebar tab rows already used `frame + contentShape`; the strip did not.)

2. **The cell's drag gesture competed for the press.** The strip attaches a `DragGesture(minimumDistance: 0)` to each cell, which runs `onSelectTab` on `mouseDown` (tab switch + terminal relayout = perceived delay) and cancels the tap outright once the pointer moved past the 4pt drag threshold.

3. **`DoubleClickView` sat above the close button in the overlay stack.** A rapid close sequence could register the second click as `clickCount == 2`, routing it to rename mode instead of close.

## Fix

- **`LeftClickView`** (new, `Muxy/Views/Components/Interaction/LeftClickView.swift`): an `NSViewRepresentable` mirroring the existing `MiddleClickView`/`DoubleClickView` pattern. Its `hitTest` only claims the view during a primary press, and it fires on `mouseUp` inside bounds. Because AppKit handles the event at the `NSView` layer, the SwiftUI drag gesture never competes for it — the tab closes without first being activated. Hover, right-click, and wheel still pass through (`hitTest` returns `nil` otherwise).
- **`TabCloseButton`** (new, `Muxy/Views/Components/Buttons/TabCloseButton.swift`): shared control that uses the full `iconMD` slot as its `contentShape`. On hover the glyph brightens (`fgMuted` → `fg`) and a soft rounded chip fills behind it.
- **`TabStrip.swift`**: replaces the inline `xmark` with `TabCloseButton`. The overlay order is left untouched — keeping it is what preserves inactive-tab hover (the button is a child of the hover-owning cell content, so the cell stays hovered while the pointer is over the x).
- **`TabFocusedTabsList.swift`**: sidebar tab rows now use the same `TabCloseButton` (was an inline `xmark` with its own styling), unifying hit area and hover behavior.

## Scope notes

- The "process still running" confirmation dialog (when `TabCloseConfirmationPreferences.confirmRunningProcess` is on) is by design and not touched here.
- A residual interaction in the **sidebar** tab rows (rapid close sequence can still route the second click to rename) is out of scope and intentionally left as-is.

## Tests

- New `Tests/MuxyTests/Views/Components/Interaction/LeftClickViewTests.swift` covers: transparent when no primary press is routed; fires on release inside bounds; ignores release outside bounds; fires for every press in a rapid sequence.
- `scripts/checks.sh` passes (format, lint, build, tests). The only failing tests — `TerminalCJKFontConfig` (font-environment dependent) and `MuxyAPIPanesMaterialize` (flaky) — fail identically on a clean `main` checkout and are unrelated to this change.

---

🤖 Implementation assistance provided by Claude Opus 5 (Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable close-tab button with hover styling, accessibility support, and consistent click behavior.
  * Improved left-click handling so actions trigger only when the release occurs within the control.
* **Improvements**
  * Standardized close controls across tab views for a more consistent experience.
* **Tests**
  * Added coverage for valid clicks, outside releases, transparent states, and rapid repeated clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->