### PR TITLE
Speed up worktree branch picker

### DIFF
--- a/Muxy/Views/Components/Pickers/SearchableListPicker.swift
+++ b/Muxy/Views/Components/Pickers/SearchableListPicker.swift
@@ -48,6 +48,11 @@ struct SearchableListPicker<Item: Identifiable, RowContent: View>: View {
     }
 
     var body: some View {
+        let visibleItems = filteredItems
+        let highlightedID = highlightedIndex.flatMap { index in
+            visibleItems.indices.contains(index) ? visibleItems[index].id : nil
+        }
+
         VStack(spacing: 0) {
             HStack(spacing: UIMetrics.spacing3) {
                 Image(systemName: "magnifyingglass")
@@ -72,7 +77,7 @@ struct SearchableListPicker<Item: Identifiable, RowContent: View>: View {
 
             Divider().overlay(MuxyTheme.border)
 
-            if filteredItems.isEmpty {
+            if visibleItems.isEmpty {
                 Text(emptyLabel)
                     .font(.system(size: UIMetrics.fontBody))
                     .foregroundStyle(MuxyTheme.fgMuted)
@@ -81,22 +86,22 @@ struct SearchableListPicker<Item: Identifiable, RowContent: View>: View {
                 ScrollViewReader { proxy in
                     ScrollView(.vertical, showsIndicators: false) {
                         LazyVStack(spacing: 0) {
-                            ForEach(Array(filteredItems.enumerated()), id: \.element.id) { index, item in
-                                rowContent(item, isHighlighted: index == highlightedIndex)
+                            ForEach(visibleItems) { item in
+                                rowContent(item, isHighlighted: item.id == highlightedID)
                                     .id(item.id)
                             }
                         }
                         .padding(.vertical, UIMetrics.spacing2)
                     }
                     .onChange(of: highlightedIndex) { _, newIndex in
-                        guard let newIndex, newIndex < filteredItems.count else { return }
-                        proxy.scrollTo(filteredItems[newIndex].id, anchor: nil)
+                        guard let newIndex, visibleItems.indices.contains(newIndex) else { return }
+                        proxy.scrollTo(visibleItems[newIndex].id, anchor: nil)
                     }
                 }
             }
         }
         .background(MuxyTheme.bg)
-        .onChange(of: searchText) { highlightedIndex = filteredItems.isEmpty ? nil : 0 }
+        .onChange(of: searchText) { highlightedIndex = visibleItems.isEmpty ? nil : 0 }
     }
 
     @ViewBuilder

--- a/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
@@ -6,8 +6,13 @@ enum CreateWorktreeResult {
     case cancelled
 }
 
+struct WorktreeBranchOption: Equatable, Identifiable {
+    let name: String
+    var id: String { name }
+}
+
 struct WorktreeBranchLoadState: Equatable {
-    var branches: [String] = []
+    var branchOptions: [WorktreeBranchOption] = []
     var selectedExistingBranch = ""
     var selectedBaseBranch = ""
     private(set) var isLoading = true
@@ -17,7 +22,7 @@ struct WorktreeBranchLoadState: Equatable {
     }
 
     mutating func finishLoading(branches: [String], defaultBranch: String?) {
-        self.branches = branches
+        branchOptions = branches.map(WorktreeBranchOption.init)
         if selectedExistingBranch.isEmpty {
             selectedExistingBranch = branches.first ?? ""
         }
@@ -37,20 +42,11 @@ struct WorktreeBranchLoadState: Equatable {
 }
 
 private struct WorktreeBranchPicker: View {
-    private struct BranchOption: Identifiable {
-        let name: String
-        var id: String { name }
-    }
-
     let label: String
-    let branches: [String]
+    let options: [WorktreeBranchOption]
     let isLoading: Bool
     @Binding var selection: String
     @State private var isPresented = false
-
-    private var options: [BranchOption] {
-        branches.map(BranchOption.init)
-    }
 
     var body: some View {
         if isLoading {
@@ -100,7 +96,7 @@ private struct WorktreeBranchPicker: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(branches.isEmpty)
+        .disabled(options.isEmpty)
         .accessibilityLabel(label)
         .accessibilityValue(selection.isEmpty ? L10n.string("No branches") : selection)
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {
@@ -132,7 +128,7 @@ private struct WorktreeBranchPicker: View {
         }
     }
 
-    private func select(_ option: BranchOption) {
+    private func select(_ option: WorktreeBranchOption) {
         selection = option.name
         isPresented = false
     }
@@ -198,7 +194,7 @@ struct CreateWorktreeSheet: View {
                     Text(L10n.resource("Base Branch")).font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
                     WorktreeBranchPicker(
                         label: L10n.string("Base Branch"),
-                        branches: branchLoadState.branches,
+                        options: branchLoadState.branchOptions,
                         isLoading: branchLoadState.isLoading,
                         selection: $branchLoadState.selectedBaseBranch
                     )
@@ -208,7 +204,7 @@ struct CreateWorktreeSheet: View {
                     Text(L10n.resource("Branch")).font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
                     WorktreeBranchPicker(
                         label: L10n.string("Branch"),
-                        branches: branchLoadState.branches,
+                        options: branchLoadState.branchOptions,
                         isLoading: branchLoadState.isLoading,
                         selection: $branchLoadState.selectedExistingBranch
                     )

--- a/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
@@ -9,7 +9,7 @@ struct CreateWorktreeSheetTests {
         let state = WorktreeBranchLoadState()
 
         #expect(state.isLoading)
-        #expect(state.branches.isEmpty)
+        #expect(state.branchOptions.isEmpty)
         #expect(state.selectedExistingBranch.isEmpty)
         #expect(state.selectedBaseBranch.isEmpty)
     }
@@ -21,7 +21,7 @@ struct CreateWorktreeSheetTests {
         state.finishLoading(branches: ["feature", "main"], defaultBranch: "main")
 
         #expect(!state.isLoading)
-        #expect(state.branches == ["feature", "main"])
+        #expect(state.branchOptions.map(\.name) == ["feature", "main"])
         #expect(state.selectedExistingBranch == "feature")
         #expect(state.selectedBaseBranch == "main")
     }
@@ -58,7 +58,7 @@ struct CreateWorktreeSheetTests {
         state.failLoading()
 
         #expect(!state.isLoading)
-        #expect(state.branches.isEmpty)
+        #expect(state.branchOptions.isEmpty)
         #expect(state.selectedExistingBranch.isEmpty)
         #expect(state.selectedBaseBranch.isEmpty)
     }

--- a/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
@@ -22,6 +22,7 @@ struct CreateWorktreeSheetTests {
 
         #expect(!state.isLoading)
         #expect(state.branchOptions.map(\.name) == ["feature", "main"])
+        #expect(state.branchOptions.map(\.id) == ["feature", "main"])
         #expect(state.selectedExistingBranch == "feature")
         #expect(state.selectedBaseBranch == "main")
     }


### PR DESCRIPTION
## Summary

Improve New Worktree responsiveness for repositories with many local branches.

## Changes

- build identifiable branch options once when branch loading completes instead of on every sheet render
- reuse one filtered collection per searchable-picker render
- remove the eager enumerated-array allocation while preserving stable item identity and keyboard highlighting
- update branch loading tests for the prebuilt picker options

## Testing

- [x] `swift test --filter CreateWorktreeSheetTests`
- [x] `scripts/checks.sh --fix`
- [x] Tested manually with a repository containing many branches

## Screenshots

Not applicable.

## AI assistance

OpenAI GPT-5.6 Sol assisted with this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved searchable list behavior so displayed results, highlighting, scrolling, and empty states remain consistent while filtering.
  - Ensured highlighted selections reset correctly when search criteria change.

- **Improvements**
  - Enhanced worktree branch selection with clearer branch choices, identifiers, and more reliable disabled-state handling.
  - Improved branch-loading validation across initial, successful, and failed loading states.
  - Updated selection behavior to provide consistent results when branch data changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->