### PR TITLE
Close the browser tab when a page calls window.close()

### DIFF
--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -435,9 +435,17 @@ final class AppState {
     }
 
     func locateTab(forPane paneID: UUID) -> PaneTabLocation? {
+        locateTab { $0.content.pane?.id == paneID }
+    }
+
+    func locateTab(forBrowserState stateID: UUID) -> PaneTabLocation? {
+        locateTab { $0.content.browserState?.id == stateID }
+    }
+
+    private func locateTab(matching predicate: (TerminalTab) -> Bool) -> PaneTabLocation? {
         for (key, root) in workspaceRoots {
             for area in root.allAreas() {
-                for tab in area.tabs where tab.content.pane?.id == paneID {
+                for tab in area.tabs where predicate(tab) {
                     return PaneTabLocation(worktreeKey: key, areaID: area.id, tab: tab)
                 }
             }

--- a/Muxy/Views/Browser/BrowserWebView.swift
+++ b/Muxy/Views/Browser/BrowserWebView.swift
@@ -401,6 +401,14 @@ extension BrowserWebView.Coordinator: WKNavigationDelegate, WKUIDelegate {
         return nil
     }
 
+    func webViewDidClose(_: WKWebView) {
+        guard let state,
+              let appState,
+              let location = appState.locateTab(forBrowserState: state.id)
+        else { return }
+        appState.closeTab(location.tab.id, areaID: location.areaID, key: location.worktreeKey)
+    }
+
     private func isHandoffScheme(_ url: URL) -> Bool {
         guard let scheme = url.scheme?.lowercased() else { return false }
         return !["file", "javascript", "data"].contains(scheme)

--- a/Tests/MuxyTests/Views/Browser/BrowserWebViewCloseTests.swift
+++ b/Tests/MuxyTests/Views/Browser/BrowserWebViewCloseTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+import WebKit
+
+@testable import Muxy
+
+@Suite("BrowserWebView window.close", .serialized)
+@MainActor
+struct BrowserWebViewCloseTests {
+    private let testPath = "/tmp/test"
+
+    private struct Fixture {
+        let appState: AppState
+        let key: WorktreeKey
+        let tabID: UUID
+        let state: BrowserTabState
+        let coordinator: BrowserWebView.Coordinator
+    }
+
+    private func makeFixture() throws -> Fixture {
+        UserDefaults.standard.removeObject(forKey: BrowserPreferences.enabledKey)
+        let projectID = UUID()
+        let worktreeID = UUID()
+        let appState = AppState(
+            selectionStore: CloseSelectionStoreStub(),
+            terminalViews: CloseTerminalViewRemovingStub(),
+            workspacePersistence: CloseWorkspacePersistenceStub()
+        )
+        let key = WorktreeKey(projectID: projectID, worktreeID: worktreeID)
+        let area = TabArea(projectPath: testPath)
+        appState.activeProjectID = projectID
+        appState.activeWorktreeID[projectID] = worktreeID
+        appState.workspaceRoots[key] = .tabArea(area)
+        appState.focusedAreaID[key] = area.id
+
+        let tabID = try MuxyAPI.Browser.open(url: "https://example.com", appState: appState).get()
+        let tab = try #require(appState.workspaceRoots[key]?.locateTab(id: tabID)?.tab)
+        let state = try #require(tab.content.browserState)
+        let coordinator = BrowserWebView.Coordinator(
+            state: state,
+            appState: appState,
+            historyStore: BrowserHistoryStore(persistence: InMemoryBrowserHistoryPersistence())
+        )
+        return Fixture(appState: appState, key: key, tabID: tabID, state: state, coordinator: coordinator)
+    }
+
+    private func tabIDs(_ fixture: Fixture) -> [UUID] {
+        fixture.appState.workspaceRoots[fixture.key]?.allAreas().flatMap { $0.tabs.map(\.id) } ?? []
+    }
+
+    @Test("webViewDidClose closes the browser tab that hosts the page")
+    func closesOwningTab() throws {
+        let fixture = try makeFixture()
+        #expect(tabIDs(fixture).contains(fixture.tabID))
+
+        fixture.coordinator.webViewDidClose(WKWebView(frame: .zero))
+
+        #expect(!tabIDs(fixture).contains(fixture.tabID))
+    }
+
+    @Test("webViewDidClose leaves a pinned tab open")
+    func keepsPinnedTabOpen() throws {
+        let fixture = try makeFixture()
+        let tab = try #require(fixture.appState.workspaceRoots[fixture.key]?.locateTab(id: fixture.tabID)?.tab)
+        tab.isPinned = true
+
+        fixture.coordinator.webViewDidClose(WKWebView(frame: .zero))
+
+        #expect(tabIDs(fixture).contains(fixture.tabID))
+    }
+
+    @Test("webViewDidClose closes only the tab that owns the state")
+    func leavesSiblingTabsOpen() throws {
+        let fixture = try makeFixture()
+        let siblingID = try MuxyAPI.Browser.open(url: "https://sibling.test", appState: fixture.appState).get()
+
+        fixture.coordinator.webViewDidClose(WKWebView(frame: .zero))
+
+        #expect(!tabIDs(fixture).contains(fixture.tabID))
+        #expect(tabIDs(fixture).contains(siblingID))
+    }
+
+    @Test("locateTab finds the tab hosting a browser state")
+    func locatesBrowserStateTab() throws {
+        let fixture = try makeFixture()
+
+        let located = try #require(fixture.appState.locateTab(forBrowserState: fixture.state.id))
+
+        #expect(located.tab.id == fixture.tabID)
+        #expect(located.worktreeKey == fixture.key)
+    }
+
+    @Test("locateTab returns nil for an unknown browser state")
+    func locateUnknownBrowserStateReturnsNil() throws {
+        let fixture = try makeFixture()
+
+        #expect(fixture.appState.locateTab(forBrowserState: UUID()) == nil)
+    }
+}
+
+@MainActor
+private final class CloseSelectionStoreStub: ActiveProjectSelectionStoring {
+    func loadActiveProjectID() -> UUID? { nil }
+    func saveActiveProjectID(_: UUID?) {}
+    func loadActiveWorktreeIDs() -> [UUID: UUID] { [:] }
+    func saveActiveWorktreeIDs(_: [UUID: UUID]) {}
+}
+
+@MainActor
+private final class CloseTerminalViewRemovingStub: TerminalViewRemoving {
+    func removeView(for _: UUID) {}
+    func needsConfirmQuit(for _: UUID) -> Bool { false }
+}
+
+private final class CloseWorkspacePersistenceStub: WorkspacePersisting {
+    func loadWorkspaces() throws -> [WorkspaceSnapshot] { [] }
+    func saveWorkspaces(_: [WorkspaceSnapshot]) throws {}
+}


### PR DESCRIPTION
<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

Fixes https://github.com/muxy-app/muxy/issues/1026

I am not a swift guy. I know golang more than anything. This change is AI, I've reviewed it but I dont know swift very well so I might have missed something.

I am running this locally now and the issue I reported is fixed with this change. Would just like to be able to switch back to stable when this is released so I dont have to maintain a fork anymore.

I use claude-opus-5


## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS
running locally now, no issues AFAIK

## Screenshots

<!-- If applicable, add screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing a browser view now automatically closes its associated unpinned tab.
  * Pinned tabs and neighboring tabs remain unaffected.
  * Browser tabs are correctly located using their browser state.

* **Tests**
  * Added coverage for browser view closing, tab preservation, and unknown browser states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->