### PR TITLE
feat(sidebar): surface agent attention status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.worktrees
 /Packages
 /.vscode
 .idea/

--- a/Muxy/Models/Terminal/TerminalActivity.swift
+++ b/Muxy/Models/Terminal/TerminalActivity.swift
@@ -19,20 +19,20 @@ enum TerminalActivity: Equatable {
         unreadCount: Int,
         completionPending: Bool
     ) -> TerminalActivity? {
+        if agentStatus == .waiting {
+            return .waiting
+        }
+        if completionPending {
+            return .finished
+        }
         if let progress {
             return .working(progress)
         }
         if agentStatus == .working {
             return .working(TerminalProgress(kind: .indeterminate, percent: nil))
         }
-        if agentStatus == .waiting {
-            return .waiting
-        }
         if unreadCount > 0 {
             return .unread(unreadCount)
-        }
-        if completionPending {
-            return .finished
         }
         return nil
     }

--- a/Muxy/Services/AI/AgentStatusStore.swift
+++ b/Muxy/Services/AI/AgentStatusStore.swift
@@ -9,7 +9,7 @@ enum AgentStatus: String, Equatable, Codable {
     var priority: Int {
         switch self {
         case .working: 2
-        case .waiting: 1
+        case .waiting: 3
         case .idle: 0
         }
     }
@@ -245,6 +245,17 @@ final class AgentStatusStore {
 
     func hasCompletionPending(forProject projectID: UUID) -> Bool {
         completionPending.contains { panes[$0]?.projectID == projectID }
+    }
+
+    func attentionEntries() -> [Entry] {
+        panes.values
+            .filter { $0.status == .waiting || completionPending.contains($0.paneID) }
+            .sorted { lhs, rhs in
+                if lhs.status.priority != rhs.status.priority {
+                    return lhs.status.priority > rhs.status.priority
+                }
+                return lhs.updatedAt > rhs.updatedAt
+            }
     }
 
     nonisolated static func marksCompletion(from previous: AgentStatus?, to current: AgentStatus) -> Bool {

--- a/Muxy/Views/Components/Badges/TerminalActivityIndicator.swift
+++ b/Muxy/Views/Components/Badges/TerminalActivityIndicator.swift
@@ -10,16 +10,16 @@ struct TerminalActivityIndicator: View {
                 .controlSize(.mini)
                 .accessibilityLabel(L10n.string("Working"))
         case .waiting:
-            Circle()
-                .fill(MuxyTheme.warning)
-                .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
+            Image(systemName: "questionmark.circle.fill")
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                .foregroundStyle(MuxyTheme.warning)
                 .accessibilityLabel(L10n.string("Waiting for attention"))
         case let .unread(count):
             NotificationBadge(count: count)
         case .finished:
-            Circle()
-                .fill(MuxyTheme.accent)
-                .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: UIMetrics.fontBody, weight: .semibold))
+                .foregroundStyle(MuxyTheme.accent)
                 .accessibilityLabel(L10n.string("Finished"))
         }
     }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedAttentionMenu.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedAttentionMenu.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct TabFocusedAttentionItem: Identifiable {
+    enum State: Equatable {
+        case waiting
+        case finished
+
+        var systemImage: String {
+            switch self {
+            case .waiting: "questionmark.circle.fill"
+            case .finished: "checkmark.circle.fill"
+            }
+        }
+    }
+
+    let paneID: UUID
+    let projectID: UUID
+    let worktreeID: UUID
+    let worktreePath: String
+    let areaID: UUID
+    let tabID: UUID
+    let tabTitle: String
+    let scopeTitle: String
+    let state: State
+
+    var id: UUID { paneID }
+}
+
+struct TabFocusedAttentionMenu: View {
+    let items: [TabFocusedAttentionItem]
+    let onSelect: (TabFocusedAttentionItem) -> Void
+
+    private var waitingItems: [TabFocusedAttentionItem] {
+        items.filter { $0.state == .waiting }
+    }
+
+    private var finishedItems: [TabFocusedAttentionItem] {
+        items.filter { $0.state == .finished }
+    }
+
+    var body: some View {
+        Menu {
+            if !waitingItems.isEmpty {
+                Section(L10n.string("Waiting for attention")) {
+                    attentionItems(waitingItems)
+                }
+            }
+            if !finishedItems.isEmpty {
+                Section(L10n.string("Finished")) {
+                    attentionItems(finishedItems)
+                }
+            }
+        } label: {
+            label
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var label: some View {
+        HStack(spacing: UIMetrics.spacing2) {
+            if !waitingItems.isEmpty {
+                Image(systemName: TabFocusedAttentionItem.State.waiting.systemImage)
+                    .foregroundStyle(color(for: .waiting))
+                Text(L10n.resource("Waiting for attention"))
+                countBadge(waitingItems.count, color: color(for: .waiting))
+            } else {
+                Image(systemName: TabFocusedAttentionItem.State.finished.systemImage)
+                    .foregroundStyle(color(for: .finished))
+                Text(L10n.resource("Finished"))
+                countBadge(finishedItems.count, color: color(for: .finished))
+            }
+
+            if !waitingItems.isEmpty, !finishedItems.isEmpty {
+                Image(systemName: TabFocusedAttentionItem.State.finished.systemImage)
+                    .foregroundStyle(color(for: .finished))
+                Text("\(finishedItems.count)")
+                    .foregroundStyle(MuxyTheme.fgMuted)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .font(.system(size: UIMetrics.fontFootnote, weight: .medium))
+        .foregroundStyle(MuxyTheme.fg)
+        .padding(.horizontal, UIMetrics.spacing3)
+        .padding(.vertical, UIMetrics.spacing2)
+        .background {
+            RoundedRectangle(cornerRadius: TabFocusedSidebarMetrics.rowCornerRadius, style: .continuous)
+                .fill(MuxyTheme.surface)
+        }
+    }
+
+    private func countBadge(_ count: Int, color: Color) -> some View {
+        Text("\(count)")
+            .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+            .foregroundStyle(MuxyTheme.bg)
+            .padding(.horizontal, UIMetrics.spacing2)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(color))
+    }
+
+    private func color(for state: TabFocusedAttentionItem.State) -> Color {
+        switch state {
+        case .waiting: MuxyTheme.warning
+        case .finished: MuxyTheme.accent
+        }
+    }
+
+    @ViewBuilder
+    private func attentionItems(_ items: [TabFocusedAttentionItem]) -> some View {
+        ForEach(items) { item in
+            Button {
+                onSelect(item)
+            } label: {
+                Label {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(item.tabTitle)
+                        Text(item.scopeTitle)
+                            .font(.caption)
+                    }
+                } icon: {
+                    Image(systemName: item.state.systemImage)
+                        .foregroundStyle(color(for: item.state))
+                }
+            }
+        }
+    }
+
+    private var accessibilityLabel: String {
+        if !waitingItems.isEmpty {
+            return L10n.string("Waiting for attention")
+        }
+        return L10n.string("Finished")
+    }
+}

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedSidebar.swift
@@ -13,6 +13,7 @@ struct TabFocusedSidebar: View {
     @Environment(WorktreeStore.self) private var worktreeStore
     @Environment(ProjectGroupStore.self) private var projectGroupStore
     @State private var expansionStore = TabFocusedSidebarState.shared
+    @State private var agentStatusStore = AgentStatusStore.shared
     @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
     @AppStorage(ProjectSortMode.storageKey) private var sortModeRaw = ProjectSortMode.defaultValue.rawValue
     @AppStorage(WorktreeListPreferences.groupWorktreesKey)
@@ -40,15 +41,41 @@ struct TabFocusedSidebar: View {
         return Project.home
     }
 
-    private var projects: [Project] {
+    private var allProjects: [Project] {
         let stored = projectGroupStore.displayProjects(localProjects: projectStore.storedProjects, sortMode: sortMode)
-        let all = homeProject.map { [$0] + stored } ?? stored
+        return homeProject.map { [$0] + stored } ?? stored
+    }
+
+    private var projects: [Project] {
+        let all = allProjects
         return TabFocusedSidebarProjectSelection.resolve(
             projects: all,
             focusMode: expansionStore.focusMode,
             activeProjectID: appState.activeProjectID,
             content: content
         )
+    }
+
+    private var attentionItems: [TabFocusedAttentionItem] {
+        agentStatusStore.attentionEntries().compactMap { entry in
+            guard let location = appState.locateTab(forPane: entry.paneID) else { return nil }
+            let project = allProjects.first { $0.id == entry.projectID }
+            let worktree = worktreeStore.worktree(projectID: entry.projectID, worktreeID: entry.worktreeID)
+            let scopeTitle = [project?.localizedDisplayName, worktree?.sidebarDisplayName]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+            return TabFocusedAttentionItem(
+                paneID: entry.paneID,
+                projectID: entry.projectID,
+                worktreeID: entry.worktreeID,
+                worktreePath: worktree?.path ?? location.tab.content.projectPath,
+                areaID: location.areaID,
+                tabID: location.tab.id,
+                tabTitle: location.tab.localizedTitle,
+                scopeTitle: scopeTitle.isEmpty ? location.tab.content.projectPath : scopeTitle,
+                state: entry.status == .waiting ? .waiting : .finished
+            )
+        }
     }
 
     private var rows: [TabFocusedSidebarRowItem] {
@@ -88,6 +115,12 @@ struct TabFocusedSidebar: View {
             }
             .padding(.horizontal, UIMetrics.spacing3)
             .padding(.top, UIMetrics.spacing2)
+
+            if !attentionItems.isEmpty {
+                TabFocusedAttentionMenu(items: attentionItems, onSelect: navigate(to:))
+                    .padding(.horizontal, UIMetrics.spacing3)
+                    .padding(.top, UIMetrics.spacing2)
+            }
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
@@ -145,6 +178,16 @@ struct TabFocusedSidebar: View {
             worktreeStore: worktreeStore,
             projectGroupStore: projectGroupStore
         )
+    }
+
+    private func navigate(to item: TabFocusedAttentionItem) {
+        appState.dispatch(.selectProject(
+            projectID: item.projectID,
+            worktreeID: item.worktreeID,
+            worktreePath: item.worktreePath
+        ))
+        appState.dispatch(.focusArea(projectID: item.projectID, areaID: item.areaID))
+        appState.dispatch(.selectTab(projectID: item.projectID, areaID: item.areaID, tabID: item.tabID))
     }
 
     private var displayedRecentlyRemovedProjects: [RecentlyRemovedProject] {

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -363,6 +363,15 @@ struct TabFocusedTabRow: View {
         TerminalProgress.tabIndicator(progress: paneProgress, agentStatus: agentStatus)
     }
 
+    private var tabAttention: TerminalActivity? {
+        TerminalActivity.resolve(
+            progress: nil,
+            agentStatus: agentStatus == .waiting ? .waiting : nil,
+            unreadCount: !active && hasUnread ? 1 : 0,
+            completionPending: !active && hasCompletionPending
+        )
+    }
+
     private var hasCompletionPending: Bool {
         relatedTabs.compactMap { $0.content.pane?.id }.contains {
             progressStore.isCompletionPending(for: $0)
@@ -384,16 +393,6 @@ struct TabFocusedTabRow: View {
             AgentStatusStore.shared.status(forPane: tab.content.pane?.id)
         }
         return statuses.contains(.waiting) ? .waiting : statuses.first
-    }
-
-    private var statusDotColor: Color? {
-        if agentStatus == .waiting {
-            return MuxyTheme.warning
-        }
-        if !active, hasUnread || hasCompletionPending {
-            return MuxyTheme.accent
-        }
-        return nil
     }
 
     @State private var hovered = false
@@ -627,22 +626,20 @@ struct TabFocusedTabRow: View {
 
     @ViewBuilder
     private var statusAccessory: some View {
-        if tab.isPinned {
+        if let tabAttention {
+            TerminalActivityIndicator(activity: tabAttention)
+                .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
+        } else if tab.isPinned {
             Image(systemName: "pin.fill")
                 .font(.system(size: UIMetrics.fontXS, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fgMuted)
-                .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
-        } else if let shortcutNumber, let combo = shortcutHint {
-            ShortcutIconBadge(number: shortcutNumber, size: UIMetrics.iconMD, combo: combo)
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
         } else if let progress = tabProgress {
             TerminalProgressCircle(progress: progress)
                 .frame(width: UIMetrics.iconSM, height: UIMetrics.iconSM)
                 .transition(.opacity)
-        } else if let dotColor = statusDotColor {
-            Circle()
-                .fill(dotColor)
-                .frame(width: UIMetrics.scaled(7), height: UIMetrics.scaled(7))
+        } else if let shortcutNumber, let combo = shortcutHint {
+            ShortcutIconBadge(number: shortcutNumber, size: UIMetrics.iconMD, combo: combo)
                 .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
         } else if isIdle, !active {
             Image(systemName: "moon.zzz")

--- a/Tests/MuxyTests/Models/Terminal/TerminalActivityTests.swift
+++ b/Tests/MuxyTests/Models/Terminal/TerminalActivityTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 @Suite("TerminalActivity")
 struct TerminalActivityTests {
-    @Test("explicit progress has highest priority")
-    func explicitProgressWins() {
+    @Test("waiting takes priority over explicit progress")
+    func waitingWinsOverExplicitProgress() {
         let progress = TerminalProgress(kind: .set, percent: 40)
         let activity = TerminalActivity.resolve(
             progress: progress,
@@ -13,16 +13,28 @@ struct TerminalActivityTests {
             unreadCount: 2,
             completionPending: true
         )
-        #expect(activity == .working(progress))
+        #expect(activity == .waiting)
     }
 
-    @Test("agent working takes priority over waiting indicators")
+    @Test("finished takes priority over active progress and unread")
+    func finishedWinsOverProgressAndUnread() {
+        let progress = TerminalProgress(kind: .set, percent: 40)
+        let activity = TerminalActivity.resolve(
+            progress: progress,
+            agentStatus: .working,
+            unreadCount: 2,
+            completionPending: true
+        )
+        #expect(activity == .finished)
+    }
+
+    @Test("agent working takes priority over unread")
     func agentWorkingWins() {
         let activity = TerminalActivity.resolve(
             progress: nil,
             agentStatus: .working,
             unreadCount: 2,
-            completionPending: true
+            completionPending: false
         )
         #expect(activity == .working(TerminalProgress(kind: .indeterminate, percent: nil)))
     }
@@ -38,15 +50,15 @@ struct TerminalActivityTests {
         #expect(activity == .waiting)
     }
 
-    @Test("unread takes priority over finished")
-    func unreadWins() {
+    @Test("finished takes priority over unread")
+    func finishedWinsOverUnread() {
         let activity = TerminalActivity.resolve(
             progress: nil,
             agentStatus: .idle,
             unreadCount: 2,
             completionPending: true
         )
-        #expect(activity == .unread(2))
+        #expect(activity == .finished)
     }
 
     @Test("finished appears without higher-priority activity")

--- a/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
+++ b/Tests/MuxyTests/Services/AI/AgentStatusTests.swift
@@ -247,13 +247,13 @@ struct AgentStatusTests {
         #expect(AgentStatusStore.winningEntry(among: []) == nil)
     }
 
-    @Test("the most active pane wins regardless of recency")
-    func aggregatePrefersMostActive() {
+    @Test("a waiting pane wins over a working pane regardless of recency")
+    func aggregatePrefersWaiting() {
         let worktreeID = UUID()
         let working = entry(.working, worktreeID: worktreeID, at: 0)
         let waiting = entry(.waiting, worktreeID: worktreeID, at: 100)
         let idle = entry(.idle, worktreeID: worktreeID, at: 200)
-        #expect(AgentStatusStore.winningEntry(among: [idle, waiting, working]) == working)
+        #expect(AgentStatusStore.winningEntry(among: [idle, waiting, working]) == waiting)
     }
 
     @Test("ties on status break toward the most recent pane")
@@ -384,6 +384,21 @@ struct AgentStatusStoreTests {
         store.clearCompletion(for: paneID)
         send(store, paneID, .idle, sequence: 2)
         #expect(!store.isCompletionPending(forPane: paneID))
+    }
+
+    @Test("attention entries include waiting and finished panes")
+    func attentionEntriesIncludeWaitingAndFinishedPanes() {
+        let (store, _, paneIDs) = makeContext(paneCount: 2)
+        let finishedPaneID = paneIDs[0]
+        let waitingPaneID = paneIDs[1]
+
+        send(store, finishedPaneID, .working, sequence: 1)
+        send(store, finishedPaneID, .idle, sequence: 2)
+        send(store, waitingPaneID, .waiting, sequence: 3)
+
+        let entries = store.attentionEntries()
+        #expect(entries.map(\.paneID).contains(finishedPaneID))
+        #expect(entries.map(\.paneID).contains(waitingPaneID))
     }
 
     @Test("detection loss idles a working agent only after grace with no hook events")


### PR DESCRIPTION
## Summary
- Prioritize waiting and finished agent states over progress spinners, unread markers, pins, and shortcut badges.
- Show distinct question and check icons for waiting and finished states.
- Add an attention menu that lists each waiting or finished tab with its project and worktree, then navigates to the selected tab.

## Testing
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=hooks.protectedBranches GIT_CONFIG_VALUE_0= scripts/run-tests-isolated.sh swift test --enable-swift-testing --disable-xctest --quiet`
  - 3,214 tests passed in 394 suites.
- `scripts/checks.sh --fix` could not run because `swiftformat` is not installed locally.

## Limitation
Codex does not expose a stable hook for `request_user_input`. This change makes supported waiting and completed states visible, but cannot reliably identify a Codex multiple-choice prompt until Codex exposes such an event.

## AI assistance
Implemented with assistance from OpenAI Codex (GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an attention menu in the sidebar for quickly locating waiting and finished tabs.
  * Added grouped status counts and selection shortcuts for tabs needing attention.
  * Improved tab indicators for waiting, finished, unread, and in-progress activity.

* **Bug Fixes**
  * Waiting and finished states now take priority over progress and unread activity.
  * Improved accessibility and visual clarity for attention indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->