### PR TITLE
Respect the Auto-copy setting in the selection-clipboard write path

### DIFF
--- a/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
@@ -137,6 +137,10 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
 
     func writeClipboard(location: ghostty_clipboard_e, content: UnsafePointer<ghostty_clipboard_content_s>?, len: UInt) {
         guard let content, len > 0 else { return }
+        if location == GHOSTTY_CLIPBOARD_SELECTION {
+            let autoCopyEnabled = UserDefaults.standard.bool(forKey: GeneralSettingsKeys.autoCopyTerminalSelection)
+            guard Self.shouldWriteSelectionClipboard(settingEnabled: autoCopyEnabled) else { return }
+        }
         let buffer = UnsafeBufferPointer(start: content, count: Int(len))
         for item in buffer {
             guard let dataPtr = item.data else { continue }
@@ -148,6 +152,10 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
             NSPasteboard.general.setString(String(cString: dataPtr), forType: .string)
             return
         }
+    }
+
+    static func shouldWriteSelectionClipboard(settingEnabled: Bool) -> Bool {
+        settingEnabled
     }
 
     func closeSurface(userdata: UnsafeMutableRawPointer?, needsConfirm: Bool) {

--- a/Tests/MuxyTests/Services/Terminal/SelectionClipboardWriteTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/SelectionClipboardWriteTests.swift
@@ -5,6 +5,7 @@ import Testing
 
 @testable import Muxy
 
+@MainActor
 @Suite("SelectionClipboardWrite", .serialized)
 struct SelectionClipboardWriteTests {
     @Test("shouldWriteSelectionClipboard is false when the setting is disabled")
@@ -68,6 +69,28 @@ struct SelectionClipboardWriteTests {
         }
     }
 
+    @Test("selection-clipboard cleanup restores non-text pasteboard types")
+    func cleanupPreservesNonTextPasteboardTypes() throws {
+        let pasteboard = NSPasteboard.general
+        let outerSnapshot = SystemPasteboardSnapshot.capture()
+        defer { SystemPasteboardSnapshot.restore(items: outerSnapshot) }
+
+        let pngData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x6D, 0x75, 0x78, 0x79])
+        pasteboard.clearContents()
+        pasteboard.setData(pngData, forType: .png)
+        pasteboard.setString("muxy-original-string", forType: .string)
+
+        try withControlledGlobals(autoCopy: true) {
+            Self.writeToAdapter(location: GHOSTTY_CLIPBOARD_SELECTION, payload: "copied-by-ghostty")
+
+            #expect(pasteboard.string(forType: .string) == "copied-by-ghostty")
+            #expect(pasteboard.data(forType: .png) == nil)
+        }
+
+        #expect(pasteboard.string(forType: .string) == "muxy-original-string")
+        #expect(pasteboard.data(forType: .png) == pngData)
+    }
+
     private static func writeToAdapter(location: ghostty_clipboard_e, payload: String) {
         let adapter = GhosttyRuntimeEventAdapter()
         payload.withCString { dataPtr in
@@ -83,8 +106,7 @@ struct SelectionClipboardWriteTests {
     private func withControlledGlobals<T>(autoCopy: Bool?, _ body: () throws -> T) throws -> T {
         let key = GeneralSettingsKeys.autoCopyTerminalSelection
         let originalValue = UserDefaults.standard.object(forKey: key)
-        let pasteboard = NSPasteboard.general
-        let originalPasteboard = pasteboard.string(forType: .string)
+        let savedPasteboard = SystemPasteboardSnapshot.capture()
 
         if let autoCopy {
             UserDefaults.standard.set(autoCopy, forKey: key)
@@ -97,10 +119,7 @@ struct SelectionClipboardWriteTests {
             } else {
                 UserDefaults.standard.removeObject(forKey: key)
             }
-            if let originalPasteboard {
-                pasteboard.clearContents()
-                pasteboard.setString(originalPasteboard, forType: .string)
-            }
+            SystemPasteboardSnapshot.restore(items: savedPasteboard)
         }
         return try body()
     }

--- a/Tests/MuxyTests/Services/Terminal/SelectionClipboardWriteTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/SelectionClipboardWriteTests.swift
@@ -1,0 +1,107 @@
+import AppKit
+import Foundation
+import GhosttyKit
+import Testing
+
+@testable import Muxy
+
+@Suite("SelectionClipboardWrite", .serialized)
+struct SelectionClipboardWriteTests {
+    @Test("shouldWriteSelectionClipboard is false when the setting is disabled")
+    func helperFalseWhenDisabled() {
+        #expect(!GhosttyRuntimeEventAdapter.shouldWriteSelectionClipboard(settingEnabled: false))
+    }
+
+    @Test("shouldWriteSelectionClipboard is true when the setting is enabled")
+    func helperTrueWhenEnabled() {
+        #expect(GhosttyRuntimeEventAdapter.shouldWriteSelectionClipboard(settingEnabled: true))
+    }
+
+    @Test("selection-clipboard write is a no-op when the setting is absent")
+    func selectionWriteNoOpWhenAbsent() throws {
+        try withControlledGlobals(autoCopy: nil) {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString("muxy-before-absent", forType: .string)
+
+            Self.writeToAdapter(location: GHOSTTY_CLIPBOARD_SELECTION, payload: "should-not-write")
+
+            #expect(pasteboard.string(forType: .string) == "muxy-before-absent")
+        }
+    }
+
+    @Test("selection-clipboard write is a no-op when the setting is disabled")
+    func selectionWriteNoOpWhenDisabled() throws {
+        try withControlledGlobals(autoCopy: false) {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString("muxy-before-disabled", forType: .string)
+
+            Self.writeToAdapter(location: GHOSTTY_CLIPBOARD_SELECTION, payload: "should-not-write")
+
+            #expect(pasteboard.string(forType: .string) == "muxy-before-disabled")
+        }
+    }
+
+    @Test("selection-clipboard write copies text when the setting is enabled")
+    func selectionWriteCopiesWhenEnabled() throws {
+        try withControlledGlobals(autoCopy: true) {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString("muxy-before-enabled", forType: .string)
+
+            Self.writeToAdapter(location: GHOSTTY_CLIPBOARD_SELECTION, payload: "copied-by-ghostty")
+
+            #expect(pasteboard.string(forType: .string) == "copied-by-ghostty")
+        }
+    }
+
+    @Test("standard-clipboard write ignores the auto-copy setting")
+    func standardWriteIgnoresSetting() throws {
+        try withControlledGlobals(autoCopy: false) {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+
+            Self.writeToAdapter(location: GHOSTTY_CLIPBOARD_STANDARD, payload: "standard-payload")
+
+            #expect(pasteboard.string(forType: .string) == "standard-payload")
+        }
+    }
+
+    private static func writeToAdapter(location: ghostty_clipboard_e, payload: String) {
+        let adapter = GhosttyRuntimeEventAdapter()
+        payload.withCString { dataPtr in
+            "text/plain".withCString { mimePtr in
+                var item = ghostty_clipboard_content_s(mime: mimePtr, data: dataPtr)
+                withUnsafePointer(to: &item) { itemPtr in
+                    adapter.writeClipboard(location: location, content: itemPtr, len: 1)
+                }
+            }
+        }
+    }
+
+    private func withControlledGlobals<T>(autoCopy: Bool?, _ body: () throws -> T) throws -> T {
+        let key = GeneralSettingsKeys.autoCopyTerminalSelection
+        let originalValue = UserDefaults.standard.object(forKey: key)
+        let pasteboard = NSPasteboard.general
+        let originalPasteboard = pasteboard.string(forType: .string)
+
+        if let autoCopy {
+            UserDefaults.standard.set(autoCopy, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        defer {
+            if let originalValue {
+                UserDefaults.standard.set(originalValue, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+            if let originalPasteboard {
+                pasteboard.clearContents()
+                pasteboard.setString(originalPasteboard, forType: .string)
+            }
+        }
+        return try body()
+    }
+}


### PR DESCRIPTION
When "Auto-copy terminal selection" is off, selecting text in a terminal still copied it behind the scenes. The mouse-up path already respected the preference and showed the "Copied" toast, but the separate path libghostty uses to write the selection clipboard ignored it entirely — so the setting wasn't actually the single source of truth it appeared to be.

This makes that ghostty-side write path honor the same setting: when a selection-clipboard write comes in and auto-copy is disabled (or simply unset, which reads as disabled), it is now a no-op. The standard clipboard is left alone, and the existing mouse-up behavior plus the toast are unchanged.

The decision is pulled out into a tiny pure helper (`shouldWriteSelectionClipboard`) so it can be covered directly by unit tests, alongside adapter-level tests that drive the real preference and pasteboard.

Closes #963.

Generated with the assistance of GLM-5.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selection clipboard writes now respect the auto-copy setting.
  * Standard clipboard writes continue to work independently of the auto-copy preference.
  * Clipboard contents and non-text formats are preserved during selection clipboard operations.

* **Tests**
  * Added coverage for enabled, disabled, and unset auto-copy settings.
  * Added coverage confirming standard clipboard behavior and pasteboard cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->