### PR TITLE
fix: parse the minus key as a literal key in KeyCombo

### DIFF
--- a/Muxy/Models/Keyboard/KeyCombo.swift
+++ b/Muxy/Models/Keyboard/KeyCombo.swift
@@ -162,7 +162,7 @@ struct KeyCombo: Codable, Equatable, Hashable {
     init?(parsing description: String) {
         let tokens = description
             .lowercased()
-            .split(whereSeparator: { $0 == "+" || $0 == "-" })
+            .split(whereSeparator: { $0 == "+" })
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
         guard let rawKey = tokens.last else { return nil }

--- a/Tests/MuxyTests/Services/Extensions/ExtensionShortcutStoreTests.swift
+++ b/Tests/MuxyTests/Services/Extensions/ExtensionShortcutStoreTests.swift
@@ -256,6 +256,13 @@ struct KeyComboParsingTests {
         #expect(KeyCombo(parsing: "cmd+return") == KeyCombo(key: KeyCombo.returnKey, command: true))
     }
 
+    @Test("parses the minus key as a literal key instead of a separator")
+    func parsesMinusKey() {
+        #expect(KeyCombo(parsing: "cmd+-") == KeyCombo(key: "-", command: true))
+        #expect(KeyCombo(parsing: "cmd+shift+-") == KeyCombo(key: "-", command: true, shift: true))
+        #expect(KeyCombo(parsing: "ctrl+-") == KeyCombo(key: "-", control: true))
+    }
+
     @Test("rejects combos without a command, control, or option modifier")
     func rejectsModifierlessCombos() {
         #expect(KeyCombo(parsing: "e") == nil)
@@ -272,7 +279,7 @@ struct KeyComboParsingTests {
 
     @Test("tokenString round-trips through parsing")
     func tokenStringRoundTrips() {
-        for combo in ["cmd+b", "cmd+shift+e", "ctrl+opt+k", "cmd+return", "cmd+left"] {
+        for combo in ["cmd+b", "cmd+shift+e", "ctrl+opt+k", "cmd+return", "cmd+left", "cmd+c", "cmd+-"] {
             let parsed = KeyCombo(parsing: combo)
             #expect(parsed != nil)
             #expect(KeyCombo(parsing: parsed?.tokenString ?? "") == parsed)


### PR DESCRIPTION
<!--
  DRAFT for the orchestrator/human to REWRITE in natural human voice.
  Repo policy: PR title/description/comments must be human-written; AI-generated
  PR text is closed without review. AI-assisted code is fine if the LLM is named.
  (Code written with assistance from GLM-5.2.)
-->

**Suggested title:** `fix(keyboard): parse the minus key as a literal key in KeyCombo`

<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

<!-- What does this PR do and why? Write this yourself — no AI-generated text. -->

`KeyCombo(parsing: "cmd+-")` returned `nil`, so the minus key could never be bound through the
shortcut parser. The parser split its token string on both `+` and `-`; since `-` is also a real
key (`kVK_ANSI_Minus` / keypad minus), a literal minus was eaten as a separator. This splits on
`+` only, so `cmd+-` now parses to `KeyCombo(key: "-", command: true)`.

## Changes

<!-- List the key changes -->

- `KeyCombo.init(parsing:)`: split tokens on `+` only instead of `+` and `-`.
- `KeyComboParsingTests`: add `parsesMinusKey` (covers `cmd+-`, `cmd+shift+-`, `ctrl+-`) and extend the `tokenString` round-trip list with `cmd+c` and `cmd+-`.

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [ ] Tested manually on macOS

Added parsing tests fail at HEAD (RED: `cmd+-` → nil) and pass after the fix (GREEN). Full gate
(format → lint → build-tests → test) is green.

## Screenshots

<!-- If applicable, add screenshots -->

No UI changes.

---

**Note for review (not part of the PR text):** the plus key (`cmd++`) still cannot round-trip —
`tokenString` serialises a cmd+plus combo as `"cmd++"`, and splitting that on `+` consumes both
plus signs. That is a separate, format-level problem (the `+` key collides with the `+` separator)
and is intentionally out of scope here; only the `-` separator was removed.

Code written with assistance from GLM-5.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortcut parsing so the minus key is recognized correctly when used with modifier keys.
  * Shortcut descriptions containing `-` now remain intact during parsing.

* **Tests**
  * Added coverage for minus-key shortcuts and token round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->