### PR TITLE
fix(git): reset inHunk on new file header in combined diff parsing

### DIFF
--- a/Muxy/Services/Git/GitDiffParser.swift
+++ b/Muxy/Services/Git/GitDiffParser.swift
@@ -18,6 +18,11 @@ enum GitDiffParser {
         for rawLine in patch.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
             let line = String(rawLine)
 
+            if line.hasPrefix("diff --git ") {
+                inHunk = false
+                continue
+            }
+
             if line.hasPrefix("@@") {
                 inHunk = true
                 let (oldStart, newStart) = parseHunkHeader(line)

--- a/Tests/MuxyTests/Git/GitDiffParserTests.swift
+++ b/Tests/MuxyTests/Git/GitDiffParserTests.swift
@@ -120,6 +120,86 @@ struct GitDiffParserTests {
         #expect(secondAddition.newLineNumber == 21)
     }
 
+    @Test("parseRows skips file headers in a combined staged+unstaged diff")
+    func parseRowsCombinedStagedAndUnstagedSkipsFileHeaders() {
+        let patch = """
+        diff --git a/f.swift b/f.swift
+        index 5fcb7b1..b3f861e 100644
+        --- a/f.swift
+        +++ b/f.swift
+        @@ -1,5 +1,5 @@
+         line1
+        -line2
+        +STAGED
+         line3
+         line4
+         line5
+        diff --git a/f.swift b/f.swift
+        index b3f861e..d0d1742 100644
+        --- a/f.swift
+        +++ b/f.swift
+        @@ -2,5 +2,5 @@ line1
+         STAGED
+         line3
+         line4
+        -line5
+        +UNSTAGED
+         line6
+        """
+        let result = GitDiffParser.parseRows(patch)
+
+        #expect(result.additions == 2)
+        #expect(result.deletions == 2)
+
+        let leakedHeaders = result.rows.filter { row in
+            (row.kind == .deletion && row.text.hasPrefix("--- a/"))
+                || (row.kind == .addition && row.text.hasPrefix("+++ b/"))
+        }
+        #expect(leakedHeaders.isEmpty)
+
+        let addedTexts = result.rows.filter { $0.kind == .addition }.compactMap { $0.newText }
+        #expect(addedTexts == ["STAGED", "UNSTAGED"])
+
+        let deletedTexts = result.rows.filter { $0.kind == .deletion }.compactMap { $0.oldText }
+        #expect(deletedTexts == ["line2", "line5"])
+    }
+
+    @Test("parseRows skips file headers in a multi-file diff")
+    func parseRowsMultiFileDiffSkipsFileHeaders() {
+        let patch = """
+        diff --git a/alpha.swift b/alpha.swift
+        index 111..222 100644
+        --- a/alpha.swift
+        +++ b/alpha.swift
+        @@ -1,1 +1,1 @@
+        -oldAlpha
+        +newAlpha
+        diff --git a/beta.swift b/beta.swift
+        index 333..444 100644
+        --- a/beta.swift
+        +++ b/beta.swift
+        @@ -1,1 +1,1 @@
+        -oldBeta
+        +newBeta
+        """
+        let result = GitDiffParser.parseRows(patch)
+
+        #expect(result.additions == 2)
+        #expect(result.deletions == 2)
+
+        let leakedHeaders = result.rows.filter { row in
+            (row.kind == .deletion && row.text.hasPrefix("--- a/"))
+                || (row.kind == .addition && row.text.hasPrefix("+++ b/"))
+        }
+        #expect(leakedHeaders.isEmpty)
+
+        let addedTexts = result.rows.filter { $0.kind == .addition }.compactMap { $0.newText }
+        #expect(addedTexts == ["newAlpha", "newBeta"])
+
+        let deletedTexts = result.rows.filter { $0.kind == .deletion }.compactMap { $0.oldText }
+        #expect(deletedTexts == ["oldAlpha", "oldBeta"])
+    }
+
     @Test("parseRows captures text content correctly")
     func parseRowsTextContent() {
         let patch = """


### PR DESCRIPTION
# w-muxy-combined-diff — combined diff parser leaked file-header rows

## Status
- **Bug confirmed at HEAD** — not a false positive (empirically reproduced, then proven via the project test harness with red-on-HEAD / green-on-fix).
- **Fixed** with a minimal, behavior-preserving change.
- **Regression tests added** (combined staged+unstaged + multi-file).
- **Gate green**: swiftformat ✓, swiftlint ✓, build ✓, 3228/3230 tests pass (the 2 failures are pre-existing flaky terminal-lifecycle tests, unrelated — they pass in isolation).
- **Committed locally on `YuriNachos/w-muxy-combined-diff`. NOT pushed, no PR opened.**

## HEAD confirmation
- HEAD: `2f6be818a1efca3f9636db21659d4511641c6765` (`2f6be81`) — matches the task spec.
- Reproduced against a **real** combined staged+unstaged diff generated in a throwaway git repo
  (`git diff --cached -- f` concatenated with `git diff -- f`, exactly how
  `GitRepositoryService.resolveAndDiff` builds `combinedPatch` at line 1481:
  `stagedResult.stdout + "\n" + unstagedResult.stdout`).
- Feeding that combined patch through the HEAD `GitDiffParser.parseRows` produced:
  - `additions = 3` (true = 2), `deletions = 3` (true = 2);
  - a leaked `deletion` row with `text == "--- a/f.swift"` (`oldText "-- a/f.swift"`);
  - a leaked `addition` row with `text == "+++ b/f.swift"` (`newText "++ b/f.swift"`).

## Root cause
`GitDiffParser.parseRows` drives an `inHunk` flag: it becomes `true` on a `@@` hunk header and
gates whether ` `/`-`/`+`-prefixed lines are parsed as context/deletion/addition rows.

When a patch contains more than one `diff --git` file section (the normal case for the combined
staged+unstaged path, or any multi-file diff), the parser never resets `inHunk` when a new file
header begins. So for the 2nd+ files the structural header lines are misread as hunk content:

- `--- a/path` starts with `-` → parsed as a **deletion** (`content = "-- a/path"`).
- `+++ b/path` starts with `+` → parsed as an **addition** (`content = "++ b/path"`).

Result: garbage rows in the diff view and the `+`/`-` counters inflated by one per extra file
section. (`diff --git …`, `index …`, etc. start with a letter and fall through harmlessly — only
the `---`/`+++` pair is affected, which is exactly the reported symptom.)

Glue: `Muxy/Services/Git/GitRepositoryService.swift:1481` builds the combined patch;
`parsePatchOffMain` (:1430) feeds it to `GitDiffParser.parseRows`.

## Fix
`Muxy/Services/Git/GitDiffParser.swift` — reset `inHunk = false` when a line begins a new file
header, placed before the `@@` check:

```swift
if line.hasPrefix("diff --git ") {
    inHunk = false
    continue
}
```

Why `diff --git ` is the correct and complete reset trigger:
- Every file section in `git diff` / `git diff --cached` output begins with `diff --git a/X b/X`,
  so it always precedes the `---`/`+++` pair — the reset lands before them and they are then
  skipped by the existing `guard inHunk else { continue }`.
- A hunk *content* line can never start with a bare `diff …` (content is always prefixed with
  ` `, `-` or `+`), so this cannot mis-classify real content.

Single-file diffs are unaffected: the leading `diff --git` sets an already-`false` `inHunk` to
`false` and is skipped — identical to the previous implicit fall-through.

## Files changed
- `Muxy/Services/Git/GitDiffParser.swift` (+5) — the `diff --git` `inHunk` reset.
- `Tests/MuxyTests/Git/GitDiffParserTests.swift` (+80) — two regression tests.

## Regression test (TDD proof — red on HEAD, green on fix)
Two new tests in the `GitDiffParser` suite, both feeding multi-section patches:

1. `parseRowsCombinedStagedAndUnstagedSkipsFileHeaders` — two `diff --git` blocks for the **same
   file** (the real combined staged+unstaged scenario). Asserts `additions == 2`, `deletions == 2`,
   no leaked `--- a/`/`+++ b/` rows, and exact added/deleted texts.
2. `parseRowsMultiFileDiffSkipsFileHeaders` — two **distinct** files. Same assertions.

Harness proof (run in this worktree):
- **HEAD parser** (fix stashed): both tests **FAIL** with 10 issues — `(additions → 3) == 2`,
  `(deletions → 3) == 2`, and `leakedHeaders` containing `deletion "-- a/…"` / `addition "++ b/…"`.
- **Fixed parser**: both tests **PASS**; the full `GitDiffParser` suite is 19/19 green.

## Gate command + result
Command: `scripts/checks.sh` (project gate; pins swiftformat 0.62.1, swiftlint 0.57.1).

```
✓ Formatting   (swiftformat --lint .)
✓ Linting      (swiftlint lint --strict)
✓ Build tests  (swift build --build-tests)
· Test         (scripts/run-tests-isolated.sh swift test)
```

Test result: **3230 tests in 396 suites, 3228 passed, 2 failed.**

The 2 failures are **pre-existing, environment-sensitive terminal-lifecycle tests**, in subsystems
with no code path to the diff parser:
- `SessionDaemonEndToEndTests` — "kills an entire session whose processes ignore hangup and
  termination" (real process spawn/SIGTERM/SIGHUP killing under load).
- `AppRelaunchTests` — "termination persists user state before terminal cleanup" (terminal cleanup
  deadline, timing-sensitive).

Proof they are unrelated: run in isolation (`swift test --filter SessionDaemonEndToEndTests|AppRelaunchTests`),
**all 25 tests in both suites pass**, including those two. They only fail under the concurrent load
of the full 3230-test run — classic flaky/order-dependent behavior, not a regression from this change.

Note on environment: this worktree was provisioned with gitignored build artifacts
(`GhosttyKit.xcframework`, `GhosttyKit/ghostty.h`, `Muxy/Resources/terminfo`,
`Muxy/Resources/ghostty/shell-integration`) symlinked/copied from a sibling worktree so `swift build`
could link Ghostty and bundle resources. These are `.gitignore`d and are **not** part of the commit.

## PR body draft

```markdown
## Summary
Fixes a parsing bug where combined staged+unstaged (and any multi-file) diffs leaked `-- a/path`
and `++ b/path` file-header lines into the diff view as content rows and inflated the `+`/`-`
counters by one per extra file section.

## Root cause
`GitDiffParser.parseRows` sets `inHunk = true` on a `@@` hunk header but never resets it when a new
`diff --git` file section begins. For the 2nd+ files, the `--- a/path` / `+++ b/path` header lines
match the deletion/addition branches and are mis-parsed as content, producing garbage rows and
bumping the counters.

## Fix
Reset `inHunk = false` when a line begins a new file header (`diff --git `), before the `@@` check.
Minimal and behavior-preserving for single-file diffs.

## Test plan
- New regression tests: `parseRowsCombinedStagedAndUnstagedSkipsFileHeaders` (same file, staged +
  unstaged — the real `resolveAndDiff` scenario) and `parseRowsMultiFileDiffSkipsFileHeaders`
  (two distinct files). Both assert no `--- a/`/`+++ b/` leak and correct `+`/`-` counts.
- Verified red on HEAD / green on fix in the project test harness.
- `scripts/checks.sh`: swiftformat ✓, swiftlint ✓, build ✓, 3228/3230 tests pass (2 failures are
  pre-existing flaky terminal-lifecycle tests unrelated to this change; both pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code). Contributed using GLM-5.2.
```

## Commit
Conventional-Commits format, committed locally only:
`fix: reset GitDiffParser hunk state on new file header` (parser + tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git diff handling for combined staged and unstaged changes.
  * Prevented file metadata from being incorrectly interpreted as changed lines.
  * Preserved accurate addition, deletion, and changed-line details across multi-file diffs.

* **Tests**
  * Added coverage for combined and multi-file Git diff scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->