### PR TITLE
fix(localization): treat l length modifier as no-op on float conversions

### DIFF
--- a/Muxy/Models/Extension/ExtensionLocalizationCatalog.swift
+++ b/Muxy/Models/Extension/ExtensionLocalizationCatalog.swift
@@ -252,7 +252,8 @@ struct FormatSignature {
              "a",
              "A":
             switch length {
-            case "": .double
+            case "",
+                 "l": .double
             case "L": .longDouble
             default: nil
             }

--- a/Tests/MuxyTests/Models/Extension/ExtensionLocalizationCatalogTests.swift
+++ b/Tests/MuxyTests/Models/Extension/ExtensionLocalizationCatalogTests.swift
@@ -193,4 +193,14 @@ struct ExtensionLocalizationCatalogTests {
 
         #expect(ExtensionLocalizationCatalog.incompatibleKey(in: catalog) == "beta %@")
     }
+
+    @Test("treats the l length modifier as a no-op on float conversions")
+    func treatsLowerLAsNoOpOnFloats() {
+        let catalog: [String: Any] = [
+            "%f units": "%lf units",
+            "%.2g ratio": "%.2lg ratio",
+        ]
+
+        #expect(ExtensionLocalizationCatalog.incompatibleKey(in: catalog) == nil)
+    }
 }

--- a/docs/extensions/localizations.md
+++ b/docs/extensions/localizations.md
@@ -68,7 +68,7 @@ Every placeholder in a translated value must match the placeholder at the same a
 "Settings"          = "Einstellungen %@";         ❌ key takes no arguments
 ```
 
-Use positional placeholders (`%1$@`, `%2$lld`) whenever the translation needs a different word order. `%ld` and `%lld` are interchangeable, as are `%d` and `%u` with their `h`/`hh` variants; `%*d`-style widths that consume an extra argument are rejected. In `Localizable.stringsdict`, the same rule applies to `NSStringLocalizedFormatKey` and to every plural variant inside each variable.
+Use positional placeholders (`%1$@`, `%2$lld`) whenever the translation needs a different word order. `%ld` and `%lld` are interchangeable, as are `%d` and `%u` with their `h`/`hh` variants. For floating-point conversions (`aAeEfFgG`), the lowercase `l` modifier is a no-op, so forms such as `%lf` and `%f` are interchangeable; uppercase `L` remains the distinct long-double modifier. `%*d`-style widths that consume an extra argument are rejected. In `Localizable.stringsdict`, the same rules apply to `NSStringLocalizedFormatKey` and to every plural variant inside each variable.
 
 A minimal `Info.plist` is:
 


### PR DESCRIPTION
## Summary

The extension localization validator rejects any float conversion that carries the `l` length modifier – `%lf`, `%.2lg`, `%le`, and so on – and marks the translation as incompatible with its key.

This is a false positive. C99 (7.19.6.1) states the `l` length modifier has no effect on the `a A e E f F g G` conversions, so `%lf` is identical to `%f` and consumes a `double`. Foundation's `NSString` formatting treats them the same way.

The validator already normalizes equivalent length modifiers for integers (`%ld` and `%lld` both collapse to `int64`), so float conversions should follow the same rule instead of rejecting a valid format string outright.

## Changes

- Map the `l` length modifier to `double` for float conversions in `FormatSignature.argumentType` (one extra case), mirroring the existing integer-modifier normalization.

## Testing

- Added a regression test (`treatsLowerLAsNoOpOnFloats`) covering `%f`/`%lf` and `%g`/`%lg`; it fails on `main` and passes with the fix.
- `swift test --filter ExtensionLocalizationCatalogTests` – 20/20 pass.

## Screenshots

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved localization compatibility for floating-point format strings using the `l` length modifier.
  - Ensures supported `%a`, `%e`, `%f`, `%g`, and related conversions are handled correctly.

- **Documentation**
  - Clarified that `%lf` and `%f` are equivalent for supported floating-point conversions.
  - Documented the distinct behavior of the uppercase `L` modifier across pluralized localization variants.

- **Tests**
  - Added coverage for `%f` and `%g` formats with the `l` modifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
