### PR TITLE
fix: use singular "1 match" in terminal search display

### DIFF
--- a/Muxy/Models/Terminal/TerminalSearchState.swift
+++ b/Muxy/Models/Terminal/TerminalSearchState.swift
@@ -12,7 +12,7 @@ final class TerminalSearchState {
 
     var displayText: String {
         guard let total else { return "" }
-        guard let selected else { return "\(total) matches" }
+        guard let selected else { return total == 1 ? "1 match" : "\(total) matches" }
         return "\(selected) of \(total)"
     }
 

--- a/Tests/MuxyTests/Models/ModelCoverageTests.swift
+++ b/Tests/MuxyTests/Models/ModelCoverageTests.swift
@@ -235,6 +235,15 @@ struct ModelCoverageTests {
         #expect(values == ["abc", "", "ab"])
     }
 
+    @Test("Terminal search display text uses the singular form for a single match")
+    func terminalSearchDisplayTextSingularMatch() {
+        let state = TerminalSearchState()
+        state.total = 1
+        #expect(state.displayText == "1 match")
+        state.total = 3
+        #expect(state.displayText == "3 matches")
+    }
+
     @Test("Terminal pane consumeRestoredLaunch returns startup launch and updates state")
     func terminalPaneConsumeRestoredLaunchReturnsStartupLaunch() {
         let pane = TerminalPaneState(


### PR DESCRIPTION
## Summary

When a terminal search finds exactly one match and none is selected yet, the count badge reads **"1 matches"**.

`TerminalSearchState.displayText` always built `"\(total) matches"`, with no singular form. The repo already does this correctly elsewhere – `RepositoryChangesPresentation` renders `1 change` vs `n changes` – the search count was just never given the same treatment.

## Changes

- Use the singular form when `total == 1` (one line in `TerminalSearchState.displayText`).

## Testing

- Added a regression test (`terminalSearchDisplayTextSingularMatch`) asserting `total = 1` reads `"1 match"` and `total = 3` reads `"3 matches"`; it fails on `main` and passes with the fix.
- The existing `terminalSearchPublishesNeedles` assertions (`"12 matches"`, `"3 of 12"`) still pass.

## Screenshots

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected terminal search messaging to display “1 match” for a single result.
  - Continued displaying plural wording for multiple results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
