### PR TITLE
Launch agent tabs through shell commands

### DIFF
--- a/Muxy/Services/AI/AIAgentLaunchProvider.swift
+++ b/Muxy/Services/AI/AIAgentLaunchProvider.swift
@@ -71,7 +71,8 @@ extension AIAgentLaunchProvider {
 
 enum AgentTabLaunchCommand {
     static func local(provider: any AIAgentLaunchProvider) -> String? {
-        provider.agentCLIExecutablePath().map(ShellEscaper.escape)
+        guard provider.agentCLIExecutablePath() != nil else { return nil }
+        return ShellEscaper.escape(provider.agentLaunchConfiguration.executable)
     }
 
     static func remote(provider: any AIAgentLaunchProvider) -> String {

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -110,18 +110,13 @@ struct AIAgentLaunchProviderTests {
         ])
     }
 
-    @Test("agent tabs launch installed local executables safely")
-    func localAgentTabCommand() {
-        let provider = AgentTabLaunchTestProvider(executablePath: "/tmp/Agent Tools/codex")
-
-        #expect(AgentTabLaunchCommand.local(provider: provider) == "'/tmp/Agent Tools/codex'")
-    }
-
-    @Test("agent tabs omit unavailable local providers")
+    @Test("agent tab menus omit unavailable local providers")
     func unavailableLocalAgentTabCommand() {
         let provider = AgentTabLaunchTestProvider(executablePath: nil)
+        let options = AgentTabLaunchOption.resolveLocal(providers: [provider])
 
-        #expect(AgentTabLaunchCommand.local(provider: provider) == nil)
+        #expect(options.first?.command == nil)
+        #expect(options.first?.title == "Test Agent · Not installed")
     }
 
     @Test("agent tabs escape remote executable names")
@@ -131,14 +126,14 @@ struct AIAgentLaunchProviderTests {
         #expect(AgentTabLaunchCommand.remote(provider: provider) == "test-agent")
     }
 
-    @Test("agent launch options resolve each local executable once")
-    func launchOptionsSnapshotExecutableResolution() {
+    @Test("agent tab menus launch available local providers through shell commands")
+    func launchOptionsUseShellCommandAfterAvailabilityCheck() {
         let provider = CountingAgentTabLaunchTestProvider()
 
         let options = AgentTabLaunchOption.resolveLocal(providers: [provider])
 
         #expect(provider.resolutionCount == 1)
-        #expect(options.first?.command == "/tmp/test-agent")
+        #expect(options.first?.command == "test-agent")
         #expect(options.first?.title == "Test Agent")
     }
 

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -110,8 +110,8 @@ struct AIAgentLaunchProviderTests {
         ])
     }
 
-    @Test("agent tab menus omit unavailable local providers")
-    func unavailableLocalAgentTabCommand() {
+    @Test("agent tab menus mark unavailable local providers as not installed")
+    func unavailableLocalProviderIsMarkedNotInstalled() {
         let provider = AgentTabLaunchTestProvider(executablePath: nil)
         let options = AgentTabLaunchOption.resolveLocal(providers: [provider])
 
@@ -135,6 +135,18 @@ struct AIAgentLaunchProviderTests {
         #expect(provider.resolutionCount == 1)
         #expect(options.first?.command == "test-agent")
         #expect(options.first?.title == "Test Agent")
+    }
+
+    @Test("agent tabs shell-escape configured local executable names")
+    func localAgentTabCommandEscapesConfiguredExecutable() {
+        let provider = AgentTabLaunchTestProvider(
+            executable: "test agent",
+            executablePath: "/tmp/test-agent"
+        )
+
+        let options = AgentTabLaunchOption.resolveLocal(providers: [provider])
+
+        #expect(options.first?.command == "'test agent'")
     }
 
     @Test("remote launch options disable providers missing from the remote PATH")
@@ -263,10 +275,15 @@ private struct AgentTabLaunchTestProvider: AIAgentLaunchProvider {
     let displayName = "Test Agent"
     let iconName = "sparkles"
     let executablePath: String?
-    let agentLaunchConfiguration = AIAgentLaunchConfiguration(
-        executable: "test-agent",
-        headlessArguments: []
-    )
+    let agentLaunchConfiguration: AIAgentLaunchConfiguration
+
+    init(executable: String = "test-agent", executablePath: String?) {
+        self.executablePath = executablePath
+        agentLaunchConfiguration = AIAgentLaunchConfiguration(
+            executable: executable,
+            headlessArguments: []
+        )
+    }
 
     func agentCLIExecutablePath() -> String? {
         executablePath


### PR DESCRIPTION
## Summary
- Keep the existing local availability check.
- Launch available agent tabs through their configured shell commands so terminal login-shell wrappers apply.
- Replaces #1002.

## Testing
- `scripts/run-tests-isolated.sh swift test --filter AIAgentLaunchProviderTests`
- `scripts/checks.sh --fix` and `scripts/checks.sh` (format, lint, and build passed; an existing `WorktreeTeardownRunnerTests` timeout test failed)

AI assistance: OpenAI GPT-5 Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an AI provider’s command-line tool is unavailable.
  * Unavailable providers now clearly appear as “Not installed” instead of offering an unusable launch option.
  * Available providers now launch using their configured executable path.
  * Improved support for executable paths containing shell-special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->