### PR TITLE
Make the terminal's right-edge padding usable instead of scrollbar-owned

### DIFF
--- a/Muxy/Resources/ghostty-overrides/muxy-defaults.conf
+++ b/Muxy/Resources/ghostty-overrides/muxy-defaults.conf
@@ -1,0 +1,1 @@
+window-padding-color = extend

--- a/Muxy/Services/Terminal/GhosttyDefaultsConfig.swift
+++ b/Muxy/Services/Terminal/GhosttyDefaultsConfig.swift
@@ -1,0 +1,16 @@
+import Foundation
+import GhosttyKit
+
+enum GhosttyDefaultsConfig {
+    static func defaultsURL(bundle: Bundle) -> URL? {
+        guard let resourceURL = bundle.resourceURL else { return nil }
+        let url = resourceURL.appendingPathComponent("ghostty-overrides/muxy-defaults.conf")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
+    }
+
+    static func load(into config: ghostty_config_t) {
+        guard let url = defaultsURL(bundle: .appResources) else { return }
+        url.path.withCString { ghostty_config_load_file(config, $0) }
+    }
+}

--- a/Muxy/Services/Terminal/GhosttyService.swift
+++ b/Muxy/Services/Terminal/GhosttyService.swift
@@ -149,6 +149,7 @@ final class GhosttyService {
     private func loadMuxyGhosttyConfig() -> ghostty_config_t? {
         guard let cfg = ghostty_config_new() else { return nil }
         let userConfig = muxyConfig.readGhosttyConfig()
+        GhosttyDefaultsConfig.load(into: cfg)
         TerminalCJKFontConfig.load(into: cfg, userConfig: userConfig)
         let configPath = muxyConfig.ghosttyConfigPath
         configPath.withCString { ptr in

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -1194,7 +1194,7 @@ final class GhosttyTerminalNSView: NSView,
         lastMouseTopDownPoint = pt
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, modsFromEvent(event))
         updateCmdHoverCursor(modifierFlags: event.modifierFlags)
-        scrollbarOverlay.flashIfNearScroller(point: convert(event.locationInWindow, from: nil))
+        scrollbarOverlay.extendReveal(point: convert(event.locationInWindow, from: nil))
     }
 
     override func mouseExited(with event: NSEvent) {

--- a/Muxy/Views/Terminal/TerminalScrollbarInteraction.swift
+++ b/Muxy/Views/Terminal/TerminalScrollbarInteraction.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct TerminalScrollbarInteraction {
+    static let revealDuration: TimeInterval = 1.25
+
+    private var revealedUntil: Date?
+    private(set) var isDragging = false
+
+    mutating func reveal(now: Date) {
+        revealedUntil = now.addingTimeInterval(Self.revealDuration)
+    }
+
+    mutating func beginDrag() {
+        isDragging = true
+    }
+
+    mutating func endDrag(now: Date) {
+        isDragging = false
+        reveal(now: now)
+    }
+
+    func allowsScrollerHit(now: Date) -> Bool {
+        guard !isDragging else { return true }
+        guard let revealedUntil else { return false }
+        return now < revealedUntil
+    }
+}

--- a/Muxy/Views/Terminal/TerminalScrollbarOverlay.swift
+++ b/Muxy/Views/Terminal/TerminalScrollbarOverlay.swift
@@ -10,7 +10,8 @@ final class TerminalScrollbarOverlay: NSView {
     private var len = 0
     private var offset = 0
     private var cellHeight: CGFloat = 0
-    private var isLiveScrolling = false
+    private var interaction = TerminalScrollbarInteraction()
+    private var isLiveScrolling: Bool { interaction.isDragging }
     private var lastSentRow: Int?
     nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
 
@@ -39,6 +40,9 @@ final class TerminalScrollbarOverlay: NSView {
         scrollView.drawsBackground = false
         scrollView.contentView.clipsToBounds = false
         scrollView.documentView = documentView
+        scrollView.allowsScrollerHit = { [weak self] in
+            self?.interaction.allowsScrollerHit(now: Date()) ?? false
+        }
         addSubview(scrollView)
     }
 
@@ -48,14 +52,14 @@ final class TerminalScrollbarOverlay: NSView {
             object: scrollView,
             queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.isLiveScrolling = true }
+            MainActor.assumeIsolated { self?.interaction.beginDrag() }
         })
         observers.append(NotificationCenter.default.addObserver(
             forName: NSScrollView.didEndLiveScrollNotification,
             object: scrollView,
             queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.isLiveScrolling = false }
+            MainActor.assumeIsolated { self?.interaction.endDrag(now: Date()) }
         })
         observers.append(NotificationCenter.default.addObserver(
             forName: NSScrollView.didLiveScrollNotification,
@@ -83,13 +87,15 @@ final class TerminalScrollbarOverlay: NSView {
 
     func flash() {
         guard hasScrollableContent else { return }
+        interaction.reveal(now: Date())
         scrollView.flashScrollers()
     }
 
-    func flashIfNearScroller(point: NSPoint) {
-        guard hasScrollableContent else { return }
+    func extendReveal(point: NSPoint) {
+        guard hasScrollableContent, interaction.allowsScrollerHit(now: Date()) else { return }
         let scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: scrollView.scrollerStyle)
         guard point.x >= bounds.maxX - scrollerWidth * 2 else { return }
+        interaction.reveal(now: Date())
         scrollView.flashScrollers()
     }
 
@@ -133,7 +139,10 @@ final class TerminalScrollbarOverlay: NSView {
 }
 
 private final class TerminalScrollbarScrollView: NSScrollView {
+    var allowsScrollerHit: () -> Bool = { false }
+
     override func hitTest(_ point: NSPoint) -> NSView? {
+        guard allowsScrollerHit() else { return nil }
         guard let scroller = verticalScroller, !scroller.isHidden else { return nil }
         let scrollerPoint = scroller.convert(point, from: superview)
         guard scroller.bounds.contains(scrollerPoint) else { return nil }

--- a/Tests/MuxyTests/Services/Terminal/GhosttyDefaultsConfigTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/GhosttyDefaultsConfigTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Ghostty defaults config")
+struct GhosttyDefaultsConfigTests {
+    @Test("loads the packaged defaults outside the managed Ghostty resources")
+    func packagedDefaults() throws {
+        let url = try #require(GhosttyDefaultsConfig.defaultsURL(bundle: .module))
+
+        #expect(url.lastPathComponent == "muxy-defaults.conf")
+        #expect(url.deletingLastPathComponent().lastPathComponent == "ghostty-overrides")
+        #expect(try String(contentsOf: url, encoding: .utf8) == "window-padding-color = extend\n")
+    }
+}

--- a/Tests/MuxyTests/Views/Terminal/TerminalScrollbarInteractionTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalScrollbarInteractionTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Terminal scrollbar interaction")
+struct TerminalScrollbarInteractionTests {
+    private let start = Date(timeIntervalSinceReferenceDate: 0)
+
+    @Test("scroller is not interactive before any reveal")
+    func idleByDefault() {
+        let interaction = TerminalScrollbarInteraction()
+
+        #expect(!interaction.allowsScrollerHit(now: start))
+    }
+
+    @Test("reveal opens an interaction window that expires")
+    func revealWindowExpires() {
+        var interaction = TerminalScrollbarInteraction()
+
+        interaction.reveal(now: start)
+
+        #expect(interaction.allowsScrollerHit(now: start))
+        #expect(interaction.allowsScrollerHit(now: start.addingTimeInterval(1.0)))
+        #expect(!interaction.allowsScrollerHit(now: start.addingTimeInterval(1.5)))
+    }
+
+    @Test("repeated reveals extend the interaction window")
+    func revealExtendsWindow() {
+        var interaction = TerminalScrollbarInteraction()
+
+        interaction.reveal(now: start)
+        interaction.reveal(now: start.addingTimeInterval(1.0))
+
+        #expect(interaction.allowsScrollerHit(now: start.addingTimeInterval(2.0)))
+        #expect(!interaction.allowsScrollerHit(now: start.addingTimeInterval(2.5)))
+    }
+
+    @Test("dragging keeps the scroller interactive past the reveal window")
+    func draggingKeepsInteractive() {
+        var interaction = TerminalScrollbarInteraction()
+
+        interaction.reveal(now: start)
+        interaction.beginDrag()
+
+        #expect(interaction.isDragging)
+        #expect(interaction.allowsScrollerHit(now: start.addingTimeInterval(60)))
+    }
+
+    @Test("ending a drag leaves a grace window before ownership returns")
+    func endDragGraceWindow() {
+        var interaction = TerminalScrollbarInteraction()
+
+        interaction.beginDrag()
+        interaction.endDrag(now: start.addingTimeInterval(60))
+
+        #expect(!interaction.isDragging)
+        #expect(interaction.allowsScrollerHit(now: start.addingTimeInterval(61)))
+        #expect(!interaction.allowsScrollerHit(now: start.addingTimeInterval(62)))
+    }
+}


### PR DESCRIPTION
## Problem

The strip between the terminal content and the pane edge looked sacrificed: content never rendered there, hovering near it summoned the scrollbar, and clicks/drags in that area were stolen by the scroller instead of reaching the terminal.

Investigation showed the strip is not reserved by the scrollbar at all — it is Ghostty's window padding (the leftover width that cannot fit another full cell column, plus the default 2pt edge padding), painted with the plain background color. The scrollbar overlay merely floats over the same region and claimed all events in its track whenever scrollable content existed.

## Changes

**Visual: extend cell colors into the padding**
- New bundled `ghostty-overrides/muxy-defaults.conf` with `window-padding-color = extend`, loaded by `GhosttyDefaultsConfig` before the user's `ghostty.conf` so it stays overridable. Adjacent cell background colors now bleed into the padding, so the strip reads as part of the terminal.

**Interaction: the scrollbar owns the area only while in use**
- New `TerminalScrollbarInteraction` value type decides when the scroller may claim events: while the knob is being dragged, or within 1.25s of the last reveal. State is checked lazily at hit-test time — no timers.
- `TerminalScrollbarOverlay.hitTest` now passes events through to the terminal (clicks, drags, selection) unless that window is open. Scrolling reveals the scrollbar and opens the window; each wheel tick renews it; releasing the knob leaves a short grace window.
- Hovering no longer summons the scrollbar — `flashIfNearScroller` became `extendReveal`, which only keeps an already-revealed scroller alive so it can be grabbed right after scrolling.

## Tests

- `GhosttyDefaultsConfigTests` verifies the packaged defaults file ships with the expected content.
- `TerminalScrollbarInteractionTests` covers the ownership rules: idle by default, reveal window opens and expires, repeated reveals extend it, dragging holds ownership, and ending a drag leaves the grace window.

`scripts/checks.sh` passes (format, lint, build, tests).

---

Contributed with AI: Claude Fable 5 (Claude Code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved terminal scrollbar interaction with smoother reveal behavior when moving the pointer.
  - Scrollbars remain available during scrolling and dragging, including a brief grace period after dragging ends.
  - Added default terminal styling that extends the window padding color for a more consistent Ghostty appearance.

- **Bug Fixes**
  - Prevented the scrollbar from flashing unnecessarily when the pointer moves near it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->