### PR TITLE
Keep the new tab button beside the tab row

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
- included:
+included:
   - Muxy
 
 excluded:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-included:
+ included:
   - Muxy
 
 excluded:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Test processes use isolated Application Support storage.
 - For every task, Consider how it will impact the architecture and code quality, not just the immediate problem
 - Follow the existing code's pattern but offer refactors if they improve code quality and maintainability.
 - Use logs for debugging.
-- If the feature is testable, then you must write tests.
+- Test the critical and reasonable paths only and do not overtest.
 - Never answer any question without a proper investigation and exploring the codebase.
 - Prioritize problem comprehension over premature implementation. Validate the approach before execution to avoid rework
 - Plan properly before executing to not double work

--- a/Muxy/Models/UI/TabStripLayout.swift
+++ b/Muxy/Models/UI/TabStripLayout.swift
@@ -1,0 +1,24 @@
+import CoreGraphics
+import Foundation
+
+struct TabStripLayout {
+    static let minTabWidth: CGFloat = 44
+    static let maxTabWidth: CGFloat = 200
+
+    let perTabWidth: CGFloat
+    let tabRowWidth: CGFloat
+    let pinsNewTabButton: Bool
+
+    init(availableWidth: CGFloat, tabCount: Int, maxTabWidth: CGFloat?, newTabButtonWidth: CGFloat) {
+        let count = CGFloat(max(tabCount, 1))
+        let isMeasured = availableWidth > 0
+        let widthForTabs = max(availableWidth - newTabButtonWidth, 0)
+        let idealWidth = isMeasured ? widthForTabs / count : Self.maxTabWidth
+        let cappedWidth = maxTabWidth.map { min($0, idealWidth) } ?? idealWidth
+        let overflows = isMeasured && idealWidth < Self.minTabWidth
+
+        perTabWidth = max(Self.minTabWidth, cappedWidth)
+        tabRowWidth = overflows ? widthForTabs : availableWidth
+        pinsNewTabButton = overflows
+    }
+}

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -423,7 +423,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         SentryService.shared.start()
         NSWindow.allowsAutomaticWindowTabbing = false
         NSApp.setActivationPolicy(.regular)
-        NSApp.activate()
+        DispatchQueue.main.async {
+            NSApp.activate(ignoringOtherApps: true)
+        }
         setAppIcon()
         _ = GhosttyService.shared
         GhosttyService.shared.applyInitialColorScheme()

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -94,10 +94,16 @@ struct PaneTabStrip: View {
     var body: some View {
         HStack(spacing: 0) {
             GeometryReader { geo in
-                ScrollView(.horizontal, showsIndicators: false) {
-                    tabRow(availableWidth: geo.size.width)
-                        .frame(minWidth: geo.size.width, alignment: .leading)
-                        .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
+                let layout = tabStripLayout(availableWidth: geo.size.width)
+                HStack(spacing: 0) {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        tabRow(layout: layout)
+                            .frame(minWidth: layout.tabRowWidth, alignment: .leading)
+                            .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
+                    }
+                    if layout.pinsNewTabButton {
+                        newTabButton
+                    }
                 }
             }
             .frame(maxWidth: .infinity)
@@ -154,16 +160,17 @@ struct PaneTabStrip: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func tabRow(availableWidth: CGFloat) -> some View {
-        let count = max(tabs.count, 1)
-        let widthForTabs = availableWidth - newTabButtonWidth
-        let effectiveWidth = widthForTabs > 0 ? widthForTabs : TabCell.maxWidth * CGFloat(count)
-        let perTabIdeal = effectiveWidth / CGFloat(count)
-        let perTabMaxWidth = TabWidthPreferences.effectiveMaxWidth(from: maxTabWidth)
-        let cappedWidth = perTabMaxWidth.map { min($0, perTabIdeal) } ?? perTabIdeal
-        let perTabWidth = max(TabCell.minWidth, cappedWidth)
+    private func tabStripLayout(availableWidth: CGFloat) -> TabStripLayout {
+        TabStripLayout(
+            availableWidth: availableWidth,
+            tabCount: tabs.count,
+            maxTabWidth: TabWidthPreferences.effectiveMaxWidth(from: maxTabWidth),
+            newTabButtonWidth: Self.newTabButtonWidth
+        )
+    }
 
-        return HStack(spacing: 0) {
+    private func tabRow(layout: TabStripLayout) -> some View {
+        HStack(spacing: 0) {
             ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
                 let globalIndex = shortcutIndicesByTabID?[tab.id] ?? index
                 TabCell(
@@ -188,7 +195,7 @@ struct PaneTabStrip: View {
                     onSetCustomTitle: { onSetCustomTitle(tab.id, $0) },
                     onSetColorID: { onSetColorID(tab.id, $0) }
                 )
-                .frame(width: perTabWidth)
+                .frame(width: layout.perTabWidth)
                 .background {
                     if dragState.draggedID != nil {
                         GeometryReader { geo in
@@ -218,18 +225,24 @@ struct PaneTabStrip: View {
                 )
             }
 
-            newTabButton
-                .padding(.leading, UIMetrics.spacing2)
+            if !layout.pinsNewTabButton {
+                newTabButton
+            }
         }
+    }
+
+    private static var newTabButtonSpacing: CGFloat {
+        UIMetrics.spacing2
+    }
+
+    private static var newTabButtonWidth: CGFloat {
+        UIMetrics.controlMedium + newTabButtonSpacing
     }
 
     private var newTabButton: some View {
         IconButton(symbol: "plus", accessibilityLabel: L10n.string("New Tab")) { onCreateTab() }
             .help(shortcutTooltip(L10n.string("New Tab"), for: .newTab))
-    }
-
-    private var newTabButtonWidth: CGFloat {
-        UIMetrics.controlMedium + UIMetrics.spacing2
+            .padding(.leading, Self.newTabButtonSpacing)
     }
 
     private func closableOthersCount(excluding tabID: UUID) -> Int {
@@ -360,8 +373,6 @@ private struct TabWidthPreferenceKey: PreferenceKey {
 }
 
 private struct TabCell: View {
-    static let minWidth: CGFloat = 44
-    static let maxWidth: CGFloat = 200
     static let titleHideThreshold: CGFloat = 80
 
     let tab: PaneTabStrip.TabSnapshot
@@ -388,7 +399,7 @@ private struct TabCell: View {
     @State private var isRenaming = false
     @State private var renameText = ""
     @State private var showColorPicker = false
-    @State private var measuredWidth: CGFloat = TabCell.maxWidth
+    @State private var measuredWidth: CGFloat = TabStripLayout.maxTabWidth
     @State private var externalDragOverCell = false
     @State private var springLoadTask: Task<Void, any Error>?
     @State private var completionFlashOn = false

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -136,8 +136,6 @@ struct PaneTabStrip: View {
                     .help(shortcutTooltip(L10n.string("Split Right"), for: .splitRight))
                 IconButton(symbol: "square.split.1x2", accessibilityLabel: L10n.string("Split Down")) { onSplit(.vertical) }
                     .help(shortcutTooltip(L10n.string("Split Down"), for: .splitDown))
-                IconButton(symbol: "plus", accessibilityLabel: L10n.string("New Tab")) { onCreateTab() }
-                    .help(shortcutTooltip(L10n.string("New Tab"), for: .newTab))
                 if let onOpenBrowser {
                     IconButton(symbol: "globe", accessibilityLabel: L10n.string("Open Browser Tab"), action: onOpenBrowser)
                         .help(L10n.string("Open Browser Tab"))
@@ -158,7 +156,8 @@ struct PaneTabStrip: View {
 
     private func tabRow(availableWidth: CGFloat) -> some View {
         let count = max(tabs.count, 1)
-        let effectiveWidth = availableWidth > 0 ? availableWidth : TabCell.maxWidth * CGFloat(count)
+        let widthForTabs = availableWidth - newTabButtonWidth
+        let effectiveWidth = widthForTabs > 0 ? widthForTabs : TabCell.maxWidth * CGFloat(count)
         let perTabIdeal = effectiveWidth / CGFloat(count)
         let perTabMaxWidth = TabWidthPreferences.effectiveMaxWidth(from: maxTabWidth)
         let cappedWidth = perTabMaxWidth.map { min($0, perTabIdeal) } ?? perTabIdeal
@@ -218,7 +217,19 @@ struct PaneTabStrip: View {
                         }
                 )
             }
+
+            newTabButton
+                .padding(.leading, UIMetrics.spacing2)
         }
+    }
+
+    private var newTabButton: some View {
+        IconButton(symbol: "plus", accessibilityLabel: L10n.string("New Tab")) { onCreateTab() }
+            .help(shortcutTooltip(L10n.string("New Tab"), for: .newTab))
+    }
+
+    private var newTabButtonWidth: CGFloat {
+        UIMetrics.controlMedium + UIMetrics.spacing2
     }
 
     private func closableOthersCount(excluding tabID: UUID) -> Int {

--- a/Tests/MuxyTests/Models/UI/TabStripLayoutTests.swift
+++ b/Tests/MuxyTests/Models/UI/TabStripLayoutTests.swift
@@ -43,12 +43,6 @@ struct TabStripLayoutTests {
         #expect(!result.pinsNewTabButton)
     }
 
-    @Test("honours a narrower configured maximum before measurement")
-    func usesConfiguredMaximumWhenUnmeasured() {
-        let result = layout(width: 0, tabs: 3, maxTabWidth: 120)
-        #expect(result.perTabWidth == 120)
-    }
-
     @Test("pins the new tab button once tabs hit the minimum width")
     func pinsButtonOnOverflow() {
         let result = layout(width: 400, tabs: 9)
@@ -67,29 +61,5 @@ struct TabStripLayoutTests {
         let overflowing = layout(width: exactWidth - 1, tabs: 9)
         #expect(overflowing.pinsNewTabButton)
         #expect(overflowing.perTabWidth == TabStripLayout.minTabWidth)
-    }
-
-    @Test("never drops below the minimum tab width when the strip is narrower than the button")
-    func clampsToMinimumWidthWhenStripIsTiny() {
-        let result = layout(width: 20, tabs: 3)
-        #expect(result.perTabWidth == TabStripLayout.minTabWidth)
-        #expect(result.pinsNewTabButton)
-        #expect(result.tabRowWidth == 0)
-    }
-
-    @Test("treats an empty strip as a single tab")
-    func treatsEmptyStripAsSingleTab() {
-        let result = layout(width: 400, tabs: 0)
-        #expect(result.perTabWidth == 200)
-        #expect(!result.pinsNewTabButton)
-    }
-
-    @Test("ignores the maximum when no cap is configured")
-    func ignoresMissingMaximum() {
-        let availableWidth: CGFloat = 1400
-        let expectedWidth = (availableWidth - Self.buttonWidth) / 2
-        let result = layout(width: availableWidth, tabs: 2, maxTabWidth: nil)
-        #expect(result.perTabWidth == expectedWidth)
-        #expect(!result.pinsNewTabButton)
     }
 }

--- a/Tests/MuxyTests/Models/UI/TabStripLayoutTests.swift
+++ b/Tests/MuxyTests/Models/UI/TabStripLayoutTests.swift
@@ -1,0 +1,95 @@
+import CoreGraphics
+import Testing
+
+@testable import Muxy
+
+@Suite("TabStripLayout")
+struct TabStripLayoutTests {
+    private static let buttonWidth: CGFloat = 28
+
+    private func layout(width: CGFloat, tabs: Int, maxTabWidth: CGFloat? = 200) -> TabStripLayout {
+        TabStripLayout(
+            availableWidth: width,
+            tabCount: tabs,
+            maxTabWidth: maxTabWidth,
+            newTabButtonWidth: Self.buttonWidth
+        )
+    }
+
+    @Test("reserves the new tab button width so the row fills the strip exactly")
+    func reservesButtonWidth() {
+        let availableWidth: CGFloat = 400
+        let tabCount: CGFloat = 5
+        let expectedWidth = (availableWidth - Self.buttonWidth) / tabCount
+        let result = layout(width: availableWidth, tabs: 5)
+        #expect(!result.pinsNewTabButton)
+        #expect(result.perTabWidth == expectedWidth)
+        #expect(result.tabRowWidth == availableWidth)
+        #expect(tabCount * result.perTabWidth + Self.buttonWidth == availableWidth)
+    }
+
+    @Test("caps tab width at the configured maximum and keeps the button inline")
+    func capsAtMaxTabWidth() {
+        let result = layout(width: 1400, tabs: 2)
+        #expect(result.perTabWidth == 200)
+        #expect(!result.pinsNewTabButton)
+        #expect(result.tabRowWidth == 1400)
+    }
+
+    @Test("falls back to the maximum tab width before the geometry is measured")
+    func usesFallbackWidthWhenUnmeasured() {
+        let result = layout(width: 0, tabs: 3)
+        #expect(result.perTabWidth == TabStripLayout.maxTabWidth)
+        #expect(!result.pinsNewTabButton)
+    }
+
+    @Test("honours a narrower configured maximum before measurement")
+    func usesConfiguredMaximumWhenUnmeasured() {
+        let result = layout(width: 0, tabs: 3, maxTabWidth: 120)
+        #expect(result.perTabWidth == 120)
+    }
+
+    @Test("pins the new tab button once tabs hit the minimum width")
+    func pinsButtonOnOverflow() {
+        let result = layout(width: 400, tabs: 9)
+        #expect(result.pinsNewTabButton)
+        #expect(result.perTabWidth == TabStripLayout.minTabWidth)
+        #expect(result.tabRowWidth == 400 - Self.buttonWidth)
+    }
+
+    @Test("keeps the button inline at the exact overflow boundary")
+    func keepsButtonInlineAtBoundary() {
+        let exactWidth = Self.buttonWidth + TabStripLayout.minTabWidth * 9
+        let fitting = layout(width: exactWidth, tabs: 9)
+        #expect(!fitting.pinsNewTabButton)
+        #expect(fitting.perTabWidth == TabStripLayout.minTabWidth)
+
+        let overflowing = layout(width: exactWidth - 1, tabs: 9)
+        #expect(overflowing.pinsNewTabButton)
+        #expect(overflowing.perTabWidth == TabStripLayout.minTabWidth)
+    }
+
+    @Test("never drops below the minimum tab width when the strip is narrower than the button")
+    func clampsToMinimumWidthWhenStripIsTiny() {
+        let result = layout(width: 20, tabs: 3)
+        #expect(result.perTabWidth == TabStripLayout.minTabWidth)
+        #expect(result.pinsNewTabButton)
+        #expect(result.tabRowWidth == 0)
+    }
+
+    @Test("treats an empty strip as a single tab")
+    func treatsEmptyStripAsSingleTab() {
+        let result = layout(width: 400, tabs: 0)
+        #expect(result.perTabWidth == 200)
+        #expect(!result.pinsNewTabButton)
+    }
+
+    @Test("ignores the maximum when no cap is configured")
+    func ignoresMissingMaximum() {
+        let availableWidth: CGFloat = 1400
+        let expectedWidth = (availableWidth - Self.buttonWidth) / 2
+        let result = layout(width: availableWidth, tabs: 2, maxTabWidth: nil)
+        #expect(result.perTabWidth == expectedWidth)
+        #expect(!result.pinsNewTabButton)
+    }
+}

--- a/docs/extensions/topbar.md
+++ b/docs/extensions/topbar.md
@@ -58,7 +58,7 @@ Needs `panels:write`. The override is in-memory for the session; disabling or re
 
 ## Placement and order
 
-Items sit in the window title bar's right-hand cluster. In a single-pane Project Focused workspace they precede the built-in **Split / New Tab** group. Among themselves they are ordered by extension directory name, then by their order in the `topbarItems` array.
+Items sit in the window title bar's right-hand cluster. In a single-pane Project Focused workspace they precede the built-in **Split** group. Among themselves they are ordered by extension directory name, then by their order in the `topbarItems` array.
 
 ## Limits
 


### PR DESCRIPTION
Move the new tab button from the trailing toolbar into the tab row and reserve its width when calculating tab sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved tab layout dynamically adapts to available space and tab count.
  - The New Tab button remains visible and is positioned appropriately when the tab row is crowded.
  - Improved application activation when launching.

- **Documentation**
  - Clarified top bar item placement relative to the built-in Split controls.

- **Tests**
  - Added coverage for tab sizing, overflow behavior, button placement, and exact-fit layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->