### PR TITLE
Prioritize user themes over bundled themes

### DIFF
--- a/Muxy/Resources/ghostty/themes/Muxy
+++ b/Muxy/Resources/ghostty/themes/Muxy
@@ -1,4 +1,4 @@
-palette = 0=#141219
+palette = 0=#464056
 palette = 1=#EC4899
 palette = 2=#34d399
 palette = 3=#e0af68
@@ -6,7 +6,7 @@ palette = 4=#C370D3
 palette = 5=#6366F1
 palette = 6=#22D3EE
 palette = 7=#a9b1d6
-palette = 8=#2e2b34
+palette = 8=#7c7393
 palette = 9=#F472B6
 palette = 10=#6ee7b7
 palette = 11=#fbbf24

--- a/Muxy/Services/Theme/ThemeService.swift
+++ b/Muxy/Services/Theme/ThemeService.swift
@@ -280,7 +280,9 @@ final class ThemeService {
         for dir in themeDirectories() {
             guard let files = try? FileManager.default.contentsOfDirectory(atPath: dir) else { continue }
             for file in files {
-                guard let theme = parseThemeFile(atPath: dir + "/" + file, name: file) else { continue }
+                guard themesByName[file] == nil,
+                      let theme = parseThemeFile(atPath: dir + "/" + file, name: file)
+                else { continue }
                 themesByName[theme.name] = theme
             }
         }
@@ -299,11 +301,10 @@ final class ThemeService {
     }
 
     nonisolated private static func themeDirectories() -> [String] {
-        var dirs: [String] = []
+        var dirs: [String] = [NSHomeDirectory() + "/.config/ghostty/themes"]
         if let bundled = Bundle.appResources.resourceURL?.appendingPathComponent("ghostty/themes").path {
             dirs.append(bundled)
         }
-        dirs.append(NSHomeDirectory() + "/.config/ghostty/themes")
         return dirs
     }
 


### PR DESCRIPTION
Load user-defined Ghostty themes before bundled themes so custom themes take precedence, and improve contrast for the Muxy theme’s black palette colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-provided Ghostty themes now take priority over bundled themes when names overlap.
* **Bug Fixes**
  * Duplicate theme names are handled consistently, preserving the first discovered theme.
  * Updated the Muxy Ghostty theme palette for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->