### PR TITLE
Use grok-build --output-format plain for repository AI actions

### DIFF
--- a/Muxy/Services/Providers/GrokProvider.swift
+++ b/Muxy/Services/Providers/GrokProvider.swift
@@ -20,7 +20,7 @@ struct GrokProvider: AIProviderIntegration, AIAgentLaunchProvider {
                 "--no-subagents",
                 "--disable-web-search",
                 "--output-format",
-                "text",
+                "plain",
                 "-p",
             ]
         )

--- a/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
+++ b/Tests/MuxyTests/Services/AI/AIAgentLaunchProviderTests.swift
@@ -48,7 +48,7 @@ struct AIAgentLaunchProviderTests {
                     "--no-subagents",
                     "--disable-web-search",
                     "--output-format",
-                    "text",
+                    "plain",
                     "-p",
                     prompt,
                 ]

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -63,6 +63,7 @@ After authenticating, restart Muxy so it picks up the new credentials.
 - Muxy resolves local provider CLIs through your interactive login shell, matching the `PATH` used by a normal terminal session.
 - For an SSH workspace, the selected provider CLI and `gh` must be installed and authenticated on the remote host. If **Auto** selects a CLI that is unavailable remotely, choose the installed provider explicitly from the action dropdown.
 - Provider CLIs run headlessly and cannot show interactive authentication or permission prompts. Authenticate the chosen CLI in a terminal first, then retry the button; failures are shown in a toast.
+- Muxy launches Grok (`grok` / Homebrew grok-build) as `grok -p … --output-format plain`. You do not set this flag. A toast that says `text` is not a valid `--output-format` means an older Muxy build is talking to current grok-build.
 - AI only generates metadata. Muxy always owns staging, branch creation, commits, pushes, and pull request creation. Update the prompt when the provider returns invalid JSON or unsuitable metadata, not to change the native Git sequence.
 - **Add Prompt** appends one-time instructions after the configured global or project prompt for the current action without changing Settings.
 


### PR DESCRIPTION
Grok-build rejects --output-format text, which broke Commit & Push and Create PR metadata generation.

<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

When using Grok Build as your agent trying to generate a commit message fails with an error "invalid output-format 'text'".

## Changes

<!-- List the key changes -->

- Grok Build CLI accepts only plain, json, streaming-json, and streaming-messages-json.
- Switched to 'plain'

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [ ] Tested manually on macOS

## Screenshots

<!-- If applicable, add screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Grok agent launches to use the supported `plain` output format, improving execution reliability.

* **Documentation**
  * Added troubleshooting guidance for Grok execution and invalid output-format errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->