### PR TITLE
Add setting to hide top bar actions

### DIFF
--- a/Muxy/Models/Preferences/TopbarPreferences.swift
+++ b/Muxy/Models/Preferences/TopbarPreferences.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum TopbarPreferences {
+    static let actionsVisibleKey = "muxy.showTopBarActions"
+    static let defaultActionsVisible = true
+}

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -815,6 +815,7 @@
 "Show Tips" = "Show Tips";
 "Show Resource Usage in Status Bar" = "Show Resource Usage in Status Bar";
 "Show Status Bar" = "Show Status Bar";
+"Show Top Bar Actions" = "Show Top Bar Actions";
 "Show unread notification indicator on worktrees" = "Show unread notification indicator on worktrees";
 "Sidebar" = "Sidebar";
 "Size" = "Size";
@@ -1428,6 +1429,7 @@
 "Shows a macOS notification when Muxy is not frontmost." = "Shows a macOS notification when Muxy is not frontmost.";
 "Shows app and subprocess CPU and memory usage in the status bar. Disabling it stops the sampling." = "Shows app and subprocess CPU and memory usage in the status bar. Disabling it stops the sampling.";
 "Shows or hides the status bar." = "Shows or hides the status bar.";
+"Shows or hides the window-level controls on the right side of the top bar." = "Shows or hides the window-level controls on the right side of the top bar.";
 "Shows the project search field whenever the project-focused sidebar is expanded." = "Shows the project search field whenever the project-focused sidebar is expanded.";
 "Shows the QR code used to pair a mobile device." = "Shows the QR code used to pair a mobile device.";
 "Shows the permanent Home project at the top of the sidebar." = "Shows the permanent Home project at the top of the sidebar.";

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -159,6 +159,8 @@ struct MainWindow: View {
     @State private var layoutStore = AppLayoutStore.shared
     @State private var extensionStore = ExtensionStore.shared
     @AppStorage(SidebarSelection.storageKey) private var activeSidebarRaw = SidebarSelection.builtinValue
+    @AppStorage(TopbarPreferences.actionsVisibleKey)
+    private var showTopbarActions = TopbarPreferences.defaultActionsVisible
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
     @AppStorage(HomeProjectPreferences.visibleKey) private var showHomeProject = HomeProjectPreferences.defaultVisible
     @AppStorage("muxy.extensionOutputSelected") private var extensionOutputSelectedStored = ""
@@ -689,6 +691,7 @@ struct MainWindow: View {
                 worktreeKey: key,
                 groupID: group.id,
                 isWindowTitleBar: true,
+                showsWindowTopbarActions: showTopbarActions,
                 showDevelopmentBadge: AppEnvironment.isDevelopment,
                 openProjectPath: project.isRemote ? nil : activeWorktreePath(for: project)
             )
@@ -701,7 +704,9 @@ struct MainWindow: View {
                                 .allowsHitTesting(false)
                         }
                     }
-                fallbackTopbarActions
+                if showTopbarActions {
+                    fallbackTopbarActions
+                }
             }
             .frame(height: UIMetrics.scaled(32))
         }

--- a/Muxy/Views/Settings/InterfaceSettingsView.swift
+++ b/Muxy/Views/Settings/InterfaceSettingsView.swift
@@ -15,6 +15,8 @@ struct InterfaceSettingsView: View {
     private var appTransparency = AppTransparencyPreferences.defaultTransparency
     @AppStorage(AppTransparencyPreferences.blurIntensityKey)
     private var appBlurIntensity = AppTransparencyPreferences.defaultBlurIntensity
+    @AppStorage(TopbarPreferences.actionsVisibleKey)
+    private var showTopbarActions = TopbarPreferences.defaultActionsVisible
     @AppStorage("muxy.showStatusBar") private var showStatusBar = true
     @AppStorage(ResourceUsagePreferences.visibleKey) private var showResourceUsage = ResourceUsagePreferences.defaultVisible
     @State private var layoutStore = AppLayoutStore.shared
@@ -167,6 +169,8 @@ struct InterfaceSettingsView: View {
                 }
 
                 TabHeaderWidthSettingRow()
+
+                SettingsToggleRow(label: L10n.resource("Show Top Bar Actions"), isOn: $showTopbarActions)
 
                 SettingsToggleRow(label: L10n.resource("Show Status Bar"), isOn: $showStatusBar)
 

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -392,6 +392,15 @@ enum SettingsCatalog {
             aliases: ["tabs", "tab width", "full-width"]
         ),
         SettingsCatalogItem(
+            key: TopbarPreferences.actionsVisibleKey,
+            title: "Show Top Bar Actions",
+            description: "Shows or hides the window-level controls on the right side of the top bar.",
+            category: .appearance,
+            section: "Interface",
+            defaultValue: TopbarPreferences.defaultActionsVisible,
+            aliases: ["topbar", "title bar", "tab strip controls", "hide top bar icons"]
+        ),
+        SettingsCatalogItem(
             key: "muxy.showStatusBar",
             title: "Show Status Bar",
             description: "Shows or hides the status bar.",

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -31,6 +31,7 @@ struct PaneTabStrip: View {
     let activeTabID: UUID?
     let isFocused: Bool
     var isWindowTitleBar: Bool = false
+    var showsWindowTopbarActions = true
     var showDevelopmentBadge = false
     var openProjectPath: String?
     let projectID: UUID
@@ -110,47 +111,57 @@ struct PaneTabStrip: View {
             .layoutPriority(1)
             .frame(height: UIMetrics.scaled(32))
 
-            HStack(spacing: 0) {
-                if isWindowTitleBar, let openProjectPath {
-                    OpenProjectControl(projectPath: openProjectPath)
-                }
-                if isWindowTitleBar, let version = UpdateService.shared.availableUpdateVersion {
-                    UpdateBadge(version: version) {
-                        UpdateService.shared.checkForUpdates()
+            if !isWindowTitleBar || showsWindowTopbarActions {
+                HStack(spacing: 0) {
+                    if isWindowTitleBar, let openProjectPath {
+                        OpenProjectControl(projectPath: openProjectPath)
                     }
-                    .padding(.trailing, UIMetrics.spacing2)
-                }
-                if showDevelopmentBadge {
-                    developmentBadge
-                        .padding(.trailing, UIMetrics.spacing3)
-                }
-                if isWindowTitleBar {
-                    LayoutPickerMenu(projectID: projectID)
-                    ExtensionTopbarItems()
-                }
-                if showMaximizeButton || isMaximized, let onToggleMaximize {
-                    let symbol = isMaximized
-                        ? "arrow.down.right.and.arrow.up.left"
-                        : "arrow.up.left.and.arrow.down.right"
-                    let label = isMaximized
-                        ? L10n.string("Restore Pane")
-                        : L10n.string("Maximize Pane")
-                    IconButton(symbol: symbol, accessibilityLabel: label, action: onToggleMaximize)
-                        .help(shortcutTooltip(L10n.string("Toggle Maximize Pane"), for: .toggleMaximizePane))
-                }
-                IconButton(symbol: "square.split.2x1", accessibilityLabel: L10n.string("Split Right")) { onSplit(.horizontal) }
+                    if isWindowTitleBar, let version = UpdateService.shared.availableUpdateVersion {
+                        UpdateBadge(version: version) {
+                            UpdateService.shared.checkForUpdates()
+                        }
+                        .padding(.trailing, UIMetrics.spacing2)
+                    }
+                    if showDevelopmentBadge {
+                        developmentBadge
+                            .padding(.trailing, UIMetrics.spacing3)
+                    }
+                    if isWindowTitleBar {
+                        LayoutPickerMenu(projectID: projectID)
+                        ExtensionTopbarItems()
+                    }
+                    if showMaximizeButton || isMaximized, let onToggleMaximize {
+                        let symbol = isMaximized
+                            ? "arrow.down.right.and.arrow.up.left"
+                            : "arrow.up.left.and.arrow.down.right"
+                        let label = isMaximized
+                            ? L10n.string("Restore Pane")
+                            : L10n.string("Maximize Pane")
+                        IconButton(symbol: symbol, accessibilityLabel: label, action: onToggleMaximize)
+                            .help(shortcutTooltip(L10n.string("Toggle Maximize Pane"), for: .toggleMaximizePane))
+                    }
+                    IconButton(symbol: "square.split.2x1", accessibilityLabel: L10n.string("Split Right")) {
+                        onSplit(.horizontal)
+                    }
                     .help(shortcutTooltip(L10n.string("Split Right"), for: .splitRight))
-                IconButton(symbol: "square.split.1x2", accessibilityLabel: L10n.string("Split Down")) { onSplit(.vertical) }
+                    IconButton(symbol: "square.split.1x2", accessibilityLabel: L10n.string("Split Down")) {
+                        onSplit(.vertical)
+                    }
                     .help(shortcutTooltip(L10n.string("Split Down"), for: .splitDown))
-                if let onOpenBrowser {
-                    IconButton(symbol: "globe", accessibilityLabel: L10n.string("Open Browser Tab"), action: onOpenBrowser)
+                    if let onOpenBrowser {
+                        IconButton(
+                            symbol: "globe",
+                            accessibilityLabel: L10n.string("Open Browser Tab"),
+                            action: onOpenBrowser
+                        )
                         .help(L10n.string("Open Browser Tab"))
+                    }
                 }
+                .padding(.leading, UIMetrics.spacing4)
+                .padding(.trailing, UIMetrics.spacing2)
+                .fixedSize(horizontal: true, vertical: false)
+                .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
             }
-            .padding(.leading, UIMetrics.spacing4)
-            .padding(.trailing, UIMetrics.spacing2)
-            .fixedSize(horizontal: true, vertical: false)
-            .background(WindowDragRepresentable(alwaysEnabled: isWindowTitleBar))
         }
         .frame(height: UIMetrics.scaled(32))
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in

--- a/Muxy/Views/Workspace/TopLevelTabGroupStrip.swift
+++ b/Muxy/Views/Workspace/TopLevelTabGroupStrip.swift
@@ -5,6 +5,7 @@ struct TopLevelTabGroupStrip: View {
     let worktreeKey: WorktreeKey
     let groupID: UUID
     var isWindowTitleBar = false
+    var showsWindowTopbarActions = true
     var showDevelopmentBadge = false
     var openProjectPath: String?
 
@@ -61,6 +62,7 @@ struct TopLevelTabGroupStrip: View {
                 activeTabID: group.activeTabID,
                 isFocused: appState.activeTopLevelTabID(for: worktreeKey) == group.activeTabID,
                 isWindowTitleBar: isWindowTitleBar,
+                showsWindowTopbarActions: showsWindowTopbarActions,
                 showDevelopmentBadge: showDevelopmentBadge,
                 openProjectPath: openProjectPath,
                 projectID: project.id,

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -133,6 +133,19 @@ struct SettingsCatalogTests {
     }
 
     @Test
+    func topbarActionsSettingIsRegisteredAndSearchable() {
+        let item = SettingsCatalog.items.first { $0.key == TopbarPreferences.actionsVisibleKey }
+
+        #expect(item?.category == .appearance)
+        #expect(item?.section == "Interface")
+        #expect(item?.defaultValue as? Bool == TopbarPreferences.defaultActionsVisible)
+        #expect(SettingsCatalog.matchingItems(query: "hide top bar icons").contains {
+            $0.key == TopbarPreferences.actionsVisibleKey
+        })
+        #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == TopbarPreferences.actionsVisibleKey })
+    }
+
+    @Test
     func matchCountSummaryIsOmittedWithoutQuery() {
         #expect(SettingsCatalog.matchCountSummary(for: .general, query: "") == nil)
         #expect(SettingsCatalog.matchCountSummary(for: .general, query: "   ") == nil)

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -58,6 +58,13 @@ In **Appearance → Sidebar**, select **Tab Focused** or **Agents Focused** to s
 It is off by default. Turn it on to nest all worktrees under their project; turn it off to keep worktrees as top-level rows. Tab
 Focused shows top-level worktrees only when they have open tabs, while Agents Focused shows every secondary worktree.
 
+## Top bar actions
+
+Turn off **Settings → Interface → Interface → Show Top Bar Actions** to hide every window-level control on the right
+side of the top bar. The top bar remains visible in every layout, including the tab strip and its new-tab button in
+Projects Focused and Agents Focused. Pane-local tab strips and their controls are unaffected. The preference is stored
+as `muxy.showTopBarActions` in `settings.json` and defaults to on.
+
 ## Project search
 
 In the Project Focused layout, turn on **Settings → Interface → Sidebar → Always Show Project Search** to keep the


### PR DESCRIPTION
Adds an Interface setting that hides window-level actions from the top bar while preserving pane-local controls. Registers and localizes the preference, documents its behavior, and tests settings catalog discovery and JSON editing support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Interface setting to show or hide window-level actions in the top bar.
  - The preference is saved and applied across sessions.
  - Pane-specific controls remain available when top-bar actions are hidden.

- **Documentation**
  - Added user-guide documentation describing the setting, behavior, and default state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->