### PR TITLE
Add mobile scrollback replay for terminal panes

### DIFF
--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -945,6 +945,7 @@ final class AppState {
             TerminalProgressStore.shared.resetPane(paneID)
             DetectedAgentStore.shared.resetPane(paneID)
             PersistentSessionExitHandler.shared.resetPane(paneID)
+            RemoteTerminalStreamer.shared.resetPane(paneID)
         }
 
         for paneID in effects.paneIDsToRelease {

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -1474,7 +1474,7 @@
 "In a local workspace, open Add Project → Recently Removed to restore a removed project whose folder still exists, without changing its files." = "In a local workspace, open Add Project → Recently Removed to restore a removed project whose folder still exists, without changing its files.";
 "Install the muxy CLI from the Muxy menu to script splits, send keys, and read visible terminal output. [Read the CLI docs](https://muxy.app/docs/features/muxy-cli)." = "Install the muxy CLI from the Muxy menu to script splits, send keys, and read visible terminal output. [Read the CLI docs](https://muxy.app/docs/features/muxy-cli).";
 "Muxy can track supported coding agents and notify you when a turn finishes or needs input. Check Settings → Notifications." = "Muxy can track supported coding agents and notify you when a turn finishes or needs input. Check Settings → Notifications.";
-"Scrollback buffer cap (MB)" = "Scrollback buffer cap (MB)";
+"Scrollback per terminal (MB)" = "Scrollback per terminal (MB)";
 "Enter a value between 1 and 128 MB." = "Enter a value between 1 and 128 MB.";
 "Scrollback Buffer Cap" = "Scrollback Buffer Cap";
-"Maximum scrollback history size in MB for mobile terminal sessions." = "Maximum scrollback history size in MB for mobile terminal sessions.";
+"Scrollback history kept per terminal, in MB, for replay to mobile devices." = "Scrollback history kept per terminal, in MB, for replay to mobile devices.";

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -1474,3 +1474,7 @@
 "In a local workspace, open Add Project → Recently Removed to restore a removed project whose folder still exists, without changing its files." = "In a local workspace, open Add Project → Recently Removed to restore a removed project whose folder still exists, without changing its files.";
 "Install the muxy CLI from the Muxy menu to script splits, send keys, and read visible terminal output. [Read the CLI docs](https://muxy.app/docs/features/muxy-cli)." = "Install the muxy CLI from the Muxy menu to script splits, send keys, and read visible terminal output. [Read the CLI docs](https://muxy.app/docs/features/muxy-cli).";
 "Muxy can track supported coding agents and notify you when a turn finishes or needs input. Check Settings → Notifications." = "Muxy can track supported coding agents and notify you when a turn finishes or needs input. Check Settings → Notifications.";
+"Scrollback buffer cap (MB)" = "Scrollback buffer cap (MB)";
+"Enter a value between 1 and 128 MB." = "Enter a value between 1 and 128 MB.";
+"Scrollback Buffer Cap" = "Scrollback Buffer Cap";
+"Maximum scrollback history size in MB for mobile terminal sessions." = "Maximum scrollback history size in MB for mobile terminal sessions.";

--- a/Muxy/Services/Mobile/MobileServerService.swift
+++ b/Muxy/Services/Mobile/MobileServerService.swift
@@ -59,6 +59,9 @@ final class MobileServerService {
         didSet {
             guard scrollbackCapMB != oldValue else { return }
             UserDefaults.standard.set(scrollbackCapMB, forKey: Self.scrollbackCapKey)
+            RemoteTerminalStreamer.shared.trimAllScrollback(
+                toByteLimit: scrollbackCapMB * 1_048_576
+            )
         }
     }
 

--- a/Muxy/Services/Mobile/MobileServerService.swift
+++ b/Muxy/Services/Mobile/MobileServerService.swift
@@ -16,6 +16,10 @@ final class MobileServerService {
     static let minPort: UInt16 = 1024
     static let maxPort: UInt16 = 65535
 
+    static let defaultScrollbackCapMB = 8
+    static let minScrollbackCapMB = 1
+    static let maxScrollbackCapMB = 128
+
     static var enabledKey: String {
         AppEnvironment.isDevelopment
             ? "app.muxy.mobile.serverEnabled.dev"
@@ -26,6 +30,12 @@ final class MobileServerService {
         AppEnvironment.isDevelopment
             ? "app.muxy.mobile.serverPort.dev"
             : "app.muxy.mobile.serverPort"
+    }
+
+    static var scrollbackCapKey: String {
+        AppEnvironment.isDevelopment
+            ? "app.muxy.mobile.scrollbackCap.dev"
+            : "app.muxy.mobile.scrollbackCap"
     }
 
     private(set) var isEnabled: Bool {
@@ -42,6 +52,13 @@ final class MobileServerService {
                 setEnabled(false)
             }
             lastError = nil
+        }
+    }
+
+    var scrollbackCapMB: Int {
+        didSet {
+            guard scrollbackCapMB != oldValue else { return }
+            UserDefaults.standard.set(scrollbackCapMB, forKey: Self.scrollbackCapKey)
         }
     }
 
@@ -65,6 +82,12 @@ final class MobileServerService {
             } else {
                 port = Self.defaultPort
             }
+        }
+        let storedCap = UserDefaults.standard.object(forKey: Self.scrollbackCapKey) as? Int
+        if let storedCap, Self.isValidScrollbackCap(storedCap) {
+            scrollbackCapMB = storedCap
+        } else {
+            scrollbackCapMB = Self.defaultScrollbackCapMB
         }
         ApprovedDevicesStore.shared.onRevoke = { [weak self] deviceID in
             self?.server?.disconnect(deviceID: deviceID)
@@ -105,6 +128,10 @@ final class MobileServerService {
 
     static func isValid(port: UInt16) -> Bool {
         port >= minPort && port <= maxPort
+    }
+
+    static func isValidScrollbackCap(_ mb: Int) -> Bool {
+        mb >= minScrollbackCapMB && mb <= maxScrollbackCapMB
     }
 
     private func retireCurrentServer() {

--- a/Muxy/Services/Mobile/RemoteServerDelegate.swift
+++ b/Muxy/Services/Mobile/RemoteServerDelegate.swift
@@ -390,12 +390,16 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         // the server terminal. Main-buffer shells scroll from the client's replayed
         // scrollback; forwarding those deltas re-renders the server terminal and mirrors
         // output back to the client, which re-triggers scroll in a feedback loop.
-        guard RemoteTerminalStreamer.shared.isAltBuffer(for: paneID) else { return }
+        guard isAlternateScreen(paneID: paneID) else { return }
         ensureTerminalView(paneID: paneID)?.scrollTerminal(
             deltaX: deltaX,
             deltaY: deltaY,
             precise: precise
         )
+    }
+
+    private func isAlternateScreen(paneID: UUID) -> Bool {
+        getTerminalContent(paneID: paneID)?.altScreen ?? false
     }
 
     func resizeTerminal(paneID: UUID, cols: UInt32, rows: UInt32, clientID: UUID) {
@@ -450,19 +454,14 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
 
     func takeOverPane(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32) {
         guard ensureTerminalView(paneID: paneID) != nil else { return }
-
-        let content = getTerminalContent(paneID: paneID)
-        if let content {
-            RemoteTerminalStreamer.shared.setAltBuffer(for: paneID, active: content.altScreen)
-        }
-
-        if let replay = RemoteTerminalStreamer.shared.scrollbackData(for: paneID) {
+        // Replay buffered history first so the client rebuilds scrollback, then let the
+        // snapshot below settle the visible screen.
+        if let replay = RemoteTerminalStreamer.shared.scrollbackData(for: paneID), !replay.isEmpty {
             let dto = TerminalOutputEventDTO(paneID: paneID, bytes: replay)
             let event = MuxyEvent(event: .terminalOutput, data: .terminalOutput(dto))
             server?.send(event, to: clientID)
         }
-
-        let snapshotBytes = content.map { RemoteTerminalSnapshotBuilder.buildBytes(from: $0) }
+        let snapshotBytes = buildTerminalSnapshot(paneID: paneID)
         PaneOwnershipStore.shared.assign(paneID: paneID, to: clientID)
         if let bytes = snapshotBytes, !bytes.isEmpty {
             let dto = TerminalOutputEventDTO(paneID: paneID, bytes: bytes)

--- a/Muxy/Services/Mobile/RemoteServerDelegate.swift
+++ b/Muxy/Services/Mobile/RemoteServerDelegate.swift
@@ -386,6 +386,11 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         guard PaneOwnershipStore.shared.isOwnedBy(clientID: clientID, paneID: paneID) else {
             return
         }
+        // Alt-screen apps (opencode, vim, ...) scroll inside the app, so deltas must reach
+        // the server terminal. Main-buffer shells scroll from the client's replayed
+        // scrollback; forwarding those deltas re-renders the server terminal and mirrors
+        // output back to the client, which re-triggers scroll in a feedback loop.
+        guard RemoteTerminalStreamer.shared.isAltBuffer(for: paneID) else { return }
         ensureTerminalView(paneID: paneID)?.scrollTerminal(
             deltaX: deltaX,
             deltaY: deltaY,
@@ -445,7 +450,19 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
 
     func takeOverPane(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32) {
         guard ensureTerminalView(paneID: paneID) != nil else { return }
-        let snapshotBytes = buildTerminalSnapshot(paneID: paneID)
+
+        let content = getTerminalContent(paneID: paneID)
+        if let content {
+            RemoteTerminalStreamer.shared.setAltBuffer(for: paneID, active: content.altScreen)
+        }
+
+        if let replay = RemoteTerminalStreamer.shared.scrollbackData(for: paneID) {
+            let dto = TerminalOutputEventDTO(paneID: paneID, bytes: replay)
+            let event = MuxyEvent(event: .terminalOutput, data: .terminalOutput(dto))
+            server?.send(event, to: clientID)
+        }
+
+        let snapshotBytes = content.map { RemoteTerminalSnapshotBuilder.buildBytes(from: $0) }
         PaneOwnershipStore.shared.assign(paneID: paneID, to: clientID)
         if let bytes = snapshotBytes, !bytes.isEmpty {
             let dto = TerminalOutputEventDTO(paneID: paneID, bytes: bytes)

--- a/Muxy/Services/Mobile/RemoteServerDelegate.swift
+++ b/Muxy/Services/Mobile/RemoteServerDelegate.swift
@@ -386,10 +386,6 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
         guard PaneOwnershipStore.shared.isOwnedBy(clientID: clientID, paneID: paneID) else {
             return
         }
-        // Alt-screen apps (opencode, vim, ...) scroll inside the app, so deltas must reach
-        // the server terminal. Main-buffer shells scroll from the client's replayed
-        // scrollback; forwarding those deltas re-renders the server terminal and mirrors
-        // output back to the client, which re-triggers scroll in a feedback loop.
         guard isAlternateScreen(paneID: paneID) else { return }
         ensureTerminalView(paneID: paneID)?.scrollTerminal(
             deltaX: deltaX,
@@ -454,12 +450,12 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
 
     func takeOverPane(paneID: UUID, clientID: UUID, cols: UInt32, rows: UInt32) {
         guard ensureTerminalView(paneID: paneID) != nil else { return }
-        // Replay buffered history first so the client rebuilds scrollback, then let the
-        // snapshot below settle the visible screen.
         if let replay = RemoteTerminalStreamer.shared.scrollbackData(for: paneID), !replay.isEmpty {
-            let dto = TerminalOutputEventDTO(paneID: paneID, bytes: replay)
-            let event = MuxyEvent(event: .terminalOutput, data: .terminalOutput(dto))
-            server?.send(event, to: clientID)
+            for chunk in replay.chunks(ofByteCount: 262_144) {
+                let dto = TerminalOutputEventDTO(paneID: paneID, bytes: chunk)
+                let event = MuxyEvent(event: .terminalOutput, data: .terminalOutput(dto))
+                server?.send(event, to: clientID)
+            }
         }
         let snapshotBytes = buildTerminalSnapshot(paneID: paneID)
         PaneOwnershipStore.shared.assign(paneID: paneID, to: clientID)
@@ -1134,5 +1130,19 @@ final class RemoteServerDelegate: MuxyRemoteServerDelegate {
               let worktree = worktreeStore.worktree(projectID: projectID, worktreeID: worktreeID)
         else { return nil }
         return worktree
+    }
+}
+
+private extension Data {
+    func chunks(ofByteCount chunkSize: Int) -> [Data] {
+        guard chunkSize > 0 else { return [self] }
+        var chunks: [Data] = []
+        var start = startIndex
+        while start < endIndex {
+            let end = index(start, offsetBy: chunkSize, limitedBy: endIndex) ?? endIndex
+            chunks.append(self[start ..< end])
+            start = end
+        }
+        return chunks
     }
 }

--- a/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
+++ b/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
@@ -18,7 +18,6 @@ final class RemoteTerminalStreamer {
 
     private var attachments: [UUID: Attachment] = [:]
     private var scrollbackBuffers: [UUID: Data] = [:]
-    private var altBufferActive: [UUID: Bool] = [:]
 
     private var scrollbackByteLimit: Int {
         MobileServerService.shared.scrollbackCapMB * 1_048_576
@@ -46,7 +45,6 @@ final class RemoteTerminalStreamer {
 
     private func forward(paneID: UUID, bytes: Data) {
         appendScrollback(paneID: paneID, bytes: bytes, byteLimit: scrollbackByteLimit)
-        trackAltBuffer(paneID: paneID, bytes: bytes)
 
         guard let clientID = PaneOwnershipStore.shared.remoteOwner(for: paneID) else { return }
         let event = MuxyEvent(
@@ -56,34 +54,21 @@ final class RemoteTerminalStreamer {
         server?.send(event, to: clientID)
     }
 
-    private func trackAltBuffer(paneID: UUID, bytes: Data) {
-        guard let text = String(data: bytes, encoding: .utf8) else { return }
-        if text.contains("\u{1B}[?1049h") || text.contains("\u{1B}[?47h") {
-            altBufferActive[paneID] = true
-        } else if text.contains("\u{1B}[?1049l") || text.contains("\u{1B}[?47l") {
-            altBufferActive[paneID] = false
-        }
-    }
-
-    func isAltBuffer(for paneID: UUID) -> Bool {
-        altBufferActive[paneID] ?? false
-    }
-
-    func setAltBuffer(for paneID: UUID, active: Bool) {
-        altBufferActive[paneID] = active
-    }
-
+    // Appends in place: binding the stored buffer to a local `var` would make the
+    // dictionary and the local share storage, so every append would copy the whole
+    // buffer (up to the configured cap) before mutating it.
     func appendScrollback(paneID: UUID, bytes: Data, byteLimit: Int) {
-        var buffer = scrollbackBuffers[paneID] ?? Data()
-        buffer.append(bytes)
-        if buffer.count > byteLimit {
-            let trimTarget = max(byteLimit * 3 / 4, 1)
-            buffer.removeFirst(buffer.count - trimTarget)
-        }
-        scrollbackBuffers[paneID] = buffer
+        scrollbackBuffers[paneID, default: Data()].append(bytes)
+        guard let count = scrollbackBuffers[paneID]?.count, count > byteLimit else { return }
+        let trimTarget = max(byteLimit * 3 / 4, 1)
+        scrollbackBuffers[paneID]?.removeFirst(count - trimTarget)
     }
 
     func scrollbackData(for paneID: UUID) -> Data? {
         scrollbackBuffers[paneID]
+    }
+
+    func resetPane(_ paneID: UUID) {
+        scrollbackBuffers.removeValue(forKey: paneID)
     }
 }

--- a/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
+++ b/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
@@ -17,6 +17,12 @@ final class RemoteTerminalStreamer {
     }
 
     private var attachments: [UUID: Attachment] = [:]
+    private var scrollbackBuffers: [UUID: Data] = [:]
+    private var altBufferActive: [UUID: Bool] = [:]
+
+    private var scrollbackByteLimit: Int {
+        MobileServerService.shared.scrollbackCapMB * 1_048_576
+    }
 
     init() {}
 
@@ -39,11 +45,45 @@ final class RemoteTerminalStreamer {
     }
 
     private func forward(paneID: UUID, bytes: Data) {
+        appendScrollback(paneID: paneID, bytes: bytes, byteLimit: scrollbackByteLimit)
+        trackAltBuffer(paneID: paneID, bytes: bytes)
+
         guard let clientID = PaneOwnershipStore.shared.remoteOwner(for: paneID) else { return }
         let event = MuxyEvent(
             event: .terminalOutput,
             data: .terminalOutput(TerminalOutputEventDTO(paneID: paneID, bytes: bytes))
         )
         server?.send(event, to: clientID)
+    }
+
+    private func trackAltBuffer(paneID: UUID, bytes: Data) {
+        guard let text = String(data: bytes, encoding: .utf8) else { return }
+        if text.contains("\u{1B}[?1049h") || text.contains("\u{1B}[?47h") {
+            altBufferActive[paneID] = true
+        } else if text.contains("\u{1B}[?1049l") || text.contains("\u{1B}[?47l") {
+            altBufferActive[paneID] = false
+        }
+    }
+
+    func isAltBuffer(for paneID: UUID) -> Bool {
+        altBufferActive[paneID] ?? false
+    }
+
+    func setAltBuffer(for paneID: UUID, active: Bool) {
+        altBufferActive[paneID] = active
+    }
+
+    func appendScrollback(paneID: UUID, bytes: Data, byteLimit: Int) {
+        var buffer = scrollbackBuffers[paneID] ?? Data()
+        buffer.append(bytes)
+        if buffer.count > byteLimit {
+            let trimTarget = max(byteLimit * 3 / 4, 1)
+            buffer.removeFirst(buffer.count - trimTarget)
+        }
+        scrollbackBuffers[paneID] = buffer
+    }
+
+    func scrollbackData(for paneID: UUID) -> Data? {
+        scrollbackBuffers[paneID]
     }
 }

--- a/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
+++ b/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
@@ -65,6 +65,14 @@ final class RemoteTerminalStreamer {
         scrollbackBuffers[paneID]
     }
 
+    func trimAllScrollback(toByteLimit byteLimit: Int) {
+        let trimTarget = max(byteLimit * 3 / 4, 1)
+        for paneID in scrollbackBuffers.keys {
+            guard let count = scrollbackBuffers[paneID]?.count, count > byteLimit else { continue }
+            scrollbackBuffers[paneID]?.removeFirst(count - trimTarget)
+        }
+    }
+
     func resetPane(_ paneID: UUID) {
         scrollbackBuffers.removeValue(forKey: paneID)
     }

--- a/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
+++ b/Muxy/Services/Terminal/RemoteTerminalStreamer.swift
@@ -54,9 +54,6 @@ final class RemoteTerminalStreamer {
         server?.send(event, to: clientID)
     }
 
-    // Appends in place: binding the stored buffer to a local `var` would make the
-    // dictionary and the local share storage, so every append would copy the whole
-    // buffer (up to the configured cap) before mutating it.
     func appendScrollback(paneID: UUID, bytes: Data, byteLimit: Int) {
         scrollbackBuffers[paneID, default: Data()].append(bytes)
         guard let count = scrollbackBuffers[paneID]?.count, count > byteLimit else { return }

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -28,7 +28,7 @@ struct MobileSettingsView: View {
         Binding(
             get: { service.isEnabled },
             set: { newValue in
-                if newValue, !commitPort() {
+                if newValue, !commitPort() || !commitCap() {
                     return
                 }
                 service.setEnabled(newValue)

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -80,7 +80,7 @@ struct MobileSettingsView: View {
                     .padding(.vertical, SettingsMetrics.rowVerticalPadding)
                 }
 
-                SettingsRow("Scrollback buffer cap (MB)") {
+                SettingsRow("Scrollback per terminal (MB)") {
                     TextField(L10n.string("\(MobileServerService.defaultScrollbackCapMB)"), text: $capText)
                         .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
                         .settingsTextInput(width: SettingsMetrics.controlWidth)

--- a/Muxy/Views/Settings/MobileSettingsView.swift
+++ b/Muxy/Views/Settings/MobileSettingsView.swift
@@ -16,6 +16,8 @@ struct MobileSettingsView: View {
     @State private var showBatchRevokeConfirmation = false
     @State private var portText: String = ""
     @State private var portValidationError: String?
+    @State private var capText: String = ""
+    @State private var capValidationError: String?
     @State private var showFreePortConfirmation = false
     @State private var didCopyPairingLink = false
     @State private var pairingHosts: [MobilePairingHost] = []
@@ -77,6 +79,25 @@ struct MobileSettingsView: View {
                     .padding(.horizontal, SettingsMetrics.horizontalPadding)
                     .padding(.vertical, SettingsMetrics.rowVerticalPadding)
                 }
+
+                SettingsRow("Scrollback buffer cap (MB)") {
+                    TextField(L10n.string("\(MobileServerService.defaultScrollbackCapMB)"), text: $capText)
+                        .font(.system(size: SettingsMetrics.labelFontSize, design: .monospaced))
+                        .settingsTextInput(width: SettingsMetrics.controlWidth)
+                        .onChange(of: capText) { _, _ in
+                            capValidationError = nil
+                        }
+                        .onSubmit { _ = commitCap() }
+                }
+
+                if let error = capValidationError {
+                    Text(error)
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(SettingsStyle.destructive)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, SettingsMetrics.horizontalPadding)
+                        .padding(.vertical, SettingsMetrics.rowVerticalPadding)
+                }
             }
 
             if service.isEnabled, let selectedHost, let uri = pairingURI(for: selectedHost) {
@@ -109,6 +130,7 @@ struct MobileSettingsView: View {
         }
         .onAppear {
             portText = String(service.port)
+            capText = String(service.scrollbackCapMB)
             refreshPairingHosts()
             startPathMonitor()
         }
@@ -117,6 +139,12 @@ struct MobileSettingsView: View {
             let text = String(newValue)
             if portText != text {
                 portText = text
+            }
+        }
+        .onChange(of: service.scrollbackCapMB) { _, newValue in
+            let text = String(newValue)
+            if capText != text {
+                capText = text
             }
         }
         .onChange(of: service.isEnabled) { _, _ in
@@ -185,6 +213,20 @@ struct MobileSettingsView: View {
         portValidationError = nil
         service.port = value
         portText = String(value)
+        return true
+    }
+
+    private func commitCap() -> Bool {
+        let trimmed = capText.trimmingCharacters(in: .whitespaces)
+        guard let value = Int(trimmed), MobileServerService.isValidScrollbackCap(value) else {
+            capValidationError = L10n.string(
+                "Enter a value between \(MobileServerService.minScrollbackCapMB) and \(MobileServerService.maxScrollbackCapMB) MB."
+            )
+            return false
+        }
+        capValidationError = nil
+        service.scrollbackCapMB = value
+        capText = String(value)
         return true
     }
 

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -707,7 +707,7 @@ enum SettingsCatalog {
         SettingsCatalogItem(
             key: MobileServerService.scrollbackCapKey,
             title: "Scrollback Buffer Cap",
-            description: "Maximum scrollback history size in MB for mobile terminal sessions.",
+            description: "Scrollback history kept per terminal, in MB, for replay to mobile devices.",
             category: .mobile,
             section: "Mobile",
             defaultValue: MobileServerService.defaultScrollbackCapMB,

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -705,6 +705,15 @@ enum SettingsCatalog {
             defaultValue: MobileServerService.defaultPort
         ),
         SettingsCatalogItem(
+            key: MobileServerService.scrollbackCapKey,
+            title: "Scrollback Buffer Cap",
+            description: "Maximum scrollback history size in MB for mobile terminal sessions.",
+            category: .mobile,
+            section: "Mobile",
+            defaultValue: MobileServerService.defaultScrollbackCapMB,
+            aliases: ["scrollback", "buffer", "history", "terminal history"]
+        ),
+        SettingsCatalogItem(
             key: "mobile.pairing",
             title: "Pair Mobile Device",
             description: "Shows the QR code used to pair a mobile device.",

--- a/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
@@ -60,6 +60,112 @@ struct RemoteTerminalStreamerTests {
         #expect(recreated.handlerInstallCount == 1)
         #expect(recreated.handlerRemovalCount == 0)
     }
+
+    @Test("appendScrollback accumulates output")
+    func appendScrollbackAccumulates() {
+        let streamer = RemoteTerminalStreamer()
+        let paneID = UUID()
+
+        streamer.appendScrollback(paneID: paneID, bytes: Data("hello".utf8), byteLimit: 1024)
+        streamer.appendScrollback(paneID: paneID, bytes: Data(" world".utf8), byteLimit: 1024)
+
+        #expect(streamer.scrollbackData(for: paneID) == Data("hello world".utf8))
+    }
+
+    @Test("appendScrollback trims oldest bytes when over the limit")
+    func appendScrollbackTrimsToLimit() {
+        let streamer = RemoteTerminalStreamer()
+        let paneID = UUID()
+
+        streamer.appendScrollback(paneID: paneID, bytes: Data("abcdef".utf8), byteLimit: 5)
+
+        #expect(streamer.scrollbackData(for: paneID) == Data("def".utf8))
+    }
+
+    @Test("appendScrollback keeps the buffer within the limit across repeated appends")
+    func appendScrollbackBoundsBuffer() {
+        let streamer = RemoteTerminalStreamer()
+        let paneID = UUID()
+        let byteLimit = 10
+
+        for _ in 0..<20 {
+            streamer.appendScrollback(paneID: paneID, bytes: Data("abcdefghij".utf8), byteLimit: byteLimit)
+        }
+
+        #expect((streamer.scrollbackData(for: paneID)?.count ?? 0) <= byteLimit)
+    }
+
+    @Test("scrollbackData does not consume the buffer")
+    func scrollbackDataIsNonDestructive() {
+        let streamer = RemoteTerminalStreamer()
+        let paneID = UUID()
+        let bytes = Data("hello".utf8)
+
+        streamer.appendScrollback(paneID: paneID, bytes: bytes, byteLimit: 1024)
+
+        #expect(streamer.scrollbackData(for: paneID) == bytes)
+        #expect(streamer.scrollbackData(for: paneID) == bytes)
+    }
+
+    @Test("forward buffers output from the surface handler")
+    func forwardBuffersOutput() {
+        let streamer = RemoteTerminalStreamer()
+        let surface = TerminalRawOutputTestSource()
+        let paneID = UUID()
+
+        streamer.attach(paneID: paneID, surface: surface)
+        surface.fire(Data("hello".utf8))
+        surface.fire(Data(" world".utf8))
+
+        #expect(streamer.scrollbackData(for: paneID) == Data("hello world".utf8))
+        streamer.detach(paneID: paneID, surface: surface)
+    }
+
+    @Test("isAltBuffer defaults to false for an unknown pane")
+    func isAltBufferDefaultsFalse() {
+        let streamer = RemoteTerminalStreamer()
+
+        #expect(!streamer.isAltBuffer(for: UUID()))
+    }
+
+    @Test("setAltBuffer sets the tracked buffer mode")
+    func setAltBufferSetsState() {
+        let streamer = RemoteTerminalStreamer()
+        let paneID = UUID()
+
+        streamer.setAltBuffer(for: paneID, active: true)
+        #expect(streamer.isAltBuffer(for: paneID))
+
+        streamer.setAltBuffer(for: paneID, active: false)
+        #expect(!streamer.isAltBuffer(for: paneID))
+    }
+
+    @Test("forward detects alt buffer entry from the output stream")
+    func forwardDetectsAltBufferEnable() {
+        let streamer = RemoteTerminalStreamer()
+        let surface = TerminalRawOutputTestSource()
+        let paneID = UUID()
+
+        streamer.attach(paneID: paneID, surface: surface)
+        surface.fire(Data("hello\u{1B}[?1049h".utf8))
+
+        #expect(streamer.isAltBuffer(for: paneID))
+        streamer.detach(paneID: paneID, surface: surface)
+    }
+
+    @Test("forward detects alt buffer exit from the output stream")
+    func forwardDetectsAltBufferDisable() {
+        let streamer = RemoteTerminalStreamer()
+        let surface = TerminalRawOutputTestSource()
+        let paneID = UUID()
+
+        streamer.attach(paneID: paneID, surface: surface)
+        surface.fire(Data("\u{1B}[?1049h".utf8))
+        surface.fire(Data("\u{1B}[?1049l".utf8))
+
+        #expect(!streamer.isAltBuffer(for: paneID))
+        streamer.detach(paneID: paneID, surface: surface)
+    }
 }
 
 @MainActor
@@ -79,5 +185,9 @@ private final class TerminalRawOutputTestSource: TerminalRawOutputSource {
         } else {
             handlerInstallCount += 1
         }
+    }
+
+    func fire(_ bytes: Data) {
+        handler?(bytes)
     }
 }

--- a/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
@@ -121,50 +121,55 @@ struct RemoteTerminalStreamerTests {
         streamer.detach(paneID: paneID, surface: surface)
     }
 
-    @Test("isAltBuffer defaults to false for an unknown pane")
-    func isAltBufferDefaultsFalse() {
-        let streamer = RemoteTerminalStreamer()
-
-        #expect(!streamer.isAltBuffer(for: UUID()))
-    }
-
-    @Test("setAltBuffer sets the tracked buffer mode")
-    func setAltBufferSetsState() {
+    @Test("resetPane releases the buffer for a removed pane")
+    func resetPaneReleasesBuffer() {
         let streamer = RemoteTerminalStreamer()
         let paneID = UUID()
 
-        streamer.setAltBuffer(for: paneID, active: true)
-        #expect(streamer.isAltBuffer(for: paneID))
+        streamer.appendScrollback(paneID: paneID, bytes: Data("hello".utf8), byteLimit: 1024)
+        streamer.resetPane(paneID)
 
-        streamer.setAltBuffer(for: paneID, active: false)
-        #expect(!streamer.isAltBuffer(for: paneID))
+        #expect(streamer.scrollbackData(for: paneID) == nil)
     }
 
-    @Test("forward detects alt buffer entry from the output stream")
-    func forwardDetectsAltBufferEnable() {
+    @Test("resetPane leaves other panes untouched")
+    func resetPaneIsScopedToOnePane() {
+        let streamer = RemoteTerminalStreamer()
+        let removed = UUID()
+        let kept = UUID()
+
+        streamer.appendScrollback(paneID: removed, bytes: Data("gone".utf8), byteLimit: 1024)
+        streamer.appendScrollback(paneID: kept, bytes: Data("stays".utf8), byteLimit: 1024)
+        streamer.resetPane(removed)
+
+        #expect(streamer.scrollbackData(for: kept) == Data("stays".utf8))
+    }
+
+    @Test("detach preserves the buffer so a later takeover can replay it")
+    func detachPreservesBuffer() {
         let streamer = RemoteTerminalStreamer()
         let surface = TerminalRawOutputTestSource()
         let paneID = UUID()
 
         streamer.attach(paneID: paneID, surface: surface)
-        surface.fire(Data("hello\u{1B}[?1049h".utf8))
-
-        #expect(streamer.isAltBuffer(for: paneID))
+        surface.fire(Data("history".utf8))
         streamer.detach(paneID: paneID, surface: surface)
+
+        #expect(streamer.scrollbackData(for: paneID) == Data("history".utf8))
     }
 
-    @Test("forward detects alt buffer exit from the output stream")
-    func forwardDetectsAltBufferDisable() {
+    @Test("appendScrollback keeps the newest bytes after trimming")
+    func appendScrollbackKeepsNewestBytes() {
         let streamer = RemoteTerminalStreamer()
-        let surface = TerminalRawOutputTestSource()
         let paneID = UUID()
+        let byteLimit = 8
 
-        streamer.attach(paneID: paneID, surface: surface)
-        surface.fire(Data("\u{1B}[?1049h".utf8))
-        surface.fire(Data("\u{1B}[?1049l".utf8))
+        streamer.appendScrollback(paneID: paneID, bytes: Data("abcdefgh".utf8), byteLimit: byteLimit)
+        streamer.appendScrollback(paneID: paneID, bytes: Data("ij".utf8), byteLimit: byteLimit)
 
-        #expect(!streamer.isAltBuffer(for: paneID))
-        streamer.detach(paneID: paneID, surface: surface)
+        let buffer = streamer.scrollbackData(for: paneID)
+        #expect(buffer?.count ?? 0 <= byteLimit)
+        #expect(buffer?.suffix(2) == Data("ij".utf8))
     }
 }
 

--- a/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
@@ -176,12 +176,15 @@ struct RemoteTerminalStreamerTests {
     func trimAllScrollbackShrinksOversizedBuffers() {
         let streamer = RemoteTerminalStreamer()
         let paneID = UUID()
+        let bytes = Data((0 ..< 128).map { UInt8($0) })
 
-        streamer.appendScrollback(paneID: paneID, bytes: Data(repeating: 0x61, count: 128), byteLimit: 256)
+        streamer.appendScrollback(paneID: paneID, bytes: bytes, byteLimit: 256)
 
         streamer.trimAllScrollback(toByteLimit: 64)
 
-        #expect(streamer.scrollbackData(for: paneID)?.count == 48)
+        let buffer = streamer.scrollbackData(for: paneID)
+        #expect((buffer?.count ?? 0) <= 64)
+        #expect(buffer?.suffix(48) == bytes.suffix(48))
     }
 
     @Test("trimAllScrollback leaves buffers at or under the limit untouched")
@@ -202,13 +205,16 @@ struct RemoteTerminalStreamerTests {
         let streamer = RemoteTerminalStreamer()
         let oversized = UUID()
         let small = UUID()
+        let oversizedBytes = Data((0 ..< 128).map { UInt8($0) })
 
-        streamer.appendScrollback(paneID: oversized, bytes: Data(repeating: 0x61, count: 128), byteLimit: 256)
+        streamer.appendScrollback(paneID: oversized, bytes: oversizedBytes, byteLimit: 256)
         streamer.appendScrollback(paneID: small, bytes: Data("keep".utf8), byteLimit: 256)
 
         streamer.trimAllScrollback(toByteLimit: 64)
 
-        #expect(streamer.scrollbackData(for: oversized)?.count == 48)
+        let buffer = streamer.scrollbackData(for: oversized)
+        #expect((buffer?.count ?? 0) <= 64)
+        #expect(buffer?.suffix(48) == oversizedBytes.suffix(48))
         #expect(streamer.scrollbackData(for: small) == Data("keep".utf8))
     }
 }

--- a/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/RemoteTerminalStreamerTests.swift
@@ -171,6 +171,46 @@ struct RemoteTerminalStreamerTests {
         #expect(buffer?.count ?? 0 <= byteLimit)
         #expect(buffer?.suffix(2) == Data("ij".utf8))
     }
+
+    @Test("trimAllScrollback shrinks oversized buffers to the new limit")
+    func trimAllScrollbackShrinksOversizedBuffers() {
+        let streamer = RemoteTerminalStreamer()
+        let paneID = UUID()
+
+        streamer.appendScrollback(paneID: paneID, bytes: Data(repeating: 0x61, count: 128), byteLimit: 256)
+
+        streamer.trimAllScrollback(toByteLimit: 64)
+
+        #expect(streamer.scrollbackData(for: paneID)?.count == 48)
+    }
+
+    @Test("trimAllScrollback leaves buffers at or under the limit untouched")
+    func trimAllScrollbackLeavesSmallBuffers() {
+        let streamer = RemoteTerminalStreamer()
+        let paneID = UUID()
+        let bytes = Data("small".utf8)
+
+        streamer.appendScrollback(paneID: paneID, bytes: bytes, byteLimit: 256)
+
+        streamer.trimAllScrollback(toByteLimit: 64)
+
+        #expect(streamer.scrollbackData(for: paneID) == bytes)
+    }
+
+    @Test("trimAllScrollback trims every pane independently")
+    func trimAllScrollbackTrimsEveryPane() {
+        let streamer = RemoteTerminalStreamer()
+        let oversized = UUID()
+        let small = UUID()
+
+        streamer.appendScrollback(paneID: oversized, bytes: Data(repeating: 0x61, count: 128), byteLimit: 256)
+        streamer.appendScrollback(paneID: small, bytes: Data("keep".utf8), byteLimit: 256)
+
+        streamer.trimAllScrollback(toByteLimit: 64)
+
+        #expect(streamer.scrollbackData(for: oversized)?.count == 48)
+        #expect(streamer.scrollbackData(for: small) == Data("keep".utf8))
+    }
 }
 
 @MainActor


### PR DESCRIPTION
<!--
Humans only: this PR's title, description, and comments must be written by you, not an AI.
You may use AI to help write code, but not to draft this PR text. AI-generated text will be closed without review.
-->

## Summary

<!-- What does this PR do and why? Write this yourself — no AI-generated text. -->
Mobile clients only received the current screen on takeover, so finished terminals had no scrollback to scroll through. The server now keeps a capped buffer of each pane's raw output and replays it before the snapshot.

## Changes

<!-- List the key changes -->
- Buffer raw terminal output per pane in `RemoteTerminalStreamer`, trimming
  oldest bytes once the cap is reached
- Replay the buffer ahead of the screen snapshot in `takeOverPane` so xterm
  rebuilds scrollback before the current screen is drawn
- Route scroll input by buffer type: alt-screen panes forward scroll to the
  host surface, main-buffer panes rely on the client's own scrollback
- Add a per-terminal scrollback cap setting (default 8 MB, range 1–128 MB)
  under Settings → Mobile
- Drop a pane's buffer when the pane is removed

**Panes still need a live surface for buffering to start**

## Testing

<!-- How was this tested? -->

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

`RemoteTerminalStreamerTests` covers buffering, cap trimming, newest-bytes
retention, handler lifecycle, and per-pane teardown.

## Screenshots

<!-- If applicable, add screenshots -->
<img width="981" height="682" alt="image" src="https://github.com/user-attachments/assets/a49ad4fd-6cf4-4167-9008-0ea04c48bb22" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable per-terminal scrollback buffer limit in mobile settings.
  - Added validation guidance, supported range information, and mobile replay behavior.
  - Preserved recent terminal output for replay when taking over a pane.

- **Bug Fixes**
  - Prevented unnecessary scrollback feedback loops during terminal scrolling.
  - Reset buffered terminal output when panes are removed.

- **Tests**
  - Added coverage for buffering, trimming, replay, pane isolation, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->