### PR TITLE
Add extension home view manifests

### DIFF
--- a/Muxy/Models/Extension/Extension.swift
+++ b/Muxy/Models/Extension/Extension.swift
@@ -284,6 +284,14 @@ struct ExtensionSidebar: Codable, Equatable, Identifiable {
     }
 }
 
+struct ExtensionHomeView: Codable, Equatable, Identifiable {
+    let id: String
+    let title: String
+    let icon: ExtensionIcon?
+    let entry: String
+    let defaultData: ExtensionJSON?
+}
+
 enum ExtensionIcon: Codable, Equatable {
     case symbol(String)
     case svg(String)
@@ -667,6 +675,7 @@ struct ExtensionManifest: Codable, Equatable {
     let events: [String]
     let commands: [ExtensionPaletteCommand]
     let tabTypes: [ExtensionTabType]
+    let homeViews: [ExtensionHomeView]
     let panels: [ExtensionPanel]
     let popovers: [ExtensionPopover]
     let sidebar: ExtensionSidebar?
@@ -686,6 +695,7 @@ struct ExtensionManifest: Codable, Equatable {
         case events
         case commands
         case tabTypes
+        case homeViews
         case panels
         case popovers
         case sidebar
@@ -706,6 +716,7 @@ struct ExtensionManifest: Codable, Equatable {
         events: [String] = [],
         commands: [ExtensionPaletteCommand] = [],
         tabTypes: [ExtensionTabType] = [],
+        homeViews: [ExtensionHomeView] = [],
         panels: [ExtensionPanel] = [],
         popovers: [ExtensionPopover] = [],
         sidebar: ExtensionSidebar? = nil,
@@ -724,6 +735,7 @@ struct ExtensionManifest: Codable, Equatable {
         self.events = events
         self.commands = commands
         self.tabTypes = tabTypes
+        self.homeViews = homeViews
         self.panels = panels
         self.popovers = popovers
         self.sidebar = sidebar
@@ -745,6 +757,7 @@ struct ExtensionManifest: Codable, Equatable {
         events = try container.decodeIfPresent([String].self, forKey: .events) ?? []
         commands = try container.decodeIfPresent([ExtensionPaletteCommand].self, forKey: .commands) ?? []
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
+        homeViews = try container.decodeIfPresent([ExtensionHomeView].self, forKey: .homeViews) ?? []
         panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
         popovers = try container.decodeIfPresent([ExtensionPopover].self, forKey: .popovers) ?? []
         sidebar = try container.decodeIfPresent(ExtensionSidebar.self, forKey: .sidebar)
@@ -766,6 +779,7 @@ struct ExtensionManifest: Codable, Equatable {
         events = muxy.events
         commands = muxy.commands
         tabTypes = muxy.tabTypes
+        homeViews = muxy.homeViews
         panels = muxy.panels
         popovers = muxy.popovers
         sidebar = muxy.sidebar
@@ -780,6 +794,10 @@ struct ExtensionManifest: Codable, Equatable {
 
     func tabType(id: String) -> ExtensionTabType? {
         tabTypes.first { $0.id == id }
+    }
+
+    func homeView(id: String) -> ExtensionHomeView? {
+        homeViews.first { $0.id == id }
     }
 
     func panel(id: String) -> ExtensionPanel? {
@@ -833,6 +851,7 @@ struct MuxyManifestBody: Codable, Equatable {
     let events: [String]
     let commands: [ExtensionPaletteCommand]
     let tabTypes: [ExtensionTabType]
+    let homeViews: [ExtensionHomeView]
     let panels: [ExtensionPanel]
     let popovers: [ExtensionPopover]
     let sidebar: ExtensionSidebar?
@@ -850,6 +869,7 @@ struct MuxyManifestBody: Codable, Equatable {
         case events
         case commands
         case tabTypes
+        case homeViews
         case panels
         case popovers
         case sidebar
@@ -869,6 +889,7 @@ struct MuxyManifestBody: Codable, Equatable {
         events = try container.decodeIfPresent([String].self, forKey: .events) ?? []
         commands = try container.decodeIfPresent([ExtensionPaletteCommand].self, forKey: .commands) ?? []
         tabTypes = try container.decodeIfPresent([ExtensionTabType].self, forKey: .tabTypes) ?? []
+        homeViews = try container.decodeIfPresent([ExtensionHomeView].self, forKey: .homeViews) ?? []
         panels = try container.decodeIfPresent([ExtensionPanel].self, forKey: .panels) ?? []
         popovers = try container.decodeIfPresent([ExtensionPopover].self, forKey: .popovers) ?? []
         sidebar = try container.decodeIfPresent(ExtensionSidebar.self, forKey: .sidebar)
@@ -893,6 +914,14 @@ enum ExtensionLoadError: LocalizedError, Equatable {
     case tabTypeEntryMissing(tabTypeID: String, url: URL)
     case tabTypeEntryOutsideDirectory(tabTypeID: String, url: URL)
     case duplicateTabType(String)
+    case homeViewEmptyID
+    case homeViewEmptyTitle(homeViewID: String)
+    case homeViewEntryEmpty(homeViewID: String)
+    case homeViewEntryMissing(homeViewID: String, url: URL)
+    case homeViewEntryOutsideDirectory(homeViewID: String, url: URL)
+    case homeViewSVGMissing(homeViewID: String, url: URL)
+    case homeViewSVGOutsideDirectory(homeViewID: String, url: URL)
+    case duplicateHomeView(String)
     case panelEntryMissing(panelID: String, url: URL)
     case panelEntryOutsideDirectory(panelID: String, url: URL)
     case duplicatePanel(String)
@@ -974,6 +1003,22 @@ enum ExtensionLoadError: LocalizedError, Equatable {
             "Tab type '\(tabTypeID)' entry at \(url.path) escapes the extension directory"
         case let .duplicateTabType(id):
             "Duplicate tab type '\(id)'"
+        case .homeViewEmptyID:
+            "Home view id must not be empty"
+        case let .homeViewEmptyTitle(homeViewID):
+            "Home view '\(homeViewID)' title must not be empty"
+        case let .homeViewEntryEmpty(homeViewID):
+            "Home view '\(homeViewID)' entry must not be empty"
+        case let .homeViewEntryMissing(homeViewID, url):
+            "Home view '\(homeViewID)' entry not found at \(url.path)"
+        case let .homeViewEntryOutsideDirectory(homeViewID, url):
+            "Home view '\(homeViewID)' entry at \(url.path) escapes the extension directory"
+        case let .homeViewSVGMissing(homeViewID, url):
+            "Home view '\(homeViewID)' icon SVG not found at \(url.path)"
+        case let .homeViewSVGOutsideDirectory(homeViewID, url):
+            "Home view '\(homeViewID)' icon SVG at \(url.path) escapes the extension directory"
+        case let .duplicateHomeView(id):
+            "Duplicate home view '\(id)'"
         case let .panelEntryMissing(panelID, url):
             "Panel '\(panelID)' entry not found at \(url.path)"
         case let .panelEntryOutsideDirectory(panelID, url):
@@ -1171,6 +1216,7 @@ enum ExtensionManifestLoader {
         }
 
         try validateTabTypes(manifest: manifest, in: muxyExtension)
+        try validateHomeViews(manifest: manifest, in: muxyExtension)
         try validateFileOpeners(manifest: manifest)
         try validateLocalizations(manifest: manifest, in: muxyExtension)
         try validatePanels(manifest: manifest, in: muxyExtension)
@@ -1236,6 +1282,39 @@ enum ExtensionManifestLoader {
             }
             guard FileManager.default.fileExists(atPath: url.path) else {
                 throw ExtensionLoadError.tabTypeEntryMissing(tabTypeID: tabType.id, url: url)
+            }
+        }
+    }
+
+    private static func validateHomeViews(manifest: ExtensionManifest, in muxyExtension: MuxyExtension) throws {
+        var seen = Set<String>()
+        for homeView in manifest.homeViews {
+            guard !homeView.id.isEmpty else { throw ExtensionLoadError.homeViewEmptyID }
+            guard seen.insert(homeView.id).inserted else {
+                throw ExtensionLoadError.duplicateHomeView(homeView.id)
+            }
+            guard !homeView.title.isEmpty else {
+                throw ExtensionLoadError.homeViewEmptyTitle(homeViewID: homeView.id)
+            }
+            guard !homeView.entry.isEmpty else {
+                throw ExtensionLoadError.homeViewEntryEmpty(homeViewID: homeView.id)
+            }
+            guard let url = muxyExtension.resolveResource(homeView.entry) else {
+                throw ExtensionLoadError.homeViewEntryOutsideDirectory(
+                    homeViewID: homeView.id,
+                    url: muxyExtension.directory.appendingPathComponent(homeView.entry)
+                )
+            }
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ExtensionLoadError.homeViewEntryMissing(homeViewID: homeView.id, url: url)
+            }
+            if let icon = homeView.icon {
+                try validateIcon(
+                    icon,
+                    in: muxyExtension,
+                    missing: { ExtensionLoadError.homeViewSVGMissing(homeViewID: homeView.id, url: $0) },
+                    outside: { ExtensionLoadError.homeViewSVGOutsideDirectory(homeViewID: homeView.id, url: $0) }
+                )
             }
         }
     }

--- a/Muxy/Models/Extension/Extension.swift
+++ b/Muxy/Models/Extension/Extension.swift
@@ -302,25 +302,36 @@ enum ExtensionIcon: Codable, Equatable {
     }
 
     init(from decoder: Decoder) throws {
-        if let container = try? decoder.singleValueContainer(),
-           let raw = try? container.decode(String.self)
-        {
+        let container = try decoder.singleValueContainer()
+        if let raw = try? container.decode(String.self) {
+            guard !raw.isEmpty else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Icon symbol must not be empty"
+                )
+            }
             self = .symbol(raw)
             return
         }
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let symbol = try container.decodeIfPresent(String.self, forKey: .symbol) {
+
+        let values = try container.decode([String: String].self)
+        guard values.count == 1 else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Icon requires exactly one 'symbol' or 'svg' field"
+            )
+        }
+        if let symbol = values[CodingKeys.symbol.rawValue], !symbol.isEmpty {
             self = .symbol(symbol)
             return
         }
-        if let svg = try container.decodeIfPresent(String.self, forKey: .svg) {
+        if let svg = values[CodingKeys.svg.rawValue], !svg.isEmpty {
             self = .svg(svg)
             return
         }
         throw DecodingError.dataCorruptedError(
-            forKey: CodingKeys.symbol,
             in: container,
-            debugDescription: "Icon requires either a 'symbol' or 'svg' field"
+            debugDescription: "Icon requires one non-empty 'symbol' or 'svg' field"
         )
     }
 

--- a/Muxy/Resources/skills/muxy-extension/SKILL.md
+++ b/Muxy/Resources/skills/muxy-extension/SKILL.md
@@ -19,7 +19,8 @@ The goal of everything below: an extension should be indistinguishable from a na
 
 ## Pick the right surface
 
-- **Showing something to the user** → a **UI page** (tab, panel, or popover). Page scripts get the full `window.muxy` API.
+- **A global full-window destination outside project tab restoration** → a **`homeView`**. Use it for an overview or launch surface that spans projects and worktrees; see [Home Views](https://muxy.app/docs/extensions/home-views) for current presentation availability.
+- **Showing something inside a project workspace or transient app chrome** → a **UI page** (tab, panel, or popover). Page scripts get the full `window.muxy` API.
 - **A persistent, full-height navigation or control surface that replaces the built-in left sidebar** → a **`sidebar`** (one per extension; the user selects it in Settings → Sidebar). It fills the entire region — the project list *and* the footer — so own your own navigation. Same `window.muxy` API and theme variables as a panel.
 - **Reacting durably to events, coordinating multiple webviews, or running shell commands headlessly** → a **`background.js`** script. It can also call `muxy.tabs.open` to show a result in the active workspace. Most extensions don't need one.
 - **One-shot logic from the palette** → a **`runScript`** command, not a hidden tab. Its `muxy.*` calls are **synchronous** except for the Promise-based `muxy.execAsync`. It has `tabs`/`panes`/`projects`/`worktrees`/`browser`/`agents`/`files`/`git`/`exec`/`execAsync`/`dialog`/`modal`/`topbar`/`statusbar`/`notifications`, but **not** `http`, `events`, `remote`, `panels`, or `popover`. It can open a modal and act on the choice inline — no page or background listener needed.

--- a/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
@@ -84,6 +84,33 @@ struct ExtensionManifestTests {
         #expect(command.action.requiredPermission == .panelsWrite)
     }
 
+    @Test("decodes home views")
+    func decodesHomeViews() throws {
+        let json = #"""
+        {
+            "name": "overview",
+            "version": "1.0.0",
+            "homeViews": [
+                {
+                    "id": "board",
+                    "title": "Overview",
+                    "icon": "rectangle.3.group",
+                    "entry": "overview/index.html",
+                    "defaultData": { "showIdle": false }
+                }
+            ]
+        }
+        """#
+
+        let manifest = try JSONDecoder().decode(ExtensionManifest.self, from: Data(json.utf8))
+        let home = try #require(manifest.homeViews.first)
+
+        #expect(home.id == "board")
+        #expect(home.title == "Overview")
+        #expect(home.entry == "overview/index.html")
+        #expect(home.defaultData == .object(["showIdle": .bool(false)]))
+    }
+
     @Test("openModal defaults dismissOnOutsideClick to true when omitted")
     func openModalDefaultsDismiss() throws {
         let json = #"""
@@ -1606,6 +1633,48 @@ struct ExtensionManifestTests {
         defer { try? FileManager.default.removeItem(at: directory) }
 
         #expect(throws: ExtensionLoadError.sidebarEntryEmpty(sidebarID: "main")) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("loads a home view and validates its entry")
+    func loadsHomeView() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-view",
+                "version": "1.0.0",
+                "homeViews": [
+                    { "id": "overview", "title": "Overview", "entry": "overview/index.html" }
+                ]
+            }
+            """,
+            files: ["overview/index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let loaded = try ExtensionManifestLoader.load(from: directory)
+
+        #expect(loaded.manifest.homeView(id: "overview")?.title == "Overview")
+    }
+
+    @Test("rejects a home view with an empty title")
+    func rejectsHomeViewEmptyTitle() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-empty-title",
+                "version": "1.0.0",
+                "homeViews": [
+                    { "id": "overview", "title": "", "entry": "index.html" }
+                ]
+            }
+            """,
+            files: ["index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.homeViewEmptyTitle(homeViewID: "overview")) {
             try ExtensionManifestLoader.load(from: directory)
         }
     }

--- a/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
@@ -107,6 +107,7 @@ struct ExtensionManifestTests {
 
         #expect(home.id == "board")
         #expect(home.title == "Overview")
+        #expect(home.icon == .symbol("rectangle.3.group"))
         #expect(home.entry == "overview/index.html")
         #expect(home.defaultData == .object(["showIdle": .bool(false)]))
     }
@@ -1645,17 +1646,26 @@ struct ExtensionManifestTests {
                 "name": "home-view",
                 "version": "1.0.0",
                 "homeViews": [
-                    { "id": "overview", "title": "Overview", "entry": "overview/index.html" }
+                    {
+                        "id": "overview",
+                        "title": "Overview",
+                        "icon": { "svg": "assets/overview.svg" },
+                        "entry": "overview/index.html"
+                    }
                 ]
             }
             """,
-            files: ["overview/index.html": "<html></html>"]
+            files: [
+                "assets/overview.svg": "<svg></svg>",
+                "overview/index.html": "<html></html>",
+            ]
         )
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let loaded = try ExtensionManifestLoader.load(from: directory)
 
         #expect(loaded.manifest.homeView(id: "overview")?.title == "Overview")
+        #expect(loaded.manifest.homeView(id: "overview")?.icon == .svg("assets/overview.svg"))
     }
 
     @Test("rejects a home view with an empty title")

--- a/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
@@ -1668,6 +1668,38 @@ struct ExtensionManifestTests {
         #expect(loaded.manifest.homeView(id: "overview")?.icon == .svg("assets/overview.svg"))
     }
 
+    @Test("rejects malformed home view icons", arguments: [
+        "\"\"",
+        #"{ "symbol": "" }"#,
+        #"{ "svg": "" }"#,
+        #"{ "symbol": "star", "svg": "assets/icon.svg" }"#,
+        #"{ "symbol": "star", "unexpected": "value" }"#,
+    ])
+    func rejectsMalformedHomeViewIcon(icon: String) throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-invalid-icon",
+                "version": "1.0.0",
+                "homeViews": [
+                    {
+                        "id": "overview",
+                        "title": "Overview",
+                        "icon": \(icon),
+                        "entry": "index.html"
+                    }
+                ]
+            }
+            """,
+            files: ["index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.self) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     @Test("rejects a home view with an empty title")
     func rejectsHomeViewEmptyTitle() throws {
         let directory = try makeTemporaryExtension(

--- a/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
+++ b/Tests/MuxyTests/Models/Extension/ExtensionManifestTests.swift
@@ -1679,6 +1679,164 @@ struct ExtensionManifestTests {
         }
     }
 
+    @Test("rejects a home view with an empty id")
+    func rejectsHomeViewEmptyID() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-empty-id",
+                "version": "1.0.0",
+                "homeViews": [
+                    { "id": "", "title": "Overview", "entry": "index.html" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.homeViewEmptyID) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects duplicate home view ids")
+    func rejectsDuplicateHomeViewIDs() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-duplicate-id",
+                "version": "1.0.0",
+                "homeViews": [
+                    { "id": "overview", "title": "Overview", "entry": "index.html" },
+                    { "id": "overview", "title": "Overview", "entry": "index.html" }
+                ]
+            }
+            """,
+            files: ["index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.duplicateHomeView("overview")) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects a home view with an empty entry")
+    func rejectsHomeViewEmptyEntry() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-empty-entry",
+                "version": "1.0.0",
+                "homeViews": [
+                    { "id": "overview", "title": "Overview", "entry": "" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: ExtensionLoadError.homeViewEntryEmpty(homeViewID: "overview")) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects a home view with a missing entry")
+    func rejectsHomeViewMissingEntry() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-missing-entry",
+                "version": "1.0.0",
+                "homeViews": [
+                    { "id": "overview", "title": "Overview", "entry": "missing.html" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let entryURL = directory.appendingPathComponent("missing.html")
+
+        #expect(throws: ExtensionLoadError.homeViewEntryMissing(homeViewID: "overview", url: entryURL)) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects a home view entry outside its extension directory")
+    func rejectsHomeViewEntryOutsideDirectory() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-outside-entry",
+                "version": "1.0.0",
+                "homeViews": [
+                    { "id": "overview", "title": "Overview", "entry": "../outside.html" }
+                ]
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let entryURL = directory.appendingPathComponent("../outside.html")
+
+        #expect(throws: ExtensionLoadError.homeViewEntryOutsideDirectory(homeViewID: "overview", url: entryURL)) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects a home view with a missing SVG icon")
+    func rejectsHomeViewMissingSVG() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-missing-svg",
+                "version": "1.0.0",
+                "homeViews": [
+                    {
+                        "id": "overview",
+                        "title": "Overview",
+                        "entry": "index.html",
+                        "icon": { "svg": "assets/missing.svg" }
+                    }
+                ]
+            }
+            """,
+            files: ["index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let iconURL = directory.appendingPathComponent("assets/missing.svg")
+
+        #expect(throws: ExtensionLoadError.homeViewSVGMissing(homeViewID: "overview", url: iconURL)) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
+    @Test("rejects a home view SVG icon outside its extension directory")
+    func rejectsHomeViewSVGOutsideDirectory() throws {
+        let directory = try makeTemporaryExtension(
+            manifest: """
+            {
+                "name": "home-outside-svg",
+                "version": "1.0.0",
+                "homeViews": [
+                    {
+                        "id": "overview",
+                        "title": "Overview",
+                        "entry": "index.html",
+                        "icon": { "svg": "../outside.svg" }
+                    }
+                ]
+            }
+            """,
+            files: ["index.html": "<html></html>"]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let iconURL = directory.appendingPathComponent("../outside.svg")
+
+        #expect(throws: ExtensionLoadError.homeViewSVGOutsideDirectory(homeViewID: "overview", url: iconURL)) {
+            try ExtensionManifestLoader.load(from: directory)
+        }
+    }
+
     private func makeTemporaryExtension(
         manifest: String,
         files: [String: String] = [:]

--- a/docs/extensions/home-views.md
+++ b/docs/extensions/home-views.md
@@ -1,0 +1,57 @@
+# Extension Home Views
+
+A home view declares a global, full-window extension page that is independent of project tabs and their restored layouts. Use one for an overview or launch destination that spans projects and worktrees. Use a [tab](tabs.md) instead when the page belongs to the active project workspace and should participate in tab restoration.
+
+> **Current availability:** Muxy currently decodes and validates the `homeViews` manifest contract. App navigation, launch-destination selection, fallback behavior, and visible presentation are integrated separately. Declaring a home view alone does not yet add a visible destination.
+
+## Declaring a home view
+
+Add `homeViews` to the `muxy` object in `package.json`:
+
+```json
+{
+  "name": "workspace-overview",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "vite build && node scripts/copy-manifest.mjs"
+  },
+  "muxy": {
+    "homeViews": [
+      {
+        "id": "overview",
+        "title": "Workspace Overview",
+        "icon": "rectangle.3.group",
+        "entry": "overview/index.html",
+        "defaultData": {
+          "showIdle": false
+        }
+      }
+    ]
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | yes | Non-empty identifier that is unique within the extension. Keep it stable across releases. |
+| `title` | string | yes | Non-empty user-facing title. |
+| `icon` | string \| object | no | Non-empty SF Symbol name, `{ "symbol": "…" }`, or `{ "svg": "assets/icon.svg" }`. |
+| `entry` | string | yes | Non-empty HTML path relative to the build output. It must exist and resolve inside the extension directory. |
+| `defaultData` | JSON value | no | Initial data retained for the home-view webview. |
+
+An extension may declare multiple home views, but every `id` must be unique within that extension.
+
+## Resources and validation
+
+Muxy resolves `entry` and SVG icon paths against the installed build output, normally `dist/`. Paths may use any internal directory layout, but they cannot escape the extension directory through `..` components or symbolic links.
+
+SVG icons must:
+
+- Use a relative path ending in `.svg`.
+- Exist when the extension is loaded.
+- Resolve inside the extension directory.
+- Be no larger than 256 KiB.
+
+A home-view declaration does not grant permissions or allow an extension to select itself as the default launch destination. Any APIs used by its page remain subject to the permissions declared in the manifest. Default selection and fallback are app-owned behavior rather than manifest fields.

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -2,7 +2,7 @@
 
 Every extension is an npm + [Vite](https://vitejs.dev) project. Its manifest is the `muxy` object inside the `package.json` at the root of its directory.
 
-Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `fileOpeners`, `localizations`, `panels`, `popovers`, `sidebar`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
+Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `homeViews`, `fileOpeners`, `localizations`, `panels`, `popovers`, `sidebar`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
 
 `package.json` must also declare a `build` script. The publishing pipeline runs `npm run build` (Vite) and ships **only** the build output directory, `dist/`. The app installs and reads from `dist/`, so every entry/asset path inside `muxy` (popover/tab `entry`, `background`, marketplace `icon`/`screenshots`) resolves against the build output, not your source tree.
 
@@ -53,6 +53,7 @@ All Muxy-specific manifest fields live under the `muxy` object.
 | `events` | string[] | no | Workspace events the extension may subscribe to. Local `extension.*` events are not declared here. See [Events](events.md). Defaults to empty. |
 | `commands` | object[] | no | Palette commands to register. See [Palette Commands](palette-commands.md). |
 | `tabTypes` | object[] | no | Webview tab types the extension exposes. See [Tabs](tabs.md). |
+| `homeViews` | object[] | no | Global full-window webviews shown outside project tab restoration. See [Home Views](home-views.md). |
 | `fileOpeners` | object[] | no | Project-file openers the extension contributes. Each opener references one of the extension's `tabTypes`; Muxy opens it with `{ filePath, line?, column?, source }` when a terminal link opens a file. See [File openers](tabs.md#file-openers). |
 | `localizations` | object[] | no | App-language providers backed by resource-only `.bundle` directories copied into `dist/`. See [Localizations](localizations.md). |
 | `panels` | object[] | no | Dockable/floating webview panels. See [Panels](panels.md). |

--- a/docs/extensions/manifest.md
+++ b/docs/extensions/manifest.md
@@ -4,7 +4,7 @@ Every extension is an npm + [Vite](https://vitejs.dev) project. Its manifest is 
 
 Identity (`name` and `version`) lives at the **top level** of `package.json` — npm's single source of truth. **Every other manifest field** (`description`, `background`, `events`, `permissions`, `tabTypes`, `homeViews`, `fileOpeners`, `localizations`, `panels`, `popovers`, `sidebar`, `commands`, `topbarItems`, `statusBarItems`, `settings`, `remoteMethods`, `marketplace`) lives under the `muxy` key.
 
-`package.json` must also declare a `build` script. The publishing pipeline runs `npm run build` (Vite) and ships **only** the build output directory, `dist/`. The app installs and reads from `dist/`, so every entry/asset path inside `muxy` (popover/tab `entry`, `background`, marketplace `icon`/`screenshots`) resolves against the build output, not your source tree.
+`package.json` must also declare a `build` script. The publishing pipeline runs `npm run build` (Vite) and ships **only** the build output directory, `dist/`. The app installs and reads from `dist/`, so every entry/asset path inside `muxy` (home-view, popover, and tab `entry`; `background`; marketplace `icon` and `screenshots`) resolves against the build output, not your source tree.
 
 Because only `dist/` ships, **your `build` must copy `package.json` into `dist/`** — `vite build` emits your entry/asset paths but not the manifest. Without the copy, the published `dist/` has no manifest and fails to install. (It still loads in local dev via **Load Unpacked**, which falls back to the root `package.json`, so the gap surfaces only at validation or install time.) Append a copy step: `"build": "vite build && node scripts/copy-manifest.mjs"`. See [Contributing](contributing.md#3-build-and-develop-live) for the script; the vanilla starter kit already includes it.
 
@@ -69,14 +69,14 @@ Extensions are disabled by default after loading and must be enabled explicitly 
 
 ## Icons
 
-Topbar and status-bar items accept an `icon` field in one of two forms:
+Home views, panels, sidebars, topbar items, and status-bar items accept an `icon` field in one of two forms:
 
 ```json
 { "icon": { "symbol": "puzzlepiece.extension" } }
 { "icon": { "svg": "assets/badge.svg" } }
 ```
 
-A bare string (`"icon": "puzzlepiece.extension"`) is shorthand for `{ "symbol": ... }`.
+A bare string (`"icon": "puzzlepiece.extension"`) is shorthand for `{ "symbol": ... }`. Icon values must be non-empty, and an object must contain exactly one of `symbol` or `svg`.
 
 - **`symbol`** — any SF Symbol name. Tinted with the chrome's foreground color.
 - **`svg`** — a path relative to the build output to a `.svg` file. The file must exist in `dist/` at load time, must not escape the extension directory, and must be at most 256 KiB. Rendered as a template image, so fills/strokes using `currentColor` (or a single solid color) pick up the chrome tint.

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -18,6 +18,7 @@ Workspace events originate in the main process (`ExtensionEventEmitter` diffs wo
 | Page | What's in it |
 | --- | --- |
 | [Manifest](manifest.md) | `package.json` `muxy` fields and examples |
+| [Home Views](home-views.md) | Global full-window destination declarations and current availability |
 | [Permissions](permissions.md) | Permission grants and runtime consent |
 | [Events](events.md) | Subscribable events and payloads |
 | [Palette Commands](palette-commands.md) | Commands that appear in the command palette |

--- a/docs/extensions/schema/manifest.schema.json
+++ b/docs/extensions/schema/manifest.schema.json
@@ -62,6 +62,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/tabType" }
         },
+        "homeViews": {
+          "type": "array",
+          "description": "Global full-window extension views shown outside project tab restoration.",
+          "items": { "$ref": "#/$defs/homeView" }
+        },
         "fileOpeners": {
           "type": "array",
           "description": "File openers this extension contributes. Muxy passes filePath plus optional line/column data to the referenced tabType when a terminal link opens a project file.",
@@ -197,6 +202,18 @@
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "title": { "type": "string" },
+        "entry": { "type": "string", "minLength": 1 },
+        "defaultData": {}
+      }
+    },
+    "homeView": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "entry"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "icon": { "$ref": "#/$defs/icon" },
         "entry": { "type": "string", "minLength": 1 },
         "defaultData": {}
       }


### PR DESCRIPTION
## Summary

Adds the extension manifest contract for global home views.

## Changes

- add the `homeViews` extension manifest contribution
- validate home view IDs, titles, entries, icons, and duplicate declarations
- update the manifest schema and extension documentation
- cover all home-view decoding and load-validation boundaries

## Testing

- `scripts/checks.sh --fix` (all checks passed)
- `swift test --filter ExtensionManifestTests` (87 tests passed before the final icon assertions; the complete suite passed afterward through `scripts/checks.sh --fix`)
- `swift test --filter AppRelaunchTests` (6 tests passed in isolation after the earlier contention failure)
- `git diff --check`

## Screenshots

Not applicable; this PR adds a manifest contract without UI changes.

## Split Plan

This is the second independently reviewable part split from the closed #1041 scope. It is independent of #1056 and can merge in either order.

1. #1056: workspace overview state foundations
2. **This PR:** extension home view manifest contract
3. Extension workspace overview APIs, to open after #1056 merges
4. Global extension home presentation, to open after the API and manifest prerequisites merge

## Related

Replaces part of #1041
Related to #1040

## AI Contribution

Contributed with OpenAI GPT-5.6 Sol (`openai/gpt-5.6-sol`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining global, full-window extension home views.
  * Home views can include titles, icons, entry files, and default data.
  * Added lookup support for individual home views.

* **Validation**
  * Added validation for required fields, duplicate IDs, inaccessible resources, and invalid SVG icons.

* **Documentation**
  * Documented the `homeViews` manifest field, schema, resource requirements, and when to use home views versus UI pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->