### PR TITLE
Add workspace overview state foundations

### DIFF
--- a/Muxy/Models/Project/ProjectGroup.swift
+++ b/Muxy/Models/Project/ProjectGroup.swift
@@ -10,12 +10,20 @@ struct RemoteProject: Identifiable, Codable, Hashable {
     var name: String
     var path: String
     var worktreesEnabled: Bool
+    var lastActiveAt: Date?
 
-    init(id: UUID = UUID(), name: String, path: String, worktreesEnabled: Bool = false) {
+    init(
+        id: UUID = UUID(),
+        name: String,
+        path: String,
+        worktreesEnabled: Bool = false,
+        lastActiveAt: Date? = nil
+    ) {
         self.id = id
         self.name = name
         self.path = path
         self.worktreesEnabled = worktreesEnabled
+        self.lastActiveAt = lastActiveAt
     }
 
     init(from decoder: Decoder) throws {
@@ -24,11 +32,13 @@ struct RemoteProject: Identifiable, Codable, Hashable {
         name = try container.decode(String.self, forKey: .name)
         path = try container.decode(String.self, forKey: .path)
         worktreesEnabled = try container.decodeIfPresent(Bool.self, forKey: .worktreesEnabled) ?? false
+        lastActiveAt = try container.decodeIfPresent(Date.self, forKey: .lastActiveAt)
     }
 
     func asProject(workspaceID: UUID, sortOrder: Int) -> Project {
         var project = Project(id: id, name: name, path: path, sortOrder: sortOrder, remoteWorkspaceID: workspaceID)
         project.worktreesEnabled = worktreesEnabled
+        project.lastActiveAt = lastActiveAt
         return project
     }
 }

--- a/Muxy/Models/Project/Worktree.swift
+++ b/Muxy/Models/Project/Worktree.swift
@@ -13,6 +13,7 @@ struct Worktree: Identifiable, Codable, Hashable {
     var source: WorktreeSource
     var isPrimary: Bool
     var createdAt: Date
+    var lastActiveAt: Date?
 
     init(
         id: UUID = UUID(),
@@ -21,7 +22,8 @@ struct Worktree: Identifiable, Codable, Hashable {
         branch: String? = nil,
         source: WorktreeSource = .muxy,
         isPrimary: Bool,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        lastActiveAt: Date? = nil
     ) {
         self.id = id
         self.name = name
@@ -30,6 +32,7 @@ struct Worktree: Identifiable, Codable, Hashable {
         self.source = source
         self.isPrimary = isPrimary
         self.createdAt = createdAt
+        self.lastActiveAt = lastActiveAt
     }
 
     var isExternallyManaged: Bool {
@@ -52,6 +55,7 @@ struct Worktree: Identifiable, Codable, Hashable {
         case source
         case isPrimary
         case createdAt
+        case lastActiveAt
     }
 
     init(from decoder: Decoder) throws {
@@ -63,5 +67,6 @@ struct Worktree: Identifiable, Codable, Hashable {
         source = try container.decodeIfPresent(WorktreeSource.self, forKey: .source) ?? .muxy
         isPrimary = try container.decode(Bool.self, forKey: .isPrimary)
         createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        lastActiveAt = try container.decodeIfPresent(Date.self, forKey: .lastActiveAt)
     }
 }

--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -83,7 +83,7 @@ final class AppState {
     private let terminalViews: any TerminalViewRemoving
     private let workspacePersistence: any WorkspacePersisting
     var onProjectsEmptied: (([UUID]) -> Void)?
-    var onProjectSelected: ((UUID) -> Void)?
+    var onWorkspaceSelected: ((WorktreeKey) -> Void)?
 
     var activeProjectID: UUID?
 
@@ -174,6 +174,9 @@ final class AppState {
         activeProjectID = id
         recordCurrentNavigationEntry()
         recordActiveWorktreeUsage()
+        if let key = activeWorktreeKey(for: id) {
+            onWorkspaceSelected?(key)
+        }
     }
 
     func saveWorkspaces() {
@@ -219,14 +222,11 @@ final class AppState {
     }
 
     func selectProject(_ project: Project, worktree: Worktree) {
-        let wasActive = activeProjectID == project.id
         dispatch(.selectProject(
             projectID: project.id,
             worktreeID: worktree.id,
             worktreePath: worktree.path
         ))
-        guard !wasActive else { return }
-        onProjectSelected?(project.id)
     }
 
     func selectWorktree(projectID: UUID, worktree: Worktree) {
@@ -902,6 +902,7 @@ final class AppState {
             let after = ExtensionEventEmitter.snapshot(from: self)
             ExtensionEventEmitter.emit(before: extensionSnapshot, after: after)
         }
+        let previousActiveWorktreeKey = activeProjectID.flatMap { activeWorktreeKey(for: $0) }
 
         switch action {
         case let .focusPaneLeft(projectID),
@@ -960,6 +961,10 @@ final class AppState {
         }
         if activeWorktreeID != workspace.activeWorktreeID {
             activeWorktreeID = workspace.activeWorktreeID
+        }
+        let currentActiveWorktreeKey = activeProjectID.flatMap { activeWorktreeKey(for: $0) }
+        if currentActiveWorktreeKey != previousActiveWorktreeKey, let currentActiveWorktreeKey {
+            onWorkspaceSelected?(currentActiveWorktreeKey)
         }
         if currentWorkspaceRootSignature != workspaceRootSignature(workspace.workspaceRoots) {
             workspaceRoots = workspace.workspaceRoots

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -48,6 +48,14 @@ struct MuxyApp: App {
             persistence: environment.projectGroupPersistence,
             remoteDeviceStore: remoteDeviceStore
         )
+        appState.onWorkspaceSelected = { key in
+            if projectStore.storedProjects.contains(where: { $0.id == key.projectID }) {
+                projectStore.markActive(id: key.projectID)
+            } else {
+                projectGroupStore.markRemoteProjectActive(id: key.projectID)
+            }
+            worktreeStore.markActive(projectID: key.projectID, worktreeID: key.worktreeID)
+        }
         appState.restoreSelection(
             projects: projectStore.projects,
             worktrees: worktreeStore.worktrees,
@@ -174,9 +182,6 @@ struct MuxyApp: App {
                                 name: ExtensionEventName.projectsChanged,
                                 payload: [:]
                             ))
-                        }
-                        appState.onProjectSelected = { [projectStore] projectID in
-                            projectStore.markActive(id: projectID)
                         }
                         Task { @MainActor in
                             await Task.yield()

--- a/Muxy/Services/Extensions/ExtensionCommandProcess.swift
+++ b/Muxy/Services/Extensions/ExtensionCommandProcess.swift
@@ -390,7 +390,9 @@ final class OutputReader: @unchecked Sendable {
                 read(descriptor, bytes.baseAddress, bytes.count)
             }
             if bytesRead > 0 {
-                callbackEvents.append(.data(Data(buffer.prefix(Int(bytesRead)))))
+                let data = Data(buffer.prefix(Int(bytesRead)))
+                box.append(data)
+                callbackEvents.append(.data(data))
                 continue
             }
             if bytesRead == -1, errno == EINTR {
@@ -415,6 +417,7 @@ final class OutputReader: @unchecked Sendable {
         }
         let data = handle.availableData
         if !data.isEmpty {
+            box.append(data)
             callbackEvents.append(.data(data))
             let shouldDeliver = beginDeliveringCallbacks()
             lock.unlock()
@@ -452,7 +455,6 @@ final class OutputReader: @unchecked Sendable {
             lock.unlock()
             switch event {
             case let .data(data):
-                box.append(data)
                 onData?(data)
             case .finish:
                 onFinish?()

--- a/Muxy/Services/Mobile/RemoteDeviceStore.swift
+++ b/Muxy/Services/Mobile/RemoteDeviceStore.swift
@@ -8,6 +8,7 @@ private let logger = Logger(subsystem: "app.muxy", category: "RemoteDeviceStore"
 final class RemoteDeviceStore {
     private(set) var devices: [RemoteDevice] = []
     private let persistence: any RemoteDevicePersisting
+    var onDevicesChanged: (() -> Void)?
 
     init(persistence: any RemoteDevicePersisting) {
         self.persistence = persistence
@@ -54,6 +55,7 @@ final class RemoteDeviceStore {
         } catch {
             logger.error("Failed to save remote devices: \(error)")
         }
+        onDevicesChanged?()
     }
 
     private func load() {

--- a/Muxy/Services/Project/ProjectGroupStore.swift
+++ b/Muxy/Services/Project/ProjectGroupStore.swift
@@ -11,6 +11,7 @@ final class ProjectGroupStore {
     private let persistence: any ProjectGroupPersisting
     private let workspaceContextSink: any WorkspaceContextSink
     private let remoteDeviceStore: RemoteDeviceStore
+    var onProjectsChanged: (() -> Void)?
 
     init(
         persistence: any ProjectGroupPersisting,
@@ -238,6 +239,17 @@ final class ProjectGroupStore {
         save()
     }
 
+    func markRemoteProjectActive(id: UUID) {
+        for groupIndex in groups.indices {
+            guard let projectIndex = groups[groupIndex].remoteProjects.firstIndex(where: { $0.id == id }) else {
+                continue
+            }
+            groups[groupIndex].remoteProjects[projectIndex].lastActiveAt = Date()
+            save()
+            return
+        }
+    }
+
     func updateRemoteProject(id: UUID, _ mutate: (inout RemoteProject) -> Void) {
         for groupIndex in groups.indices {
             guard let projectIndex = groups[groupIndex].remoteProjects.firstIndex(where: { $0.id == id })
@@ -311,6 +323,7 @@ final class ProjectGroupStore {
         } catch {
             logger.error("Failed to save project groups: \(error)")
         }
+        onProjectsChanged?()
     }
 
     private func load() {

--- a/Muxy/Services/Project/ProjectOpenService.swift
+++ b/Muxy/Services/Project/ProjectOpenService.swift
@@ -105,11 +105,11 @@ enum ProjectOpenService {
         let previousWorktrees = worktreeStore.list(for: project.id)
         worktreeStore.ensurePrimary(for: project)
         guard let primary = worktreeStore.primary(for: project.id) else {
-            worktreeStore.restoreProjectWorktrees(previousWorktrees, for: project.id)
+            worktreeStore.restoreProjectWorktrees(previousWorktrees, for: project)
             throw RestoreError.worktreeUnavailable
         }
         guard let restoredProject = projectStore.restoreRecentlyRemovedProject(id: id) else {
-            worktreeStore.restoreProjectWorktrees(previousWorktrees, for: project.id)
+            worktreeStore.restoreProjectWorktrees(previousWorktrees, for: project)
             throw RestoreError.persistenceFailed
         }
         projectGroupStore.addProjectToActiveGroup(projectID: restoredProject.id)

--- a/Muxy/Services/Project/WorktreeStore.swift
+++ b/Muxy/Services/Project/WorktreeStore.swift
@@ -25,10 +25,12 @@ final class WorktreeStore {
     private(set) var worktrees: [UUID: [Worktree]] = [:]
     private(set) var preparingRemovalWorktreeIDs: Set<UUID> = []
     private(set) var removingWorktreeIDs: Set<UUID> = []
-    private var projectIDByPath: [String: UUID] = [:]
+    private var projectIDsByPath: [String: Set<UUID>] = [:]
+    private var localProjectIDs: Set<UUID> = []
     private var projectsBeingRemoved: Set<UUID> = []
     private var activeProjectMutationCounts: [UUID: Int] = [:]
     private var projectMutationWaiters: [UUID: [CheckedContinuation<Void, Never>]] = [:]
+    var onWorktreesChanged: ((UUID, UUID?) -> Void)?
     private let persistence: any WorktreePersisting
     private let listGitWorktrees: @Sendable (String) async throws -> [GitWorktreeRecord]
     private let addGitWorktree: @Sendable (String, String, String, Bool, String?) async throws -> Void
@@ -58,6 +60,7 @@ final class WorktreeStore {
 
     func loadAll(projects: [Project]) {
         for project in projects {
+            trackProject(project)
             guard !projectsBeingRemoved.contains(project.id) else { continue }
             do {
                 var loaded = try persistence.loadWorktrees(projectID: project.id)
@@ -75,6 +78,7 @@ final class WorktreeStore {
     }
 
     func ensurePrimary(for project: Project) {
+        trackProject(project)
         guard !projectsBeingRemoved.contains(project.id) else { return }
         var list = worktrees[project.id] ?? []
         if list.contains(where: \.isPrimary) {
@@ -83,6 +87,7 @@ final class WorktreeStore {
         list.insert(makePrimary(for: project), at: 0)
         setWorktrees(sortPrimaryFirst(list), for: project.id)
         save(projectID: project.id)
+        onWorktreesChanged?(project.id, list.first(where: \.isPrimary)?.id)
     }
 
     func list(for projectID: UUID) -> [Worktree] {
@@ -90,7 +95,8 @@ final class WorktreeStore {
     }
 
     func projectID(forWorktreePath path: String) -> UUID? {
-        projectIDByPath[path]
+        guard let projectIDs = projectIDsByPath[path] else { return nil }
+        return projectIDs.first(where: { localProjectIDs.contains($0) }) ?? projectIDs.first
     }
 
     func primary(for projectID: UUID) -> Worktree? {
@@ -106,6 +112,16 @@ final class WorktreeStore {
         return list.first(where: { $0.id == preferredID })
             ?? list.first(where: { $0.isPrimary })
             ?? list.first
+    }
+
+    func markActive(projectID: UUID, worktreeID: UUID) {
+        guard var list = worktrees[projectID],
+              let index = list.firstIndex(where: { $0.id == worktreeID })
+        else { return }
+        list[index].lastActiveAt = Date()
+        setWorktrees(list, for: projectID)
+        save(projectID: projectID)
+        onWorktreesChanged?(projectID, worktreeID)
     }
 
     func add(_ worktree: Worktree, to projectID: UUID, context: WorkspaceContext = .local) {
@@ -125,6 +141,7 @@ final class WorktreeStore {
         }
         setWorktrees(sortPrimaryFirst(list), for: projectID)
         save(projectID: projectID)
+        onWorktreesChanged?(projectID, worktree.id)
     }
 
     func createWorktree(
@@ -194,6 +211,7 @@ final class WorktreeStore {
         list.removeAll { $0.id == worktreeID && $0.canBeRemoved }
         setWorktrees(list, for: projectID)
         save(projectID: projectID)
+        onWorktreesChanged?(projectID, worktreeID)
     }
 
     func isRemoving(worktreeID: UUID) -> Bool {
@@ -213,7 +231,7 @@ final class WorktreeStore {
     }
 
     func beginRemovalPreparation(worktree: Worktree) -> Bool {
-        if let projectID = projectIDByPath[worktree.path], projectsBeingRemoved.contains(projectID) {
+        if projectIDsByPath[worktree.path]?.contains(where: { projectsBeingRemoved.contains($0) }) == true {
             return false
         }
         guard worktree.canBeRemoved, !isRemoving(worktreeID: worktree.id) else { return false }
@@ -328,6 +346,7 @@ final class WorktreeStore {
         let sorted = sortPrimaryFirst(collapseDuplicatePaths(filtered, context: context))
         setWorktrees(sorted, for: project.id)
         save(projectID: project.id)
+        onWorktreesChanged?(project.id, nil)
         return sorted
     }
 
@@ -453,6 +472,7 @@ final class WorktreeStore {
         list[index].name = newName
         setWorktrees(list, for: projectID)
         save(projectID: projectID)
+        onWorktreesChanged?(projectID, worktreeID)
     }
 
     func updateBranch(worktreeID: UUID, in projectID: UUID, branch: String?) {
@@ -463,6 +483,7 @@ final class WorktreeStore {
         list[index].branch = branch
         setWorktrees(list, for: projectID)
         save(projectID: projectID)
+        onWorktreesChanged?(projectID, worktreeID)
     }
 
     func removeProject(_ projectID: UUID) {
@@ -476,17 +497,21 @@ final class WorktreeStore {
 
     private func removeProjectState(_ projectID: UUID) {
         if let existing = worktrees[projectID] {
-            for worktree in existing where projectIDByPath[worktree.path] == projectID {
-                projectIDByPath.removeValue(forKey: worktree.path)
+            for worktree in existing {
+                removePathOwnership(worktree.path, projectID: projectID)
             }
         }
-        worktrees.removeValue(forKey: projectID)
+        let removed = worktrees.removeValue(forKey: projectID)
+        localProjectIDs.remove(projectID)
         projectsBeingRemoved.remove(projectID)
         pruneRemovalState()
         do {
             try persistence.removeWorktrees(projectID: projectID)
         } catch {
             logger.error("Failed to remove worktrees file for project \(projectID): \(error)")
+        }
+        if removed != nil {
+            onWorktreesChanged?(projectID, nil)
         }
     }
 
@@ -514,16 +539,17 @@ final class WorktreeStore {
         }
         setWorktrees(list, for: projectID)
         save(projectID: projectID)
+        onWorktreesChanged?(projectID, nil)
     }
 
     private func setWorktrees(_ list: [Worktree], for projectID: UUID) {
         if let previous = worktrees[projectID] {
-            for worktree in previous where projectIDByPath[worktree.path] == projectID {
-                projectIDByPath.removeValue(forKey: worktree.path)
+            for worktree in previous {
+                removePathOwnership(worktree.path, projectID: projectID)
             }
         }
         for worktree in list {
-            projectIDByPath[worktree.path] = projectID
+            projectIDsByPath[worktree.path, default: []].insert(projectID)
         }
         worktrees[projectID] = list
         pruneRemovalState()
@@ -533,6 +559,24 @@ final class WorktreeStore {
         let liveIDs = Set(worktrees.values.flatMap(\.self).map(\.id))
         preparingRemovalWorktreeIDs.formIntersection(liveIDs)
         removingWorktreeIDs.formIntersection(liveIDs)
+    }
+
+    private func trackProject(_ project: Project) {
+        if project.isRemote {
+            localProjectIDs.remove(project.id)
+        } else {
+            localProjectIDs.insert(project.id)
+        }
+    }
+
+    private func removePathOwnership(_ path: String, projectID: UUID) {
+        guard var projectIDs = projectIDsByPath[path] else { return }
+        projectIDs.remove(projectID)
+        if projectIDs.isEmpty {
+            projectIDsByPath.removeValue(forKey: path)
+        } else {
+            projectIDsByPath[path] = projectIDs
+        }
     }
 
     private func makePrimary(for project: Project) -> Worktree {

--- a/Muxy/Services/Project/WorktreeStore.swift
+++ b/Muxy/Services/Project/WorktreeStore.swift
@@ -230,10 +230,8 @@ final class WorktreeStore {
         isPreparingRemoval(worktreeID: worktreeID) || isRemoving(worktreeID: worktreeID)
     }
 
-    func beginRemovalPreparation(worktree: Worktree) -> Bool {
-        if projectIDsByPath[worktree.path]?.contains(where: { projectsBeingRemoved.contains($0) }) == true {
-            return false
-        }
+    func beginRemovalPreparation(worktree: Worktree, projectID: UUID) -> Bool {
+        guard !projectsBeingRemoved.contains(projectID) else { return false }
         guard worktree.canBeRemoved, !isRemoving(worktreeID: worktree.id) else { return false }
         return preparingRemovalWorktreeIDs.insert(worktree.id).inserted
     }

--- a/Muxy/Services/Project/WorktreeStore.swift
+++ b/Muxy/Services/Project/WorktreeStore.swift
@@ -532,14 +532,15 @@ final class WorktreeStore {
         projectsBeingRemoved.contains(projectID)
     }
 
-    func restoreProjectWorktrees(_ list: [Worktree], for projectID: UUID) {
+    func restoreProjectWorktrees(_ list: [Worktree], for project: Project) {
+        trackProject(project)
         guard !list.isEmpty else {
-            removeProject(projectID)
+            removeProject(project.id)
             return
         }
-        setWorktrees(list, for: projectID)
-        save(projectID: projectID)
-        onWorktreesChanged?(projectID, nil)
+        setWorktrees(list, for: project.id)
+        save(projectID: project.id)
+        onWorktreesChanged?(project.id, nil)
     }
 
     private func setWorktrees(_ list: [Worktree], for projectID: UUID) {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -1420,7 +1420,7 @@ struct MainWindow: View {
                   isInspecting: worktreeStore.isPreparingRemoval(worktreeID: worktree.id),
                   isRemoving: worktreeStore.isRemoving(worktreeID: worktree.id)
               ),
-              worktreeStore.beginRemovalPreparation(worktree: worktree)
+              worktreeStore.beginRemovalPreparation(worktree: worktree, projectID: project.id)
         else { return }
         let request = WorktreeKey(projectID: project.id, worktreeID: worktree.id)
         Task { await requestRemoveWorktree(worktree, in: project, request: request) }

--- a/Tests/MuxyTests/Models/Workspace/AppStateSelectProjectTests.swift
+++ b/Tests/MuxyTests/Models/Workspace/AppStateSelectProjectTests.swift
@@ -6,31 +6,71 @@ import Testing
 @Suite("AppState.selectProject")
 @MainActor
 struct AppStateSelectProjectTests {
-    @Test("selecting a new project notifies onProjectSelected")
+    @Test("selecting a new project notifies onWorkspaceSelected")
     func notifiesOnNewSelection() {
         let project = Project(name: "api", path: "/tmp/api")
         let worktree = Worktree(name: project.name, path: project.path, isPrimary: true)
         let appState = makeAppState()
-        var selected: [UUID] = []
-        appState.onProjectSelected = { selected.append($0) }
+        var selected: [WorktreeKey] = []
+        appState.onWorkspaceSelected = { selected.append($0) }
 
         appState.selectProject(project, worktree: worktree)
 
-        #expect(selected == [project.id])
+        #expect(selected == [WorktreeKey(projectID: project.id, worktreeID: worktree.id)])
     }
 
-    @Test("reselecting the active project does not notify again")
+    @Test("reselecting the active workspace does not notify again")
     func skipsNotificationWhenAlreadyActive() {
         let project = Project(name: "api", path: "/tmp/api")
         let worktree = Worktree(name: project.name, path: project.path, isPrimary: true)
         let appState = makeAppState()
-        var selected: [UUID] = []
-        appState.onProjectSelected = { selected.append($0) }
+        var selected: [WorktreeKey] = []
+        appState.onWorkspaceSelected = { selected.append($0) }
 
         appState.selectProject(project, worktree: worktree)
         appState.selectProject(project, worktree: worktree)
 
-        #expect(selected == [project.id])
+        #expect(selected == [WorktreeKey(projectID: project.id, worktreeID: worktree.id)])
+    }
+
+    @Test("selecting another worktree notifies onWorkspaceSelected")
+    func notifiesOnWorktreeSelection() {
+        let project = Project(name: "api", path: "/tmp/api")
+        let primary = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let feature = Worktree(name: "feature", path: "/tmp/api-feature", isPrimary: false)
+        let appState = makeAppState()
+        var selected: [WorktreeKey] = []
+        appState.onWorkspaceSelected = { selected.append($0) }
+
+        appState.selectProject(project, worktree: primary)
+        appState.selectWorktree(projectID: project.id, worktree: feature)
+
+        #expect(selected == [
+            WorktreeKey(projectID: project.id, worktreeID: primary.id),
+            WorktreeKey(projectID: project.id, worktreeID: feature.id),
+        ])
+    }
+
+    @Test("cycling projects notifies onWorkspaceSelected")
+    func notifiesWhenCyclingProjects() {
+        let projectA = Project(name: "api", path: "/tmp/api")
+        let projectB = Project(name: "web", path: "/tmp/web")
+        let worktreeA = Worktree(name: projectA.name, path: projectA.path, isPrimary: true)
+        let worktreeB = Worktree(name: projectB.name, path: projectB.path, isPrimary: true)
+        let appState = makeAppState()
+        var selected: [WorktreeKey] = []
+        appState.onWorkspaceSelected = { selected.append($0) }
+
+        appState.selectProject(projectA, worktree: worktreeA)
+        appState.selectNextProject(
+            projects: [projectA, projectB],
+            worktrees: [projectA.id: [worktreeA], projectB.id: [worktreeB]]
+        )
+
+        #expect(selected == [
+            WorktreeKey(projectID: projectA.id, worktreeID: worktreeA.id),
+            WorktreeKey(projectID: projectB.id, worktreeID: worktreeB.id),
+        ])
     }
 
     @Test("selecting projects swaps extension panels via the registry")

--- a/Tests/MuxyTests/Services/Mobile/RemoteDeviceStoreTests.swift
+++ b/Tests/MuxyTests/Services/Mobile/RemoteDeviceStoreTests.swift
@@ -26,6 +26,19 @@ struct RemoteDeviceStoreTests {
         #expect(try persistence.loadDevices().count == 1)
     }
 
+    @Test("mutations notify observers")
+    func mutationsNotifyObservers() {
+        let (store, _) = makeStore()
+        var changeCount = 0
+        store.onDevicesChanged = { changeCount += 1 }
+
+        let device = store.add(name: "Prod", ssh: SSHWorkspaceData(host: "example.com"))
+        store.update(id: device.id) { $0.ssh.remoteRoot = "/srv" }
+        store.remove(id: device.id)
+
+        #expect(changeCount == 3)
+    }
+
     @Test("device(id:) resolves a stored device and nil for unknown")
     func deviceLookup() {
         let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com"))

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -41,6 +41,20 @@ struct ProjectGroupStoreTests {
         #expect(changeCount == 2)
     }
 
+    @Test("remote project activity persists")
+    func remoteProjectActivityPersists() throws {
+        let remoteProject = RemoteProject(name: "API", path: "/srv/api")
+        let group = ProjectGroup(name: "Remote", type: .ssh, remoteProjects: [remoteProject])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+
+        store.markRemoteProjectActive(id: remoteProject.id)
+
+        let lastActiveAt = try #require(store.groups.first?.remoteProjects.first?.lastActiveAt)
+        let reloaded = makeStore(persistence: persistence)
+        #expect(reloaded.groups.first?.remoteProjects.first?.lastActiveAt == lastActiveAt)
+    }
+
     @Test("removeGroup deletes the group and persists")
     func removeGroup() {
         let group = ProjectGroup(name: "Work")

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -28,6 +28,19 @@ struct ProjectGroupStoreTests {
         #expect(persistence.savedGroups?.count == 1)
     }
 
+    @Test("project changes notify observers")
+    func projectChangesNotifyObservers() {
+        let persistence = ProjectGroupPersistenceStub()
+        let store = makeStore(persistence: persistence)
+        var changeCount = 0
+        store.onProjectsChanged = { changeCount += 1 }
+
+        let workspace = store.addRemoteWorkspace(name: "Remote", deviceID: UUID())
+        store.addRemoteProject(name: "API", path: "/srv/api", toGroup: workspace.id)
+
+        #expect(changeCount == 2)
+    }
+
     @Test("removeGroup deletes the group and persists")
     func removeGroup() {
         let group = ProjectGroup(name: "Work")

--- a/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
@@ -7,6 +7,62 @@ import Testing
 @Suite("WorktreeStore")
 @MainActor
 struct WorktreeStoreTests {
+    @Test("ensuring a primary worktree notifies observers")
+    func ensurePrimaryNotifiesObservers() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
+        var change: (projectID: UUID, worktreeID: UUID?)?
+        store.onWorktreesChanged = { change = ($0, $1) }
+
+        store.ensurePrimary(for: project)
+
+        #expect(change?.projectID == project.id)
+        #expect(change?.worktreeID == store.primary(for: project.id)?.id)
+    }
+
+    @Test("local path ownership wins over an identical remote path")
+    func localPathOwnershipWinsRemoteCollision() {
+        let sharedPath = "/workspace/api"
+        let local = Project(name: "Local", path: sharedPath)
+        let remote = RemoteProject(name: "Remote", path: sharedPath).asProject(
+            workspaceID: UUID(),
+            sortOrder: 0
+        )
+        let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
+
+        store.loadAll(projects: [local, remote])
+
+        #expect(store.projectID(forWorktreePath: sharedPath) == local.id)
+    }
+
+    @Test("removing a project notifies worktree observers")
+    func removingProjectNotifiesObservers() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
+        store.ensurePrimary(for: project)
+        var change: (projectID: UUID, worktreeID: UUID?)?
+        store.onWorktreesChanged = { change = ($0, $1) }
+
+        store.removeProject(project.id)
+
+        #expect(change?.projectID == project.id)
+        #expect(change?.worktreeID == nil)
+    }
+
+    @Test("restoring worktrees notifies observers")
+    func restoringWorktreesNotifiesObservers() {
+        let projectID = UUID()
+        let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
+        let worktree = Worktree(name: "Repo", path: "/tmp/repo", isPrimary: true)
+        var change: (projectID: UUID, worktreeID: UUID?)?
+        store.onWorktreesChanged = { change = ($0, $1) }
+
+        store.restoreProjectWorktrees([worktree], for: projectID)
+
+        #expect(change?.projectID == projectID)
+        #expect(change?.worktreeID == nil)
+    }
+
     @Test("Worktree decodes legacy records without source metadata")
     func worktreeLegacyDecodeDefaultsToMuxy() throws {
         let json = """

--- a/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
@@ -51,16 +51,38 @@ struct WorktreeStoreTests {
 
     @Test("restoring worktrees notifies observers")
     func restoringWorktreesNotifiesObservers() {
-        let projectID = UUID()
+        let project = Project(name: "Repo", path: "/tmp/repo")
         let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
         let worktree = Worktree(name: "Repo", path: "/tmp/repo", isPrimary: true)
         var change: (projectID: UUID, worktreeID: UUID?)?
         store.onWorktreesChanged = { change = ($0, $1) }
 
-        store.restoreProjectWorktrees([worktree], for: projectID)
+        store.restoreProjectWorktrees([worktree], for: project)
 
-        #expect(change?.projectID == projectID)
+        #expect(change?.projectID == project.id)
         #expect(change?.worktreeID == nil)
+    }
+
+    @Test("restoring local worktrees owns a path shared with a remote project")
+    func restoringLocalWorktreesOwnsSharedRemotePath() {
+        let sharedPath = "/workspace/api"
+        let local = Project(name: "Local", path: sharedPath)
+        let remote = RemoteProject(name: "Remote", path: sharedPath).asProject(
+            workspaceID: UUID(),
+            sortOrder: 0
+        )
+        let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
+
+        store.restoreProjectWorktrees(
+            [Worktree(name: remote.name, path: sharedPath, isPrimary: true)],
+            for: remote
+        )
+        store.restoreProjectWorktrees(
+            [Worktree(name: local.name, path: sharedPath, isPrimary: true)],
+            for: local
+        )
+
+        #expect(store.projectID(forWorktreePath: sharedPath) == local.id)
     }
 
     @Test("Worktree decodes legacy records without source metadata")

--- a/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/WorktreeStoreTests.swift
@@ -20,6 +20,20 @@ struct WorktreeStoreTests {
         #expect(change?.worktreeID == store.primary(for: project.id)?.id)
     }
 
+    @Test("worktree activity persists")
+    func worktreeActivityPersists() throws {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let worktree = Worktree(name: project.name, path: project.path, isPrimary: true)
+        let persistence = WorktreePersistenceStub(initial: [project.id: [worktree]])
+        let store = WorktreeStore(persistence: persistence, projects: [project])
+
+        store.markActive(projectID: project.id, worktreeID: worktree.id)
+
+        let lastActiveAt = try #require(store.worktree(projectID: project.id, worktreeID: worktree.id)?.lastActiveAt)
+        let reloaded = WorktreeStore(persistence: persistence, projects: [project])
+        #expect(reloaded.worktree(projectID: project.id, worktreeID: worktree.id)?.lastActiveAt == lastActiveAt)
+    }
+
     @Test("local path ownership wins over an identical remote path")
     func localPathOwnershipWinsRemoteCollision() {
         let sharedPath = "/workspace/api"
@@ -33,6 +47,23 @@ struct WorktreeStoreTests {
         store.loadAll(projects: [local, remote])
 
         #expect(store.projectID(forWorktreePath: sharedPath) == local.id)
+    }
+
+    @Test("project removal only blocks removal preparation for that project")
+    func projectRemovalOnlyBlocksOwnWorktreePreparation() async {
+        let sharedPath = "/workspace/feature"
+        let localProjectID = UUID()
+        let remoteProjectID = UUID()
+        let localWorktree = Worktree(name: "Local", path: sharedPath, isPrimary: false)
+        let remoteWorktree = Worktree(name: "Remote", path: sharedPath, isPrimary: false)
+        let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
+        store.add(localWorktree, to: localProjectID)
+        store.add(remoteWorktree, to: remoteProjectID, context: .ssh(SSHDestination(host: "example.com")))
+
+        #expect(await store.beginProjectRemoval(remoteProjectID))
+
+        #expect(store.beginRemovalPreparation(worktree: localWorktree, projectID: localProjectID))
+        #expect(!store.beginRemovalPreparation(worktree: remoteWorktree, projectID: remoteProjectID))
     }
 
     @Test("removing a project notifies worktree observers")
@@ -127,6 +158,7 @@ struct WorktreeStoreTests {
 
     @Test("removal preparation serializes a worktree removal lifecycle")
     func removalPreparationSerializesLifecycle() {
+        let projectID = UUID()
         let store = WorktreeStore(persistence: WorktreePersistenceStub(initial: [:]))
         let worktree = Worktree(
             name: "feature",
@@ -134,8 +166,8 @@ struct WorktreeStoreTests {
             isPrimary: false
         )
 
-        #expect(store.beginRemovalPreparation(worktree: worktree))
-        #expect(!store.beginRemovalPreparation(worktree: worktree))
+        #expect(store.beginRemovalPreparation(worktree: worktree, projectID: projectID))
+        #expect(!store.beginRemovalPreparation(worktree: worktree, projectID: projectID))
         #expect(store.hasRemovalPreparation)
         #expect(store.isPreparingRemoval(worktreeID: worktree.id))
         #expect(store.isRemovalInProgress(worktreeID: worktree.id))
@@ -158,7 +190,7 @@ struct WorktreeStoreTests {
         )
         store.add(worktree, to: projectID)
 
-        #expect(store.beginRemovalPreparation(worktree: worktree))
+        #expect(store.beginRemovalPreparation(worktree: worktree, projectID: projectID))
         #expect(store.isPreparingRemoval(worktreeID: worktree.id))
 
         store.remove(worktreeID: worktree.id, from: projectID)
@@ -177,7 +209,7 @@ struct WorktreeStoreTests {
             isPrimary: false
         )
         store.add(worktree, to: projectID)
-        _ = store.beginRemovalPreparation(worktree: worktree)
+        _ = store.beginRemovalPreparation(worktree: worktree, projectID: projectID)
 
         store.removeProject(projectID)
 


### PR DESCRIPTION
## Summary

Adds the workspace state foundations required by global extension overview screens.

## Changes

- persist recent activity for remote projects and worktrees
- support local and remote projects sharing the same worktree path without losing ownership
- preserve local-project precedence when worktrees are restored without a prior store load
- expose project, device, and worktree mutation callbacks for later extension invalidation wiring
- cover observer delivery, restoration invalidation, removal invalidation, and path-collision behavior

## Testing

- `scripts/checks.sh --fix` completed formatting, linting, and build; the full test run hit one unrelated timing-sensitive `NotificationStoreTests` failure under concurrent suite contention
- `swift test --filter WorktreeStoreTests` (24 tests passed)
- `swift test --filter NotificationStoreTests` (6 tests passed in isolation)
- `git diff --check`

## Screenshots

Not applicable; this PR has no UI changes.

## Split Plan

This replaces #1041 with a focused review scope.

1. **This PR:** workspace overview state foundations
2. #1055: extension home view manifest contract (independent; can merge in either order)
3. Extension workspace overview APIs, prepared on `pedrommone:feature/1040-extension-overview-api` and to open after this PR merges
4. Global extension home presentation, prepared on `pedrommone:feature/1040-extension-home-presentation` and to open after its prerequisites merge

## Related

Replaces #1041
Related to #1040

## AI Contribution

Contributed with OpenAI GPT-5.6 Sol (`openai/gpt-5.6-sol`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added activity tracking for remote projects and worktrees.
  * Improved workspace selection and restoration across projects and worktrees.
  * Added change notifications for devices, projects, and worktrees.
  * Activity updates and worktree changes are saved automatically.

* **Bug Fixes**
  * Improved handling of shared paths and failed project restoration.
  * Ensured notifications are sent after save attempts, including failures.
  * Improved extension output handling to prevent missing or duplicated data.

* **Tests**
  * Added coverage for activity tracking, notifications, restoration, selection, and shared-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->