### PR TITLE
Fix split-pane agent indicators

### DIFF
--- a/Muxy/Models/Terminal/TabIndicatorPolicy.swift
+++ b/Muxy/Models/Terminal/TabIndicatorPolicy.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum TabIndicatorPolicy {
+    static func agentStatus(from statuses: [AgentStatus]) -> AgentStatus? {
+        if statuses.contains(.waiting) {
+            return .waiting
+        }
+        if statuses.contains(.working) {
+            return .working
+        }
+        return statuses.first
+    }
+
+    static func showsAttentionDot(isActive: Bool, hasAttention: Bool, hasUnfocusedAttention: Bool) -> Bool {
+        isActive ? hasUnfocusedAttention : hasAttention
+    }
+
+    static func newlyPendingPaneIDs(previous: Set<UUID>, current: Set<UUID>) -> Set<UUID> {
+        current.subtracting(previous)
+    }
+
+    static func completionPaneIDToClear(
+        isActive: Bool,
+        focusedPaneID: UUID?,
+        newlyPendingPaneIDs: Set<UUID>
+    ) -> UUID? {
+        guard isActive,
+              let focusedPaneID,
+              newlyPendingPaneIDs.contains(focusedPaneID)
+        else { return nil }
+        return focusedPaneID
+    }
+}

--- a/Muxy/Views/Layouts/TabFocused/AgentsFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/AgentsFocusedTabsList.swift
@@ -45,13 +45,16 @@ struct AgentsFocusedTabsList: View {
             ForEach(tabBlocks) { block in
                 VStack(spacing: 0) {
                     ForEach(block.locations) { location in
+                        let active = isActive(location)
                         TabFocusedTabRow(
                             project: project,
                             area: location.area,
                             tab: location.tab,
                             relatedTabs: [location.tab],
                             topLevelTabs: topLevelTabs,
-                            active: isActive(location),
+                            active: active,
+                            focusedTabID: active ? location.tab.id : nil,
+                            focusedPaneID: active ? location.tab.content.pane?.id : nil,
                             worktree: worktree
                         )
                     }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedTabsList.swift
@@ -218,6 +218,14 @@ struct TabFocusedTabsList: View {
         return appState.activeTopLevelTabID(for: worktreeKey)
     }
 
+    private var focusedTab: TerminalTab? {
+        guard appState.activeProjectID == project.id,
+              appState.activeWorktreeID[project.id] == worktree.id,
+              let areaID = appState.focusedAreaID[worktreeKey]
+        else { return nil }
+        return appState.workspaceRoots[worktreeKey]?.findArea(id: areaID)?.activeTab
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             tabRows(areaTabs, numbers: shortcutNumbers)
@@ -238,6 +246,8 @@ struct TabFocusedTabsList: View {
                 relatedTabs: item.relatedTabs,
                 topLevelTabs: areaTabs.map { ($0.area, $0.tab) },
                 active: item.tab.id == activeTabID,
+                focusedTabID: focusedTab?.id,
+                focusedPaneID: focusedTab?.content.pane?.id,
                 worktree: item.worktree,
                 shortcutNumber: numbers[item.tab.id]
             )
@@ -334,6 +344,8 @@ struct TabFocusedTabRow: View {
     let relatedTabs: [TerminalTab]
     let topLevelTabs: [(area: TabArea, tab: TerminalTab)]
     let active: Bool
+    let focusedTabID: UUID?
+    let focusedPaneID: UUID?
     var worktree: Worktree?
     var shortcutNumber: Int?
 
@@ -354,7 +366,7 @@ struct TabFocusedTabRow: View {
     @State private var notificationStore = NotificationStore.shared
 
     private var paneProgress: TerminalProgress? {
-        relatedTabs.compactMap { $0.content.pane?.id }
+        relatedPaneIDs
             .compactMap { progressStore.progress(for: $0) }
             .first
     }
@@ -364,14 +376,35 @@ struct TabFocusedTabRow: View {
     }
 
     private var hasCompletionPending: Bool {
-        relatedTabs.compactMap { $0.content.pane?.id }.contains {
+        !completionPendingPaneIDs.isEmpty
+    }
+
+    private var completionPendingPaneIDs: Set<UUID> {
+        Set(relatedPaneIDs.filter {
             progressStore.isCompletionPending(for: $0)
                 || AgentStatusStore.shared.isCompletionPending(forPane: $0)
-        }
+        })
+    }
+
+    private var relatedPaneIDs: [UUID] {
+        relatedTabs.compactMap { $0.content.pane?.id }
+    }
+
+    private var unreadTabIDs: [UUID] {
+        relatedTabs.filter { notificationStore.hasUnread(tabID: $0.id) }.map(\.id)
     }
 
     private var hasUnread: Bool {
-        relatedTabs.contains { notificationStore.hasUnread(tabID: $0.id) }
+        !unreadTabIDs.isEmpty
+    }
+
+    private var hasUnreadOutsideFocusedTab: Bool {
+        guard let focusedTabID else { return hasUnread }
+        return unreadTabIDs.contains { $0 != focusedTabID }
+    }
+
+    private var hasCompletionOutsideFocusedPane: Bool {
+        completionPendingPaneIDs.contains { $0 != focusedPaneID }
     }
 
     private var isIdle: Bool {
@@ -383,14 +416,18 @@ struct TabFocusedTabRow: View {
         let statuses = relatedTabs.compactMap { tab in
             AgentStatusStore.shared.status(forPane: tab.content.pane?.id)
         }
-        return statuses.contains(.waiting) ? .waiting : statuses.first
+        return TabIndicatorPolicy.agentStatus(from: statuses)
     }
 
     private var statusDotColor: Color? {
         if agentStatus == .waiting {
             return MuxyTheme.warning
         }
-        if !active, hasUnread || hasCompletionPending {
+        if TabIndicatorPolicy.showsAttentionDot(
+            isActive: active,
+            hasAttention: hasUnread || hasCompletionPending,
+            hasUnfocusedAttention: hasUnreadOutsideFocusedTab || hasCompletionOutsideFocusedPane
+        ) {
             return MuxyTheme.accent
         }
         return nil
@@ -513,9 +550,13 @@ struct TabFocusedTabRow: View {
         .contentShape(RoundedRectangle(cornerRadius: TabFocusedSidebarMetrics.rowCornerRadius, style: .continuous))
         .onHover { hovered = $0 }
         .onTapGesture { select() }
-        .onChange(of: hasCompletionPending) { _, pending in
-            guard pending else { return }
-            triggerCompletionFlash()
+        .onChange(of: completionPendingPaneIDs) { previous, current in
+            let newlyPendingPaneIDs = TabIndicatorPolicy.newlyPendingPaneIDs(
+                previous: previous,
+                current: current
+            )
+            guard !newlyPendingPaneIDs.isEmpty else { return }
+            triggerCompletionFlash(newlyPendingPaneIDs: newlyPendingPaneIDs)
         }
         .onDisappear { flashTask?.cancel() }
         .overlay {
@@ -653,8 +694,7 @@ struct TabFocusedTabRow: View {
     private var leadingIcon: some View {
         switch tab.kind {
         case .terminal:
-            let paneIDs = relatedTabs.compactMap { $0.content.pane?.id }
-            let agentIconName = AgentPaneIdentity.iconName(forPanes: paneIDs)
+            let agentIconName = AgentPaneIdentity.iconName(forPanes: relatedPaneIDs)
             if let agentIconName {
                 ProviderIconView(iconName: agentIconName, size: UIMetrics.iconMD)
             } else {
@@ -689,16 +729,18 @@ struct TabFocusedTabRow: View {
         }
     }
 
-    private func triggerCompletionFlash() {
+    private func triggerCompletionFlash(newlyPendingPaneIDs: Set<UUID>) {
         flashTask?.cancel()
         withAnimation(.easeIn(duration: 0.15)) {
             completionFlashOn = true
         }
-        if active {
-            for paneID in relatedTabs.compactMap({ $0.content.pane?.id }) {
-                progressStore.clearCompletion(for: paneID)
-                AgentStatusStore.shared.clearCompletion(for: paneID)
-            }
+        if let paneID = TabIndicatorPolicy.completionPaneIDToClear(
+            isActive: active,
+            focusedPaneID: focusedPaneID,
+            newlyPendingPaneIDs: newlyPendingPaneIDs
+        ) {
+            progressStore.clearCompletion(for: paneID)
+            AgentStatusStore.shared.clearCompletion(for: paneID)
         }
         flashTask = Task { @MainActor in
             try await Task.sleep(for: .milliseconds(450))

--- a/Muxy/Views/Workspace/TabStrip.swift
+++ b/Muxy/Views/Workspace/TabStrip.swift
@@ -7,6 +7,7 @@ struct PaneTabStrip: View {
         let id: UUID
         let paneID: UUID?
         let relatedPaneIDs: [UUID]
+        let unreadTabIDs: [UUID]
         let title: String
         let kind: TerminalTab.Kind
         let isPinned: Bool
@@ -19,10 +20,13 @@ struct PaneTabStrip: View {
         let faviconImage: NSImage?
         let detectedAgentIconName: String?
         let agentStatus: AgentStatus?
-        let hasUnread: Bool
 
         var hasCustomTitle: Bool {
             customTitle != nil
+        }
+
+        var hasUnread: Bool {
+            !unreadTabIDs.isEmpty
         }
     }
 
@@ -30,6 +34,8 @@ struct PaneTabStrip: View {
     let tabs: [TabSnapshot]
     let activeTabID: UUID?
     let isFocused: Bool
+    let focusedTabID: UUID?
+    let focusedPaneID: UUID?
     var isWindowTitleBar: Bool = false
     var showsWindowTopbarActions = true
     var showDevelopmentBadge = false
@@ -68,13 +74,13 @@ struct PaneTabStrip: View {
             let panes = relatedTabs.compactMap(\.content.pane)
             let paneIDs = panes.map(\.id)
             let agentStatuses = paneIDs.compactMap { AgentStatusStore.shared.status(forPane: $0) }
-            let agentStatus = agentStatuses.contains(.waiting)
-                ? AgentStatus.waiting
-                : agentStatuses.first
             return TabSnapshot(
                 id: tab.id,
                 paneID: tab.content.pane?.id,
                 relatedPaneIDs: paneIDs,
+                unreadTabIDs: relatedTabs.filter {
+                    NotificationStore.shared.hasUnread(tabID: $0.id)
+                }.map(\.id),
                 title: tab.localizedTitle,
                 kind: tab.kind,
                 isPinned: tab.isPinned,
@@ -86,8 +92,7 @@ struct PaneTabStrip: View {
                 isOffline: !panes.isEmpty && panes.allSatisfy(\.isOffline),
                 faviconImage: tab.content.browserState?.faviconImage,
                 detectedAgentIconName: AgentPaneIdentity.iconName(forPanes: paneIDs),
-                agentStatus: agentStatus,
-                hasUnread: relatedTabs.contains { NotificationStore.shared.hasUnread(tabID: $0.id) }
+                agentStatus: TabIndicatorPolicy.agentStatus(from: agentStatuses)
             )
         }
     }
@@ -188,6 +193,8 @@ struct PaneTabStrip: View {
                     tab: tab,
                     active: tab.id == activeTabID,
                     paneFocused: isFocused,
+                    focusedTabID: focusedTabID,
+                    focusedPaneID: focusedPaneID,
                     areaID: areaID,
                     hasUnread: tab.hasUnread,
                     isAnyDragging: dragState.draggedID != nil,
@@ -389,6 +396,8 @@ private struct TabCell: View {
     let tab: PaneTabStrip.TabSnapshot
     let active: Bool
     let paneFocused: Bool
+    let focusedTabID: UUID?
+    let focusedPaneID: UUID?
     let areaID: UUID
     var hasUnread: Bool = false
     var isAnyDragging: Bool = false
@@ -465,17 +474,34 @@ private struct TabCell: View {
     }
 
     private var hasCompletionPending: Bool {
-        tab.relatedPaneIDs.contains {
+        !completionPendingPaneIDs.isEmpty
+    }
+
+    private var completionPendingPaneIDs: Set<UUID> {
+        Set(tab.relatedPaneIDs.filter {
             progressStore.isCompletionPending(for: $0)
                 || AgentStatusStore.shared.isCompletionPending(forPane: $0)
-        }
+        })
+    }
+
+    private var hasUnreadOutsideFocusedTab: Bool {
+        guard let focusedTabID else { return hasUnread }
+        return tab.unreadTabIDs.contains { $0 != focusedTabID }
+    }
+
+    private var hasCompletionOutsideFocusedPane: Bool {
+        completionPendingPaneIDs.contains { $0 != focusedPaneID }
     }
 
     private var statusDotColor: Color? {
         if tab.agentStatus == .waiting {
             return MuxyTheme.warning
         }
-        if !active, hasUnread || hasCompletionPending {
+        if TabIndicatorPolicy.showsAttentionDot(
+            isActive: active,
+            hasAttention: hasUnread || hasCompletionPending,
+            hasUnfocusedAttention: hasUnreadOutsideFocusedTab || hasCompletionOutsideFocusedPane
+        ) {
             return MuxyTheme.accent
         }
         return nil
@@ -628,9 +654,13 @@ private struct TabCell: View {
         .onChange(of: externalDragOverCell) { _, hovering in
             handleExternalDragHover(hovering: hovering)
         }
-        .onChange(of: hasCompletionPending) { _, pending in
-            guard pending else { return }
-            triggerCompletionFlash()
+        .onChange(of: completionPendingPaneIDs) { previous, current in
+            let newlyPendingPaneIDs = TabIndicatorPolicy.newlyPendingPaneIDs(
+                previous: previous,
+                current: current
+            )
+            guard !newlyPendingPaneIDs.isEmpty else { return }
+            triggerCompletionFlash(newlyPendingPaneIDs: newlyPendingPaneIDs)
         }
         .onDisappear {
             springLoadTask?.cancel()
@@ -672,16 +702,18 @@ private struct TabCell: View {
         .frame(width: UIMetrics.iconMD, height: UIMetrics.iconMD)
     }
 
-    private func triggerCompletionFlash() {
+    private func triggerCompletionFlash(newlyPendingPaneIDs: Set<UUID>) {
         flashTask?.cancel()
         withAnimation(.easeIn(duration: 0.15)) {
             completionFlashOn = true
         }
-        if active {
-            for paneID in tab.relatedPaneIDs {
-                progressStore.clearCompletion(for: paneID)
-                AgentStatusStore.shared.clearCompletion(for: paneID)
-            }
+        if let paneID = TabIndicatorPolicy.completionPaneIDToClear(
+            isActive: active,
+            focusedPaneID: focusedPaneID,
+            newlyPendingPaneIDs: newlyPendingPaneIDs
+        ) {
+            progressStore.clearCompletion(for: paneID)
+            AgentStatusStore.shared.clearCompletion(for: paneID)
         }
         flashTask = Task { @MainActor in
             try await Task.sleep(for: .milliseconds(450))

--- a/Muxy/Views/Workspace/TopLevelTabGroupStrip.swift
+++ b/Muxy/Views/Workspace/TopLevelTabGroupStrip.swift
@@ -29,6 +29,17 @@ struct TopLevelTabGroupStrip: View {
         appState.visibleLayout(for: worktreeKey, groupID: groupID)
     }
 
+    private var isFocused: Bool {
+        appState.activeTopLevelTabID(for: worktreeKey) == group?.activeTabID
+    }
+
+    private var focusedTab: TerminalTab? {
+        guard isFocused,
+              let focusedAreaID = appState.focusedAreaID[worktreeKey]
+        else { return nil }
+        return root?.findArea(id: focusedAreaID)?.activeTab
+    }
+
     private var targetAreaID: UUID? {
         let panes = visibleLayout?.allPanes() ?? []
         if appState.activeTopLevelTabID(for: worktreeKey) == group?.activeTabID,
@@ -60,7 +71,9 @@ struct TopLevelTabGroupStrip: View {
                     including: root.allTabs()
                 ),
                 activeTabID: group.activeTabID,
-                isFocused: appState.activeTopLevelTabID(for: worktreeKey) == group.activeTabID,
+                isFocused: isFocused,
+                focusedTabID: focusedTab?.id,
+                focusedPaneID: focusedTab?.content.pane?.id,
                 isWindowTitleBar: isWindowTitleBar,
                 showsWindowTopbarActions: showsWindowTopbarActions,
                 showDevelopmentBadge: showDevelopmentBadge,

--- a/Tests/MuxyTests/Models/Terminal/TabIndicatorPolicyTests.swift
+++ b/Tests/MuxyTests/Models/Terminal/TabIndicatorPolicyTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("TabIndicatorPolicy")
+@MainActor
+struct TabIndicatorPolicyTests {
+    @Test("working child overrides an idle parent")
+    func workingChildOverridesIdleParent() {
+        #expect(TabIndicatorPolicy.agentStatus(from: [.idle, .working]) == .working)
+        #expect(TabIndicatorPolicy.agentStatus(from: [.working, .idle]) == .working)
+    }
+
+    @Test("waiting pane remains the highest tab attention state")
+    func waitingPaneWins() {
+        #expect(TabIndicatorPolicy.agentStatus(from: [.idle, .working, .waiting]) == .waiting)
+        #expect(TabIndicatorPolicy.agentStatus(from: [.waiting, .working]) == .waiting)
+    }
+
+    @Test("idle and empty pane groups retain their stable status")
+    func idleAndEmptyGroups() {
+        #expect(TabIndicatorPolicy.agentStatus(from: [.idle, .idle]) == .idle)
+        #expect(TabIndicatorPolicy.agentStatus(from: []) == nil)
+    }
+
+    @Test("active tabs show attention from an unfocused child")
+    func activeTabsShowUnfocusedAttention() {
+        #expect(TabIndicatorPolicy.showsAttentionDot(
+            isActive: true,
+            hasAttention: true,
+            hasUnfocusedAttention: true
+        ))
+        #expect(!TabIndicatorPolicy.showsAttentionDot(
+            isActive: true,
+            hasAttention: true,
+            hasUnfocusedAttention: false
+        ))
+        #expect(TabIndicatorPolicy.showsAttentionDot(
+            isActive: false,
+            hasAttention: true,
+            hasUnfocusedAttention: false
+        ))
+    }
+
+    @Test("completion clears only the focused related pane")
+    func completionClearsFocusedRelatedPane() {
+        let focusedPaneID = UUID()
+        let siblingPaneID = UUID()
+
+        #expect(TabIndicatorPolicy.completionPaneIDToClear(
+            isActive: true,
+            focusedPaneID: focusedPaneID,
+            newlyPendingPaneIDs: [focusedPaneID, siblingPaneID]
+        ) == focusedPaneID)
+        #expect(TabIndicatorPolicy.completionPaneIDToClear(
+            isActive: false,
+            focusedPaneID: focusedPaneID,
+            newlyPendingPaneIDs: [focusedPaneID, siblingPaneID]
+        ) == nil)
+        #expect(TabIndicatorPolicy.completionPaneIDToClear(
+            isActive: true,
+            focusedPaneID: focusedPaneID,
+            newlyPendingPaneIDs: [siblingPaneID]
+        ) == nil)
+    }
+
+    @Test("sequential sibling completions acknowledge the newly completed focused pane")
+    func sequentialSiblingCompletions() {
+        let store = TerminalProgressStore()
+        let focusedPaneID = UUID()
+        let siblingPaneID = UUID()
+        let paneIDs = [focusedPaneID, siblingPaneID]
+        let worktreeKey = WorktreeKey(projectID: UUID(), worktreeID: UUID())
+
+        func pendingPaneIDs() -> Set<UUID> {
+            Set(paneIDs.filter { store.isCompletionPending(for: $0) })
+        }
+
+        store.setProgress(.clamping(kind: .indeterminate, percent: nil), for: siblingPaneID, worktreeKey: worktreeKey)
+        store.setProgress(nil, for: siblingPaneID, worktreeKey: worktreeKey)
+        let siblingPendingPaneIDs = pendingPaneIDs()
+
+        #expect(TabIndicatorPolicy.newlyPendingPaneIDs(
+            previous: [],
+            current: siblingPendingPaneIDs
+        ) == [siblingPaneID])
+
+        store.setProgress(.clamping(kind: .indeterminate, percent: nil), for: focusedPaneID, worktreeKey: worktreeKey)
+        store.setProgress(nil, for: focusedPaneID, worktreeKey: worktreeKey)
+        let allPendingPaneIDs = pendingPaneIDs()
+        let newlyPendingPaneIDs = TabIndicatorPolicy.newlyPendingPaneIDs(
+            previous: siblingPendingPaneIDs,
+            current: allPendingPaneIDs
+        )
+        let paneIDToClear = TabIndicatorPolicy.completionPaneIDToClear(
+            isActive: true,
+            focusedPaneID: focusedPaneID,
+            newlyPendingPaneIDs: newlyPendingPaneIDs
+        )
+
+        #expect(newlyPendingPaneIDs == [focusedPaneID])
+        #expect(paneIDToClear == focusedPaneID)
+        if let paneIDToClear {
+            store.clearCompletion(for: paneIDToClear)
+        }
+        #expect(!store.isCompletionPending(for: focusedPaneID))
+        #expect(store.isCompletionPending(for: siblingPaneID))
+    }
+}


### PR DESCRIPTION
## Summary

- Keep OpenCode agent activity visible when a top-level tab owns multiple child panes.
- Preserve completion and unread attention for unfocused sibling panes.
- Acknowledge completion only for the newly completed focused pane.

## Changes

- Aggregate related pane status with waiting, working, and idle precedence.
- Pass actual focused child tab and pane identity into tab indicator rendering.
- Observe pending pane identity transitions instead of one aggregate Boolean.
- Add policy and TerminalProgressStore regression coverage for sequential sibling completions.

## Testing

- scripts/checks.sh --fix
- 3,365 tests passed

## AI Attribution

- Generated with OpenAI gpt-5.6-sol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab indicators to accurately reflect agent status, unread activity, and pending completions.
  * Attention dots now distinguish activity outside the focused tab or pane.
  * Completion flashes are shown only for newly pending panes.
  * Completion states are cleared only for the selected pane, preventing unrelated indicators from disappearing.
* **Tests**
  * Added coverage for indicator priority, attention visibility, and sequential completion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->