### PR TITLE
Add opt-in local performance profiler

### DIFF
--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -425,6 +425,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: ["ApplePressAndHoldEnabled": false])
         SentryService.shared.start()
+        ProfilerService.shared.configure()
         NSWindow.allowsAutomaticWindowTabbing = false
         NSApp.setActivationPolicy(.regular)
         DispatchQueue.main.async {

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -306,6 +306,7 @@
 "Extensions can add tabs, panels, popovers, top-bar and status-bar items, palette commands, and workspace automation. [Read the extension docs](https://muxy.app/docs/extensions/overview)." = "Extensions can add tabs, panels, popovers, top-bar and status-bar items, palette commands, and workspace automation. [Read the extension docs](https://muxy.app/docs/extensions/overview).";
 "Device" = "Device";
 "Diagnostics" = "Diagnostics";
+"Crash reports are sent only with your permission. Performance samples record CPU, memory, profiler uptime, app and macOS versions, device architecture, and timestamps once per minute. They stay on this Mac unless you share the file. Project paths, file contents, terminal output, and commands are never recorded." = "Crash reports are sent only with your permission. Performance samples record CPU, memory, profiler uptime, app and macOS versions, device architecture, and timestamps once per minute. They stay on this Mac unless you share the file. Project paths, file contents, terminal output, and commands are never recorded.";
 "Disable Periodic Logging" = "Disable Periodic Logging";
 "Disable extension" = "Disable extension";
 "Disabled" = "Disabled";
@@ -637,7 +638,10 @@
 "Previous Tab" = "Previous Tab";
 "Previous Tip" = "Previous Tip";
 "Primary worktree" = "Primary worktree";
+"Performance samples record CPU, memory, profiler uptime, app and macOS versions, device architecture, and timestamps once per minute. They stay on this Mac unless you share the file. Project paths, file contents, terminal output, and commands are never recorded." = "Performance samples record CPU, memory, profiler uptime, app and macOS versions, device architecture, and timestamps once per minute. They stay on this Mac unless you share the file. Project paths, file contents, terminal output, and commands are never recorded.";
 "Profile name" = "Profile name";
+"Profiler Data" = "Profiler Data";
+"Profiler data" = "Profiler data";
 "Profiles" = "Profiles";
 "Project %lld" = "Project %lld";
 "Project 1" = "Project 1";
@@ -678,7 +682,10 @@
 "Recently Added" = "Recently Added";
 "Recently Removed" = "Recently Removed";
 "Recently Removed Projects" = "Recently Removed Projects";
+"Record Anonymous Performance Samples" = "Record Anonymous Performance Samples";
+"Record anonymous performance samples" = "Record anonymous performance samples";
 "Record Custom…" = "Record Custom…";
+"Records local CPU and memory samples for diagnosing long-running performance issues." = "Records local CPU and memory samples for diagnosing long-running performance issues.";
 "Refresh" = "Refresh";
 "Refresh Worktrees" = "Refresh Worktrees";
 "Refresh pull request" = "Refresh pull request";
@@ -744,6 +751,7 @@
 "Reveal Log" = "Reveal Log";
 "Reveal Logs Folder" = "Reveal Logs Folder";
 "Reveal in Finder" = "Reveal in Finder";
+"Reveals the local JSONL performance profile in Finder for manual sharing." = "Reveals the local JSONL performance profile in Finder for manual sharing.";
 "Revoke" = "Revoke";
 "Revoke %@?" = "Revoke %@?";
 "Revoke %lld devices?" = "Revoke %lld devices?";

--- a/Muxy/Services/Diagnostics/ProfilerJSONLWriter.swift
+++ b/Muxy/Services/Diagnostics/ProfilerJSONLWriter.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+protocol ProfilerRecordWriting: Sendable {
+    var fileURL: URL { get }
+    func startSession(_ session: ProfilerSessionRecord) throws
+    func append(_ sample: ProfilerSampleRecord, session: ProfilerSessionRecord) throws
+}
+
+final class ProfilerJSONLWriter: ProfilerRecordWriting, @unchecked Sendable {
+    static let maximumFileSize = 25 * 1024 * 1024
+
+    let fileURL: URL
+
+    private let directoryURL: URL
+    private let maximumFileSize: Int
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL,
+        maximumFileSize: Int = ProfilerJSONLWriter.maximumFileSize,
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        directoryURL = fileURL.deletingLastPathComponent()
+        self.maximumFileSize = maximumFileSize
+        self.fileManager = fileManager
+    }
+
+    func startSession(_ session: ProfilerSessionRecord) throws {
+        try prepareStorage()
+        try appendLine(ProfilerRecordEncoder.encode(session), rolloverSession: session)
+    }
+
+    func append(_ sample: ProfilerSampleRecord, session: ProfilerSessionRecord) throws {
+        try prepareStorage()
+        try appendLine(ProfilerRecordEncoder.encode(sample), rolloverSession: session)
+    }
+
+    private func prepareStorage() throws {
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directoryURL.path)
+
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+    }
+
+    private func appendLine(_ record: Data, rolloverSession: ProfilerSessionRecord) throws {
+        let existingSize = try repairTrailingRecordIfNeeded()
+        let sessionLine = try ProfilerRecordEncoder.encode(rolloverSession)
+        if existingSize == 0, record != sessionLine {
+            try replaceFile(with: record, session: rolloverSession)
+            return
+        }
+        let appendedSize = existingSize + record.count + 1
+
+        if appendedSize > maximumFileSize {
+            try replaceFile(with: record, session: rolloverSession)
+            return
+        }
+
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            guard fileManager.createFile(
+                atPath: fileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
+            else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+
+        var line = record
+        line.append(0x0A)
+        let handle = try FileHandle(forWritingTo: fileURL)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: line)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+    }
+
+    private func replaceFile(with record: Data, session: ProfilerSessionRecord) throws {
+        let sessionLine = try ProfilerRecordEncoder.encode(session)
+        var replacement = Data()
+        replacement.append(sessionLine)
+        replacement.append(0x0A)
+        if record != sessionLine {
+            replacement.append(record)
+            replacement.append(0x0A)
+        }
+        try replacement.write(to: fileURL, options: .atomic)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+    }
+
+    private func repairTrailingRecordIfNeeded() throws -> Int {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return 0 }
+        let handle = try FileHandle(forUpdating: fileURL)
+        defer { try? handle.close() }
+        let end = try handle.seekToEnd()
+        guard end > 0 else { return 0 }
+
+        try handle.seek(toOffset: end - 1)
+        guard try handle.read(upToCount: 1) != Data([0x0A]) else { return Int(end) }
+
+        let recordStart = try trailingRecordStart(in: handle, endOffset: end)
+        try handle.seek(toOffset: recordStart)
+        let trailingData = try handle.readToEnd() ?? Data()
+        if (try? JSONSerialization.jsonObject(with: trailingData)) != nil {
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data([0x0A]))
+            return Int(end) + 1
+        }
+
+        try handle.truncate(atOffset: recordStart)
+        return Int(recordStart)
+    }
+
+    private func trailingRecordStart(in handle: FileHandle, endOffset: UInt64) throws -> UInt64 {
+        let chunkSize: UInt64 = 4096
+        var searchEnd = endOffset
+        while searchEnd > 0 {
+            let searchStart = searchEnd > chunkSize ? searchEnd - chunkSize : 0
+            try handle.seek(toOffset: searchStart)
+            let data = try handle.read(upToCount: Int(searchEnd - searchStart)) ?? Data()
+            if let newlineIndex = data.lastIndex(of: 0x0A) {
+                return searchStart + UInt64(newlineIndex) + 1
+            }
+            searchEnd = searchStart
+        }
+        return 0
+    }
+}

--- a/Muxy/Services/Diagnostics/ProfilerRecorder.swift
+++ b/Muxy/Services/Diagnostics/ProfilerRecorder.swift
@@ -1,0 +1,219 @@
+import Darwin
+import Foundation
+import os
+
+private let profilerLogger = Logger(subsystem: "app.muxy", category: "Profiler")
+
+protocol ProfilerRecording: AnyObject {
+    var fileURL: URL { get }
+    func start()
+    func stop()
+}
+
+protocol ProfilerClock: Sendable {
+    func now() -> Date
+    func monotonicNanoseconds() -> UInt64
+}
+
+protocol ProfilerProcessSampling: Sendable {
+    func sample() throws -> ProfilerProcessMeasurement
+}
+
+protocol ProfilerSessionProviding: Sendable {
+    func session(timestamp: Date, samplingInterval: TimeInterval) -> ProfilerSessionRecord
+}
+
+struct SystemProfilerClock: ProfilerClock {
+    func now() -> Date {
+        Date()
+    }
+
+    func monotonicNanoseconds() -> UInt64 {
+        clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+    }
+}
+
+struct CurrentProcessProfilerSampler: ProfilerProcessSampling {
+    func sample() throws -> ProfilerProcessMeasurement {
+        var info = rusage_info_v4()
+        let result = withUnsafeMutablePointer(to: &info) { pointer -> Int32 in
+            pointer.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { rebound in
+                proc_pid_rusage(getpid(), RUSAGE_INFO_V4, rebound)
+            }
+        }
+        guard result == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return ProfilerProcessMeasurement(
+            cumulativeCPUNanoseconds: info.ri_user_time &+ info.ri_system_time,
+            physicalFootprintBytes: info.ri_phys_footprint
+        )
+    }
+}
+
+struct BundleProfilerSessionProvider: ProfilerSessionProviding {
+    private let bundle: Bundle
+    private let processInfo: ProcessInfo
+
+    init(bundle: Bundle = .main, processInfo: ProcessInfo = .processInfo) {
+        self.bundle = bundle
+        self.processInfo = processInfo
+    }
+
+    func session(timestamp: Date, samplingInterval: TimeInterval) -> ProfilerSessionRecord {
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+        let operatingSystem = processInfo.operatingSystemVersion
+        let macOSVersion = "\(operatingSystem.majorVersion).\(operatingSystem.minorVersion).\(operatingSystem.patchVersion)"
+        return ProfilerSessionRecord(
+            timestamp: timestamp,
+            appVersion: version,
+            appBuild: build,
+            macOSVersion: macOSVersion,
+            architecture: Self.architecture,
+            samplingIntervalSeconds: samplingInterval
+        )
+    }
+
+    private static var architecture: String {
+        #if arch(arm64)
+        "arm64"
+        #elseif arch(x86_64)
+        "x86_64"
+        #else
+        "unknown"
+        #endif
+    }
+}
+
+final class DefaultProfilerRecorder: ProfilerRecording, @unchecked Sendable {
+    let fileURL: URL
+
+    private let samplingInterval: TimeInterval
+    private let queue: DispatchQueue
+    private let clock: any ProfilerClock
+    private let sampler: any ProfilerProcessSampling
+    private let writer: any ProfilerRecordWriting
+    private let sessionProvider: any ProfilerSessionProviding
+
+    private var timer: DispatchSourceTimer?
+    private var session: ProfilerSessionRecord?
+    private var sampleBuilder: ProfilerSampleBuilder?
+    private var isRunning = false
+
+    init(
+        samplingInterval: TimeInterval = 60,
+        queue: DispatchQueue = DispatchQueue(label: "app.muxy.profiler", qos: .utility),
+        clock: any ProfilerClock = SystemProfilerClock(),
+        sampler: any ProfilerProcessSampling = CurrentProcessProfilerSampler(),
+        writer: any ProfilerRecordWriting,
+        sessionProvider: any ProfilerSessionProviding = BundleProfilerSessionProvider()
+    ) {
+        self.samplingInterval = samplingInterval
+        self.queue = queue
+        self.clock = clock
+        self.sampler = sampler
+        self.writer = writer
+        self.sessionProvider = sessionProvider
+        fileURL = writer.fileURL
+    }
+
+    func start() {
+        queue.async { [weak self] in
+            self?.startOnQueue()
+        }
+    }
+
+    func stop() {
+        queue.async { [weak self] in
+            self?.stopOnQueue()
+        }
+    }
+
+    private func startOnQueue() {
+        guard !isRunning else { return }
+        timer?.cancel()
+        timer = nil
+        isRunning = true
+
+        do {
+            let sessionStart = clock.monotonicNanoseconds()
+            let currentSession = sessionProvider.session(
+                timestamp: clock.now(),
+                samplingInterval: samplingInterval
+            )
+            try writer.startSession(currentSession)
+            let baselineMeasurement = try sampler.sample()
+            sampleBuilder = ProfilerSampleBuilder(
+                sessionStartNanoseconds: sessionStart,
+                baselineMeasurement: baselineMeasurement,
+                baselineMonotonicNanoseconds: clock.monotonicNanoseconds()
+            )
+            session = currentSession
+            startTimer()
+            profilerLogger.info("Profiler started")
+        } catch {
+            scheduleRetryOnQueue(after: error)
+        }
+    }
+
+    private func startTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(
+            deadline: .now() + samplingInterval,
+            repeating: samplingInterval,
+            leeway: .seconds(1)
+        )
+        timer.setEventHandler { [weak self] in
+            self?.recordSampleOnQueue()
+        }
+        timer.resume()
+        self.timer = timer
+    }
+
+    private func recordSampleOnQueue() {
+        guard isRunning, let session, var sampleBuilder else { return }
+
+        do {
+            let measurement = try sampler.sample()
+            let sample = try sampleBuilder.makeSample(
+                measurement: measurement,
+                timestamp: clock.now(),
+                monotonicNanoseconds: clock.monotonicNanoseconds()
+            )
+            try writer.append(sample, session: session)
+            self.sampleBuilder = sampleBuilder
+        } catch {
+            scheduleRetryOnQueue(after: error)
+        }
+    }
+
+    private func stopOnQueue() {
+        let wasActive = isRunning || timer != nil
+        timer?.cancel()
+        timer = nil
+        isRunning = false
+        session = nil
+        sampleBuilder = nil
+        if wasActive {
+            profilerLogger.info("Profiler stopped")
+        }
+    }
+
+    private func scheduleRetryOnQueue(after error: Error) {
+        timer?.cancel()
+        timer = nil
+        isRunning = false
+        session = nil
+        sampleBuilder = nil
+
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + samplingInterval, leeway: .seconds(1))
+        timer.setEventHandler { [weak self] in
+            self?.startOnQueue()
+        }
+        timer.resume()
+        self.timer = timer
+        profilerLogger.error("Profiler will retry after a sampling or write failure: \(error.localizedDescription, privacy: .public)")
+    }
+}

--- a/Muxy/Services/Diagnostics/ProfilerRecorder.swift
+++ b/Muxy/Services/Diagnostics/ProfilerRecorder.swift
@@ -23,6 +23,21 @@ protocol ProfilerSessionProviding: Sendable {
     func session(timestamp: Date, samplingInterval: TimeInterval) -> ProfilerSessionRecord
 }
 
+protocol ProfilerScheduledTask: Sendable {
+    func cancel()
+}
+
+protocol ProfilerScheduling: Sendable {
+    func scheduleRepeating(
+        every interval: TimeInterval,
+        action: @escaping @Sendable () -> Void
+    ) -> any ProfilerScheduledTask
+    func scheduleOnce(
+        after delay: TimeInterval,
+        action: @escaping @Sendable () -> Void
+    ) -> any ProfilerScheduledTask
+}
+
 struct SystemProfilerClock: ProfilerClock {
     func now() -> Date {
         Date()
@@ -86,6 +101,57 @@ struct BundleProfilerSessionProvider: ProfilerSessionProviding {
     }
 }
 
+struct DispatchProfilerScheduler: ProfilerScheduling {
+    private let queue: DispatchQueue
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    func scheduleRepeating(
+        every interval: TimeInterval,
+        action: @escaping @Sendable () -> Void
+    ) -> any ProfilerScheduledTask {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(
+            deadline: .now() + interval,
+            repeating: interval,
+            leeway: .seconds(1)
+        )
+        return activate(timer, action: action)
+    }
+
+    func scheduleOnce(
+        after delay: TimeInterval,
+        action: @escaping @Sendable () -> Void
+    ) -> any ProfilerScheduledTask {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + delay, leeway: .seconds(1))
+        return activate(timer, action: action)
+    }
+
+    private func activate(
+        _ timer: DispatchSourceTimer,
+        action: @escaping @Sendable () -> Void
+    ) -> any ProfilerScheduledTask {
+        timer.setEventHandler(handler: action)
+        timer.resume()
+        return DispatchProfilerScheduledTask(timer: timer)
+    }
+}
+
+private final class DispatchProfilerScheduledTask: ProfilerScheduledTask, @unchecked Sendable {
+    private let timer: DispatchSourceTimer
+
+    init(timer: DispatchSourceTimer) {
+        self.timer = timer
+    }
+
+    func cancel() {
+        timer.cancel()
+    }
+}
+
 final class DefaultProfilerRecorder: ProfilerRecording, @unchecked Sendable {
     let fileURL: URL
 
@@ -95,8 +161,9 @@ final class DefaultProfilerRecorder: ProfilerRecording, @unchecked Sendable {
     private let sampler: any ProfilerProcessSampling
     private let writer: any ProfilerRecordWriting
     private let sessionProvider: any ProfilerSessionProviding
+    private let scheduler: any ProfilerScheduling
 
-    private var timer: DispatchSourceTimer?
+    private var timer: (any ProfilerScheduledTask)?
     private var session: ProfilerSessionRecord?
     private var sampleBuilder: ProfilerSampleBuilder?
     private var isRunning = false
@@ -107,7 +174,8 @@ final class DefaultProfilerRecorder: ProfilerRecording, @unchecked Sendable {
         clock: any ProfilerClock = SystemProfilerClock(),
         sampler: any ProfilerProcessSampling = CurrentProcessProfilerSampler(),
         writer: any ProfilerRecordWriting,
-        sessionProvider: any ProfilerSessionProviding = BundleProfilerSessionProvider()
+        sessionProvider: any ProfilerSessionProviding = BundleProfilerSessionProvider(),
+        scheduler: (any ProfilerScheduling)? = nil
     ) {
         self.samplingInterval = samplingInterval
         self.queue = queue
@@ -115,6 +183,7 @@ final class DefaultProfilerRecorder: ProfilerRecording, @unchecked Sendable {
         self.sampler = sampler
         self.writer = writer
         self.sessionProvider = sessionProvider
+        self.scheduler = scheduler ?? DispatchProfilerScheduler(queue: queue)
         fileURL = writer.fileURL
     }
 
@@ -158,17 +227,9 @@ final class DefaultProfilerRecorder: ProfilerRecording, @unchecked Sendable {
     }
 
     private func startTimer() {
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(
-            deadline: .now() + samplingInterval,
-            repeating: samplingInterval,
-            leeway: .seconds(1)
-        )
-        timer.setEventHandler { [weak self] in
+        timer = scheduler.scheduleRepeating(every: samplingInterval) { [weak self] in
             self?.recordSampleOnQueue()
         }
-        timer.resume()
-        self.timer = timer
     }
 
     private func recordSampleOnQueue() {
@@ -207,13 +268,9 @@ final class DefaultProfilerRecorder: ProfilerRecording, @unchecked Sendable {
         session = nil
         sampleBuilder = nil
 
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + samplingInterval, leeway: .seconds(1))
-        timer.setEventHandler { [weak self] in
+        timer = scheduler.scheduleOnce(after: samplingInterval) { [weak self] in
             self?.startOnQueue()
         }
-        timer.resume()
-        self.timer = timer
         profilerLogger.error("Profiler will retry after a sampling or write failure: \(error.localizedDescription, privacy: .public)")
     }
 }

--- a/Muxy/Services/Diagnostics/ProfilerRecords.swift
+++ b/Muxy/Services/Diagnostics/ProfilerRecords.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+struct ProfilerSessionRecord: Codable, Equatable, Sendable {
+    let schemaVersion: Int
+    let recordType: String
+    let timestamp: Date
+    let appVersion: String
+    let appBuild: String
+    let macOSVersion: String
+    let architecture: String
+    let samplingIntervalSeconds: Double
+
+    init(
+        timestamp: Date,
+        appVersion: String,
+        appBuild: String,
+        macOSVersion: String,
+        architecture: String,
+        samplingIntervalSeconds: Double
+    ) {
+        schemaVersion = 1
+        recordType = "session"
+        self.timestamp = timestamp
+        self.appVersion = appVersion
+        self.appBuild = appBuild
+        self.macOSVersion = macOSVersion
+        self.architecture = architecture
+        self.samplingIntervalSeconds = samplingIntervalSeconds
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case recordType = "record_type"
+        case timestamp
+        case appVersion = "app_version"
+        case appBuild = "app_build"
+        case macOSVersion = "macos_version"
+        case architecture
+        case samplingIntervalSeconds = "sampling_interval_seconds"
+    }
+}
+
+struct ProfilerSampleRecord: Codable, Equatable, Sendable {
+    let schemaVersion: Int
+    let recordType: String
+    let timestamp: Date
+    let profilerUptimeSeconds: Double
+    let cpuPercent: Double
+    let physicalFootprintBytes: UInt64
+
+    init(
+        timestamp: Date,
+        profilerUptimeSeconds: Double,
+        cpuPercent: Double,
+        physicalFootprintBytes: UInt64
+    ) {
+        schemaVersion = 1
+        recordType = "sample"
+        self.timestamp = timestamp
+        self.profilerUptimeSeconds = profilerUptimeSeconds
+        self.cpuPercent = cpuPercent
+        self.physicalFootprintBytes = physicalFootprintBytes
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case recordType = "record_type"
+        case timestamp
+        case profilerUptimeSeconds = "profiler_uptime_seconds"
+        case cpuPercent = "cpu_percent"
+        case physicalFootprintBytes = "physical_footprint_bytes"
+    }
+}
+
+struct ProfilerProcessMeasurement: Equatable, Sendable {
+    let cumulativeCPUNanoseconds: UInt64
+    let physicalFootprintBytes: UInt64
+}
+
+enum ProfilerCPUCalculator {
+    static func percent(
+        previousCPUNanoseconds: UInt64,
+        currentCPUNanoseconds: UInt64,
+        previousMonotonicNanoseconds: UInt64,
+        currentMonotonicNanoseconds: UInt64
+    ) -> Double? {
+        guard currentCPUNanoseconds >= previousCPUNanoseconds,
+              currentMonotonicNanoseconds > previousMonotonicNanoseconds
+        else { return nil }
+
+        let cpuDelta = Double(currentCPUNanoseconds - previousCPUNanoseconds)
+        let wallDelta = Double(currentMonotonicNanoseconds - previousMonotonicNanoseconds)
+        return cpuDelta / wallDelta * 100
+    }
+}
+
+struct ProfilerSampleBuilder {
+    private let sessionStartNanoseconds: UInt64
+    private var previousMeasurement: ProfilerProcessMeasurement
+    private var previousMonotonicNanoseconds: UInt64
+
+    init(
+        sessionStartNanoseconds: UInt64,
+        baselineMeasurement: ProfilerProcessMeasurement,
+        baselineMonotonicNanoseconds: UInt64
+    ) {
+        self.sessionStartNanoseconds = sessionStartNanoseconds
+        previousMeasurement = baselineMeasurement
+        previousMonotonicNanoseconds = baselineMonotonicNanoseconds
+    }
+
+    mutating func makeSample(
+        measurement: ProfilerProcessMeasurement,
+        timestamp: Date,
+        monotonicNanoseconds: UInt64
+    ) throws -> ProfilerSampleRecord {
+        guard let cpuPercent = ProfilerCPUCalculator.percent(
+            previousCPUNanoseconds: previousMeasurement.cumulativeCPUNanoseconds,
+            currentCPUNanoseconds: measurement.cumulativeCPUNanoseconds,
+            previousMonotonicNanoseconds: previousMonotonicNanoseconds,
+            currentMonotonicNanoseconds: monotonicNanoseconds
+        ), monotonicNanoseconds >= sessionStartNanoseconds
+        else {
+            throw ProfilerRecorderError.invalidMeasurementDelta
+        }
+
+        previousMeasurement = measurement
+        previousMonotonicNanoseconds = monotonicNanoseconds
+        return ProfilerSampleRecord(
+            timestamp: timestamp,
+            profilerUptimeSeconds: Double(monotonicNanoseconds - sessionStartNanoseconds) / 1_000_000_000,
+            cpuPercent: cpuPercent,
+            physicalFootprintBytes: measurement.physicalFootprintBytes
+        )
+    }
+}
+
+enum ProfilerRecorderError: Error {
+    case invalidMeasurementDelta
+}
+
+enum ProfilerRecordEncoder {
+    static func encode(_ record: some Encodable) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(record)
+    }
+}

--- a/Muxy/Services/Diagnostics/ProfilerService.swift
+++ b/Muxy/Services/Diagnostics/ProfilerService.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ProfilerService {
+    static let shared = ProfilerService()
+    static let enabledKey = "diagnostics.profiler.enabled"
+
+    private(set) var isEnabled: Bool
+    let fileURL: URL
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let recorder: any ProfilerRecording
+    @ObservationIgnored private var recorderStarted = false
+
+    convenience init() {
+        let fileURL = Self.defaultFileURL
+        let writer = ProfilerJSONLWriter(fileURL: fileURL)
+        let recorder = DefaultProfilerRecorder(writer: writer)
+        self.init(defaults: .standard, recorder: recorder)
+    }
+
+    init(defaults: UserDefaults, recorder: any ProfilerRecording) {
+        self.defaults = defaults
+        self.recorder = recorder
+        isEnabled = defaults.bool(forKey: Self.enabledKey)
+        fileURL = recorder.fileURL
+    }
+
+    func configure() {
+        isEnabled = defaults.bool(forKey: Self.enabledKey)
+        reconcileRecorder()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Self.enabledKey)
+        isEnabled = enabled
+        reconcileRecorder()
+    }
+
+    private func reconcileRecorder() {
+        if isEnabled {
+            guard !recorderStarted else { return }
+            recorder.start()
+            recorderStarted = true
+            return
+        }
+
+        guard recorderStarted else { return }
+        recorder.stop()
+        recorderStarted = false
+    }
+
+    private static var defaultFileURL: URL {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        return applicationSupport
+            .appendingPathComponent("Muxy", isDirectory: true)
+            .appendingPathComponent("Diagnostics", isDirectory: true)
+            .appendingPathComponent("profiler.jsonl", isDirectory: false)
+    }
+}

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -489,6 +489,14 @@ enum SettingsJSONStore {
             } else if let consent = SentryConsent(rawValue: rawValue) {
                 SentryService.shared.setConsent(consent)
             }
+        case ProfilerService.enabledKey:
+            if value is NSNull {
+                ProfilerService.shared.setEnabled(false)
+            } else if let enabled = value as? Bool {
+                ProfilerService.shared.setEnabled(enabled)
+            } else {
+                return false
+            }
         case "muxy.ui.scale":
             guard let rawValue = value as? String, let preset = UIScale.Preset(rawValue: rawValue) else { return false }
             UIScale.shared.preset = preset

--- a/Muxy/Views/Settings/GeneralSettingsView.swift
+++ b/Muxy/Views/Settings/GeneralSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct GeneralSettingsView: View {
@@ -5,6 +6,8 @@ struct GeneralSettingsView: View {
     private var updateChannelRaw = UpdateChannel.stable.rawValue
     @AppStorage(QuitConfirmationPreferences.confirmQuitKey)
     private var confirmQuit = true
+    @AppStorage(ProfilerService.enabledKey)
+    private var profilerEnabled = false
     @State private var sentry = SentryService.shared
     @State private var updateService = UpdateService.shared
 
@@ -34,28 +37,53 @@ struct GeneralSettingsView: View {
                 .help(L10n.string("Automatic updates are unavailable for this configuration."))
             }
 
-            SettingsSection("Quit", showsDivider: sentry.hasDSN) {
+            SettingsSection("Quit") {
                 SettingsToggleRow(
                     label: L10n.resource("Confirm before quitting Muxy"),
                     isOn: $confirmQuit
                 )
             }
 
-            if sentry.hasDSN {
-                SettingsSection(
-                    "Diagnostics",
-                    footer: """
-                    Anonymous crash reports help us fix bugs. Reports never include project paths, file contents, or \
-                    personal data.
-                    """,
-                    showsDivider: false
-                ) {
+            SettingsSection(
+                "Diagnostics",
+                footer: diagnosticsFooter,
+                showsDivider: false
+            ) {
+                if sentry.hasDSN {
                     SettingsToggleRow(
                         label: L10n.resource("Send anonymous crash reports"),
                         isOn: sentryConsentBinding
                     )
                 }
+                SettingsToggleRow(
+                    label: L10n.resource("Record anonymous performance samples"),
+                    isOn: profilerBinding
+                )
+                SettingsRow("Profiler data") {
+                    Button(action: revealProfilerData) {
+                        Text(L10n.resource("Reveal in Finder"))
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: SettingsMetrics.labelFontSize, weight: .medium))
+                    .foregroundStyle(SettingsStyle.accent)
+                }
             }
+        }
+    }
+
+    private var diagnosticsFooter: LocalizedStringResource {
+        if sentry.hasDSN {
+            """
+            Crash reports are sent only with your permission. Performance samples record CPU, memory, profiler uptime, \
+            app and macOS versions, device architecture, and timestamps once per minute. They stay on this Mac unless \
+            you share the file. Project paths, file contents, terminal output, and commands are never recorded.
+            """
+        } else {
+            """
+            Performance samples record CPU, memory, profiler uptime, app and macOS versions, device architecture, and \
+            timestamps once per minute. They stay on this Mac unless you share the file. Project paths, file contents, \
+            terminal output, and commands are never recorded.
+            """
         }
     }
 
@@ -64,6 +92,28 @@ struct GeneralSettingsView: View {
             get: { sentry.consent == .allowed },
             set: { newValue in sentry.setConsent(newValue ? .allowed : .denied) }
         )
+    }
+
+    private var profilerBinding: Binding<Bool> {
+        Binding(
+            get: { profilerEnabled },
+            set: { enabled in
+                profilerEnabled = enabled
+                ProfilerService.shared.setEnabled(enabled)
+            }
+        )
+    }
+
+    private func revealProfilerData() {
+        let fileURL = ProfilerService.shared.fileURL
+        let directoryURL = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: FilePermissions.privateDirectory]
+        )
+        let targetURL = FileManager.default.fileExists(atPath: fileURL.path) ? fileURL : directoryURL
+        NSWorkspace.shared.activateFileViewerSelecting([targetURL])
     }
 
     private var channelBinding: Binding<UpdateChannel> {

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -158,6 +158,23 @@ enum SettingsCatalog {
             aliases: ["release", "beta"]
         ),
         SettingsCatalogItem(
+            key: ProfilerService.enabledKey,
+            title: "Record Anonymous Performance Samples",
+            description: "Records local CPU and memory samples for diagnosing long-running performance issues.",
+            category: .general,
+            section: "Diagnostics",
+            defaultValue: false,
+            aliases: ["profile", "profiler", "CPU", "memory", "performance"]
+        ),
+        SettingsCatalogItem(
+            key: "diagnostics.profiler.reveal",
+            title: "Profiler Data",
+            description: "Reveals the local JSONL performance profile in Finder for manual sharing.",
+            category: .general,
+            section: "Diagnostics",
+            aliases: ["JSONL", "file", "share", "Finder"]
+        ),
+        SettingsCatalogItem(
             key: LocalizationSelection.storageKey,
             title: "App Language",
             description: "Chooses built-in English or a language provided by an enabled extension.",

--- a/Tests/MuxyTests/Services/Diagnostics/ProfilerJSONLWriterTests.swift
+++ b/Tests/MuxyTests/Services/Diagnostics/ProfilerJSONLWriterTests.swift
@@ -76,11 +76,23 @@ struct ProfilerJSONLWriterTests {
     func rolloverRetainsSessionAndNewestRecord() throws {
         let context = try makeContext()
         defer { try? FileManager.default.removeItem(at: context.directoryURL) }
-        let writer = ProfilerJSONLWriter(fileURL: context.fileURL, maximumFileSize: 700)
+        let maximumFileSize = 700
+        let writer = ProfilerJSONLWriter(fileURL: context.fileURL, maximumFileSize: maximumFileSize)
         let session = makeSession()
         let newestSample = makeSample(footprint: 999)
-        try writer.startSession(session)
-        try Data(repeating: 0x78, count: 700).write(to: context.fileURL)
+        let sessionLine = try ProfilerRecordEncoder.encode(session)
+        let sampleLine = try ProfilerRecordEncoder.encode(newestSample)
+        var existingData = Data()
+        existingData.append(sessionLine)
+        existingData.append(0x0A)
+        while existingData.count + sampleLine.count + 1 <= maximumFileSize {
+            existingData.append(sampleLine)
+            existingData.append(0x0A)
+        }
+        #expect(existingData.count <= maximumFileSize)
+        #expect(existingData.count + sampleLine.count + 1 > maximumFileSize)
+        try FileManager.default.createDirectory(at: context.directoryURL, withIntermediateDirectories: true)
+        try existingData.write(to: context.fileURL)
 
         try writer.append(newestSample, session: session)
 

--- a/Tests/MuxyTests/Services/Diagnostics/ProfilerJSONLWriterTests.swift
+++ b/Tests/MuxyTests/Services/Diagnostics/ProfilerJSONLWriterTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Profiler JSONL writer")
+struct ProfilerJSONLWriterTests {
+    @Test("records append as valid newline-delimited JSON with private permissions")
+    func appendsJSONLines() throws {
+        let context = try makeContext()
+        defer { try? FileManager.default.removeItem(at: context.directoryURL) }
+        let writer = ProfilerJSONLWriter(fileURL: context.fileURL)
+        let session = makeSession()
+
+        try writer.startSession(session)
+        try writer.append(makeSample(footprint: 123), session: session)
+
+        let data = try Data(contentsOf: context.fileURL)
+        let lines = data.split(separator: 0x0A)
+        #expect(data.last == 0x0A)
+        #expect(lines.count == 2)
+        for line in lines {
+            #expect(throws: Never.self) {
+                try JSONSerialization.jsonObject(with: Data(line))
+            }
+        }
+
+        let directoryPermissions = try permissions(at: context.directoryURL)
+        let filePermissions = try permissions(at: context.fileURL)
+        #expect(directoryPermissions == 0o700)
+        #expect(filePermissions == 0o600)
+    }
+
+    @Test("append repairs a missing newline before the next record")
+    func repairsMissingNewline() throws {
+        let context = try makeContext()
+        defer { try? FileManager.default.removeItem(at: context.directoryURL) }
+        try FileManager.default.createDirectory(at: context.directoryURL, withIntermediateDirectories: true)
+        try Data("{\"existing\":true}".utf8).write(to: context.fileURL)
+        let writer = ProfilerJSONLWriter(fileURL: context.fileURL)
+
+        try writer.startSession(makeSession())
+
+        let text = try String(contentsOf: context.fileURL, encoding: .utf8)
+        #expect(text.contains("{\"existing\":true}\n{"))
+        #expect(text.hasSuffix("\n"))
+    }
+
+    @Test("append removes a truncated trailing record")
+    func removesTruncatedTrailingRecord() throws {
+        let context = try makeContext()
+        defer { try? FileManager.default.removeItem(at: context.directoryURL) }
+        let writer = ProfilerJSONLWriter(fileURL: context.fileURL)
+        let session = makeSession()
+        try writer.startSession(session)
+        let validSessionData = try Data(contentsOf: context.fileURL)
+        var interruptedData = validSessionData
+        interruptedData.append(Data("{\"record_type\":\"sam".utf8))
+        try interruptedData.write(to: context.fileURL)
+
+        try writer.append(makeSample(footprint: 321), session: session)
+
+        let data = try Data(contentsOf: context.fileURL)
+        let lines = data.split(separator: 0x0A)
+        #expect(lines.count == 2)
+        for line in lines {
+            #expect(throws: Never.self) {
+                try JSONSerialization.jsonObject(with: Data(line))
+            }
+        }
+        let sample = try #require(JSONSerialization.jsonObject(with: Data(lines[1])) as? [String: Any])
+        #expect(sample["physical_footprint_bytes"] as? Int == 321)
+    }
+
+    @Test("rollover keeps the current session header and newest sample")
+    func rolloverRetainsSessionAndNewestRecord() throws {
+        let context = try makeContext()
+        defer { try? FileManager.default.removeItem(at: context.directoryURL) }
+        let writer = ProfilerJSONLWriter(fileURL: context.fileURL, maximumFileSize: 700)
+        let session = makeSession()
+        let newestSample = makeSample(footprint: 999)
+        try writer.startSession(session)
+        try Data(repeating: 0x78, count: 700).write(to: context.fileURL)
+
+        try writer.append(newestSample, session: session)
+
+        let data = try Data(contentsOf: context.fileURL)
+        let lines = data.split(separator: 0x0A)
+        #expect(lines.count == 2)
+        let header = try #require(JSONSerialization.jsonObject(with: Data(lines[0])) as? [String: Any])
+        let sample = try #require(JSONSerialization.jsonObject(with: Data(lines[1])) as? [String: Any])
+        #expect(header["record_type"] as? String == "session")
+        #expect(header["app_version"] as? String == "1.2.3")
+        #expect(sample["record_type"] as? String == "sample")
+        #expect(sample["physical_footprint_bytes"] as? Int == 999)
+        #expect(data.last == 0x0A)
+    }
+
+    private func makeContext() throws -> (directoryURL: URL, fileURL: URL) {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-profiler-tests-\(UUID().uuidString)", isDirectory: true)
+        return (directoryURL, directoryURL.appendingPathComponent("profiler.jsonl"))
+    }
+
+    private func permissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return try #require((attributes[.posixPermissions] as? NSNumber)?.intValue) & 0o777
+    }
+
+    private func makeSession() -> ProfilerSessionRecord {
+        ProfilerSessionRecord(
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            appVersion: "1.2.3",
+            appBuild: "456",
+            macOSVersion: "15.4.0",
+            architecture: "arm64",
+            samplingIntervalSeconds: 60
+        )
+    }
+
+    private func makeSample(footprint: UInt64) -> ProfilerSampleRecord {
+        ProfilerSampleRecord(
+            timestamp: Date(timeIntervalSince1970: 1_060),
+            profilerUptimeSeconds: 60,
+            cpuPercent: 12.5,
+            physicalFootprintBytes: footprint
+        )
+    }
+}

--- a/Tests/MuxyTests/Services/Diagnostics/ProfilerRecorderTests.swift
+++ b/Tests/MuxyTests/Services/Diagnostics/ProfilerRecorderTests.swift
@@ -1,0 +1,344 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Default profiler recorder")
+struct ProfilerRecorderTests {
+    @Test("start is idempotent and a scheduled tick records a sample")
+    func recordsScheduledSample() throws {
+        let sessionDate = Date(timeIntervalSince1970: 1_000)
+        let sampleDate = Date(timeIntervalSince1970: 1_060)
+        let harness = makeHarness(
+            measurements: [
+                .success(measurement(cpu: 10_000_000_000, memory: 100)),
+                .success(measurement(cpu: 22_000_000_000, memory: 200)),
+            ],
+            dates: [sessionDate, sampleDate],
+            monotonicNanoseconds: [1_000_000_000, 1_000_000_000, 61_000_000_000]
+        )
+
+        harness.recorder.start()
+        harness.recorder.start()
+        harness.drainQueue()
+
+        #expect(harness.writer.sessions.count == 1)
+        #expect(harness.writer.sessions.first?.timestamp == sessionDate)
+        #expect(harness.writer.sessions.first?.samplingIntervalSeconds == 60)
+        #expect(harness.sampler.sampleCount == 1)
+        #expect(harness.scheduler.tasks.count == 1)
+        #expect(harness.scheduler.tasks.first?.repeatingInterval == 60)
+
+        try harness.fireLatestTimer()
+
+        let sample = try #require(harness.writer.samples.first)
+        #expect(harness.writer.samples.count == 1)
+        #expect(sample.timestamp == sampleDate)
+        #expect(sample.profilerUptimeSeconds == 60)
+        #expect(sample.cpuPercent == 20)
+        #expect(sample.physicalFootprintBytes == 200)
+        #expect(harness.writer.sampleSessions.first == harness.writer.sessions.first)
+        #expect(harness.sampler.sampleCount == 2)
+
+        harness.recorder.stop()
+        harness.drainQueue()
+    }
+
+    @Test("stop cancels scheduled sampling")
+    func stopCancelsSampling() throws {
+        let harness = makeHarness(
+            measurements: [.success(measurement(cpu: 10, memory: 100))],
+            dates: [Date(timeIntervalSince1970: 1_000)],
+            monotonicNanoseconds: [1_000_000_000, 1_000_000_000]
+        )
+
+        harness.recorder.start()
+        harness.drainQueue()
+        let timer = try #require(harness.scheduler.tasks.last)
+
+        harness.recorder.stop()
+        harness.drainQueue()
+        harness.fire(timer)
+
+        #expect(timer.isCancelled)
+        #expect(harness.writer.samples.isEmpty)
+        #expect(harness.sampler.sampleCount == 1)
+    }
+
+    @Test("sampling failure retries with a new session")
+    func samplingFailureRetries() throws {
+        let firstSessionDate = Date(timeIntervalSince1970: 1_000)
+        let secondSessionDate = Date(timeIntervalSince1970: 1_060)
+        let sampleDate = Date(timeIntervalSince1970: 1_120)
+        let harness = makeHarness(
+            measurements: [
+                .success(measurement(cpu: 10_000_000_000, memory: 100)),
+                .failure(.samplingFailed),
+                .success(measurement(cpu: 20_000_000_000, memory: 200)),
+                .success(measurement(cpu: 26_000_000_000, memory: 300)),
+            ],
+            dates: [firstSessionDate, secondSessionDate, sampleDate],
+            monotonicNanoseconds: [
+                1_000_000_000,
+                1_000_000_000,
+                61_000_000_000,
+                61_000_000_000,
+                121_000_000_000,
+            ]
+        )
+
+        harness.recorder.start()
+        harness.drainQueue()
+        let failedSamplingTimer = try #require(harness.scheduler.tasks.last)
+        harness.fire(failedSamplingTimer)
+
+        #expect(failedSamplingTimer.isCancelled)
+        #expect(harness.writer.sessions.count == 1)
+        #expect(harness.writer.samples.isEmpty)
+        let retryTimer = try #require(harness.scheduler.tasks.last)
+        #expect(retryTimer.repeatingInterval == nil)
+        #expect(retryTimer.delay == 60)
+
+        harness.fire(retryTimer)
+
+        #expect(harness.writer.sessions.map(\.timestamp) == [firstSessionDate, secondSessionDate])
+        let resumedSamplingTimer = try #require(harness.scheduler.tasks.last)
+        #expect(resumedSamplingTimer.repeatingInterval == 60)
+
+        harness.fire(resumedSamplingTimer)
+
+        let sample = try #require(harness.writer.samples.first)
+        #expect(sample.timestamp == sampleDate)
+        #expect(sample.profilerUptimeSeconds == 60)
+        #expect(sample.cpuPercent == 10)
+        #expect(sample.physicalFootprintBytes == 300)
+        #expect(harness.sampler.sampleCount == 4)
+
+        harness.recorder.stop()
+        harness.drainQueue()
+    }
+
+    @Test("stop cancels a pending retry after a writing failure")
+    func stopCancelsRetry() throws {
+        let harness = makeHarness(
+            measurements: [
+                .success(measurement(cpu: 10, memory: 100)),
+                .success(measurement(cpu: 20, memory: 200)),
+            ],
+            dates: [
+                Date(timeIntervalSince1970: 1_000),
+                Date(timeIntervalSince1970: 1_060),
+            ],
+            monotonicNanoseconds: [1_000_000_000, 1_000_000_000, 61_000_000_000],
+            appendResults: [.failure(.writingFailed)]
+        )
+
+        harness.recorder.start()
+        harness.drainQueue()
+        try harness.fireLatestTimer()
+        let retryTimer = try #require(harness.scheduler.tasks.last)
+
+        harness.recorder.stop()
+        harness.drainQueue()
+        harness.fire(retryTimer)
+
+        #expect(retryTimer.isCancelled)
+        #expect(harness.writer.sessions.count == 1)
+        #expect(harness.writer.samples.isEmpty)
+        #expect(harness.sampler.sampleCount == 2)
+    }
+
+    private func makeHarness(
+        measurements: [Result<ProfilerProcessMeasurement, ProfilerRecorderTestError>],
+        dates: [Date],
+        monotonicNanoseconds: [UInt64],
+        appendResults: [Result<Void, ProfilerRecorderTestError>] = []
+    ) -> ProfilerRecorderHarness {
+        let queue = DispatchQueue(label: "app.muxy.profiler.tests.\(UUID().uuidString)")
+        let clock = SequenceProfilerClock(dates: dates, monotonicNanoseconds: monotonicNanoseconds)
+        let sampler = SequenceProfilerSampler(results: measurements)
+        let writer = CapturingProfilerWriter(appendResults: appendResults)
+        let scheduler = ManualProfilerScheduler()
+        let recorder = DefaultProfilerRecorder(
+            samplingInterval: 60,
+            queue: queue,
+            clock: clock,
+            sampler: sampler,
+            writer: writer,
+            sessionProvider: TestProfilerSessionProvider(),
+            scheduler: scheduler
+        )
+        return ProfilerRecorderHarness(
+            recorder: recorder,
+            queue: queue,
+            sampler: sampler,
+            writer: writer,
+            scheduler: scheduler
+        )
+    }
+
+    private func measurement(cpu: UInt64, memory: UInt64) -> ProfilerProcessMeasurement {
+        ProfilerProcessMeasurement(cumulativeCPUNanoseconds: cpu, physicalFootprintBytes: memory)
+    }
+}
+
+private struct ProfilerRecorderHarness {
+    let recorder: DefaultProfilerRecorder
+    let queue: DispatchQueue
+    let sampler: SequenceProfilerSampler
+    let writer: CapturingProfilerWriter
+    let scheduler: ManualProfilerScheduler
+
+    func drainQueue() {
+        queue.sync {}
+    }
+
+    func fireLatestTimer() throws {
+        let timer = try #require(scheduler.tasks.last)
+        fire(timer)
+    }
+
+    func fire(_ timer: ManualProfilerScheduledTask) {
+        queue.sync {
+            timer.fire()
+        }
+    }
+}
+
+private enum ProfilerRecorderTestError: Error {
+    case samplingFailed
+    case writingFailed
+}
+
+private final class SequenceProfilerClock: ProfilerClock, @unchecked Sendable {
+    private var dates: [Date]
+    private var monotonicValues: [UInt64]
+
+    init(dates: [Date], monotonicNanoseconds: [UInt64]) {
+        self.dates = dates
+        monotonicValues = monotonicNanoseconds
+    }
+
+    func now() -> Date {
+        precondition(!dates.isEmpty)
+        return dates.removeFirst()
+    }
+
+    func monotonicNanoseconds() -> UInt64 {
+        precondition(!monotonicValues.isEmpty)
+        return monotonicValues.removeFirst()
+    }
+}
+
+private final class SequenceProfilerSampler: ProfilerProcessSampling, @unchecked Sendable {
+    private var results: [Result<ProfilerProcessMeasurement, ProfilerRecorderTestError>]
+    private(set) var sampleCount = 0
+
+    init(results: [Result<ProfilerProcessMeasurement, ProfilerRecorderTestError>]) {
+        self.results = results
+    }
+
+    func sample() throws -> ProfilerProcessMeasurement {
+        precondition(!results.isEmpty)
+        sampleCount += 1
+        return try results.removeFirst().get()
+    }
+}
+
+private struct TestProfilerSessionProvider: ProfilerSessionProviding {
+    func session(timestamp: Date, samplingInterval: TimeInterval) -> ProfilerSessionRecord {
+        ProfilerSessionRecord(
+            timestamp: timestamp,
+            appVersion: "1.2.3",
+            appBuild: "456",
+            macOSVersion: "15.4.0",
+            architecture: "arm64",
+            samplingIntervalSeconds: samplingInterval
+        )
+    }
+}
+
+private final class CapturingProfilerWriter: ProfilerRecordWriting, @unchecked Sendable {
+    let fileURL = URL(fileURLWithPath: "/tmp/muxy-profiler-recorder-tests.jsonl")
+    private(set) var sessions: [ProfilerSessionRecord] = []
+    private(set) var samples: [ProfilerSampleRecord] = []
+    private(set) var sampleSessions: [ProfilerSessionRecord] = []
+    private var appendResults: [Result<Void, ProfilerRecorderTestError>]
+
+    init(appendResults: [Result<Void, ProfilerRecorderTestError>]) {
+        self.appendResults = appendResults
+    }
+
+    func startSession(_ session: ProfilerSessionRecord) throws {
+        sessions.append(session)
+    }
+
+    func append(_ sample: ProfilerSampleRecord, session: ProfilerSessionRecord) throws {
+        if !appendResults.isEmpty {
+            try appendResults.removeFirst().get()
+        }
+        samples.append(sample)
+        sampleSessions.append(session)
+    }
+}
+
+private final class ManualProfilerScheduler: ProfilerScheduling, @unchecked Sendable {
+    private(set) var tasks: [ManualProfilerScheduledTask] = []
+
+    func scheduleRepeating(
+        every interval: TimeInterval,
+        action: @escaping @Sendable () -> Void
+    ) -> any ProfilerScheduledTask {
+        schedule(delay: interval, repeatingInterval: interval, action: action)
+    }
+
+    func scheduleOnce(
+        after delay: TimeInterval,
+        action: @escaping @Sendable () -> Void
+    ) -> any ProfilerScheduledTask {
+        schedule(delay: delay, repeatingInterval: nil, action: action)
+    }
+
+    private func schedule(
+        delay: TimeInterval,
+        repeatingInterval: TimeInterval?,
+        action: @escaping @Sendable () -> Void
+    ) -> ManualProfilerScheduledTask {
+        let task = ManualProfilerScheduledTask(
+            delay: delay,
+            repeatingInterval: repeatingInterval,
+            action: action
+        )
+        tasks.append(task)
+        return task
+    }
+}
+
+private final class ManualProfilerScheduledTask: ProfilerScheduledTask, @unchecked Sendable {
+    let delay: TimeInterval
+    let repeatingInterval: TimeInterval?
+    private let action: @Sendable () -> Void
+    private(set) var isCancelled = false
+
+    init(
+        delay: TimeInterval,
+        repeatingInterval: TimeInterval?,
+        action: @escaping @Sendable () -> Void
+    ) {
+        self.delay = delay
+        self.repeatingInterval = repeatingInterval
+        self.action = action
+    }
+
+    func fire() {
+        guard !isCancelled else { return }
+        if repeatingInterval == nil {
+            isCancelled = true
+        }
+        action()
+    }
+
+    func cancel() {
+        isCancelled = true
+    }
+}

--- a/Tests/MuxyTests/Services/Diagnostics/ProfilerRecordsTests.swift
+++ b/Tests/MuxyTests/Services/Diagnostics/ProfilerRecordsTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Profiler records")
+struct ProfilerRecordsTests {
+    @Test("session and sample JSON contain only anonymous schema fields")
+    func anonymousJSONFieldSet() throws {
+        let session = makeSession()
+        let sample = makeSample()
+
+        let sessionObject = try jsonObject(ProfilerRecordEncoder.encode(session))
+        let sampleObject = try jsonObject(ProfilerRecordEncoder.encode(sample))
+
+        #expect(Set(sessionObject.keys) == [
+            "schema_version",
+            "record_type",
+            "timestamp",
+            "app_version",
+            "app_build",
+            "macos_version",
+            "architecture",
+            "sampling_interval_seconds",
+        ])
+        #expect(Set(sampleObject.keys) == [
+            "schema_version",
+            "record_type",
+            "timestamp",
+            "profiler_uptime_seconds",
+            "cpu_percent",
+            "physical_footprint_bytes",
+        ])
+        #expect(sessionObject["record_type"] as? String == "session")
+        #expect(sampleObject["record_type"] as? String == "sample")
+        #expect(sessionObject["schema_version"] as? Int == 1)
+        #expect(sampleObject["schema_version"] as? Int == 1)
+    }
+
+    @Test("CPU and uptime use the baseline and monotonic deltas")
+    func cpuDeltaBehavior() throws {
+        var builder = ProfilerSampleBuilder(
+            sessionStartNanoseconds: 99_000_000_000,
+            baselineMeasurement: ProfilerProcessMeasurement(
+                cumulativeCPUNanoseconds: 10_000_000_000,
+                physicalFootprintBytes: 100
+            ),
+            baselineMonotonicNanoseconds: 100_000_000_000
+        )
+
+        let sample = try builder.makeSample(
+            measurement: ProfilerProcessMeasurement(
+                cumulativeCPUNanoseconds: 10_500_000_000,
+                physicalFootprintBytes: 200
+            ),
+            timestamp: Date(timeIntervalSince1970: 2_000),
+            monotonicNanoseconds: 102_000_000_000
+        )
+
+        #expect(sample.cpuPercent == 25)
+        #expect(sample.profilerUptimeSeconds == 3)
+        #expect(sample.physicalFootprintBytes == 200)
+        #expect(ProfilerCPUCalculator.percent(
+            previousCPUNanoseconds: 20,
+            currentCPUNanoseconds: 19,
+            previousMonotonicNanoseconds: 10,
+            currentMonotonicNanoseconds: 11
+        ) == nil)
+        #expect(ProfilerCPUCalculator.percent(
+            previousCPUNanoseconds: 20,
+            currentCPUNanoseconds: 21,
+            previousMonotonicNanoseconds: 10,
+            currentMonotonicNanoseconds: 10
+        ) == nil)
+    }
+
+    private func jsonObject(_ data: Data) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func makeSession() -> ProfilerSessionRecord {
+        ProfilerSessionRecord(
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            appVersion: "1.2.3",
+            appBuild: "456",
+            macOSVersion: "15.4.0",
+            architecture: "arm64",
+            samplingIntervalSeconds: 60
+        )
+    }
+
+    private func makeSample() -> ProfilerSampleRecord {
+        ProfilerSampleRecord(
+            timestamp: Date(timeIntervalSince1970: 1_060),
+            profilerUptimeSeconds: 60,
+            cpuPercent: 12.5,
+            physicalFootprintBytes: 123_456
+        )
+    }
+}

--- a/Tests/MuxyTests/Services/Diagnostics/ProfilerServiceTests.swift
+++ b/Tests/MuxyTests/Services/Diagnostics/ProfilerServiceTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("ProfilerService")
+@MainActor
+struct ProfilerServiceTests {
+    @Test("profiling stays disabled when no preference exists")
+    func profilingIsDisabledByDefault() {
+        let suiteName = "muxy.tests.profiler.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            Issue.record("Unable to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = FakeProfilerRecorder()
+        let service = ProfilerService(defaults: defaults, recorder: recorder)
+
+        service.configure()
+        service.configure()
+
+        #expect(!service.isEnabled)
+        #expect(defaults.object(forKey: ProfilerService.enabledKey) == nil)
+        #expect(recorder.startCount == 0)
+        #expect(recorder.stopCount == 0)
+    }
+
+    @Test("configure and setEnabled persist and reconcile recorder state")
+    func enableStatePersistenceAndRecorderLifecycle() {
+        let suiteName = "muxy.tests.profiler.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            Issue.record("Unable to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: ProfilerService.enabledKey)
+        let recorder = FakeProfilerRecorder()
+        let service = ProfilerService(defaults: defaults, recorder: recorder)
+
+        #expect(service.isEnabled)
+        #expect(service.fileURL == recorder.fileURL)
+        #expect(recorder.startCount == 0)
+
+        service.configure()
+        service.configure()
+        #expect(recorder.startCount == 1)
+
+        service.setEnabled(false)
+        service.setEnabled(false)
+        #expect(!service.isEnabled)
+        #expect(!defaults.bool(forKey: ProfilerService.enabledKey))
+        #expect(recorder.stopCount == 1)
+
+        service.setEnabled(true)
+        service.setEnabled(true)
+        #expect(service.isEnabled)
+        #expect(defaults.bool(forKey: ProfilerService.enabledKey))
+        #expect(recorder.startCount == 2)
+    }
+}
+
+private final class FakeProfilerRecorder: ProfilerRecording {
+    let fileURL = URL(fileURLWithPath: "/tmp/muxy-profiler-test.jsonl")
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    func start() {
+        startCount += 1
+    }
+
+    func stop() {
+        stopCount += 1
+    }
+}

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -22,6 +22,17 @@ struct SettingsCatalogTests {
     }
 
     @Test
+    func profilerSettingIsSearchableAndJSONEditable() {
+        let item = SettingsCatalog.items.first { $0.key == ProfilerService.enabledKey }
+
+        #expect(item?.category == .general)
+        #expect(item?.section == "Diagnostics")
+        #expect(item?.defaultValue as? Bool == false)
+        #expect(SettingsCatalog.matchingItems(query: "CPU").contains { $0.key == ProfilerService.enabledKey })
+        #expect(SettingsCatalog.jsonEditableItems.contains { $0.key == ProfilerService.enabledKey })
+    }
+
+    @Test
     func searchFindsSettingsByLocalizedVisibleText() throws {
         let fixture = try LocalizationTestSupport.makeService(
             translations: #"""


### PR DESCRIPTION
Adds an opt-in profiler that records minute-by-minute CPU and memory samples to a private, size-limited local JSONL file. Integrates profiler controls and file reveal actions into diagnostics settings, supports settings persistence, and adds coverage for recording, storage, service behavior, and catalog entries. AI-assisted by GPT-5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional anonymous performance profiling for CPU and memory usage.
  * Added General → Diagnostics controls to enable profiling and reveal locally stored data in Finder.
  * Added clear descriptions for crash reports and performance data.
  * Profiling is disabled by default and starts automatically when enabled.

* **Bug Fixes**
  * Improved recovery, incomplete-record handling, and file rollover for locally stored profiling data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->