### PR TITLE
Fix worktree base branch selection

### DIFF
--- a/Muxy/Services/Git/GitMetadataCache.swift
+++ b/Muxy/Services/Git/GitMetadataCache.swift
@@ -15,6 +15,16 @@ final class GitMetadataCache: @unchecked Sendable {
         let storedAt: Date
     }
 
+    private struct DefaultBranchKey: Hashable {
+        let context: WorkspaceContext
+        let repoPath: String
+    }
+
+    private struct DefaultBranchEntry {
+        let branch: String
+        let storedAt: Date
+    }
+
     struct ReadKey: Hashable {
         let repoPath: String
         let endpoint: String
@@ -29,7 +39,7 @@ final class GitMetadataCache: @unchecked Sendable {
 
     private let lock = NSLock()
     private var prInfo: [PRKey: PREntry] = [:]
-    private var defaultBranch: [String: String?] = [:]
+    private var defaultBranch: [DefaultBranchKey: DefaultBranchEntry] = [:]
     private var ghInstalled: Bool?
     private var remoteWebURL: [String: URL?] = [:]
     private var verifiedGitRepo: Set<String> = []
@@ -37,6 +47,7 @@ final class GitMetadataCache: @unchecked Sendable {
     private var readOrder: [ReadKey] = []
 
     private let prTTL: TimeInterval = 300
+    private let defaultBranchTTL: TimeInterval = 300
     private let readTTL: TimeInterval = 5
     private let readCapacity = 128
 
@@ -123,17 +134,39 @@ final class GitMetadataCache: @unchecked Sendable {
         prInfo = prInfo.filter { key, _ in key.context != context || key.repoPath != repoPath }
     }
 
-    func cachedDefaultBranch(repoPath: String) -> String?? {
+    func cachedDefaultBranch(
+        context: WorkspaceContext,
+        repoPath: String,
+        now: Date = Date()
+    ) -> String? {
         lock.lock()
         defer { lock.unlock() }
-        guard let value = defaultBranch[repoPath] else { return nil }
-        return .some(value)
+        let key = DefaultBranchKey(context: context, repoPath: repoPath)
+        guard let entry = defaultBranch[key] else { return nil }
+        if now.timeIntervalSince(entry.storedAt) > defaultBranchTTL {
+            defaultBranch.removeValue(forKey: key)
+            return nil
+        }
+        return entry.branch
     }
 
-    func storeDefaultBranch(_ branch: String?, repoPath: String) {
+    func storeDefaultBranch(
+        _ branch: String,
+        context: WorkspaceContext,
+        repoPath: String,
+        storedAt: Date = Date()
+    ) {
         lock.lock()
         defer { lock.unlock() }
-        defaultBranch[repoPath] = branch
+        let key = DefaultBranchKey(context: context, repoPath: repoPath)
+        defaultBranch[key] = DefaultBranchEntry(branch: branch, storedAt: storedAt)
+    }
+
+    func invalidateDefaultBranch(context: WorkspaceContext, repoPath: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        let key = DefaultBranchKey(context: context, repoPath: repoPath)
+        defaultBranch.removeValue(forKey: key)
     }
 
     func cachedGhInstalled() -> Bool? {

--- a/Muxy/Services/Git/GitMetadataCache.swift
+++ b/Muxy/Services/Git/GitMetadataCache.swift
@@ -143,7 +143,7 @@ final class GitMetadataCache: @unchecked Sendable {
         defer { lock.unlock() }
         let key = DefaultBranchKey(context: context, repoPath: repoPath)
         guard let entry = defaultBranch[key] else { return nil }
-        if now.timeIntervalSince(entry.storedAt) > defaultBranchTTL {
+        if now.timeIntervalSince(entry.storedAt) >= defaultBranchTTL {
             defaultBranch.removeValue(forKey: key)
             return nil
         }

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -800,6 +800,19 @@ struct GitRepositoryService {
         return !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    func remoteTrackingBranchReference(
+        repoPath: String,
+        remote: String = "origin",
+        branch: String
+    ) async -> String? {
+        let reference = "refs/remotes/\(remote)/\(branch)"
+        let result = try? await runGit(
+            repoPath: repoPath,
+            arguments: ["show-ref", "--verify", "--quiet", reference]
+        )
+        return result?.status == 0 ? reference : nil
+    }
+
     func listRemoteBranches(repoPath: String) async throws -> [String] {
         let result = try await runGit(
             repoPath: repoPath,

--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -822,12 +822,12 @@ struct GitRepositoryService {
     }
 
     func defaultBranch(repoPath: String) async -> String? {
-        if let cached = GitMetadataCache.shared.cachedDefaultBranch(repoPath: repoPath) {
+        if let cached = GitMetadataCache.shared.cachedDefaultBranch(context: context, repoPath: repoPath) {
             return cached
         }
         let resolved = await resolveDefaultBranch(repoPath: repoPath)
-        if resolved != nil {
-            GitMetadataCache.shared.storeDefaultBranch(resolved, repoPath: repoPath)
+        if let resolved {
+            GitMetadataCache.shared.storeDefaultBranch(resolved, context: context, repoPath: repoPath)
         }
         return resolved
     }

--- a/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
@@ -40,18 +40,21 @@ struct WorktreeBranchLoadState: Equatable {
         if selectedExistingBranch.isEmpty {
             selectedExistingBranch = branches.first ?? ""
         }
-        if selectedBaseBranch.isEmpty {
-            if let defaultBranch, branches.contains(defaultBranch) {
-                selectedBaseBranch = defaultBranch
-            } else if let remoteDefaultBranchReference {
-                selectedBaseBranch = remoteDefaultBranchReference
-            } else if let currentBranch, branches.contains(currentBranch) {
-                selectedBaseBranch = currentBranch
-            } else if let fallbackBranch = ["develop", "main", "master"].first(where: branches.contains) {
-                selectedBaseBranch = fallbackBranch
-            }
-        }
         isLoading = false
+        guard selectedBaseBranch.isEmpty else { return }
+        if let defaultBranch, branches.contains(defaultBranch) {
+            selectedBaseBranch = defaultBranch
+            return
+        }
+        if let remoteDefaultBranchReference {
+            selectedBaseBranch = remoteDefaultBranchReference
+            return
+        }
+        if let currentBranch, branches.contains(currentBranch) {
+            selectedBaseBranch = currentBranch
+            return
+        }
+        selectedBaseBranch = ["develop", "main", "master"].first(where: branches.contains) ?? ""
     }
 
     mutating func failLoading() {

--- a/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
@@ -8,11 +8,13 @@ enum CreateWorktreeResult {
 
 struct WorktreeBranchOption: Equatable, Identifiable {
     let name: String
-    var id: String { name }
+    let reference: String
+    var id: String { reference }
 }
 
 struct WorktreeBranchLoadState: Equatable {
     var branchOptions: [WorktreeBranchOption] = []
+    var baseBranchOptions: [WorktreeBranchOption] = []
     var selectedExistingBranch = ""
     var selectedBaseBranch = ""
     private(set) var isLoading = true
@@ -21,18 +23,32 @@ struct WorktreeBranchLoadState: Equatable {
         isLoading = true
     }
 
-    mutating func finishLoading(branches: [String], defaultBranch: String?, currentBranch: String?) {
-        branchOptions = branches.map(WorktreeBranchOption.init)
+    mutating func finishLoading(
+        branches: [String],
+        defaultBranch: String?,
+        remoteDefaultBranchReference: String?,
+        currentBranch: String?
+    ) {
+        branchOptions = branches.map { WorktreeBranchOption(name: $0, reference: $0) }
+        baseBranchOptions = branchOptions
+        if let defaultBranch, let remoteDefaultBranchReference, !branches.contains(defaultBranch) {
+            baseBranchOptions.insert(
+                WorktreeBranchOption(name: defaultBranch, reference: remoteDefaultBranchReference),
+                at: 0
+            )
+        }
         if selectedExistingBranch.isEmpty {
             selectedExistingBranch = branches.first ?? ""
         }
         if selectedBaseBranch.isEmpty {
             if let defaultBranch, branches.contains(defaultBranch) {
                 selectedBaseBranch = defaultBranch
-            } else if let fallbackBranch = ["develop", "main", "master"].first(where: branches.contains) {
-                selectedBaseBranch = fallbackBranch
+            } else if let remoteDefaultBranchReference {
+                selectedBaseBranch = remoteDefaultBranchReference
             } else if let currentBranch, branches.contains(currentBranch) {
                 selectedBaseBranch = currentBranch
+            } else if let fallbackBranch = ["develop", "main", "master"].first(where: branches.contains) {
+                selectedBaseBranch = fallbackBranch
             }
         }
         isLoading = false
@@ -74,15 +90,16 @@ private struct WorktreeBranchPicker: View {
     }
 
     private var selectionButton: some View {
-        Button {
+        let selectedName = options.first { $0.reference == selection }?.name ?? selection
+        return Button {
             isPresented = true
         } label: {
             HStack(spacing: UIMetrics.spacing3) {
-                if selection.isEmpty {
+                if selectedName.isEmpty {
                     Text(L10n.resource("No branches"))
                         .foregroundStyle(MuxyTheme.fgDim)
                 } else {
-                    Text(selection)
+                    Text(selectedName)
                         .foregroundStyle(MuxyTheme.fg)
                 }
                 Spacer(minLength: UIMetrics.spacing3)
@@ -100,7 +117,7 @@ private struct WorktreeBranchPicker: View {
         .buttonStyle(.plain)
         .disabled(options.isEmpty)
         .accessibilityLabel(label)
-        .accessibilityValue(selection.isEmpty ? L10n.string("No branches") : selection)
+        .accessibilityValue(selectedName.isEmpty ? L10n.string("No branches") : selectedName)
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {
             PopoverPicker(
                 items: options,
@@ -115,7 +132,7 @@ private struct WorktreeBranchPicker: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                         Spacer(minLength: UIMetrics.spacing3)
-                        if option.name == selection {
+                        if option.reference == selection {
                             Image(systemName: "checkmark")
                                 .font(.system(size: UIMetrics.fontXS, weight: .bold))
                                 .foregroundStyle(MuxyTheme.accent)
@@ -131,7 +148,7 @@ private struct WorktreeBranchPicker: View {
     }
 
     private func select(_ option: WorktreeBranchOption) {
-        selection = option.name
+        selection = option.reference
         isPresented = false
     }
 }
@@ -196,7 +213,7 @@ struct CreateWorktreeSheet: View {
                     Text(L10n.resource("Base Branch")).font(.system(size: UIMetrics.fontFootnote)).foregroundStyle(MuxyTheme.fgMuted)
                     WorktreeBranchPicker(
                         label: L10n.string("Base Branch"),
-                        options: branchLoadState.branchOptions,
+                        options: branchLoadState.baseBranchOptions,
                         isLoading: branchLoadState.isLoading,
                         selection: $branchLoadState.selectedBaseBranch
                     )
@@ -525,9 +542,18 @@ struct CreateWorktreeSheet: View {
             let branches = try await branchesValue
             let resolvedDefault = await defaultValue
             let currentBranch = await currentValue
+            let remoteDefaultBranchReference: String? = if let resolvedDefault, !branches.contains(resolvedDefault) {
+                await gitRepository.remoteTrackingBranchReference(
+                    repoPath: project.path,
+                    branch: resolvedDefault
+                )
+            } else {
+                nil
+            }
             branchLoadState.finishLoading(
                 branches: branches,
                 defaultBranch: resolvedDefault,
+                remoteDefaultBranchReference: remoteDefaultBranchReference,
                 currentBranch: currentBranch
             )
         } catch {

--- a/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
+++ b/Muxy/Views/Layouts/Shared/CreateWorktreeSheet.swift
@@ -21,7 +21,7 @@ struct WorktreeBranchLoadState: Equatable {
         isLoading = true
     }
 
-    mutating func finishLoading(branches: [String], defaultBranch: String?) {
+    mutating func finishLoading(branches: [String], defaultBranch: String?, currentBranch: String?) {
         branchOptions = branches.map(WorktreeBranchOption.init)
         if selectedExistingBranch.isEmpty {
             selectedExistingBranch = branches.first ?? ""
@@ -29,8 +29,10 @@ struct WorktreeBranchLoadState: Equatable {
         if selectedBaseBranch.isEmpty {
             if let defaultBranch, branches.contains(defaultBranch) {
                 selectedBaseBranch = defaultBranch
-            } else {
-                selectedBaseBranch = branches.first ?? ""
+            } else if let fallbackBranch = ["develop", "main", "master"].first(where: branches.contains) {
+                selectedBaseBranch = fallbackBranch
+            } else if let currentBranch, branches.contains(currentBranch) {
+                selectedBaseBranch = currentBranch
             }
         }
         isLoading = false
@@ -519,9 +521,15 @@ struct CreateWorktreeSheet: View {
         do {
             async let branchesValue = gitRepository.listBranches(repoPath: project.path)
             async let defaultValue = gitRepository.defaultBranch(repoPath: project.path)
+            async let currentValue = try? gitRepository.currentBranch(repoPath: project.path)
             let branches = try await branchesValue
             let resolvedDefault = await defaultValue
-            branchLoadState.finishLoading(branches: branches, defaultBranch: resolvedDefault)
+            let currentBranch = await currentValue
+            branchLoadState.finishLoading(
+                branches: branches,
+                defaultBranch: resolvedDefault,
+                currentBranch: currentBranch
+            )
         } catch {
             branchLoadState.failLoading()
             errorMessage = error.localizedDescription

--- a/Tests/MuxyTests/Git/GitReadCacheTests.swift
+++ b/Tests/MuxyTests/Git/GitReadCacheTests.swift
@@ -142,16 +142,19 @@ struct GitReadCacheTests {
         #expect(cache.cachedDefaultBranch(context: remoteContext, repoPath: repoPath) == "develop")
     }
 
-    @Test("expires stale default branches")
-    func defaultBranchExpiration() {
+    @Test("expires default branches at the TTL boundary")
+    func defaultBranchExpirationAtBoundary() {
         let cache = GitMetadataCache.shared
         let repoPath = "/repo/default-expiration-\(UUID().uuidString)"
         let context = WorkspaceContext.local
+        let storedAt = Date(timeIntervalSinceReferenceDate: 1_000)
         defer { cache.invalidateDefaultBranch(context: context, repoPath: repoPath) }
 
-        cache.storeDefaultBranch("basic-ui", context: context, repoPath: repoPath, storedAt: .distantPast)
+        cache.storeDefaultBranch("basic-ui", context: context, repoPath: repoPath, storedAt: storedAt)
 
-        #expect(cache.cachedDefaultBranch(context: context, repoPath: repoPath) == nil)
+        #expect(
+            cache.cachedDefaultBranch(context: context, repoPath: repoPath, now: storedAt.addingTimeInterval(300)) == nil
+        )
     }
 
     private func key(_ repoPath: String) -> GitMetadataCache.ReadKey {

--- a/Tests/MuxyTests/Git/GitReadCacheTests.swift
+++ b/Tests/MuxyTests/Git/GitReadCacheTests.swift
@@ -124,6 +124,36 @@ struct GitReadCacheTests {
         #expect(retainedRemoteEntry == remoteInfo)
     }
 
+    @Test("isolates default branches by workspace context")
+    func defaultBranchContextIsolation() {
+        let cache = GitMetadataCache.shared
+        let repoPath = "/repo/default-context-\(UUID().uuidString)"
+        let localContext = WorkspaceContext.local
+        let remoteContext = WorkspaceContext.ssh(SSHDestination(host: "example.test"))
+        defer {
+            cache.invalidateDefaultBranch(context: localContext, repoPath: repoPath)
+            cache.invalidateDefaultBranch(context: remoteContext, repoPath: repoPath)
+        }
+
+        cache.storeDefaultBranch("main", context: localContext, repoPath: repoPath)
+        cache.storeDefaultBranch("develop", context: remoteContext, repoPath: repoPath)
+
+        #expect(cache.cachedDefaultBranch(context: localContext, repoPath: repoPath) == "main")
+        #expect(cache.cachedDefaultBranch(context: remoteContext, repoPath: repoPath) == "develop")
+    }
+
+    @Test("expires stale default branches")
+    func defaultBranchExpiration() {
+        let cache = GitMetadataCache.shared
+        let repoPath = "/repo/default-expiration-\(UUID().uuidString)"
+        let context = WorkspaceContext.local
+        defer { cache.invalidateDefaultBranch(context: context, repoPath: repoPath) }
+
+        cache.storeDefaultBranch("basic-ui", context: context, repoPath: repoPath, storedAt: .distantPast)
+
+        #expect(cache.cachedDefaultBranch(context: context, repoPath: repoPath) == nil)
+    }
+
     private func key(_ repoPath: String) -> GitMetadataCache.ReadKey {
         GitMetadataCache.ReadKey(repoPath: repoPath, endpoint: "branches", params: "")
     }

--- a/Tests/MuxyTests/Git/GitRepositoryServiceNewAPIsTests.swift
+++ b/Tests/MuxyTests/Git/GitRepositoryServiceNewAPIsTests.swift
@@ -88,6 +88,23 @@ struct GitRepositoryServiceNewAPIsTests {
         #expect(await GitRepositoryService().defaultBranch(repoPath: repo.path) == "main")
     }
 
+    @Test("finds an existing remote-tracking branch reference")
+    func findsRemoteTrackingBranchReference() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        let remotePath = try repo.createBareRemote()
+        try repo.run("remote", "add", "origin", remotePath)
+        try repo.commit(file: "main.txt", contents: "main", message: "main")
+        try repo.run("push", "-u", "origin", "main")
+        let service = GitRepositoryService()
+
+        #expect(
+            await service.remoteTrackingBranchReference(repoPath: repo.path, branch: "main")
+                == "refs/remotes/origin/main"
+        )
+        #expect(await service.remoteTrackingBranchReference(repoPath: repo.path, branch: "missing") == nil)
+    }
+
     @Test("repoInfo reports root, gitDir and current branch for a normal repo")
     func repoInfoForNormalRepo() async throws {
         let repo = try TempGitRepo()

--- a/Tests/MuxyTests/Git/GitWorktreeServiceAddTests.swift
+++ b/Tests/MuxyTests/Git/GitWorktreeServiceAddTests.swift
@@ -52,6 +52,33 @@ struct GitWorktreeServiceAddTests {
         let mainHead = try repo.runCapturing("rev-parse", "main")
         #expect(head == mainHead)
     }
+
+    @Test("new branch can start from a full remote-tracking reference")
+    func newBranchUsesRemoteTrackingReference() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "remote.txt", contents: "remote", message: "remote base")
+        let remotePath = repo.siblingPath("remote.git")
+        try repo.run("init", "--bare", remotePath)
+        try repo.run("remote", "add", "origin", remotePath)
+        try repo.run("push", "-u", "origin", "main")
+        try repo.commit(file: "local.txt", contents: "local", message: "local head")
+
+        let worktreePath = repo.siblingPath("remote-base-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "feature",
+            createBranch: true,
+            baseBranch: "refs/remotes/origin/main"
+        )
+
+        let head = try repo.runCapturing(at: worktreePath, "rev-parse", "HEAD")
+        let remoteHead = try repo.runCapturing("rev-parse", "refs/remotes/origin/main")
+        #expect(head == remoteHead)
+        #expect(!FileManager.default.fileExists(atPath: "\(worktreePath)/local.txt"))
+    }
 }
 
 private struct TempGitRepo {

--- a/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
@@ -10,6 +10,7 @@ struct CreateWorktreeSheetTests {
 
         #expect(state.isLoading)
         #expect(state.branchOptions.isEmpty)
+        #expect(state.baseBranchOptions.isEmpty)
         #expect(state.selectedExistingBranch.isEmpty)
         #expect(state.selectedBaseBranch.isEmpty)
     }
@@ -21,24 +22,48 @@ struct CreateWorktreeSheetTests {
         state.finishLoading(
             branches: ["develop", "feature", "release"],
             defaultBranch: "release",
+            remoteDefaultBranchReference: nil,
             currentBranch: "feature"
         )
 
         #expect(!state.isLoading)
         #expect(state.branchOptions.map(\.name) == ["develop", "feature", "release"])
-        #expect(state.branchOptions.map(\.id) == ["develop", "feature", "release"])
+        #expect(state.branchOptions.map(\.reference) == ["develop", "feature", "release"])
+        #expect(state.baseBranchOptions == state.branchOptions)
         #expect(state.selectedExistingBranch == "develop")
         #expect(state.selectedBaseBranch == "release")
     }
 
-    @Test("missing local default branch falls back to develop before the current branch")
-    func missingLocalDefaultBranchFallsBackToDevelop() {
+    @Test("remote-tracking default branch remains available as a base")
+    func remoteTrackingDefaultBranchIsAvailableAsBase() {
         var state = WorktreeBranchLoadState()
 
-        state.finishLoading(branches: ["basic-ui", "develop"], defaultBranch: "main", currentBranch: "basic-ui")
+        state.finishLoading(
+            branches: ["basic-ui", "develop"],
+            defaultBranch: "main",
+            remoteDefaultBranchReference: "refs/remotes/origin/main",
+            currentBranch: "basic-ui"
+        )
 
         #expect(state.selectedExistingBranch == "basic-ui")
-        #expect(state.selectedBaseBranch == "develop")
+        #expect(state.branchOptions.map(\.name) == ["basic-ui", "develop"])
+        #expect(state.baseBranchOptions.map(\.name) == ["main", "basic-ui", "develop"])
+        #expect(state.baseBranchOptions.map(\.reference) == ["refs/remotes/origin/main", "basic-ui", "develop"])
+        #expect(state.selectedBaseBranch == "refs/remotes/origin/main")
+    }
+
+    @Test("current branch is preferred before conventional branch fallbacks")
+    func currentBranchPrecedesConventionalFallbacks() {
+        var state = WorktreeBranchLoadState()
+
+        state.finishLoading(
+            branches: ["basic-ui", "develop"],
+            defaultBranch: "main",
+            remoteDefaultBranchReference: nil,
+            currentBranch: "basic-ui"
+        )
+
+        #expect(state.selectedBaseBranch == "basic-ui")
     }
 
     @Test("conventional branch fallback order is develop, main, then master")
@@ -50,10 +75,21 @@ struct CreateWorktreeSheetTests {
         developState.finishLoading(
             branches: ["master", "main", "develop"],
             defaultBranch: nil,
-            currentBranch: "master"
+            remoteDefaultBranchReference: nil,
+            currentBranch: nil
         )
-        mainState.finishLoading(branches: ["master", "main"], defaultBranch: nil, currentBranch: "master")
-        masterState.finishLoading(branches: ["feature", "master"], defaultBranch: nil, currentBranch: "feature")
+        mainState.finishLoading(
+            branches: ["master", "main"],
+            defaultBranch: nil,
+            remoteDefaultBranchReference: nil,
+            currentBranch: nil
+        )
+        masterState.finishLoading(
+            branches: ["feature", "master"],
+            defaultBranch: nil,
+            remoteDefaultBranchReference: nil,
+            currentBranch: nil
+        )
 
         #expect(developState.selectedBaseBranch == "develop")
         #expect(mainState.selectedBaseBranch == "main")
@@ -64,7 +100,12 @@ struct CreateWorktreeSheetTests {
     func missingDefaultAndCurrentBranchesLeaveBaseUnselected() {
         var state = WorktreeBranchLoadState()
 
-        state.finishLoading(branches: ["basic-ui", "feature"], defaultBranch: "main", currentBranch: nil)
+        state.finishLoading(
+            branches: ["basic-ui", "feature"],
+            defaultBranch: "main",
+            remoteDefaultBranchReference: nil,
+            currentBranch: nil
+        )
 
         #expect(state.selectedExistingBranch == "basic-ui")
         #expect(state.selectedBaseBranch.isEmpty)
@@ -79,6 +120,7 @@ struct CreateWorktreeSheetTests {
         state.finishLoading(
             branches: ["feature", "develop", "main"],
             defaultBranch: "main",
+            remoteDefaultBranchReference: nil,
             currentBranch: "main"
         )
 
@@ -94,6 +136,7 @@ struct CreateWorktreeSheetTests {
 
         #expect(!state.isLoading)
         #expect(state.branchOptions.isEmpty)
+        #expect(state.baseBranchOptions.isEmpty)
         #expect(state.selectedExistingBranch.isEmpty)
         #expect(state.selectedBaseBranch.isEmpty)
     }

--- a/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/CreateWorktreeSheetTests.swift
@@ -18,23 +18,56 @@ struct CreateWorktreeSheetTests {
     func loadedBranchesSelectDefaults() {
         var state = WorktreeBranchLoadState()
 
-        state.finishLoading(branches: ["feature", "main"], defaultBranch: "main")
+        state.finishLoading(
+            branches: ["develop", "feature", "release"],
+            defaultBranch: "release",
+            currentBranch: "feature"
+        )
 
         #expect(!state.isLoading)
-        #expect(state.branchOptions.map(\.name) == ["feature", "main"])
-        #expect(state.branchOptions.map(\.id) == ["feature", "main"])
-        #expect(state.selectedExistingBranch == "feature")
-        #expect(state.selectedBaseBranch == "main")
+        #expect(state.branchOptions.map(\.name) == ["develop", "feature", "release"])
+        #expect(state.branchOptions.map(\.id) == ["develop", "feature", "release"])
+        #expect(state.selectedExistingBranch == "develop")
+        #expect(state.selectedBaseBranch == "release")
     }
 
-    @Test("missing default branch falls back to the first branch")
-    func missingDefaultBranchFallsBack() {
+    @Test("missing local default branch falls back to develop before the current branch")
+    func missingLocalDefaultBranchFallsBackToDevelop() {
         var state = WorktreeBranchLoadState()
 
-        state.finishLoading(branches: ["develop", "feature"], defaultBranch: "main")
+        state.finishLoading(branches: ["basic-ui", "develop"], defaultBranch: "main", currentBranch: "basic-ui")
 
-        #expect(state.selectedExistingBranch == "develop")
+        #expect(state.selectedExistingBranch == "basic-ui")
         #expect(state.selectedBaseBranch == "develop")
+    }
+
+    @Test("conventional branch fallback order is develop, main, then master")
+    func conventionalBranchFallbackOrder() {
+        var developState = WorktreeBranchLoadState()
+        var mainState = WorktreeBranchLoadState()
+        var masterState = WorktreeBranchLoadState()
+
+        developState.finishLoading(
+            branches: ["master", "main", "develop"],
+            defaultBranch: nil,
+            currentBranch: "master"
+        )
+        mainState.finishLoading(branches: ["master", "main"], defaultBranch: nil, currentBranch: "master")
+        masterState.finishLoading(branches: ["feature", "master"], defaultBranch: nil, currentBranch: "feature")
+
+        #expect(developState.selectedBaseBranch == "develop")
+        #expect(mainState.selectedBaseBranch == "main")
+        #expect(masterState.selectedBaseBranch == "master")
+    }
+
+    @Test("missing default and current branches leave the base unselected")
+    func missingDefaultAndCurrentBranchesLeaveBaseUnselected() {
+        var state = WorktreeBranchLoadState()
+
+        state.finishLoading(branches: ["basic-ui", "feature"], defaultBranch: "main", currentBranch: nil)
+
+        #expect(state.selectedExistingBranch == "basic-ui")
+        #expect(state.selectedBaseBranch.isEmpty)
     }
 
     @Test("loaded branches preserve existing selections")
@@ -45,7 +78,8 @@ struct CreateWorktreeSheetTests {
 
         state.finishLoading(
             branches: ["feature", "develop", "main"],
-            defaultBranch: "main"
+            defaultBranch: "main",
+            currentBranch: "main"
         )
 
         #expect(state.selectedExistingBranch == "feature")


### PR DESCRIPTION
## Summary
- stop choosing the alphabetically first branch when selecting a new worktree base
- honor the repository default through its full remote-tracking ref when no matching local branch exists
- select bases in this order: local or remote-tracking default, current branch, then `develop`, `main`, or `master`
- keep existing-branch choices local-only while displaying a friendly branch name for exact Git refs
- isolate default-branch cache entries by workspace and expire them after five minutes

## Testing
- `swift test --filter CreateWorktreeSheetTests`
- `swift test --filter GitReadCacheTests`
- `swift test --filter GitRepositoryServiceNewAPIsTests.findsRemoteTrackingBranchReference`
- `swift test --filter GitWorktreeServiceAddTests.newBranchUsesRemoteTrackingReference`
- `scripts/checks.sh --fix`

## AI Assistance
- OpenAI `gpt-5.6-sol` assisted with investigation, web research, implementation, review, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default-branch caching to prevent stale or cross-workspace results.
  * Create Worktree now selects base branches more reliably, prioritizing local and remote defaults, the current branch, and recognized fallback branches.
  * Supports creating worktrees from remote-tracking branch references.
  * Preserves the current selection and clearly handles cases where no suitable base branch is available.

* **Tests**
  * Added coverage for cache isolation, expiration, remote branches, worktree creation, and base-branch selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->