### PR TITLE
Add project activity indicator tooltips

### DIFF
--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -82,6 +82,7 @@
 "Always Show Project Search" = "Always Show Project Search";
 "Automatic updates are unavailable for this configuration." = "Automatic updates are unavailable for this configuration.";
 "Anonymous crash reports help us fix bugs. Reports never include project paths, file contents, or personal data." = "Anonymous crash reports help us fix bugs. Reports never include project paths, file contents, or personal data.";
+"An agent is waiting for your attention." = "An agent is waiting for your attention.";
 "App" = "App";
 "App & subprocess resource usage" = "App & subprocess resource usage";
 "App Default" = "App Default";
@@ -1260,6 +1261,8 @@
 "When enabled, releasing the mouse after selecting text in the terminal copies it to the clipboard." = "When enabled, releasing the mouse after selecting text in the terminal copies it to the clipboard.";
 "Wide" = "Wide";
 "Width" = "Width";
+"Work finished and is ready to review." = "Work finished and is ready to review.";
+"Work is in progress." = "Work is in progress.";
 "Working" = "Working";
 "Working tree clean" = "Working tree clean";
 "Working tree is clean" = "Working tree is clean";

--- a/Muxy/Views/Components/Badges/TerminalActivityIndicator.swift
+++ b/Muxy/Views/Components/Badges/TerminalActivityIndicator.swift
@@ -4,23 +4,42 @@ struct TerminalActivityIndicator: View {
     let activity: TerminalActivity
 
     var body: some View {
+        Group {
+            switch activity {
+            case .working:
+                ProgressView()
+                    .controlSize(.mini)
+                    .accessibilityLabel(L10n.string("Working"))
+            case .waiting:
+                Circle()
+                    .fill(MuxyTheme.warning)
+                    .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
+                    .accessibilityLabel(L10n.string("Waiting for attention"))
+            case let .unread(count):
+                NotificationBadge(count: count)
+            case .finished:
+                Circle()
+                    .fill(MuxyTheme.accent)
+                    .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
+                    .accessibilityLabel(L10n.string("Finished"))
+            }
+        }
+        .help(Self.tooltip(for: activity))
+    }
+
+    static func tooltip(for activity: TerminalActivity) -> String {
         switch activity {
         case .working:
-            ProgressView()
-                .controlSize(.mini)
-                .accessibilityLabel(L10n.string("Working"))
+            return L10n.string("Work is in progress.")
         case .waiting:
-            Circle()
-                .fill(MuxyTheme.warning)
-                .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
-                .accessibilityLabel(L10n.string("Waiting for attention"))
+            return L10n.string("An agent is waiting for your attention.")
         case let .unread(count):
-            NotificationBadge(count: count)
+            if count == 1 {
+                return L10n.string("1 unread notification")
+            }
+            return L10n.string("\(count) unread notifications")
         case .finished:
-            Circle()
-                .fill(MuxyTheme.accent)
-                .frame(width: UIMetrics.scaled(8), height: UIMetrics.scaled(8))
-                .accessibilityLabel(L10n.string("Finished"))
+            return L10n.string("Work finished and is ready to review.")
         }
     }
 }

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
@@ -283,7 +283,13 @@ struct ProjectRow: View {
         .overlay(alignment: .topTrailing) {
             if let projectActivity {
                 let offset = SidebarLayout.projectActivityIndicatorOffset(isUnread: projectActivity.isUnread)
-                TerminalActivityIndicator(activity: projectActivity)
+                Color.clear
+                    .frame(width: UIMetrics.scaled(18), height: UIMetrics.scaled(18))
+                    .overlay(alignment: .topTrailing) {
+                        TerminalActivityIndicator(activity: projectActivity)
+                    }
+                    .contentShape(Rectangle())
+                    .help(TerminalActivityIndicator.tooltip(for: projectActivity))
                     .offset(x: offset, y: -offset)
             }
         }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -388,6 +388,7 @@ struct TabFocusedProjectRow: View {
         HStack(spacing: 0) {
             if hovered || showAgentProviderMenu {
                 actions
+                statusIndicator
             } else if !isFocused {
                 if isWorktreeRow {
                     worktreeIndicator

--- a/Muxy/Views/Layouts/TabFocused/WorktreeLeafRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/WorktreeLeafRow.swift
@@ -62,6 +62,7 @@ struct WorktreeLeafRow: View {
 
             if hovered || showAgentProviderMenu {
                 leafAction
+                statusIndicator
             } else {
                 statusIndicator
             }

--- a/Tests/MuxyTests/Views/Components/Badges/TerminalActivityIndicatorTests.swift
+++ b/Tests/MuxyTests/Views/Components/Badges/TerminalActivityIndicatorTests.swift
@@ -1,0 +1,18 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("TerminalActivityIndicator")
+@MainActor
+struct TerminalActivityIndicatorTests {
+    @Test("tooltips explain every activity state")
+    func tooltipsExplainActivity() {
+        let progress = TerminalProgress(kind: .indeterminate, percent: nil)
+
+        #expect(TerminalActivityIndicator.tooltip(for: .working(progress)) == "Work is in progress.")
+        #expect(TerminalActivityIndicator.tooltip(for: .waiting) == "An agent is waiting for your attention.")
+        #expect(TerminalActivityIndicator.tooltip(for: .unread(1)) == "1 unread notification")
+        #expect(TerminalActivityIndicator.tooltip(for: .unread(3)) == "3 unread notifications")
+        #expect(TerminalActivityIndicator.tooltip(for: .finished) == "Work finished and is ready to review.")
+    }
+}


### PR DESCRIPTION
## Summary
- explain working, waiting, unread, and finished project activity indicators on hover
- keep indicators visible beside tab-focused hover actions so tooltips remain reachable
- enlarge the collapsed project indicator hover target without changing the visible bullet
- cover tooltip text, including unread singular and plural states

## Testing
- `scripts/checks.sh --fix`
- `scripts/run-tests-isolated.sh swift test --filter TerminalActivityIndicatorTests --quiet`

## AI assistance
- Implemented with assistance from OpenAI `gpt-5.6-sol`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localized status messages for working, waiting, unread notifications, and completed activity.
  - Added helpful tooltips describing terminal activity states, including unread notification counts.
  - Improved activity indicator visibility and positioning in project, tab, and worktree rows.
  - Status indicators now remain visible while hover actions are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->