### PR TITLE
feat: option to create independent terminal tabs on split

### DIFF
--- a/Muxy/Models/Preferences/TerminalSplitPreferences.swift
+++ b/Muxy/Models/Preferences/TerminalSplitPreferences.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum TerminalSplitPreferences {
+    static let independentTabsKey = "muxy.terminalSplit.independentTabs"
+    static let defaultIndependentTabs = false
+
+    static var independentTabs: Bool {
+        get {
+            let defaults = UserDefaults.standard
+            guard defaults.object(forKey: independentTabsKey) != nil else { return defaultIndependentTabs }
+            return defaults.bool(forKey: independentTabsKey)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: independentTabsKey) }
+    }
+}

--- a/Muxy/Models/Workspace/AppState.swift
+++ b/Muxy/Models/Workspace/AppState.swift
@@ -502,6 +502,30 @@ final class AppState {
         )))
     }
 
+    @discardableResult
+    func splitFocusedAreaAsTopLevelTab(direction: SplitDirection, projectID: UUID) -> Bool {
+        guard let key = activeWorktreeKey(for: projectID),
+              let area = focusedArea(for: projectID),
+              let activeTab = area.activeTab,
+              let layout = topLevelTabLayouts[key],
+              let sourceGroup = layout.group(containingTabID: activeTab.parentTabID ?? activeTab.id)
+        else { return false }
+
+        dispatch(.createTab(projectID: projectID, areaID: area.id))
+
+        guard let newActiveTab = focusedArea(for: projectID)?.activeTab else { return false }
+        dispatch(.moveTopLevelTab(
+            projectID: projectID,
+            request: .toNewSplit(
+                tabID: newActiveTab.id,
+                sourceGroupID: sourceGroup.id,
+                targetGroupID: sourceGroup.id,
+                split: SplitPlacement(direction: direction, position: .second)
+            )
+        ))
+        return true
+    }
+
     func toggleMaximize(
         areaID: UUID,
         topLevelTabID requestedTopLevelTabID: UUID? = nil,

--- a/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
+++ b/Muxy/Services/Keyboard/ShortcutActionDispatcher.swift
@@ -134,10 +134,16 @@ struct ShortcutActionDispatcher {
             return true
         case .splitRight:
             guard let projectID = appState.activeProjectID else { return false }
+            if TerminalSplitPreferences.independentTabs {
+                return appState.splitFocusedAreaAsTopLevelTab(direction: .horizontal, projectID: projectID)
+            }
             appState.splitFocusedArea(direction: .horizontal, projectID: projectID)
             return true
         case .splitDown:
             guard let projectID = appState.activeProjectID else { return false }
+            if TerminalSplitPreferences.independentTabs {
+                return appState.splitFocusedAreaAsTopLevelTab(direction: .vertical, projectID: projectID)
+            }
             appState.splitFocusedArea(direction: .vertical, projectID: projectID)
             return true
         case .closePane:

--- a/Muxy/Views/Settings/TerminalSettingsView.swift
+++ b/Muxy/Views/Settings/TerminalSettingsView.swift
@@ -67,6 +67,22 @@ struct TerminalSettingsView: View {
             }
 
             SettingsSection(
+                "Split panes",
+                footer: """
+                When enabled, Command-D and Command-Shift-D create independent \
+                terminal tabs instead of grouping the new terminal under the current tab.
+                """
+            ) {
+                SettingsToggleRow(
+                    label: "Create independent terminal tabs",
+                    isOn: Binding(
+                        get: { TerminalSplitPreferences.independentTabs },
+                        set: { TerminalSplitPreferences.independentTabs = $0 }
+                    )
+                )
+            }
+
+            SettingsSection(
                 "Background sessions",
                 footer: """
                 Runs each new terminal in a separate background process, the way tmux does. Quitting Muxy leaves \


### PR DESCRIPTION
## Summary

Adds a **"Create independent terminal tabs"** setting under Terminal Settings. When enabled, Command-D / Command-Shift-D open the new terminal as its own top-level tab group — side-by-side in one screen, each pane with its own tab strip — instead of the current in-tab split that groups the new pane under the active tab. The default is unchanged.

## Why

The current split groups the new terminal under the active tab in the tab strip. Some users prefer the older behavior where each split pane behaves as an independent terminal tab. Making it a setting keeps the existing default for everyone while allowing the older workflow.

## Checks

- `swiftformat --lint` passes on all changed files
- `swiftlint lint --strict` passes on all changed files
- `swift build -c release` passes
- `swift test` — full suite passes

## AI contribution notice

As required by the contribution guidelines, this work was developed with the assistance of DeepSeek V4 flash. The author reviewed and verified the code.
