### PR TITLE
Count nested untracked files in repository summaries

### DIFF
--- a/Muxy/Services/Git/GitRepositoryService.swift
+++ b/Muxy/Services/Git/GitRepositoryService.swift
@@ -258,7 +258,7 @@ struct GitRepositoryService {
     func repositorySummary(repoPath: String) async throws -> GitRepositorySummary {
         let result = try await runGit(
             repoPath: repoPath,
-            arguments: ["status", "--porcelain=v2", "--branch", "--untracked-files=normal"]
+            arguments: ["status", "--porcelain=v2", "--branch", "--untracked-files=all"]
         )
         guard result.status == 0 else {
             let message = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/MuxyTests/Git/GitRepositoryServiceNewAPIsTests.swift
+++ b/Tests/MuxyTests/Git/GitRepositoryServiceNewAPIsTests.swift
@@ -340,6 +340,41 @@ struct GitRepositoryServiceNewAPIsTests {
         #expect(before != after)
     }
 
+    @Test("repository summary counts every file shown in changes")
+    func repositorySummaryMatchesChangedFiles() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        try repo.commit(file: "tracked.txt", contents: "original\n", message: "init")
+        try "modified\n".write(
+            to: URL(fileURLWithPath: repo.path).appendingPathComponent("tracked.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "staged\n".write(
+            to: URL(fileURLWithPath: repo.path).appendingPathComponent("staged.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try repo.run("add", "staged.txt")
+        let nestedDirectory = URL(fileURLWithPath: repo.path).appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+        try "one\n".write(to: nestedDirectory.appendingPathComponent("one.txt"), atomically: true, encoding: .utf8)
+        try "two\n".write(to: nestedDirectory.appendingPathComponent("two.txt"), atomically: true, encoding: .utf8)
+
+        let service = GitRepositoryService()
+        let summary = try await service.repositorySummary(repoPath: repo.path)
+        let files = try await service.changedFiles(repoPath: repo.path, includeUntrackedLineCounts: false)
+        let snapshot = RepositoryChangesPresentation.makeSnapshot(files)
+
+        #expect(summary.changedCount == 4)
+        #expect(summary.changedCount == snapshot.fileCount)
+        #expect(summary.stagedCount == 1)
+        #expect(summary.unstagedCount == 1)
+        #expect(summary.untrackedCount == 2)
+        #expect(snapshot.stagedFiles.map(\.path) == ["staged.txt"])
+        #expect(snapshot.unstagedFiles.map(\.path) == ["nested/one.txt", "nested/two.txt", "tracked.txt"])
+    }
+
     @Test("stage and unstage rename include both repository paths")
     func stageAndUnstageRename() async throws {
         let repo = try TempGitRepo()


### PR DESCRIPTION
Use full untracked-file reporting so repository summary counts match the files shown in changes, with regression coverage for staged, modified, and nested untracked files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository summaries now include all untracked files, including files within nested directories.
  * File counts and staged/unstaged lists more accurately reflect the repository state.

* **Tests**
  * Added coverage for modified, staged, and nested untracked files in repository summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->