### PR TITLE
Export MUXY_WORKTREE_ID in worktree teardown environment

### DIFF
--- a/Muxy/Services/Project/WorktreeTeardownRunner.swift
+++ b/Muxy/Services/Project/WorktreeTeardownRunner.swift
@@ -86,6 +86,7 @@ enum WorktreeTeardownRunner {
 
     private static func environment(for worktree: Worktree) -> [String: String] {
         var environment = ProcessInfo.processInfo.environment
+        environment["MUXY_WORKTREE_ID"] = worktree.id.uuidString
         environment["MUXY_WORKTREE_PATH"] = worktree.path
         environment["MUXY_WORKTREE_NAME"] = worktree.name
         environment["MUXY_WORKTREE_BRANCH"] = worktree.branch ?? ""

--- a/Tests/MuxyTests/Services/Project/WorktreeTeardownRunnerTests.swift
+++ b/Tests/MuxyTests/Services/Project/WorktreeTeardownRunnerTests.swift
@@ -44,6 +44,7 @@ struct WorktreeTeardownRunnerTests {
         )
 
         #expect(capture.commands == ["first", "second"])
+        #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_ID"] == worktree.id.uuidString })
         #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_PATH"] == worktreePath })
         #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_NAME"] == "Feature" })
         #expect(capture.environments.allSatisfy { $0["MUXY_WORKTREE_BRANCH"] == "feature/test" })


### PR DESCRIPTION
### Summary

When running worktree teardown commands configured in `.muxy/worktree.json`, `WorktreeTeardownRunner` set `MUXY_WORKTREE_PATH`, `MUXY_WORKTREE_NAME`, and `MUXY_WORKTREE_BRANCH`, but did not export `MUXY_WORKTREE_ID`.

This prevented teardown hooks (such as DockerTree or Compose teardown scripts that derive deterministic container project names using `MUXY_WORKTREE_ID`) from running successfully, causing worktree deletion to fail with exit code 69.

### Changes
- In `WorktreeTeardownRunner.environment(for:)`, export `MUXY_WORKTREE_ID = worktree.id.uuidString`.
- Update `WorktreeTeardownRunnerTests` to assert `MUXY_WORKTREE_ID` is passed to teardown command executions.

### Test Plan
- Run `swift test --filter WorktreeTeardownRunnerTests` (all 8 tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Teardown commands now receive the correct worktree identifier through the environment.
  * Improved reliability for workflows that need to identify the worktree being removed.

* **Tests**
  * Added coverage confirming the worktree identifier is passed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->