### PR TITLE
Add multi-select staging in the changes popover

### DIFF
--- a/Muxy/Models/Layout/RepositoryChangesFileSelection.swift
+++ b/Muxy/Models/Layout/RepositoryChangesFileSelection.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+struct RepositoryChangesFileSelection: Equatable {
+    enum Click: Equatable {
+        case exclusive
+        case toggle
+        case range
+        case addingRange
+
+        static func from(command: Bool, shift: Bool) -> Click {
+            switch (command, shift) {
+            case (true, true):
+                .addingRange
+            case (false, true):
+                .range
+            case (true, false):
+                .toggle
+            case (false, false):
+                .exclusive
+            }
+        }
+    }
+
+    private(set) var selectedIDs: Set<String> = []
+    private(set) var anchorID: String?
+
+    var isEmpty: Bool { selectedIDs.isEmpty }
+
+    func contains(_ id: String) -> Bool {
+        selectedIDs.contains(id)
+    }
+
+    func files(in files: [GitStatusFile]) -> [GitStatusFile] {
+        files.filter { selectedIDs.contains($0.id) }
+    }
+
+    func actionTargets(_ file: GitStatusFile, in files: [GitStatusFile]) -> [GitStatusFile] {
+        let selected = self.files(in: files)
+        if selected.contains(where: { $0.id == file.id }) {
+            return selected
+        }
+        return [file]
+    }
+
+    mutating func handleClick(id: String, ids: [String], kind: Click) {
+        guard ids.contains(id) else { return }
+
+        switch kind {
+        case .exclusive:
+            if selectedIDs == [id] {
+                selectedIDs = []
+                anchorID = nil
+                return
+            }
+            selectedIDs = [id]
+            anchorID = id
+        case .toggle:
+            if selectedIDs.contains(id) {
+                selectedIDs.remove(id)
+            } else {
+                selectedIDs.insert(id)
+            }
+            anchorID = id
+        case .range:
+            selectedIDs = rangedIDs(to: id, ids: ids)
+        case .addingRange:
+            selectedIDs.formUnion(rangedIDs(to: id, ids: ids))
+        }
+    }
+
+    mutating func retain(ids: [String]) {
+        let valid = Set(ids)
+        selectedIDs.formIntersection(valid)
+        if let anchorID, !valid.contains(anchorID) {
+            self.anchorID = nil
+        }
+    }
+
+    mutating func remove(ids: [String]) {
+        selectedIDs.subtract(ids)
+        if let anchorID, !selectedIDs.contains(anchorID) {
+            self.anchorID = nil
+        }
+    }
+
+    private mutating func rangedIDs(to id: String, ids: [String]) -> Set<String> {
+        guard let end = ids.firstIndex(of: id) else { return [] }
+        let start: Int
+        if let anchorID, let anchorIndex = ids.firstIndex(of: anchorID) {
+            start = anchorIndex
+        } else {
+            start = end
+            self.anchorID = id
+        }
+        return Set(ids[min(start, end) ... max(start, end)])
+    }
+}

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -846,6 +846,7 @@
 "Stable" = "Stable";
 "Stage %@" = "Stage %@";
 "Stage All" = "Stage All";
+"Stage Selected" = "Stage Selected";
 "Stage resolved file %@" = "Stage resolved file %@";
 "Staged" = "Staged";
 "Start Voice Recording" = "Start Voice Recording";
@@ -1213,6 +1214,7 @@
 "Unpin Tab" = "Unpin Tab";
 "Unstage %@" = "Unstage %@";
 "Unstage All" = "Unstage All";
+"Unstage Selected" = "Unstage Selected";
 "Unstaged changes to this file will be permanently discarded." = "Unstaged changes to this file will be permanently discarded.";
 "Up to date" = "Up to date";
 "Update" = "Update";

--- a/Muxy/Views/Components/Interaction/LeftClickView.swift
+++ b/Muxy/Views/Components/Interaction/LeftClickView.swift
@@ -2,7 +2,15 @@ import AppKit
 import SwiftUI
 
 struct LeftClickView: NSViewRepresentable {
-    let action: () -> Void
+    let action: (NSEvent) -> Void
+
+    init(action: @escaping () -> Void) {
+        self.action = { _ in action() }
+    }
+
+    init(action: @escaping (NSEvent) -> Void) {
+        self.action = action
+    }
 
     func makeNSView(context: Context) -> LeftClickNSView {
         let view = LeftClickNSView()
@@ -16,7 +24,7 @@ struct LeftClickView: NSViewRepresentable {
 }
 
 final class LeftClickNSView: NSView {
-    var action: (() -> Void)?
+    var action: ((NSEvent) -> Void)?
     private var isPressed = false
 
     override func isAccessibilityElement() -> Bool {
@@ -40,6 +48,6 @@ final class LeftClickNSView: NSView {
         guard wasPressed,
               bounds.contains(convert(event.locationInWindow, from: nil))
         else { return }
-        action?()
+        action?(event)
     }
 }

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedChangesPopover.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct TabFocusedChangesPopover: View {
@@ -13,10 +14,8 @@ struct TabFocusedChangesPopover: View {
     let worktreeRemovalState: RepositoryToolbarPresentation.WorktreeRemovalState
     let worktreeRemovalHelp: String?
     let onRefresh: () async -> Void
-    let onStage: (GitStatusFile) -> Void
-    let onStageAll: () -> Void
-    let onUnstage: (GitStatusFile) -> Void
-    let onUnstageAll: () -> Void
+    let onStage: ([GitStatusFile]) -> Void
+    let onUnstage: ([GitStatusFile]) -> Void
     let onDiscard: (GitStatusFile) -> Void
     let onLoadLineStats: (GitStatusFile) async -> Void
     let onRemoveWorktree: () -> Void
@@ -24,6 +23,9 @@ struct TabFocusedChangesPopover: View {
     @State private var pendingDiscard: GitStatusFile?
     @State private var isRemoveWorktreeHovered = false
     @State private var refreshGeneration = 0
+    @State private var conflictedSelection = RepositoryChangesFileSelection()
+    @State private var stagedSelection = RepositoryChangesFileSelection()
+    @State private var unstagedSelection = RepositoryChangesFileSelection()
 
     private var isInteractionDisabled: Bool {
         isLoading || isMutating || isRepositoryInteractionDisabled
@@ -57,6 +59,15 @@ struct TabFocusedChangesPopover: View {
                 },
                 secondaryButton: .cancel()
             )
+        }
+        .onChange(of: changes.conflictedFiles.map(\.id)) { _, ids in
+            conflictedSelection.retain(ids: ids)
+        }
+        .onChange(of: changes.stagedFiles.map(\.id)) { _, ids in
+            stagedSelection.retain(ids: ids)
+        }
+        .onChange(of: changes.unstagedFiles.map(\.id)) { _, ids in
+            unstagedSelection.retain(ids: ids)
         }
         .task(id: refreshGeneration) {
             await Task.yield()
@@ -121,7 +132,7 @@ struct TabFocusedChangesPopover: View {
                             files: changes.conflictedFiles,
                             lineStats: changes.conflictedLineStats,
                             side: .conflicted,
-                            batchAction: nil
+                            batchActions: conflictedBatchActions
                         )
                     }
                     if !changes.stagedFiles.isEmpty {
@@ -130,7 +141,7 @@ struct TabFocusedChangesPopover: View {
                             files: changes.stagedFiles,
                             lineStats: changes.stagedLineStats,
                             side: .staged,
-                            batchAction: ("Unstage All", onUnstageAll)
+                            batchActions: stagedBatchActions
                         )
                     }
                     if !changes.unstagedFiles.isEmpty {
@@ -139,7 +150,7 @@ struct TabFocusedChangesPopover: View {
                             files: changes.unstagedFiles,
                             lineStats: changes.unstagedLineStats.merging(untrackedLineStatsSummary),
                             side: .unstaged,
-                            batchAction: ("Stage All", onStageAll)
+                            batchActions: unstagedBatchActions
                         )
                     }
                 }
@@ -153,11 +164,12 @@ struct TabFocusedChangesPopover: View {
         files: [GitStatusFile],
         lineStats sectionLineStats: RepositoryChangesLineStats,
         side: ChangeSide,
-        batchAction: (title: LocalizedStringResource, action: () -> Void)?
+        batchActions: [ChangesPopoverBatchAction]
     ) -> some View {
         Section {
             ForEach(files) { file in
                 fileRow(file, side: side)
+                    .id(rowID(file, side: side))
             }
         } header: {
             HStack(spacing: UIMetrics.spacing3) {
@@ -169,12 +181,16 @@ struct TabFocusedChangesPopover: View {
                     .foregroundStyle(MuxyTheme.fgDim)
                 lineStats(sectionLineStats)
                 Spacer(minLength: UIMetrics.spacing3)
-                if let batchAction {
-                    Button(L10n.string(batchAction.title), action: batchAction.action)
-                        .buttonStyle(.plain)
-                        .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
-                        .foregroundStyle(MuxyTheme.accent)
-                        .disabled(isInteractionDisabled)
+                HStack(spacing: UIMetrics.spacing4) {
+                    ForEach(batchActions.indices, id: \.self) { index in
+                        let action = batchActions[index]
+                        Button(L10n.string(action.title), action: action.action)
+                            .buttonStyle(.plain)
+                            .font(.system(size: UIMetrics.fontCaption, weight: .semibold))
+                            .foregroundStyle(isInteractionDisabled ? MuxyTheme.fgDim : MuxyTheme.accent)
+                            .disabled(isInteractionDisabled)
+                            .fixedSize()
+                    }
                 }
             }
             .padding(.horizontal, UIMetrics.spacing4)
@@ -185,29 +201,47 @@ struct TabFocusedChangesPopover: View {
     }
 
     private func fileRow(_ file: GitStatusFile, side: ChangeSide) -> some View {
-        ChangesPopoverFileRow {
+        let isSelected = selection(for: side).contains(file.id)
+        return ChangesPopoverFileRow(isSelected: isSelected) {
             HStack(spacing: UIMetrics.spacing3) {
-                Text(file.displayStatusText(isStaged: side == .staged))
-                    .font(.system(size: UIMetrics.fontXS, weight: .bold, design: .monospaced))
-                    .foregroundStyle(statusColor(file, side: side))
-                    .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
-                    .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
+                HStack(spacing: UIMetrics.spacing3) {
+                    Text(file.displayStatusText(isStaged: side == .staged))
+                        .font(.system(size: UIMetrics.fontXS, weight: .bold, design: .monospaced))
+                        .foregroundStyle(statusColor(file, side: side))
+                        .frame(width: UIMetrics.controlSmall, height: UIMetrics.controlSmall)
+                        .background(MuxyTheme.surface, in: RoundedRectangle(cornerRadius: UIMetrics.radiusSM))
 
-                VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
-                    Text((file.path as NSString).lastPathComponent)
-                        .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
-                        .foregroundStyle(MuxyTheme.fg)
-                        .lineLimit(1)
-                    Text(fileDetail(file))
-                        .font(.system(size: UIMetrics.fontXS, design: .monospaced))
-                        .foregroundStyle(MuxyTheme.fgMuted)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                    VStack(alignment: .leading, spacing: UIMetrics.spacing1) {
+                        Text((file.path as NSString).lastPathComponent)
+                            .font(.system(size: UIMetrics.fontFootnote, weight: .semibold))
+                            .foregroundStyle(MuxyTheme.fg)
+                            .lineLimit(1)
+                        Text(fileDetail(file))
+                            .font(.system(size: UIMetrics.fontXS, design: .monospaced))
+                            .foregroundStyle(MuxyTheme.fgMuted)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+
+                    Spacer(minLength: UIMetrics.spacing2)
+                    fileLineStats(file, side: side)
+                        .frame(minWidth: UIMetrics.scaled(56), alignment: .trailing)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .overlay {
+                    LeftClickView { event in
+                        handleFileClick(file, side: side, event: event)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityHidden(true)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+                .accessibilityAction {
+                    handleFileClick(file, side: side, kind: .exclusive)
                 }
 
-                Spacer(minLength: UIMetrics.spacing2)
-                fileLineStats(file, side: side)
-                    .frame(minWidth: UIMetrics.scaled(56), alignment: .trailing)
                 rowActions(file, side: side)
             }
         }
@@ -228,21 +262,21 @@ struct TabFocusedChangesPopover: View {
                 symbol: "plus",
                 help: L10n.string("Stage resolved file \(file.path)"),
                 isDisabled: isInteractionDisabled,
-                action: { onStage(file) }
+                action: { stage(actionTargets(file, side: side), from: side) }
             )
         case .staged:
             ChangesPopoverActionButton(
                 symbol: "minus",
                 help: L10n.string("Unstage \(file.path)"),
                 isDisabled: isInteractionDisabled,
-                action: { onUnstage(file) }
+                action: { unstage(actionTargets(file, side: side), from: side) }
             )
         case .unstaged:
             ChangesPopoverActionButton(
                 symbol: "plus",
                 help: L10n.string("Stage \(file.path)"),
                 isDisabled: isInteractionDisabled,
-                action: { onStage(file) }
+                action: { stage(actionTargets(file, side: side), from: side) }
             )
             ChangesPopoverActionButton(
                 symbol: "trash",
@@ -402,6 +436,116 @@ struct TabFocusedChangesPopover: View {
         refreshGeneration &+= 1
     }
 
+    private var conflictedBatchActions: [ChangesPopoverBatchAction] {
+        guard !conflictedSelection.isEmpty else { return [] }
+        return [
+            ChangesPopoverBatchAction(
+                title: "Stage Selected",
+                action: { stage(conflictedSelection.files(in: changes.conflictedFiles), from: .conflicted) }
+            ),
+        ]
+    }
+
+    private var stagedBatchActions: [ChangesPopoverBatchAction] {
+        var actions: [ChangesPopoverBatchAction] = []
+        if !stagedSelection.isEmpty {
+            actions.append(ChangesPopoverBatchAction(
+                title: "Unstage Selected",
+                action: { unstage(stagedSelection.files(in: changes.stagedFiles), from: .staged) }
+            ))
+        }
+        actions.append(ChangesPopoverBatchAction(
+            title: "Unstage All",
+            action: { unstage(changes.stagedFiles, from: .staged) }
+        ))
+        return actions
+    }
+
+    private var unstagedBatchActions: [ChangesPopoverBatchAction] {
+        var actions: [ChangesPopoverBatchAction] = []
+        if !unstagedSelection.isEmpty {
+            actions.append(ChangesPopoverBatchAction(
+                title: "Stage Selected",
+                action: { stage(unstagedSelection.files(in: changes.unstagedFiles), from: .unstaged) }
+            ))
+        }
+        actions.append(ChangesPopoverBatchAction(
+            title: "Stage All",
+            action: { stage(changes.unstagedFiles, from: .unstaged) }
+        ))
+        return actions
+    }
+
+    private func selection(for side: ChangeSide) -> RepositoryChangesFileSelection {
+        switch side {
+        case .conflicted: conflictedSelection
+        case .staged: stagedSelection
+        case .unstaged: unstagedSelection
+        }
+    }
+
+    private func files(for side: ChangeSide) -> [GitStatusFile] {
+        switch side {
+        case .conflicted: changes.conflictedFiles
+        case .staged: changes.stagedFiles
+        case .unstaged: changes.unstagedFiles
+        }
+    }
+
+    private func handleFileClick(_ file: GitStatusFile, side: ChangeSide, event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        handleFileClick(
+            file,
+            side: side,
+            kind: .from(command: flags.contains(.command), shift: flags.contains(.shift))
+        )
+    }
+
+    private func handleFileClick(
+        _ file: GitStatusFile,
+        side: ChangeSide,
+        kind: RepositoryChangesFileSelection.Click
+    ) {
+        let ids = files(for: side).map(\.id)
+        switch side {
+        case .conflicted:
+            conflictedSelection.handleClick(id: file.id, ids: ids, kind: kind)
+        case .staged:
+            stagedSelection.handleClick(id: file.id, ids: ids, kind: kind)
+        case .unstaged:
+            unstagedSelection.handleClick(id: file.id, ids: ids, kind: kind)
+        }
+    }
+
+    private func actionTargets(_ file: GitStatusFile, side: ChangeSide) -> [GitStatusFile] {
+        selection(for: side).actionTargets(file, in: files(for: side))
+    }
+
+    private func rowID(_ file: GitStatusFile, side: ChangeSide) -> String {
+        "\(side.rawValue):\(file.path)"
+    }
+
+    private func stage(_ files: [GitStatusFile], from side: ChangeSide) {
+        removeFromSelection(files.map(\.id), side: side)
+        onStage(files)
+    }
+
+    private func unstage(_ files: [GitStatusFile], from side: ChangeSide) {
+        removeFromSelection(files.map(\.id), side: side)
+        onUnstage(files)
+    }
+
+    private func removeFromSelection(_ ids: [String], side: ChangeSide) {
+        switch side {
+        case .conflicted:
+            conflictedSelection.remove(ids: ids)
+        case .staged:
+            stagedSelection.remove(ids: ids)
+        case .unstaged:
+            unstagedSelection.remove(ids: ids)
+        }
+    }
+
     private func statusColor(_ file: GitStatusFile, side: ChangeSide) -> Color {
         if side == .conflicted {
             return MuxyTheme.warning
@@ -415,7 +559,7 @@ struct TabFocusedChangesPopover: View {
         }
     }
 
-    private enum ChangeSide: Equatable {
+    private enum ChangeSide: String, Equatable, Hashable {
         case conflicted
         case staged
         case unstaged
@@ -428,6 +572,11 @@ struct TabFocusedChangesPopover: View {
             }
         }
     }
+}
+
+private struct ChangesPopoverBatchAction {
+    let title: LocalizedStringResource
+    let action: () -> Void
 }
 
 private struct ChangesPopoverActionButton: View {
@@ -466,11 +615,13 @@ private struct ChangesPopoverActionButton: View {
 }
 
 private struct ChangesPopoverFileRow<Content: View>: View {
+    let isSelected: Bool
     let content: Content
 
     @State private var isHovered = false
 
-    init(@ViewBuilder content: () -> Content) {
+    init(isSelected: Bool, @ViewBuilder content: () -> Content) {
+        self.isSelected = isSelected
         self.content = content()
     }
 
@@ -479,11 +630,21 @@ private struct ChangesPopoverFileRow<Content: View>: View {
             .padding(.horizontal, UIMetrics.spacing4)
             .frame(height: UIMetrics.scaled(34))
             .background(
-                isHovered ? MuxyTheme.hover : .clear,
+                rowBackground,
                 in: RoundedRectangle(cornerRadius: UIMetrics.radiusMD)
             )
             .padding(.horizontal, UIMetrics.spacing2)
             .contentShape(Rectangle())
             .onHover { isHovered = $0 }
+    }
+
+    private var rowBackground: Color {
+        if isSelected {
+            return MuxyTheme.accentSoft
+        }
+        if isHovered {
+            return MuxyTheme.hover
+        }
+        return .clear
     }
 }

--- a/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
+++ b/Muxy/Views/Terminal/RepositoryStatusBarItems.swift
@@ -275,18 +275,10 @@ struct RepositoryStatusBarItems: View {
                     onRefresh: {
                         await repositoryState.refreshWorkingTreeDetails()
                     },
-                    onStage: { file in
-                        modifyChanges { await repositoryState.stage(file) }
-                    },
-                    onStageAll: {
-                        let files = repositoryState.changesSnapshot.unstagedFiles
+                    onStage: { files in
                         modifyChanges { await repositoryState.stage(files) }
                     },
-                    onUnstage: { file in
-                        modifyChanges { await repositoryState.unstage(file) }
-                    },
-                    onUnstageAll: {
-                        let files = repositoryState.changesSnapshot.stagedFiles
+                    onUnstage: { files in
                         modifyChanges { await repositoryState.unstage(files) }
                     },
                     onDiscard: { file in

--- a/Tests/MuxyTests/Models/Layout/RepositoryChangesFileSelectionTests.swift
+++ b/Tests/MuxyTests/Models/Layout/RepositoryChangesFileSelectionTests.swift
@@ -1,0 +1,154 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("RepositoryChangesFileSelection")
+struct RepositoryChangesFileSelectionTests {
+    private let ids = ["a.swift", "b.swift", "c.swift", "d.swift", "e.swift"]
+
+    @Test("plain click selects only the clicked file")
+    func exclusiveClickReplacesSelection() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "b.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "d.swift", ids: ids, kind: .exclusive)
+
+        #expect(selection.selectedIDs == ["d.swift"])
+        #expect(selection.anchorID == "d.swift")
+    }
+
+    @Test("plain click on the only selected file clears the selection")
+    func exclusiveClickOnSoleSelectionClears() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "b.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "b.swift", ids: ids, kind: .exclusive)
+
+        #expect(selection.isEmpty)
+        #expect(selection.anchorID == nil)
+    }
+
+    @Test("command click toggles files without clearing the rest")
+    func commandClickToggles() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "a.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "c.swift", ids: ids, kind: .toggle)
+        selection.handleClick(id: "e.swift", ids: ids, kind: .toggle)
+        selection.handleClick(id: "c.swift", ids: ids, kind: .toggle)
+
+        #expect(selection.selectedIDs == ["a.swift", "e.swift"])
+        #expect(selection.anchorID == "c.swift")
+    }
+
+    @Test("shift click selects a contiguous range from the anchor")
+    func shiftClickSelectsRange() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "b.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "d.swift", ids: ids, kind: .range)
+
+        #expect(selection.selectedIDs == ["b.swift", "c.swift", "d.swift"])
+        #expect(selection.anchorID == "b.swift")
+    }
+
+    @Test("later shift clicks keep the original anchor")
+    func shiftClickKeepsAnchor() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "c.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "e.swift", ids: ids, kind: .range)
+        selection.handleClick(id: "a.swift", ids: ids, kind: .range)
+
+        #expect(selection.selectedIDs == ["a.swift", "b.swift", "c.swift"])
+        #expect(selection.anchorID == "c.swift")
+    }
+
+    @Test("command-shift click adds a range to the existing selection")
+    func commandShiftAddsRange() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "a.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "e.swift", ids: ids, kind: .toggle)
+        selection.handleClick(id: "c.swift", ids: ids, kind: .addingRange)
+
+        #expect(selection.selectedIDs == ["a.swift", "c.swift", "d.swift", "e.swift"])
+        #expect(selection.anchorID == "e.swift")
+    }
+
+    @Test("shift click without an anchor selects the clicked file")
+    func shiftClickWithoutAnchor() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "c.swift", ids: ids, kind: .range)
+
+        #expect(selection.selectedIDs == ["c.swift"])
+        #expect(selection.anchorID == "c.swift")
+    }
+
+    @Test("clicks on unknown ids are ignored")
+    func ignoresUnknownIDs() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "b.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "missing.swift", ids: ids, kind: .toggle)
+
+        #expect(selection.selectedIDs == ["b.swift"])
+        #expect(selection.anchorID == "b.swift")
+    }
+
+    @Test("maps modifier flags onto click kinds")
+    func clickKindFromModifiers() {
+        #expect(RepositoryChangesFileSelection.Click.from(command: false, shift: false) == .exclusive)
+        #expect(RepositoryChangesFileSelection.Click.from(command: true, shift: false) == .toggle)
+        #expect(RepositoryChangesFileSelection.Click.from(command: false, shift: true) == .range)
+        #expect(RepositoryChangesFileSelection.Click.from(command: true, shift: true) == .addingRange)
+    }
+
+    @Test("row actions apply to the selection when the clicked file is selected")
+    func actionTargetsUseSelection() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "a.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "c.swift", ids: ids, kind: .toggle)
+        let files = ids.map { file(path: $0) }
+
+        #expect(selection.actionTargets(files[0], in: files).map(\.path) == ["a.swift", "c.swift"])
+        #expect(selection.actionTargets(files[3], in: files).map(\.path) == ["d.swift"])
+    }
+
+    @Test("retain drops files that left the list and preserves list order")
+    func retainDropsMissingFiles() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "a.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "c.swift", ids: ids, kind: .toggle)
+        selection.handleClick(id: "e.swift", ids: ids, kind: .toggle)
+        selection.retain(ids: ["c.swift", "d.swift", "e.swift"])
+
+        let remaining = [
+            file(path: "c.swift"),
+            file(path: "d.swift"),
+            file(path: "e.swift"),
+        ]
+        #expect(selection.files(in: remaining).map(\.path) == ["c.swift", "e.swift"])
+        #expect(selection.anchorID == "e.swift")
+
+        selection.retain(ids: ["c.swift"])
+        #expect(selection.selectedIDs == ["c.swift"])
+        #expect(selection.anchorID == nil)
+    }
+
+    @Test("remove drops staged files without selecting them in another list")
+    func removeDropsIDs() {
+        var selection = RepositoryChangesFileSelection()
+        selection.handleClick(id: "a.swift", ids: ids, kind: .exclusive)
+        selection.handleClick(id: "c.swift", ids: ids, kind: .toggle)
+        selection.remove(ids: ["a.swift", "c.swift"])
+
+        #expect(selection.isEmpty)
+        #expect(selection.anchorID == nil)
+    }
+
+    private func file(path: String) -> GitStatusFile {
+        GitStatusFile(
+            path: path,
+            oldPath: nil,
+            xStatus: " ",
+            yStatus: "M",
+            additions: nil,
+            deletions: nil,
+            isBinary: false
+        )
+    }
+}

--- a/Tests/MuxyTests/Views/Components/Interaction/LeftClickViewTests.swift
+++ b/Tests/MuxyTests/Views/Components/Interaction/LeftClickViewTests.swift
@@ -17,7 +17,7 @@ struct LeftClickViewTests {
     @Test("fires once the primary press is released inside the control")
     func firesWhenReleasedInsideControl() throws {
         var closes = 0
-        let view = hostedView { closes += 1 }
+        let view = hostedView { _ in closes += 1 }
 
         view.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: 17, y: 17)))
         view.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: 17, y: 17)))
@@ -28,7 +28,7 @@ struct LeftClickViewTests {
     @Test("ignores a press released outside the control")
     func ignoresReleaseOutsideControl() throws {
         var closes = 0
-        let view = hostedView { closes += 1 }
+        let view = hostedView { _ in closes += 1 }
 
         view.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: 17, y: 17)))
         view.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: 60, y: 60)))
@@ -39,7 +39,7 @@ struct LeftClickViewTests {
     @Test("fires for every press of a rapid click sequence")
     func firesForRapidClickSequence() throws {
         var closes = 0
-        let view = hostedView { closes += 1 }
+        let view = hostedView { _ in closes += 1 }
 
         for clickCount in 1 ... 3 {
             view.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: 17, y: 17), clickCount: clickCount))
@@ -49,7 +49,19 @@ struct LeftClickViewTests {
         #expect(closes == 3)
     }
 
-    private func hostedView(action: @escaping () -> Void) -> LeftClickNSView {
+    @Test("forwards modifier flags from the completing click")
+    func forwardsModifierFlags() throws {
+        var flags: NSEvent.ModifierFlags = []
+        let view = hostedView { flags = $0.modifierFlags }
+
+        view.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: 17, y: 17), modifierFlags: [.command]))
+        view.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: 17, y: 17), modifierFlags: [.command, .shift]))
+
+        #expect(flags.contains(.command))
+        #expect(flags.contains(.shift))
+    }
+
+    private func hostedView(action: @escaping (NSEvent) -> Void) -> LeftClickNSView {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
             styleMask: [.borderless],
@@ -66,12 +78,13 @@ struct LeftClickViewTests {
     private func event(
         _ type: NSEvent.EventType,
         at location: NSPoint,
-        clickCount: Int = 1
+        clickCount: Int = 1,
+        modifierFlags: NSEvent.ModifierFlags = []
     ) throws -> NSEvent {
         try #require(NSEvent.mouseEvent(
             with: type,
             location: location,
-            modifierFlags: [],
+            modifierFlags: modifierFlags,
             timestamp: 0,
             windowNumber: 0,
             context: nil,


### PR DESCRIPTION
## Summary

The status bar Changes popover could only Stage All or Unstage All. This adds file selection so you can stage or unstage a subset, similar to VS Code:

- Click selects one file; click it again to clear
- Command-click toggles individual files
- Shift-click selects a contiguous range from the last clicked file
- When a section has a selection, Stage Selected / Unstage Selected appear next to Stage All / Unstage All
- All stays available and uses the same accent color while a selection exists
- Row identity includes the staged/unstaged side, so a file that moves between sections does not keep a stale highlight or fire the wrong row action

## Test Plan

- [x] Unit tests for exclusive click, Command toggle, Shift range, Command-Shift add range, retain/remove when files leave a list
- [x] LeftClickView tests for modifier flags on mouse up
- [x] `swift build --product Muxy`
- [ ] Manual: select files in Changes, Stage Selected, confirm they land in Staged unselected and row click no longer unstages
- [ ] Manual: Stage All still works with a selection present

## AI contribution notice

This work was developed with assistance from Grok 4.6 (xAI). I reviewed the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-file selection in the changes popover, including command-click, shift-click, and additive range selection.
  * Added batch staging and unstaging for selected files, with section-level actions for all files.
  * Preserved selections when file lists refresh and added selected-row highlighting and accessibility support.

* **Bug Fixes**
  * Improved click handling so modifier keys are correctly recognized during file selection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->