### PR TITLE
Support remote project actions

### DIFF
--- a/Muxy/Models/Project/ProjectGroup.swift
+++ b/Muxy/Models/Project/ProjectGroup.swift
@@ -9,21 +9,33 @@ struct RemoteProject: Identifiable, Codable, Hashable {
     let id: UUID
     var name: String
     var path: String
+    var icon: String?
+    var logo: String?
+    var iconColor: String?
     var worktreesEnabled: Bool
     var lastActiveAt: Date?
+    var isPinned: Bool
 
     init(
         id: UUID = UUID(),
         name: String,
         path: String,
+        icon: String? = nil,
+        logo: String? = nil,
+        iconColor: String? = nil,
         worktreesEnabled: Bool = false,
-        lastActiveAt: Date? = nil
+        lastActiveAt: Date? = nil,
+        isPinned: Bool = false
     ) {
         self.id = id
         self.name = name
         self.path = path
+        self.icon = icon
+        self.logo = logo
+        self.iconColor = iconColor
         self.worktreesEnabled = worktreesEnabled
         self.lastActiveAt = lastActiveAt
+        self.isPinned = isPinned
     }
 
     init(from decoder: Decoder) throws {
@@ -31,14 +43,22 @@ struct RemoteProject: Identifiable, Codable, Hashable {
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         path = try container.decode(String.self, forKey: .path)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        logo = try container.decodeIfPresent(String.self, forKey: .logo)
+        iconColor = try container.decodeIfPresent(String.self, forKey: .iconColor)
         worktreesEnabled = try container.decodeIfPresent(Bool.self, forKey: .worktreesEnabled) ?? false
         lastActiveAt = try container.decodeIfPresent(Date.self, forKey: .lastActiveAt)
+        isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
     }
 
     func asProject(workspaceID: UUID, sortOrder: Int) -> Project {
         var project = Project(id: id, name: name, path: path, sortOrder: sortOrder, remoteWorkspaceID: workspaceID)
+        project.icon = icon
+        project.logo = logo
+        project.iconColor = iconColor
         project.worktreesEnabled = worktreesEnabled
         project.lastActiveAt = lastActiveAt
+        project.isPinned = isPinned
         return project
     }
 }

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -1406,7 +1406,9 @@ enum MuxyAPI {
             guard group.projectIDs.isEmpty, group.remoteProjects.isEmpty else {
                 return .failure(.invalidArguments("workspace '\(group.name)' still contains projects"))
             }
-            projectGroupStore.removeGroup(id: group.id)
+            guard projectGroupStore.removeGroup(id: group.id) else {
+                return .failure(.underlying("could not save workspace deletion"))
+            }
             return .success(())
         }
     }

--- a/Muxy/Services/MuxyAPI/MuxyAPI.swift
+++ b/Muxy/Services/MuxyAPI/MuxyAPI.swift
@@ -969,20 +969,20 @@ enum MuxyAPI {
             guard !trimmed.isEmpty else {
                 return .failure(.invalidArguments("name cannot be empty"))
             }
-            return resolveMutableProject(identifier, context: context).map {
-                context.projectStore.rename(id: $0.id, to: trimmed)
+            return resolveMutableProject(identifier, context: context).flatMap {
+                projectUpdateResult(context.projectStore.rename(id: $0.id, to: trimmed))
             }
         }
 
         static func setColor(identifier: String, color: String?, context: Context) -> Result<Void, APIError> {
-            resolveMutableProject(identifier, context: context).map {
-                context.projectStore.setIconColor(id: $0.id, to: color)
+            resolveMutableProject(identifier, context: context).flatMap {
+                projectUpdateResult(context.projectStore.setIconColor(id: $0.id, to: color))
             }
         }
 
         static func setIcon(identifier: String, icon: String?, context: Context) -> Result<Void, APIError> {
-            resolveMutableProject(identifier, context: context).map {
-                context.projectStore.setIcon(id: $0.id, to: icon)
+            resolveMutableProject(identifier, context: context).flatMap {
+                projectUpdateResult(context.projectStore.setIcon(id: $0.id, to: icon))
             }
         }
 
@@ -992,8 +992,7 @@ enum MuxyAPI {
                 if let logo, !ProjectLogoStorage.isStoredLogoFilename(logo, forProjectID: project.id) {
                     return .failure(.invalidArguments("invalid project logo"))
                 }
-                context.projectStore.setLogo(id: project.id, to: logo)
-                return .success(())
+                return projectUpdateResult(context.projectStore.setLogo(id: project.id, to: logo))
             case let .failure(error):
                 return .failure(error)
             }
@@ -1166,6 +1165,12 @@ enum MuxyAPI {
                 return .failure(.invalidArguments("remote projects cannot be modified"))
             }
             return .success(project)
+        }
+
+        private static func projectUpdateResult(_ didUpdate: Bool) -> Result<Void, APIError> {
+            didUpdate
+                ? .success(())
+                : .failure(.underlying("could not save project changes"))
         }
     }
 

--- a/Muxy/Services/Project/ProjectEditingService.swift
+++ b/Muxy/Services/Project/ProjectEditingService.swift
@@ -1,0 +1,92 @@
+import AppKit
+
+@MainActor
+struct ProjectEditingService {
+    let projectStore: ProjectStore
+    let projectGroupStore: ProjectGroupStore
+
+    @discardableResult
+    func rename(_ project: Project, to name: String) -> Bool {
+        update(project, to: name, remoteKeyPath: \.name) { store, id, value in
+            store.rename(id: id, to: value)
+        }
+    }
+
+    @discardableResult
+    func setLogo(_ project: Project, to logo: String?) -> Bool {
+        guard project.remoteWorkspaceID != nil else {
+            return projectStore.setLogo(id: project.id, to: logo)
+        }
+        let didUpdate = projectGroupStore.updateRemoteProject(id: project.id) { remoteProject in
+            remoteProject.logo = logo
+        }
+        if didUpdate, logo == nil {
+            ProjectLogoStorage.remove(forProjectID: project.id)
+        }
+        return didUpdate
+    }
+
+    @discardableResult
+    func setLogo(_ project: Project, croppedImage: NSImage) -> Bool {
+        guard let storedProject = storedProject(for: project) else { return false }
+        guard let logo = ProjectLogoStorage.save(croppedImage: croppedImage, forProjectID: project.id) else { return false }
+        guard storedProject.logo != logo else { return true }
+        guard setLogo(project, to: logo) else {
+            ProjectLogoStorage.remove(forProjectID: project.id)
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    func setIcon(_ project: Project, to icon: String?) -> Bool {
+        update(project, to: icon, remoteKeyPath: \.icon) { store, id, value in
+            store.setIcon(id: id, to: value)
+        }
+    }
+
+    @discardableResult
+    func setIconColor(_ project: Project, to color: String?) -> Bool {
+        update(project, to: color, remoteKeyPath: \.iconColor) { store, id, value in
+            store.setIconColor(id: id, to: value)
+        }
+    }
+
+    @discardableResult
+    func setWorktreesEnabled(_ project: Project, to enabled: Bool) -> Bool {
+        update(project, to: enabled, remoteKeyPath: \.worktreesEnabled) { store, id, value in
+            store.setWorktreesEnabled(id: id, to: value)
+        }
+    }
+
+    @discardableResult
+    func setPinned(_ project: Project, to pinned: Bool) -> Bool {
+        update(project, to: pinned, remoteKeyPath: \.isPinned) { store, id, value in
+            store.setPinned(id: id, to: value)
+        }
+    }
+
+    private func update<Value>(
+        _ project: Project,
+        to value: Value,
+        remoteKeyPath: WritableKeyPath<RemoteProject, Value>,
+        localUpdate: (ProjectStore, UUID, Value) -> Bool
+    ) -> Bool {
+        guard project.remoteWorkspaceID != nil else {
+            return localUpdate(projectStore, project.id, value)
+        }
+        return projectGroupStore.updateRemoteProject(id: project.id) { remoteProject in
+            remoteProject[keyPath: remoteKeyPath] = value
+        }
+    }
+
+    private func storedProject(for project: Project) -> Project? {
+        guard let workspaceID = project.remoteWorkspaceID else {
+            return projectStore.storedProjects.first { $0.id == project.id }
+        }
+        guard let group = projectGroupStore.groups.first(where: { $0.id == workspaceID }),
+              let index = group.remoteProjects.firstIndex(where: { $0.id == project.id })
+        else { return nil }
+        return group.remoteProjects[index].asProject(workspaceID: workspaceID, sortOrder: index)
+    }
+}

--- a/Muxy/Services/Project/ProjectGroupStore.swift
+++ b/Muxy/Services/Project/ProjectGroupStore.swift
@@ -329,6 +329,7 @@ final class ProjectGroupStore {
         do {
             try persistence.saveProjectGroups(updatedGroups)
             groups = updatedGroups
+            onProjectsChanged?()
             return true
         } catch {
             logger.error("Failed to save project groups: \(error)")

--- a/Muxy/Services/Project/ProjectGroupStore.swift
+++ b/Muxy/Services/Project/ProjectGroupStore.swift
@@ -103,9 +103,10 @@ final class ProjectGroupStore {
         guard let group = activeGroup, group.type == .ssh else {
             return sortMode.sorted(filteredProjects(from: localProjects))
         }
-        return group.remoteProjects.enumerated().map { index, remote in
+        let projects = group.remoteProjects.enumerated().map { index, remote in
             remote.asProject(workspaceID: group.id, sortOrder: index)
         }
+        return sortMode.sorted(projects)
     }
 
     var activeGroup: ProjectGroup? {
@@ -206,11 +207,9 @@ final class ProjectGroupStore {
         groups.filter { $0.remoteDeviceID == deviceID }.map(\.name)
     }
 
-    func removeWorkspaces(usingDevice deviceID: UUID) {
-        let affected = groups.filter { $0.remoteDeviceID == deviceID }
-        for group in affected {
-            removeGroup(id: group.id)
-        }
+    @discardableResult
+    func removeWorkspaces(usingDevice deviceID: UUID) -> Bool {
+        removeGroups { $0.remoteDeviceID == deviceID }
     }
 
     @discardableResult
@@ -228,54 +227,52 @@ final class ProjectGroupStore {
             return existing
         }
         let project = RemoteProject(name: name, path: path)
-        groups[index].remoteProjects.append(project)
-        save()
-        return project
+        let didAdd = commitMutation { groups in
+            guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return false }
+            groups[index].remoteProjects.append(project)
+            return true
+        }
+        return didAdd ? project : nil
     }
 
-    func removeRemoteProject(id: UUID, fromGroup groupID: UUID) {
-        guard let index = groups.firstIndex(where: { $0.id == groupID }) else { return }
-        groups[index].remoteProjects.removeAll { $0.id == id }
-        save()
+    @discardableResult
+    func removeRemoteProject(id: UUID, fromGroup groupID: UUID) -> Bool {
+        let didRemove = commitMutation { groups in
+            guard let groupIndex = groups.firstIndex(where: { $0.id == groupID }),
+                  groups[groupIndex].remoteProjects.contains(where: { $0.id == id })
+            else { return false }
+            groups[groupIndex].remoteProjects.removeAll { $0.id == id }
+            return true
+        }
+        if didRemove {
+            ProjectLogoStorage.remove(forProjectID: id)
+        }
+        return didRemove
     }
 
     func markRemoteProjectActive(id: UUID) {
-        for groupIndex in groups.indices {
-            guard let projectIndex = groups[groupIndex].remoteProjects.firstIndex(where: { $0.id == id }) else {
-                continue
+        updateRemoteProject(id: id) { project in
+            project.lastActiveAt = Date()
+        }
+    }
+
+    @discardableResult
+    func updateRemoteProject(id: UUID, _ mutate: (inout RemoteProject) -> Void) -> Bool {
+        commitMutation { groups in
+            for groupIndex in groups.indices {
+                guard let projectIndex = groups[groupIndex].remoteProjects.firstIndex(where: { $0.id == id })
+                else { continue }
+                mutate(&groups[groupIndex].remoteProjects[projectIndex])
+                return true
             }
-            groups[groupIndex].remoteProjects[projectIndex].lastActiveAt = Date()
-            save()
-            return
+            return false
         }
     }
 
-    func updateRemoteProject(id: UUID, _ mutate: (inout RemoteProject) -> Void) {
-        for groupIndex in groups.indices {
-            guard let projectIndex = groups[groupIndex].remoteProjects.firstIndex(where: { $0.id == id })
-            else { continue }
-            mutate(&groups[groupIndex].remoteProjects[projectIndex])
-            save()
-            return
-        }
-    }
-
-    func renameRemoteProject(id: UUID, to name: String) {
-        updateRemoteProject(id: id) { $0.name = name }
-    }
-
-    func setRemoteProjectWorktreesEnabled(id: UUID, to enabled: Bool) {
-        updateRemoteProject(id: id) { $0.worktreesEnabled = enabled }
-    }
-
-    func removeGroup(id: UUID) {
-        if activeGroupID == id {
-            activeGroupID = nil
-            persistence.saveActiveGroupID(nil)
-            syncActiveWorkspaceContext()
-        }
-        groups.removeAll { $0.id == id }
-        save()
+    @discardableResult
+    func removeGroup(id: UUID) -> Bool {
+        guard groups.contains(where: { $0.id == id }) else { return false }
+        return removeGroups { $0.id == id }
     }
 
     func renameGroup(id: UUID, to newName: String) {
@@ -324,6 +321,39 @@ final class ProjectGroupStore {
             logger.error("Failed to save project groups: \(error)")
         }
         onProjectsChanged?()
+    }
+
+    private func commitMutation(_ mutate: (inout [ProjectGroup]) -> Bool) -> Bool {
+        var updatedGroups = groups
+        guard mutate(&updatedGroups) else { return false }
+        do {
+            try persistence.saveProjectGroups(updatedGroups)
+            groups = updatedGroups
+            return true
+        } catch {
+            logger.error("Failed to save project groups: \(error)")
+            return false
+        }
+    }
+
+    private func removeGroups(where shouldRemove: (ProjectGroup) -> Bool) -> Bool {
+        let removedGroups = groups.filter(shouldRemove)
+        guard !removedGroups.isEmpty else { return true }
+        let removedIDs = Set(removedGroups.map(\.id))
+        guard commitMutation({ groups in
+            groups.removeAll(where: shouldRemove)
+            return true
+        })
+        else { return false }
+        if let activeGroupID, removedIDs.contains(activeGroupID) {
+            self.activeGroupID = nil
+            persistence.saveActiveGroupID(nil)
+            syncActiveWorkspaceContext()
+        }
+        for projectID in removedGroups.flatMap(\.remoteProjects).map(\.id) {
+            ProjectLogoStorage.remove(forProjectID: projectID)
+        }
+        return true
     }
 
     private func load() {

--- a/Muxy/Services/Project/ProjectRemovalService.swift
+++ b/Muxy/Services/Project/ProjectRemovalService.swift
@@ -58,7 +58,10 @@ enum ProjectRemovalService {
         )
 
         if let workspaceID = project.remoteWorkspaceID {
-            projectGroupStore.removeRemoteProject(id: project.id, fromGroup: workspaceID)
+            guard projectGroupStore.removeRemoteProject(id: project.id, fromGroup: workspaceID) else {
+                worktreeStore.cancelProjectRemoval(project.id)
+                throw RemovalError.persistenceFailed
+            }
         } else {
             guard await projectStore.prepareRemovalWhenAvailable(id: project.id) else {
                 worktreeStore.cancelProjectRemoval(project.id)

--- a/Muxy/Services/Project/ProjectStore.swift
+++ b/Muxy/Services/Project/ProjectStore.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import MuxyShared
 import os
@@ -91,7 +90,7 @@ final class ProjectStore {
                 project: project,
                 previousRecentlyRemovedProjects: previous,
                 finalRecentlyRemovedProjects: previous,
-                logoIDsToRemove: []
+                logoIDsToRemove: [project.id]
             )
             return true
         }
@@ -173,57 +172,54 @@ final class ProjectStore {
         return project
     }
 
-    func rename(id: UUID, to newName: String) {
-        guard pendingRemoval?.project.id != id else { return }
-        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
-        storedProjects[index].name = newName
-        save()
+    @discardableResult
+    func rename(id: UUID, to newName: String) -> Bool {
+        updateProject(id: id) { $0.name = newName }
     }
 
-    func setLogo(id: UUID, to logo: String?) {
-        guard pendingRemoval?.project.id != id else { return }
-        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
-        if logo == nil {
+    @discardableResult
+    func setLogo(id: UUID, to logo: String?) -> Bool {
+        let didUpdate = updateProject(id: id) { $0.logo = logo }
+        if didUpdate, logo == nil {
             ProjectLogoStorage.remove(forProjectID: id)
         }
-        storedProjects[index].logo = logo
-        save()
+        return didUpdate
     }
 
-    func setLogo(id: UUID, croppedImage: NSImage) {
-        guard pendingRemoval?.project.id != id else { return }
-        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
-        let logo = ProjectLogoStorage.save(croppedImage: croppedImage, forProjectID: id)
-        storedProjects[index].logo = logo
-        save()
+    @discardableResult
+    func setIcon(id: UUID, to icon: String?) -> Bool {
+        updateProject(id: id) { $0.icon = icon }
     }
 
-    func setIcon(id: UUID, to icon: String?) {
-        guard pendingRemoval?.project.id != id else { return }
-        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
-        storedProjects[index].icon = icon
-        save()
+    @discardableResult
+    func setIconColor(id: UUID, to color: String?) -> Bool {
+        updateProject(id: id) { $0.iconColor = color }
     }
 
-    func setIconColor(id: UUID, to color: String?) {
-        guard pendingRemoval?.project.id != id else { return }
-        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
-        storedProjects[index].iconColor = color
-        save()
+    @discardableResult
+    func setPinned(id: UUID, to pinned: Bool) -> Bool {
+        updateProject(id: id) { $0.isPinned = pinned }
     }
 
-    func setPinned(id: UUID, to pinned: Bool) {
-        guard pendingRemoval?.project.id != id else { return }
-        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
-        storedProjects[index].isPinned = pinned
-        save()
+    @discardableResult
+    func setWorktreesEnabled(id: UUID, to enabled: Bool) -> Bool {
+        updateProject(id: id) { $0.worktreesEnabled = enabled }
     }
 
-    func setWorktreesEnabled(id: UUID, to enabled: Bool) {
-        guard pendingRemoval?.project.id != id else { return }
-        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return }
-        storedProjects[index].worktreesEnabled = enabled
-        save()
+    private func updateProject(id: UUID, mutate: (inout Project) -> Void) -> Bool {
+        guard pendingRemoval?.project.id != id else { return false }
+        guard let index = storedProjects.firstIndex(where: { $0.id == id }) else { return false }
+        var updatedProjects = storedProjects
+        mutate(&updatedProjects[index])
+        do {
+            try persistence.saveProjects(updatedProjects)
+            storedProjects = updatedProjects
+            onProjectsChanged?()
+            return true
+        } catch {
+            logger.error("Failed to save project update: \(error)")
+            return false
+        }
     }
 
     func setPreferredWorktreeLocation(id: UUID, pathTemplate: String?, parentPath: String?) throws {

--- a/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ExpandedProjectRow.swift
@@ -11,12 +11,6 @@ struct ExpandedProjectRow: View {
     let onResolveWorktreeAutoExpand: (Bool) -> Void
     let onSelect: () -> Void
     let onRemove: () -> Void
-    let onRename: (String) -> Void
-    let onSetLogo: (String?) -> Void
-    let onSetIcon: (String?) -> Void
-    let onSetIconColor: (String?) -> Void
-    let onSetWorktreesEnabled: (Bool) -> Void
-    let onSetPinned: (Bool) -> Void
 
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
@@ -79,20 +73,12 @@ struct ExpandedProjectRow: View {
         String(project.localizedDisplayName.prefix(1)).uppercased()
     }
 
-    private func hideHome() {
-        HomeProjectPreferences.isVisible = false
+    private var editor: ProjectEditingService {
+        ProjectEditingService(projectStore: projectStore, projectGroupStore: projectGroupStore)
     }
 
-    private var worktreesEnabledBinding: Binding<Bool> {
-        Binding(
-            get: { project.worktreesEnabled },
-            set: { enabled in
-                onSetWorktreesEnabled(enabled)
-                if !enabled {
-                    worktreesExpanded = false
-                }
-            }
-        )
+    private func hideHome() {
+        HomeProjectPreferences.isVisible = false
     }
 
     var body: some View {
@@ -167,7 +153,7 @@ struct ExpandedProjectRow: View {
                 sourceImage: item.image,
                 onConfirm: { cropped in
                     logoCropImage = nil
-                    projectStore.setLogo(id: project.id, croppedImage: cropped)
+                    editor.setLogo(project, croppedImage: cropped)
                 },
                 onCancel: { logoCropImage = nil }
             )
@@ -181,13 +167,13 @@ struct ExpandedProjectRow: View {
         }
         .popover(isPresented: $showColorPicker, arrowEdge: .trailing) {
             ProjectIconColorPicker(selectedID: project.iconColor) { id in
-                onSetIconColor(id)
+                editor.setIconColor(project, to: id)
                 showColorPicker = false
             }
         }
         .popover(isPresented: $showSymbolPicker, arrowEdge: .trailing) {
             SFSymbolPicker(selectedName: project.icon) { name in
-                onSetIcon(name)
+                editor.setIcon(project, to: name)
                 showSymbolPicker = false
             }
         }
@@ -420,54 +406,28 @@ struct ExpandedProjectRow: View {
         return label
     }
 
-    @ViewBuilder
     private var projectContextMenu: some View {
-        if !project.isRemote, !project.isHome {
-            Button(
-                project.isPinned
-                    ? L10n.string("Unpin")
-                    : L10n.string("Pin")
-            ) {
-                onSetPinned(!project.isPinned)
-            }
-            Divider()
-        }
-        Button(L10n.string("Set Logo...")) { pickLogoImage() }
-        if project.logo != nil {
-            Button(L10n.string("Remove Logo")) { onSetLogo(nil) }
-        }
-        Button(L10n.string("Set Icon...")) { showSymbolPicker = true }
-        if project.icon != nil {
-            Button(L10n.string("Remove Icon")) { onSetIcon(nil) }
-        }
-        Button(L10n.string("Set Icon Color...")) { showColorPicker = true }
-        if project.iconColor != nil {
-            Button(L10n.string("Reset Icon Color")) { onSetIconColor(nil) }
-        }
-        Divider()
-        Button(L10n.string("Rename Project")) { startRename() }
-        if isGitRepo {
-            Divider()
-            Toggle(L10n.string("Worktrees"), isOn: worktreesEnabledBinding)
-            if project.worktreesEnabled {
-                Button(L10n.string("Refresh Worktrees")) { Task { await refreshWorktrees() } }
-                Button(L10n.string("New Worktree…")) { showCreateWorktreeSheet = true }
-            }
-        } else if isCheckingGitRepo {
-            Divider()
-            Button(L10n.string("Loading Worktrees…")) {}
-                .disabled(true)
-        }
-        if !projectGroupStore.groups.isEmpty {
-            Divider()
-            ProjectGroupMembershipMenu(project: project)
-        }
-        ProjectContextMenuFooter(
-            path: project.path,
-            workspaceContext: projectGroupStore.workspaceContext(for: project)
-        ) {
-            Button(L10n.string("Remove Project"), role: .destructive, action: onRemove)
-        }
+        ProjectActionsContextMenu(
+            project: project,
+            editor: editor,
+            isGitRepo: isGitRepo,
+            isCheckingGitRepo: isCheckingGitRepo,
+            worktreeCount: worktrees.count,
+            onPickLogo: pickLogoImage,
+            onPickIcon: { showSymbolPicker = true },
+            onPickIconColor: { showColorPicker = true },
+            onRename: startRename,
+            onSetWorktreesEnabled: { enabled in
+                editor.setWorktreesEnabled(project, to: enabled)
+                if !enabled {
+                    worktreesExpanded = false
+                }
+            },
+            onRefreshWorktrees: { Task { await refreshWorktrees() } },
+            onCreateWorktree: { showCreateWorktreeSheet = true },
+            onSwitchWorktree: nil,
+            onRemove: onRemove
+        )
     }
 
     private var resolvedLogo: NSImage? {
@@ -605,7 +565,7 @@ struct ExpandedProjectRow: View {
     private func commitRename() {
         let trimmed = renameText.trimmingCharacters(in: .whitespaces)
         if !trimmed.isEmpty {
-            onRename(trimmed)
+            editor.rename(project, to: trimmed)
         }
         isRenaming = false
     }

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectFocusedSidebar.swift
@@ -568,13 +568,7 @@ struct ProjectFocusedSidebar: View {
                     worktreeExpansion.resolveAutoExpand(projectID: project.id, isEligible: isEligible)
                 },
                 onSelect: { select(project) },
-                onRemove: { remove(project) },
-                onRename: { renameProject(project, to: $0) },
-                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
-                onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
-                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) },
-                onSetWorktreesEnabled: { setWorktreesEnabled(project, to: $0) },
-                onSetPinned: { projectStore.setPinned(id: project.id, to: $0) }
+                onRemove: { remove(project) }
             )
         } else {
             ProjectRow(
@@ -582,13 +576,7 @@ struct ProjectFocusedSidebar: View {
                 shortcutIndex: shortcutIndex,
                 isAnyDragging: dragState.draggedID != nil,
                 onSelect: { select(project) },
-                onRemove: { remove(project) },
-                onRename: { renameProject(project, to: $0) },
-                onSetLogo: { projectStore.setLogo(id: project.id, to: $0) },
-                onSetIcon: { projectStore.setIcon(id: project.id, to: $0) },
-                onSetIconColor: { projectStore.setIconColor(id: project.id, to: $0) },
-                onSetWorktreesEnabled: { setWorktreesEnabled(project, to: $0) },
-                onSetPinned: { projectStore.setPinned(id: project.id, to: $0) }
+                onRemove: { remove(project) }
             )
         }
     }
@@ -608,25 +596,6 @@ struct ProjectFocusedSidebar: View {
               projectCandidates.first(where: { $0.id == projectID })?.worktreesEnabled == true
         else { return }
         worktreeExpansion.requestAutoExpand(projectID: projectID)
-    }
-
-    private func renameProject(_ project: Project, to name: String) {
-        guard project.remoteWorkspaceID == nil else {
-            projectGroupStore.renameRemoteProject(id: project.id, to: name)
-            return
-        }
-        projectStore.rename(id: project.id, to: name)
-    }
-
-    private func setWorktreesEnabled(_ project: Project, to enabled: Bool) {
-        if !enabled {
-            worktreeExpansion[project.id] = false
-        }
-        guard project.remoteWorkspaceID == nil else {
-            projectGroupStore.setRemoteProjectWorktreesEnabled(id: project.id, to: enabled)
-            return
-        }
-        projectStore.setWorktreesEnabled(id: project.id, to: enabled)
     }
 
     private func shortcutTooltip(_ name: String, for action: ShortcutAction) -> String {

--- a/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/ProjectRow.swift
@@ -8,12 +8,6 @@ struct ProjectRow: View {
     let isAnyDragging: Bool
     let onSelect: () -> Void
     let onRemove: () -> Void
-    let onRename: (String) -> Void
-    let onSetLogo: (String?) -> Void
-    let onSetIcon: (String?) -> Void
-    let onSetIconColor: (String?) -> Void
-    let onSetWorktreesEnabled: (Bool) -> Void
-    let onSetPinned: (Bool) -> Void
 
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
@@ -57,11 +51,8 @@ struct ProjectRow: View {
         project.worktreesEnabled && (isGitRepo || worktrees.count > 1)
     }
 
-    private var worktreesEnabledBinding: Binding<Bool> {
-        Binding(
-            get: { project.worktreesEnabled },
-            set: { onSetWorktreesEnabled($0) }
-        )
+    private var editor: ProjectEditingService {
+        ProjectEditingService(projectStore: projectStore, projectGroupStore: projectGroupStore)
     }
 
     private var displayLetter: String {
@@ -156,7 +147,7 @@ struct ProjectRow: View {
                     sourceImage: item.image,
                     onConfirm: { cropped in
                         logoCropImage = nil
-                        projectStore.setLogo(id: project.id, croppedImage: cropped)
+                        editor.setLogo(project, croppedImage: cropped)
                     },
                     onCancel: { logoCropImage = nil }
                 )
@@ -170,69 +161,35 @@ struct ProjectRow: View {
             }
             .popover(isPresented: $showColorPicker, arrowEdge: .trailing) {
                 ProjectIconColorPicker(selectedID: project.iconColor) { id in
-                    onSetIconColor(id)
+                    editor.setIconColor(project, to: id)
                     showColorPicker = false
                 }
             }
             .popover(isPresented: $showSymbolPicker, arrowEdge: .trailing) {
                 SFSymbolPicker(selectedName: project.icon) { name in
-                    onSetIcon(name)
+                    editor.setIcon(project, to: name)
                     showSymbolPicker = false
                 }
             }
     }
 
-    @ViewBuilder
     private var projectContextMenu: some View {
-        if !project.isRemote, !project.isHome {
-            Button(
-                project.isPinned
-                    ? L10n.string("Unpin")
-                    : L10n.string("Pin")
-            ) {
-                onSetPinned(!project.isPinned)
-            }
-            Divider()
-        }
-        Button(L10n.string("Set Logo...")) { pickLogoImage() }
-        if project.logo != nil {
-            Button(L10n.string("Remove Logo")) { onSetLogo(nil) }
-        }
-        Button(L10n.string("Set Icon...")) { showSymbolPicker = true }
-        if project.icon != nil {
-            Button(L10n.string("Remove Icon")) { onSetIcon(nil) }
-        }
-        Button(L10n.string("Set Icon Color...")) { showColorPicker = true }
-        if project.iconColor != nil {
-            Button(L10n.string("Reset Icon Color")) { onSetIconColor(nil) }
-        }
-        Divider()
-        Button(L10n.string("Rename Project")) { startRename() }
-        if isGitRepo {
-            Divider()
-            Toggle(L10n.string("Worktrees"), isOn: worktreesEnabledBinding)
-            if project.worktreesEnabled {
-                Button(L10n.string("Refresh Worktrees")) { Task { await refreshWorktrees() } }
-                Button(L10n.string("New Worktree…")) { showCreateWorktreeSheet = true }
-                if worktrees.count > 1 {
-                    Button(L10n.string("Switch Worktree…")) { showWorktreePopover = true }
-                }
-            }
-        } else if isCheckingGitRepo {
-            Divider()
-            Button(L10n.string("Loading Worktrees…")) {}
-                .disabled(true)
-        }
-        if !projectGroupStore.groups.isEmpty {
-            Divider()
-            ProjectGroupMembershipMenu(project: project)
-        }
-        ProjectContextMenuFooter(
-            path: project.path,
-            workspaceContext: projectGroupStore.workspaceContext(for: project)
-        ) {
-            Button(L10n.string("Remove Project"), role: .destructive, action: onRemove)
-        }
+        ProjectActionsContextMenu(
+            project: project,
+            editor: editor,
+            isGitRepo: isGitRepo,
+            isCheckingGitRepo: isCheckingGitRepo,
+            worktreeCount: worktrees.count,
+            onPickLogo: pickLogoImage,
+            onPickIcon: { showSymbolPicker = true },
+            onPickIconColor: { showColorPicker = true },
+            onRename: startRename,
+            onSetWorktreesEnabled: { editor.setWorktreesEnabled(project, to: $0) },
+            onRefreshWorktrees: { Task { await refreshWorktrees() } },
+            onCreateWorktree: { showCreateWorktreeSheet = true },
+            onSwitchWorktree: { showWorktreePopover = true },
+            onRemove: onRemove
+        )
     }
 
     private var resolvedLogo: NSImage? {
@@ -374,7 +331,7 @@ struct ProjectRow: View {
     private func commitRename() {
         let trimmed = renameText.trimmingCharacters(in: .whitespaces)
         if !trimmed.isEmpty {
-            onRename(trimmed)
+            editor.rename(project, to: trimmed)
         }
         isRenaming = false
     }

--- a/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
@@ -60,7 +60,13 @@ struct WorkspaceSwitcher: View {
             presenting: groupPendingDelete
         ) { group in
             Button(L10n.string("Delete"), role: .destructive) {
-                projectGroupStore.removeGroup(id: group.id)
+                guard projectGroupStore.removeGroup(id: group.id) else {
+                    ToastState.shared.show(
+                        title: L10n.string("Could not delete workspace"),
+                        body: L10n.string("Muxy could not save the workspace deletion.")
+                    )
+                    return
+                }
                 groupPendingDelete = nil
             }
             .keyboardShortcut(.defaultAction)

--- a/Muxy/Views/Layouts/Shared/ProjectActionsContextMenu.swift
+++ b/Muxy/Views/Layouts/Shared/ProjectActionsContextMenu.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+enum ProjectActionsContextMenuPolicy {
+    static func showsPin(isHome: Bool) -> Bool {
+        !isHome
+    }
+
+    static func showsWorktreeActions(isGitRepo: Bool) -> Bool {
+        isGitRepo
+    }
+
+    static func showsLoadingWorktrees(isGitRepo: Bool, isCheckingGitRepo: Bool) -> Bool {
+        !isGitRepo && isCheckingGitRepo
+    }
+
+    static func showsSwitchWorktree(
+        worktreesEnabled: Bool,
+        worktreeCount: Int,
+        supportsSwitchWorktree: Bool
+    ) -> Bool {
+        worktreesEnabled && worktreeCount > 1 && supportsSwitchWorktree
+    }
+}
+
+struct ProjectActionsContextMenu: View {
+    let project: Project
+    let editor: ProjectEditingService
+    let isGitRepo: Bool
+    let isCheckingGitRepo: Bool
+    let worktreeCount: Int
+    let onPickLogo: () -> Void
+    let onPickIcon: () -> Void
+    let onPickIconColor: () -> Void
+    let onRename: () -> Void
+    let onSetWorktreesEnabled: (Bool) -> Void
+    let onRefreshWorktrees: () -> Void
+    let onCreateWorktree: () -> Void
+    let onSwitchWorktree: (() -> Void)?
+    let onRemove: () -> Void
+
+    @Environment(ProjectGroupStore.self) private var projectGroupStore
+
+    private var canMoveToWorkspace: Bool {
+        !project.isRemote && projectGroupStore.groups.contains { $0.type == .local }
+    }
+
+    var body: some View {
+        if ProjectActionsContextMenuPolicy.showsPin(isHome: project.isHome) {
+            Button(project.isPinned ? L10n.string("Unpin") : L10n.string("Pin")) {
+                editor.setPinned(project, to: !project.isPinned)
+            }
+            Divider()
+        }
+        Button(L10n.string("Set Logo..."), action: onPickLogo)
+        if project.logo != nil {
+            Button(L10n.string("Remove Logo")) { editor.setLogo(project, to: nil) }
+        }
+        Button(L10n.string("Set Icon..."), action: onPickIcon)
+        if project.icon != nil {
+            Button(L10n.string("Remove Icon")) { editor.setIcon(project, to: nil) }
+        }
+        Button(L10n.string("Set Icon Color..."), action: onPickIconColor)
+        if project.iconColor != nil {
+            Button(L10n.string("Reset Icon Color")) { editor.setIconColor(project, to: nil) }
+        }
+        Divider()
+        Button(L10n.string("Rename Project"), action: onRename)
+        worktreeActions
+        if canMoveToWorkspace {
+            Divider()
+            ProjectGroupMembershipMenu(project: project)
+        }
+        ProjectContextMenuFooter(
+            path: project.path,
+            workspaceContext: projectGroupStore.workspaceContext(for: project)
+        ) {
+            Button(L10n.string("Remove Project"), role: .destructive, action: onRemove)
+        }
+    }
+
+    @ViewBuilder
+    private var worktreeActions: some View {
+        if ProjectActionsContextMenuPolicy.showsWorktreeActions(isGitRepo: isGitRepo) {
+            Divider()
+            Toggle(L10n.string("Worktrees"), isOn: worktreesEnabledBinding)
+            if project.worktreesEnabled {
+                Button(L10n.string("Refresh Worktrees"), action: onRefreshWorktrees)
+                Button(L10n.string("New Worktree…"), action: onCreateWorktree)
+                if ProjectActionsContextMenuPolicy.showsSwitchWorktree(
+                    worktreesEnabled: project.worktreesEnabled,
+                    worktreeCount: worktreeCount,
+                    supportsSwitchWorktree: onSwitchWorktree != nil
+                ), let onSwitchWorktree {
+                    Button(L10n.string("Switch Worktree…"), action: onSwitchWorktree)
+                }
+            }
+        } else if ProjectActionsContextMenuPolicy.showsLoadingWorktrees(
+            isGitRepo: isGitRepo,
+            isCheckingGitRepo: isCheckingGitRepo
+        ) {
+            Divider()
+            Button(L10n.string("Loading Worktrees…")) {}
+                .disabled(true)
+        }
+    }
+
+    private var worktreesEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { project.worktreesEnabled },
+            set: { onSetWorktreesEnabled($0) }
+        )
+    }
+}

--- a/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
+++ b/Muxy/Views/Layouts/TabFocused/TabFocusedProjectRow.swift
@@ -52,6 +52,10 @@ struct TabFocusedProjectRow: View {
 
     private var rowID: UUID { worktree?.id ?? project.id }
 
+    private var editor: ProjectEditingService {
+        ProjectEditingService(projectStore: projectStore, projectGroupStore: projectGroupStore)
+    }
+
     private var rowTitle: String {
         worktree?.name ?? project.localizedDisplayName
     }
@@ -232,20 +236,20 @@ struct TabFocusedProjectRow: View {
                 sourceImage: item.image,
                 onConfirm: { cropped in
                     logoCropImage = nil
-                    projectStore.setLogo(id: project.id, croppedImage: cropped)
+                    editor.setLogo(project, croppedImage: cropped)
                 },
                 onCancel: { logoCropImage = nil }
             )
         }
         .popover(isPresented: $showColorPicker, arrowEdge: .trailing) {
             ProjectIconColorPicker(selectedID: project.iconColor) { id in
-                projectStore.setIconColor(id: project.id, to: id)
+                editor.setIconColor(project, to: id)
                 showColorPicker = false
             }
         }
         .popover(isPresented: $showSymbolPicker, arrowEdge: .trailing) {
             SFSymbolPicker(selectedName: project.icon) { name in
-                projectStore.setIcon(id: project.id, to: name)
+                editor.setIcon(project, to: name)
                 showSymbolPicker = false
             }
         }
@@ -277,62 +281,22 @@ struct TabFocusedProjectRow: View {
             }
     }
 
-    @ViewBuilder
     private var projectContextMenu: some View {
-        if !project.isRemote {
-            Button(
-                project.isPinned
-                    ? L10n.string("Unpin")
-                    : L10n.string("Pin")
-            ) {
-                projectStore.setPinned(id: project.id, to: !project.isPinned)
-            }
-            Divider()
-        }
-        Button(L10n.string("Set Logo…")) { pickLogoImage() }
-        if project.logo != nil {
-            Button(L10n.string("Remove Logo")) { projectStore.setLogo(id: project.id, to: nil) }
-        }
-        Button(L10n.string("Set Icon…")) { showSymbolPicker = true }
-        if project.icon != nil {
-            Button(L10n.string("Remove Icon")) { projectStore.setIcon(id: project.id, to: nil) }
-        }
-        Button(L10n.string("Set Icon Color…")) { showColorPicker = true }
-        if project.iconColor != nil {
-            Button(L10n.string("Reset Icon Color")) { projectStore.setIconColor(id: project.id, to: nil) }
-        }
-        Divider()
-        Button(L10n.string("Rename Project")) { startRename() }
-        if isGitRepo {
-            Divider()
-            Toggle(L10n.string("Worktrees"), isOn: worktreesEnabledBinding)
-            if project.worktreesEnabled {
-                Button(L10n.string("Refresh Worktrees")) { Task { await refreshWorktrees() } }
-                Button(L10n.string("New Worktree…")) { showCreateWorktreeSheet = true }
-            }
-        } else if isCheckingGitRepo {
-            Divider()
-            Button(L10n.string("Loading Worktrees…")) {}
-                .disabled(true)
-        }
-        if !projectGroupStore.groups.isEmpty {
-            Divider()
-            ProjectGroupMembershipMenu(project: project)
-        }
-        ProjectContextMenuFooter(
-            path: project.path,
-            workspaceContext: projectGroupStore.workspaceContext(for: project)
-        ) {
-            Button(L10n.string("Remove Project"), role: .destructive) { projectPendingRemoval = true }
-        }
-    }
-
-    private var worktreesEnabledBinding: Binding<Bool> {
-        Binding(
-            get: { project.worktreesEnabled },
-            set: { enabled in
-                projectStore.setWorktreesEnabled(id: project.id, to: enabled)
-            }
+        ProjectActionsContextMenu(
+            project: project,
+            editor: editor,
+            isGitRepo: isGitRepo,
+            isCheckingGitRepo: isCheckingGitRepo,
+            worktreeCount: worktreeStore.list(for: project.id).count,
+            onPickLogo: pickLogoImage,
+            onPickIcon: { showSymbolPicker = true },
+            onPickIconColor: { showColorPicker = true },
+            onRename: startRename,
+            onSetWorktreesEnabled: { editor.setWorktreesEnabled(project, to: $0) },
+            onRefreshWorktrees: { Task { await refreshWorktrees() } },
+            onCreateWorktree: { showCreateWorktreeSheet = true },
+            onSwitchWorktree: nil,
+            onRemove: { projectPendingRemoval = true }
         )
     }
 
@@ -561,7 +525,7 @@ struct TabFocusedProjectRow: View {
             if let worktree {
                 worktreeStore.rename(worktreeID: worktree.id, in: project.id, to: trimmed)
             } else {
-                projectStore.rename(id: project.id, to: trimmed)
+                editor.rename(project, to: trimmed)
             }
         }
         isRenaming = false

--- a/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
+++ b/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
@@ -51,8 +51,9 @@ struct RemoteDevicesSettingsView: View {
             presenting: devicePendingDelete
         ) { device in
             Button(L10n.string("Delete"), role: .destructive) {
-                deleteDevice(device)
-                devicePendingDelete = nil
+                if deleteDevice(device) {
+                    devicePendingDelete = nil
+                }
             }
             .keyboardShortcut(.defaultAction)
             Button(L10n.string("Cancel"), role: .cancel) {
@@ -122,15 +123,16 @@ struct RemoteDevicesSettingsView: View {
         }
     }
 
-    private func deleteDevice(_ device: RemoteDevice) {
+    private func deleteDevice(_ device: RemoteDevice) -> Bool {
         guard projectGroupStore.removeWorkspaces(usingDevice: device.id) else {
             ToastState.shared.show(
                 title: L10n.string("Could not delete device"),
                 body: L10n.string("Muxy could not save the workspace deletion.")
             )
-            return
+            return false
         }
         deviceStore.remove(id: device.id)
+        return true
     }
 }
 

--- a/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
+++ b/Muxy/Views/Settings/RemoteDevicesSettingsView.swift
@@ -123,7 +123,13 @@ struct RemoteDevicesSettingsView: View {
     }
 
     private func deleteDevice(_ device: RemoteDevice) {
-        projectGroupStore.removeWorkspaces(usingDevice: device.id)
+        guard projectGroupStore.removeWorkspaces(usingDevice: device.id) else {
+            ToastState.shared.show(
+                title: L10n.string("Could not delete device"),
+                body: L10n.string("Muxy could not save the workspace deletion.")
+            )
+            return
+        }
         deviceStore.remove(id: device.id)
     }
 }

--- a/Tests/MuxyTests/Models/Project/ProjectGroupMigrationTests.swift
+++ b/Tests/MuxyTests/Models/Project/ProjectGroupMigrationTests.swift
@@ -34,7 +34,15 @@ struct ProjectGroupMigrationTests {
             sortOrder: 1,
             type: .ssh,
             remoteDeviceID: UUID(),
-            remoteProjects: [RemoteProject(name: "api", path: "~/code/api")]
+            remoteProjects: [RemoteProject(
+                name: "api",
+                path: "~/code/api",
+                icon: "server.rack",
+                logo: "logo.png",
+                iconColor: "blue",
+                worktreesEnabled: true,
+                isPinned: true
+            )]
         )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(ProjectGroup.self, from: data)
@@ -42,6 +50,36 @@ struct ProjectGroupMigrationTests {
         #expect(decoded.remoteDeviceID == original.remoteDeviceID)
         #expect(decoded.legacySSHData == nil)
         #expect(decoded.remoteProjects.first?.path == "~/code/api")
+        #expect(decoded.remoteProjects.first?.icon == "server.rack")
+        #expect(decoded.remoteProjects.first?.logo == "logo.png")
+        #expect(decoded.remoteProjects.first?.iconColor == "blue")
+        #expect(decoded.remoteProjects.first?.worktreesEnabled == true)
+        #expect(decoded.remoteProjects.first?.isPinned == true)
+    }
+
+    @Test("legacy remote projects default editable metadata")
+    func legacyRemoteProjectMetadata() throws {
+        let json = """
+        {
+          "id": "00000000-0000-0000-0000-000000000003",
+          "name": "prod",
+          "sortOrder": 0,
+          "type": "ssh",
+          "remoteProjects": [{
+            "id": "00000000-0000-0000-0000-000000000004",
+            "name": "api",
+            "path": "~/code/api"
+          }]
+        }
+        """
+
+        let project = try #require(decode(json).remoteProjects.first)
+
+        #expect(project.icon == nil)
+        #expect(project.logo == nil)
+        #expect(project.iconColor == nil)
+        #expect(project.worktreesEnabled == false)
+        #expect(project.isPinned == false)
     }
 
     @Test("legacy ssh rows decode their inline sshData for migration")

--- a/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectDeleteTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectDeleteTests.swift
@@ -272,15 +272,15 @@ struct MuxyAPIProjectDeleteRoutingTests {
     }
 
     @Test("ProjectRemovalService preserves an SSH workspace project when group persistence fails")
-    func removalServicePreservesSSHWorkspaceProjectAfterPersistenceFailure() async {
+    func removalServicePreservesSSHWorkspaceProjectAfterPersistenceFailure() async throws {
         let groupPersistence = ProjectGroupPersistenceStub()
         let env = makeEnvironment(projects: [], groupPersistence: groupPersistence)
         let group = env.projectGroupStore.addRemoteWorkspace(name: "Remote", deviceID: UUID())
-        let remoteProject = env.projectGroupStore.addRemoteProject(
+        let remoteProject = try #require(env.projectGroupStore.addRemoteProject(
             name: "Repo",
             path: "~/repo",
             toGroup: group.id
-        )!
+        ))
         let project = remoteProject.asProject(workspaceID: group.id, sortOrder: 0)
         groupPersistence.saveError = ProjectGroupDeleteSaveError()
 

--- a/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectDeleteTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectDeleteTests.swift
@@ -271,6 +271,33 @@ struct MuxyAPIProjectDeleteRoutingTests {
         #expect(try persistence.loadWorktrees(projectID: project.id).isEmpty)
     }
 
+    @Test("ProjectRemovalService preserves an SSH workspace project when group persistence fails")
+    func removalServicePreservesSSHWorkspaceProjectAfterPersistenceFailure() async {
+        let groupPersistence = ProjectGroupPersistenceStub()
+        let env = makeEnvironment(projects: [], groupPersistence: groupPersistence)
+        let group = env.projectGroupStore.addRemoteWorkspace(name: "Remote", deviceID: UUID())
+        let remoteProject = env.projectGroupStore.addRemoteProject(
+            name: "Repo",
+            path: "~/repo",
+            toGroup: group.id
+        )!
+        let project = remoteProject.asProject(workspaceID: group.id, sortOrder: 0)
+        groupPersistence.saveError = ProjectGroupDeleteSaveError()
+
+        await #expect(throws: ProjectRemovalService.RemovalError.self) {
+            try await ProjectRemovalService.remove(
+                project,
+                appState: env.appState,
+                projectStore: env.projectStore,
+                worktreeStore: env.worktreeStore,
+                projectGroupStore: env.projectGroupStore
+            )
+        }
+
+        #expect(env.projectGroupStore.groups.first?.remoteProjects.first?.id == project.id)
+        #expect(!env.worktreeStore.isProjectRemovalInProgress(project.id))
+    }
+
     @Test("ProjectRemovalService waits for active worktree creation before removing a remote-device project")
     func removalServiceWaitsForRemoteDeviceMutation() async throws {
         let root = FileManager.default.temporaryDirectory
@@ -345,7 +372,11 @@ struct MuxyAPIProjectDeleteRoutingTests {
         }
     }
 
-    private func makeEnvironment(projects: [Project], worktreeStore: WorktreeStore? = nil) -> Environment {
+    private func makeEnvironment(
+        projects: [Project],
+        worktreeStore: WorktreeStore? = nil,
+        groupPersistence: ProjectGroupPersistenceStub = ProjectGroupPersistenceStub()
+    ) -> Environment {
         let projectPersistence = ProjectDeletePersistenceStub(initial: projects)
         let projectStore = ProjectStore(persistence: projectPersistence)
         let worktreeStore = worktreeStore ?? WorktreeStore(
@@ -357,7 +388,7 @@ struct MuxyAPIProjectDeleteRoutingTests {
             workspacePersistence: ProjectDeleteWorkspacePersistenceStub()
         )
         let projectGroupStore = ProjectGroupStore(
-            persistence: ProjectGroupPersistenceStub(),
+            persistence: groupPersistence,
             remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
             workspaceContextSink: InMemoryWorkspaceContextSink()
         )
@@ -370,6 +401,8 @@ struct MuxyAPIProjectDeleteRoutingTests {
         )
     }
 }
+
+private struct ProjectGroupDeleteSaveError: Error {}
 
 private final class ProjectDeletePersistenceStub: ProjectPersisting {
     struct SaveError: Error {}

--- a/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectManagementTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectManagementTests.swift
@@ -80,6 +80,7 @@ struct MuxyAPIProjectManagementRoutingTests {
             #expect(error == .underlying("could not save project changes"))
         }
         #expect(env.projectStore.storedProjects.first == project)
+        #expect(env.projectPersistence.projects == [project])
     }
 
     @Test("setLogo rejects path traversal")

--- a/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectManagementTests.swift
+++ b/Tests/MuxyTests/Services/MuxyAPI/MuxyAPIProjectManagementTests.swift
@@ -58,6 +58,30 @@ struct MuxyAPIProjectManagementRoutingTests {
         #expect(stored?.logo == "\(project.id.uuidString).png")
     }
 
+    @Test("metadata mutations report persistence failures")
+    func metadataPersistenceFailures() {
+        let project = Project(name: "Repo", path: "/tmp/muxy-meta-failure-\(UUID().uuidString)")
+        let env = ProjectManagementEnvironment(projects: [project])
+        let id = project.id.uuidString
+        env.projectPersistence.saveError = ProjectManagementSaveError()
+
+        let results = [
+            MuxyAPI.Projects.rename(identifier: id, name: "Renamed", context: env.context),
+            MuxyAPI.Projects.setColor(identifier: id, color: "#E5484D", context: env.context),
+            MuxyAPI.Projects.setIcon(identifier: id, icon: "star.fill", context: env.context),
+            MuxyAPI.Projects.setLogo(identifier: id, logo: "\(project.id.uuidString).png", context: env.context),
+        ]
+
+        for result in results {
+            guard case let .failure(error) = result else {
+                Issue.record("expected project metadata persistence failure")
+                continue
+            }
+            #expect(error == .underlying("could not save project changes"))
+        }
+        #expect(env.projectStore.storedProjects.first == project)
+    }
+
     @Test("setLogo rejects path traversal")
     func setLogoRejectsPathTraversal() {
         var project = Project(name: "Repo", path: "/tmp/muxy-logo-\(UUID().uuidString)")
@@ -315,3 +339,5 @@ struct MuxyAPIProjectManagementRoutingTests {
         return false
     }
 }
+
+private struct ProjectManagementSaveError: Error {}

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -466,12 +466,12 @@ struct ProjectGroupStoreTests {
     }
 
     @Test("project editing updates remote metadata and persists")
-    func editRemoteProject() {
+    func editRemoteProject() throws {
         let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
         let group = ProjectGroup(name: "Remote", type: .ssh, remoteDeviceID: device.id)
         let persistence = ProjectGroupPersistenceStub(initial: [group])
         let store = makeStore(persistence: persistence, devices: [device])
-        let remote = store.addRemoteProject(name: "api", path: "~/code/api", toGroup: group.id)!
+        let remote = try #require(store.addRemoteProject(name: "api", path: "~/code/api", toGroup: group.id))
         let project = remote.asProject(workspaceID: group.id, sortOrder: 0)
         let projectStore = ProjectStore(persistence: ProjectManagementPersistenceStub(initial: []))
         let editor = ProjectEditingService(projectStore: projectStore, projectGroupStore: store)
@@ -545,6 +545,7 @@ struct ProjectGroupStoreTests {
     func remoteWorkspaceRemovalCleansLogos() throws {
         let projectID = UUID()
         let logo = try createStoredLogo(projectID: projectID)
+        defer { ProjectLogoStorage.remove(forProjectID: projectID) }
         let remote = RemoteProject(id: projectID, name: "api", path: "~/code/api", logo: logo)
         let group = ProjectGroup(name: "Remote", type: .ssh, remoteProjects: [remote])
         let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [group]))

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -465,32 +465,142 @@ struct ProjectGroupStoreTests {
         #expect(persistence.savedGroups?.first?.remoteProjects.isEmpty == true)
     }
 
-    @Test("renameRemoteProject updates the name and persists")
-    func renameRemoteProject() {
+    @Test("project editing updates remote metadata and persists")
+    func editRemoteProject() {
         let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
         let group = ProjectGroup(name: "Remote", type: .ssh, remoteDeviceID: device.id)
         let persistence = ProjectGroupPersistenceStub(initial: [group])
         let store = makeStore(persistence: persistence, devices: [device])
-        let project = store.addRemoteProject(name: "api", path: "~/code/api", toGroup: group.id)
+        let remote = store.addRemoteProject(name: "api", path: "~/code/api", toGroup: group.id)!
+        let project = remote.asProject(workspaceID: group.id, sortOrder: 0)
+        let projectStore = ProjectStore(persistence: ProjectManagementPersistenceStub(initial: []))
+        let editor = ProjectEditingService(projectStore: projectStore, projectGroupStore: store)
 
-        store.renameRemoteProject(id: project!.id, to: "service")
+        editor.rename(project, to: "service")
+        editor.setLogo(project, to: "logo.png")
+        editor.setIcon(project, to: "server.rack")
+        editor.setIconColor(project, to: "blue")
+        editor.setWorktreesEnabled(project, to: true)
+        editor.setPinned(project, to: true)
 
-        #expect(store.groups.first?.remoteProjects.first?.name == "service")
-        #expect(persistence.savedGroups?.first?.remoteProjects.first?.name == "service")
+        let edited = store.groups.first?.remoteProjects.first
+        #expect(edited?.name == "service")
+        #expect(edited?.logo == "logo.png")
+        #expect(edited?.icon == "server.rack")
+        #expect(edited?.iconColor == "blue")
+        #expect(edited?.worktreesEnabled == true)
+        #expect(edited?.isPinned == true)
+        #expect(persistence.savedGroups?.first?.remoteProjects.first == edited)
+        #expect(projectStore.storedProjects.isEmpty)
     }
 
-    @Test("setRemoteProjectWorktreesEnabled toggles the flag and persists")
-    func setRemoteProjectWorktreesEnabled() {
-        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
-        let group = ProjectGroup(name: "Remote", type: .ssh, remoteDeviceID: device.id)
+    @Test("failed remote editing preserves in-memory and persisted metadata")
+    func failedRemoteProjectEdit() throws {
+        let projectID = UUID()
+        let logo = try createStoredLogo(projectID: projectID)
+        defer { ProjectLogoStorage.remove(forProjectID: projectID) }
+        let remote = RemoteProject(id: projectID, name: "api", path: "~/code/api", logo: logo)
+        let group = ProjectGroup(name: "Remote", type: .ssh, remoteProjects: [remote])
         let persistence = ProjectGroupPersistenceStub(initial: [group])
-        let store = makeStore(persistence: persistence, devices: [device])
-        let project = store.addRemoteProject(name: "api", path: "~/code/api", toGroup: group.id)
+        let store = makeStore(persistence: persistence)
+        let projectStore = ProjectStore(persistence: ProjectManagementPersistenceStub(initial: []))
+        let editor = ProjectEditingService(projectStore: projectStore, projectGroupStore: store)
+        persistence.saveError = ProjectGroupSaveError()
 
-        store.setRemoteProjectWorktreesEnabled(id: project!.id, to: true)
+        let project = remote.asProject(workspaceID: group.id, sortOrder: 0)
+        let didUpdate = editor.setPinned(project, to: true)
+        let didRemoveLogo = editor.setLogo(project, to: nil)
 
-        #expect(store.groups.first?.remoteProjects.first?.worktreesEnabled == true)
-        #expect(persistence.savedGroups?.first?.remoteProjects.first?.worktreesEnabled == true)
+        #expect(!didUpdate)
+        #expect(!didRemoveLogo)
+        #expect(store.groups.first?.remoteProjects.first?.isPinned == false)
+        #expect(store.groups.first?.remoteProjects.first?.logo == logo)
+        #expect(persistence.groups.first?.remoteProjects.first?.isPinned == false)
+        #expect(FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: logo)))
+    }
+
+    @Test("remote project removal deletes its logo only after persistence succeeds")
+    func remoteProjectRemovalLogoTransaction() throws {
+        let projectID = UUID()
+        let logo = try createStoredLogo(projectID: projectID)
+        defer { ProjectLogoStorage.remove(forProjectID: projectID) }
+        let remote = RemoteProject(id: projectID, name: "api", path: "~/code/api", logo: logo)
+        let group = ProjectGroup(name: "Remote", type: .ssh, remoteProjects: [remote])
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+        persistence.saveError = ProjectGroupSaveError()
+
+        #expect(!store.removeRemoteProject(id: projectID, fromGroup: group.id))
+        #expect(store.groups.first?.remoteProjects.first?.id == projectID)
+        #expect(FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: logo)))
+
+        persistence.saveError = nil
+
+        #expect(store.removeRemoteProject(id: projectID, fromGroup: group.id))
+        #expect(store.groups.first?.remoteProjects.isEmpty == true)
+        #expect(!FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: logo)))
+    }
+
+    @Test("remote workspace removal cleans project logos after persistence")
+    func remoteWorkspaceRemovalCleansLogos() throws {
+        let projectID = UUID()
+        let logo = try createStoredLogo(projectID: projectID)
+        let remote = RemoteProject(id: projectID, name: "api", path: "~/code/api", logo: logo)
+        let group = ProjectGroup(name: "Remote", type: .ssh, remoteProjects: [remote])
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [group]))
+
+        #expect(store.removeGroup(id: group.id))
+        #expect(store.groups.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: logo)))
+    }
+
+    @Test("failed device workspace removal preserves groups and logos")
+    func failedDeviceWorkspaceRemoval() throws {
+        let deviceID = UUID()
+        let projectID = UUID()
+        let logo = try createStoredLogo(projectID: projectID)
+        defer { ProjectLogoStorage.remove(forProjectID: projectID) }
+        let remote = RemoteProject(id: projectID, name: "api", path: "~/code/api", logo: logo)
+        let group = ProjectGroup(
+            name: "Remote",
+            type: .ssh,
+            remoteDeviceID: deviceID,
+            remoteProjects: [remote]
+        )
+        let persistence = ProjectGroupPersistenceStub(initial: [group])
+        let store = makeStore(persistence: persistence)
+        persistence.saveError = ProjectGroupSaveError()
+
+        #expect(!store.removeWorkspaces(usingDevice: deviceID))
+        #expect(store.groups.first?.id == group.id)
+        #expect(FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: logo)))
+    }
+
+    @Test("pinned remote projects are listed first")
+    func pinnedRemoteProjectsFirst() {
+        let first = RemoteProject(name: "first", path: "~/code/first")
+        let pinned = RemoteProject(name: "pinned", path: "~/code/pinned", isPinned: true)
+        let group = ProjectGroup(name: "Remote", type: .ssh, remoteProjects: [first, pinned])
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [group]))
+        store.selectGroup(id: group.id)
+
+        let projects = store.displayProjects(localProjects: [], sortMode: .manual)
+
+        #expect(projects.map(\.name) == ["pinned", "first"])
+    }
+
+    @Test("remote projects honor the selected sort mode after pinned partitioning")
+    func remoteProjectSortMode() {
+        let zebra = RemoteProject(name: "Zebra", path: "~/code/zebra")
+        let alpha = RemoteProject(name: "Alpha", path: "~/code/alpha")
+        let pinned = RemoteProject(name: "Pinned", path: "~/code/pinned", isPinned: true)
+        let group = ProjectGroup(name: "Remote", type: .ssh, remoteProjects: [zebra, pinned, alpha])
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [group]))
+        store.selectGroup(id: group.id)
+
+        let projects = store.displayProjects(localProjects: [], sortMode: .nameAscending)
+
+        #expect(projects.map(\.name) == ["Pinned", "Alpha", "Zebra"])
     }
 
     @Test("loading a legacy ssh group migrates its inline data into a device")
@@ -626,16 +736,36 @@ struct ProjectGroupStoreTests {
         #expect(persistence.storedActiveGroupID == target.id)
     }
 
-    @Test("RemoteProject.asProject preserves the worktrees flag and workspace id")
+    @Test("RemoteProject.asProject preserves editable metadata and workspace id")
     func remoteProjectAsProjectRoundTrip() {
         let workspaceID = UUID()
-        let remote = RemoteProject(name: "api", path: "~/code/api", worktreesEnabled: true)
+        let remote = RemoteProject(
+            name: "api",
+            path: "~/code/api",
+            icon: "server.rack",
+            logo: "logo.png",
+            iconColor: "blue",
+            worktreesEnabled: true,
+            isPinned: true
+        )
 
         let project = remote.asProject(workspaceID: workspaceID, sortOrder: 3)
 
         #expect(project.id == remote.id)
+        #expect(project.icon == "server.rack")
+        #expect(project.logo == "logo.png")
+        #expect(project.iconColor == "blue")
         #expect(project.worktreesEnabled == true)
+        #expect(project.isPinned == true)
         #expect(project.remoteWorkspaceID == workspaceID)
         #expect(project.sortOrder == 3)
     }
+
+    private func createStoredLogo(projectID: UUID) throws -> String {
+        let filename = "\(projectID.uuidString).png"
+        try Data([0]).write(to: URL(fileURLWithPath: ProjectLogoStorage.logoPath(for: filename)))
+        return filename
+    }
 }
+
+private struct ProjectGroupSaveError: Error {}

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -740,6 +740,7 @@ struct ProjectGroupStoreTests {
     @Test("RemoteProject.asProject preserves editable metadata and workspace id")
     func remoteProjectAsProjectRoundTrip() {
         let workspaceID = UUID()
+        let lastActiveAt = Date(timeIntervalSinceReferenceDate: 123_456)
         let remote = RemoteProject(
             name: "api",
             path: "~/code/api",
@@ -747,6 +748,7 @@ struct ProjectGroupStoreTests {
             logo: "logo.png",
             iconColor: "blue",
             worktreesEnabled: true,
+            lastActiveAt: lastActiveAt,
             isPinned: true
         )
 
@@ -757,6 +759,7 @@ struct ProjectGroupStoreTests {
         #expect(project.logo == "logo.png")
         #expect(project.iconColor == "blue")
         #expect(project.worktreesEnabled == true)
+        #expect(project.lastActiveAt == lastActiveAt)
         #expect(project.isPinned == true)
         #expect(project.remoteWorkspaceID == workspaceID)
         #expect(project.sortOrder == 3)

--- a/Tests/MuxyTests/Services/Project/ProjectStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectStoreTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 
@@ -175,6 +176,135 @@ struct ProjectStoreTests {
 
         #expect(store.storedProjects.first { $0.id == project.id }?.isPinned == true)
         #expect(persistence.projects.first?.isPinned == true)
+    }
+
+    @Test("project editing routes local and device-backed changes to ProjectStore")
+    func editingStoredProjects() {
+        let local = Project(name: "Local", path: "/tmp/local")
+        let remote = Project(name: "Remote", path: "~/remote", remoteDeviceID: UUID())
+        let persistence = ProjectPersistenceStub(initial: [local, remote])
+        let projectStore = ProjectStore(persistence: persistence)
+        let projectGroupStore = ProjectGroupStore(
+            persistence: ProjectGroupPersistenceStub(),
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        let editor = ProjectEditingService(projectStore: projectStore, projectGroupStore: projectGroupStore)
+
+        for project in [local, remote] {
+            editor.rename(project, to: "Edited")
+            editor.setIcon(project, to: "folder.fill")
+            editor.setIconColor(project, to: "blue")
+            editor.setWorktreesEnabled(project, to: true)
+            editor.setPinned(project, to: true)
+        }
+
+        #expect(projectStore.storedProjects.allSatisfy { $0.name == "Edited" })
+        #expect(projectStore.storedProjects.allSatisfy { $0.icon == "folder.fill" })
+        #expect(projectStore.storedProjects.allSatisfy { $0.iconColor == "blue" })
+        #expect(projectStore.storedProjects.allSatisfy { $0.worktreesEnabled })
+        #expect(projectStore.storedProjects.allSatisfy { $0.isPinned })
+        #expect(projectGroupStore.groups.isEmpty)
+    }
+
+    @Test("failed project editing rolls back in-memory metadata")
+    func failedProjectEditing() throws {
+        let projectID = UUID()
+        let filename = "\(projectID.uuidString).png"
+        try Data([0]).write(to: URL(fileURLWithPath: ProjectLogoStorage.logoPath(for: filename)))
+        defer { ProjectLogoStorage.remove(forProjectID: projectID) }
+        var project = Project(id: projectID, name: "Repo", path: "/tmp/repo")
+        project.logo = filename
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let projectStore = ProjectStore(persistence: persistence)
+        let projectGroupStore = ProjectGroupStore(
+            persistence: ProjectGroupPersistenceStub(),
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        let editor = ProjectEditingService(projectStore: projectStore, projectGroupStore: projectGroupStore)
+        persistence.projectSaveError = ProjectPersistenceTestError.saveFailed
+
+        let didUpdate = editor.setPinned(project, to: true)
+        let didRemoveLogo = editor.setLogo(project, to: nil)
+
+        #expect(!didUpdate)
+        #expect(!didRemoveLogo)
+        #expect(projectStore.storedProjects.first?.isPinned == false)
+        #expect(projectStore.storedProjects.first?.logo == filename)
+        #expect(persistence.projects.first?.isPinned == false)
+        #expect(FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: filename)))
+    }
+
+    @Test("failed cropped logo persistence removes an unreferenced file")
+    func failedCroppedLogoPersistence() {
+        let project = Project(name: "Repo", path: "/tmp/repo")
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let projectStore = ProjectStore(persistence: persistence)
+        let projectGroupStore = ProjectGroupStore(
+            persistence: ProjectGroupPersistenceStub(),
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        let editor = ProjectEditingService(projectStore: projectStore, projectGroupStore: projectGroupStore)
+        let image = NSImage(size: NSSize(width: 1, height: 1), flipped: false) { rect in
+            NSColor.red.setFill()
+            rect.fill()
+            return true
+        }
+        let filename = "\(project.id.uuidString).png"
+        defer { ProjectLogoStorage.remove(forProjectID: project.id) }
+        persistence.projectSaveError = ProjectPersistenceTestError.saveFailed
+
+        let didUpdate = editor.setLogo(project, croppedImage: image)
+
+        #expect(!didUpdate)
+        #expect(projectStore.storedProjects.first?.logo == nil)
+        #expect(!FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: filename)))
+    }
+
+    @Test("replacing an existing cropped logo does not require a metadata write")
+    func replaceExistingCroppedLogo() throws {
+        let projectID = UUID()
+        let filename = "\(projectID.uuidString).png"
+        let logoURL = URL(fileURLWithPath: ProjectLogoStorage.logoPath(for: filename))
+        try Data([0]).write(to: logoURL)
+        defer { ProjectLogoStorage.remove(forProjectID: projectID) }
+        var project = Project(id: projectID, name: "Repo", path: "/tmp/repo")
+        project.logo = filename
+        let persistence = ProjectPersistenceStub(initial: [project])
+        let projectStore = ProjectStore(persistence: persistence)
+        let projectGroupStore = ProjectGroupStore(
+            persistence: ProjectGroupPersistenceStub(),
+            remoteDeviceStore: RemoteDeviceStore(persistence: InMemoryRemoteDevicePersistence()),
+            workspaceContextSink: InMemoryWorkspaceContextSink()
+        )
+        let editor = ProjectEditingService(projectStore: projectStore, projectGroupStore: projectGroupStore)
+        let image = NSImage(size: NSSize(width: 1, height: 1), flipped: false) { rect in
+            NSColor.blue.setFill()
+            rect.fill()
+            return true
+        }
+        persistence.projectSaveError = ProjectPersistenceTestError.saveFailed
+
+        let didUpdate = editor.setLogo(project, croppedImage: image)
+
+        #expect(didUpdate)
+        #expect(projectStore.storedProjects.first?.logo == filename)
+        #expect(try Data(contentsOf: logoURL) != Data([0]))
+    }
+
+    @Test("removing a device-backed project cleans its logo")
+    func removeDeviceBackedProjectLogo() throws {
+        let projectID = UUID()
+        let filename = "\(projectID.uuidString).png"
+        try Data([0]).write(to: URL(fileURLWithPath: ProjectLogoStorage.logoPath(for: filename)))
+        var project = Project(id: projectID, name: "Remote", path: "~/remote", remoteDeviceID: UUID())
+        project.logo = filename
+        let store = ProjectStore(persistence: ProjectPersistenceStub(initial: [project]))
+
+        #expect(store.remove(id: project.id))
+        #expect(!FileManager.default.fileExists(atPath: ProjectLogoStorage.logoPath(for: filename)))
     }
 
     @Test("setPinned ignores the Home project")

--- a/Tests/MuxyTests/Support/MuxyAPIEnvironment.swift
+++ b/Tests/MuxyTests/Support/MuxyAPIEnvironment.swift
@@ -34,13 +34,17 @@ final class ProjectGroupPersistenceStub: ProjectGroupPersisting {
 
 final class ProjectManagementPersistenceStub: ProjectPersisting {
     var projects: [Project]
+    var saveError: Error?
 
     init(initial: [Project]) {
         projects = initial
     }
 
     func loadProjects() throws -> [Project] { projects }
-    func saveProjects(_ projects: [Project]) throws { self.projects = projects }
+    func saveProjects(_ projects: [Project]) throws {
+        if let saveError { throw saveError }
+        self.projects = projects
+    }
 }
 
 final class ProjectManagementWorktreePersistenceStub: WorktreePersisting {
@@ -73,12 +77,14 @@ final class ProjectManagementTerminalViewRemovingStub: TerminalViewRemoving {
 @MainActor
 struct ProjectManagementEnvironment {
     let appState: AppState
+    let projectPersistence: ProjectManagementPersistenceStub
     let projectStore: ProjectStore
     let worktreeStore: WorktreeStore
     let projectGroupStore: ProjectGroupStore
 
     init(projects: [Project] = []) {
-        projectStore = ProjectStore(persistence: ProjectManagementPersistenceStub(initial: projects))
+        projectPersistence = ProjectManagementPersistenceStub(initial: projects)
+        projectStore = ProjectStore(persistence: projectPersistence)
         worktreeStore = WorktreeStore(
             persistence: ProjectManagementWorktreePersistenceStub(),
             projects: projects

--- a/Tests/MuxyTests/Support/MuxyAPIEnvironment.swift
+++ b/Tests/MuxyTests/Support/MuxyAPIEnvironment.swift
@@ -6,6 +6,7 @@ final class ProjectGroupPersistenceStub: ProjectGroupPersisting {
     var groups: [ProjectGroup]
     var savedGroups: [ProjectGroup]?
     var storedActiveGroupID: UUID?
+    var saveError: Error?
 
     init(initial: [ProjectGroup] = [], storedActiveGroupID: UUID? = nil) {
         groups = initial
@@ -17,6 +18,7 @@ final class ProjectGroupPersistenceStub: ProjectGroupPersisting {
     }
 
     func saveProjectGroups(_ groups: [ProjectGroup]) throws {
+        if let saveError { throw saveError }
         savedGroups = groups
         self.groups = groups
     }

--- a/Tests/MuxyTests/Views/Layouts/ProjectFocused/ProjectWorktreeExpansionStateTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/ProjectFocused/ProjectWorktreeExpansionStateTests.swift
@@ -22,13 +22,7 @@ struct ProjectWorktreeExpansionStateTests {
             isWorktreeAutoExpandPending: false,
             onResolveWorktreeAutoExpand: { _ in },
             onSelect: {},
-            onRemove: {},
-            onRename: { _ in },
-            onSetLogo: { _ in },
-            onSetIcon: { _ in },
-            onSetIconColor: { _ in },
-            onSetWorktreesEnabled: { _ in },
-            onSetPinned: { _ in }
+            onRemove: {}
         )
 
         row.worktreesExpanded = true
@@ -368,13 +362,7 @@ private struct ProjectWorktreeExpansionLifecycleHarness: View {
                         model.expansion.resolveAutoExpand(projectID: project.id, isEligible: isEligible)
                     },
                     onSelect: {},
-                    onRemove: {},
-                    onRename: { _ in },
-                    onSetLogo: { _ in },
-                    onSetIcon: { _ in },
-                    onSetIconColor: { _ in },
-                    onSetWorktreesEnabled: { _ in },
-                    onSetPinned: { _ in }
+                    onRemove: {}
                 )
                 .onDisappear {
                     model.rowDisappearances += 1

--- a/Tests/MuxyTests/Views/Layouts/Shared/ProjectActionsContextMenuTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/ProjectActionsContextMenuTests.swift
@@ -1,0 +1,50 @@
+import Testing
+
+@testable import Muxy
+
+@Suite("ProjectActionsContextMenuPolicy")
+struct ProjectActionsContextMenuPolicyTests {
+    @Test("pin is available for persisted projects only")
+    func pinAvailability() {
+        #expect(ProjectActionsContextMenuPolicy.showsPin(isHome: false))
+        #expect(!ProjectActionsContextMenuPolicy.showsPin(isHome: true))
+    }
+
+    @Test("worktree actions distinguish repositories from pending checks")
+    func worktreeAvailability() {
+        #expect(ProjectActionsContextMenuPolicy.showsWorktreeActions(isGitRepo: true))
+        #expect(!ProjectActionsContextMenuPolicy.showsWorktreeActions(isGitRepo: false))
+        #expect(ProjectActionsContextMenuPolicy.showsLoadingWorktrees(
+            isGitRepo: false,
+            isCheckingGitRepo: true
+        ))
+        #expect(!ProjectActionsContextMenuPolicy.showsLoadingWorktrees(
+            isGitRepo: true,
+            isCheckingGitRepo: true
+        ))
+    }
+
+    @Test("switch worktree requires the normal row capability and multiple worktrees")
+    func switchWorktreeAvailability() {
+        #expect(ProjectActionsContextMenuPolicy.showsSwitchWorktree(
+            worktreesEnabled: true,
+            worktreeCount: 2,
+            supportsSwitchWorktree: true
+        ))
+        #expect(!ProjectActionsContextMenuPolicy.showsSwitchWorktree(
+            worktreesEnabled: true,
+            worktreeCount: 2,
+            supportsSwitchWorktree: false
+        ))
+        #expect(!ProjectActionsContextMenuPolicy.showsSwitchWorktree(
+            worktreesEnabled: true,
+            worktreeCount: 1,
+            supportsSwitchWorktree: true
+        ))
+        #expect(!ProjectActionsContextMenuPolicy.showsSwitchWorktree(
+            worktreesEnabled: false,
+            worktreeCount: 2,
+            supportsSwitchWorktree: true
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Fix remote project listing parity so remote projects expose and persist the same actions as stored projects, including pinning and visual metadata.

## Changes

- centralize project edits behind an ownership-aware editing service
- share project context-menu behavior across sidebar layouts
- persist remote pin, icon, logo, color, and worktree preferences with backward-compatible decoding
- make project metadata updates and removals transactional across persistence failures
- clean up project logos safely when projects, workspaces, or devices are removed
- add migration, routing, sorting, rollback, cleanup, and menu-policy coverage

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

## AI Attribution

Implementation assisted by `openai/gpt-5.6-sol`.

## Screenshots

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added project customization for logos, icons, icon colors, names, pinned status, and worktree settings.
  - Added a unified project actions menu across project views.
  - Project metadata now persists across synchronized projects and legacy data migrations.

- **Bug Fixes**
  - Workspace and project deletion now reports failures and preserves data when saving fails.
  - Improved cleanup of stored project logos after successful removal.
  - Project sorting now respects the requested sort mode.

- **Tests**
  - Added coverage for editing, sorting, migration, cleanup, and persistence failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->