### PR TITLE
Recover remote terminals after SSH disconnects

### DIFF
--- a/Muxy/Models/Terminal/TerminalPaneState.swift
+++ b/Muxy/Models/Terminal/TerminalPaneState.swift
@@ -23,6 +23,7 @@ final class TerminalPaneState: Identifiable {
     let externalEditorFilePath: String?
     var isOffline = false
     var sessionRecoveryFailed = false
+    var remoteSessionRecoveryFailed = false
     let searchState = TerminalSearchState()
     @ObservationIgnored private var titleDebounceTask: Task<Void, Never>?
 

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -114,6 +114,11 @@
 "Back (%@)" = "Back (%@)";
 "Back to Extensions" = "Back to Extensions";
 "Background session unreachable" = "Background session unreachable";
+"Muxy could not restore this remote terminal automatically." = "Muxy could not restore this remote terminal automatically.";
+"Remote Device Settings…" = "Remote Device Settings…";
+"Retry" = "Retry";
+"Retry the remote terminal connection" = "Retry the remote terminal connection";
+"SSH connection unavailable" = "SSH connection unavailable";
 "Background sessions" = "Background sessions";
 "Background vibrancy" = "Background vibrancy";
 "Backup" = "Backup";

--- a/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
@@ -72,6 +72,7 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         guard let titlePtr = title.title else { return }
         let titleString = String(cString: titlePtr)
         DispatchQueue.main.async {
+            guard !view.handleRemoteSessionRecoveryTitle(titleString) else { return }
             if let paneID = TerminalViewRegistry.shared.paneID(for: view) {
                 TerminalCommandTracker.shared.recordShellCommandCandidate(titleString, paneID: paneID)
             }

--- a/Muxy/Services/Terminal/TerminalLaunchCommand.swift
+++ b/Muxy/Services/Terminal/TerminalLaunchCommand.swift
@@ -1,7 +1,17 @@
 import Foundation
 
 enum TerminalLaunchCommand {
+    struct RemoteShellConfiguration {
+        let interactive: Bool
+        let keepsShellOpen: Bool
+        let recoveryToken: UUID
+    }
+
     static let environmentKey = "MUXY_STARTUP_COMMAND"
+    static let remoteReconnectAttemptLimit = 5
+    static let remoteReconnectResetInterval = 60
+    static let remoteReconnectMinimumSessionDuration = 10
+    private static let remoteReconnectRequiredTitlePrefix = "__MUXY_SSH_RECONNECT_REQUIRED__"
 
     static func shellCommand(
         interactive: Bool,
@@ -17,31 +27,119 @@ enum TerminalLaunchCommand {
         destination: SSHDestination,
         workingDirectory: String,
         startupCommand: String?,
+        configuration: RemoteShellConfiguration
+    ) -> String {
+        let initialCommand = remoteCommand(
+            destination: destination,
+            workingDirectory: workingDirectory,
+            startupCommand: startupCommand,
+            interactive: configuration.interactive,
+            keepsShellOpen: configuration.keepsShellOpen
+        )
+        let reconnectCommand = remoteCommand(
+            destination: destination,
+            workingDirectory: workingDirectory,
+            startupCommand: nil,
+            interactive: configuration.interactive,
+            keepsShellOpen: configuration.keepsShellOpen
+        )
+        let options = SSHDestination.terminalOptions
+        let baseArguments = destination.connectionArguments + options + ["-tt", destination.target, "--"]
+        let initialSSH = (["/usr/bin/ssh"] + baseArguments + [initialCommand])
+            .map(ShellEscaper.escape)
+            .joined(separator: " ")
+        let reconnectSSH = (["/usr/bin/ssh"] + baseArguments + [reconnectCommand])
+            .map(ShellEscaper.escape)
+            .joined(separator: " ")
+        let retryScript = remoteReconnectScript(
+            initialSSH: initialSSH,
+            reconnectSSH: reconnectSSH,
+            recoveryToken: configuration.recoveryToken
+        )
+        return "/bin/sh -c \(ShellEscaper.escape(retryScript))"
+    }
+
+    static func remoteReconnectRequiredTitle(recoveryToken: UUID) -> String {
+        remoteReconnectRequiredTitlePrefix + recoveryToken.uuidString
+    }
+
+    static func remoteReconnectScript(
+        initialSSH: String,
+        reconnectSSH: String,
+        recoveryToken: UUID,
+        attemptLimit: Int = remoteReconnectAttemptLimit,
+        resetInterval: Int = remoteReconnectResetInterval,
+        minimumSessionDuration: Int = remoteReconnectMinimumSessionDuration
+    ) -> String {
+        let retryMessage =
+            "printf '\\r\\nMuxy: SSH connection lost. Reconnecting in %ss (%s/\(attemptLimit))...\\r\\n' "
+                + "\"$muxy_delay\" \"$muxy_attempt\" >&2"
+        let recoveryTitle = remoteReconnectRequiredTitle(recoveryToken: recoveryToken)
+        let reconnectRequired = "printf '\\033]2;\(recoveryTitle)\\007'"
+        return [
+            "trap 'exit 130' INT",
+            "trap 'exit 143' TERM",
+            "muxy_attempt=0",
+            "muxy_initial=1",
+            "muxy_recovering=0",
+            "while true; do",
+            "muxy_started=$(date +%s)",
+            "if [ \"$muxy_initial\" -eq 1 ]; then \(initialSSH); else \(reconnectSSH); fi",
+            "muxy_status=$?",
+            "muxy_now=$(date +%s)",
+            "muxy_elapsed=$((muxy_now - muxy_started))",
+            "[ \"$muxy_status\" -eq 255 ] || exit \"$muxy_status\"",
+            "if [ \"$muxy_recovering\" -eq 0 ] && [ \"$muxy_elapsed\" -lt \(minimumSessionDuration) ]; then",
+            "muxy_attempt=$((\(attemptLimit) + 1))",
+            "else",
+            "muxy_recovering=1",
+            "[ \"$muxy_elapsed\" -lt \(resetInterval) ] || muxy_attempt=0",
+            "muxy_attempt=$((muxy_attempt + 1))",
+            "fi",
+            "muxy_initial=0",
+            "if [ \"$muxy_attempt\" -gt \(attemptLimit) ]; then",
+            reconnectRequired,
+            "printf '\\r\\nMuxy: SSH connection unavailable. Select Retry to try again.\\r\\n' >&2",
+            "while :; do sleep 3600; done",
+            "else",
+            "case \"$muxy_attempt\" in 1) muxy_delay=1 ;; 2) muxy_delay=2 ;; 3) muxy_delay=4 ;; *) muxy_delay=8 ;; esac",
+            retryMessage,
+            "sleep \"$muxy_delay\"",
+            "fi",
+            "done",
+        ].joined(separator: "\n")
+    }
+
+    private static func remoteCommand(
+        destination: SSHDestination,
+        workingDirectory: String,
+        startupCommand: String?,
         interactive: Bool,
         keepsShellOpen: Bool
     ) -> String {
-        let command: String
-        if let startupCommand, !startupCommand.isEmpty {
-            let inner = remoteLoginShell(
-                startupCommand: startupCommand,
-                interactive: interactive,
-                keepsShellOpen: keepsShellOpen
-            )
-            let remoteCommand = RemoteCommandBuilder.changeDirectoryPrefix(workingDirectory) + inner
-            let bootstrap = RemoteCommandBuilder.environmentPrefix(destination.environment) + remoteCommand
-            command = RemoteLoginShellCommand.bootstrap(bootstrap)
+        let inner = remoteLoginShell(
+            startupCommand: startupCommand,
+            interactive: interactive,
+            keepsShellOpen: keepsShellOpen
+        )
+        let remoteCommand = RemoteCommandBuilder.changeDirectoryPrefix(workingDirectory) + inner
+        let command = RemoteCommandBuilder.environmentPrefix(destination.environment) + remoteCommand
+        let executableCommand = if let startupCommand, !startupCommand.isEmpty {
+            RemoteLoginShellCommand.bootstrap(command)
         } else {
-            let inner = remoteLoginShell(
-                startupCommand: nil,
-                interactive: interactive,
-                keepsShellOpen: keepsShellOpen
-            )
-            let remoteCommand = RemoteCommandBuilder.changeDirectoryPrefix(workingDirectory) + inner
-            command = RemoteCommandBuilder.environmentPrefix(destination.environment) + remoteCommand
+            command
         }
-        let options = SSHDestination.terminalOptions
-        let arguments = destination.connectionArguments + options + ["-tt", destination.target, "--", command]
-        return (["/usr/bin/ssh"] + arguments.map(ShellEscaper.escape)).joined(separator: " ")
+        return remoteCommandReservingTransportFailureStatus(executableCommand)
+    }
+
+    static func remoteCommandReservingTransportFailureStatus(_ command: String) -> String {
+        let script = [
+            "/bin/sh -c \(ShellEscaper.escape(command))",
+            "muxy_remote_status=$?",
+            "[ \"$muxy_remote_status\" -eq 255 ] && exit 254",
+            "exit \"$muxy_remote_status\"",
+        ].joined(separator: "\n")
+        return "/bin/sh -c \(ShellEscaper.escape(script))"
     }
 
     private static func remoteLoginShell(

--- a/Muxy/Services/Terminal/TerminalSurface.swift
+++ b/Muxy/Services/Terminal/TerminalSurface.swift
@@ -141,6 +141,15 @@ protocol TerminalSessionRecoverySurface: AnyObject {
 }
 
 @MainActor
+protocol TerminalRemoteSessionRecoverySurface: AnyObject {
+    var onRemoteSessionRecoveryFailed: ((Bool) -> Void)? { get set }
+    var isRemoteSessionRecoveryFailed: Bool { get }
+
+    func handleRemoteSessionRecoveryTitle(_ title: String) -> Bool
+    func retryRemoteSession()
+}
+
+@MainActor
 protocol TerminalInputSubmissionTarget: AnyObject {
     func sendRemoteBytes(_ bytes: Data)
     func submitRichInput(text: String)

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -65,6 +65,10 @@ struct SettingsView: View {
                 searchText = ""
                 selectedRoute = .builtin(.quickTerminal)
             }
+            if SettingsFocusCoordinator.shared.consume(.remoteDevices) {
+                searchText = ""
+                selectedRoute = .builtin(.remoteDevices)
+            }
         }
         .onChange(of: searchText) { _, _ in
             guard !isRouteVisible(selectedRoute) else { return }
@@ -78,6 +82,7 @@ struct SettingsView: View {
             selectedRoute = .builtin(.projects)
         }
         .onReceive(NotificationCenter.default.publisher(for: .focusRemoteDevicesSettings)) { _ in
+            _ = SettingsFocusCoordinator.shared.consume(.remoteDevices)
             searchText = ""
             selectedRoute = .builtin(.remoteDevices)
         }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -2,6 +2,9 @@ import AppKit
 import Darwin
 import GhosttyKit
 import MuxyShared
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "GhosttyTerminal")
 
 final class GhosttyTerminalNSView: NSView,
     TerminalSurface,
@@ -674,6 +677,7 @@ final class GhosttyTerminalNSView: NSView,
     func handleRemoteSessionRecoveryTitle(_ title: String) -> Bool {
         let expected = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: remoteRecoveryToken)
         guard workspaceContext.isRemote, title == expected else { return false }
+        logger.info("Remote terminal requires manual recovery")
         processExitHandled = true
         onSearchEnd?()
         destroySurface()
@@ -691,6 +695,7 @@ final class GhosttyTerminalNSView: NSView,
 
     func retryRemoteSession(recreateSurface: () -> Bool) {
         guard isRemoteSessionRecoveryFailed else { return }
+        logger.info("Retrying remote terminal recovery")
         if surface != nil {
             processExitHandled = true
             destroySurface()
@@ -699,6 +704,7 @@ final class GhosttyTerminalNSView: NSView,
         setRemoteSessionRecoveryFailed(false)
         processExitHandled = false
         if !recreateSurface() {
+            logger.error("Remote terminal surface recreation failed")
             setRemoteSessionRecoveryFailed(true)
         }
     }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -682,6 +682,14 @@ final class GhosttyTerminalNSView: NSView,
     }
 
     func retryRemoteSession() {
+        retryRemoteSession {
+            createSurface()
+            applyOcclusionState()
+            return surface != nil || pendingSurfaceCreation
+        }
+    }
+
+    func retryRemoteSession(recreateSurface: () -> Bool) {
         guard isRemoteSessionRecoveryFailed else { return }
         if surface != nil {
             processExitHandled = true
@@ -690,9 +698,7 @@ final class GhosttyTerminalNSView: NSView,
         remoteRecoveryToken = UUID()
         setRemoteSessionRecoveryFailed(false)
         processExitHandled = false
-        createSurface()
-        applyOcclusionState()
-        if surface == nil, !pendingSurfaceCreation {
+        if !recreateSurface() {
             setRemoteSessionRecoveryFailed(true)
         }
     }

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -12,7 +12,8 @@ final class GhosttyTerminalNSView: NSView,
     TerminalSearchSurface,
     TerminalUploadSurface,
     TerminalBackgroundingSurface,
-    TerminalSessionRecoverySurface
+    TerminalSessionRecoverySurface,
+    TerminalRemoteSessionRecoverySurface
 {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
     var terminalView: NSView { self }
@@ -23,6 +24,7 @@ final class GhosttyTerminalNSView: NSView,
     private let commandInteractive: Bool
     private let commandClosesOnExit: Bool
     private let workspaceContext: WorkspaceContext
+    private var remoteRecoveryToken: UUID
     let persistentSessionID: UUID?
     var envVars: [(key: String, value: String)] = []
     var sessionMetadata: [(key: String, value: String)] = []
@@ -36,6 +38,8 @@ final class GhosttyTerminalNSView: NSView,
     var onSendToBackground: (() -> Void)?
     var onSessionRecoveryFailed: ((Bool) -> Void)?
     private(set) var isSessionRecoveryFailed = false
+    var onRemoteSessionRecoveryFailed: ((Bool) -> Void)?
+    private(set) var isRemoteSessionRecoveryFailed = false
     var onSearchStart: ((String?) -> Void)?
     var onSearchEnd: (() -> Void)?
     var onSearchTotal: ((Int?) -> Void)?
@@ -118,7 +122,8 @@ final class GhosttyTerminalNSView: NSView,
         commandInteractive: Bool = false,
         closesOnCommandExit: Bool = true,
         workspaceContext: WorkspaceContext = .local,
-        persistentSessionID: UUID? = nil
+        persistentSessionID: UUID? = nil,
+        remoteRecoveryToken: UUID = UUID()
     ) {
         self.workingDirectory = workingDirectory
         self.command = command
@@ -126,6 +131,7 @@ final class GhosttyTerminalNSView: NSView,
         commandClosesOnExit = closesOnCommandExit
         self.workspaceContext = workspaceContext
         self.persistentSessionID = persistentSessionID
+        self.remoteRecoveryToken = remoteRecoveryToken
         super.init(frame: .zero)
         wantsLayer = true
         setupTrackingArea()
@@ -211,8 +217,11 @@ final class GhosttyTerminalNSView: NSView,
                 destination: destination,
                 workingDirectory: workingDirectory,
                 startupCommand: launchCommand,
-                interactive: commandInteractive,
-                keepsShellOpen: !commandClosesOnExit
+                configuration: TerminalLaunchCommand.RemoteShellConfiguration(
+                    interactive: commandInteractive,
+                    keepsShellOpen: !commandClosesOnExit,
+                    recoveryToken: remoteRecoveryToken
+                )
             )) {
                 surfaceCStringPointers.append(remoteWrapped)
                 config.command = UnsafePointer(remoteWrapped)
@@ -385,6 +394,7 @@ final class GhosttyTerminalNSView: NSView,
         canSendToBackground = nil
         onSendToBackground = nil
         onSessionRecoveryFailed = nil
+        onRemoteSessionRecoveryFailed = nil
         onSearchStart = nil
         onSearchEnd = nil
         onSearchTotal = nil
@@ -659,6 +669,38 @@ final class GhosttyTerminalNSView: NSView,
         destroySurface()
         isSessionRecoveryFailed = true
         onSessionRecoveryFailed?(true)
+    }
+
+    func handleRemoteSessionRecoveryTitle(_ title: String) -> Bool {
+        let expected = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: remoteRecoveryToken)
+        guard workspaceContext.isRemote, title == expected else { return false }
+        processExitHandled = true
+        onSearchEnd?()
+        destroySurface()
+        setRemoteSessionRecoveryFailed(true)
+        return true
+    }
+
+    func retryRemoteSession() {
+        guard isRemoteSessionRecoveryFailed else { return }
+        if surface != nil {
+            processExitHandled = true
+            destroySurface()
+        }
+        remoteRecoveryToken = UUID()
+        setRemoteSessionRecoveryFailed(false)
+        processExitHandled = false
+        createSurface()
+        applyOcclusionState()
+        if surface == nil, !pendingSurfaceCreation {
+            setRemoteSessionRecoveryFailed(true)
+        }
+    }
+
+    private func setRemoteSessionRecoveryFailed(_ failed: Bool) {
+        guard isRemoteSessionRecoveryFailed != failed else { return }
+        isRemoteSessionRecoveryFailed = failed
+        onRemoteSessionRecoveryFailed?(failed)
     }
 
     func applyColorScheme(isDark: Bool) {

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -38,6 +38,10 @@ struct TerminalPane: View {
         )
     }
 
+    private var showsRemoteSessionRecoveryPlaceholder: Bool {
+        state.remoteSessionRecoveryFailed && remoteOwnerName == nil
+    }
+
     private func wakePane() {
         let surface = TerminalViewRegistry.shared.existingView(for: state.id)
         (surface as? any TerminalOfflineSurface)?.wake()
@@ -48,6 +52,16 @@ struct TerminalPane: View {
         let surface = TerminalViewRegistry.shared.existingView(for: state.id)
         (surface as? any TerminalSessionRecoverySurface)?.reattachPersistentSession()
         onFocus()
+    }
+
+    private func retryRemoteSession() {
+        let surface = TerminalViewRegistry.shared.existingView(for: state.id)
+        (surface as? any TerminalRemoteSessionRecoverySurface)?.retryRemoteSession()
+        onFocus()
+    }
+
+    private func openRemoteDeviceSettings() {
+        SettingsFocusCoordinator.shared.openSettings(focusedOn: .remoteDevices)
     }
 
     var body: some View {
@@ -110,7 +124,14 @@ struct TerminalPane: View {
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
 
-            if showsUnreachableSessionPlaceholder {
+            if showsRemoteSessionRecoveryPlaceholder {
+                RemoteSessionDisconnectedPlaceholder(
+                    isFocused: focused,
+                    onRetry: retryRemoteSession,
+                    onOpenSettings: openRemoteDeviceSettings
+                )
+                .transition(.opacity)
+            } else if showsUnreachableSessionPlaceholder {
                 UnreachableSessionPlaceholder(isFocused: focused, onReconnect: reconnectPane)
                     .transition(.opacity)
             } else if showsSleepingPlaceholder {
@@ -118,6 +139,52 @@ struct TerminalPane: View {
                     .transition(.opacity)
             }
         }
+    }
+}
+
+struct RemoteSessionDisconnectedPlaceholder: View {
+    let isFocused: Bool
+    let onRetry: () -> Void
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(spacing: UIMetrics.spacing7) {
+            Spacer()
+            Image(systemName: "network.slash")
+                .font(.system(size: UIMetrics.fontMega))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .accessibilityHidden(true)
+            Text(L10n.resource("SSH connection unavailable"))
+                .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
+                .foregroundStyle(MuxyTheme.fg)
+            Text(L10n.resource("Muxy could not restore this remote terminal automatically."))
+                .font(.system(size: UIMetrics.fontBody))
+                .foregroundStyle(MuxyTheme.fgMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: UIMetrics.scaled(360))
+            HStack(spacing: UIMetrics.spacing4) {
+                Button(action: onRetry) {
+                    HStack(spacing: UIMetrics.spacing4) {
+                        Text(L10n.resource("Retry"))
+                        if isFocused {
+                            Text(L10n.resource("⏎"))
+                                .font(.system(size: UIMetrics.fontFootnote, weight: .medium, design: .rounded))
+                                .opacity(0.72)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                }
+                .keyboardShortcut(isFocused ? KeyboardShortcut(.return, modifiers: []) : nil)
+                .buttonStyle(.borderedProminent)
+                .accessibilityHint(L10n.string("Retry the remote terminal connection"))
+
+                Button(L10n.resource("Remote Device Settings…"), action: onOpenSettings)
+                    .buttonStyle(.bordered)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(MuxyTheme.bg)
     }
 }
 
@@ -467,6 +534,7 @@ struct TerminalBridge: NSViewRepresentable {
         }
         configureOfflineCallback(surface)
         configureSessionRecoveryCallback(surface)
+        configureRemoteSessionRecoveryCallback(surface)
         configureAgentDetectionCallback(surface)
         if let searchSurface = surface as? any TerminalSearchSurface {
             configureSearchCallbacks(searchSurface)
@@ -495,6 +563,17 @@ struct TerminalBridge: NSViewRepresentable {
         }
         recoverySurface?.onSessionRecoveryFailed = { [weak state] failed in
             state?.sessionRecoveryFailed = failed
+        }
+    }
+
+    private func configureRemoteSessionRecoveryCallback(_ surface: any TerminalSurface) {
+        let recoverySurface = surface as? any TerminalRemoteSessionRecoverySurface
+        let hasFailed = recoverySurface?.isRemoteSessionRecoveryFailed ?? false
+        if state.remoteSessionRecoveryFailed != hasFailed {
+            state.remoteSessionRecoveryFailed = hasFailed
+        }
+        recoverySurface?.onRemoteSessionRecoveryFailed = { [weak state] failed in
+            state?.remoteSessionRecoveryFailed = failed
         }
     }
 

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -178,8 +178,10 @@ struct RemoteSessionDisconnectedPlaceholder: View {
                 .buttonStyle(.borderedProminent)
                 .accessibilityHint(L10n.string("Retry the remote terminal connection"))
 
-                Button(L10n.resource("Remote Device Settings…"), action: onOpenSettings)
-                    .buttonStyle(.bordered)
+                Button(action: onOpenSettings) {
+                    Text(L10n.resource("Remote Device Settings…"))
+                }
+                .buttonStyle(.bordered)
             }
             Spacer()
         }

--- a/Tests/MuxyTests/Services/Terminal/TerminalLaunchCommandTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/TerminalLaunchCommandTests.swift
@@ -123,37 +123,6 @@ struct TerminalLaunchCommandTests {
         #expect(script.contains("while :; do sleep 3600; done"))
     }
 
-    @Test("Remote recovery state notifies the pane")
-    @MainActor
-    func remoteRecoveryStateNotifiesPane() {
-        let recoveryToken = UUID()
-        let view = GhosttyTerminalNSView(
-            workingDirectory: "~",
-            workspaceContext: .ssh(SSHDestination(host: "prod")),
-            remoteRecoveryToken: recoveryToken
-        )
-        var events: [String] = []
-        view.onSearchEnd = { events.append("search-ended") }
-        view.onRemoteSessionRecoveryFailed = { events.append("recovery-\($0)") }
-
-        let forgedTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: UUID())
-        let validTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)
-
-        #expect(!view.handleRemoteSessionRecoveryTitle(forgedTitle))
-        #expect(!view.processExitHandled)
-        #expect(view.handleRemoteSessionRecoveryTitle(validTitle))
-        #expect(events == ["search-ended", "recovery-true"])
-        #expect(view.isRemoteSessionRecoveryFailed)
-        #expect(view.processExitHandled)
-
-        view.retryRemoteSession()
-
-        #expect(events == ["search-ended", "recovery-true", "recovery-false"])
-        #expect(!view.isRemoteSessionRecoveryFailed)
-        #expect(!view.processExitHandled)
-        #expect(!view.handleRemoteSessionRecoveryTitle(validTitle))
-    }
-
     @Test("Remote reconnect wrapper is valid POSIX shell")
     func remoteReconnectWrapperIsValidShell() throws {
         let process = Process()

--- a/Tests/MuxyTests/Services/Terminal/TerminalLaunchCommandTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/TerminalLaunchCommandTests.swift
@@ -1,9 +1,12 @@
+import Foundation
 import Testing
 
 @testable import Muxy
 
 @Suite("TerminalLaunchCommand")
 struct TerminalLaunchCommandTests {
+    private let recoveryToken = UUID(uuidString: "06D7D8FB-BAA8-4465-991B-8CBEEFD79E94")!
+
     @Test("Builds non-interactive login shell command")
     func buildsNonInteractiveLoginShellCommand() {
         let command = TerminalLaunchCommand.shellCommand(interactive: false, shell: "/bin/zsh")
@@ -80,12 +83,182 @@ struct TerminalLaunchCommandTests {
             destination: SSHDestination(host: "prod"),
             workingDirectory: "~/code/api",
             startupCommand: nil,
-            interactive: true,
-            keepsShellOpen: false
+            configuration: remoteConfiguration()
         )
-        #expect(command.hasPrefix("/usr/bin/ssh "))
+        #expect(command.hasPrefix("/bin/sh -c "))
+        #expect(command.contains("/usr/bin/ssh "))
         #expect(command.contains("-tt"))
-        #expect(command.contains("'export TERM=xterm-256color; cd ~/code/api && exec \"${SHELL:-/bin/sh}\" -l -i'"))
+        #expect(command.contains("export TERM=xterm-256color; cd ~/code/api && exec \"${SHELL:-/bin/sh}\" -l -i"))
+    }
+
+    @Test("Remote shell retries transport failures with bounded backoff")
+    func remoteShellRetriesTransportFailures() {
+        let command = TerminalLaunchCommand.remoteShellCommand(
+            destination: SSHDestination(host: "prod"),
+            workingDirectory: "~",
+            startupCommand: nil,
+            configuration: remoteConfiguration()
+        )
+
+        #expect(command.contains("[ \"$muxy_status\" -eq 255 ]"))
+        #expect(command.contains("[ \"$muxy_attempt\" -gt 5 ]"))
+        #expect(command.contains("muxy_elapsed\" -lt 60"))
+        #expect(command.contains("1) muxy_delay=1"))
+        #expect(command.contains("2) muxy_delay=2"))
+        #expect(command.contains("3) muxy_delay=4"))
+        #expect(command.contains("*) muxy_delay=8"))
+        #expect(command.contains("SSH connection lost. Reconnecting"))
+    }
+
+    @Test("Remote shell waits for manual retry after automatic recovery is exhausted")
+    func remoteShellWaitsForManualRetry() {
+        let script = TerminalLaunchCommand.remoteReconnectScript(
+            initialSSH: "exit 255",
+            reconnectSSH: "exit 255",
+            recoveryToken: recoveryToken
+        )
+
+        let recoveryTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)
+        #expect(script.contains(recoveryTitle))
+        #expect(script.contains("while :; do sleep 3600; done"))
+    }
+
+    @Test("Remote recovery state notifies the pane")
+    @MainActor
+    func remoteRecoveryStateNotifiesPane() {
+        let recoveryToken = UUID()
+        let view = GhosttyTerminalNSView(
+            workingDirectory: "~",
+            workspaceContext: .ssh(SSHDestination(host: "prod")),
+            remoteRecoveryToken: recoveryToken
+        )
+        var events: [String] = []
+        view.onSearchEnd = { events.append("search-ended") }
+        view.onRemoteSessionRecoveryFailed = { events.append("recovery-\($0)") }
+
+        let forgedTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: UUID())
+        let validTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)
+
+        #expect(!view.handleRemoteSessionRecoveryTitle(forgedTitle))
+        #expect(!view.processExitHandled)
+        #expect(view.handleRemoteSessionRecoveryTitle(validTitle))
+        #expect(events == ["search-ended", "recovery-true"])
+        #expect(view.isRemoteSessionRecoveryFailed)
+        #expect(view.processExitHandled)
+
+        view.retryRemoteSession()
+
+        #expect(events == ["search-ended", "recovery-true", "recovery-false"])
+        #expect(!view.isRemoteSessionRecoveryFailed)
+        #expect(!view.processExitHandled)
+        #expect(!view.handleRemoteSessionRecoveryTitle(validTitle))
+    }
+
+    @Test("Remote reconnect wrapper is valid POSIX shell")
+    func remoteReconnectWrapperIsValidShell() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-n",
+            "-c",
+            TerminalLaunchCommand.remoteReconnectScript(
+                initialSSH: "exit 0",
+                reconnectSSH: "exit 0",
+                recoveryToken: recoveryToken
+            ),
+        ]
+
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+    }
+
+    @Test("Immediate SSH failures wait for manual recovery without automatic retries")
+    func immediateSSHFailuresWaitForManualRecovery() throws {
+        let script = executableRecoveryScript(TerminalLaunchCommand.remoteReconnectScript(
+            initialSSH: "/bin/sh -c 'printf [INITIAL]; exit 255'",
+            reconnectSSH: "/bin/sh -c 'printf [RECONNECT]; exit 255'",
+            recoveryToken: recoveryToken
+        ))
+
+        let result = try runShell(script)
+
+        #expect(result.status == 75)
+        #expect(occurrences(of: "[INITIAL]", in: result.output) == 1)
+        #expect(!result.output.contains("[RECONNECT]"))
+        #expect(result.output.contains(TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)))
+    }
+
+    @Test("Established SSH failures consume the bounded automatic retry budget")
+    func establishedSSHFailuresRetryWithinBudget() throws {
+        let script = executableRecoveryScript(TerminalLaunchCommand.remoteReconnectScript(
+            initialSSH: "/bin/sh -c 'printf [INITIAL]; exit 255'",
+            reconnectSSH: "/bin/sh -c 'printf [RECONNECT]; exit 255'",
+            recoveryToken: recoveryToken,
+            attemptLimit: 2,
+            minimumSessionDuration: 0
+        ))
+
+        let result = try runShell(script)
+
+        #expect(result.status == 75)
+        #expect(occurrences(of: "[INITIAL]", in: result.output) == 1)
+        #expect(occurrences(of: "[RECONNECT]", in: result.output) == 2)
+    }
+
+    @Test("Non-transport SSH exits preserve status without retrying")
+    func nonTransportSSHExitsWithoutRetrying() throws {
+        let script = TerminalLaunchCommand.remoteReconnectScript(
+            initialSSH: "/bin/sh -c 'printf [INITIAL]; exit 42'",
+            reconnectSSH: "/bin/sh -c 'printf [RECONNECT]; exit 255'",
+            recoveryToken: recoveryToken
+        )
+
+        let result = try runShell(script)
+
+        #expect(result.status == 42)
+        #expect(occurrences(of: "[INITIAL]", in: result.output) == 1)
+        #expect(!result.output.contains("[RECONNECT]"))
+        #expect(!result.output.contains(TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)))
+    }
+
+    @Test("Remote command status 255 is reserved for SSH transport failures")
+    func remoteCommandStatus255IsRemapped() throws {
+        let command = TerminalLaunchCommand.remoteCommandReservingTransportFailureStatus("exit 255")
+
+        let result = try runShell(command)
+
+        #expect(result.status == 254)
+    }
+
+    @Test("Local cancellation does not trigger SSH recovery")
+    func localCancellationDoesNotTriggerRecovery() throws {
+        let script = TerminalLaunchCommand.remoteReconnectScript(
+            initialSSH: "kill -INT $$",
+            reconnectSSH: "printf [RECONNECT]",
+            recoveryToken: recoveryToken
+        )
+
+        let result = try runShell(script)
+
+        #expect(result.status == 130)
+        #expect(!result.output.contains("[RECONNECT]"))
+        #expect(!result.output.contains(TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)))
+    }
+
+    @Test("Remote shell does not replay startup command after reconnecting")
+    func remoteShellDoesNotReplayStartupCommand() {
+        let startupCommand = "printf MUXY_UNIQUE_STARTUP"
+        let command = TerminalLaunchCommand.remoteShellCommand(
+            destination: SSHDestination(host: "prod"),
+            workingDirectory: "~",
+            startupCommand: startupCommand,
+            configuration: remoteConfiguration(keepsShellOpen: true)
+        )
+
+        #expect(command.components(separatedBy: startupCommand).count == 2)
+        #expect(command.contains("muxy_initial"))
     }
 
     @Test("Remote shell escapes an injected startup command so it cannot break out")
@@ -95,8 +268,7 @@ struct TerminalLaunchCommandTests {
             destination: SSHDestination(host: "prod"),
             workingDirectory: "~",
             startupCommand: payload,
-            interactive: false,
-            keepsShellOpen: false
+            configuration: remoteConfiguration(interactive: false)
         )
         #expect(command.contains("export MUXY_STARTUP_COMMAND="))
         #expect(command.contains("export TERM=xterm-256color"))
@@ -110,8 +282,7 @@ struct TerminalLaunchCommandTests {
             destination: SSHDestination(host: "prod"),
             workingDirectory: "~",
             startupCommand: "printf REMOTE_FISH",
-            interactive: true,
-            keepsShellOpen: true
+            configuration: remoteConfiguration(keepsShellOpen: true)
         )
 
         #expect(command.contains("exec /bin/sh -c"))
@@ -130,9 +301,46 @@ struct TerminalLaunchCommandTests {
             destination: SSHDestination(host: "prod", environment: ["TERM": "screen-256color", "LANG": "C.UTF-8"]),
             workingDirectory: "~",
             startupCommand: nil,
-            interactive: true,
-            keepsShellOpen: false
+            configuration: remoteConfiguration()
         )
-        #expect(command.contains("'export LANG=C.UTF-8; export TERM=screen-256color; cd ~ && exec \"${SHELL:-/bin/sh}\" -l -i'"))
+        #expect(command.contains("export LANG=C.UTF-8; export TERM=screen-256color; cd ~ && exec \"${SHELL:-/bin/sh}\" -l -i"))
+    }
+
+    private func executableRecoveryScript(_ script: String) -> String {
+        precondition(script.contains("sleep \"$muxy_delay\""))
+        precondition(script.contains("while :; do sleep 3600; done"))
+        return script
+            .replacingOccurrences(of: "sleep \"$muxy_delay\"", with: ":")
+            .replacingOccurrences(of: "while :; do sleep 3600; done", with: "exit 75")
+    }
+
+    private func remoteConfiguration(
+        interactive: Bool = true,
+        keepsShellOpen: Bool = false
+    ) -> TerminalLaunchCommand.RemoteShellConfiguration {
+        TerminalLaunchCommand.RemoteShellConfiguration(
+            interactive: interactive,
+            keepsShellOpen: keepsShellOpen,
+            recoveryToken: recoveryToken
+        )
+    }
+
+    private func runShell(_ script: String) throws -> (status: Int32, output: String) {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", script]
+        process.standardOutput = output
+        process.standardError = output
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+
+    private func occurrences(of needle: String, in haystack: String) -> Int {
+        haystack.components(separatedBy: needle).count - 1
     }
 }

--- a/Tests/MuxyTests/Services/UIHosts/SettingsFocusCoordinatorTests.swift
+++ b/Tests/MuxyTests/Services/UIHosts/SettingsFocusCoordinatorTests.swift
@@ -79,6 +79,38 @@ struct SettingsFocusCoordinatorTests {
         #expect(coordinator.consume(.terminal))
         #expect(!coordinator.consume(.terminal))
     }
+
+    @Test("opening remote device settings retains focus and emits both notifications")
+    func remoteDeviceSettingsOpenRoutesToRemoteDevices() {
+        let notificationCenter = NotificationCenter()
+        let coordinator = SettingsFocusCoordinator(notificationCenter: notificationCenter)
+        let flag = SettingsOpenNotificationFlag()
+        let focusObserver = notificationCenter.addObserver(
+            forName: .focusRemoteDevicesSettings,
+            object: nil,
+            queue: nil
+        ) { _ in
+            flag.didPostFocus = true
+        }
+        let openObserver = notificationCenter.addObserver(
+            forName: .openSettingsModal,
+            object: nil,
+            queue: nil
+        ) { _ in
+            flag.didPostOpen = true
+        }
+        defer {
+            notificationCenter.removeObserver(focusObserver)
+            notificationCenter.removeObserver(openObserver)
+        }
+
+        coordinator.openSettings(focusedOn: .remoteDevices)
+
+        #expect(flag.didPostFocus)
+        #expect(flag.didPostOpen)
+        #expect(coordinator.consume(.remoteDevices))
+        #expect(!coordinator.consume(.remoteDevices))
+    }
 }
 
 private final class SettingsFocusNotificationFlag: @unchecked Sendable {

--- a/Tests/MuxyTests/Views/Terminal/GhosttyTerminalNSViewRecoveryTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/GhosttyTerminalNSViewRecoveryTests.swift
@@ -40,4 +40,24 @@ struct GhosttyTerminalNSViewRecoveryTests {
         #expect(!view.processExitHandled)
         #expect(!view.handleRemoteSessionRecoveryTitle(validTitle))
     }
+
+    @Test("Failed surface recreation restores recovery state")
+    func failedSurfaceRecreationRestoresRecoveryState() {
+        let recoveryToken = UUID()
+        let view = GhosttyTerminalNSView(
+            workingDirectory: "~",
+            workspaceContext: .ssh(SSHDestination(host: "prod")),
+            remoteRecoveryToken: recoveryToken
+        )
+        var recoveryStates: [Bool] = []
+        view.onRemoteSessionRecoveryFailed = { recoveryStates.append($0) }
+        let validTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)
+
+        #expect(view.handleRemoteSessionRecoveryTitle(validTitle))
+
+        view.retryRemoteSession { false }
+
+        #expect(view.isRemoteSessionRecoveryFailed)
+        #expect(recoveryStates == [true, false, true])
+    }
 }

--- a/Tests/MuxyTests/Views/Terminal/GhosttyTerminalNSViewRecoveryTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/GhosttyTerminalNSViewRecoveryTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Ghostty terminal remote recovery")
+@MainActor
+struct GhosttyTerminalNSViewRecoveryTests {
+    @Test("Validated recovery titles reset state with a rotated token")
+    func validatedRecoveryTitleResetsState() {
+        let recoveryToken = UUID()
+        let view = GhosttyTerminalNSView(
+            workingDirectory: "~",
+            workspaceContext: .ssh(SSHDestination(host: "prod")),
+            remoteRecoveryToken: recoveryToken
+        )
+        var events: [String] = []
+        var recreatedSurface = false
+        view.onSearchEnd = { events.append("search-ended") }
+        view.onRemoteSessionRecoveryFailed = { events.append("recovery-\($0)") }
+
+        let forgedTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: UUID())
+        let validTitle = TerminalLaunchCommand.remoteReconnectRequiredTitle(recoveryToken: recoveryToken)
+
+        #expect(!view.handleRemoteSessionRecoveryTitle(forgedTitle))
+        #expect(!view.processExitHandled)
+        #expect(view.handleRemoteSessionRecoveryTitle(validTitle))
+        #expect(events == ["search-ended", "recovery-true"])
+        #expect(view.isRemoteSessionRecoveryFailed)
+        #expect(view.processExitHandled)
+
+        view.retryRemoteSession {
+            recreatedSurface = true
+            return true
+        }
+
+        #expect(recreatedSurface)
+        #expect(events == ["search-ended", "recovery-true", "recovery-false"])
+        #expect(!view.isRemoteSessionRecoveryFailed)
+        #expect(!view.processExitHandled)
+        #expect(!view.handleRemoteSessionRecoveryTitle(validTitle))
+    }
+}

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -177,7 +177,7 @@ Muxy tracks the cwd via Ghostty's shell integration (OSC 7). The directory is pe
 
 Remote terminals use the selected SSH device's environment before starting the remote login shell. New SSH devices default to `TERM=xterm-256color`; edit the device in Settings -> Remote Devices to change or remove it.
 
-When an SSH session that has been connected for at least 10 seconds exits with status `255`, Muxy retries up to five times with capped exponential backoff. A connection that lasts at least 60 seconds resets the retry budget. Immediate connection failures skip automatic retries, and exhausted recovery offers Retry and a shortcut to Remote Device settings. Reconnects open a fresh login shell in the pane's working directory without replaying its original startup command; normal logout, command completion, and cancellation are not retried.
+When an SSH process runs for at least 10 seconds before exiting with status `255`, Muxy retries up to five times with capped exponential backoff. An SSH process that runs for at least 60 seconds resets the retry budget. Failures before the initial 10-second threshold skip automatic retries, and exhausted recovery offers Retry and a shortcut to Remote Device settings. Reconnects open a fresh login shell in the pane's working directory without replaying its original startup command; normal logout, command completion, and cancellation are not retried.
 
 ## Muxy CLI
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -177,6 +177,8 @@ Muxy tracks the cwd via Ghostty's shell integration (OSC 7). The directory is pe
 
 Remote terminals use the selected SSH device's environment before starting the remote login shell. New SSH devices default to `TERM=xterm-256color`; edit the device in Settings -> Remote Devices to change or remove it.
 
+When an SSH session that has been connected for at least 10 seconds exits with status `255`, Muxy retries up to five times with capped exponential backoff. A connection that lasts at least 60 seconds resets the retry budget. Immediate connection failures skip automatic retries, and exhausted recovery offers Retry and a shortcut to Remote Device settings. Reconnects open a fresh login shell in the pane's working directory without replaying its original startup command; normal logout, command completion, and cancellation are not retried.
+
 ## Muxy CLI
 
 Use the `muxy` command to open projects and control panes from a shell or automation script. See [Muxy CLI](muxy-cli.md).


### PR DESCRIPTION
## Summary
- retry established SSH sessions with bounded backoff after transport failures
- show an accessible recovery placeholder with Retry and Remote Device Settings actions
- recreate failed Ghostty surfaces without replaying startup commands or stale search state
- preserve remote command completion and local cancellation semantics

## Testing
- `swift test --filter TerminalLaunchCommandTests`
- `swift test --filter SettingsFocusCoordinator`
- `scripts/checks.sh --fix`
- `git diff --check`

## AI Assistance
- OpenAI GPT-5.6 Sol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for interrupted SSH sessions with limited retries and increasing delays.
  * Added a disconnected state with options to retry or open Remote Device Settings.
  * Reconnection starts a fresh shell in the existing working directory.
  * Added localized recovery and connection status messages.

* **Documentation**
  * Clarified SSH recovery behavior, including failures before the initial 10-second threshold.

* **Tests**
  * Expanded coverage for recovery, retries, cancellations, exit statuses, and settings navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->