### PR TITLE
Add terminal view to the accessibility tree

### DIFF
--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -145,6 +145,18 @@ final class GhosttyTerminalNSView: NSView,
         fatalError("init(coder:) is not supported")
     }
 
+    override func isAccessibilityElement() -> Bool {
+        true
+    }
+
+    override func accessibilityValue() -> Any? {
+        readScreenText()
+    }
+
+    override func accessibilityNumberOfCharacters() -> Int {
+        readScreenText().utf16.count
+    }
+
     override func accessibilitySelectedText() -> String? {
         readSelectionText()
     }

--- a/Tests/MuxyTests/Views/Terminal/TerminalAccessibilityTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalAccessibilityTests.swift
@@ -1,0 +1,32 @@
+import AppKit
+import Testing
+@testable import Muxy
+
+@Suite("GhosttyTerminalNSView accessibility")
+@MainActor
+struct TerminalAccessibilityTests {
+    @Test func terminalIsExposedAsAccessibilityElement() {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+
+        #expect(view.isAccessibilityElement())
+    }
+
+    @Test func terminalReportsTextAreaRole() {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+
+        #expect(view.accessibilityRole() == .textArea)
+    }
+
+    @Test func terminalWithoutSurfaceReportsEmptyValue() {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+
+        #expect((view.accessibilityValue() as? String)?.isEmpty == true)
+        #expect(view.accessibilityNumberOfCharacters() == 0)
+    }
+
+    @Test func terminalWithoutSelectionReportsNoSelectedText() {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+
+        #expect(view.accessibilitySelectedText() == nil)
+    }
+}


### PR DESCRIPTION
## Summary

### Issue description

Third-party apps that use macOS Accessibility to interact with Muxy, such as Typeless, cannot detect interactions with the terminal. For example, after dictation in Typeless, the transcribed text is successfully pasted into Muxy. However, Typeless does not recognize that the paste succeeded and continues to show a floating window prompting the user to copy the transcript manually.

This happens because Muxy’s terminal view is not properly exposed through the accessibility tree. As a result, accessibility clients cannot recognize the terminal or confirm that an interaction with it completed successfully.

This PR fixes the accessibility behavior so other third-party accessibility clients can correctly discover and interact with the terminal.

### Root cause analysis

The issue is in `GhosttyTerminalNSView`. Its initializer assigns the view an accessibility role of `.textArea` and an accessibility label, but the class does not override `isAccessibilityElement()`.

`NSView` returns `false` by default, which prevents the terminal view from being included in the accessibility tree. As a result, the configured role and label are attached to a view that accessibility clients cannot actually discover.

From the client's perspective, the terminal accessibility element is simply absent rather than returning an explicit error. This is why the failure is silent and why apps such as Typeless cannot determine that the interaction completed successfully.

### Changes

* Override `isAccessibilityElement()` to return `true`, making the terminal discoverable through the accessibility tree.
* Implement `accessibilityValue()` to expose the currently visible terminal text using the existing `readScreenText()` implementation.
* Implement `accessibilityNumberOfCharacters()` to report the accessibility value's UTF-16 length, as expected by macOS accessibility APIs.
* Add a new `TerminalAccessibilityTests` suite covering:

  * the terminal being exposed as an accessibility element;
  * the `.textArea` accessibility role; and
  * behavior when no terminal surface is available.

## Testing
- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

Build: 0 errors. Full suite passed, 3462 tests across 424 suites.

Contributed with Claude (Opus 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility support for terminal views, including readable terminal content and character counts.
  * Improved compatibility with assistive technologies by exposing the terminal as a text area.

* **Bug Fixes**
  * Ensured empty or unavailable terminal content is reported correctly.
  * Prevented selected-text information from appearing when no text is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->