### PR TITLE
Safely forget missing remote worktrees

### DIFF
--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -25,6 +25,11 @@ struct GitWorktreeRecord: Hashable {
     }
 }
 
+struct GitWorktreeRegistration: Equatable, Sendable {
+    let path: String
+    let isRegistered: Bool
+}
+
 protocol GitWorktreeListing {
     func listWorktrees(repoPath: String) async throws -> [GitWorktreeRecord]
 }
@@ -364,6 +369,20 @@ actor GitWorktreeService: GitWorktreeListing {
         context: WorkspaceContext = .local,
         timeout: TimeInterval = defaultWorktreeRemovalTimeout
     ) async throws -> Bool {
+        try await worktreeRegistration(
+            repoPath: repoPath,
+            path: path,
+            context: context,
+            timeout: timeout
+        ).isRegistered
+    }
+
+    func worktreeRegistration(
+        repoPath: String,
+        path: String,
+        context: WorkspaceContext = .local,
+        timeout: TimeInterval = defaultWorktreeRemovalTimeout
+    ) async throws -> GitWorktreeRegistration {
         let deadline = OperationDeadline(timeout: timeout)
         let records = try await listWorktrees(
             repoPath: repoPath,
@@ -376,11 +395,14 @@ actor GitWorktreeService: GitWorktreeListing {
             context: context,
             timeout: deadline.remaining()
         )
-        guard let resolvedPath = resolutions.first?.path else { return false }
+        guard let resolvedPath = resolutions.first?.path else {
+            throw WorkspacePathResolverError.invalidOutput
+        }
         let target = Self.canonicalPath(resolvedPath, context: context)
-        return resolutions.dropFirst().contains {
+        let isRegistered = resolutions.dropFirst().contains {
             Self.canonicalPath($0.path, context: context) == target
         }
+        return GitWorktreeRegistration(path: resolvedPath, isRegistered: isRegistered)
     }
 
     private func pruneWorktrees(repoPath: String, context: WorkspaceContext, timeout: TimeInterval) async throws {

--- a/Muxy/Services/Project/WorktreeStore.swift
+++ b/Muxy/Services/Project/WorktreeStore.swift
@@ -82,6 +82,30 @@ final class WorktreeStore {
 
     private typealias FileIdentity = WorktreeProcessQuiescer.DirectoryIdentity
 
+    struct CleanupDependencies: Sendable {
+        let worktreeRegistration: @Sendable (
+            String,
+            String,
+            WorkspaceContext,
+            TimeInterval
+        ) async throws -> GitWorktreeRegistration
+        let pathExists: @Sendable (String, WorkspaceContext, TimeInterval) async throws -> Bool
+
+        static let live = CleanupDependencies(
+            worktreeRegistration: { repoPath, path, context, timeout in
+                try await GitWorktreeService.shared.worktreeRegistration(
+                    repoPath: repoPath,
+                    path: path,
+                    context: context,
+                    timeout: timeout
+                )
+            },
+            pathExists: { path, context, timeout in
+                try await context.fileOps.exists(at: path, timeout: timeout)
+            }
+        )
+    }
+
     private enum CleanupPlan {
         case registered
         case staleManaged(projectID: UUID, identity: FileIdentity)
@@ -100,6 +124,7 @@ final class WorktreeStore {
         let context: WorkspaceContext
         let force: Bool
         let deadline: OperationDeadline
+        let dependencies: CleanupDependencies
     }
 
     private(set) var worktrees: [UUID: [Worktree]] = [:]
@@ -658,6 +683,7 @@ final class WorktreeStore {
         teardownGlobalConfigURL: URL = WorktreeConfig.globalConfigURL(),
         force: Bool = true,
         timeout: TimeInterval = GitWorktreeService.defaultWorktreeRemovalTimeout,
+        dependencies: CleanupDependencies = .live,
         teardownEmit: @Sendable @escaping (WorktreeTeardownOutputLine) -> Void = { _ in }
     ) async throws -> WorktreeCleanupResult {
         guard worktree.canBeRemoved else {
@@ -673,7 +699,8 @@ final class WorktreeStore {
             repoPath: repoPath,
             context: context,
             force: force,
-            deadline: deadline
+            deadline: deadline,
+            dependencies: dependencies
         )
         let plan = try await cleanupPlan(for: operation)
         if case let .finished(result) = plan {
@@ -730,23 +757,26 @@ final class WorktreeStore {
         if !operation.context.isRemote, !isUnambiguousLocalPath(worktree.path) {
             throw GitWorktreeService.GitWorktreeError.notRegistered
         }
-        let isRegistered = try await GitWorktreeService.shared.isWorktreeRegistered(
-            repoPath: operation.repoPath,
-            path: worktree.path,
-            context: operation.context,
-            timeout: operation.deadline.remaining()
+        let registration = try await operation.dependencies.worktreeRegistration(
+            operation.repoPath,
+            worktree.path,
+            operation.context,
+            operation.deadline.remaining()
         )
-        guard !isRegistered else { return .registered }
-        guard !operation.context.isRemote else {
-            throw GitWorktreeService.GitWorktreeError.notRegistered
-        }
-        guard try await operation.context.fileOps.exists(
-            at: worktree.path,
-            timeout: operation.deadline.remaining()
+        guard !registration.isRegistered else { return .registered }
+        guard try await operation.dependencies.pathExists(
+            registration.path,
+            operation.context,
+            operation.deadline.remaining()
         )
         else {
-            await removeParentDirectoryIfEmpty(for: worktree.path)
+            if !operation.context.isRemote {
+                await removeParentDirectoryIfEmpty(for: worktree.path)
+            }
             return .finished(.removed)
+        }
+        guard !operation.context.isRemote else {
+            throw GitWorktreeService.GitWorktreeError.notRegistered
         }
         guard operation.force,
               let projectID = operation.projectID,
@@ -768,18 +798,19 @@ final class WorktreeStore {
         identity: FileIdentity
     ) async throws -> StaleRemovalResult {
         let worktree = operation.worktree
-        let isNowRegistered = try await GitWorktreeService.shared.isWorktreeRegistered(
-            repoPath: operation.repoPath,
-            path: worktree.path,
-            context: operation.context,
-            timeout: operation.deadline.remaining()
-        )
+        let isNowRegistered = try await operation.dependencies.worktreeRegistration(
+            operation.repoPath,
+            worktree.path,
+            operation.context,
+            operation.deadline.remaining()
+        ).isRegistered
         guard !isNowRegistered else {
             throw GitWorktreeService.GitWorktreeError.commandFailed("Worktree changed during removal.")
         }
-        guard try await operation.context.fileOps.exists(
-            at: worktree.path,
-            timeout: operation.deadline.remaining()
+        guard try await operation.dependencies.pathExists(
+            worktree.path,
+            operation.context,
+            operation.deadline.remaining()
         )
         else {
             await removeParentDirectoryIfEmpty(for: worktree.path)
@@ -802,12 +833,12 @@ final class WorktreeStore {
         else {
             return .finished(.preservedUnverifiedDirectory)
         }
-        let isRegisteredAfterQuiescing = try await GitWorktreeService.shared.isWorktreeRegistered(
-            repoPath: operation.repoPath,
-            path: worktree.path,
-            context: operation.context,
-            timeout: operation.deadline.remaining()
-        )
+        let isRegisteredAfterQuiescing = try await operation.dependencies.worktreeRegistration(
+            operation.repoPath,
+            worktree.path,
+            operation.context,
+            operation.deadline.remaining()
+        ).isRegistered
         guard !isRegisteredAfterQuiescing else {
             throw GitWorktreeService.GitWorktreeError.commandFailed("Worktree changed during removal.")
         }

--- a/Muxy/Services/Remote/RemoteFileOps.swift
+++ b/Muxy/Services/Remote/RemoteFileOps.swift
@@ -83,33 +83,43 @@ struct SSHFileOps: RemoteFileOps {
     }
 
     func exists(at path: String) async -> Bool {
-        let quoted = RemoteCommandBuilder.quoteRemotePath(path)
-        let quotedParent = RemoteCommandBuilder.quoteRemotePath(parentPath(of: path))
         let result = try? await SSHCommandRunner.run(
             destination: destination,
-            remoteCommand: presenceCommand(path: quoted, parent: quotedParent)
+            remoteCommand: Self.presenceCommand(path: path)
         )
         return result?.status != 1
     }
 
     func exists(at path: String, timeout: TimeInterval) async throws -> Bool {
-        let quoted = RemoteCommandBuilder.quoteRemotePath(path)
-        let quotedParent = RemoteCommandBuilder.quoteRemotePath(parentPath(of: path))
         let result = try await SSHCommandRunner.run(
             destination: destination,
-            remoteCommand: presenceCommand(path: quoted, parent: quotedParent),
+            remoteCommand: Self.presenceCommand(path: path),
             timeout: timeout
         )
         return result.status != 1
     }
 
-    private func parentPath(of path: String) -> String {
-        let parent = NSString(string: path).deletingLastPathComponent
-        return parent.isEmpty ? "." : parent
-    }
-
-    private func presenceCommand(path: String, parent: String) -> String {
-        "if [ -e \(path) ] || [ -L \(path) ]; then exit 0; fi; [ ! -e \(parent) ] && exit 1; [ -x \(parent) ] && exit 1; exit 2"
+    static func presenceCommand(path: String) -> String {
+        let quotedPath = RemoteCommandBuilder.quoteRemotePath(path)
+        return """
+        __muxy_path=\(quotedPath)
+        if [ -e "$__muxy_path" ] || [ -L "$__muxy_path" ]; then exit 0; fi
+        case "$__muxy_path" in
+          */*) __muxy_probe=${__muxy_path%/*}; [ -n "$__muxy_probe" ] || __muxy_probe=/ ;;
+          *) __muxy_probe=. ;;
+        esac
+        while [ ! -e "$__muxy_probe" ] && [ ! -L "$__muxy_probe" ]; do
+          [ "$__muxy_probe" = / ] && exit 2
+          case "$__muxy_probe" in
+            */*) __muxy_parent=${__muxy_probe%/*}; [ -n "$__muxy_parent" ] || __muxy_parent=/ ;;
+            *) __muxy_parent=. ;;
+          esac
+          [ "$__muxy_parent" = "$__muxy_probe" ] && exit 2
+          __muxy_probe=$__muxy_parent
+        done
+        [ -x "$__muxy_probe" ] && exit 1
+        exit 2
+        """
     }
 
     private func run(_ remoteCommand: String, timeout: TimeInterval = SSHCommandRunner.defaultTimeout) async throws {

--- a/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
+++ b/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
@@ -651,6 +651,59 @@ struct GitWorktreeServiceRemoveTests {
         #expect(result == .removed)
     }
 
+    @Test("cleanup forgets an unregistered remote worktree that is already absent")
+    func cleanupSucceedsForAbsentRemoteWorktree() async throws {
+        let resolvedPath = "/home/user/repos/removed-remote-worktree"
+        let worktree = Worktree(
+            name: "removed-remote-worktree",
+            path: "../removed-remote-worktree",
+            branch: "removed-remote-worktree",
+            source: .external,
+            isPrimary: false
+        )
+        let dependencies = WorktreeStore.CleanupDependencies(
+            worktreeRegistration: { _, _, _, _ in
+                GitWorktreeRegistration(path: resolvedPath, isRegistered: false)
+            },
+            pathExists: { path, _, _ in path != resolvedPath }
+        )
+
+        let result = try await WorktreeStore.cleanupOnDisk(
+            worktree: worktree,
+            repoPath: "/home/user/repos/main",
+            context: .ssh(SSHDestination(host: "example.test")),
+            dependencies: dependencies
+        )
+
+        #expect(result == .removed)
+    }
+
+    @Test("cleanup preserves an unregistered remote directory that still exists")
+    func cleanupPreservesExistingUnregisteredRemoteDirectory() async {
+        let worktree = Worktree(
+            name: "unregistered-remote-worktree",
+            path: "/home/user/repos/unregistered-remote-worktree",
+            branch: "unregistered-remote-worktree",
+            source: .external,
+            isPrimary: false
+        )
+        let dependencies = WorktreeStore.CleanupDependencies(
+            worktreeRegistration: { _, path, _, _ in
+                GitWorktreeRegistration(path: path, isRegistered: false)
+            },
+            pathExists: { _, _, _ in true }
+        )
+
+        await #expect(throws: GitWorktreeService.GitWorktreeError.self) {
+            try await WorktreeStore.cleanupOnDisk(
+                worktree: worktree,
+                repoPath: "/home/user/repos/main",
+                context: .ssh(SSHDestination(host: "example.test")),
+                dependencies: dependencies
+            )
+        }
+    }
+
     @Test("force cleanup retains a reused managed checkout without Git ownership")
     func forceCleanupRetainsReusedManagedCheckout() async throws {
         let repo = try TempGitRepo()

--- a/Tests/MuxyTests/Services/Remote/RemoteFileOpsTests.swift
+++ b/Tests/MuxyTests/Services/Remote/RemoteFileOpsTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Remote file operations")
+struct RemoteFileOpsTests {
+    @Test("presence probe distinguishes missing paths from inaccessible paths")
+    func presenceProbeFailsClosed() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-presence-probe-\(UUID().uuidString)", isDirectory: true)
+        let existing = root.appendingPathComponent("existing", isDirectory: true)
+        let inaccessible = root.appendingPathComponent("inaccessible", isDirectory: true)
+        try FileManager.default.createDirectory(at: existing, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: inaccessible, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: inaccessible.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let existingResult = try await runPresenceProbe(existing.path)
+        let missingResult = try await runPresenceProbe(root.appendingPathComponent("missing/nested").path)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: inaccessible.path)
+        let inaccessibleResult = try await runPresenceProbe(inaccessible.appendingPathComponent("nested").path)
+
+        #expect(existingResult.status == 0)
+        #expect(missingResult.status == 1)
+        #expect(inaccessibleResult.status == 2)
+    }
+
+    private func runPresenceProbe(_ path: String) async throws -> SubprocessResult {
+        try await SubprocessRunner.run(SubprocessRequest(
+            executablePath: "/bin/sh",
+            arguments: ["-c", SSHFileOps.presenceCommand(path: path)]
+        ))
+    }
+}

--- a/Tests/MuxyTests/Services/Remote/WorkspacePathResolverTests.swift
+++ b/Tests/MuxyTests/Services/Remote/WorkspacePathResolverTests.swift
@@ -67,13 +67,25 @@ struct WorkspacePathResolverTests {
         let missing = physicalHome + "/repos/missing/nested"
 
         let resolutions = try await resolver.resolve(
-            paths: ["~/repos/app feature's", "../app feature's", alias.path, "~/repos/missing/nested"],
+            paths: [
+                "~/repos/app feature's",
+                "../app feature's",
+                alias.path,
+                "~/repos/missing/nested",
+                "~/Code/org/.muxy-worktrees/app/feature"
+            ],
             relativeTo: "~/repos/app",
             context: .ssh(destination),
             timeout: 5
         )
 
-        #expect(resolutions.map(\.path) == [resolvedWorktree, resolvedWorktree, resolvedWorktree, missing])
+        #expect(resolutions.map(\.path) == [
+            resolvedWorktree,
+            resolvedWorktree,
+            resolvedWorktree,
+            missing,
+            physicalHome + "/Code/org/.muxy-worktrees/app/feature"
+        ])
     }
 
     @Test("absolute SSH paths do not require HOME")


### PR DESCRIPTION
## Summary
- resolve remote worktree paths consistently for registration and cleanup checks
- forget stale Muxy metadata only when the remote path is confirmed absent
- fail closed for existing or inaccessible remote directories

## Context
Remote worktree state can outlive both its Git registration and checkout directory. Muxy previously rejected deletion as unregistered before checking whether the resolved remote path was already absent, leaving stale entries that could not be removed.

## Testing
- `scripts/checks.sh --fix` passed formatting, strict linting, and test compilation
- targeted remote cleanup, presence probe, and removal deadline tests passed
- full suite: 3,614 of 3,615 tests passed; the existing `reconciles after the removal deadline has elapsed` timing test failed at its 0.5-second deadline under full parallel load and passed in isolation

## AI Assistance
This change was developed and reviewed with OpenAI GPT-5.6 Sol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of remote worktrees, including safely handling missing paths and preserving existing unregistered directories.
  * Improved detection of remote paths nested beneath missing or inaccessible directories.
  * Improved worktree status reporting and handling of unresolved paths during cleanup.

* **Tests**
  * Expanded SSH path resolution coverage to include `.muxy-worktrees`.
  * Added verification for remote path existence, missing paths, inaccessible directories, and cleanup safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->