### PR TITLE
Prevent active processes from corrupting worktree removal

### DIFF
--- a/Muxy/Services/Diagnostics/ProcessArgumentsInspector.swift
+++ b/Muxy/Services/Diagnostics/ProcessArgumentsInspector.swift
@@ -57,7 +57,7 @@ enum ProcessArgumentsInspector {
         )
     }
 
-    private static func workingDirectory(pid: Int32) -> String? {
+    static func workingDirectory(pid: Int32) -> String? {
         var info = proc_vnodepathinfo()
         let size = Int32(MemoryLayout<proc_vnodepathinfo>.size)
         let result = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &info, size)

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -36,6 +36,16 @@ actor GitWorktreeService: GitWorktreeListing {
         _ context: WorkspaceContext,
         _ timeout: TimeInterval
     ) async throws -> GitProcessResult
+    typealias ProcessQuiescer = @Sendable (_ path: String, _ timeout: TimeInterval) async throws -> Void
+
+    private struct RemovalTarget {
+        let canonicalPath: String
+        let residualPath: String
+        let repoPath: String
+        let context: WorkspaceContext
+        let wasRegistered: Bool
+        let originalDirectoryIdentity: WorktreeProcessQuiescer.DirectoryIdentity?
+    }
 
     static let shared = GitWorktreeService()
     static let defaultWorktreeRemovalTimeout: TimeInterval = 300
@@ -190,7 +200,8 @@ actor GitWorktreeService: GitWorktreeListing {
         force: Bool = false,
         context: WorkspaceContext = .local,
         timeout: TimeInterval = defaultWorktreeRemovalTimeout,
-        removalRunner: RemovalRunner = runRemoval
+        removalRunner: RemovalRunner = runRemoval,
+        processQuiescer: ProcessQuiescer = WorktreeProcessQuiescer.quiesce
     ) async throws -> String {
         let deadline = OperationDeadline(timeout: timeout)
         let records = try await listWorktrees(
@@ -211,8 +222,29 @@ actor GitWorktreeService: GitWorktreeListing {
         let wasRegistered = resolutions.dropFirst().contains {
             Self.canonicalPath($0.path, context: context) == target
         }
+        let primaryTarget = resolutions.dropFirst().first.map {
+            Self.canonicalPath($0.path, context: context)
+        }
+        if target == primaryTarget {
+            throw GitWorktreeError.commandFailed("The primary worktree cannot be removed.")
+        }
         if !wasRegistered, try await context.fileOps.exists(at: removalPath, timeout: deadline.remaining()) {
             throw GitWorktreeError.notRegistered
+        }
+        let residualPath = removalPath
+        let originalDirectoryIdentity = context.isRemote
+            ? nil
+            : WorktreeProcessQuiescer.directoryIdentity(at: residualPath)
+        let removalTarget = RemovalTarget(
+            canonicalPath: target,
+            residualPath: residualPath,
+            repoPath: repoPath,
+            context: context,
+            wasRegistered: wasRegistered,
+            originalDirectoryIdentity: originalDirectoryIdentity
+        )
+        if wasRegistered, !context.isRemote {
+            try await processQuiescer(residualPath, deadline.remaining())
         }
 
         var args: [String] = ["worktree", "remove"]
@@ -224,38 +256,76 @@ actor GitWorktreeService: GitWorktreeListing {
         do {
             result = try await removalRunner(repoPath, args, context, deadline.remaining())
         } catch {
-            guard Self.isTimeout(error), try await !isRegistered(
-                target: target,
-                repoPath: repoPath,
-                context: context,
-                timeout: Self.removalReconciliationTimeout
+            guard Self.isTimeout(error) else { throw error }
+            try await reconcileRemoval(
+                removalTarget,
+                processQuiescer: processQuiescer,
+                timeout: Self.removalReconciliationTimeout,
+                failureMessage: error.localizedDescription
             )
-            else { throw error }
             return removalPath
         }
-        guard result.status != 0 else { return removalPath }
-        if try await context.fileOps.exists(at: removalPath, timeout: deadline.remaining()) {
-            throw GitWorktreeError.commandFailed(
-                result.stderr.isEmpty ? "Failed to remove worktree." : result.stderr
-            )
-        }
-
-        if let remaining = try? deadline.remaining() {
+        if result.status != 0, let remaining = try? deadline.remaining() {
             try? await pruneWorktrees(repoPath: repoPath, context: context, timeout: remaining)
         }
         try Task.checkCancellation()
         let verificationTimeout = (try? deadline.remaining()) ?? Self.removalReconciliationTimeout
-        let stillRegistered = try await isRegistered(
-            target: target,
-            repoPath: repoPath,
-            context: context,
-            timeout: verificationTimeout
+        try await reconcileRemoval(
+            removalTarget,
+            processQuiescer: processQuiescer,
+            timeout: verificationTimeout,
+            failureMessage: result.stderr.isEmpty ? "Failed to remove worktree." : result.stderr
         )
-        guard stillRegistered else { return removalPath }
+        return removalPath
+    }
 
-        throw GitWorktreeError.commandFailed(
-            result.stderr.isEmpty ? "Failed to remove worktree." : result.stderr
+    private func reconcileRemoval(
+        _ target: RemovalTarget,
+        processQuiescer: ProcessQuiescer,
+        timeout: TimeInterval,
+        failureMessage: String
+    ) async throws {
+        let deadline = OperationDeadline(timeout: timeout)
+        let stillRegistered = try await isRegistered(
+            target: target.canonicalPath,
+            repoPath: target.repoPath,
+            context: target.context,
+            timeout: deadline.remaining()
         )
+        guard !stillRegistered else {
+            throw GitWorktreeError.commandFailed(failureMessage)
+        }
+
+        guard try await target.context.fileOps.exists(
+            at: target.residualPath,
+            timeout: deadline.remaining()
+        )
+        else { return }
+        guard target.wasRegistered else {
+            throw GitWorktreeError.commandFailed(failureMessage)
+        }
+        guard !target.context.isRemote, let originalDirectoryIdentity = target.originalDirectoryIdentity else {
+            throw GitWorktreeError.commandFailed("\(failureMessage) The remaining directory could not be verified.")
+        }
+
+        do {
+            try await processQuiescer(target.residualPath, deadline.remaining())
+            try await GitProcessRunner.offMainThrowing {
+                try WorktreeProcessQuiescer.removeDirectory(
+                    at: target.residualPath,
+                    matching: originalDirectoryIdentity
+                )
+            }
+        } catch {
+            throw GitWorktreeError.commandFailed("\(failureMessage) Residual cleanup failed: \(error.localizedDescription)")
+        }
+        guard try await !target.context.fileOps.exists(
+            at: target.residualPath,
+            timeout: deadline.remaining()
+        )
+        else {
+            throw GitWorktreeError.commandFailed("\(failureMessage) The worktree directory still exists.")
+        }
     }
 
     func isWorktreeRegistered(

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -36,7 +36,11 @@ actor GitWorktreeService: GitWorktreeListing {
         _ context: WorkspaceContext,
         _ timeout: TimeInterval
     ) async throws -> GitProcessResult
-    typealias ProcessQuiescer = @Sendable (_ path: String, _ timeout: TimeInterval) async throws -> Void
+    typealias ProcessQuiescer = @Sendable (
+        _ path: String,
+        _ identity: WorktreeProcessQuiescer.DirectoryIdentity,
+        _ timeout: TimeInterval
+    ) async throws -> Void
 
     private struct RemovalTarget {
         let canonicalPath: String
@@ -201,7 +205,9 @@ actor GitWorktreeService: GitWorktreeListing {
         context: WorkspaceContext = .local,
         timeout: TimeInterval = defaultWorktreeRemovalTimeout,
         removalRunner: RemovalRunner = runRemoval,
-        processQuiescer: ProcessQuiescer = WorktreeProcessQuiescer.quiesce
+        processQuiescer: ProcessQuiescer = { path, identity, timeout in
+            try await WorktreeProcessQuiescer.quiesce(path: path, matching: identity, timeout: timeout)
+        }
     ) async throws -> String {
         let deadline = OperationDeadline(timeout: timeout)
         let records = try await listWorktrees(
@@ -244,7 +250,23 @@ actor GitWorktreeService: GitWorktreeListing {
             originalDirectoryIdentity: originalDirectoryIdentity
         )
         if wasRegistered, !context.isRemote {
-            try await processQuiescer(residualPath, deadline.remaining())
+            if try await context.fileOps.exists(at: residualPath, timeout: deadline.remaining()) {
+                guard Self.isOwnedLocalCheckout(
+                    originalPath: path,
+                    checkoutPath: residualPath,
+                    repoPath: repoPath
+                )
+                else {
+                    throw GitWorktreeError.commandFailed("Worktree ownership could not be verified.")
+                }
+                guard let originalDirectoryIdentity else {
+                    throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
+                }
+                try await processQuiescer(residualPath, originalDirectoryIdentity, deadline.remaining())
+                guard WorktreeProcessQuiescer.directoryIdentity(at: residualPath) == originalDirectoryIdentity else {
+                    throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
+                }
+            }
         }
 
         var args: [String] = ["worktree", "remove"]
@@ -310,15 +332,20 @@ actor GitWorktreeService: GitWorktreeListing {
         guard !target.context.isRemote, let originalDirectoryIdentity = target.originalDirectoryIdentity else {
             throw GitWorktreeError.commandFailed("\(failureMessage) The remaining directory could not be verified.")
         }
+        guard WorktreeProcessQuiescer.directoryIdentity(at: target.residualPath) == originalDirectoryIdentity else {
+            throw GitWorktreeError.commandFailed("\(failureMessage) The remaining directory changed during removal.")
+        }
 
         do {
-            try await processQuiescer(target.residualPath, deadline.remaining())
-            try await GitProcessRunner.offMainThrowing {
-                try WorktreeProcessQuiescer.removeDirectory(
-                    at: target.residualPath,
-                    matching: originalDirectoryIdentity
-                )
+            try await processQuiescer(target.residualPath, originalDirectoryIdentity, deadline.remaining())
+            guard WorktreeProcessQuiescer.directoryIdentity(at: target.residualPath) == originalDirectoryIdentity else {
+                throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
             }
+            try await WorktreeProcessQuiescer.removeDirectory(
+                at: target.residualPath,
+                matching: originalDirectoryIdentity,
+                timeout: deadline.remaining()
+            )
         } catch {
             throw GitWorktreeError.commandFailed("\(failureMessage) Residual cleanup failed: \(error.localizedDescription)")
         }
@@ -413,6 +440,77 @@ actor GitWorktreeService: GitWorktreeListing {
             return true
         }
         return false
+    }
+
+    private static func isOwnedLocalCheckout(originalPath: String, checkoutPath: String, repoPath: String) -> Bool {
+        let inputPath = localInputPath(originalPath, relativeTo: repoPath)
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: inputPath)) == nil else { return false }
+        let checkout = URL(fileURLWithPath: checkoutPath, isDirectory: true).standardizedFileURL
+        let checkoutGit = checkout.appendingPathComponent(".git")
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: checkoutGit.path)) == nil,
+              let attributes = try? FileManager.default.attributesOfItem(atPath: checkoutGit.path),
+              attributes[.type] as? FileAttributeType == .typeRegular,
+              let size = attributes[.size] as? NSNumber,
+              size.intValue <= 4096,
+              let gitdir = gitDirectoryReference(at: checkoutGit)
+        else { return false }
+        guard let commonGitDirectory = commonGitDirectory(repoPath: repoPath) else { return false }
+        let worktrees = commonGitDirectory.appendingPathComponent("worktrees", isDirectory: true)
+        guard gitdir.deletingLastPathComponent() == worktrees else { return false }
+        let adminGitdir = gitdir.appendingPathComponent("gitdir")
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: adminGitdir.path)) == nil,
+              let backlink = adminGitdirBacklink(at: adminGitdir),
+              backlink == checkoutGit.resolvingSymlinksInPath().standardizedFileURL
+        else { return false }
+        return true
+    }
+
+    private static func commonGitDirectory(repoPath: String) -> URL? {
+        let dotGit = URL(fileURLWithPath: repoPath, isDirectory: true).appendingPathComponent(".git")
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: dotGit.path)) == nil else { return nil }
+        if (try? dotGit.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+            return dotGit.resolvingSymlinksInPath().standardizedFileURL
+        }
+        guard let gitdir = gitDirectoryReference(at: dotGit) else { return nil }
+        if gitdir.deletingLastPathComponent().lastPathComponent == "worktrees" {
+            return gitdir.deletingLastPathComponent().deletingLastPathComponent()
+        }
+        return gitdir
+    }
+
+    private static func localInputPath(_ path: String, relativeTo repoPath: String) -> String {
+        let expanded = NSString(string: path).expandingTildeInPath
+        guard !expanded.hasPrefix("/") else {
+            return URL(fileURLWithPath: expanded).standardizedFileURL.path
+        }
+        return URL(fileURLWithPath: repoPath, isDirectory: true)
+            .appendingPathComponent(expanded)
+            .standardizedFileURL.path
+    }
+
+    private static func gitDirectoryReference(at file: URL) -> URL? {
+        guard let contents = try? String(contentsOf: file, encoding: .utf8),
+              let firstLine = contents.split(whereSeparator: \Character.isNewline).first,
+              firstLine.hasPrefix("gitdir: ")
+        else { return nil }
+        let reference = firstLine.dropFirst("gitdir: ".count).trimmingCharacters(in: .whitespaces)
+        guard !reference.isEmpty else { return nil }
+        return URL(fileURLWithPath: reference, relativeTo: file.deletingLastPathComponent())
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+    }
+
+    private static func adminGitdirBacklink(at file: URL) -> URL? {
+        guard let contents = try? String(contentsOf: file, encoding: .utf8),
+              let firstLine = contents.split(whereSeparator: \Character.isNewline).first
+        else { return nil }
+        let reference = firstLine.trimmingCharacters(in: .whitespaces)
+        guard !reference.isEmpty else { return nil }
+        return URL(fileURLWithPath: reference, relativeTo: file.deletingLastPathComponent())
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
     }
 
     private func listWorktrees(

--- a/Muxy/Services/Git/GitWorktreeService.swift
+++ b/Muxy/Services/Git/GitWorktreeService.swift
@@ -269,7 +269,10 @@ actor GitWorktreeService: GitWorktreeListing {
             try? await pruneWorktrees(repoPath: repoPath, context: context, timeout: remaining)
         }
         try Task.checkCancellation()
-        let verificationTimeout = (try? deadline.remaining()) ?? Self.removalReconciliationTimeout
+        let verificationTimeout = max(
+            (try? deadline.remaining()) ?? 0,
+            Self.removalReconciliationTimeout
+        )
         try await reconcileRemoval(
             removalTarget,
             processQuiescer: processQuiescer,

--- a/Muxy/Services/Git/WorktreeProcessQuiescer.swift
+++ b/Muxy/Services/Git/WorktreeProcessQuiescer.swift
@@ -1,0 +1,110 @@
+import Darwin
+import Foundation
+
+enum WorktreeProcessQuiescerError: LocalizedError {
+    case processesStillRunning
+    case directoryChanged(recoveryPath: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .processesStillRunning:
+            "Processes using this worktree could not be stopped."
+        case let .directoryChanged(recoveryPath):
+            if let recoveryPath {
+                "The worktree directory changed during removal. Its files were preserved at \"\(recoveryPath)\"."
+            } else {
+                "The worktree directory changed during removal."
+            }
+        }
+    }
+}
+
+enum WorktreeProcessQuiescer {
+    static let quarantinePrefix = ".muxy-removal-"
+
+    struct DirectoryIdentity: Equatable, Sendable {
+        let device: UInt64
+        let inode: UInt64
+    }
+
+    static func quiesce(path: String, timeout: TimeInterval) async throws {
+        let deadline = OperationDeadline(timeout: timeout)
+        var processIDs = matchingProcessIDs(using: path)
+        guard !processIDs.isEmpty else { return }
+
+        signal(SIGTERM, processIDs: processIDs, path: path)
+        try await sleep(for: 0.3, deadline: deadline)
+
+        processIDs = matchingProcessIDs(using: path)
+        guard !processIDs.isEmpty else { return }
+
+        signal(SIGKILL, processIDs: processIDs, path: path)
+        for _ in 0 ..< 10 {
+            try await sleep(for: 0.05, deadline: deadline)
+            processIDs = matchingProcessIDs(using: path)
+            guard !processIDs.isEmpty else { return }
+        }
+
+        throw WorktreeProcessQuiescerError.processesStillRunning
+    }
+
+    static func matchingProcessIDs(
+        using path: String,
+        candidates: [pid_t] = ProcSampling.listAllPIDs(),
+        currentProcessID: pid_t = getpid(),
+        workingDirectory: (pid_t) -> String? = ProcessArgumentsInspector.workingDirectory
+    ) -> [pid_t] {
+        let root = canonicalPath(path)
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        return candidates.filter { processID in
+            guard processID != currentProcessID,
+                  let directory = workingDirectory(processID)
+            else { return false }
+            let canonicalDirectory = canonicalPath(directory)
+            return canonicalDirectory == root || canonicalDirectory.hasPrefix(prefix)
+        }
+    }
+
+    private static func canonicalPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    static func directoryIdentity(at path: String) -> DirectoryIdentity? {
+        var info = stat()
+        guard lstat(path, &info) == 0, info.st_mode & S_IFMT == S_IFDIR else { return nil }
+        return DirectoryIdentity(device: UInt64(info.st_dev), inode: UInt64(info.st_ino))
+    }
+
+    static func removeDirectory(at path: String, matching expectedIdentity: DirectoryIdentity) throws {
+        let source = URL(fileURLWithPath: path)
+        let quarantine = source.deletingLastPathComponent().appendingPathComponent(
+            "\(quarantinePrefix)\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.moveItem(at: source, to: quarantine)
+        guard directoryIdentity(at: quarantine.path) == expectedIdentity else {
+            if !FileManager.default.fileExists(atPath: source.path) {
+                do {
+                    try FileManager.default.moveItem(at: quarantine, to: source)
+                } catch {
+                    throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: quarantine.path)
+                }
+                throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
+            }
+            throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: quarantine.path)
+        }
+        try FileManager.default.removeItem(at: quarantine)
+    }
+
+    private static func signal(_ value: Int32, processIDs: [pid_t], path: String) {
+        let currentMatches = Set(matchingProcessIDs(using: path, candidates: processIDs))
+        for processID in processIDs where currentMatches.contains(processID) {
+            kill(processID, value)
+        }
+    }
+
+    private static func sleep(for duration: TimeInterval, deadline: OperationDeadline) async throws {
+        let remaining = try deadline.remaining()
+        try await Task.sleep(for: .seconds(min(duration, remaining)))
+    }
+}

--- a/Muxy/Services/Git/WorktreeProcessQuiescer.swift
+++ b/Muxy/Services/Git/WorktreeProcessQuiescer.swift
@@ -24,28 +24,72 @@ enum WorktreeProcessQuiescerError: LocalizedError {
 
 enum WorktreeProcessQuiescer {
     static let quarantinePrefix = ".muxy-removal-"
+    typealias BoundedRemover = @Sendable (_ path: String, _ timeout: TimeInterval) async throws -> Void
 
     struct DirectoryIdentity: Equatable, Sendable {
         let device: UInt64
         let inode: UInt64
     }
 
-    static func quiesce(path: String, timeout: TimeInterval) async throws {
-        let deadline = OperationDeadline(timeout: timeout)
-        var processIDs = matchingProcessIDs(using: path)
-        guard !processIDs.isEmpty else { return }
+    private struct ProcessMatcher {
+        let path: String
+        let identity: DirectoryIdentity
+        let workingDirectory: @Sendable (pid_t) -> String?
 
-        signal(SIGTERM, processIDs: processIDs, path: path)
+        func matching(_ candidates: [pid_t]) throws -> [pid_t] {
+            try validate()
+            let matches = WorktreeProcessQuiescer.matchingProcessIDs(
+                using: path,
+                candidates: candidates,
+                workingDirectory: workingDirectory
+            )
+            try validate()
+            return matches
+        }
+
+        func validate() throws {
+            guard WorktreeProcessQuiescer.directoryIdentity(at: path) == identity else {
+                throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
+            }
+        }
+    }
+
+    static func quiesce(
+        path: String,
+        matching expectedIdentity: DirectoryIdentity,
+        timeout: TimeInterval,
+        processIDs: @escaping @Sendable () -> [pid_t] = { ProcSampling.listAllPIDs() },
+        workingDirectory: @escaping @Sendable (pid_t) -> String? = ProcessArgumentsInspector.workingDirectory,
+        sendSignal: @escaping @Sendable (pid_t, Int32) -> Int32 = { kill($0, $1) }
+    ) async throws {
+        let deadline = OperationDeadline(timeout: timeout)
+        let matcher = ProcessMatcher(path: path, identity: expectedIdentity, workingDirectory: workingDirectory)
+        var matchedProcessIDs = try matcher.matching(processIDs())
+        guard !matchedProcessIDs.isEmpty else { return }
+
+        try signal(
+            SIGTERM,
+            processIDs: matchedProcessIDs,
+            matcher: matcher,
+            deadline: deadline,
+            sendSignal: sendSignal
+        )
         try await sleep(for: 0.3, deadline: deadline)
 
-        processIDs = matchingProcessIDs(using: path)
-        guard !processIDs.isEmpty else { return }
+        matchedProcessIDs = try matcher.matching(processIDs())
+        guard !matchedProcessIDs.isEmpty else { return }
 
-        signal(SIGKILL, processIDs: processIDs, path: path)
+        try signal(
+            SIGKILL,
+            processIDs: matchedProcessIDs,
+            matcher: matcher,
+            deadline: deadline,
+            sendSignal: sendSignal
+        )
         for _ in 0 ..< 10 {
             try await sleep(for: 0.05, deadline: deadline)
-            processIDs = matchingProcessIDs(using: path)
-            guard !processIDs.isEmpty else { return }
+            matchedProcessIDs = try matcher.matching(processIDs())
+            guard !matchedProcessIDs.isEmpty else { return }
         }
 
         throw WorktreeProcessQuiescerError.processesStillRunning
@@ -78,35 +122,72 @@ enum WorktreeProcessQuiescer {
         return DirectoryIdentity(device: UInt64(info.st_dev), inode: UInt64(info.st_ino))
     }
 
-    static func removeDirectory(at path: String, matching expectedIdentity: DirectoryIdentity) throws {
+    static func removeDirectory(
+        at path: String,
+        matching expectedIdentity: DirectoryIdentity,
+        timeout: TimeInterval,
+        boundedRemover: @escaping BoundedRemover = { path, timeout in
+            try await LocalFileOps().removeItem(at: path, timeout: timeout)
+        }
+    ) async throws {
         let source = URL(fileURLWithPath: path)
         let quarantine = source.deletingLastPathComponent().appendingPathComponent(
             "\(quarantinePrefix)\(UUID().uuidString)",
             isDirectory: true
         )
-        try FileManager.default.moveItem(at: source, to: quarantine)
-        guard directoryIdentity(at: quarantine.path) == expectedIdentity else {
-            if !FileManager.default.fileExists(atPath: source.path) {
-                do {
-                    try FileManager.default.moveItem(at: quarantine, to: source)
-                } catch {
-                    throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: quarantine.path)
-                }
+        guard directoryIdentity(at: source.path) == expectedIdentity else {
+            throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
+        }
+        try await GitProcessRunner.offMainThrowing {
+            guard directoryIdentity(at: source.path) == expectedIdentity else {
                 throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
             }
-            throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: quarantine.path)
+            try FileManager.default.moveItem(at: source, to: quarantine)
         }
-        try FileManager.default.removeItem(at: quarantine)
+        guard directoryIdentity(at: quarantine.path) == expectedIdentity else {
+            try await restore(quarantine, to: source)
+            throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: nil)
+        }
+        do {
+            try await boundedRemover(quarantine.path, timeout)
+        } catch {
+            guard await LocalFileOps().exists(at: quarantine.path) else { return }
+            try await restore(quarantine, to: source)
+            throw error
+        }
     }
 
-    private static func signal(_ value: Int32, processIDs: [pid_t], path: String) {
-        let currentMatches = Set(matchingProcessIDs(using: path, candidates: processIDs))
+    private static func signal(
+        _ value: Int32,
+        processIDs: [pid_t],
+        matcher: ProcessMatcher,
+        deadline: OperationDeadline,
+        sendSignal: (pid_t, Int32) -> Int32
+    ) throws {
+        let currentMatches = try Set(matcher.matching(processIDs))
         let identifiers = String(describing: currentMatches.sorted())
         logger.info(
-            "Signal \(value), pids \(identifiers, privacy: .public), worktree \(path, privacy: .private(mask: .hash))"
+            "Signal \(value), pids \(identifiers, privacy: .public), worktree \(matcher.path, privacy: .private(mask: .hash))"
         )
         for processID in processIDs where currentMatches.contains(processID) {
-            kill(processID, value)
+            try matcher.validate()
+            _ = try deadline.remaining()
+            _ = sendSignal(processID, value)
+        }
+    }
+
+    private static func restore(_ quarantine: URL, to source: URL) async throws {
+        do {
+            try await GitProcessRunner.offMainThrowing {
+                guard !FileManager.default.fileExists(atPath: source.path),
+                      (try? FileManager.default.destinationOfSymbolicLink(atPath: source.path)) == nil
+                else {
+                    throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: quarantine.path)
+                }
+                try FileManager.default.moveItem(at: quarantine, to: source)
+            }
+        } catch {
+            throw WorktreeProcessQuiescerError.directoryChanged(recoveryPath: quarantine.path)
         }
     }
 

--- a/Muxy/Services/Git/WorktreeProcessQuiescer.swift
+++ b/Muxy/Services/Git/WorktreeProcessQuiescer.swift
@@ -1,5 +1,8 @@
 import Darwin
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "app.muxy", category: "WorktreeProcessQuiescer")
 
 enum WorktreeProcessQuiescerError: LocalizedError {
     case processesStillRunning
@@ -98,6 +101,10 @@ enum WorktreeProcessQuiescer {
 
     private static func signal(_ value: Int32, processIDs: [pid_t], path: String) {
         let currentMatches = Set(matchingProcessIDs(using: path, candidates: processIDs))
+        let identifiers = String(describing: currentMatches.sorted())
+        logger.info(
+            "Signal \(value), pids \(identifiers, privacy: .public), worktree \(path, privacy: .private(mask: .hash))"
+        )
         for processID in processIDs where currentMatches.contains(processID) {
             kill(processID, value)
         }

--- a/Muxy/Services/Project/WorktreeStore.swift
+++ b/Muxy/Services/Project/WorktreeStore.swift
@@ -80,10 +80,7 @@ struct WorktreeRemovalRequest {
 final class WorktreeStore {
     private static let maxRefreshAttempts = 3
 
-    private struct FileIdentity: Equatable {
-        let device: UInt64
-        let inode: UInt64
-    }
+    private typealias FileIdentity = WorktreeProcessQuiescer.DirectoryIdentity
 
     private enum CleanupPlan {
         case registered
@@ -794,7 +791,31 @@ final class WorktreeStore {
         else {
             return .finished(.preservedUnverifiedDirectory)
         }
-        let quarantine = try await quarantineManagedCheckout(worktree.path, projectID: projectID)
+        try await WorktreeProcessQuiescer.quiesce(
+            path: worktree.path,
+            matching: identity,
+            timeout: operation.deadline.remaining()
+        )
+        guard isMuxyManagedCheckout(worktree, projectID: projectID),
+              checkoutReferencesRepository(worktreePath: worktree.path, repoPath: operation.repoPath),
+              fileIdentity(at: worktree.path) == identity
+        else {
+            return .finished(.preservedUnverifiedDirectory)
+        }
+        let isRegisteredAfterQuiescing = try await GitWorktreeService.shared.isWorktreeRegistered(
+            repoPath: operation.repoPath,
+            path: worktree.path,
+            context: operation.context,
+            timeout: operation.deadline.remaining()
+        )
+        guard !isRegisteredAfterQuiescing else {
+            throw GitWorktreeService.GitWorktreeError.commandFailed("Worktree changed during removal.")
+        }
+        let quarantine = try await quarantineManagedCheckout(
+            worktree.path,
+            projectID: projectID,
+            matching: identity
+        )
         guard fileIdentity(at: quarantine.path) == identity else {
             try await restoreOrReport(quarantine, to: worktree.path)
             return .finished(.preservedUnverifiedDirectory)
@@ -847,18 +868,24 @@ final class WorktreeStore {
         return (try? FileManager.default.destinationOfSymbolicLink(atPath: path)) == nil
     }
 
-    private static func fileIdentity(at path: String) -> FileIdentity? {
-        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
-              let device = attributes[.systemNumber] as? NSNumber,
-              let inode = attributes[.systemFileNumber] as? NSNumber
-        else { return nil }
-        return FileIdentity(device: device.uint64Value, inode: inode.uint64Value)
+    nonisolated private static func fileIdentity(at path: String) -> FileIdentity? {
+        WorktreeProcessQuiescer.directoryIdentity(at: path)
     }
 
-    private static func quarantineManagedCheckout(_ path: String, projectID: UUID) async throws -> URL {
+    private static func quarantineManagedCheckout(
+        _ path: String,
+        projectID: UUID,
+        matching identity: FileIdentity
+    ) async throws -> URL {
         let quarantine = MuxyFileStorage.worktreeRoot(forProjectID: projectID, create: false)
             .appendingPathComponent(".muxy-removing-\(UUID().uuidString)", isDirectory: true)
+        guard fileIdentity(at: path) == identity else {
+            throw GitWorktreeService.GitWorktreeError.commandFailed("Worktree changed during removal.")
+        }
         try await GitProcessRunner.offMainThrowing {
+            guard fileIdentity(at: path) == identity else {
+                throw GitWorktreeService.GitWorktreeError.commandFailed("Worktree changed during removal.")
+            }
             try FileManager.default.moveItem(atPath: path, toPath: quarantine.path)
         }
         return quarantine

--- a/Muxy/Views/Layouts/Shared/WorktreeRemovalConfirmation.swift
+++ b/Muxy/Views/Layouts/Shared/WorktreeRemovalConfirmation.swift
@@ -16,7 +16,8 @@ struct WorktreeRemovalConfirmation: Identifiable, Equatable {
         worktree: Worktree,
         hasUncommittedChanges: Bool,
         teardownCommands: [WorktreeConfig.ResolvedCommand] = [],
-        approvesProjectHooks: Bool = false
+        approvesProjectHooks: Bool = false,
+        stopsLocalProcesses: Bool = true
     ) {
         self.worktree = worktree
         title = "Remove worktree \"\(worktree.name)\"?"
@@ -27,7 +28,8 @@ struct WorktreeRemovalConfirmation: Identifiable, Equatable {
             : nil
         message = Self.message(
             hasUncommittedChanges: hasUncommittedChanges,
-            teardownCommands: normalizedCommands
+            teardownCommands: normalizedCommands,
+            stopsLocalProcesses: stopsLocalProcesses
         )
     }
 
@@ -44,7 +46,8 @@ struct WorktreeRemovalConfirmation: Identifiable, Equatable {
         guard !context.isRemote, !worktree.isExternallyManaged else {
             return WorktreeRemovalConfirmation(
                 worktree: worktree,
-                hasUncommittedChanges: hasChanges
+                hasUncommittedChanges: hasChanges,
+                stopsLocalProcesses: !context.isRemote
             )
         }
         let commands = try WorktreeConfig.resolvedTeardownCommands(
@@ -55,19 +58,26 @@ struct WorktreeRemovalConfirmation: Identifiable, Equatable {
             worktree: worktree,
             hasUncommittedChanges: hasChanges,
             teardownCommands: commands,
-            approvesProjectHooks: true
+            approvesProjectHooks: true,
+            stopsLocalProcesses: true
         )
     }
 
     @MainActor
     private static func message(
         hasUncommittedChanges: Bool,
-        teardownCommands: [WorktreeConfig.ResolvedCommand]
+        teardownCommands: [WorktreeConfig.ResolvedCommand],
+        stopsLocalProcesses: Bool
     ) -> String {
         let removalMessage = hasUncommittedChanges
             ? L10n.string("This worktree has uncommitted changes. Removing it will permanently discard them.")
             : L10n.string("This will remove the worktree from Muxy and delete its files on disk.")
-        guard !teardownCommands.isEmpty else { return removalMessage }
+        let processMessage = stopsLocalProcesses
+            ? L10n.string("Local processes running from this worktree will be stopped.")
+            : nil
+        guard !teardownCommands.isEmpty else {
+            return [removalMessage, processMessage].compactMap(\.self).joined(separator: "\n\n")
+        }
         let heading = L10n.string("The following teardown commands will run before removal:")
         let commands = teardownCommands.map { command in
             let source = switch command.source {
@@ -76,7 +86,7 @@ struct WorktreeRemovalConfirmation: Identifiable, Equatable {
             }
             return "\(source): \(command.command.command)"
         }
-        return ([removalMessage, heading] + commands).joined(separator: "\n\n")
+        return ([removalMessage, processMessage, heading].compactMap(\.self) + commands).joined(separator: "\n\n")
     }
 }
 

--- a/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
+++ b/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
@@ -52,6 +52,37 @@ struct GitWorktreeServiceRemoveTests {
         #expect(!records.contains { $0.path == worktreePath })
     }
 
+    @Test("removes a worktree when the repository path is another linked worktree")
+    func removesFromLinkedWorktreeRepositoryPath() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let linkedRepoPath = repo.siblingPath("linked-repository-wt")
+        let worktreePath = repo.siblingPath("linked-repository-target-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: linkedRepoPath,
+            branch: "linked-repository-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: linkedRepoPath,
+            path: worktreePath,
+            branch: "linked-repository-target-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        try await GitWorktreeService.shared.removeWorktree(
+            repoPath: linkedRepoPath,
+            path: worktreePath,
+            force: true
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: worktreePath))
+    }
+
     @Test("rejects the primary worktree without stopping its processes")
     func rejectsPrimaryWorktreeWithoutStoppingProcesses() async throws {
         let repo = try TempGitRepo()
@@ -197,6 +228,158 @@ struct GitWorktreeServiceRemoveTests {
         #expect(try String(contentsOf: marker, encoding: .utf8) == "replacement")
     }
 
+    @Test("does not invoke Git after quiescing replaces a registered worktree")
+    func doesNotInvokeGitAfterQuiescingReplacement() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("quiesce-race-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "quiesce-race-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        let marker = URL(fileURLWithPath: worktreePath).appendingPathComponent("replacement.txt")
+        let invoked = InvocationRecorder()
+
+        await #expect(throws: WorktreeProcessQuiescerError.self) {
+            try await GitWorktreeService.shared.removeWorktree(
+                repoPath: repo.path,
+                path: worktreePath,
+                force: true,
+                removalRunner: { _, _, _, _ in
+                    invoked.record()
+                    return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
+                },
+                processQuiescer: { _, _, _ in
+                    try FileManager.default.removeItem(atPath: worktreePath)
+                    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+                    try "replacement".write(to: marker, atomically: true, encoding: .utf8)
+                }
+            )
+        }
+
+        #expect(!invoked.wasInvoked)
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "replacement")
+    }
+
+    @Test("rejects a registered path reused by an unrelated directory")
+    func rejectsRegisteredPathReusedByUnrelatedDirectory() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("preexisting-replacement-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "preexisting-replacement-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        try FileManager.default.removeItem(atPath: worktreePath)
+        try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+        let marker = URL(fileURLWithPath: worktreePath).appendingPathComponent("preserved.txt")
+        try "preserved".write(to: marker, atomically: true, encoding: .utf8)
+        let invoked = InvocationRecorder()
+
+        await #expect(throws: GitWorktreeService.GitWorktreeError.self) {
+            try await GitWorktreeService.shared.removeWorktree(
+                repoPath: repo.path,
+                path: worktreePath,
+                force: true,
+                removalRunner: { _, _, _, _ in
+                    invoked.record()
+                    return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
+                },
+                processQuiescer: { _, _, _ in invoked.record() }
+            )
+        }
+
+        #expect(!invoked.wasInvoked)
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "preserved")
+    }
+
+    @Test("rejects a registered path replaced by a symlink")
+    func rejectsRegisteredPathReplacedBySymlink() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("symlink-replacement-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "symlink-replacement-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        let replacement = URL(fileURLWithPath: repo.siblingPath("symlink-replacement-target"), isDirectory: true)
+        try FileManager.default.createDirectory(at: replacement, withIntermediateDirectories: true)
+        let marker = replacement.appendingPathComponent("preserved.txt")
+        try "preserved".write(to: marker, atomically: true, encoding: .utf8)
+        try FileManager.default.removeItem(atPath: worktreePath)
+        try FileManager.default.createSymbolicLink(
+            at: URL(fileURLWithPath: worktreePath),
+            withDestinationURL: replacement
+        )
+        let invoked = InvocationRecorder()
+
+        await #expect(throws: GitWorktreeService.GitWorktreeError.self) {
+            try await GitWorktreeService.shared.removeWorktree(
+                repoPath: repo.path,
+                path: worktreePath,
+                force: true,
+                removalRunner: { _, _, _, _ in
+                    invoked.record()
+                    return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
+                },
+                processQuiescer: { _, _, _ in invoked.record() }
+            )
+        }
+
+        #expect(!invoked.wasInvoked)
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "preserved")
+    }
+
+    @Test("does not quiesce a replacement during reconciliation")
+    func doesNotQuiesceReplacementDuringReconciliation() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("reconciliation-race-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "reconciliation-race-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        let quiescer = InvocationRecorder()
+
+        await #expect(throws: Error.self) {
+            try await GitWorktreeService.shared.removeWorktree(
+                repoPath: repo.path,
+                path: worktreePath,
+                force: true,
+                removalRunner: { repoPath, arguments, context, timeout in
+                    _ = try await GitProcessRunner.runGit(
+                        repoPath: repoPath,
+                        arguments: arguments,
+                        context: context,
+                        timeout: timeout
+                    )
+                    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+                    return GitProcessResult(status: 255, stdout: "", stdoutData: Data(), stderr: "Directory not empty", truncated: false)
+                },
+                processQuiescer: { _, _, _ in quiescer.record() }
+            )
+        }
+
+        #expect(quiescer.invocationCount == 1)
+        #expect(FileManager.default.fileExists(atPath: worktreePath))
+    }
+
     @Test("succeeds when the worktree folder is gone and git admin metadata is orphaned")
     func succeedsForOrphanedWorktree() async throws {
         let repo = try TempGitRepo()
@@ -218,6 +401,34 @@ struct GitWorktreeServiceRemoveTests {
 
         let records = try await GitWorktreeService.shared.listWorktrees(repoPath: repo.path)
         #expect(!records.contains { $0.path == worktreePath })
+    }
+
+    @Test("removes registered administrative metadata when the local checkout is absent")
+    func removesRegisteredMetadataWhenCheckoutIsAbsent() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("missing-checkout-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "missing-checkout-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        try FileManager.default.removeItem(atPath: worktreePath)
+
+        try await GitWorktreeService.shared.removeWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            force: true,
+            processQuiescer: { _, _, _ in
+                throw WorktreeProcessQuiescerError.processesStillRunning
+            }
+        )
+
+        let records = try await GitWorktreeService.shared.listWorktrees(repoPath: repo.path)
+        #expect(!records.contains { GitWorktreeService.canonicalPath($0.path) == GitWorktreeService.canonicalPath(worktreePath) })
     }
 
     @Test("throws when git leaves the worktree registered")
@@ -302,6 +513,43 @@ struct GitWorktreeServiceRemoveTests {
 
         #expect(cleanupResult == .removed)
         #expect(!FileManager.default.fileExists(atPath: worktreePath))
+    }
+
+    @Test("force cleanup stops active processes in a stale managed checkout")
+    func forceCleanupStopsActiveProcessesInStaleManagedCheckout() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        let projectID = UUID()
+        let worktreeRoot = MuxyFileStorage.worktreeRoot(forProjectID: projectID)
+        defer { try? FileManager.default.removeItem(at: worktreeRoot) }
+        let worktreePath = worktreeRoot.appendingPathComponent("active-stale", isDirectory: true).path
+        try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+        try "gitdir: \(repo.path)/.git/worktrees/missing\n".write(
+            toFile: URL(fileURLWithPath: worktreePath).appendingPathComponent(".git").path,
+            atomically: true,
+            encoding: .utf8
+        )
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        process.currentDirectoryURL = URL(fileURLWithPath: worktreePath)
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+        let worktree = Worktree(name: "active-stale", path: worktreePath, branch: "active-stale", source: .muxy, isPrimary: false)
+
+        let result = try await WorktreeStore.cleanupOnDisk(
+            worktree: worktree,
+            projectID: projectID,
+            repoPath: repo.path,
+            force: true
+        )
+
+        #expect(result == .removed)
+        #expect(!process.isRunning)
     }
 
     @Test("force cleanup succeeds when teardown removes an unregistered Muxy-managed checkout")
@@ -657,6 +905,42 @@ struct GitWorktreeServiceRemoveTests {
         #expect(!records.contains { GitWorktreeService.canonicalPath($0.path) == target })
     }
 
+    @Test("reconciles after the removal deadline has elapsed")
+    func reconcilesAfterRemovalDeadlineElapsed() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("timeout-floor-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "timeout-floor-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        try await GitWorktreeService.shared.removeWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            force: true,
+            timeout: 0.5,
+            removalRunner: { repoPath, arguments, context, timeout in
+                _ = try await GitProcessRunner.runGit(
+                    repoPath: repoPath,
+                    arguments: arguments,
+                    context: context,
+                    timeout: timeout
+                )
+                try await Task.sleep(for: .milliseconds(600))
+                return GitProcessResult(status: 0, stdout: "", stdoutData: Data(), stderr: "", truncated: false)
+            }
+        )
+
+        let records = try await GitWorktreeService.shared.listWorktrees(repoPath: repo.path)
+        #expect(!records.contains { GitWorktreeService.canonicalPath($0.path) == GitWorktreeService.canonicalPath(worktreePath) })
+    }
+
     @Test("cleanupOnDisk preserves an orphaned worktree when its main repo is missing")
     func cleanupPreservesOrphanedWorktreeWhenRepoIsMissing() async throws {
         let repo = try TempGitRepo()
@@ -850,6 +1134,18 @@ struct GitWorktreeServiceRemoveTests {
         try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: restricted.path)
         defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: restricted.path) }
         #expect(try await LocalFileOps().exists(at: restricted.appendingPathComponent("unknown").path, timeout: 1))
+    }
+}
+
+private final class InvocationRecorder: @unchecked Sendable {
+    private(set) var invocationCount = 0
+
+    var wasInvoked: Bool {
+        invocationCount > 0
+    }
+
+    func record() {
+        invocationCount += 1
     }
 }
 

--- a/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
+++ b/Tests/MuxyTests/Git/GitWorktreeServiceRemoveTests.swift
@@ -52,6 +52,151 @@ struct GitWorktreeServiceRemoveTests {
         #expect(!records.contains { $0.path == worktreePath })
     }
 
+    @Test("rejects the primary worktree without stopping its processes")
+    func rejectsPrimaryWorktreeWithoutStoppingProcesses() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        process.currentDirectoryURL = URL(fileURLWithPath: repo.path)
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+
+        await #expect(throws: Error.self) {
+            try await GitWorktreeService.shared.removeWorktree(
+                repoPath: repo.path,
+                path: repo.path,
+                force: true
+            )
+        }
+
+        #expect(process.isRunning)
+        #expect(FileManager.default.fileExists(atPath: repo.path))
+    }
+
+    @Test("stops a process writing inside the worktree before removal")
+    func stopsActiveWriterBeforeRemoval() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("active-writer-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "active-writer-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        let writer = Process()
+        writer.executableURL = URL(fileURLWithPath: "/bin/sh")
+        writer.arguments = ["-c", "while :; do mkdir -p generated; touch generated/$RANDOM; done"]
+        writer.currentDirectoryURL = URL(fileURLWithPath: worktreePath)
+        try writer.run()
+        defer {
+            if writer.isRunning {
+                writer.terminate()
+            }
+        }
+
+        try await GitWorktreeService.shared.removeWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            force: true
+        )
+
+        #expect(!writer.isRunning)
+        #expect(!FileManager.default.fileExists(atPath: worktreePath))
+        let records = try await GitWorktreeService.shared.listWorktrees(repoPath: repo.path)
+        #expect(!records.contains { $0.path == worktreePath })
+    }
+
+    @Test("removes a residual directory after Git partially deregisters a worktree")
+    func removesResidualDirectoryAfterPartialRemoval() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("partial-removal-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "partial-removal-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+
+        try await GitWorktreeService.shared.removeWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            force: true,
+            removalRunner: { repoPath, arguments, context, timeout in
+                _ = (repoPath, arguments, context, timeout)
+                try repo.removeWorktreeAdmin(named: "partial-removal-wt")
+                return GitProcessResult(
+                    status: 255,
+                    stdout: "",
+                    stdoutData: Data(),
+                    stderr: "Directory not empty",
+                    truncated: false
+                )
+            }
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: worktreePath))
+        let records = try await GitWorktreeService.shared.listWorktrees(repoPath: repo.path)
+        #expect(!records.contains { $0.path == worktreePath })
+    }
+
+    @Test("preserves a replacement directory after Git deregisters the old worktree")
+    func preservesReplacementDirectoryAfterDeregistration() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+
+        try repo.commit(file: "a.txt", contents: "1", message: "base")
+        let worktreePath = repo.siblingPath("replaced-removal-wt")
+        try await GitWorktreeService.shared.addWorktree(
+            repoPath: repo.path,
+            path: worktreePath,
+            branch: "replaced-removal-feature",
+            createBranch: true,
+            baseBranch: nil
+        )
+        let marker = URL(fileURLWithPath: worktreePath).appendingPathComponent("replacement.txt")
+
+        await #expect(throws: Error.self) {
+            try await GitWorktreeService.shared.removeWorktree(
+                repoPath: repo.path,
+                path: worktreePath,
+                force: true,
+                removalRunner: { repoPath, arguments, context, timeout in
+                    _ = try await GitProcessRunner.runGit(
+                        repoPath: repoPath,
+                        arguments: arguments,
+                        context: context,
+                        timeout: timeout
+                    )
+                    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+                    try "replacement".write(to: marker, atomically: true, encoding: .utf8)
+                    return GitProcessResult(
+                        status: 255,
+                        stdout: "",
+                        stdoutData: Data(),
+                        stderr: "Directory not empty",
+                        truncated: false
+                    )
+                }
+            )
+        }
+
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "replacement")
+    }
+
     @Test("succeeds when the worktree folder is gone and git admin metadata is orphaned")
     func succeedsForOrphanedWorktree() async throws {
         let repo = try TempGitRepo()
@@ -640,6 +785,26 @@ struct GitWorktreeServiceRemoveTests {
         #expect(FileManager.default.fileExists(atPath: unknownPath.path))
     }
 
+    @Test("project cleanup preserves quarantined replacement directories")
+    func projectCleanupPreservesQuarantinedReplacementDirectories() async throws {
+        let repo = try TempGitRepo()
+        defer { repo.cleanup() }
+        let project = Project(name: "Repo", path: repo.path)
+        let worktreeRoot = MuxyFileStorage.worktreeRoot(forProjectID: project.id)
+        defer { try? FileManager.default.removeItem(at: worktreeRoot) }
+        let quarantine = worktreeRoot.appendingPathComponent(
+            "\(WorktreeProcessQuiescer.quarantinePrefix)replacement",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: quarantine, withIntermediateDirectories: true)
+        let marker = quarantine.appendingPathComponent("preserved.txt")
+        try "preserved".write(to: marker, atomically: true, encoding: .utf8)
+
+        try await WorktreeStore.cleanupOnDisk(for: project, knownWorktrees: [])
+
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "preserved")
+    }
+
     @Test("heals an orphaned worktree referenced through a symlinked parent")
     func healsOrphanThroughSymlinkedParent() async throws {
         let repo = try TempGitRepo()
@@ -745,6 +910,12 @@ private struct TempGitRepo {
         let gitdir = URL(fileURLWithPath: path)
             .appendingPathComponent(".git/worktrees/\(name)/gitdir")
         try "/nonexistent/\(name)/.git\n".write(to: gitdir, atomically: true, encoding: .utf8)
+    }
+
+    func removeWorktreeAdmin(named name: String) throws {
+        try FileManager.default.removeItem(
+            at: URL(fileURLWithPath: path).appendingPathComponent(".git/worktrees/\(name)")
+        )
     }
 
     func run(_ args: String...) throws {

--- a/Tests/MuxyTests/Git/WorktreeProcessQuiescerTests.swift
+++ b/Tests/MuxyTests/Git/WorktreeProcessQuiescerTests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import Foundation
 import Testing
 
 @testable import Muxy
@@ -34,5 +35,112 @@ struct WorktreeProcessQuiescerTests {
         )
 
         #expect(processIDs.isEmpty)
+    }
+
+    @Test("rejects a symlink root before signaling")
+    func rejectsSymlinkRootBeforeSignaling() async throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let link = root.appendingPathComponent("link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: root)
+        let recorder = SignalRecorder()
+        let identity = try #require(WorktreeProcessQuiescer.directoryIdentity(at: root.path))
+
+        await #expect(throws: WorktreeProcessQuiescerError.self) {
+            try await WorktreeProcessQuiescer.quiesce(
+                path: link.path,
+                matching: identity,
+                timeout: 1,
+                processIDs: { [42] },
+                workingDirectory: { _ in root.path },
+                sendSignal: { processID, signal in
+                    recorder.record(processID: processID, signal: signal)
+                    return 0
+                }
+            )
+        }
+
+        #expect(recorder.signals.isEmpty)
+    }
+
+    @Test("rejects a replaced root immediately before signaling")
+    func rejectsReplacementBeforeSignaling() async throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = root.appendingPathComponent("worktree")
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        let recorder = SignalRecorder()
+        let identity = try #require(WorktreeProcessQuiescer.directoryIdentity(at: target.path))
+
+        await #expect(throws: WorktreeProcessQuiescerError.self) {
+            try await WorktreeProcessQuiescer.quiesce(
+                path: target.path,
+                matching: identity,
+                timeout: 1,
+                processIDs: { [42] },
+                workingDirectory: { _ in
+                    try? FileManager.default.removeItem(at: target)
+                    try? FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+                    return target.path
+                },
+                sendSignal: { processID, signal in
+                    recorder.record(processID: processID, signal: signal)
+                    return 0
+                }
+            )
+        }
+
+        #expect(recorder.signals.isEmpty)
+    }
+
+    @Test("restores a quarantined directory when bounded deletion fails")
+    func restoresDirectoryWhenDeletionFails() async throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = root.appendingPathComponent("worktree")
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        let identity = try #require(WorktreeProcessQuiescer.directoryIdentity(at: target.path))
+
+        let recorder = RemovalRecorder()
+
+        await #expect(throws: AsyncTimeoutError.self) {
+            try await WorktreeProcessQuiescer.removeDirectory(
+                at: target.path,
+                matching: identity,
+                timeout: 7,
+                boundedRemover: { path, timeout in
+                    recorder.record(path: path, timeout: timeout)
+                    throw AsyncTimeoutError.timedOut(timeout)
+                }
+            )
+        }
+
+        #expect(WorktreeProcessQuiescer.directoryIdentity(at: target.path) == identity)
+        #expect(recorder.timeout == 7)
+    }
+
+    private func makeDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muxy-quiescer-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}
+
+private final class SignalRecorder: @unchecked Sendable {
+    private(set) var signals: [(pid_t, Int32)] = []
+
+    func record(processID: pid_t, signal: Int32) {
+        signals.append((processID, signal))
+    }
+}
+
+private final class RemovalRecorder: @unchecked Sendable {
+    private(set) var path: String?
+    private(set) var timeout: TimeInterval?
+
+    func record(path: String, timeout: TimeInterval) {
+        self.path = path
+        self.timeout = timeout
     }
 }

--- a/Tests/MuxyTests/Git/WorktreeProcessQuiescerTests.swift
+++ b/Tests/MuxyTests/Git/WorktreeProcessQuiescerTests.swift
@@ -1,0 +1,38 @@
+import Darwin
+import Testing
+
+@testable import Muxy
+
+@Suite("WorktreeProcessQuiescer")
+struct WorktreeProcessQuiescerTests {
+    @Test("matches only processes working inside the worktree")
+    func matchesProcessesInsideWorktree() {
+        let directories: [pid_t: String] = [
+            10: "/tmp/repo-feature",
+            11: "/tmp/repo-feature/generated",
+            12: "/tmp/repo-feature-other",
+            13: "/tmp/repo",
+        ]
+
+        let processIDs = WorktreeProcessQuiescer.matchingProcessIDs(
+            using: "/tmp/repo-feature",
+            candidates: [10, 11, 12, 13],
+            currentProcessID: 99,
+            workingDirectory: { directories[$0] }
+        )
+
+        #expect(processIDs == [10, 11])
+    }
+
+    @Test("excludes the current process")
+    func excludesCurrentProcess() {
+        let processIDs = WorktreeProcessQuiescer.matchingProcessIDs(
+            using: "/tmp/repo-feature",
+            candidates: [10],
+            currentProcessID: 10,
+            workingDirectory: { _ in "/tmp/repo-feature" }
+        )
+
+        #expect(processIDs.isEmpty)
+    }
+}

--- a/Tests/MuxyTests/Views/Layouts/Shared/WorktreeRemovalConfirmationTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/WorktreeRemovalConfirmationTests.swift
@@ -14,7 +14,11 @@ struct WorktreeRemovalConfirmationTests {
         )
 
         #expect(String(localized: confirmation.title) == "Remove worktree \"feature\"?")
-        #expect(confirmation.message == "This will remove the worktree from Muxy and delete its files on disk.")
+        #expect(confirmation.message == """
+        This will remove the worktree from Muxy and delete its files on disk.
+
+        Local processes running from this worktree will be stopped.
+        """)
     }
 
     @Test
@@ -27,7 +31,11 @@ struct WorktreeRemovalConfirmationTests {
         )
 
         #expect(String(localized: confirmation.title) == "Remove worktree \"feature\"?")
-        #expect(confirmation.message == "This worktree has uncommitted changes. Removing it will permanently discard them.")
+        #expect(confirmation.message == """
+        This worktree has uncommitted changes. Removing it will permanently discard them.
+
+        Local processes running from this worktree will be stopped.
+        """)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- stop local processes whose working directory is inside a verified secondary worktree before deleting it
- require Git deregistration and checkout removal before reporting success
- safely reconcile partial Git removals using filesystem identity checks and preserve raced replacement directories
- warn users that local processes will be stopped during removal

## Root cause
`git worktree remove --force` can remove central `.git/worktrees` metadata and then fail with `Directory not empty` when a dev server is concurrently generating files. Muxy previously started disk deletion before stopping those processes, leaving a checkout with a stale `.git` pointer that could not be retried.

## Safety
- reject primary and arbitrary unregistered directories before process termination
- include quiescing in the existing removal timeout
- only clean residual files when the directory device and inode match the pre-removal worktree
- atomically quarantine and verify residual directories before recursive deletion
- retain quarantine directories when a concurrent replacement cannot be restored

## Testing
- `swift test --filter GitWorktreeServiceRemoveTests`
- `swift test --filter WorktreeProcessQuiescerTests`
- `swift test --filter WorktreeRemovalConfirmationTests`
- `scripts/checks.sh --fix`

## AI assistance
This change was developed and reviewed with OpenAI GPT-5.6-SOL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Worktree removal now stops active local processes before cleanup.
  - Confirmation messages indicate when local processes will be stopped.
  - Worktree operations handle repository-relative paths more reliably.

- **Bug Fixes**
  - Prevents removal of the primary worktree.
  - Reliably cleans up residual directories after partial removal.
  - Preserves replacement directories during failed cleanup.
  - Improves cleanup of temporary quarantine directories.
  - Prevents conflicts when worktree data changes during refresh.
  - Improves recovery from failed or incomplete worktree removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->