### PR TITLE
feat: add Global Workspace

### DIFF
--- a/Muxy/Models/Layout/AppLayoutStore.swift
+++ b/Muxy/Models/Layout/AppLayoutStore.swift
@@ -6,11 +6,13 @@ final class AppLayoutStore {
     static let shared = AppLayoutStore()
 
     private let defaults: UserDefaults
+    private let storageKey: String
     private(set) var layout: AppLayout
 
-    init(defaults: UserDefaults = .standard) {
+    init(defaults: UserDefaults = .standard, storageKey: String = AppLayout.storageKey) {
         self.defaults = defaults
-        let stored = defaults.string(forKey: AppLayout.storageKey)
+        self.storageKey = storageKey
+        let stored = defaults.string(forKey: storageKey)
         layout = stored.flatMap(AppLayout.init(rawValue:)) ?? AppLayout.defaultValue
     }
 
@@ -19,7 +21,7 @@ final class AppLayoutStore {
     func set(_ layout: AppLayout) {
         guard self.layout != layout else { return }
         self.layout = layout
-        defaults.set(layout.rawValue, forKey: AppLayout.storageKey)
+        defaults.set(layout.rawValue, forKey: storageKey)
     }
 
     func toggle() {

--- a/Muxy/MuxyApp.swift
+++ b/Muxy/MuxyApp.swift
@@ -90,6 +90,13 @@ struct MuxyApp: App {
                     .environment(ExtensionSettingsStore.shared)
                     .preferredColorScheme(MuxyTheme.colorScheme)
                     .onAppear {
+                        GlobalWorkspaceController.shared.configure(
+                            projectStore: projectStore,
+                            worktreeStore: worktreeStore,
+                            projectGroupStore: projectGroupStore,
+                            remoteDeviceStore: remoteDeviceStore,
+                            browserStores: (profiles: browserProfileStore, history: browserHistoryStore)
+                        )
                         startDeferredServicesIfNeeded()
                         startWorktreeAutoRefreshIfNeeded()
                         NotificationStore.shared.appState = appState
@@ -844,9 +851,12 @@ struct WindowConfigurator: NSViewRepresentable {
         let v = NSView()
         DispatchQueue.main.async {
             guard let w = v.window else { return }
-            w.identifier = ShortcutContext.mainWindowIdentifier
-            if Self.closeDuplicateMainWindow(w) {
-                return
+            let isGlobalWorkspace = ShortcutContext.isGlobalWorkspaceWindow(w)
+            if !isGlobalWorkspace {
+                w.identifier = ShortcutContext.mainWindowIdentifier
+                if Self.closeDuplicateMainWindow(w) {
+                    return
+                }
             }
             w.titlebarAppearsTransparent = true
             w.titleVisibility = .hidden
@@ -858,7 +868,9 @@ struct WindowConfigurator: NSViewRepresentable {
             Self.repositionTrafficLights(in: w)
             Self.hideTitlebarDecorationView(in: w)
             Self.neutralizeSafeAreaInsets(in: w)
-            Self.interceptCloseButton(in: w, coordinator: context.coordinator)
+            if !isGlobalWorkspace {
+                Self.interceptCloseButton(in: w, coordinator: context.coordinator)
+            }
             context.coordinator.observe(window: w)
         }
         return v
@@ -1004,7 +1016,7 @@ struct WindowConfigurator: NSViewRepresentable {
                             let isFullScreen = w.styleMask.contains(.fullScreen)
                             NotificationCenter.default.post(
                                 name: .windowFullScreenDidChange,
-                                object: nil,
+                                object: w,
                                 userInfo: ["isFullScreen": isFullScreen]
                             )
                         }

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -1385,6 +1385,8 @@
 "Chooses the search engine used when you type a query in the browser address bar." = "Chooses the search engine used when you type a query in the browser address bar.";
 "Chooses the terminal theme for dark appearance." = "Chooses the terminal theme for dark appearance.";
 "Chooses the terminal theme for light appearance." = "Chooses the terminal theme for light appearance.";
+"Chooses the modifier double-tap gesture used to show Global Workspace." = "Chooses the modifier double-tap gesture used to show Global Workspace.";
+"Custom Shortcut" = "Custom Shortcut";
 "Collapsed Sidebar Style" = "Collapsed Sidebar Style";
 "Commit Prompt" = "Commit Prompt";
 "Commit Provider" = "Commit Provider";
@@ -1421,9 +1423,19 @@
 "Default Worktree Parent Folder" = "Default Worktree Parent Folder";
 "Default Worktree Path Template" = "Default Worktree Path Template";
 "Desktop Notifications" = "Desktop Notifications";
+"Double Tap Interval" = "Double Tap Interval";
+"Double Command" = "Double Command";
+"Double Control" = "Double Control";
+"Double Modifier" = "Double Modifier";
+"Double Option" = "Double Option";
+"Enable Global Workspace" = "Enable Global Workspace";
+"Enables the system-wide Global Workspace trigger." = "Enables the system-wide Global Workspace trigger.";
 "Expanded Sidebar Style" = "Expanded Sidebar Style";
 "Free Idle Background Terminals" = "Free Idle Background Terminals";
 "Frees a background tab's terminal after it stays idle, reclaiming memory." = "Frees a background tab's terminal after it stays idle, reclaiming memory.";
+"Global Workspace" = "Global Workspace";
+"Global Workspace Trigger" = "Global Workspace Trigger";
+"Hides Global Workspace when its trigger is used while it is visible." = "Hides Global Workspace when its trigger is used while it is visible.";
 "How long a background tab stays idle before its terminal is freed." = "How long a background tab stays idle before its terminal is freed.";
 "Idle Timeout (seconds)" = "Idle Timeout (seconds)";
 "Interface Size" = "Interface Size";
@@ -1447,6 +1459,8 @@
 "Restores a backup and replaces all current Muxy data." = "Restores a backup and replaces all current Muxy data.";
 "Saves settings, projects, remote devices and customizations to a file." = "Saves settings, projects, remote devices and customizations to a file.";
 "Sets the height of the quick terminal in points." = "Sets the height of the quick terminal in points.";
+"Sets the maximum interval between modifier taps in milliseconds." = "Sets the maximum interval between modifier taps in milliseconds.";
+"Shortcut Error" = "Shortcut Error";
 "Sets the maximum tab header width in pixels; the widest setting lets tabs fill the titlebar." = "Sets the maximum tab header width in pixels; the widest setting lets tabs fill the titlebar.";
 "Sets the page new browser tabs open to. Blank by default, or a website you choose." = "Sets the page new browser tabs open to. Blank by default, or a website you choose.";
 "Sets the width of the quick terminal in points." = "Sets the width of the quick terminal in points.";
@@ -1463,6 +1477,7 @@
 "Shows the QR code used to pair a mobile device." = "Shows the QR code used to pair a mobile device.";
 "Shows the permanent Home project at the top of the sidebar." = "Shows the permanent Home project at the top of the sidebar.";
 "Shows Muxy tips at the bottom of the built-in sidebar." = "Shows Muxy tips at the bottom of the built-in sidebar.";
+"Toggle to Hide" = "Toggle to Hide";
 "Shows toast notifications." = "Shows toast notifications.";
 "Sidebar Vibrancy" = "Sidebar Vibrancy";
 "Sorts the worktree switcher with the active worktree first, then by most-recently-used." = "Sorts the worktree switcher with the active worktree first, then by most-recently-used.";

--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -1423,6 +1423,7 @@
 "Default Worktree Parent Folder" = "Default Worktree Parent Folder";
 "Default Worktree Path Template" = "Default Worktree Path Template";
 "Desktop Notifications" = "Desktop Notifications";
+"Double-tap the selected modifier to show a full Muxy workspace from any app." = "Double-tap the selected modifier to show a full Muxy workspace from any app.";
 "Double Tap Interval" = "Double Tap Interval";
 "Double Command" = "Double Command";
 "Double Control" = "Double Control";
@@ -1461,6 +1462,8 @@
 "Sets the height of the quick terminal in points." = "Sets the height of the quick terminal in points.";
 "Sets the maximum interval between modifier taps in milliseconds." = "Sets the maximum interval between modifier taps in milliseconds.";
 "Shortcut Error" = "Shortcut Error";
+"Status" = "Status";
+"System-wide Access" = "System-wide Access";
 "Sets the maximum tab header width in pixels; the widest setting lets tabs fill the titlebar." = "Sets the maximum tab header width in pixels; the widest setting lets tabs fill the titlebar.";
 "Sets the page new browser tabs open to. Blank by default, or a website you choose." = "Sets the page new browser tabs open to. Blank by default, or a website you choose.";
 "Sets the width of the quick terminal in points." = "Sets the width of the quick terminal in points.";
@@ -1483,6 +1486,7 @@
 "Sorts the worktree switcher with the active worktree first, then by most-recently-used." = "Sorts the worktree switcher with the active worktree first, then by most-recently-used.";
 "Toast Notifications" = "Toast Notifications";
 "Toast Position" = "Toast Position";
+"Trigger" = "Trigger";
 "Update Channel" = "Update Channel";
 "Uses the separately selected top-bar project target or an extension opener for terminal file links." = "Uses the separately selected top-bar project target or an extension opener for terminal file links.";
 "Uses tinted native macOS vibrancy for the sidebar and its left title strip. Turn off for a solid background." = "Uses tinted native macOS vibrancy for the sidebar and its left title strip. Turn off for a solid background.";

--- a/Muxy/Services/GlobalWorkspace/GlobalWorkspaceController.swift
+++ b/Muxy/Services/GlobalWorkspace/GlobalWorkspaceController.swift
@@ -1,0 +1,406 @@
+import AppKit
+import CoreGraphics
+import SwiftUI
+
+@MainActor
+private final class GlobalWorkspaceModel {
+    let appState: AppState
+    let projectStore: ProjectStore
+    let worktreeStore: WorktreeStore
+    let projectGroupStore: ProjectGroupStore
+    let remoteDeviceStore: RemoteDeviceStore
+    let browserProfileStore: BrowserProfileStore
+    let browserHistoryStore: BrowserHistoryStore
+
+    init(
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore,
+        remoteDeviceStore: RemoteDeviceStore,
+        browserProfileStore: BrowserProfileStore,
+        browserHistoryStore: BrowserHistoryStore
+    ) {
+        let environment = AppEnvironment.live
+        let appState = AppState(
+            selectionStore: UserDefaultsActiveProjectSelectionStore(
+                projectKey: "muxy.hotkey.activeProjectID",
+                worktreesKey: "muxy.hotkey.activeWorktreeIDs"
+            ),
+            terminalViews: environment.terminalViews,
+            workspacePersistence: FileWorkspacePersistence(
+                fileURL: MuxyFileStorage.fileURL(filename: "hotkey-workspaces.json")
+            )
+        )
+        appState.onWorkspaceSelected = { key in
+            if projectStore.storedProjects.contains(where: { $0.id == key.projectID }) {
+                projectStore.markActive(id: key.projectID)
+            } else {
+                projectGroupStore.markRemoteProjectActive(id: key.projectID)
+            }
+            worktreeStore.markActive(projectID: key.projectID, worktreeID: key.worktreeID)
+        }
+        appState.restoreSelection(
+            projects: projectStore.projects,
+            worktrees: worktreeStore.worktrees,
+            skippingProjectIDs: projectGroupStore.activeRemoteProjectIDs
+        )
+
+        self.appState = appState
+        self.projectStore = projectStore
+        self.worktreeStore = worktreeStore
+        self.projectGroupStore = projectGroupStore
+        self.remoteDeviceStore = remoteDeviceStore
+        self.browserProfileStore = browserProfileStore
+        self.browserHistoryStore = browserHistoryStore
+    }
+
+    func ensureWorkspaceReady() {
+        if appState.activeProjectID == nil {
+            _ = HomeProjectService.openHomeTab(
+                appState: appState,
+                worktreeStore: worktreeStore,
+                projectGroupStore: projectGroupStore
+            )
+        }
+        guard let projectID = appState.activeProjectID, !appState.hasTabs(for: projectID) else { return }
+        appState.createTab(projectID: projectID)
+    }
+
+    func save() {
+        appState.saveWorkspaces()
+    }
+}
+
+private final class GlobalWorkspacePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+final class GlobalWorkspaceController: NSObject, NSWindowDelegate {
+    static let shared = GlobalWorkspaceController()
+
+    private struct Dependencies {
+        let projectStore: ProjectStore
+        let worktreeStore: WorktreeStore
+        let projectGroupStore: ProjectGroupStore
+        let remoteDeviceStore: RemoteDeviceStore
+        let browserProfileStore: BrowserProfileStore
+        let browserHistoryStore: BrowserHistoryStore
+    }
+
+    private static let windowCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
+        .transient,
+        .ignoresCycle,
+    ]
+    private static let windowLevel = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) - 2)
+    private static let fullScreenWindowLevel = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 1)
+
+    private var dependencies: Dependencies?
+    private var panel: GlobalWorkspacePanel?
+    private var model: GlobalWorkspaceModel?
+    private var previousApplication: NSRunningApplication?
+    private var fullScreenShortcutMonitor: Any?
+    private var terminationObserver: NSObjectProtocol?
+    private var overlayRestoreFrame: NSRect?
+    private var overlayRestoreStyleMask: NSWindow.StyleMask?
+    private var overlayRestoreHasShadow = true
+    private(set) var isPresented = false
+    private(set) var isOverlayFullScreen = false
+
+    override private init() {
+        super.init()
+        terminationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.stop(restoresFocus: false)
+            }
+        }
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            if let terminationObserver {
+                NotificationCenter.default.removeObserver(terminationObserver)
+            }
+        }
+    }
+
+    func configure(
+        projectStore: ProjectStore,
+        worktreeStore: WorktreeStore,
+        projectGroupStore: ProjectGroupStore,
+        remoteDeviceStore: RemoteDeviceStore,
+        browserStores: (profiles: BrowserProfileStore, history: BrowserHistoryStore)
+    ) {
+        dependencies = Dependencies(
+            projectStore: projectStore,
+            worktreeStore: worktreeStore,
+            projectGroupStore: projectGroupStore,
+            remoteDeviceStore: remoteDeviceStore,
+            browserProfileStore: browserStores.profiles,
+            browserHistoryStore: browserStores.history
+        )
+    }
+
+    func toggle() {
+        if isPresented {
+            hide()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        guard !isPresented else { return }
+        createPanelIfNeeded()
+        guard let panel, let model else { return }
+        model.ensureWorkspaceReady()
+        capturePreviousApplication()
+        if !isOverlayFullScreen {
+            applyWindowPresentation(panel)
+            panel.setFrame(preferredFrame(), display: true)
+        }
+        isPresented = true
+        panel.orderFrontRegardless()
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    func hide() {
+        guard isPresented else { return }
+        model?.save()
+        panel?.orderOut(nil)
+        isPresented = false
+        restorePreviousApplication()
+    }
+
+    func toggleOverlayFullScreen() {
+        guard let panel else { return }
+        if isOverlayFullScreen {
+            exitOverlayFullScreen(panel)
+        } else {
+            enterOverlayFullScreen(panel)
+        }
+    }
+
+    func stop(restoresFocus: Bool) {
+        if restoresFocus, isPresented {
+            restorePreviousApplication()
+        } else {
+            previousApplication = nil
+        }
+        model?.save()
+        removeFullScreenShortcutMonitor()
+        panel?.orderOut(nil)
+        panel?.contentViewController = nil
+        panel?.delegate = nil
+        panel?.close()
+        panel = nil
+        model = nil
+        isPresented = false
+        isOverlayFullScreen = false
+        overlayRestoreFrame = nil
+        overlayRestoreStyleMask = nil
+    }
+
+    private func createPanelIfNeeded() {
+        guard panel == nil, let dependencies else { return }
+        let model = GlobalWorkspaceModel(
+            projectStore: dependencies.projectStore,
+            worktreeStore: dependencies.worktreeStore,
+            projectGroupStore: dependencies.projectGroupStore,
+            remoteDeviceStore: dependencies.remoteDeviceStore,
+            browserProfileStore: dependencies.browserProfileStore,
+            browserHistoryStore: dependencies.browserHistoryStore
+        )
+        let panel = GlobalWorkspacePanel(
+            contentRect: preferredFrame(),
+            styleMask: normalStyleMask,
+            backing: .buffered,
+            defer: false
+        )
+        panel.identifier = ShortcutContext.globalWorkspaceWindowIdentifier
+        panel.delegate = self
+        panel.isReleasedWhenClosed = false
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.becomesKeyOnlyIfNeeded = false
+        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .hidden
+        panel.isMovable = false
+        panel.isMovableByWindowBackground = false
+        configureWindowButtons(panel)
+        applyWindowPresentation(panel)
+        installFullScreenShortcutMonitor(for: panel)
+
+        let rootView = LocalizationEnvironment {
+            MainWindow(windowIdentifier: ShortcutContext.globalWorkspaceWindowIdentifier)
+                .environment(model.appState)
+                .environment(model.projectStore)
+                .environment(model.worktreeStore)
+                .environment(model.projectGroupStore)
+                .environment(model.remoteDeviceStore)
+                .environment(model.browserProfileStore)
+                .environment(model.browserHistoryStore)
+                .environment(SSHConnectionService.shared)
+                .environment(GhosttyService.shared)
+                .environment(MuxyConfig.shared)
+                .environment(ThemeService.shared)
+                .environment(ExtensionStore.shared)
+                .environment(ExtensionSettingsStore.shared)
+                .preferredColorScheme(MuxyTheme.colorScheme)
+        }
+        panel.contentViewController = NSHostingController(rootView: rootView)
+        panel.orderOut(nil)
+
+        self.model = model
+        self.panel = panel
+    }
+
+    private var normalStyleMask: NSWindow.StyleMask {
+        [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView, .nonactivatingPanel]
+    }
+
+    private func configureWindowButtons(_ panel: GlobalWorkspacePanel) {
+        if let closeButton = panel.standardWindowButton(.closeButton) {
+            closeButton.target = self
+            closeButton.action = #selector(handleCloseButton(_:))
+        }
+        if let zoomButton = panel.standardWindowButton(.zoomButton) {
+            zoomButton.target = self
+            zoomButton.action = #selector(handleFullScreenButton(_:))
+        }
+    }
+
+    private func installFullScreenShortcutMonitor(for panel: NSWindow) {
+        guard fullScreenShortcutMonitor == nil else { return }
+        fullScreenShortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self, weak panel] event in
+            guard let self,
+                  let panel,
+                  panel.isKeyWindow,
+                  ShortcutContext.isGlobalWorkspaceWindow(panel),
+                  KeyBindingStore.shared.combo(for: .toggleFullScreen).matches(event: event)
+            else { return event }
+            self.toggleOverlayFullScreen()
+            return nil
+        }
+    }
+
+    private func removeFullScreenShortcutMonitor() {
+        guard let fullScreenShortcutMonitor else { return }
+        NSEvent.removeMonitor(fullScreenShortcutMonitor)
+        self.fullScreenShortcutMonitor = nil
+    }
+
+    private func enterOverlayFullScreen(_ panel: GlobalWorkspacePanel) {
+        guard !isOverlayFullScreen,
+              let screen = panel.screen ?? screenUnderMouse() ?? NSScreen.main
+        else { return }
+        overlayRestoreFrame = panel.frame
+        overlayRestoreStyleMask = panel.styleMask
+        overlayRestoreHasShadow = panel.hasShadow
+        isOverlayFullScreen = true
+        panel.styleMask = [.borderless, .resizable, .nonactivatingPanel]
+        panel.hasShadow = false
+        panel.collectionBehavior = Self.windowCollectionBehavior
+        panel.level = Self.fullScreenWindowLevel
+        panel.setFrame(screen.frame, display: true, animate: true)
+        WindowConfigurator.neutralizeSafeAreaInsets(in: panel)
+        postFullScreenChange(true, panel: panel)
+        panel.orderFrontRegardless()
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    private func exitOverlayFullScreen(_ panel: GlobalWorkspacePanel) {
+        guard isOverlayFullScreen else { return }
+        let restoreFrame = overlayRestoreFrame ?? preferredFrame()
+        let restoreStyleMask = overlayRestoreStyleMask ?? normalStyleMask
+        isOverlayFullScreen = false
+        overlayRestoreFrame = nil
+        overlayRestoreStyleMask = nil
+        postFullScreenChange(false, panel: panel)
+        panel.styleMask = restoreStyleMask
+        panel.hasShadow = overlayRestoreHasShadow
+        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .hidden
+        panel.isMovable = false
+        panel.isMovableByWindowBackground = false
+        configureWindowButtons(panel)
+        applyWindowPresentation(panel)
+        WindowConfigurator.neutralizeSafeAreaInsets(in: panel)
+        panel.setFrame(restoreFrame, display: true, animate: true)
+        panel.orderFrontRegardless()
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    private func applyWindowPresentation(_ panel: NSWindow) {
+        panel.collectionBehavior = Self.windowCollectionBehavior
+        panel.level = Self.windowLevel
+    }
+
+    private func postFullScreenChange(_ isFullScreen: Bool, panel: NSWindow) {
+        NotificationCenter.default.post(
+            name: .windowFullScreenDidChange,
+            object: panel,
+            userInfo: ["isFullScreen": isFullScreen]
+        )
+    }
+
+    private func preferredFrame() -> NSRect {
+        guard let visibleFrame = (screenUnderMouse() ?? NSScreen.main ?? NSScreen.screens.first)?.visibleFrame else {
+            return NSRect(x: 120, y: 100, width: 1200, height: 800)
+        }
+        let width = min(visibleFrame.width, max(900, visibleFrame.width * 0.86))
+        let height = min(visibleFrame.height, max(600, visibleFrame.height * 0.82))
+        return NSRect(
+            x: visibleFrame.midX - width / 2,
+            y: visibleFrame.midY - height / 2,
+            width: width,
+            height: height
+        )
+    }
+
+    private func screenUnderMouse() -> NSScreen? {
+        let location = NSEvent.mouseLocation
+        return NSScreen.screens.first { NSMouseInRect(location, $0.frame, false) }
+    }
+
+    private func capturePreviousApplication() {
+        guard let application = NSWorkspace.shared.frontmostApplication,
+              application.processIdentifier != ProcessInfo.processInfo.processIdentifier
+        else {
+            previousApplication = nil
+            return
+        }
+        previousApplication = application
+    }
+
+    private func restorePreviousApplication() {
+        let application = previousApplication
+        previousApplication = nil
+        guard let application, !application.isTerminated else { return }
+        DispatchQueue.main.async {
+            application.activate(options: [.activateIgnoringOtherApps])
+        }
+    }
+
+    @objc
+    private func handleCloseButton(_: Any?) {
+        hide()
+    }
+
+    @objc
+    private func handleFullScreenButton(_: Any?) {
+        toggleOverlayFullScreen()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        hide()
+        return false
+    }
+}

--- a/Muxy/Services/Keyboard/DoubleModifierShortcutBackend.swift
+++ b/Muxy/Services/Keyboard/DoubleModifierShortcutBackend.swift
@@ -1,0 +1,358 @@
+import AppKit
+import CoreGraphics
+
+private let doubleModifierShortcutEventTapCallback: CGEventTapCallBack = { _, type, event, userData in
+    guard let userData else { return Unmanaged.passUnretained(event) }
+    let flags = event.flags
+    let timestamp = TimeInterval(event.timestamp) / 1_000_000_000
+    let backend = Unmanaged<DoubleModifierShortcutBackend>.fromOpaque(userData).takeUnretainedValue()
+    MainActor.assumeIsolated {
+        backend.receiveGlobalEvent(type: type, flags: flags, timestamp: timestamp)
+    }
+    return Unmanaged.passUnretained(event)
+}
+
+struct DoubleModifierTapDetector {
+    struct Configuration: Equatable {
+        var maximumTapDuration: TimeInterval
+        var maximumInterval: TimeInterval
+
+        init(maximumTapDuration: TimeInterval = 0.3, maximumInterval: TimeInterval = 0.3) {
+            self.maximumTapDuration = maximumTapDuration
+            self.maximumInterval = maximumInterval
+        }
+    }
+
+    enum Input: Equatable {
+        case modifierChange(modifierPressed: Bool, otherModifierPressed: Bool, timestamp: TimeInterval)
+        case keyDown(modifierPressed: Bool, timestamp: TimeInterval)
+        case pointerDown(modifierPressed: Bool, timestamp: TimeInterval)
+
+        var timestamp: TimeInterval {
+            switch self {
+            case let .modifierChange(_, _, timestamp),
+                 let .keyDown(_, timestamp),
+                 let .pointerDown(_, timestamp): timestamp
+            }
+        }
+
+        var modifierPressed: Bool {
+            switch self {
+            case let .modifierChange(modifierPressed, _, _),
+                 let .keyDown(modifierPressed, _),
+                 let .pointerDown(modifierPressed, _): modifierPressed
+            }
+        }
+    }
+
+    private enum State: Equatable {
+        case idle
+        case firstPress(TimeInterval)
+        case awaitingSecondPress(TimeInterval)
+        case secondPress(TimeInterval)
+        case blockedUntilRelease
+    }
+
+    private let configuration: Configuration
+    private var state = State.idle
+    private var lastTimestamp: TimeInterval?
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    mutating func process(_ input: Input) -> Bool {
+        if let lastTimestamp, input.timestamp < lastTimestamp {
+            state = .idle
+        }
+        lastTimestamp = input.timestamp
+
+        switch input {
+        case let .keyDown(modifierPressed, _),
+             let .pointerDown(modifierPressed, _):
+            state = modifierPressed ? .blockedUntilRelease : .idle
+            return false
+        case let .modifierChange(modifierPressed, otherModifierPressed, timestamp):
+            return processModifierChange(
+                modifierPressed: modifierPressed,
+                otherModifierPressed: otherModifierPressed,
+                timestamp: timestamp
+            )
+        }
+    }
+
+    mutating func reset() {
+        state = .idle
+        lastTimestamp = nil
+    }
+
+    private mutating func processModifierChange(
+        modifierPressed: Bool,
+        otherModifierPressed: Bool,
+        timestamp: TimeInterval
+    ) -> Bool {
+        if otherModifierPressed {
+            state = modifierPressed ? .blockedUntilRelease : .idle
+            return false
+        }
+
+        if case .blockedUntilRelease = state {
+            if !modifierPressed {
+                state = .idle
+            }
+            return false
+        }
+
+        expireState(at: timestamp, modifierPressed: modifierPressed)
+
+        if modifierPressed {
+            switch state {
+            case .idle:
+                state = .firstPress(timestamp)
+            case .awaitingSecondPress:
+                state = .secondPress(timestamp)
+            case .firstPress,
+                 .secondPress,
+                 .blockedUntilRelease:
+                break
+            }
+            return false
+        }
+
+        switch state {
+        case let .firstPress(pressedAt):
+            guard timestamp - pressedAt <= configuration.maximumTapDuration else {
+                state = .idle
+                return false
+            }
+            state = .awaitingSecondPress(timestamp)
+            return false
+        case let .secondPress(pressedAt):
+            state = .idle
+            return timestamp - pressedAt <= configuration.maximumTapDuration
+        case .idle,
+             .awaitingSecondPress,
+             .blockedUntilRelease:
+            return false
+        }
+    }
+
+    private mutating func expireState(at timestamp: TimeInterval, modifierPressed: Bool) {
+        switch state {
+        case let .firstPress(pressedAt),
+             let .secondPress(pressedAt):
+            guard timestamp - pressedAt > configuration.maximumTapDuration else { return }
+            state = modifierPressed ? .blockedUntilRelease : .idle
+        case let .awaitingSecondPress(releasedAt):
+            guard timestamp - releasedAt > configuration.maximumInterval else { return }
+            state = .idle
+        case .idle,
+             .blockedUntilRelease:
+            break
+        }
+    }
+}
+
+@MainActor
+final class DoubleModifierShortcutBackend: QuickTerminalShortcutBackend {
+    enum Modifier: Equatable {
+        case shift
+        case command
+        case control
+        case option
+
+        var appKitFlag: NSEvent.ModifierFlags {
+            switch self {
+            case .shift: .shift
+            case .command: .command
+            case .control: .control
+            case .option: .option
+            }
+        }
+
+        var cgEventFlag: CGEventFlags {
+            switch self {
+            case .shift: .maskShift
+            case .command: .maskCommand
+            case .control: .maskControl
+            case .option: .maskAlternate
+            }
+        }
+    }
+
+    private let modifier: Modifier
+    private var detector: DoubleModifierTapDetector
+    private var capsLockEnabled: Bool?
+    private var localMonitor: Any?
+    private var eventTap: CFMachPort?
+    private var eventTapSource: CFRunLoopSource?
+    private var trigger: (@MainActor () -> Void)?
+
+    init(
+        modifier: Modifier,
+        maximumTapDuration: TimeInterval = 0.3,
+        maximumInterval: TimeInterval = 0.3
+    ) {
+        self.modifier = modifier
+        detector = DoubleModifierTapDetector(configuration: .init(
+            maximumTapDuration: maximumTapDuration,
+            maximumInterval: maximumInterval
+        ))
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            stop()
+        }
+    }
+
+    var monitoringState: QuickTerminalShortcutMonitoringState {
+        if eventTap != nil {
+            return .systemWide
+        }
+        if localMonitor != nil {
+            return .localOnly
+        }
+        return .stopped
+    }
+
+    static var hasInputMonitoringAccess: Bool {
+        CGPreflightListenEventAccess()
+    }
+
+    static func requestInputMonitoringAccess() -> Bool {
+        CGRequestListenEventAccess()
+    }
+
+    func start(trigger: @escaping @MainActor () -> Void) throws {
+        guard localMonitor == nil else { return }
+        self.trigger = trigger
+        localMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.flagsChanged, .keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { [weak self] event in
+            MainActor.assumeIsolated {
+                self?.receiveLocalEvent(event)
+            }
+            return event
+        }
+        _ = enableSystemWideMonitoringIfAuthorized()
+    }
+
+    func stop() {
+        if let localMonitor {
+            NSEvent.removeMonitor(localMonitor)
+        }
+        removeEventTap()
+        localMonitor = nil
+        trigger = nil
+        detector.reset()
+        capsLockEnabled = nil
+    }
+
+    @discardableResult
+    func enableSystemWideMonitoringIfAuthorized() -> Bool {
+        guard eventTap == nil else { return true }
+        guard Self.hasInputMonitoringAccess else { return false }
+
+        let mask = CGEventMask(1 << CGEventType.flagsChanged.rawValue)
+            | CGEventMask(1 << CGEventType.keyDown.rawValue)
+            | CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
+            | CGEventMask(1 << CGEventType.rightMouseDown.rawValue)
+            | CGEventMask(1 << CGEventType.otherMouseDown.rawValue)
+        guard let eventTap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: mask,
+            callback: doubleModifierShortcutEventTapCallback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ), let eventTapSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+        else { return false }
+
+        self.eventTap = eventTap
+        self.eventTapSource = eventTapSource
+        CFRunLoopAddSource(CFRunLoopGetMain(), eventTapSource, .commonModes)
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+        return true
+    }
+
+    func receiveGlobalEvent(type: CGEventType, flags: CGEventFlags, timestamp: TimeInterval) {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return
+        }
+        guard NSApp?.isActive != true else { return }
+
+        switch type {
+        case .flagsChanged:
+            process(.modifierChange(
+                modifierPressed: flags.contains(modifier.cgEventFlag),
+                otherModifierPressed: otherModifierPressed(flags),
+                timestamp: timestamp
+            ))
+        case .keyDown:
+            process(.keyDown(modifierPressed: flags.contains(modifier.cgEventFlag), timestamp: timestamp))
+        case .leftMouseDown,
+             .rightMouseDown,
+             .otherMouseDown:
+            process(.pointerDown(modifierPressed: flags.contains(modifier.cgEventFlag), timestamp: timestamp))
+        default:
+            break
+        }
+    }
+
+    private func receiveLocalEvent(_ event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        switch event.type {
+        case .flagsChanged:
+            process(.modifierChange(
+                modifierPressed: flags.contains(modifier.appKitFlag),
+                otherModifierPressed: otherModifierPressed(flags),
+                timestamp: event.timestamp
+            ))
+        case .keyDown:
+            process(.keyDown(modifierPressed: flags.contains(modifier.appKitFlag), timestamp: event.timestamp))
+        case .leftMouseDown,
+             .rightMouseDown,
+             .otherMouseDown:
+            process(.pointerDown(modifierPressed: flags.contains(modifier.appKitFlag), timestamp: event.timestamp))
+        default:
+            break
+        }
+    }
+
+    private func process(_ input: DoubleModifierTapDetector.Input) {
+        guard detector.process(input) else { return }
+        trigger?()
+    }
+
+    private func otherModifierPressed(_ flags: NSEvent.ModifierFlags) -> Bool {
+        let conventional: NSEvent.ModifierFlags = [.shift, .command, .control, .option, .function]
+        let otherFlags = conventional.subtracting(modifier.appKitFlag)
+        let capsLockChanged = capsLockEnabled.map { $0 != flags.contains(.capsLock) } ?? false
+        capsLockEnabled = flags.contains(.capsLock)
+        return !flags.isDisjoint(with: otherFlags) || capsLockChanged
+    }
+
+    private func otherModifierPressed(_ flags: CGEventFlags) -> Bool {
+        let conventional: CGEventFlags = [.maskShift, .maskCommand, .maskControl, .maskAlternate, .maskSecondaryFn]
+        var otherFlags = conventional
+        otherFlags.remove(modifier.cgEventFlag)
+        let capsLockChanged = capsLockEnabled.map { $0 != flags.contains(.maskAlphaShift) } ?? false
+        capsLockEnabled = flags.contains(.maskAlphaShift)
+        return !flags.isDisjoint(with: otherFlags) || capsLockChanged
+    }
+
+    private func removeEventTap() {
+        if let eventTapSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), eventTapSource, .commonModes)
+        }
+        if let eventTap {
+            CFMachPortInvalidate(eventTap)
+        }
+        eventTapSource = nil
+        eventTap = nil
+    }
+}

--- a/Muxy/Services/Keyboard/GlobalWorkspacePreferences.swift
+++ b/Muxy/Services/Keyboard/GlobalWorkspacePreferences.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+enum GlobalWorkspaceTrigger: String, CaseIterable, Codable, Identifiable {
+    case doubleCommand
+    case doubleControl
+    case doubleOption
+    case custom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .doubleCommand:
+            "Double Command"
+        case .doubleControl:
+            "Double Control"
+        case .doubleOption:
+            "Double Option"
+        case .custom:
+            "Custom Shortcut"
+        }
+    }
+
+    var modifier: DoubleModifierShortcutBackend.Modifier? {
+        switch self {
+        case .doubleCommand:
+            .command
+        case .doubleControl:
+            .control
+        case .doubleOption:
+            .option
+        case .custom:
+            nil
+        }
+    }
+}
+
+struct GlobalWorkspaceShortcutConfiguration: Codable, Equatable {
+    let trigger: GlobalWorkspaceTrigger
+    let customShortcut: QuickTerminalShortcut?
+
+    init(trigger: GlobalWorkspaceTrigger, customShortcut: QuickTerminalShortcut? = nil) {
+        self.trigger = trigger
+        self.customShortcut = customShortcut
+    }
+}
+
+enum GlobalWorkspacePreferences {
+    static let jsonShortcutKey = "shortcuts.globalWorkspace"
+    static let enabledKey = "muxy.globalHotkey.enabled"
+    static let triggerKey = "muxy.globalHotkey.trigger"
+    static let doubleTapIntervalMillisecondsKey = "muxy.globalHotkey.doubleTapIntervalMilliseconds"
+    static let toggleToHideKey = "muxy.globalHotkey.toggleToHide"
+    static let customShortcutKey = "muxy.globalHotkey.customShortcut"
+
+    static let defaultEnabled = false
+    static let defaultTrigger = GlobalWorkspaceTrigger.doubleCommand
+    static let defaultDoubleTapIntervalMilliseconds = 300.0
+    static let minimumDoubleTapIntervalMilliseconds = 100.0
+    static let maximumDoubleTapIntervalMilliseconds = 1000.0
+    static let doubleTapIntervalStepMilliseconds = 25.0
+    static let defaultToggleToHide = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: enabledKey) != nil else { return defaultEnabled }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    static func trigger(defaults: UserDefaults = .standard) -> GlobalWorkspaceTrigger {
+        guard let rawValue = defaults.string(forKey: triggerKey),
+              let trigger = GlobalWorkspaceTrigger(rawValue: rawValue)
+        else { return defaultTrigger }
+        return trigger
+    }
+
+    static func doubleTapIntervalMilliseconds(defaults: UserDefaults = .standard) -> Double {
+        guard defaults.object(forKey: doubleTapIntervalMillisecondsKey) != nil else {
+            return defaultDoubleTapIntervalMilliseconds
+        }
+        return clampedDoubleTapIntervalMilliseconds(defaults.double(forKey: doubleTapIntervalMillisecondsKey))
+    }
+
+    static func doubleTapInterval(defaults: UserDefaults = .standard) -> TimeInterval {
+        doubleTapIntervalMilliseconds(defaults: defaults) / 1000
+    }
+
+    static func toggleToHide(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: toggleToHideKey) != nil else { return defaultToggleToHide }
+        return defaults.bool(forKey: toggleToHideKey)
+    }
+
+    static func customShortcut(defaults: UserDefaults = .standard) -> QuickTerminalShortcut? {
+        guard let data = defaults.data(forKey: customShortcutKey),
+              let shortcut = try? JSONDecoder().decode(QuickTerminalShortcut.self, from: data),
+              case .keyCombo = shortcut
+        else { return nil }
+        return shortcut
+    }
+
+    static func shortcutConfiguration(defaults: UserDefaults = .standard) -> GlobalWorkspaceShortcutConfiguration {
+        GlobalWorkspaceShortcutConfiguration(
+            trigger: trigger(defaults: defaults),
+            customShortcut: customShortcut(defaults: defaults)
+        )
+    }
+
+    @MainActor
+    static func setCustomShortcut(
+        _ shortcut: QuickTerminalShortcut,
+        defaults: UserDefaults = .standard
+    ) throws {
+        guard case .keyCombo = shortcut,
+              let canonicalized = shortcut.canonicalizedForCurrentKeyboardLayout()
+        else { throw QuickTerminalShortcutError.invalidShortcut }
+        try defaults.set(JSONEncoder().encode(canonicalized), forKey: customShortcutKey)
+        defaults.set(GlobalWorkspaceTrigger.custom.rawValue, forKey: triggerKey)
+    }
+
+    @MainActor
+    static func setShortcutConfiguration(
+        _ configuration: GlobalWorkspaceShortcutConfiguration,
+        defaults: UserDefaults = .standard
+    ) throws {
+        if configuration.trigger == .custom {
+            guard let customShortcut = configuration.customShortcut else {
+                throw QuickTerminalShortcutError.invalidShortcut
+            }
+            try setCustomShortcut(customShortcut, defaults: defaults)
+            return
+        }
+        defaults.removeObject(forKey: customShortcutKey)
+        defaults.set(configuration.trigger.rawValue, forKey: triggerKey)
+    }
+
+    static func resetToDefaults(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: enabledKey)
+        defaults.removeObject(forKey: triggerKey)
+        defaults.removeObject(forKey: doubleTapIntervalMillisecondsKey)
+        defaults.removeObject(forKey: toggleToHideKey)
+        defaults.removeObject(forKey: customShortcutKey)
+    }
+
+    static func clampedDoubleTapIntervalMilliseconds(_ value: Double) -> Double {
+        min(max(value, minimumDoubleTapIntervalMilliseconds), maximumDoubleTapIntervalMilliseconds)
+    }
+}

--- a/Muxy/Services/Keyboard/GlobalWorkspaceShortcutService.swift
+++ b/Muxy/Services/Keyboard/GlobalWorkspaceShortcutService.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class GlobalWorkspaceShortcutService {
+    typealias DoubleModifierBackendFactory = @MainActor (
+        DoubleModifierShortcutBackend.Modifier,
+        TimeInterval
+    ) -> any QuickTerminalShortcutBackend
+    typealias CarbonHotKeyBackendFactory = @MainActor (KeyCombo, UInt16) -> any QuickTerminalShortcutBackend
+
+    struct Configuration: Equatable {
+        let isEnabled: Bool
+        let trigger: GlobalWorkspaceTrigger
+        let doubleTapInterval: TimeInterval
+        let toggleToHide: Bool
+        let customShortcut: QuickTerminalShortcut?
+
+        static func current(defaults: UserDefaults = .standard) -> Configuration {
+            Configuration(
+                isEnabled: GlobalWorkspacePreferences.isEnabled(defaults: defaults),
+                trigger: GlobalWorkspacePreferences.trigger(defaults: defaults),
+                doubleTapInterval: GlobalWorkspacePreferences.doubleTapInterval(defaults: defaults),
+                toggleToHide: GlobalWorkspacePreferences.toggleToHide(defaults: defaults),
+                customShortcut: GlobalWorkspacePreferences.customShortcut(defaults: defaults)
+            )
+        }
+    }
+
+    static let shared = GlobalWorkspaceShortcutService()
+
+    private(set) var monitoringState = QuickTerminalShortcutMonitoringState.stopped
+    private(set) var configuration: Configuration
+    private(set) var errorMessage: String?
+    @ObservationIgnored var onTrigger: (@MainActor (_ toggleToHide: Bool) -> Void)?
+    @ObservationIgnored private let doubleModifierBackendFactory: DoubleModifierBackendFactory
+    @ObservationIgnored private let carbonHotKeyBackendFactory: CarbonHotKeyBackendFactory
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private var backend: (any QuickTerminalShortcutBackend)?
+    @ObservationIgnored private var defaultsObserver: NSObjectProtocol?
+    @ObservationIgnored private var isStarted = false
+
+    init(
+        defaults: UserDefaults = .standard,
+        doubleModifierBackendFactory: @escaping DoubleModifierBackendFactory = { modifier, interval in
+            DoubleModifierShortcutBackend(
+                modifier: modifier,
+                maximumTapDuration: 0.3,
+                maximumInterval: interval
+            )
+        },
+        carbonHotKeyBackendFactory: @escaping CarbonHotKeyBackendFactory = {
+            CarbonHotKeyBackend(combo: $0, virtualKeyCode: $1)
+        }
+    ) {
+        self.defaults = defaults
+        self.doubleModifierBackendFactory = doubleModifierBackendFactory
+        self.carbonHotKeyBackendFactory = carbonHotKeyBackendFactory
+        configuration = Configuration.current(defaults: defaults)
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            stop()
+        }
+    }
+
+    var needsInputMonitoringAccess: Bool {
+        configuration.isEnabled && configuration.trigger.modifier != nil && monitoringState == .localOnly
+    }
+
+    func start() {
+        guard !isStarted else { return }
+        isStarted = true
+        defaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: defaults,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshConfiguration()
+            }
+        }
+        apply(Configuration.current(defaults: defaults))
+    }
+
+    func refresh() {
+        refreshConfiguration()
+    }
+
+    func stop() {
+        if let defaultsObserver {
+            NotificationCenter.default.removeObserver(defaultsObserver)
+        }
+        defaultsObserver = nil
+        backend?.stop()
+        backend = nil
+        monitoringState = .stopped
+        errorMessage = nil
+        isStarted = false
+    }
+
+    @discardableResult
+    func requestInputMonitoringAccess() -> Bool {
+        guard configuration.isEnabled, configuration.trigger.modifier != nil else { return false }
+        let granted = DoubleModifierShortcutBackend.requestInputMonitoringAccess()
+        guard granted, let backend else { return granted }
+        let enabled = backend.enableSystemWideMonitoringIfAuthorized()
+        monitoringState = backend.monitoringState
+        return enabled
+    }
+
+    @discardableResult
+    func refreshInputMonitoringAccess() -> Bool {
+        guard configuration.isEnabled, configuration.trigger.modifier != nil, let backend else { return false }
+        let enabled = backend.enableSystemWideMonitoringIfAuthorized()
+        monitoringState = backend.monitoringState
+        return enabled
+    }
+
+    func updateCustomShortcut(_ shortcut: QuickTerminalShortcut) throws {
+        try GlobalWorkspacePreferences.setCustomShortcut(shortcut, defaults: defaults)
+        refreshConfiguration()
+        if let errorMessage {
+            throw GlobalWorkspaceShortcutUpdateError.registrationFailed(errorMessage)
+        }
+    }
+
+    private func refreshConfiguration() {
+        let next = Configuration.current(defaults: defaults)
+        guard next != configuration else { return }
+        apply(next)
+    }
+
+    private func apply(_ next: Configuration) {
+        let registrationChanged = next.isEnabled != configuration.isEnabled
+            || next.trigger != configuration.trigger
+            || next.doubleTapInterval != configuration.doubleTapInterval
+            || next.customShortcut != configuration.customShortcut
+        configuration = next
+
+        guard isStarted else { return }
+        guard next.isEnabled else {
+            backend?.stop()
+            backend = nil
+            monitoringState = .stopped
+            errorMessage = nil
+            return
+        }
+        guard registrationChanged || backend == nil else { return }
+
+        backend?.stop()
+        guard let replacement = makeBackend(for: next) else {
+            backend = nil
+            monitoringState = .stopped
+            errorMessage = nil
+            return
+        }
+        do {
+            try replacement.start { [weak self] in
+                guard let self else { return }
+                self.onTrigger?(self.configuration.toggleToHide)
+            }
+            backend = replacement
+            monitoringState = replacement.monitoringState
+            errorMessage = nil
+        } catch {
+            replacement.stop()
+            backend = nil
+            monitoringState = .stopped
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func makeBackend(for configuration: Configuration) -> (any QuickTerminalShortcutBackend)? {
+        if let modifier = configuration.trigger.modifier {
+            return doubleModifierBackendFactory(modifier, configuration.doubleTapInterval)
+        }
+        guard case let .keyCombo(combo, virtualKeyCode) = configuration.customShortcut else { return nil }
+        return carbonHotKeyBackendFactory(combo, virtualKeyCode)
+    }
+}
+
+enum GlobalWorkspaceShortcutUpdateError: LocalizedError {
+    case registrationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .registrationFailed(message): message
+        }
+    }
+}

--- a/Muxy/Services/Keyboard/ModifierKeyMonitor.swift
+++ b/Muxy/Services/Keyboard/ModifierKeyMonitor.swift
@@ -38,8 +38,18 @@ final class ModifierKeyMonitor {
                 guard let self else { return }
                 let flags = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
                 self.updateFlags(flags)
+                GlobalWorkspaceShortcutService.shared.refreshInputMonitoringAccess()
             }
         }
+        let service = GlobalWorkspaceShortcutService.shared
+        service.onTrigger = { toggleToHide in
+            if toggleToHide {
+                GlobalWorkspaceController.shared.toggle()
+            } else {
+                GlobalWorkspaceController.shared.show()
+            }
+        }
+        service.start()
     }
 
     func stop() {
@@ -49,6 +59,8 @@ final class ModifierKeyMonitor {
         if let activationObserver {
             NotificationCenter.default.removeObserver(activationObserver)
         }
+        GlobalWorkspaceShortcutService.shared.stop()
+        GlobalWorkspaceController.shared.stop(restoresFocus: false)
         monitor = nil
         activationObserver = nil
         cancelHint()

--- a/Muxy/Services/Keyboard/ShortcutContext.swift
+++ b/Muxy/Services/Keyboard/ShortcutContext.swift
@@ -3,9 +3,15 @@ import AppKit
 @MainActor
 enum ShortcutContext {
     static let mainWindowIdentifier = NSUserInterfaceItemIdentifier("app.muxy.main-window")
+    static let globalWorkspaceWindowIdentifier = NSUserInterfaceItemIdentifier("app.muxy.global-workspace-window")
 
     static func isMainWindow(_ window: NSWindow?) -> Bool {
-        window?.identifier == mainWindowIdentifier
+        guard let identifier = window?.identifier else { return false }
+        return identifier == mainWindowIdentifier || identifier == globalWorkspaceWindowIdentifier
+    }
+
+    static func isGlobalWorkspaceWindow(_ window: NSWindow?) -> Bool {
+        window?.identifier == globalWorkspaceWindowIdentifier
     }
 
     static func activeScopes(

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -6,6 +6,7 @@ private let settingsJSONLogger = Logger(subsystem: "app.muxy", category: "Settin
 @MainActor
 enum SettingsJSONStore {
     typealias QuickTerminalShortcutUpdater = @MainActor (QuickTerminalShortcut) throws -> Void
+    typealias GlobalWorkspaceShortcutUpdater = @MainActor (GlobalWorkspaceShortcutConfiguration) throws -> Void
     typealias QuickTerminalEnabledUpdater = @MainActor (Bool) -> Void
     typealias QuickTerminalEnabledResetter = @MainActor () -> Void
     typealias AutomaticUpdatesUpdater = @MainActor (Bool) -> Void
@@ -20,6 +21,11 @@ enum SettingsJSONStore {
     private struct AutomaticUpdatesActions {
         let update: AutomaticUpdatesUpdater
         let reset: AutomaticUpdatesResetter
+    }
+
+    private struct ShortcutActions {
+        let quickTerminalUpdate: QuickTerminalShortcutUpdater
+        let globalWorkspaceUpdate: GlobalWorkspaceShortcutUpdater
     }
 
     private static var defaultsObserver: NSObjectProtocol?
@@ -42,8 +48,12 @@ enum SettingsJSONStore {
 
     static func saveUserSettingsText(
         _ text: String,
-        quickTerminalShortcutUpdater: QuickTerminalShortcutUpdater = {
+        quickTerminalShortcutUpdater: @escaping QuickTerminalShortcutUpdater = {
             try QuickTerminalShortcutService.shared.updateShortcut($0)
+        },
+        globalWorkspaceShortcutUpdater: @escaping GlobalWorkspaceShortcutUpdater = {
+            try GlobalWorkspacePreferences.setShortcutConfiguration($0)
+            GlobalWorkspaceShortcutService.shared.refresh()
         },
         quickTerminalEnabledUpdater: QuickTerminalEnabledUpdater = {
             QuickTerminalPreferences.setEnabled($0)
@@ -76,9 +86,13 @@ enum SettingsJSONStore {
                 update: automaticUpdatesUpdater,
                 reset: automaticUpdatesResetter
             )
+            let shortcutActions = ShortcutActions(
+                quickTerminalUpdate: quickTerminalShortcutUpdater,
+                globalWorkspaceUpdate: globalWorkspaceShortcutUpdater
+            )
             try apply(
                 settings,
-                quickTerminalShortcutUpdater: quickTerminalShortcutUpdater,
+                shortcutActions: shortcutActions,
                 quickTerminalEnabledUpdater: quickTerminalEnabledUpdater,
                 quickTerminalEnabledResetter: quickTerminalEnabledResetter,
                 automaticUpdatesActions: automaticUpdatesActions
@@ -167,6 +181,9 @@ enum SettingsJSONStore {
         })
         dictionary["shortcuts.app"] = keyBindingsJSONObject(KeyBinding.defaults)
         dictionary["shortcuts.quickTerminal"] = codableJSONObject(QuickTerminalShortcut.default) ?? [:]
+        dictionary[GlobalWorkspacePreferences.jsonShortcutKey] = codableJSONObject(
+            GlobalWorkspaceShortcutConfiguration(trigger: GlobalWorkspacePreferences.defaultTrigger)
+        ) ?? [:]
         dictionary["shortcuts.customCommands"] = commandShortcutsJSONObject(CommandShortcutConfiguration())
         dictionary["ai.providers"] = notificationProviderSettings(defaultValue: true)
         dictionary["mobile.approvedDevices"] = []
@@ -180,6 +197,9 @@ enum SettingsJSONStore {
         })
         dictionary["shortcuts.app"] = keyBindingsJSONObject(KeyBindingStore.shared.bindings)
         dictionary["shortcuts.quickTerminal"] = codableJSONObject(QuickTerminalShortcutService.shared.shortcut) ?? [:]
+        dictionary[GlobalWorkspacePreferences.jsonShortcutKey] = codableJSONObject(
+            GlobalWorkspacePreferences.shortcutConfiguration()
+        ) ?? [:]
         dictionary["shortcuts.customCommands"] = commandShortcutsJSONObject(CommandShortcutConfiguration(
             prefixCombo: CommandShortcutStore.shared.prefixCombo,
             shortcuts: CommandShortcutStore.shared.shortcuts
@@ -201,7 +221,45 @@ enum SettingsJSONStore {
             settings[key] = try validatedValue(value, for: item)
         }
         try validateQuickTerminalShortcutConflicts(in: settings)
+        try validateGlobalWorkspaceShortcutConflicts(in: settings)
         return settings
+    }
+
+    private static func validateGlobalWorkspaceShortcutConflicts(in settings: [String: Any]) throws {
+        let configuration: GlobalWorkspaceShortcutConfiguration = settings[GlobalWorkspacePreferences.jsonShortcutKey]
+            .flatMap { codableValue(from: $0) }
+            ?? GlobalWorkspacePreferences.shortcutConfiguration()
+        guard configuration.trigger == .custom,
+              let combo = configuration.customShortcut?.keyCombo
+        else { return }
+        let quickTerminalShortcut: QuickTerminalShortcut = settings["shortcuts.quickTerminal"]
+            .flatMap { codableValue(from: $0) }
+            ?? QuickTerminalShortcutService.shared.shortcut
+        guard quickTerminalShortcut.keyCombo != combo else {
+            throw SettingsJSONError.invalidValue(GlobalWorkspacePreferences.jsonShortcutKey)
+        }
+
+        let bindings = settings["shortcuts.app"].flatMap(keyBindings(from:))
+            ?? KeyBindingStore.shared.bindings
+        guard !bindings.contains(where: { $0.combo == combo }) else {
+            throw SettingsJSONError.invalidValue(GlobalWorkspacePreferences.jsonShortcutKey)
+        }
+
+        let commandConfiguration = settings["shortcuts.customCommands"].flatMap(commandShortcutConfiguration(from:))
+            ?? CommandShortcutConfiguration(
+                prefixCombo: CommandShortcutStore.shared.prefixCombo,
+                shortcuts: CommandShortcutStore.shared.shortcuts
+            )
+        guard commandConfiguration.prefixCombo != combo,
+              !commandConfiguration.shortcuts.contains(where: { $0.combo == combo }),
+              ExtensionShortcutStore.shared.conflictingShortcut(
+                  for: combo,
+                  excludingExtensionID: nil,
+                  commandID: nil
+              ) == nil
+        else {
+            throw SettingsJSONError.invalidValue(GlobalWorkspacePreferences.jsonShortcutKey)
+        }
     }
 
     private static func validateQuickTerminalShortcutConflicts(in settings: [String: Any]) throws {
@@ -235,7 +293,7 @@ enum SettingsJSONStore {
 
     private static func apply(
         _ dictionary: [String: Any],
-        quickTerminalShortcutUpdater: QuickTerminalShortcutUpdater,
+        shortcutActions: ShortcutActions,
         quickTerminalEnabledUpdater: QuickTerminalEnabledUpdater,
         quickTerminalEnabledResetter: QuickTerminalEnabledResetter,
         automaticUpdatesActions: AutomaticUpdatesActions
@@ -244,7 +302,16 @@ enum SettingsJSONStore {
             _ = try applySpecialSetting(
                 key: "shortcuts.quickTerminal",
                 value: quickTerminalShortcut,
-                quickTerminalShortcutUpdater: quickTerminalShortcutUpdater
+                quickTerminalShortcutUpdater: shortcutActions.quickTerminalUpdate,
+                globalWorkspaceShortcutUpdater: shortcutActions.globalWorkspaceUpdate
+            )
+        }
+        if let globalWorkspaceShortcut = dictionary[GlobalWorkspacePreferences.jsonShortcutKey] {
+            _ = try applySpecialSetting(
+                key: GlobalWorkspacePreferences.jsonShortcutKey,
+                value: globalWorkspaceShortcut,
+                quickTerminalShortcutUpdater: shortcutActions.quickTerminalUpdate,
+                globalWorkspaceShortcutUpdater: shortcutActions.globalWorkspaceUpdate
             )
         }
         if let enabled = dictionary[QuickTerminalPreferences.enabledKey] as? Bool {
@@ -257,14 +324,24 @@ enum SettingsJSONStore {
         } else if dictionary[UpdateService.automaticallyUpdatesKey] is NSNull {
             automaticUpdatesActions.reset()
         }
+        let globalWorkspaceKeys = Set([
+            GlobalWorkspacePreferences.enabledKey,
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
+            GlobalWorkspacePreferences.toggleToHideKey,
+        ])
+        let hasGlobalWorkspaceShortcut = dictionary[GlobalWorkspacePreferences.jsonShortcutKey] != nil
         for (key, value) in dictionary where key != "shortcuts.quickTerminal"
+            && key != GlobalWorkspacePreferences.jsonShortcutKey
             && key != QuickTerminalPreferences.enabledKey
             && key != UpdateService.automaticallyUpdatesKey
+            && (!hasGlobalWorkspaceShortcut || !globalWorkspaceKeys.contains(key))
         {
             if try applySpecialSetting(
                 key: key,
                 value: value,
-                quickTerminalShortcutUpdater: quickTerminalShortcutUpdater
+                quickTerminalShortcutUpdater: shortcutActions.quickTerminalUpdate,
+                globalWorkspaceShortcutUpdater: shortcutActions.globalWorkspaceUpdate
             ) {
                 continue
             }
@@ -366,6 +443,7 @@ enum SettingsJSONStore {
         let allowedValues: [String: Set<String>] = [
             UpdateChannel.storageKey: Set(UpdateChannel.allCases.map(\.rawValue)),
             ProjectPickerPreferences.storageKey: Set(ProjectPickerMode.allCases.map(\.rawValue)),
+            GlobalWorkspacePreferences.triggerKey: Set(GlobalWorkspaceTrigger.allCases.map(\.rawValue)),
             SentryConsent.storageKey: Set(["", SentryConsent.allowed.rawValue, SentryConsent.denied.rawValue]),
             "muxy.ui.scale": Set(UIScale.Preset.allCases.map(\.rawValue)),
             AppBackgroundStyle.storageKey: Set(AppBackgroundStyle.allCases.map(\.rawValue)),
@@ -422,6 +500,10 @@ enum SettingsJSONStore {
 
     private static func validateAllowedDouble(_ value: Double, key: String) throws {
         switch key {
+        case GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey:
+            guard (GlobalWorkspacePreferences.minimumDoubleTapIntervalMilliseconds
+                ... GlobalWorkspacePreferences.maximumDoubleTapIntervalMilliseconds).contains(value)
+            else { throw SettingsJSONError.invalidValue(key) }
         case TabWidthPreferences.maxWidthKey:
             guard TabWidthPreferences.isAllowedStoredValue(value) else { throw SettingsJSONError.invalidValue(key) }
         case "editor.richInputLineHeightMultiplier":
@@ -452,6 +534,7 @@ enum SettingsJSONStore {
         switch key {
         case "shortcuts.app",
              "shortcuts.quickTerminal",
+             GlobalWorkspacePreferences.jsonShortcutKey,
              "shortcuts.customCommands",
              "ai.providers",
              "mobile.approvedDevices":
@@ -469,6 +552,13 @@ enum SettingsJSONStore {
             guard let shortcut: QuickTerminalShortcut = codableValue(from: value),
                   let canonicalShortcut = shortcut.canonicalizedForCurrentKeyboardLayout(),
                   let canonicalValue = codableJSONObject(canonicalShortcut)
+            else {
+                throw SettingsJSONError.invalidValue(key)
+            }
+            return canonicalValue
+        case GlobalWorkspacePreferences.jsonShortcutKey:
+            guard let configuration: GlobalWorkspaceShortcutConfiguration = codableValue(from: value),
+                  let canonicalValue = canonicalGlobalWorkspaceShortcutConfiguration(configuration)
             else {
                 throw SettingsJSONError.invalidValue(key)
             }
@@ -492,7 +582,8 @@ enum SettingsJSONStore {
     private static func applySpecialSetting(
         key: String,
         value: Any,
-        quickTerminalShortcutUpdater: QuickTerminalShortcutUpdater
+        quickTerminalShortcutUpdater: QuickTerminalShortcutUpdater,
+        globalWorkspaceShortcutUpdater: GlobalWorkspaceShortcutUpdater
     ) throws -> Bool {
         switch key {
         case SentryConsent.storageKey:
@@ -532,6 +623,11 @@ enum SettingsJSONStore {
         case "shortcuts.quickTerminal":
             guard let shortcut: QuickTerminalShortcut = codableValue(from: value) else { return true }
             try quickTerminalShortcutUpdater(shortcut)
+        case GlobalWorkspacePreferences.jsonShortcutKey:
+            guard let configuration: GlobalWorkspaceShortcutConfiguration = codableValue(from: value) else {
+                return true
+            }
+            try globalWorkspaceShortcutUpdater(configuration)
         case "shortcuts.customCommands":
             guard let configuration = commandShortcutConfiguration(from: value) else { return true }
             CommandShortcutStore.shared.replaceConfiguration(configuration)
@@ -611,6 +707,21 @@ enum SettingsJSONStore {
 
     private static func isValidKeyCombo(_ combo: KeyCombo) -> Bool {
         combo.isAssigned && combo.isCanonical
+    }
+
+    private static func canonicalGlobalWorkspaceShortcutConfiguration(
+        _ configuration: GlobalWorkspaceShortcutConfiguration
+    ) -> Any? {
+        if configuration.trigger == .custom {
+            guard let customShortcut = configuration.customShortcut,
+                  let canonicalShortcut = customShortcut.canonicalizedForCurrentKeyboardLayout()
+            else { return nil }
+            return codableJSONObject(GlobalWorkspaceShortcutConfiguration(
+                trigger: .custom,
+                customShortcut: canonicalShortcut
+            ))
+        }
+        return codableJSONObject(GlobalWorkspaceShortcutConfiguration(trigger: configuration.trigger))
     }
 
     private static func isValidAppKeyCombo(_ combo: KeyCombo) -> Bool {

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -324,18 +324,12 @@ enum SettingsJSONStore {
         } else if dictionary[UpdateService.automaticallyUpdatesKey] is NSNull {
             automaticUpdatesActions.reset()
         }
-        let globalWorkspaceKeys = Set([
-            GlobalWorkspacePreferences.enabledKey,
-            GlobalWorkspacePreferences.triggerKey,
-            GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
-            GlobalWorkspacePreferences.toggleToHideKey,
-        ])
         let hasGlobalWorkspaceShortcut = dictionary[GlobalWorkspacePreferences.jsonShortcutKey] != nil
         for (key, value) in dictionary where key != "shortcuts.quickTerminal"
             && key != GlobalWorkspacePreferences.jsonShortcutKey
             && key != QuickTerminalPreferences.enabledKey
             && key != UpdateService.automaticallyUpdatesKey
-            && (!hasGlobalWorkspaceShortcut || !globalWorkspaceKeys.contains(key))
+            && (!hasGlobalWorkspaceShortcut || key != GlobalWorkspacePreferences.triggerKey)
         {
             if try applySpecialSetting(
                 key: key,

--- a/Muxy/Services/Persistence/SettingsJSONStore.swift
+++ b/Muxy/Services/Persistence/SettingsJSONStore.swift
@@ -197,7 +197,7 @@ enum SettingsJSONStore {
         })
         dictionary["shortcuts.app"] = keyBindingsJSONObject(KeyBindingStore.shared.bindings)
         dictionary["shortcuts.quickTerminal"] = codableJSONObject(QuickTerminalShortcutService.shared.shortcut) ?? [:]
-        dictionary[GlobalWorkspacePreferences.jsonShortcutKey] = codableJSONObject(
+        dictionary[GlobalWorkspacePreferences.jsonShortcutKey] = canonicalGlobalWorkspaceShortcutConfiguration(
             GlobalWorkspacePreferences.shortcutConfiguration()
         ) ?? [:]
         dictionary["shortcuts.customCommands"] = commandShortcutsJSONObject(CommandShortcutConfiguration(
@@ -226,6 +226,21 @@ enum SettingsJSONStore {
     }
 
     private static func validateGlobalWorkspaceShortcutConflicts(in settings: [String: Any]) throws {
+        if settings[GlobalWorkspacePreferences.jsonShortcutKey] == nil,
+           let triggerValue = settings[GlobalWorkspacePreferences.triggerKey]
+        {
+            if triggerValue is NSNull {
+                return
+            }
+            guard let rawValue = triggerValue as? String,
+                  let trigger = GlobalWorkspaceTrigger(rawValue: rawValue),
+                  trigger != .custom
+            else {
+                throw SettingsJSONError.invalidValue(GlobalWorkspacePreferences.triggerKey)
+            }
+            return
+        }
+
         let configuration: GlobalWorkspaceShortcutConfiguration = settings[GlobalWorkspacePreferences.jsonShortcutKey]
             .flatMap { codableValue(from: $0) }
             ?? GlobalWorkspacePreferences.shortcutConfiguration()
@@ -313,6 +328,20 @@ enum SettingsJSONStore {
                 quickTerminalShortcutUpdater: shortcutActions.quickTerminalUpdate,
                 globalWorkspaceShortcutUpdater: shortcutActions.globalWorkspaceUpdate
             )
+        } else if let triggerValue = dictionary[GlobalWorkspacePreferences.triggerKey] {
+            let trigger: GlobalWorkspaceTrigger
+            if triggerValue is NSNull {
+                trigger = GlobalWorkspacePreferences.defaultTrigger
+            } else {
+                guard let rawValue = triggerValue as? String,
+                      let parsedTrigger = GlobalWorkspaceTrigger(rawValue: rawValue),
+                      parsedTrigger != .custom
+                else {
+                    throw SettingsJSONError.invalidValue(GlobalWorkspacePreferences.triggerKey)
+                }
+                trigger = parsedTrigger
+            }
+            try shortcutActions.globalWorkspaceUpdate(GlobalWorkspaceShortcutConfiguration(trigger: trigger))
         }
         if let enabled = dictionary[QuickTerminalPreferences.enabledKey] as? Bool {
             quickTerminalEnabledUpdater(enabled)
@@ -324,12 +353,11 @@ enum SettingsJSONStore {
         } else if dictionary[UpdateService.automaticallyUpdatesKey] is NSNull {
             automaticUpdatesActions.reset()
         }
-        let hasGlobalWorkspaceShortcut = dictionary[GlobalWorkspacePreferences.jsonShortcutKey] != nil
         for (key, value) in dictionary where key != "shortcuts.quickTerminal"
             && key != GlobalWorkspacePreferences.jsonShortcutKey
+            && key != GlobalWorkspacePreferences.triggerKey
             && key != QuickTerminalPreferences.enabledKey
             && key != UpdateService.automaticallyUpdatesKey
-            && (!hasGlobalWorkspaceShortcut || key != GlobalWorkspacePreferences.triggerKey)
         {
             if try applySpecialSetting(
                 key: key,
@@ -706,16 +734,16 @@ enum SettingsJSONStore {
     private static func canonicalGlobalWorkspaceShortcutConfiguration(
         _ configuration: GlobalWorkspaceShortcutConfiguration
     ) -> Any? {
-        if configuration.trigger == .custom {
-            guard let customShortcut = configuration.customShortcut,
-                  let canonicalShortcut = customShortcut.canonicalizedForCurrentKeyboardLayout()
-            else { return nil }
-            return codableJSONObject(GlobalWorkspaceShortcutConfiguration(
-                trigger: .custom,
-                customShortcut: canonicalShortcut
-            ))
+        guard configuration.trigger == .custom else {
+            return codableJSONObject(GlobalWorkspaceShortcutConfiguration(trigger: configuration.trigger))
         }
-        return codableJSONObject(GlobalWorkspaceShortcutConfiguration(trigger: configuration.trigger))
+        guard let customShortcut = configuration.customShortcut,
+              let canonicalShortcut = customShortcut.canonicalizedForCurrentKeyboardLayout()
+        else { return nil }
+        return codableJSONObject(GlobalWorkspaceShortcutConfiguration(
+            trigger: .custom,
+            customShortcut: canonicalShortcut
+        ))
     }
 
     private static func isValidAppKeyCombo(_ combo: KeyCombo) -> Bool {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -67,7 +67,18 @@ enum MainWindowLayout {
     }
 }
 
+enum MainWindowFullScreenNotificationPolicy {
+    static func shouldApply(
+        sourceIdentifier: NSUserInterfaceItemIdentifier?,
+        targetIdentifier: NSUserInterfaceItemIdentifier
+    ) -> Bool {
+        sourceIdentifier == targetIdentifier
+    }
+}
+
 struct MainWindow: View {
+    let windowIdentifier: NSUserInterfaceItemIdentifier
+
     @Environment(AppState.self) private var appState
     @Environment(ProjectStore.self) private var projectStore
     @Environment(WorktreeStore.self) private var worktreeStore
@@ -186,6 +197,10 @@ struct MainWindow: View {
     }
 
     private var showsTabsInTitleBar: Bool { layout.topbar == .tabStrip || isExtensionSidebarActive }
+
+    init(windowIdentifier: NSUserInterfaceItemIdentifier = ShortcutContext.mainWindowIdentifier) {
+        self.windowIdentifier = windowIdentifier
+    }
 
     var body: some View {
         windowColumns
@@ -320,6 +335,7 @@ struct MainWindow: View {
             onToggleSidebar: toggleSidebar,
             onToggleAppLayout: toggleAppLayout,
             onToggleExtensionConsole: toggleExtensionConsole,
+            fullScreenWindowIdentifier: windowIdentifier,
             onFullScreenChange: { isFullScreen = $0 },
             onWorktreeKeysChange: pruneWorktreeStatesAndVisited,
             onActiveWorktreeChange: refreshWorkspaceWatcherAndVisited,
@@ -2482,6 +2498,7 @@ private struct MainWindowEventListeners: ViewModifier {
     let onToggleSidebar: () -> Void
     let onToggleAppLayout: () -> Void
     let onToggleExtensionConsole: () -> Void
+    let fullScreenWindowIdentifier: NSUserInterfaceItemIdentifier
     let onFullScreenChange: (Bool) -> Void
     let onWorktreeKeysChange: () -> Void
     let onActiveWorktreeChange: () -> Void
@@ -2504,6 +2521,7 @@ private struct MainWindowEventListeners: ViewModifier {
             onToggleSidebar: onToggleSidebar,
             onToggleAppLayout: onToggleAppLayout,
             onToggleExtensionConsole: onToggleExtensionConsole,
+            fullScreenWindowIdentifier: fullScreenWindowIdentifier,
             onFullScreenChange: onFullScreenChange,
             inputListeners: inputListeners
         )
@@ -2533,6 +2551,7 @@ private struct MainWindowNotificationListeners: ViewModifier {
     let onToggleSidebar: () -> Void
     let onToggleAppLayout: () -> Void
     let onToggleExtensionConsole: () -> Void
+    let fullScreenWindowIdentifier: NSUserInterfaceItemIdentifier
     let onFullScreenChange: (Bool) -> Void
     let inputListeners: InputNotificationListeners
 
@@ -2560,6 +2579,12 @@ private struct MainWindowNotificationListeners: ViewModifier {
                 onToggleExtensionConsole()
             }
             .onReceive(NotificationCenter.default.publisher(for: .windowFullScreenDidChange)) { notification in
+                let sourceIdentifier = (notification.object as? NSWindow)?.identifier
+                guard MainWindowFullScreenNotificationPolicy.shouldApply(
+                    sourceIdentifier: sourceIdentifier,
+                    targetIdentifier: fullScreenWindowIdentifier
+                )
+                else { return }
                 onFullScreenChange(notification.userInfo?["isFullScreen"] as? Bool ?? false)
             }
             .modifier(inputListeners)

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -81,6 +81,7 @@ struct MainWindow: View {
         static let globalWorkspaceSidebarExpanded = "muxy.globalWorkspace.sidebarExpanded"
         static let globalWorkspaceActiveSidebar = "muxy.globalWorkspace.activeSidebar"
         static let globalWorkspaceLayout = "muxy.globalWorkspace.layout"
+        static let globalWorkspaceSidebarExpandedCustomWidth = "muxy.globalWorkspace.sidebarExpandedCustomWidth"
     }
 
     let windowIdentifier: NSUserInterfaceItemIdentifier
@@ -210,6 +211,10 @@ struct MainWindow: View {
         _sidebarExpanded = AppStorage(wrappedValue: false, StorageKey.globalWorkspaceSidebarExpanded)
         _layoutStore = State(initialValue: AppLayoutStore(storageKey: StorageKey.globalWorkspaceLayout))
         _activeSidebarRaw = AppStorage(wrappedValue: SidebarSelection.builtinValue, StorageKey.globalWorkspaceActiveSidebar)
+        _sidebarExpandedCustomWidth = AppStorage(
+            wrappedValue: .init(SidebarLayout.expandedWidth),
+            StorageKey.globalWorkspaceSidebarExpandedCustomWidth
+        )
     }
 
     var body: some View {

--- a/Muxy/Views/MainWindow.swift
+++ b/Muxy/Views/MainWindow.swift
@@ -77,6 +77,12 @@ enum MainWindowFullScreenNotificationPolicy {
 }
 
 struct MainWindow: View {
+    private enum StorageKey {
+        static let globalWorkspaceSidebarExpanded = "muxy.globalWorkspace.sidebarExpanded"
+        static let globalWorkspaceActiveSidebar = "muxy.globalWorkspace.activeSidebar"
+        static let globalWorkspaceLayout = "muxy.globalWorkspace.layout"
+    }
+
     let windowIdentifier: NSUserInterfaceItemIdentifier
 
     @Environment(AppState.self) private var appState
@@ -200,6 +206,10 @@ struct MainWindow: View {
 
     init(windowIdentifier: NSUserInterfaceItemIdentifier = ShortcutContext.mainWindowIdentifier) {
         self.windowIdentifier = windowIdentifier
+        guard windowIdentifier == ShortcutContext.globalWorkspaceWindowIdentifier else { return }
+        _sidebarExpanded = AppStorage(wrappedValue: false, StorageKey.globalWorkspaceSidebarExpanded)
+        _layoutStore = State(initialValue: AppLayoutStore(storageKey: StorageKey.globalWorkspaceLayout))
+        _activeSidebarRaw = AppStorage(wrappedValue: SidebarSelection.builtinValue, StorageKey.globalWorkspaceActiveSidebar)
     }
 
     var body: some View {

--- a/Muxy/Views/Settings/GlobalWorkspaceSettingsSection.swift
+++ b/Muxy/Views/Settings/GlobalWorkspaceSettingsSection.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+
+struct GlobalWorkspaceSettingsSection: View {
+    @State private var isRecordingShortcut = false
+    @State private var shortcutError: String?
+    @AppStorage(GlobalWorkspacePreferences.enabledKey)
+    private var isEnabled = GlobalWorkspacePreferences.defaultEnabled
+    @AppStorage(GlobalWorkspacePreferences.triggerKey)
+    private var triggerRaw = GlobalWorkspacePreferences.defaultTrigger.rawValue
+    @AppStorage(GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey)
+    private var doubleTapIntervalMilliseconds = GlobalWorkspacePreferences.defaultDoubleTapIntervalMilliseconds
+    @AppStorage(GlobalWorkspacePreferences.toggleToHideKey)
+    private var toggleToHide = GlobalWorkspacePreferences.defaultToggleToHide
+
+    private var shortcutService: GlobalWorkspaceShortcutService { .shared }
+
+    private var selectedTrigger: GlobalWorkspaceTrigger {
+        GlobalWorkspaceTrigger(rawValue: triggerRaw) ?? GlobalWorkspacePreferences.defaultTrigger
+    }
+
+    private var intervalBinding: Binding<Double> {
+        Binding(
+            get: {
+                GlobalWorkspacePreferences.clampedDoubleTapIntervalMilliseconds(doubleTapIntervalMilliseconds)
+            },
+            set: { newValue in
+                let clamped = GlobalWorkspacePreferences.clampedDoubleTapIntervalMilliseconds(newValue)
+                let step = GlobalWorkspacePreferences.doubleTapIntervalStepMilliseconds
+                doubleTapIntervalMilliseconds = (clamped / step).rounded() * step
+            }
+        )
+    }
+
+    var body: some View {
+        SettingsContainer {
+            SettingsSection(
+                "General",
+                footer: "Double-tap the selected modifier to show a full Muxy workspace from any app."
+            ) {
+                SettingsToggleRow(label: "Enable Global Workspace", isOn: $isEnabled)
+            }
+
+            SettingsSection("Shortcut") {
+                SettingsRow("Trigger") {
+                    HStack(spacing: UIMetrics.spacing2) {
+                        Menu {
+                            ForEach(GlobalWorkspaceTrigger.allCases.filter { $0 != .custom }) { trigger in
+                                Button {
+                                    selectTrigger(trigger)
+                                } label: {
+                                    if trigger == selectedTrigger {
+                                        Label(trigger.title, systemImage: "checkmark")
+                                    } else {
+                                        Text(trigger.title)
+                                    }
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: UIMetrics.spacing2) {
+                                Text(doubleModifierLabel)
+                                    .foregroundStyle(SettingsStyle.foreground)
+                                Spacer(minLength: 0)
+                                Image(systemName: "chevron.up.chevron.down")
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundStyle(SettingsStyle.mutedForeground)
+                            }
+                            .font(.system(size: SettingsMetrics.labelFontSize))
+                            .padding(.horizontal, 8)
+                            .frame(width: 138, height: 26)
+                            .background(SettingsStyle.surface, in: RoundedRectangle(cornerRadius: 6))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(SettingsStyle.border, lineWidth: 1)
+                            )
+                            .contentShape(Rectangle())
+                        }
+                        .menuStyle(.borderlessButton)
+                        .fixedSize()
+
+                        ZStack {
+                            if isRecordingShortcut {
+                                ShortcutRecorderView(
+                                    onRecord: { _ in false },
+                                    onCancel: { isRecordingShortcut = false },
+                                    onRecordWithKeyCode: recordShortcut
+                                )
+                                .frame(width: 0, height: 0)
+                                .opacity(0)
+                            }
+                            Button {
+                                isRecordingShortcut = true
+                                shortcutError = nil
+                            } label: {
+                                if isRecordingShortcut {
+                                    Text(L10n.resource("Press shortcut…"))
+                                } else if selectedTrigger == .custom,
+                                          let shortcut = shortcutService.configuration.customShortcut
+                                {
+                                    Text(verbatim: shortcut.displayString)
+                                } else {
+                                    Text(L10n.resource("Record Custom…"))
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .accessibilityAddTraits(selectedTrigger == .custom ? .isSelected : [])
+                        }
+                    }
+                    .disabled(!isEnabled)
+                }
+
+                SettingsRow("Double Tap Interval") {
+                    HStack(spacing: UIMetrics.spacing3) {
+                        Slider(
+                            value: intervalBinding,
+                            in: GlobalWorkspacePreferences.minimumDoubleTapIntervalMilliseconds
+                                ... GlobalWorkspacePreferences.maximumDoubleTapIntervalMilliseconds
+                        )
+                        Text("\(Int(intervalBinding.wrappedValue.rounded())) ms")
+                            .font(.system(size: SettingsMetrics.labelFontSize).monospacedDigit())
+                            .foregroundStyle(SettingsStyle.mutedForeground)
+                            .frame(width: 58, alignment: .trailing)
+                    }
+                    .frame(width: SettingsMetrics.controlWidth)
+                    .disabled(!isEnabled || selectedTrigger == .custom)
+                }
+
+                SettingsToggleRow(label: "Toggle to Hide", isOn: $toggleToHide)
+                    .disabled(!isEnabled)
+
+                if shortcutService.needsInputMonitoringAccess {
+                    SettingsRow("System-wide Access") {
+                        Button("Enable Input Monitoring") {
+                            _ = shortcutService.requestInputMonitoringAccess()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    }
+                }
+
+                if let errorMessage = shortcutError ?? shortcutService.errorMessage {
+                    SettingsRow("Shortcut Error") {
+                        Text(errorMessage)
+                            .font(.system(size: SettingsMetrics.footnoteFontSize))
+                            .foregroundStyle(SettingsStyle.warning)
+                    }
+                }
+
+                SettingsRow("Status") {
+                    Text(statusText)
+                        .font(.system(size: SettingsMetrics.footnoteFontSize))
+                        .foregroundStyle(statusColor)
+                }
+            }
+        }
+    }
+
+    private var doubleModifierLabel: String {
+        selectedTrigger.title
+    }
+
+    private func selectTrigger(_ trigger: GlobalWorkspaceTrigger) {
+        do {
+            try GlobalWorkspacePreferences.setShortcutConfiguration(.init(trigger: trigger))
+            shortcutService.refresh()
+            shortcutError = nil
+        } catch {
+            shortcutError = error.localizedDescription
+        }
+    }
+
+    private func recordShortcut(_ combo: KeyCombo, virtualKeyCode: UInt16) -> Bool {
+        if let conflict = globalWorkspaceConflictMessage(for: combo) {
+            shortcutError = conflict
+            return false
+        }
+        do {
+            try shortcutService.updateCustomShortcut(.keyCombo(combo, virtualKeyCode: virtualKeyCode))
+            shortcutError = nil
+            isRecordingShortcut = false
+            return true
+        } catch {
+            shortcutError = error.localizedDescription
+            return false
+        }
+    }
+
+    private func globalWorkspaceConflictMessage(for combo: KeyCombo) -> String? {
+        QuickTerminalShortcutConflictResolver.conflictMessage(for: combo)
+            ?? QuickTerminalShortcutConflictResolver.quickTerminalConflictMessage(for: combo)
+    }
+
+    private var statusText: String {
+        guard isEnabled else { return "Disabled" }
+        guard selectedTrigger != .custom || shortcutService.configuration.customShortcut != nil else {
+            return "No shortcut assigned"
+        }
+        return switch shortcutService.monitoringState {
+        case .systemWide:
+            "Active system-wide"
+        case .localOnly:
+            "Active while Muxy is focused"
+        case .carbonHotKey:
+            "Active system-wide"
+        case .stopped:
+            "Inactive"
+        }
+    }
+
+    private var statusColor: Color {
+        guard isEnabled else { return SettingsStyle.mutedForeground }
+        return switch shortcutService.monitoringState {
+        case .systemWide,
+             .carbonHotKey:
+            SettingsStyle.accent
+        case .localOnly,
+             .stopped:
+            SettingsStyle.warning
+        }
+    }
+}

--- a/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
+++ b/Muxy/Views/Settings/KeyboardShortcutsSettingsView.swift
@@ -160,7 +160,8 @@ struct KeyboardShortcutsSettingsView: View {
                         conflictWarning = nil
                     },
                     onRecord: { combo in handleRecord(action: action, combo: combo) },
-                    onCancel: { recordingAction = nil
+                    onCancel: {
+                        recordingAction = nil
                         conflictWarning = nil
                     },
                     onReset: { resetBinding(action: action) },

--- a/Muxy/Views/Settings/SettingsView.swift
+++ b/Muxy/Views/Settings/SettingsView.swift
@@ -153,6 +153,8 @@ struct SettingsView: View {
             TerminalSettingsView()
         case .quickTerminal:
             QuickTerminalSettingsView()
+        case .globalWorkspace:
+            GlobalWorkspaceSettingsSection()
         case .browser:
             BrowserSettingsView()
         case .richInput:

--- a/Muxy/Views/Settings/Shared/SettingsCatalog.swift
+++ b/Muxy/Views/Settings/Shared/SettingsCatalog.swift
@@ -8,6 +8,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case appearance
     case terminal
     case quickTerminal
+    case globalWorkspace
     case browser
     case richInput
     case shortcuts
@@ -29,6 +30,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .appearance: "Interface"
         case .terminal: "Terminal"
         case .quickTerminal: "Quick Terminal"
+        case .globalWorkspace: "Global Workspace"
         case .browser: "Browser"
         case .richInput: "Composer"
         case .shortcuts: "Shortcuts"
@@ -50,6 +52,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .appearance: "macwindow"
         case .terminal: "terminal"
         case .quickTerminal: "bolt.horizontal.circle"
+        case .globalWorkspace: "rectangle.3.group"
         case .browser: "globe"
         case .richInput: "text.cursor"
         case .shortcuts: "keyboard"
@@ -570,6 +573,42 @@ enum SettingsCatalog {
             category: .terminal,
             section: "Background sessions",
             defaultValue: TerminalPersistentSessionPreferences.defaultIsEnabled
+        ),
+        SettingsCatalogItem(
+            key: GlobalWorkspacePreferences.enabledKey,
+            title: "Enable Global Workspace",
+            description: "Enables the system-wide Global Workspace trigger.",
+            category: .globalWorkspace,
+            section: "General",
+            defaultValue: GlobalWorkspacePreferences.defaultEnabled,
+            aliases: ["global hotkey", "workspace", "double command", "double control", "double option"]
+        ),
+        SettingsCatalogItem(
+            key: GlobalWorkspacePreferences.triggerKey,
+            title: "Global Workspace Trigger",
+            description: "Chooses the modifier double-tap gesture used to show Global Workspace.",
+            category: .globalWorkspace,
+            section: "Shortcut",
+            defaultValue: GlobalWorkspacePreferences.defaultTrigger.rawValue,
+            aliases: ["command", "control", "option", "modifier", "custom shortcut", "global shortcut", "hotkey"]
+        ),
+        SettingsCatalogItem(
+            key: GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
+            title: "Double Tap Interval",
+            description: "Sets the maximum interval between modifier taps in milliseconds.",
+            category: .globalWorkspace,
+            section: "Shortcut",
+            defaultValue: GlobalWorkspacePreferences.defaultDoubleTapIntervalMilliseconds,
+            aliases: ["timing", "milliseconds", "double tap"]
+        ),
+        SettingsCatalogItem(
+            key: GlobalWorkspacePreferences.toggleToHideKey,
+            title: "Toggle to Hide",
+            description: "Hides Global Workspace when its trigger is used while it is visible.",
+            category: .globalWorkspace,
+            section: "Shortcut",
+            defaultValue: GlobalWorkspacePreferences.defaultToggleToHide,
+            aliases: ["show only", "hide", "toggle"]
         ),
         SettingsCatalogItem(
             key: "shortcuts.app",

--- a/Tests/MuxyTests/Services/Keyboard/DoubleModifierTapDetectorTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/DoubleModifierTapDetectorTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("DoubleModifierTapDetector")
+struct DoubleModifierTapDetectorTests {
+    @Test("two complete modifier taps trigger once")
+    func twoCompleteTapsTrigger() {
+        var detector = DoubleModifierTapDetector()
+
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.0))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: false, otherModifierPressed: false, timestamp: 1.1))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.2))
+        expectTrigger(&detector, .modifierChange(modifierPressed: false, otherModifierPressed: false, timestamp: 1.3))
+    }
+
+    @Test("repeated press events do not replace releases")
+    func repeatedPressEventsDoNotTrigger() {
+        var detector = DoubleModifierTapDetector()
+
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.0))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.1))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.2))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: false, otherModifierPressed: false, timestamp: 1.3))
+    }
+
+    @Test("configured interval controls recognition")
+    func configuredIntervalControlsRecognition() {
+        var detector = DoubleModifierTapDetector(configuration: .init(maximumTapDuration: 0.3, maximumInterval: 0.5))
+
+        tap(&detector, startingAt: 1.0)
+        expectTap(&detector, startingAt: 1.45, triggers: true)
+    }
+
+    @Test("tap outside configured interval starts a new sequence")
+    func outsideIntervalStartsNewSequence() {
+        var detector = DoubleModifierTapDetector(configuration: .init(maximumTapDuration: 0.3, maximumInterval: 0.2))
+
+        tap(&detector, startingAt: 1.0)
+        expectTap(&detector, startingAt: 1.4, triggers: false)
+        expectTap(&detector, startingAt: 1.55, triggers: true)
+    }
+
+    @Test("key use blocks the held modifier")
+    func keyUseBlocksHeldModifier() {
+        var detector = DoubleModifierTapDetector()
+
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.0))
+        expectNoTrigger(&detector, .keyDown(modifierPressed: true, timestamp: 1.1))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: false, otherModifierPressed: false, timestamp: 1.2))
+        expectTap(&detector, startingAt: 1.3, triggers: false)
+        expectTap(&detector, startingAt: 1.5, triggers: true)
+    }
+
+    @Test("pointer use blocks the held modifier")
+    func pointerUseBlocksHeldModifier() {
+        var detector = DoubleModifierTapDetector()
+
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.0))
+        expectNoTrigger(&detector, .pointerDown(modifierPressed: true, timestamp: 1.1))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: false, otherModifierPressed: false, timestamp: 1.2))
+        expectTap(&detector, startingAt: 1.3, triggers: false)
+        expectTap(&detector, startingAt: 1.5, triggers: true)
+    }
+
+    @Test("another modifier resets and blocks the sequence")
+    func otherModifierBlocksSequence() {
+        var detector = DoubleModifierTapDetector()
+
+        tap(&detector, startingAt: 1.0)
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: true, timestamp: 1.2))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.25))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: false, otherModifierPressed: false, timestamp: 1.3))
+        expectTap(&detector, startingAt: 1.4, triggers: false)
+        expectTap(&detector, startingAt: 1.6, triggers: true)
+    }
+
+    @Test("long press does not count as a tap")
+    func longPressDoesNotCount() {
+        var detector = DoubleModifierTapDetector(configuration: .init(maximumTapDuration: 0.2, maximumInterval: 0.5))
+
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: true, otherModifierPressed: false, timestamp: 1.0))
+        expectNoTrigger(&detector, .modifierChange(modifierPressed: false, otherModifierPressed: false, timestamp: 1.3))
+        expectTap(&detector, startingAt: 1.4, triggers: false)
+        expectTap(&detector, startingAt: 1.6, triggers: true)
+    }
+
+    @Test("out-of-order timestamps reset safely")
+    func outOfOrderTimestampsReset() {
+        var detector = DoubleModifierTapDetector()
+
+        tap(&detector, startingAt: 2.0)
+        expectTap(&detector, startingAt: 1.0, triggers: false)
+        expectTap(&detector, startingAt: 1.2, triggers: true)
+    }
+
+    @discardableResult
+    private func tap(_ detector: inout DoubleModifierTapDetector, startingAt timestamp: TimeInterval) -> Bool {
+        _ = detector.process(.modifierChange(
+            modifierPressed: true,
+            otherModifierPressed: false,
+            timestamp: timestamp
+        ))
+        return detector.process(.modifierChange(
+            modifierPressed: false,
+            otherModifierPressed: false,
+            timestamp: timestamp + 0.1
+        ))
+    }
+
+    private func expectNoTrigger(
+        _ detector: inout DoubleModifierTapDetector,
+        _ input: DoubleModifierTapDetector.Input
+    ) {
+        let triggered = detector.process(input)
+        #expect(!triggered)
+    }
+
+    private func expectTrigger(
+        _ detector: inout DoubleModifierTapDetector,
+        _ input: DoubleModifierTapDetector.Input
+    ) {
+        let triggered = detector.process(input)
+        #expect(triggered)
+    }
+
+    private func expectTap(
+        _ detector: inout DoubleModifierTapDetector,
+        startingAt timestamp: TimeInterval,
+        triggers: Bool
+    ) {
+        #expect(tap(&detector, startingAt: timestamp) == triggers)
+    }
+}

--- a/Tests/MuxyTests/Services/Keyboard/GlobalWorkspacePreferencesTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/GlobalWorkspacePreferencesTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("GlobalWorkspacePreferences")
+struct GlobalWorkspacePreferencesTests {
+    @Test("defaults keep the global workspace opt-in")
+    func defaultsAreOptIn() throws {
+        let suiteName = "GlobalWorkspacePreferencesTests.defaults"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(!GlobalWorkspacePreferences.isEnabled(defaults: defaults))
+        #expect(GlobalWorkspacePreferences.trigger(defaults: defaults) == .doubleCommand)
+        #expect(GlobalWorkspacePreferences.doubleTapIntervalMilliseconds(defaults: defaults) == 300)
+        #expect(GlobalWorkspacePreferences.toggleToHide(defaults: defaults))
+    }
+
+    @Test(
+        "supported modifier triggers round trip",
+        arguments: [
+            GlobalWorkspaceTrigger.doubleCommand,
+            GlobalWorkspaceTrigger.doubleControl,
+            GlobalWorkspaceTrigger.doubleOption,
+        ]
+    )
+    func supportedModifierTriggersRoundTrip(trigger: GlobalWorkspaceTrigger) throws {
+        let suiteName = "GlobalWorkspacePreferencesTests.trigger.\(trigger.rawValue)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(trigger.rawValue, forKey: GlobalWorkspacePreferences.triggerKey)
+
+        #expect(GlobalWorkspacePreferences.trigger(defaults: defaults) == trigger)
+    }
+
+    @Test("custom shortcut is a supported trigger")
+    func customShortcutIsSupported() {
+        #expect(GlobalWorkspaceTrigger(rawValue: "custom") != nil)
+    }
+
+    @Test("custom shortcut persists with its trigger")
+    @MainActor
+    func customShortcutPersistsWithItsTrigger() throws {
+        let suiteName = "GlobalWorkspacePreferencesTests.customShortcut"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let shortcut = QuickTerminalShortcut.keyCombo(
+            KeyCombo(key: "a", command: true),
+            virtualKeyCode: 0
+        )
+        try GlobalWorkspacePreferences.setCustomShortcut(shortcut, defaults: defaults)
+
+        #expect(GlobalWorkspacePreferences.trigger(defaults: defaults) == .custom)
+        #expect(GlobalWorkspacePreferences.customShortcut(defaults: defaults) == shortcut)
+    }
+
+    @Test("invalid trigger falls back to double command")
+    func invalidTriggerFallsBack() throws {
+        let suiteName = "GlobalWorkspacePreferencesTests.invalidTrigger"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("unsupported", forKey: GlobalWorkspacePreferences.triggerKey)
+
+        #expect(GlobalWorkspacePreferences.trigger(defaults: defaults) == .doubleCommand)
+    }
+
+    @Test("stored interval is clamped")
+    func intervalIsClamped() throws {
+        let suiteName = "GlobalWorkspacePreferencesTests.interval"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(50, forKey: GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey)
+        #expect(
+            GlobalWorkspacePreferences.doubleTapIntervalMilliseconds(defaults: defaults)
+                == GlobalWorkspacePreferences.minimumDoubleTapIntervalMilliseconds
+        )
+
+        defaults.set(1500, forKey: GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey)
+        #expect(
+            GlobalWorkspacePreferences.doubleTapIntervalMilliseconds(defaults: defaults)
+                == GlobalWorkspacePreferences.maximumDoubleTapIntervalMilliseconds
+        )
+    }
+
+    @Test("reset removes all stored overrides")
+    func resetRemovesOverrides() throws {
+        let suiteName = "GlobalWorkspacePreferencesTests.reset"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: GlobalWorkspacePreferences.enabledKey)
+        defaults.set(GlobalWorkspaceTrigger.doubleOption.rawValue, forKey: GlobalWorkspacePreferences.triggerKey)
+        defaults.set(700, forKey: GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey)
+        defaults.set(false, forKey: GlobalWorkspacePreferences.toggleToHideKey)
+        defaults.set(
+            try JSONEncoder().encode(
+                QuickTerminalShortcut.keyCombo(KeyCombo(key: "a", command: true), virtualKeyCode: 0)
+            ),
+            forKey: GlobalWorkspacePreferences.customShortcutKey
+        )
+
+        GlobalWorkspacePreferences.resetToDefaults(defaults: defaults)
+
+        #expect(!GlobalWorkspacePreferences.isEnabled(defaults: defaults))
+        #expect(GlobalWorkspacePreferences.trigger(defaults: defaults) == .doubleCommand)
+        #expect(GlobalWorkspacePreferences.doubleTapIntervalMilliseconds(defaults: defaults) == 300)
+        #expect(GlobalWorkspacePreferences.toggleToHide(defaults: defaults))
+        #expect(GlobalWorkspacePreferences.customShortcut(defaults: defaults) == nil)
+    }
+}

--- a/Tests/MuxyTests/Services/Keyboard/GlobalWorkspaceShortcutServiceTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/GlobalWorkspaceShortcutServiceTests.swift
@@ -1,0 +1,57 @@
+import AppKit
+import Testing
+
+@testable import Muxy
+
+@Suite("GlobalWorkspaceShortcutService")
+@MainActor
+struct GlobalWorkspaceShortcutServiceTests {
+    @Test("custom shortcut uses the Carbon hot key backend")
+    func customShortcutUsesCarbonHotKeyBackend() throws {
+        let suiteName = "GlobalWorkspaceShortcutServiceTests.customShortcut"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: GlobalWorkspacePreferences.enabledKey)
+        try GlobalWorkspacePreferences.setCustomShortcut(
+            .keyCombo(KeyCombo(key: "space", command: true), virtualKeyCode: 49),
+            defaults: defaults
+        )
+
+        var doubleModifierCreated = false
+        var carbonHotKeyCreated = false
+        let service = GlobalWorkspaceShortcutService(
+            defaults: defaults,
+            doubleModifierBackendFactory: { _, _ in
+                doubleModifierCreated = true
+                return GlobalWorkspaceTestBackend(state: .systemWide)
+            },
+            carbonHotKeyBackendFactory: { _, _ in
+                carbonHotKeyCreated = true
+                return GlobalWorkspaceTestBackend(state: .carbonHotKey)
+            }
+        )
+
+        service.start()
+
+        #expect(carbonHotKeyCreated)
+        #expect(!doubleModifierCreated)
+        #expect(service.monitoringState == .carbonHotKey)
+
+        service.stop()
+    }
+}
+
+@MainActor
+private final class GlobalWorkspaceTestBackend: QuickTerminalShortcutBackend {
+    let monitoringState: QuickTerminalShortcutMonitoringState
+
+    init(state: QuickTerminalShortcutMonitoringState) {
+        monitoringState = state
+    }
+
+    func start(trigger _: @escaping @MainActor () -> Void) throws {}
+
+    func stop() {}
+}

--- a/Tests/MuxyTests/Services/Keyboard/ShortcutContextTests.swift
+++ b/Tests/MuxyTests/Services/Keyboard/ShortcutContextTests.swift
@@ -12,8 +12,14 @@ struct ShortcutContextTests {
         return window
     }
 
-    @Test("non-main window only exposes the global scope")
-    func nonMainWindowScopes() {
+    private func globalWorkspaceWindow() -> NSWindow {
+        let window = NSWindow()
+        window.identifier = ShortcutContext.globalWorkspaceWindowIdentifier
+        return window
+    }
+
+    @Test("non-workspace window only exposes the global scope")
+    func nonWorkspaceWindowScopes() {
         let scopes = ShortcutContext.activeScopes(for: NSWindow(), isTerminalFocused: true)
         #expect(scopes == [.global])
     }
@@ -38,6 +44,24 @@ struct ShortcutContextTests {
             isBrowserFocused: true
         )
         #expect(scopes == [.global, .mainWindow, .browser])
+    }
+
+    @Test("global workspace exposes main workspace shortcut scopes")
+    func globalWorkspaceScopes() {
+        let scopes = ShortcutContext.activeScopes(
+            for: globalWorkspaceWindow(),
+            isTerminalFocused: true,
+            isBrowserFocused: true
+        )
+        #expect(scopes == [.global, .mainWindow, .terminal, .browser])
+    }
+
+    @Test("global workspace identity remains distinguishable")
+    func globalWorkspaceIdentity() {
+        let window = globalWorkspaceWindow()
+        #expect(ShortcutContext.isMainWindow(window))
+        #expect(ShortcutContext.isGlobalWorkspaceWindow(window))
+        #expect(!ShortcutContext.isGlobalWorkspaceWindow(mainWindow()))
     }
 
     @Test("find action is gated to the terminal scope")

--- a/Tests/MuxyTests/Services/Persistence/GlobalWorkspaceSettingsJSONTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/GlobalWorkspaceSettingsJSONTests.swift
@@ -1,0 +1,165 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import Muxy
+
+@Suite("Global Workspace JSON settings", .serialized)
+@MainActor
+struct GlobalWorkspaceSettingsJSONTests {
+    @Test
+    func settingsPersistThroughJSON() throws {
+        let keys = [
+            GlobalWorkspacePreferences.enabledKey,
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
+            GlobalWorkspacePreferences.toggleToHideKey,
+        ]
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
+        defer { snapshot.restore() }
+
+        try SettingsJSONStore.saveUserSettingsText("""
+        {
+          "\(GlobalWorkspacePreferences.enabledKey)": true,
+          "\(GlobalWorkspacePreferences.triggerKey)": "doubleOption",
+          "\(GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey)": 450,
+          "\(GlobalWorkspacePreferences.toggleToHideKey)": false
+        }
+        """)
+
+        #expect(GlobalWorkspacePreferences.isEnabled())
+        #expect(GlobalWorkspacePreferences.trigger() == .doubleOption)
+        #expect(GlobalWorkspacePreferences.doubleTapIntervalMilliseconds() == 450)
+        #expect(!GlobalWorkspacePreferences.toggleToHide())
+    }
+
+    @Test
+    func customShortcutPersistsThroughJSON() throws {
+        let keys = [
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.customShortcutKey,
+        ]
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
+        defer { snapshot.restore() }
+
+        try SettingsJSONStore.saveUserSettingsText(#"""
+        {
+          "shortcuts.globalWorkspace": {
+            "trigger": "custom",
+            "customShortcut": {
+              "type": "keyCombo",
+              "keyCombo": { "key": "space", "modifiers": 1048576 },
+              "virtualKeyCode": 49
+            }
+          }
+        }
+        """#)
+
+        #expect(GlobalWorkspacePreferences.trigger() == .custom)
+        #expect(
+            GlobalWorkspacePreferences.customShortcut()
+                == .keyCombo(KeyCombo(key: "space", command: true), virtualKeyCode: 49)
+        )
+    }
+
+    @Test
+    func rejectsCustomShortcutWithoutKeyCombo() throws {
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText(#"""
+            {
+              "shortcuts.globalWorkspace": {
+                "trigger": "custom"
+              }
+            }
+            """#)
+        }
+    }
+
+    @Test
+    func rejectsCustomShortcutConflictingWithImportedQuickTerminalShortcut() throws {
+        let modifiers = NSEvent.ModifierFlags.command.rawValue
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText(#"""
+            {
+              "shortcuts.quickTerminal": {
+                "type": "keyCombo",
+                "keyCombo": { "key": "space", "modifiers": \#(modifiers) },
+                "virtualKeyCode": 49
+              },
+              "shortcuts.globalWorkspace": {
+                "trigger": "custom",
+                "customShortcut": {
+                  "type": "keyCombo",
+                  "keyCombo": { "key": "space", "modifiers": \#(modifiers) },
+                  "virtualKeyCode": 49
+                }
+              }
+            }
+            """#)
+        }
+    }
+
+    @Test
+    func rejectsUnsupportedTrigger() throws {
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: [GlobalWorkspacePreferences.triggerKey])
+        defer { snapshot.restore() }
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "\(GlobalWorkspacePreferences.triggerKey)": "unsupported"
+            }
+            """)
+        }
+    }
+
+    @Test
+    func rejectsOutOfRangeInterval() throws {
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(
+            keys: [GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey]
+        )
+        defer { snapshot.restore() }
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "\(GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey)": 5000
+            }
+            """)
+        }
+    }
+}
+
+private struct GlobalWorkspaceSettingsJSONSnapshot {
+    let data: Data?
+    let defaults: [String: Any]
+
+    @MainActor
+    static func capture(keys: [String]) -> GlobalWorkspaceSettingsJSONSnapshot {
+        GlobalWorkspaceSettingsJSONSnapshot(
+            data: try? Data(contentsOf: SettingsJSONStore.userSettingsURL),
+            defaults: Dictionary(uniqueKeysWithValues: keys.map { key in
+                (key, UserDefaults.standard.object(forKey: key) ?? NSNull())
+            })
+        )
+    }
+
+    @MainActor
+    func restore() {
+        if let data {
+            try? data.write(to: SettingsJSONStore.userSettingsURL, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: SettingsJSONStore.userSettingsURL)
+        }
+
+        for (key, value) in defaults {
+            if value is NSNull {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else {
+                UserDefaults.standard.set(value, forKey: key)
+            }
+        }
+        GlobalWorkspaceShortcutService.shared.refresh()
+    }
+}

--- a/Tests/MuxyTests/Services/Persistence/GlobalWorkspaceSettingsJSONTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/GlobalWorkspaceSettingsJSONTests.swift
@@ -63,6 +63,34 @@ struct GlobalWorkspaceSettingsJSONTests {
     }
 
     @Test
+    func shortcutAndIndependentPreferencesPersistThroughJSON() throws {
+        let keys = [
+            GlobalWorkspacePreferences.enabledKey,
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
+            GlobalWorkspacePreferences.toggleToHideKey,
+        ]
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
+        defer { snapshot.restore() }
+
+        try SettingsJSONStore.saveUserSettingsText(#"""
+        {
+          "shortcuts.globalWorkspace": {
+            "trigger": "doubleCommand"
+          },
+          "muxy.globalHotkey.enabled": true,
+          "muxy.globalHotkey.doubleTapIntervalMilliseconds": 450,
+          "muxy.globalHotkey.toggleToHide": false
+        }
+        """#)
+
+        #expect(GlobalWorkspacePreferences.trigger() == .doubleCommand)
+        #expect(GlobalWorkspacePreferences.isEnabled())
+        #expect(GlobalWorkspacePreferences.doubleTapIntervalMilliseconds() == 450)
+        #expect(!GlobalWorkspacePreferences.toggleToHide())
+    }
+
+    @Test
     func rejectsCustomShortcutWithoutKeyCombo() throws {
         #expect(throws: SettingsJSONError.self) {
             try SettingsJSONStore.saveUserSettingsText(#"""

--- a/Tests/MuxyTests/Services/Persistence/GlobalWorkspaceSettingsJSONTests.swift
+++ b/Tests/MuxyTests/Services/Persistence/GlobalWorkspaceSettingsJSONTests.swift
@@ -14,6 +14,7 @@ struct GlobalWorkspaceSettingsJSONTests {
             GlobalWorkspacePreferences.triggerKey,
             GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
             GlobalWorkspacePreferences.toggleToHideKey,
+            GlobalWorkspacePreferences.customShortcutKey,
         ]
         let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
         defer { snapshot.restore() }
@@ -69,6 +70,7 @@ struct GlobalWorkspaceSettingsJSONTests {
             GlobalWorkspacePreferences.triggerKey,
             GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
             GlobalWorkspacePreferences.toggleToHideKey,
+            GlobalWorkspacePreferences.customShortcutKey,
         ]
         let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
         defer { snapshot.restore() }
@@ -88,6 +90,82 @@ struct GlobalWorkspaceSettingsJSONTests {
         #expect(GlobalWorkspacePreferences.isEnabled())
         #expect(GlobalWorkspacePreferences.doubleTapIntervalMilliseconds() == 450)
         #expect(!GlobalWorkspacePreferences.toggleToHide())
+    }
+
+    @Test
+    func nonCustomTriggerClearsStoredCustomShortcut() throws {
+        let keys = [
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.customShortcutKey,
+        ]
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
+        defer { snapshot.restore() }
+
+        try GlobalWorkspacePreferences.setCustomShortcut(
+            .keyCombo(KeyCombo(key: "space", command: true), virtualKeyCode: 49)
+        )
+
+        try SettingsJSONStore.saveUserSettingsText("""
+        {
+          "\(GlobalWorkspacePreferences.triggerKey)": "doubleOption"
+        }
+        """)
+
+        #expect(GlobalWorkspacePreferences.trigger() == .doubleOption)
+        #expect(GlobalWorkspacePreferences.customShortcut() == nil)
+    }
+
+    @Test
+    func rejectsTriggerOnlyCustomImport() throws {
+        let keys = [
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.customShortcutKey,
+        ]
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
+        defer { snapshot.restore() }
+
+        UserDefaults.standard.set(GlobalWorkspaceTrigger.doubleCommand.rawValue, forKey: GlobalWorkspacePreferences.triggerKey)
+        UserDefaults.standard.removeObject(forKey: GlobalWorkspacePreferences.customShortcutKey)
+
+        #expect(throws: SettingsJSONError.self) {
+            try SettingsJSONStore.saveUserSettingsText("""
+            {
+              "\(GlobalWorkspacePreferences.triggerKey)": "custom"
+            }
+            """)
+        }
+    }
+
+    @Test
+    func syncedSettingsOmitStaleCustomShortcutForNonCustomTrigger() throws {
+        let keys = [
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.customShortcutKey,
+        ]
+        let snapshot = GlobalWorkspaceSettingsJSONSnapshot.capture(keys: keys)
+        defer { snapshot.restore() }
+
+        try GlobalWorkspacePreferences.setCustomShortcut(
+            .keyCombo(KeyCombo(key: "space", command: true), virtualKeyCode: 49)
+        )
+        UserDefaults.standard.set(
+            GlobalWorkspaceTrigger.doubleOption.rawValue,
+            forKey: GlobalWorkspacePreferences.triggerKey
+        )
+
+        #expect(SettingsJSONStore.syncUserSettingsFileWithCurrentSettings() != .failed)
+
+        let data = try Data(contentsOf: SettingsJSONStore.userSettingsURL)
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let dictionary = object as? [String: Any],
+              let shortcut = dictionary[GlobalWorkspacePreferences.jsonShortcutKey] as? [String: Any]
+        else {
+            #expect(Bool(false))
+            return
+        }
+
+        #expect(shortcut["trigger"] as? String == GlobalWorkspaceTrigger.doubleOption.rawValue)
+        #expect(shortcut["customShortcut"] == nil)
     }
 
     @Test

--- a/Tests/MuxyTests/Views/MainWindowTests.swift
+++ b/Tests/MuxyTests/Views/MainWindowTests.swift
@@ -2,6 +2,28 @@ import CoreGraphics
 import Testing
 @testable import Muxy
 
+@Suite("Main window full screen notification policy")
+struct MainWindowFullScreenNotificationPolicyTests {
+    @Test @MainActor func acceptsOnlyTheHostingWindowNotification() {
+        #expect(MainWindowFullScreenNotificationPolicy.shouldApply(
+            sourceIdentifier: ShortcutContext.mainWindowIdentifier,
+            targetIdentifier: ShortcutContext.mainWindowIdentifier
+        ))
+        #expect(!MainWindowFullScreenNotificationPolicy.shouldApply(
+            sourceIdentifier: ShortcutContext.globalWorkspaceWindowIdentifier,
+            targetIdentifier: ShortcutContext.mainWindowIdentifier
+        ))
+        #expect(MainWindowFullScreenNotificationPolicy.shouldApply(
+            sourceIdentifier: ShortcutContext.globalWorkspaceWindowIdentifier,
+            targetIdentifier: ShortcutContext.globalWorkspaceWindowIdentifier
+        ))
+        #expect(!MainWindowFullScreenNotificationPolicy.shouldApply(
+            sourceIdentifier: nil,
+            targetIdentifier: ShortcutContext.mainWindowIdentifier
+        ))
+    }
+}
+
 @Suite("Floating panel outside click decision")
 struct FloatingPanelOutsideClickDecisionTests {
     private let panelBounds = CGRect(x: 0, y: 0, width: 320, height: 240)

--- a/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
+++ b/Tests/MuxyTests/Views/Settings/Shared/SettingsCatalogTests.swift
@@ -88,10 +88,32 @@ struct SettingsCatalogTests {
     }
 
     @Test
-    func quickTerminalSettingsAreSearchableAndJSONEditable() {
+    func quickTerminalAndGlobalWorkspaceAreSiblingCategories() throws {
+        let quickTerminalIndex = try #require(SettingsCatalog.categories.firstIndex(of: .quickTerminal))
+        let globalWorkspaceIndex = try #require(SettingsCatalog.categories.firstIndex(of: .globalWorkspace))
+
+        #expect(globalWorkspaceIndex == quickTerminalIndex + 1)
+    }
+
+    @Test
+    func quickTerminalAndGlobalWorkspaceSettingsAreSearchableAndJSONEditable() {
         let quickTerminalItems = SettingsCatalog.items.filter { $0.category == .quickTerminal }
+        let globalWorkspaceItems = SettingsCatalog.items.filter { $0.category == .globalWorkspace }
+        let globalWorkspaceKeys = [
+            GlobalWorkspacePreferences.enabledKey,
+            GlobalWorkspacePreferences.triggerKey,
+            GlobalWorkspacePreferences.doubleTapIntervalMillisecondsKey,
+            GlobalWorkspacePreferences.toggleToHideKey,
+        ]
 
         #expect(quickTerminalItems.allSatisfy { $0.category == .quickTerminal })
+        #expect(globalWorkspaceItems.allSatisfy { $0.category == .globalWorkspace })
+        #expect(globalWorkspaceKeys.allSatisfy { key in
+            globalWorkspaceItems.contains { $0.key == key }
+        })
+        #expect(!SettingsCatalog.items.contains { item in
+            item.category != .globalWorkspace && globalWorkspaceKeys.contains(item.key)
+        })
         #expect(quickTerminalItems.contains { $0.key == QuickTerminalPreferences.enabledKey })
         #expect(quickTerminalItems.contains { $0.key == QuickTerminalSizePreferences.widthKey })
         #expect(quickTerminalItems.contains { $0.key == QuickTerminalSizePreferences.heightKey })
@@ -120,6 +142,11 @@ struct SettingsCatalogTests {
         })
         #expect(SettingsCatalog.sectionMatches(query: "terminal size", category: .quickTerminal, section: "Size"))
         #expect(SettingsCatalog.sectionMatches(query: "vibrancy", category: .quickTerminal, section: "Appearance"))
+        #expect(SettingsCatalog.sectionMatches(query: "double tap", category: .globalWorkspace, section: "Shortcut"))
+        #expect(SettingsCatalog.matchingItems(query: "custom shortcut").contains {
+            $0.category == .globalWorkspace && $0.key == GlobalWorkspacePreferences.triggerKey
+        })
+        #expect(SettingsCatalog.sectionMatches(query: "enable", category: .globalWorkspace, section: "General"))
     }
 
     @Test
@@ -356,6 +383,7 @@ struct SettingsCatalogTests {
     func settingsRoutesRoundTripStoredIDs() throws {
         #expect(SettingsRoute(storedID: "builtin.terminal") == .builtin(.terminal))
         #expect(SettingsRoute(storedID: "builtin.quickTerminal") == .builtin(.quickTerminal))
+        #expect(SettingsRoute(storedID: "builtin.globalWorkspace") == .builtin(.globalWorkspace))
         #expect(SettingsRoute(storedID: "ext.com.example.tool") == .ext("com.example.tool"))
         #expect(SettingsRoute(storedID: "builtin.missing") == nil)
         #expect(SettingsRoute(storedID: "ext.") == nil)

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -64,6 +64,10 @@ Transparency and vibrancy apply only to the terminal workspace while preserving 
 
 The quick terminal is available while Muxy is running. Closing Muxy's main window still follows the existing quit behavior.
 
+## Global workspace
+
+Global Workspace is a separate Settings page from Quick Terminal. Enable it in **Settings → Global Workspace**, then choose a double Command, Control, or Option trigger or record a custom conventional shortcut. Double-modifier triggers need Input Monitoring to work system-wide; recorded shortcuts do not. The double-tap interval and whether the trigger toggles a visible workspace are configurable there.
+
 ## App transparency
 
 **Settings → Interface → Appearance** brings the same transparency and vibrancy controls to the main window: terminal panes, the top bar, and the status bar. Transparency ranges from 0–55% and defaults to 0, keeping the window opaque until it is raised. Vibrancy mixes the native macOS material from 0–100% behind the transparent background; because the main window itself stays opaque, the desktop shows through the vibrancy material and the effect needs a vibrancy above zero. The sidebar keeps its own vibrancy toggle.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -167,6 +167,18 @@ The gear button in the quick terminal opens an in-place settings popover with th
 
 When macOS Reduce Transparency or Increase Contrast is enabled, Muxy temporarily renders the quick terminal as opaque and unblurred without changing the saved glass settings.
 
+## Global workspace
+
+Open **Settings → Global Workspace** to configure the full Muxy workspace shortcut independently of Quick Terminal:
+
+- **Enable Global Workspace** controls the feature and is off by default.
+- Choose **Double Command**, **Double Control**, or **Double Option**, or record a custom Command-, Control-, or Option-based shortcut.
+- Double-modifier triggers require **System Settings → Privacy & Security → Input Monitoring** for use outside Muxy. Recorded conventional shortcuts do not.
+- **Double Tap Interval** sets the maximum time between taps from 100–1000 ms.
+- **Toggle to Hide** controls whether using the trigger while the workspace is visible hides it.
+
+The setting values are stored as `muxy.globalHotkey.enabled`, `muxy.globalHotkey.trigger`, `muxy.globalHotkey.doubleTapIntervalMilliseconds`, and `muxy.globalHotkey.toggleToHide`. A recorded shortcut is stored in `shortcuts.globalWorkspace` as a `customShortcut` key-combo object.
+
 ## App transparency
 
 Open **Settings → Interface → Appearance** to make the main window's workspace transparent:


### PR DESCRIPTION
## Summary

Adds an optional Global Workspace: a dedicated, globally accessible full Muxy workspace that can be shown or hidden independently from the main app window.

Unlike Quick Terminal, which provides a lightweight single-terminal surface, Global Workspace hosts the full `MainWindow` experience with independent workspace state, including projects, tabs, panes, sidebar, and related workspace UI, together with overlay-fullscreen presentation.

Global Workspace is configured from **Settings → Global Workspace**.

## Changes

### Behavior

- Show or hide Global Workspace from any app using:
  - Double Command
  - Double Control
  - Double Option
  - a custom global key combination
- Configurable modifier double-tap interval
- Optional toggle-to-hide behavior
- Restores focus to the previously active application when hidden
- Keeps Global Workspace UI and workspace state independent from the main Muxy window
- Supports normal-window and overlay-fullscreen presentation
- Preserves overlay-fullscreen state across hide/show
- Can be presented across macOS Spaces and over fullscreen apps

### Quick Terminal vs. Global Workspace

Quick Terminal remains the lightweight, single-terminal workflow for fast commands.

Global Workspace provides a separate full-workspace workflow for users who want projects, tabs, panes, sidebar, and the rest of the Muxy workspace available globally without changing the main-window workspace state.

The two features share shortcut infrastructure where appropriate while retaining separate controllers, state, and lifecycles.

### Shortcut integration

This implementation is rebuilt on Muxy’s current shortcut architecture rather than carrying forward the original standalone hotkey implementation:

- reusable double-modifier backend for modifier-only gestures
- existing Carbon hotkey backend for custom global key combinations
- separate Quick Terminal and Global Workspace shortcut services
- existing Quick Terminal behavior remains unchanged

### Implementation

- dedicated `GlobalWorkspaceController` and workspace panel
- dedicated `AppState` and workspace persistence for Global Workspace
- shared application stores and services rather than duplicating application source-of-truth state
- reuse of `MainWindow` for the full workspace UI
- top-level **Settings → Global Workspace** configuration
- `settings.json` validation and persistence support
- overlay-fullscreen presentation that remains on the current Space
- overlay-fullscreen state preserved across hide/show

## Testing

- [x] `scripts/checks.sh` passes
- [x] Tested manually on macOS

Additional coverage and validation includes:

- unit coverage for Global Workspace preferences and shortcut behavior
- double-modifier backend tests
- Settings catalog and settings persistence coverage
- `settings.json` validation and persistence coverage
- global show/hide from another application
- focus restoration after hiding
- Double Command, Double Control, and Double Option triggers
- custom global shortcuts
- independent Global Workspace and main-window workspace state
- normal-window presentation
- overlay-fullscreen presentation
- overlay-fullscreen state preserved across hide/show
- full workspace interaction including projects, tabs, panes, sidebar, and terminal
- GitHub Actions full check suite, including formatting, strict linting, test builds, and the complete test suite

## Screenshots

The recording shows Global Workspace being opened from another application, hidden with focus restored to the previous application, switched to overlay fullscreen, and shown again with the fullscreen state preserved.

<img width="1920" height="1080" alt="muxy" src="https://github.com/user-attachments/assets/8260cf94-38f1-49d9-9575-6430c4f30883" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Global Workspace, a floating workspace available across apps and spaces.
  * Added configurable double-tap modifier and custom shortcut triggers.
  * Added controls for timing, visibility, full-screen behavior, and input-monitoring access.
  * Added dedicated settings with persisted configuration and shortcut conflict validation.

* **Bug Fixes**
  * Improved window identity, focus restoration, layout persistence, and full-screen notification handling.

* **Documentation**
  * Added setup and usage guidance for Global Workspace, shortcuts, permissions, and visibility controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->