### PR TITLE
Harden one-way Swift profile migration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            GhosttyKit.xcframework
-            GhosttyKit/ghostty.h
-            Muxy/Resources/ghostty
-            Muxy/Resources/terminfo
+            vendor/GhosttyKit.xcframework
+            resources/ghostty
+            resources/terminfo
           key: ghosttykit-${{ env.GHOSTTY_TAG }}
 
       - name: Setup GhosttyKit

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,26 +125,35 @@ classDiagram
 
 ```mermaid
 flowchart LR
-    subgraph disk["~/Library/Application Support/Muxy"]
-        S["settings.json / ui-scale.json"]
-        K["keybindings.json / command-shortcuts.json"]
-        W["workspaces.json / project-groups.json"]
-        G["ghostty.conf / logos/"]
+    SWIFT["Retained Swift profile\nApp Support + NSUserDefaults"]
+    MIG["One-way migration\nallowlist + destination wins"]
+    subgraph release["Release: ~/.muxy"]
+        RF["stores + ghostty.conf"]
+        RP["preferences.json"]
+        RS["swift-profile-migration.json"]
     end
-    UD["NSUserDefaults\n(muxy.* keys, projects)"]
-    PY[".muxy/layouts/*.yml\n(per project)"]
+    subgraph debug["Debug: ~/.muxy-dev"]
+        DF["stores + ghostty.conf"]
+        DP["preferences.json"]
+    end
+    PY["project .muxy/layouts/*.yml"]
     GIT["git CLI\n(worktrees, status)"]
 
-    core["muxy-core\nprefs + stores\n(atomic writes)"] <--> disk
-    core <--> UD
+    SWIFT --> MIG
+    MIG --> release
+    core["muxy-core\nprefs + stores\n(atomic writes)"] <--> release
+    core <--> debug
     api["muxy-api"] --> PY
     api --> GIT
-    api -- "watcher (notify)" --> disk
+    api -- "watcher (notify)" --> release
+    api -- "watcher (notify)" --> debug
     api -- "truth::refresh_truth" --> GIT
 ```
 
-- All file writes go through `store::persistence` (atomic temp-file rename, `0600` for private data).
-- `muxy-api::truth` recomputes per-project git facts (repo? worktrees? labels) off the UI thread; `watcher` re-triggers on file changes.
+- Release reads the Swift profile only while its versioned migration state is pending. Completed, source-missing, and abandoned outcomes do not inspect it again.
+- Normal preference reads and writes use private atomic `preferences.json`. `NSUserDefaults` is migration-only.
+- File writes go through `store::persistence`; migration copies use unique destination-side temporary files and no-replace publication.
+- `muxy-api::truth` recomputes per-project git facts off the UI thread; `watcher` retriggers on file changes.
 
 ## Development and production policy
 
@@ -162,16 +171,16 @@ flowchart LR
 
 Each binary invokes `build_mode!` locally. No runtime environment variable selects development mode.
 
-| State | Debug and release |
-|---|---|
-| App Support and `settings.json` | Shared |
-| Defaults domain and non-mobile preferences | Shared |
-| Ghostty configuration | Shared |
-| Socket, session, and hook names | Isolated by policy |
-| Mobile keys | Isolated by policy |
-| Acceptance tests | Reuse `com.muxy.tests` and `target/test-verification` |
+| State | Debug | Release | Staged test |
+|---|---|---|---|
+| Bundle identity | `com.muxy.dev` | `com.muxy.app` | `com.muxy.tests` |
+| Root | `~/.muxy-dev` | `~/.muxy` | Injected ignored root |
+| Preferences | Root-local `preferences.json` | Root-local `preferences.json` | Root-local `preferences.json` |
+| Ghostty configuration | Root-local | Root-local | Root-local |
+| Swift import | Never | One bounded migration | Injected synthetic source only |
+| Runtime names | Development policy | Production policy | Selected build policy |
 
-`settings.json` keeps both mobile namespaces. The active profile updates its three keys and preserves the inactive three exactly. P1 defines and verifies these contracts but does not start sockets, daemons, hooks, provider installers, or the mobile server.
+Debug and release select their roots by compile-time build mode. Environment overrides are honored only by recognized test executables. Mobile runtime implementation remains assigned to P12.
 
 ## App wiring (muxy binary)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,10 +3292,10 @@ name = "muxy-core"
 version = "0.1.0"
 dependencies = [
  "image",
+ "libc",
  "log",
  "objc2",
  "objc2-foundation",
- "plist",
  "resvg",
  "serde",
  "serde_json",

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,7 +4,7 @@
 
 Muxy 1.x is a Swift/SwiftUI macOS app — far more than a terminal: terminal emulator (libghostty) + project/worktree manager + JS extension platform + embedded browser + mobile WebSocket server + AI-agent hook system + tmux-like persistent sessions. The Rust + GPUI rewrite is now in this repository on the `2.x` branch, with the 8-crate workspace at the branch root and the Swift implementation retained alongside it as the parity reference. The architecture refactor is **fully complete** and mechanically enforced by `scripts/check.sh`. The old phase plans are consumed or superseded; this document is the single roadmap for finishing the rewrite. It has passed one adversarial review pass; corrections from that review are folded in.
 
-**Goal:** Muxy 2.0 for macOS — a drop-in replacement for the Swift app. Users download 2.x, replace the app, and everything just works: same config files, same storage, same sockets, same CLI, zero migration. Linux comes after (this roadmap only keeps it compiling and launching).
+**Goal:** Muxy 2.0 for macOS replaces the Swift app in `/Applications`. Release performs one bounded, source-preserving import into `~/.muxy`, then Rust owns its storage. Debug owns `~/.muxy-dev`. Linux comes after, while this roadmap keeps it compiling and launching.
 
 ## Decisions of Record (from interview)
 
@@ -24,12 +24,12 @@ Muxy 1.x is a Swift/SwiftUI macOS app — far more than a terminal: terminal emu
 | 12 | **Dogfood-first ordering** — enablers → daily-driver parity → platform → outer ring → release machinery. |
 | 13 | **Repo workflow:** the active rewrite repository is `~/Projects/muxy-2.x` on branch `2.x`. The Rust workspace lives at the branch root alongside the retained Swift parity reference. Feature branches PR into `2.x`; `~/Projects/muxy` remains the 1.x working copy. |
 | 14 | **Release gate:** beta-channel soak + full parity checklist (details in Verification). |
+| 15 | **Storage cutover:** release imports the retained Swift profile once into `~/.muxy`; debug uses `~/.muxy-dev`; existing Rust data wins and the Swift source remains untouched. |
 
 ## Open decisions (surfaced by adversarial review — resolve at owning phase's planning)
 
 | Phase | Decision |
 |---|---|
-| P2.5 | Fidelity level of `settings.json` ↔ defaults sync: genuinely live (file watcher + defaults observation like 1.x) or documented startup/write-time sync. 1.x is live; anything less must be proven safe under coexistence. |
 | P10 | Fate of the **in-process** command-script runner (`ExtensionScriptRunner`, a second JSC embed inside the app with synchronous `__muxyDispatch`): keep in-process (breaks "JSC only in host" rule, adds JIT entitlement to main binary) vs move to the host process (changes command-script semantics). |
 | P14 | 1.x latent bug: `config-export` is missing from `verbNames` so `muxy config export` gets no reply in 1.x. Reproduce or fix. |
 | P15 | 1.x sunset specifics: contents of the final 1.x release / frozen appcast, beta-channel (rolling `beta-channel` tag) cutover, and whether the Homebrew tap continues. |
@@ -66,7 +66,7 @@ flowchart TD
 **Working today** (~43.6k LOC, 303 unit tests):
 - Terminal stack: libghostty FFI → host → NSView (IME, CJK fonts, mouse, pressure) → GPUI compositing; shell launch with startup commands; OSC titles/PWD/progress; search; overlay scrollbar; clipboard/paste/close confirmations.
 - Tabs/splits: full two-level tree (top-level tab groups + per-group split trees), drag/dock/reorder, pin/color/icon/rename, maximize, directional focus.
-- Persistence **aimed at** 1.x compatibility, with known hardening debt (see P2.5): `workspaces.json` has lossless raw passthrough; `projects.json` round-trip test exists but silently skips without a real profile; `projects.json`/`worktrees/*.json` currently **drop unknown Swift fields on write**; three different serializers are in use (hand-rolled Foundation writer, `to_vec_pretty`, compact `to_vec`) so byte-shape is not yet uniform; the 68-key settings mirror syncs at startup/own-writes only (not live), 5 composite keys + 3 `editor.*` keys are write-broken via the JSON editor; startup reads bypass cfprefsd via direct bundle-domain plist reads. Defaults and filesystem tests are isolated from production state.
+- Persistence uses Rust-owned profile roots. Release imports the current allowlist once from `~/Library/Application Support/Muxy` into `~/.muxy`; debug uses `~/.muxy-dev`; staged tests inject ignored roots. Existing destination data wins, the Swift source is never modified, and terminal migration outcomes never inspect it again. Preferences use private atomic `preferences.json`; only an eligible pending macOS release migration reads the production `NSUserDefaults` suite through Foundation.
 - Projects/groups/worktrees (read + switch), git truth off-thread, FS watcher, project picker, omnibox (6 scopes), repo layouts (`.muxy/layouts/*`), 490 bundled themes + paired light/dark, keybindings (54 of 1.x's 68 bindable actions modelled + unmodelled passthrough — parity audit needed), chorded command shortcuts + editor UI, settings modal (16 categories + JSON editor), native menu bar, app bundling/signing scripts (ad-hoc, single-binary only).
 
 ## Gap Map — 1.x feature vs 2.x status
@@ -75,8 +75,8 @@ flowchart TD
 |---|---|
 | Terminal emulation, search, scrollbar, confirmations | ✅ done (CJK temp-conf machinery needs parity audit) |
 | Tabs/splits/workspace persistence | ✅ done |
-| Projects/groups/picker/omnibox/layouts/themes/keybindings/settings UI | ✅ done (some inert buttons; compat hardening pending) |
-| Compat hardening (fixtures, raw passthrough, uniform serializer, live sync) | ❌ P2.5 |
+| Projects/groups/picker/omnibox/layouts/themes/keybindings/settings UI | ✅ done (some inert buttons; later feature parity audits remain) |
+| One-way Swift profile migration and Rust-owned storage | ✅ P2.5 complete |
 | Worktree **create/remove**, path templates, setup/teardown hooks | ❌ missing (read/switch only) |
 | Titlebar buttons, welcome New Tab, sort, nav arrows, misc inert settings actions | ❌ inert |
 | Git UI (changes/branch/PR popovers, commit/push/pull, gh, AI commit/PR text) | ❌ missing |
@@ -114,7 +114,7 @@ flowchart LR
         P0["P0 Repo migration ✓\n2.x branch + local gates"]
         P1["P1 Dev/prod isolation ✓\ncontracts + settings"]
         P2["P2 muxy.sock server +\ndispatcher core + CLI compat ✓"]
-        P25["P2.5 Compat hardening\n(fixtures, passthrough, serializer)"]
+        P25["P2.5 One-way Swift import\nRust-owned profile roots"]
     end
     subgraph B["Stage B — Daily driver"]
         P3["P3 Chrome wiring +\nworktree create/hooks"]
@@ -156,17 +156,17 @@ Each phase gets its own detailed plan (grill-me per task) before implementation.
 The active rewrite repository is `~/Projects/muxy-2.x` on branch `2.x`. The 8-crate Rust workspace is at the repository root alongside the retained Swift implementation, which remains the parity reference while the rewrite proceeds. Feature branches target `2.x`; `~/Projects/muxy` remains the 1.x working copy. Local enforcement is provided by `scripts/check.sh`, `scripts/build-app.sh`, and `scripts/verify-bundle.sh`. New phases extend crate-boundary and bundle gates when they add crates or executables. The existing 1.x workflows remain in the repository, while Rust macOS/Linux CI is deliberately deferred to P15 so it lands before release.
 *Acceptance: complete.* The active repository and `2.x` workflow are established, the Rust workspace builds from the branch root, and local quality gates are available.
 
-**P1 — Dev/prod isolation. COMPLETE for contracts and current settings.**
-`muxy-core::environment` owns compile-time mode selection, socket/session/hook names, mobile keys and defaults, and typed provider-config mutation policy. App Support, `settings.json`, standard defaults, Ghostty configuration, and non-mobile preferences remain shared. Debug and release mobile namespaces coexist in the shared JSON file, and inactive values survive sync, writes, Apply, and Reset. Isolated acceptance runs permanently reuse `com.muxy.tests` and `target/test-verification`; future phases do not create phase-numbered identities. Development foreign-provider mutation policy permits only explicit AI Notifications toggle and Refresh actions; current P1 controls still write only Muxy preferences, Refresh remains inert, and Test is non-mutating.
-*Acceptance: complete for P1 scope.* Debug/release contracts, mode-aware settings, guardrails, isolated staged launches, and sequential Swift/Rust settings coexistence are proven. Runtime coexistence remains assigned to P2 sockets, P8 sessions, P11 hooks/provider mutators, and P12 mobile. P14 must deny importer-triggered foreign provider mutation while still restoring Muxy preferences.
+**P1 — Dev/prod isolation. COMPLETE.**
+`muxy-core::environment` owns compile-time mode selection, storage roots, socket/session/hook names, mobile keys and defaults, and typed provider-config mutation policy. Debug uses `com.muxy.dev`, display name `Muxy Dev`, and `~/.muxy-dev`; release uses `com.muxy.app`, display name `Muxy`, and `~/.muxy`. Isolated acceptance runs permanently reuse `com.muxy.tests` and injected roots beneath `target/test-verification`. Development foreign-provider mutation policy permits only explicit AI Notifications toggle and Refresh actions; current P1 controls write only Muxy preferences, Refresh remains inert, and Test is non-mutating.
+*Acceptance: complete.* Bundle identity, file storage, Ghostty configuration, defaults ownership, runtime endpoint names, and mobile namespaces are isolated by mode. Runtime feature implementation remains assigned to P8 sessions, P11 hooks/provider mutators, and P12 mobile.
 
 **P2 — Socket server + dispatcher core + CLI compat. COMPLETE.**
 Consume `RuntimePathPolicy::main_socket_path` with caller-local build selection, bind the selected socket, export it to panes, and prove debug Rust coexists with the production Swift socket. Reproduce the real `NotificationSocketServer` protocol — **newline-delimited pipe-separated text** with base64-nested JSON fields (not NDJSON); CLI command replies are raw text terminated by a NUL byte then close; server→client `invoke` RPC with 15s timeout; modal push channels; 128 KiB message cap; no protocol versioning; subscription allowlist enforced only for identified extensions; the in-flight cap (8) applies to every session, while the 100-drop disconnect is extension-scoped. **Hook-envelope handling is structural to the server**: every unidentified line gets an `AgentHookProtocol` v3 JSON parse attempt + JSON ack, 256-entry dedup ring, PID→pane resolution — this lands here (P11 adds the installer/binary, not the server semantics). Document the three verb surfaces distinctly: `SocketCommandHandler` pipe verbs (~60), `MuxyAPIDispatcher` (146 dispatched cases; 169 accepted names incl. 37 legacy aliases), and the ~15 verbs implemented outside the dispatcher (`panes.split`, `sessions.*`, `tabs.rename/close/move`, lifecycle). Implement in P2 the verbs backed by existing functionality; later phases own their verbs (36 `browser.*` → P9, `list-sessions`/`kill-session` → P8, `create-worktree` → P3, `config-export|import` → P14). Bundle contract: ship `muxy-cli` at the literal legacy path `Contents/Resources/Muxy_Muxy.bundle/scripts/muxy-cli` (installed shims hardcode it); note the CLI's default socket is the **prod** path (dev relies on `MUXY_SOCKET_PATH` from panes) and `open-project` uses `muxy://open` + `open -b com.muxy.app`. Terminal env contract exported into panes: `MUXY_PANE_ID`, `MUXY_PROJECT_ID`, `MUXY_WORKTREE_ID`, `MUXY_SOCKET_PATH` (`MUXY_HOOK_BIN`/`MUXY_HOOK_SCRIPT` land in P11 — verify the claude wrapper tolerates their absence, else stub the staging dir here).
 *Acceptance: complete.* All 33 P2 wire heads, path-open, raw hook, and raw notification pass through the installed 1.x shim and byte-identical nested CLI against an isolated staged Rust app. Synthetic extension sessions cover transport mechanics, the common gates pass, and the live production Swift socket remains unchanged.
 
-**P2.5 — Compatibility hardening.**
-Make the byte-parity contracts true before daily dogfooding writes real data: capture a golden fixture corpus from a real 1.x profile (checked into the repo, tests fail — not skip — without it); add lossless raw passthrough to `projects.json` and `worktrees/*.json` (matching `workspaces.json`/`project-groups.json`); unify on one Foundation-shaped serializer per 1.x's per-file profile (compact / pretty / prettySorted / `withoutEscapingSlashes`), including `workspaces.json` ordering; resolve the settings-sync open decision (live vs startup) and fix the 8 write-broken JSON-editor keys; cfprefsd-safe defaults reads (drop or fence the direct plist read); retain P1's mechanically verified defaults-suite and App Support test isolation; Foundation-date conversion tests.
-*Acceptance:* cross-run harness green — Swift writes → Rust reads → Rust writes → Swift reads, byte-diff clean per file profile; Swift 1.x launches and behaves against a profile 2.x has been writing.
+**P2.5 — One-way Swift profile migration. COMPLETE.**
+Release imports only current Rust-consumed paths from `~/Library/Application Support/Muxy` into `~/.muxy`, preserving the Swift source and every preexisting destination entry. Directory merges are recursive and do not follow symlinks or non-regular entries. Portable `preferences.json` replaces normal `NSUserDefaults` ownership; a narrow macOS reader imports only the approved production-suite keys during an eligible pending migration. Missing source, completed, and abandoned outcomes are terminal. First failure blocks startup and retries once; second failure records abandonment and continues without deleting imported data. Debug and ordinary tests never inspect the production source.
+*Acceptance: complete.* Focused migration and preference tests, Linux-neutral core compilation, 47 retained Swift tests, staged synthetic debug/release launches, source hashes, retry and abandonment assertions, review remediation, and all shared gates pass.
 
 ### Stage B — Daily-driver parity
 
@@ -246,18 +246,18 @@ Placement rules per phase:
 
 ## Cross-cutting parity contracts (apply to every phase)
 
-- **Formats:** Foundation date = f64 seconds since 2001-01-01 (except ISO-8601 in backup manifest + audit log); uppercase UUIDs; per-file JSON profile (compact vs pretty vs prettySorted, `withoutEscapingSlashes` for settings.json) via **one shared Foundation-shaped serializer** (P2.5); file modes 0600/0700 where 1.x sets them; atomic temp-file writes.
-- **Lossless passthrough everywhere:** every persisted store preserves unknown keys/files (after P2.5 this includes `projects.json` and `worktrees/*.json`); stale legacy files on real machines are never deleted.
+- **Formats:** Foundation date = f64 seconds since 2001-01-01 where retained formats require it; uppercase UUIDs; explicit JSON shape per current Rust store; private data uses atomic destination-side temporary files and file modes 0600/0700 where applicable.
+- **Migration preservation:** the one-way importer copies allowlisted App Support files without parsing or reserializing them. Existing Rust files and extension data win, and the retained Swift source is never modified or deleted.
 - **Sentinel UUIDs:** Home project `…-0001`, default browser profile `…-00B0` (→ `WKWebsiteDataStore.default()`), derived remote-Home IDs.
-- **Settings:** `settings.json` ↔ UserDefaults sync per the P2.5 fidelity decision, with per-key validation; 5 special composite keys; UserDefaults-only keys preserved.
-- **Decoding:** every store decodes with `decodeIfPresent`+defaults semantics; keybindings merge-with-defaults + conflict avoidance; per-element failure swallowing where 1.x does.
-- **The Swift app must still open cleanly against anything 2.x writes** — this stays true until 2.0 ships stable.
+- **Settings:** normal preference reads and writes use portable `preferences.json`; `settings.json` remains the user-facing settings mirror; `NSUserDefaults` is migration-only.
+- **Decoding:** every store decodes with defaults semantics appropriate to its current model; keybindings merge with defaults and avoid conflicts; malformed optional entries do not block unrelated state.
+- **Rollback:** the retained Swift profile remains untouched. Rust does not write back to Swift storage or promise that Swift can consume Rust-owned `~/.muxy` data.
 
 ## Risk register
 
 | Risk | Mitigation |
 |---|---|
-| `settings.json` ↔ defaults sync drift (the #1 compat risk) | P2.5 golden fixtures + cross-run harness (Swift↔Rust write/read cycles) run locally through P14 and in CI from P15 onward. |
+| Swift profile migration loses or overwrites user state | Allowlisted source-preserving copy, destination-wins merge, versioned terminal state, two-attempt cap, unit tests, and staged synthetic launch verification. |
 | Socket protocol fidelity (CLI + extensions + hooks all depend on it) | Real protocol pinned in P2 (pipe/NUL, hook envelope); the untouched bash CLI as continuous acceptance test; replay captured 1.x traffic. |
 | Installed CLI shim path coupling | Bundle ships `muxy-cli` at the legacy `Muxy_Muxy.bundle` path; verified in `verify-bundle.sh`. |
 | 1.x Sparkle auto-update collides with 2.0 publishing | P15 sunset design (frozen final 1.x appcast, beta-tag cutover, Homebrew decision) BEFORE any 2.0 artifacts are published to the repo's release channels. |
@@ -274,10 +274,10 @@ Placement rules per phase:
 ## Verification strategy
 
 1. **Per-phase:** unit tests in headless crates (pattern established, 303 tests); manual checklist per phase derived from exercising the Swift app; `scripts/check.sh` green locally through P14 and in CI from P15 onward.
-2. **Continuous compat harness (from P2.5):** golden-fixture round-trip tests for every persisted file against a captured 1.x profile — failing, not skipping, when fixtures are absent; "Swift 1.x still launches and behaves" cross-check after Rust writes.
+2. **One-way migration harness:** synthetic Swift-shaped sources verify allowlists, destination-wins merge, source hashes, defaults filtering, source-missing completion, retry, abandonment, and terminal no-reinspection through staged debug and release launches.
 3. **CLI acceptance:** installed 1.x `muxy` wrapper exercised against the dev socket from P2 onward, via the legacy bundle shim path.
 4. **Linux guardrail:** per-package Linux `cargo check` (excluding ghostty-sys/host) + launch check on a Linux CI runner, introduced in P15 and required before release.
-5. **Release gate (P16):** full parity checklist verified subsystem-by-subsystem against a real Swift-era profile; byte round-trips green; CLI untouched and working; marketplace extensions load and run; signed + notarized multi-binary DMG; 1.x sunset executed per P15 design; beta-channel soak with you + beta users living on it; then promote to stable as 2.0.
+5. **Release gate (P16):** full parity checklist verified subsystem-by-subsystem; one-way migration acceptance green; CLI untouched and working; marketplace extensions load and run; signed and notarized multi-binary DMG; 1.x sunset executed per P15 design; beta-channel soak with you and beta users living on it; then promote to stable as 2.0.
 
 ## Out of scope for this roadmap
 

--- a/Package.swift
+++ b/Package.swift
@@ -101,7 +101,7 @@ let package = Package(
             ],
             linkerSettings: [
                 .unsafeFlags([
-                    "GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
+                    "vendor/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
                 ]),
                 .linkedFramework("AppKit"),
                 .linkedFramework("AVFoundation"),
@@ -134,7 +134,7 @@ let package = Package(
             path: "Tests/MuxyTests",
             linkerSettings: [
                 .unsafeFlags([
-                    "GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
+                    "vendor/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
                 ]),
                 .linkedFramework("AppKit"),
                 .linkedFramework("AVFoundation"),

--- a/crates/ghostty-host/src/config.rs
+++ b/crates/ghostty-host/src/config.rs
@@ -12,8 +12,6 @@ use crate::runtime::{
     InitializationError, MainThreadError, initialize_ghostty, require_main_thread,
 };
 
-const MUXY_USER_CONFIG: &str = "Library/Application Support/Muxy/ghostty.conf";
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ColorScheme {
     Light,
@@ -38,17 +36,10 @@ pub struct ConfigPaths {
 
 impl ConfigPaths {
     pub fn new(bundled_defaults: impl Into<PathBuf>) -> Self {
-        Self::with_home(
-            bundled_defaults,
-            std::env::var_os("HOME").as_deref().map(Path::new),
-        )
-    }
-
-    pub fn with_home(bundled_defaults: impl Into<PathBuf>, home: Option<&Path>) -> Self {
         Self {
             bundled_defaults: bundled_defaults.into(),
             generated_overlay: None,
-            user_override: home.map(|home| home.join(MUXY_USER_CONFIG)),
+            user_override: None,
         }
     }
 
@@ -213,10 +204,9 @@ mod tests {
 
     #[test]
     fn config_path_order_is_defaults_then_bundle_then_existing_user_override() {
-        let home = Path::new("/Users/tester");
-        let paths =
-            ConfigPaths::with_home("/Muxy.app/Contents/Resources/muxy-defaults", Some(home));
-        let user = home.join(MUXY_USER_CONFIG);
+        let user = PathBuf::from("/Users/tester/.muxy/ghostty.conf");
+        let paths = ConfigPaths::new("/Muxy.app/Contents/Resources/muxy-defaults")
+            .with_user_override(Some(user.clone()));
         let order = paths.load_order_with(|path| path == user);
 
         assert_eq!(
@@ -231,7 +221,8 @@ mod tests {
 
     #[test]
     fn absent_optional_user_config_is_skipped_without_reordering_required_sources() {
-        let paths = ConfigPaths::with_home("/bundle/muxy-defaults", Some(Path::new("/home")));
+        let paths = ConfigPaths::new("/bundle/muxy-defaults")
+            .with_user_override(Some(PathBuf::from("/home/.muxy/ghostty.conf")));
         assert_eq!(
             paths.load_order_with(|_| false),
             vec![
@@ -243,17 +234,16 @@ mod tests {
 
     #[test]
     fn generated_overlay_precedes_user_override() {
-        let paths = ConfigPaths::with_home("/bundle/defaults", Some(Path::new("/home")))
-            .with_generated_overlay(Some(PathBuf::from("/tmp/cjk.conf")));
+        let paths = ConfigPaths::new("/bundle/defaults")
+            .with_generated_overlay(Some(PathBuf::from("/tmp/cjk.conf")))
+            .with_user_override(Some(PathBuf::from("/home/.muxy-dev/ghostty.conf")));
         assert_eq!(
             paths.load_order_with(|_| true),
             vec![
                 ConfigSource::DefaultFiles,
                 ConfigSource::File(PathBuf::from("/bundle/defaults")),
                 ConfigSource::File(PathBuf::from("/tmp/cjk.conf")),
-                ConfigSource::File(PathBuf::from(
-                    "/home/Library/Application Support/Muxy/ghostty.conf"
-                )),
+                ConfigSource::File(PathBuf::from("/home/.muxy-dev/ghostty.conf")),
             ]
         );
     }

--- a/crates/muxy-core/Cargo.toml
+++ b/crates/muxy-core/Cargo.toml
@@ -7,10 +7,10 @@ rust-version.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-plist.workspace = true
 image.workspace = true
 resvg.workspace = true
 log.workspace = true
+libc.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2.workspace = true

--- a/crates/muxy-core/src/environment.rs
+++ b/crates/muxy-core/src/environment.rs
@@ -28,6 +28,28 @@ impl BuildMode {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StoragePathPolicy {
+    mode: BuildMode,
+}
+
+impl StoragePathPolicy {
+    pub const fn new(mode: BuildMode) -> Self {
+        Self { mode }
+    }
+
+    pub fn root(self, home: impl AsRef<Path>) -> PathBuf {
+        match self.mode {
+            BuildMode::Development => home.as_ref().join(".muxy-dev"),
+            BuildMode::Production => home.as_ref().join(".muxy"),
+        }
+    }
+
+    pub fn swift_source(home: impl AsRef<Path>) -> PathBuf {
+        home.as_ref().join("Library/Application Support/Muxy")
+    }
+}
+
 #[macro_export]
 macro_rules! build_mode {
     () => {
@@ -277,7 +299,8 @@ mod tests {
 
     use super::{
         BuildMode, MobileSettingsPolicy, ProviderConfigMutationPermit,
-        ProviderConfigMutationSource, RuntimePathPolicy, provider_config_mutation_allowed,
+        ProviderConfigMutationSource, RuntimePathPolicy, StoragePathPolicy,
+        provider_config_mutation_allowed,
     };
 
     const SOURCES: [ProviderConfigMutationSource; 8] = [
@@ -312,6 +335,23 @@ mod tests {
         assert_eq!(
             crate::build_mode!(),
             BuildMode::from_debug_assertions(cfg!(debug_assertions))
+        );
+    }
+
+    #[test]
+    fn storage_path_policy_separates_release_and_development_roots() {
+        let home = Path::new("/Users/example");
+        assert_eq!(
+            StoragePathPolicy::new(BuildMode::Production).root(home),
+            home.join(".muxy")
+        );
+        assert_eq!(
+            StoragePathPolicy::new(BuildMode::Development).root(home),
+            home.join(".muxy-dev")
+        );
+        assert_eq!(
+            StoragePathPolicy::swift_source(home),
+            home.join("Library/Application Support/Muxy")
         );
     }
 

--- a/crates/muxy-core/src/lib.rs
+++ b/crates/muxy-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod environment;
 pub mod fold;
+pub mod migration;
 pub mod prefs;
 pub mod settings_catalog;
 pub mod shortcuts;

--- a/crates/muxy-core/src/migration.rs
+++ b/crates/muxy-core/src/migration.rs
@@ -1,0 +1,1252 @@
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
+
+use crate::environment::BuildMode;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+use std::fmt::{Display, Formatter};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const SCHEMA_VERSION: u32 = 1;
+const STATE_FILE: &str = "swift-profile-migration.json";
+const LOCK_FILE: &str = "swift-profile-migration.lock";
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const FILES: [&str; 14] = [
+    "projects.json",
+    "recently-removed-projects.json",
+    "project-groups.json",
+    "workspaces.json",
+    "settings.json",
+    "ui-scale.json",
+    "keybindings.json",
+    "command-shortcuts.json",
+    "editor-settings.json",
+    "quick-terminal-shortcut.json",
+    "approved-devices.json",
+    "remote-devices.json",
+    "browser-profiles.json",
+    "ghostty.conf",
+];
+const DIRECTORIES: [&str; 2] = ["worktrees", "logos"];
+const DEFAULT_STRING_KEYS: [&str; 6] = [
+    "muxy.activeProjectID",
+    "muxy.ide.selectedBundleIdentifier",
+    "muxy.projectSortMode",
+    "muxy.projectPicker.defaultDirectory",
+    "muxy.activeProjectGroupID",
+    "muxy.settings.selectedRoute",
+];
+const DEFAULT_BOOL_KEYS: [&str; 3] = [
+    "muxy.sidebarExpanded",
+    "muxy.browser.enabled",
+    "muxy.projects.keepOpenWhenNoTabs",
+];
+const DEFAULT_NUMBER_KEYS: [&str; 2] = ["muxy.sidebarExpandedCustomWidth", "muxy.tabs.maxWidth"];
+const DEFAULT_DICTIONARY_KEYS: [&str; 1] = ["muxy.activeWorktreeIDs"];
+const TEST_SOURCE: &str = "MUXY_TEST_SWIFT_APPLICATION_SUPPORT_DIRECTORY";
+const TEST_DEFAULTS: &str = "MUXY_TEST_SWIFT_DEFAULTS_PATH";
+const TEST_FAILURE: &str = "MUXY_TEST_MIGRATION_FAIL_PATH";
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationOutcome {
+    Pending,
+    Completed,
+    SourceMissing,
+    Abandoned,
+}
+
+impl MigrationOutcome {
+    fn terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::SourceMissing | Self::Abandoned
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MigrationFailure {
+    pub path: String,
+    pub category: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MigrationState {
+    pub schema_version: u32,
+    pub attempt_count: u8,
+    pub outcome: MigrationOutcome,
+    pub imported_paths: Vec<String>,
+    pub existing_paths: Vec<String>,
+    pub missing_paths: Vec<String>,
+    pub failure: Option<MigrationFailure>,
+    pub defaults_import_completed: bool,
+}
+
+impl Default for MigrationState {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            attempt_count: 0,
+            outcome: MigrationOutcome::Pending,
+            imported_paths: Vec::new(),
+            existing_paths: Vec::new(),
+            missing_paths: Vec::new(),
+            failure: None,
+            defaults_import_completed: false,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MigrationError {
+    message: String,
+}
+
+impl Display for MigrationError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for MigrationError {}
+
+#[derive(Default)]
+struct Report {
+    imported: BTreeSet<String>,
+    existing: BTreeSet<String>,
+    missing: BTreeSet<String>,
+}
+
+struct MigrationOptions<'a> {
+    root: &'a Path,
+    source: &'a Path,
+    failure_path: Option<&'a Path>,
+}
+
+pub fn state_path(root: &Path) -> PathBuf {
+    root.join(STATE_FILE)
+}
+
+pub fn read_state(root: &Path) -> std::io::Result<Option<MigrationState>> {
+    let contents = match fs::read(state_path(root)) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let state: MigrationState = serde_json::from_slice(&contents)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    if state.schema_version != SCHEMA_VERSION {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "unsupported Swift profile migration schema {}",
+                state.schema_version
+            ),
+        ));
+    }
+    Ok(Some(state))
+}
+
+fn eligible(mode: BuildMode, macos: bool) -> bool {
+    mode == BuildMode::Production && macos
+}
+
+pub fn run_startup() -> Result<(), MigrationError> {
+    let mode = crate::build_mode!();
+    let root = crate::prefs::app_support_dir();
+    create_private_directory(&root).map_err(|error| MigrationError {
+        message: format!(
+            "failed to prepare Rust profile root {}: {error}",
+            root.display()
+        ),
+    })?;
+    if !eligible(mode, cfg!(target_os = "macos")) {
+        return Ok(());
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let test_process = crate::prefs::is_test_process();
+        let test_source = test_process
+            .then(|| std::env::var_os(TEST_SOURCE))
+            .flatten()
+            .map(PathBuf::from);
+        if test_process && test_source.is_none() {
+            return Ok(());
+        }
+        let source = test_source.unwrap_or_else(|| {
+            crate::environment::StoragePathPolicy::swift_source(crate::prefs::home_dir())
+        });
+        let failure_path = test_process
+            .then(|| std::env::var_os(TEST_FAILURE))
+            .flatten()
+            .map(PathBuf::from);
+        let options = MigrationOptions {
+            root: &root,
+            source: &source,
+            failure_path: failure_path.as_deref(),
+        };
+        run_with(&options, || {
+            if test_process {
+                return read_test_defaults();
+            }
+            read_production_defaults()
+        })
+        .map(|_| ())
+    }
+}
+
+fn run_with<F>(
+    options: &MigrationOptions<'_>,
+    read_defaults: F,
+) -> Result<MigrationState, MigrationError>
+where
+    F: FnOnce() -> Result<Map<String, Value>, String>,
+{
+    create_private_directory(options.root).map_err(|error| MigrationError {
+        message: format!(
+            "failed to create Rust profile root {}: {error}",
+            options.root.display()
+        ),
+    })?;
+    let _lock = acquire_lock(options.root).map_err(|error| MigrationError {
+        message: format!("failed to lock Swift profile migration: {error}"),
+    })?;
+    let loaded = read_state(options.root).map_err(|error| MigrationError {
+        message: format!("failed to read Swift profile migration state: {error}"),
+    })?;
+    if let Some(state) = loaded.as_ref() {
+        if state.outcome.terminal() {
+            return Ok(state.clone());
+        }
+        if state.attempt_count >= 2 {
+            let mut state = state.clone();
+            state.outcome = MigrationOutcome::Abandoned;
+            write_state(options.root, &state).map_err(|error| MigrationError {
+                message: format!("failed to record interrupted migration abandonment: {error}"),
+            })?;
+            return Ok(state);
+        }
+    }
+    let mut state = loaded.unwrap_or_default();
+    state.attempt_count = state.attempt_count.saturating_add(1);
+    state.failure = None;
+    write_state(options.root, &state).map_err(|error| MigrationError {
+        message: format!("failed to record Swift migration attempt: {error}"),
+    })?;
+
+    let source_metadata = match fs::symlink_metadata(options.source) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return finish_failure(
+                options.root,
+                state,
+                Path::new("."),
+                "unsafe_source",
+                "Swift profile source is not a directory",
+            );
+        }
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            state.outcome = MigrationOutcome::SourceMissing;
+            state.missing_paths = FILES
+                .iter()
+                .chain(DIRECTORIES.iter())
+                .map(|path| (*path).to_owned())
+                .collect();
+            write_state(options.root, &state).map_err(|write_error| MigrationError {
+                message: format!("failed to record missing Swift profile: {write_error}"),
+            })?;
+            return Ok(state);
+        }
+        Err(error) => {
+            return finish_failure(
+                options.root,
+                state,
+                Path::new("."),
+                io_category(&error),
+                &error.to_string(),
+            );
+        }
+    };
+    if !source_metadata.is_dir() {
+        return finish_failure(
+            options.root,
+            state,
+            Path::new("."),
+            "unsafe_source",
+            "Swift profile source is not a directory",
+        );
+    }
+
+    let mut report = Report::default();
+    let copy_result = (|| -> Result<(), CopyFailure> {
+        for path in FILES {
+            copy_entry(options, Path::new(path), false, &mut report)?;
+        }
+        for path in DIRECTORIES {
+            copy_entry(options, Path::new(path), true, &mut report)?;
+        }
+        Ok(())
+    })();
+    if let Err(failure) = copy_result {
+        merge_report(&mut state, report);
+        return finish_failure(
+            options.root,
+            state,
+            &failure.path,
+            &failure.category,
+            &failure.message,
+        );
+    }
+
+    let imported_defaults = match read_defaults() {
+        Ok(values) => filter_defaults(&values),
+        Err(message) => {
+            merge_report(&mut state, report);
+            return finish_failure(
+                options.root,
+                state,
+                Path::new("preferences.json"),
+                "defaults_read",
+                &message,
+            );
+        }
+    };
+    if let Err(error) = crate::prefs::defaults::merge_imported(options.root, &imported_defaults) {
+        merge_report(&mut state, report);
+        return finish_failure(
+            options.root,
+            state,
+            Path::new("preferences.json"),
+            io_category(&error),
+            &error.to_string(),
+        );
+    }
+
+    merge_report(&mut state, report);
+    state.defaults_import_completed = true;
+    state.outcome = MigrationOutcome::Completed;
+    state.failure = None;
+    write_state(options.root, &state).map_err(|error| MigrationError {
+        message: format!("failed to complete Swift profile migration: {error}"),
+    })?;
+    Ok(state)
+}
+
+fn merge_report(state: &mut MigrationState, report: Report) {
+    let mut imported: BTreeSet<String> = state.imported_paths.iter().cloned().collect();
+    imported.extend(report.imported);
+    state.imported_paths = imported.into_iter().collect();
+    let mut existing: BTreeSet<String> = state.existing_paths.iter().cloned().collect();
+    existing.extend(report.existing);
+    state.existing_paths = existing.into_iter().collect();
+    let mut missing: BTreeSet<String> = state.missing_paths.iter().cloned().collect();
+    missing.extend(report.missing);
+    state.missing_paths = missing.into_iter().collect();
+}
+
+fn finish_failure(
+    root: &Path,
+    mut state: MigrationState,
+    path: &Path,
+    category: &str,
+    message: &str,
+) -> Result<MigrationState, MigrationError> {
+    state.failure = Some(MigrationFailure {
+        path: display_path(path),
+        category: category.to_owned(),
+    });
+    let abandoned = state.attempt_count >= 2;
+    state.outcome = if abandoned {
+        MigrationOutcome::Abandoned
+    } else {
+        MigrationOutcome::Pending
+    };
+    write_state(root, &state).map_err(|error| MigrationError {
+        message: format!("failed to record Swift migration failure: {error}"),
+    })?;
+    if abandoned {
+        Ok(state)
+    } else {
+        Err(MigrationError {
+            message: format!(
+                "Swift profile migration failed at {}: {message}; retry by launching Muxy again",
+                display_path(path)
+            ),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct CopyFailure {
+    path: PathBuf,
+    category: String,
+    message: String,
+}
+
+fn copy_entry(
+    options: &MigrationOptions<'_>,
+    relative: &Path,
+    expect_directory: bool,
+    report: &mut Report,
+) -> Result<(), CopyFailure> {
+    let destination = options.root.join(relative);
+    if let Ok(destination_metadata) = fs::symlink_metadata(&destination) {
+        if expect_directory && destination_metadata.is_dir() {
+            let source = options.source.join(relative);
+            let source_metadata = match fs::symlink_metadata(&source) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    report.missing.insert(display_path(relative));
+                    return Ok(());
+                }
+                Err(error) => return Err(copy_failure(relative, &error)),
+            };
+            if source_metadata.is_dir() && !source_metadata.file_type().is_symlink() {
+                return copy_directory(options, relative, report);
+            }
+        }
+        report.existing.insert(display_path(relative));
+        return Ok(());
+    }
+    let source = options.source.join(relative);
+    let metadata = match fs::symlink_metadata(&source) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            report.missing.insert(display_path(relative));
+            return Ok(());
+        }
+        Err(error) => return Err(copy_failure(relative, &error)),
+    };
+    if metadata.file_type().is_symlink()
+        || (expect_directory && !metadata.is_dir())
+        || (!expect_directory && !metadata.is_file())
+    {
+        report.missing.insert(display_path(relative));
+        return Ok(());
+    }
+    if metadata.is_dir() {
+        create_private_directory(&destination).map_err(|error| copy_failure(relative, &error))?;
+        copy_directory(options, relative, report)
+    } else {
+        if copy_regular_file(options, relative)? {
+            report.imported.insert(display_path(relative));
+        } else {
+            report.existing.insert(display_path(relative));
+        }
+        Ok(())
+    }
+}
+
+fn copy_directory(
+    options: &MigrationOptions<'_>,
+    relative: &Path,
+    report: &mut Report,
+) -> Result<(), CopyFailure> {
+    let source = options.source.join(relative);
+    let entries = fs::read_dir(&source).map_err(|error| copy_failure(relative, &error))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| copy_failure(relative, &error))?;
+        let child = relative.join(entry.file_name());
+        let destination = options.root.join(&child);
+        let metadata =
+            fs::symlink_metadata(entry.path()).map_err(|error| copy_failure(&child, &error))?;
+        if let Ok(destination_metadata) = fs::symlink_metadata(&destination) {
+            if destination_metadata.is_dir()
+                && metadata.is_dir()
+                && !metadata.file_type().is_symlink()
+            {
+                copy_directory(options, &child, report)?;
+            } else {
+                report.existing.insert(display_path(&child));
+            }
+            continue;
+        }
+        if metadata.file_type().is_symlink() {
+            report.missing.insert(display_path(&child));
+        } else if metadata.is_dir() {
+            create_private_directory(&destination).map_err(|error| copy_failure(&child, &error))?;
+            copy_directory(options, &child, report)?;
+        } else if metadata.is_file() {
+            if copy_regular_file(options, &child)? {
+                report.imported.insert(display_path(&child));
+            } else {
+                report.existing.insert(display_path(&child));
+            }
+        } else {
+            report.missing.insert(display_path(&child));
+        }
+    }
+    Ok(())
+}
+
+fn copy_regular_file(options: &MigrationOptions<'_>, relative: &Path) -> Result<bool, CopyFailure> {
+    let source = options.source.join(relative);
+    let destination = options.root.join(relative);
+    let parent = destination.parent().unwrap_or(options.root);
+    create_private_directory(parent).map_err(|error| copy_failure(relative, &error))?;
+    let (temporary, mut output) = loop {
+        let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let temporary = parent.join(format!(
+            ".{}.muxy-import-{}.{}.tmp",
+            destination
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("file"),
+            std::process::id(),
+            sequence
+        ));
+        match open_new_private_file(&temporary, false) {
+            Ok(output) => break (temporary, output),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(copy_failure(relative, &error)),
+        }
+    };
+    let result = (|| -> std::io::Result<()> {
+        let mut input = open_source_file(&source)?;
+        if options.failure_path == Some(relative) {
+            return Err(std::io::Error::other("injected migration copy failure"));
+        }
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let count = input.read(&mut buffer)?;
+            if count == 0 {
+                break;
+            }
+            output.write_all(&buffer[..count])?;
+        }
+        output.sync_all()?;
+        set_private_file_permissions(&temporary)
+    })();
+    drop(output);
+    if let Err(error) = result {
+        let _ = fs::remove_file(&temporary);
+        return Err(copy_failure(relative, &error));
+    }
+    match fs::hard_link(&temporary, &destination) {
+        Ok(()) => {
+            fs::remove_file(&temporary).map_err(|error| copy_failure(relative, &error))?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(&temporary);
+            Ok(false)
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&temporary);
+            Err(copy_failure(relative, &error))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn open_source_file(path: &Path) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_source_file(path: &Path) -> std::io::Result<File> {
+    OpenOptions::new().read(true).open(path)
+}
+
+#[cfg(unix)]
+fn open_new_private_file(path: &Path, readable: bool) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(readable)
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_new_private_file(path: &Path, readable: bool) -> std::io::Result<File> {
+    OpenOptions::new()
+        .read(readable)
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+fn acquire_lock(root: &Path) -> std::io::Result<File> {
+    let path = root.join(LOCK_FILE);
+    let created = open_new_private_file(&path, true);
+    let file = match created {
+        Ok(file) => {
+            set_private_file_permissions(&path)?;
+            file
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "migration lock is not a regular file",
+                ));
+            }
+            OpenOptions::new().read(true).write(true).open(&path)?
+        }
+        Err(error) => return Err(error),
+    };
+    file.try_lock()?;
+    Ok(file)
+}
+
+fn write_state(root: &Path, state: &MigrationState) -> std::io::Result<()> {
+    let contents = serde_json::to_vec_pretty(state)?;
+    crate::store::write_private(&state_path(root), &contents)
+}
+
+fn create_private_directory(path: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => return Ok(()),
+        Ok(_) => return Err(std::io::Error::from(std::io::ErrorKind::AlreadyExists)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    create_missing_private_directories(path)
+}
+
+#[cfg(unix)]
+fn create_missing_private_directories(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(0o700).create(path)
+}
+
+#[cfg(not(unix))]
+fn create_missing_private_directories(path: &Path) -> std::io::Result<()> {
+    fs::create_dir(path)
+}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn copy_failure(path: &Path, error: &std::io::Error) -> CopyFailure {
+    CopyFailure {
+        path: path.to_path_buf(),
+        category: io_category(error).to_owned(),
+        message: error.to_string(),
+    }
+}
+
+fn io_category(error: &std::io::Error) -> &'static str {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => "not_found",
+        std::io::ErrorKind::PermissionDenied => "permission_denied",
+        std::io::ErrorKind::AlreadyExists => "temporary_exists",
+        std::io::ErrorKind::InvalidData => "invalid_data",
+        _ => "io",
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn read_test_defaults() -> Result<Map<String, Value>, String> {
+    let Some(path) = std::env::var_os(TEST_DEFAULTS).map(PathBuf::from) else {
+        return Ok(Map::new());
+    };
+    let contents = fs::read(path).map_err(|error| error.to_string())?;
+    let value: Value = serde_json::from_slice(&contents).map_err(|error| error.to_string())?;
+    let values = value
+        .as_object()
+        .ok_or_else(|| "injected defaults must be a JSON object".to_owned())?;
+    Ok(filter_defaults(values))
+}
+
+fn filter_defaults(values: &Map<String, Value>) -> Map<String, Value> {
+    let mut filtered = Map::new();
+    for key in DEFAULT_STRING_KEYS {
+        if let Some(Value::String(value)) = values.get(key) {
+            filtered.insert(key.to_owned(), Value::String(value.clone()));
+        }
+    }
+    for key in DEFAULT_BOOL_KEYS {
+        if let Some(Value::Bool(value)) = values.get(key) {
+            filtered.insert(key.to_owned(), Value::Bool(*value));
+        }
+    }
+    for key in DEFAULT_NUMBER_KEYS {
+        if let Some(Value::Number(value)) = values.get(key) {
+            filtered.insert(key.to_owned(), Value::Number(value.clone()));
+        }
+    }
+    for key in DEFAULT_DICTIONARY_KEYS {
+        if let Some(Value::Object(values)) = values.get(key) {
+            let values: Map<String, Value> = values
+                .iter()
+                .filter_map(|(entry, value)| {
+                    Some((entry.clone(), Value::String(value.as_str()?.to_owned())))
+                })
+                .collect();
+            filtered.insert(key.to_owned(), Value::Object(values));
+        }
+    }
+    filtered
+}
+
+#[cfg(target_os = "macos")]
+fn nsnumber_is_boolean(value: &objc2_foundation::NSNumber) -> bool {
+    let encoding = unsafe { std::ffi::CStr::from_ptr(value.objCType().as_ptr()) }.to_bytes();
+    matches!(encoding, b"c" | b"B")
+}
+
+#[cfg(target_os = "macos")]
+fn read_production_defaults() -> Result<Map<String, Value>, String> {
+    use objc2_foundation::{NSDictionary, NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    let domain_name = NSString::from_str("com.muxy.app");
+    let Some(domain) = defaults.persistentDomainForName(&domain_name) else {
+        return Ok(Map::new());
+    };
+    let mut values = Map::new();
+    for key in DEFAULT_STRING_KEYS {
+        let key_string = NSString::from_str(key);
+        let Some(value) = domain.objectForKey(&key_string) else {
+            continue;
+        };
+        if let Ok(value) = value.downcast::<NSString>() {
+            values.insert(key.to_owned(), Value::String(value.to_string()));
+        }
+    }
+    for key in DEFAULT_BOOL_KEYS {
+        let key_string = NSString::from_str(key);
+        let Some(value) = domain.objectForKey(&key_string) else {
+            continue;
+        };
+        if let Ok(value) = value.downcast::<objc2_foundation::NSNumber>()
+            && nsnumber_is_boolean(&value)
+        {
+            values.insert(key.to_owned(), Value::Bool(value.boolValue()));
+        }
+    }
+    for key in DEFAULT_NUMBER_KEYS {
+        let key_string = NSString::from_str(key);
+        let Some(value) = domain.objectForKey(&key_string) else {
+            continue;
+        };
+        if let Ok(value) = value.downcast::<objc2_foundation::NSNumber>()
+            && !nsnumber_is_boolean(&value)
+            && let Some(value) = serde_json::Number::from_f64(value.doubleValue())
+        {
+            values.insert(key.to_owned(), Value::Number(value));
+        }
+    }
+    for key in DEFAULT_DICTIONARY_KEYS {
+        let key_string = NSString::from_str(key);
+        let Some(value) = domain.objectForKey(&key_string) else {
+            continue;
+        };
+        let Ok(dictionary) = value.downcast::<NSDictionary>() else {
+            continue;
+        };
+        let (keys, objects) = dictionary.to_vecs();
+        let entries = keys
+            .into_iter()
+            .zip(objects)
+            .filter_map(|(entry, value)| {
+                Some((
+                    entry.downcast::<NSString>().ok()?.to_string(),
+                    Value::String(value.downcast::<NSString>().ok()?.to_string()),
+                ))
+            })
+            .collect();
+        values.insert(key.to_owned(), Value::Object(entries));
+    }
+    Ok(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MigrationOptions, MigrationOutcome, eligible, filter_defaults, read_state, run_with,
+        state_path, write_state,
+    };
+    use crate::environment::BuildMode;
+    use serde_json::{Map, Value, json};
+    use std::cell::Cell;
+    use std::fs;
+    use std::path::Path;
+
+    fn write(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        fs::write(path, contents).expect("write fixture");
+    }
+
+    fn run(
+        root: &Path,
+        source: &Path,
+        defaults: Map<String, Value>,
+        failure_path: Option<&Path>,
+    ) -> Result<super::MigrationState, super::MigrationError> {
+        run_with(
+            &MigrationOptions {
+                root,
+                source,
+                failure_path,
+            },
+            || Ok(defaults),
+        )
+    }
+
+    #[test]
+    fn migration_eligibility_requires_macos_release() {
+        assert!(eligible(BuildMode::Production, true));
+        assert!(!eligible(BuildMode::Development, true));
+        assert!(!eligible(BuildMode::Production, false));
+        assert!(!eligible(BuildMode::Development, false));
+    }
+
+    #[test]
+    fn migration_imports_allowlisted_files_and_merges_directories() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        write(&source.join("projects.json"), "swift-projects");
+        write(&source.join("worktrees/project/one.json"), "worktree");
+        write(&source.join("logos/project/logo.png"), "logo");
+        write(&source.join("sessions/session.json"), "runtime");
+        write(&root.join("projects.json"), "rust-projects");
+        write(&root.join("worktrees/project/existing.json"), "existing");
+        let defaults = json!({
+            "muxy.activeProjectID": "project",
+            "muxy.sidebarExpanded": true,
+            "unknown": "excluded"
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        let state = run(&root, &source, defaults, None).expect("migration");
+        assert_eq!(state.outcome, MigrationOutcome::Completed);
+        assert_eq!(
+            fs::read_to_string(root.join("projects.json")).unwrap(),
+            "rust-projects"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("worktrees/project/one.json")).unwrap(),
+            "worktree"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("logos/project/logo.png")).unwrap(),
+            "logo"
+        );
+        assert!(!root.join("sessions").exists());
+        let preferences: Value =
+            serde_json::from_slice(&fs::read(root.join("preferences.json")).unwrap()).unwrap();
+        assert_eq!(preferences["muxy.activeProjectID"], "project");
+        assert_eq!(preferences["muxy.sidebarExpanded"], true);
+        assert!(preferences.get("unknown").is_none());
+        assert!(state.existing_paths.contains(&"projects.json".to_owned()));
+        assert!(
+            state
+                .imported_paths
+                .contains(&"worktrees/project/one.json".to_owned())
+        );
+        assert!(state.missing_paths.contains(&"settings.json".to_owned()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn migration_staging_is_private_from_creation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("staging");
+        let _file = super::open_new_private_file(&path, false).expect("staging");
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn migration_keeps_existing_directory_permissions_and_creates_private_directories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        write(&source.join("worktrees/project/one.json"), "worktree");
+        fs::create_dir_all(root.join("worktrees")).unwrap();
+        fs::set_permissions(root.join("worktrees"), fs::Permissions::from_mode(0o755)).unwrap();
+        run(&root, &source, Map::new(), None).expect("migration");
+        assert_eq!(
+            fs::metadata(root.join("worktrees"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            fs::metadata(root.join("worktrees/project"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    fn migration_leaves_source_bytes_unchanged() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        let file = source.join("projects.json");
+        write(&file, "source bytes\n");
+        let before = fs::read(&file).unwrap();
+        run(&root, &source, Map::new(), None).expect("migration");
+        assert_eq!(fs::read(&file).unwrap(), before);
+    }
+
+    #[test]
+    fn migration_refuses_symlinks_without_following_them() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+
+            let directory = tempfile::tempdir().expect("temp dir");
+            let source = directory.path().join("swift");
+            let root = directory.path().join("rust");
+            write(&directory.path().join("secret"), "secret");
+            fs::create_dir_all(&source).unwrap();
+            symlink(
+                directory.path().join("secret"),
+                source.join("projects.json"),
+            )
+            .unwrap();
+            let state = run(&root, &source, Map::new(), None).expect("migration");
+            assert_eq!(state.outcome, MigrationOutcome::Completed);
+            assert!(!root.join("projects.json").exists());
+            assert!(state.missing_paths.contains(&"projects.json".to_owned()));
+        }
+    }
+
+    #[test]
+    fn migration_copy_publication_never_replaces_an_existing_destination() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        write(&source.join("projects.json"), "swift");
+        write(&root.join("projects.json"), "rust");
+        let options = MigrationOptions {
+            root: &root,
+            source: &source,
+            failure_path: None,
+        };
+        assert!(!super::copy_regular_file(&options, Path::new("projects.json")).expect("copy"));
+        assert_eq!(
+            fs::read_to_string(root.join("projects.json")).unwrap(),
+            "rust"
+        );
+    }
+
+    #[test]
+    fn migration_cleans_temporary_files_after_copy_failure() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        write(&source.join("projects.json"), "projects");
+        fs::create_dir(&root).expect("root");
+        let unowned = root.join(format!(
+            ".projects.json.muxy-import-{}.tmp",
+            std::process::id()
+        ));
+        fs::write(&unowned, b"unowned").expect("unowned temporary");
+        let result = run(&root, &source, Map::new(), Some(Path::new("projects.json")));
+        assert!(result.is_err());
+        assert!(!root.join("projects.json").exists());
+        assert_eq!(fs::read(&unowned).expect("unowned preserved"), b"unowned");
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.to_string_lossy().contains("muxy-import"))
+            .collect();
+        assert_eq!(leftovers, vec![unowned]);
+    }
+
+    #[test]
+    fn migration_marks_an_absent_source_terminal_without_retrying() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("missing");
+        let root = directory.path().join("rust");
+        let state = run(&root, &source, Map::new(), None).expect("migration");
+        assert_eq!(state.outcome, MigrationOutcome::SourceMissing);
+        assert_eq!(state.attempt_count, 1);
+        fs::create_dir_all(&source).unwrap();
+        write(&source.join("projects.json"), "late");
+        let state = run(&root, &source, Map::new(), None).expect("terminal");
+        assert_eq!(state.outcome, MigrationOutcome::SourceMissing);
+        assert!(!root.join("projects.json").exists());
+    }
+
+    #[test]
+    fn migration_refuses_a_concurrent_run_before_source_inspection() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("missing-swift");
+        let root = directory.path().join("rust");
+        fs::create_dir(&root).expect("root");
+        let _lock = super::acquire_lock(&root).expect("first lock");
+        let error = run(&root, &source, Map::new(), None).expect_err("concurrent run");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to lock Swift profile migration")
+        );
+        assert!(!state_path(&root).exists());
+    }
+
+    #[test]
+    fn migration_fails_closed_on_a_malformed_state_file() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("missing-swift");
+        let root = directory.path().join("rust");
+        fs::create_dir(&root).expect("root");
+        fs::write(state_path(&root), b"not json").expect("malformed state");
+        let error = run(&root, &source, Map::new(), None).expect_err("malformed state");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to read Swift profile migration state")
+        );
+        assert_eq!(fs::read(state_path(&root)).expect("unchanged"), b"not json");
+    }
+
+    #[test]
+    fn migration_retries_once_then_abandons_and_stops_inspecting_source() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        write(&source.join("projects.json"), "projects");
+        write(
+            &source.join("recently-removed-projects.json"),
+            "recently removed",
+        );
+        let failure = Some(Path::new("recently-removed-projects.json"));
+        assert!(run(&root, &source, Map::new(), failure).is_err());
+        assert_eq!(
+            fs::read_to_string(root.join("projects.json")).unwrap(),
+            "projects"
+        );
+        let pending = read_state(&root)
+            .expect("read pending state")
+            .expect("pending state");
+        assert_eq!(pending.outcome, MigrationOutcome::Pending);
+        assert_eq!(pending.attempt_count, 1);
+        let abandoned = run(&root, &source, Map::new(), failure).expect("abandoned");
+        assert_eq!(abandoned.outcome, MigrationOutcome::Abandoned);
+        assert_eq!(abandoned.attempt_count, 2);
+        assert_eq!(
+            fs::read_to_string(root.join("projects.json")).unwrap(),
+            "projects"
+        );
+        fs::remove_dir_all(&source).unwrap();
+        let terminal = run(&root, &source, Map::new(), None).expect("terminal");
+        assert_eq!(terminal.outcome, MigrationOutcome::Abandoned);
+        assert_eq!(terminal.attempt_count, 2);
+    }
+
+    #[test]
+    fn migration_abandons_an_interrupted_second_attempt_without_source_inspection() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        write(&source.join("projects.json"), "projects");
+        assert!(run(&root, &source, Map::new(), Some(Path::new("projects.json")),).is_err());
+        let mut state = read_state(&root)
+            .expect("read pending state")
+            .expect("pending state");
+        state.attempt_count = 2;
+        write_state(&root, &state).expect("interrupted state");
+        fs::remove_dir_all(&source).unwrap();
+        let state = run(&root, &source, Map::new(), None).expect("abandoned");
+        assert_eq!(state.outcome, MigrationOutcome::Abandoned);
+        assert_eq!(state.attempt_count, 2);
+    }
+
+    #[test]
+    fn migration_terminal_state_never_calls_defaults_reader() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        fs::create_dir_all(&source).unwrap();
+        run(&root, &source, Map::new(), None).expect("migration");
+        fs::remove_dir_all(&source).unwrap();
+        let called = Cell::new(false);
+        run_with(
+            &MigrationOptions {
+                root: &root,
+                source: &source,
+                failure_path: None,
+            },
+            || {
+                called.set(true);
+                Ok(Map::new())
+            },
+        )
+        .expect("terminal");
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn migration_allowlist_fixture_covers_every_file_and_directory() {
+        const EXPECTED_FILES: [&str; 14] = [
+            "projects.json",
+            "recently-removed-projects.json",
+            "project-groups.json",
+            "workspaces.json",
+            "settings.json",
+            "ui-scale.json",
+            "keybindings.json",
+            "command-shortcuts.json",
+            "editor-settings.json",
+            "quick-terminal-shortcut.json",
+            "approved-devices.json",
+            "remote-devices.json",
+            "browser-profiles.json",
+            "ghostty.conf",
+        ];
+        const EXPECTED_DIRECTORIES: [&str; 2] = ["worktrees", "logos"];
+        assert_eq!(super::FILES, EXPECTED_FILES);
+        assert_eq!(super::DIRECTORIES, EXPECTED_DIRECTORIES);
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        for relative in EXPECTED_FILES {
+            write(&source.join(relative), &format!("source:{relative}"));
+        }
+        for relative in EXPECTED_DIRECTORIES {
+            write(
+                &source.join(relative).join("nested/value"),
+                &format!("source:{relative}"),
+            );
+        }
+
+        let existing_root = directory.path().join("existing-rust");
+        for relative in EXPECTED_FILES {
+            write(&existing_root.join(relative), &format!("rust:{relative}"));
+        }
+        for relative in EXPECTED_DIRECTORIES {
+            write(
+                &existing_root.join(relative).join("nested/value"),
+                &format!("rust:{relative}"),
+            );
+        }
+        let existing = run(&existing_root, &source, Map::new(), None).expect("existing import");
+        for relative in EXPECTED_FILES {
+            assert_eq!(
+                fs::read_to_string(existing_root.join(relative)).expect("existing file"),
+                format!("rust:{relative}")
+            );
+            assert!(existing.existing_paths.contains(&relative.to_owned()));
+        }
+        for relative in EXPECTED_DIRECTORIES {
+            assert_eq!(
+                fs::read_to_string(existing_root.join(relative).join("nested/value"))
+                    .expect("existing directory file"),
+                format!("rust:{relative}")
+            );
+        }
+
+        let imported_root = directory.path().join("imported-rust");
+        let imported = run(&imported_root, &source, Map::new(), None).expect("fresh import");
+        for relative in EXPECTED_FILES {
+            assert_eq!(
+                fs::read_to_string(imported_root.join(relative)).expect("imported file"),
+                format!("source:{relative}")
+            );
+            assert!(imported.imported_paths.contains(&relative.to_owned()));
+        }
+        for relative in EXPECTED_DIRECTORIES {
+            let nested = format!("{relative}/nested/value");
+            assert_eq!(
+                fs::read_to_string(imported_root.join(&nested)).expect("imported directory file"),
+                format!("source:{relative}")
+            );
+            assert!(imported.imported_paths.contains(&nested));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn production_defaults_distinguish_booleans_from_numbers() {
+        use objc2_foundation::NSNumber;
+
+        assert!(super::nsnumber_is_boolean(&NSNumber::new_bool(true)));
+        assert!(!super::nsnumber_is_boolean(&NSNumber::new_i64(1)));
+        assert!(!super::nsnumber_is_boolean(&NSNumber::new_f64(1.0)));
+    }
+
+    #[test]
+    fn migration_defaults_filter_is_exact_and_typed() {
+        let source = json!({
+            "muxy.activeProjectID": "project",
+            "muxy.sidebarExpanded": true,
+            "muxy.tabs.maxWidth": 240.0,
+            "muxy.activeWorktreeIDs": { "project": "worktree", "invalid": false },
+            "muxy.settings.selectedRoute": "builtin.appearance",
+            "muxy.unapproved": "excluded",
+            "muxy.browser.enabled": "wrong type"
+        });
+        let filtered = filter_defaults(source.as_object().expect("object"));
+        assert_eq!(filtered.len(), 5);
+        assert!(filtered.get("muxy.unapproved").is_none());
+        assert!(filtered.get("muxy.browser.enabled").is_none());
+        assert_eq!(
+            filtered["muxy.activeWorktreeIDs"],
+            json!({ "project": "worktree" })
+        );
+    }
+
+    #[test]
+    fn migration_defaults_existing_destination_values_win() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("swift");
+        let root = directory.path().join("rust");
+        fs::create_dir_all(&source).unwrap();
+        write(
+            &root.join("preferences.json"),
+            r#"{"muxy.activeProjectID":"rust"}"#,
+        );
+        let defaults = json!({ "muxy.activeProjectID": "swift", "muxy.sidebarExpanded": true })
+            .as_object()
+            .unwrap()
+            .clone();
+        run(&root, &source, defaults, None).expect("migration");
+        let preferences: Value =
+            serde_json::from_slice(&fs::read(root.join("preferences.json")).unwrap()).unwrap();
+        assert_eq!(preferences["muxy.activeProjectID"], "rust");
+        assert_eq!(preferences["muxy.sidebarExpanded"], true);
+    }
+}

--- a/crates/muxy-core/src/prefs/defaults.rs
+++ b/crates/muxy-core/src/prefs/defaults.rs
@@ -1,325 +1,223 @@
-#[cfg(target_os = "macos")]
-struct DefaultsStore {
-    defaults: objc2::rc::Retained<objc2_foundation::NSUserDefaults>,
+use serde_json::{Map, Number, Value};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+const FILE_NAME: &str = "preferences.json";
+
+fn path() -> PathBuf {
+    super::app_support_dir().join(FILE_NAME)
 }
 
-#[cfg(target_os = "macos")]
-impl DefaultsStore {
-    fn standard() -> Self {
-        Self {
-            defaults: objc2_foundation::NSUserDefaults::standardUserDefaults(),
+fn read_map(path: &Path) -> std::io::Result<Map<String, Value>> {
+    let contents = match std::fs::read(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Map::new()),
+        Err(error) => return Err(error),
+    };
+    let value = serde_json::from_slice::<Value>(&contents)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "expected JSON object"))
+}
+
+fn read_current() -> Option<Map<String, Value>> {
+    let path = path();
+    match read_map(&path) {
+        Ok(values) => Some(values),
+        Err(error) => {
+            log::warn!("failed to read {}: {error}", path.display());
+            None
         }
-    }
-
-    #[cfg(test)]
-    fn new(defaults: objc2::rc::Retained<objc2_foundation::NSUserDefaults>) -> Self {
-        Self { defaults }
-    }
-
-    fn store_bool(&self, key: &str, value: bool) {
-        use objc2::rc::Retained;
-        use objc2_foundation::{NSNumber, NSString};
-
-        let number: Retained<NSNumber> = NSNumber::numberWithBool(value);
-        unsafe {
-            self.defaults
-                .setObject_forKey(Some(&number), &NSString::from_str(key));
-        }
-        self.defaults.synchronize();
-    }
-
-    fn store_string(&self, key: &str, value: Option<&str>) {
-        use objc2_foundation::NSString;
-
-        let key = NSString::from_str(key);
-        match value {
-            Some(value) => {
-                let value = NSString::from_str(value);
-                unsafe { self.defaults.setObject_forKey(Some(&value), &key) };
-            }
-            None => self.defaults.removeObjectForKey(&key),
-        }
-        self.defaults.synchronize();
-    }
-
-    fn store_i64(&self, key: &str, value: i64) {
-        use objc2::rc::Retained;
-        use objc2_foundation::{NSNumber, NSString};
-
-        let number: Retained<NSNumber> = NSNumber::numberWithLongLong(value);
-        unsafe {
-            self.defaults
-                .setObject_forKey(Some(&number), &NSString::from_str(key));
-        }
-        self.defaults.synchronize();
-    }
-
-    fn store_f64(&self, key: &str, value: f64) {
-        use objc2::rc::Retained;
-        use objc2_foundation::{NSNumber, NSString};
-
-        let number: Retained<NSNumber> = NSNumber::numberWithDouble(value);
-        unsafe {
-            self.defaults
-                .setObject_forKey(Some(&number), &NSString::from_str(key));
-        }
-        self.defaults.synchronize();
-    }
-
-    fn store_dictionary(&self, key: &str, value: &std::collections::HashMap<String, String>) {
-        use objc2::rc::Retained;
-        use objc2_foundation::{NSDictionary, NSString};
-
-        let keys: Vec<Retained<NSString>> =
-            value.keys().map(|key| NSString::from_str(key)).collect();
-        let values: Vec<Retained<NSString>> = value
-            .values()
-            .map(|value| NSString::from_str(value))
-            .collect();
-        let key_refs: Vec<&NSString> = keys.iter().map(Retained::as_ref).collect();
-        let dictionary = NSDictionary::from_retained_objects(&key_refs, &values);
-        unsafe {
-            self.defaults
-                .setObject_forKey(Some(&dictionary), &NSString::from_str(key));
-        }
-        self.defaults.synchronize();
-    }
-
-    fn remove(&self, key: &str) {
-        use objc2_foundation::NSString;
-
-        self.defaults.removeObjectForKey(&NSString::from_str(key));
-        self.defaults.synchronize();
-    }
-
-    fn read_bool(&self, key: &str) -> Option<bool> {
-        Some(self.number(key)?.boolValue())
-    }
-
-    fn read_i64(&self, key: &str) -> Option<i64> {
-        Some(self.number(key)?.longLongValue())
-    }
-
-    fn read_f64(&self, key: &str) -> Option<f64> {
-        Some(self.number(key)?.doubleValue())
-    }
-
-    fn read_string(&self, key: &str) -> Option<String> {
-        use objc2_foundation::NSString;
-
-        Some(self.object(key)?.downcast::<NSString>().ok()?.to_string())
-    }
-
-    fn number(&self, key: &str) -> Option<objc2::rc::Retained<objc2_foundation::NSNumber>> {
-        self.object(key)?
-            .downcast::<objc2_foundation::NSNumber>()
-            .ok()
-    }
-
-    fn object(&self, key: &str) -> Option<objc2::rc::Retained<objc2::runtime::AnyObject>> {
-        use objc2_foundation::NSString;
-
-        self.defaults.objectForKey(&NSString::from_str(key))
     }
 }
 
-#[cfg(target_os = "macos")]
-pub(super) fn domain_name() -> Option<String> {
-    objc2_foundation::NSBundle::mainBundle()
-        .bundleIdentifier()
-        .map(|value| value.to_string())
+fn write_map(path: &Path, values: &Map<String, Value>) -> std::io::Result<()> {
+    let contents = serde_json::to_vec_pretty(values)?;
+    crate::store::write_private(path, &contents)
 }
 
-#[cfg(target_os = "macos")]
+fn update(key: &str, value: Option<Value>) {
+    let path = path();
+    if let Err(error) = update_at(&path, key, value) {
+        log::warn!("failed to update {}: {error}", path.display());
+    }
+}
+
+fn update_at(path: &Path, key: &str, value: Option<Value>) -> std::io::Result<()> {
+    let mut values = read_map(path)?;
+    match value {
+        Some(value) => {
+            values.insert(key.to_owned(), value);
+        }
+        None => {
+            values.remove(key);
+        }
+    }
+    write_map(path, &values)
+}
+
 pub fn store_bool(key: &str, value: bool) {
-    DefaultsStore::standard().store_bool(key, value);
+    update(key, Some(Value::Bool(value)));
 }
 
-#[cfg(target_os = "macos")]
 pub fn store_string(key: &str, value: Option<&str>) {
-    DefaultsStore::standard().store_string(key, value);
+    update(key, value.map(|value| Value::String(value.to_owned())));
 }
 
-#[cfg(target_os = "macos")]
 pub fn store_i64(key: &str, value: i64) {
-    DefaultsStore::standard().store_i64(key, value);
+    update(key, Some(Value::Number(Number::from(value))));
 }
 
-#[cfg(target_os = "macos")]
 pub fn store_f64(key: &str, value: f64) {
-    DefaultsStore::standard().store_f64(key, value);
+    if let Some(value) = Number::from_f64(value) {
+        update(key, Some(Value::Number(value)));
+    }
 }
 
-#[cfg(target_os = "macos")]
-pub fn store_dictionary(key: &str, value: &std::collections::HashMap<String, String>) {
-    DefaultsStore::standard().store_dictionary(key, value);
+pub fn store_dictionary(key: &str, value: &HashMap<String, String>) {
+    let value = value
+        .iter()
+        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
+        .collect();
+    update(key, Some(Value::Object(value)));
 }
 
-#[cfg(target_os = "macos")]
 pub fn remove(key: &str) {
-    DefaultsStore::standard().remove(key);
+    update(key, None);
 }
 
-#[cfg(target_os = "macos")]
 pub fn read_bool(key: &str) -> Option<bool> {
-    DefaultsStore::standard().read_bool(key)
+    read_current()?.get(key).and_then(Value::as_bool)
 }
 
-#[cfg(target_os = "macos")]
 pub fn read_i64(key: &str) -> Option<i64> {
-    DefaultsStore::standard().read_i64(key)
+    read_current()?.get(key).and_then(Value::as_i64)
 }
 
-#[cfg(target_os = "macos")]
 pub fn read_f64(key: &str) -> Option<f64> {
-    DefaultsStore::standard().read_f64(key)
+    read_current()?.get(key).and_then(Value::as_f64)
 }
 
-#[cfg(target_os = "macos")]
 pub fn read_string(key: &str) -> Option<String> {
-    DefaultsStore::standard().read_string(key)
+    read_current()?
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
 }
 
-#[cfg(not(target_os = "macos"))]
-pub(super) fn domain_name() -> Option<String> {
-    None
+pub fn read_dictionary(key: &str) -> Option<HashMap<String, String>> {
+    read_current()?
+        .get(key)
+        .and_then(Value::as_object)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|(key, value)| Some((key.clone(), value.as_str()?.to_owned())))
+                .collect()
+        })
 }
 
-#[cfg(not(target_os = "macos"))]
-pub fn store_bool(_key: &str, _value: bool) {}
-
-#[cfg(not(target_os = "macos"))]
-pub fn store_string(_key: &str, _value: Option<&str>) {}
-
-#[cfg(not(target_os = "macos"))]
-pub fn store_i64(_key: &str, _value: i64) {}
-
-#[cfg(not(target_os = "macos"))]
-pub fn store_f64(_key: &str, _value: f64) {}
-
-#[cfg(not(target_os = "macos"))]
-pub fn store_dictionary(_key: &str, _value: &std::collections::HashMap<String, String>) {}
-
-#[cfg(not(target_os = "macos"))]
-pub fn remove(_key: &str) {}
-
-#[cfg(not(target_os = "macos"))]
-pub fn read_bool(_key: &str) -> Option<bool> {
-    None
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn read_i64(_key: &str) -> Option<i64> {
-    None
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn read_f64(_key: &str) -> Option<f64> {
-    None
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn read_string(_key: &str) -> Option<String> {
-    None
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn merge_imported(root: &Path, imported: &Map<String, Value>) -> std::io::Result<()> {
+    let path = root.join(FILE_NAME);
+    let mut values = read_map(&path)?;
+    for (key, value) in imported {
+        values.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+    write_map(&path, &values)
 }
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_os = "macos")]
-    struct TestDefaults {
-        store: super::DefaultsStore,
-        suite_name: objc2::rc::Retained<objc2_foundation::NSString>,
-    }
-
-    #[cfg(target_os = "macos")]
-    impl TestDefaults {
-        fn new() -> Self {
-            use objc2::AnyThread;
-            use objc2_foundation::{NSString, NSUserDefaults};
-            use std::time::{SystemTime, UNIX_EPOCH};
-
-            let unique = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
-            let suite_name = NSString::from_str(&format!(
-                "muxy.tests.rust.{}.{}",
-                std::process::id(),
-                unique
-            ));
-            let defaults = NSUserDefaults::initWithSuiteName(
-                NSUserDefaults::alloc(),
-                Some(suite_name.as_ref()),
-            )
-            .unwrap();
-            defaults.removePersistentDomainForName(&suite_name);
-            Self {
-                store: super::DefaultsStore::new(defaults),
-                suite_name,
-            }
-        }
-    }
-
-    #[cfg(target_os = "macos")]
-    impl Drop for TestDefaults {
-        fn drop(&mut self) {
-            self.store
-                .defaults
-                .removePersistentDomainForName(&self.suite_name);
-        }
-    }
+    use serde_json::{Map, Value};
+    use std::collections::HashMap;
 
     #[test]
-    #[cfg(target_os = "macos")]
-    fn round_trips_every_accessor_in_an_isolated_suite() {
-        use objc2_foundation::{NSDictionary, NSString};
-
-        let defaults = TestDefaults::new();
-        let store = &defaults.store;
-
-        store.store_string("string", Some("hello"));
-        assert_eq!(store.read_string("string").as_deref(), Some("hello"));
-
-        store.store_bool("bool", true);
-        assert_eq!(store.read_bool("bool"), Some(true));
-        store.store_bool("bool", false);
-        assert_eq!(store.read_bool("bool"), Some(false));
-
-        store.store_i64("integer", 1800);
-        assert_eq!(store.read_i64("integer"), Some(1800));
-
-        store.store_f64("double", 1.25);
-        assert_eq!(store.read_f64("double"), Some(1.25));
-
-        let mut value = std::collections::HashMap::new();
-        value.insert("alpha".to_owned(), "one".to_owned());
-        store.store_dictionary("dictionary", &value);
-        let dictionary = store
-            .object("dictionary")
-            .unwrap()
-            .downcast::<NSDictionary>()
-            .unwrap();
-        let dictionary = unsafe { dictionary.cast_unchecked::<NSString, NSString>() };
-        assert_eq!(
-            dictionary
-                .objectForKey(&NSString::from_str("alpha"))
-                .unwrap()
-                .to_string(),
-            "one"
+    fn portable_preferences_round_trip_every_supported_type() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("preferences.json");
+        let mut values = Map::new();
+        values.insert("bool".to_owned(), Value::Bool(true));
+        values.insert("integer".to_owned(), Value::from(1800));
+        values.insert("double".to_owned(), Value::from(1.25));
+        values.insert("string".to_owned(), Value::String("hello".to_owned()));
+        values.insert(
+            "dictionary".to_owned(),
+            serde_json::json!({ "alpha": "one" }),
         );
+        super::write_map(&path, &values).expect("write");
 
-        for key in ["string", "bool", "integer", "double", "dictionary"] {
-            store.remove(key);
-            assert!(store.object(key).is_none());
-        }
+        let stored = super::read_map(&path).expect("read");
+        assert_eq!(stored.get("bool").and_then(Value::as_bool), Some(true));
+        assert_eq!(stored.get("integer").and_then(Value::as_i64), Some(1800));
+        assert_eq!(stored.get("double").and_then(Value::as_f64), Some(1.25));
+        assert_eq!(stored.get("string").and_then(Value::as_str), Some("hello"));
+        assert_eq!(
+            stored
+                .get("dictionary")
+                .and_then(Value::as_object)
+                .and_then(|value| value.get("alpha"))
+                .and_then(Value::as_str),
+            Some("one")
+        );
     }
 
     #[test]
-    #[cfg(target_os = "macos")]
-    fn string_none_removes_the_value() {
-        let defaults = TestDefaults::new();
-        defaults.store.store_string("string", Some("value"));
-        defaults.store.store_string("string", None);
-        assert_eq!(defaults.store.read_string("string"), None);
+    fn imported_preferences_never_replace_existing_values() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("preferences.json");
+        let existing = serde_json::json!({ "shared": "rust", "existing": true });
+        super::write_map(&path, existing.as_object().expect("object")).expect("write");
+        let imported = serde_json::json!({ "shared": "swift", "missing": 42 });
+        super::merge_imported(directory.path(), imported.as_object().expect("object"))
+            .expect("merge");
+        assert_eq!(
+            super::read_map(&path).expect("read"),
+            serde_json::json!({ "shared": "rust", "existing": true, "missing": 42 })
+                .as_object()
+                .expect("object")
+                .clone()
+        );
+    }
+
+    #[test]
+    fn ordinary_updates_do_not_replace_a_malformed_file() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("preferences.json");
+        std::fs::write(&path, b"not json").expect("write malformed");
+        let result = super::update_at(&path, "new", Some(Value::Bool(true)));
+        assert_eq!(
+            result.expect_err("malformed preferences").kind(),
+            std::io::ErrorKind::InvalidData
+        );
+        assert_eq!(std::fs::read(&path).expect("unchanged"), b"not json");
+    }
+
+    #[test]
+    fn imported_preferences_do_not_replace_a_malformed_file() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("preferences.json");
+        std::fs::write(&path, b"not json").expect("write malformed");
+        let imported = serde_json::json!({ "imported": true });
+        let result = super::merge_imported(directory.path(), imported.as_object().expect("object"));
+        assert_eq!(
+            result.expect_err("malformed preferences").kind(),
+            std::io::ErrorKind::InvalidData
+        );
+        assert_eq!(std::fs::read(&path).expect("unchanged"), b"not json");
+    }
+
+    #[test]
+    fn dictionary_values_are_string_maps() {
+        let value: HashMap<String, String> = [
+            ("alpha".to_owned(), "one".to_owned()),
+            ("beta".to_owned(), "two".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+        let json: Value = serde_json::to_value(&value).expect("serialize");
+        assert!(json.as_object().is_some());
     }
 }

--- a/crates/muxy-core/src/prefs/mod.rs
+++ b/crates/muxy-core/src/prefs/mod.rs
@@ -1,4 +1,4 @@
-mod defaults;
+pub(crate) mod defaults;
 pub mod settings;
 
 use serde_json::Value;
@@ -133,7 +133,7 @@ impl Prefs {
         let mut prefs = Self::default();
         prefs.apply_settings_json();
         prefs.apply_ui_scale_json();
-        prefs.apply_user_defaults();
+        prefs.apply_portable_preferences();
         prefs
     }
 
@@ -201,78 +201,45 @@ impl Prefs {
         self.scale = ScalePreset::parse(preset);
     }
 
-    fn apply_user_defaults(&mut self) {
-        let Some(domain_name) = defaults::domain_name() else {
-            return;
-        };
-        let path = home_dir().join(format!("Library/Preferences/{domain_name}.plist"));
-        let Ok(plist::Value::Dictionary(defaults)) = plist::Value::from_file(&path) else {
-            return;
-        };
-        if let Some(id) = defaults
-            .get("muxy.activeProjectID")
-            .and_then(|v| v.as_string())
-        {
-            self.active_project_id = Some(id.to_owned());
+    fn apply_portable_preferences(&mut self) {
+        if let Some(id) = defaults::read_string("muxy.activeProjectID") {
+            self.active_project_id = Some(id);
         }
-        if let Some(id) = defaults
-            .get("muxy.ide.selectedBundleIdentifier")
-            .and_then(|value| value.as_string())
-        {
-            self.ide_bundle_identifier = Some(id.to_owned());
+        if let Some(id) = defaults::read_string("muxy.ide.selectedBundleIdentifier") {
+            self.ide_bundle_identifier = Some(id);
         }
-        if let Some(expanded) = defaults.get("muxy.sidebarExpanded").and_then(as_bool) {
+        if let Some(expanded) = defaults::read_bool("muxy.sidebarExpanded") {
             self.sidebar_expanded = expanded;
         }
-        if let Some(width) = defaults
-            .get("muxy.sidebarExpandedCustomWidth")
-            .and_then(|value| value.as_real())
-        {
+        if let Some(width) = defaults::read_f64("muxy.sidebarExpandedCustomWidth") {
             self.sidebar_expanded_custom_width = Some(width as f32);
         }
-        if let Some(mode) = defaults
-            .get("muxy.projectSortMode")
-            .and_then(|value| value.as_string())
-        {
-            self.sort_mode = SortMode::parse(mode);
+        if let Some(mode) = defaults::read_string("muxy.projectSortMode") {
+            self.sort_mode = SortMode::parse(&mode);
         }
-        if let Some(value) = defaults.get("muxy.browser.enabled").and_then(as_bool) {
+        if let Some(value) = defaults::read_bool("muxy.browser.enabled") {
             self.browser_enabled = value;
         }
-        if let Some(value) = defaults
-            .get("muxy.projects.keepOpenWhenNoTabs")
-            .and_then(as_bool)
-        {
+        if let Some(value) = defaults::read_bool("muxy.projects.keepOpenWhenNoTabs") {
             self.keep_projects_open = value;
         }
-        if let Some(value) = defaults
-            .get("muxy.tabs.maxWidth")
-            .and_then(|value| value.as_real())
+        if let Some(value) = defaults::read_f64("muxy.tabs.maxWidth")
             .filter(|value| value.is_finite() && *value >= 0.0)
         {
             self.tab_max_width = value as f32;
         }
-        if let Some(root) = defaults
-            .get("muxy.projectPicker.defaultDirectory")
-            .and_then(|value| value.as_string())
+        if let Some(root) = defaults::read_string("muxy.projectPicker.defaultDirectory")
             .filter(|value| !value.trim().is_empty())
         {
-            self.project_search_root = Some(root.to_owned());
+            self.project_search_root = Some(root);
         }
-        if let Some(id) = defaults
-            .get("muxy.activeProjectGroupID")
-            .and_then(|value| value.as_string())
+        if let Some(id) = defaults::read_string("muxy.activeProjectGroupID")
             .filter(|value| !value.trim().is_empty())
         {
-            self.active_group_id = Some(id.to_owned());
+            self.active_group_id = Some(id);
         }
-        if let Some(plist::Value::Dictionary(entries)) = defaults.get("muxy.activeWorktreeIDs") {
-            self.active_worktree_ids = entries
-                .iter()
-                .filter_map(|(project_id, worktree_id)| {
-                    Some((project_id.clone(), worktree_id.as_string()?.to_owned()))
-                })
-                .collect();
+        if let Some(entries) = defaults::read_dictionary("muxy.activeWorktreeIDs") {
+            self.active_worktree_ids = entries;
         }
     }
 
@@ -289,12 +256,6 @@ impl Prefs {
     }
 }
 
-fn as_bool(value: &plist::Value) -> Option<bool> {
-    value
-        .as_boolean()
-        .or_else(|| value.as_signed_integer().map(|number| number != 0))
-}
-
 const TEST_APP_SUPPORT_DIRECTORY: &str = "MUXY_TEST_APPLICATION_SUPPORT_DIRECTORY";
 
 pub fn home_dir() -> PathBuf {
@@ -304,21 +265,26 @@ pub fn home_dir() -> PathBuf {
 }
 
 pub fn app_support_dir() -> PathBuf {
-    let executable_is_test = std::env::current_exe()
-        .ok()
-        .as_deref()
-        .is_some_and(executable_is_test_process);
-    let is_test = cfg!(test) || executable_is_test;
+    let is_test = is_test_process();
     let override_directory = is_test
         .then(|| std::env::var_os(TEST_APP_SUPPORT_DIRECTORY))
         .flatten();
     resolve_app_support_dir(
         &home_dir(),
+        crate::build_mode!(),
         is_test,
         override_directory.as_deref(),
         &std::env::temp_dir(),
         std::process::id(),
     )
+}
+
+pub fn is_test_process() -> bool {
+    cfg!(test)
+        || std::env::current_exe()
+            .ok()
+            .as_deref()
+            .is_some_and(executable_is_test_process)
 }
 
 fn executable_is_test_process(path: &Path) -> bool {
@@ -339,6 +305,7 @@ fn executable_is_test_process(path: &Path) -> bool {
 
 fn resolve_app_support_dir(
     home: &Path,
+    mode: crate::environment::BuildMode,
     is_test: bool,
     override_directory: Option<&OsStr>,
     temporary_directory: &Path,
@@ -350,7 +317,7 @@ fn resolve_app_support_dir(
         }
         return temporary_directory.join(format!("MuxyTests-{process_id}"));
     }
-    home.join("Library/Application Support/Muxy")
+    crate::environment::StoragePathPolicy::new(mode).root(home)
 }
 
 pub fn read_json(path: &PathBuf) -> Option<Value> {
@@ -362,6 +329,8 @@ pub fn read_json(path: &PathBuf) -> Option<Value> {
 mod tests {
     use std::ffi::OsStr;
     use std::path::Path;
+
+    use crate::environment::BuildMode;
 
     use super::{ScalePreset, executable_is_test_process, resolve_app_support_dir};
 
@@ -378,24 +347,39 @@ mod tests {
     }
 
     #[test]
-    fn normal_app_support_uses_the_user_home_and_ignores_test_override() {
+    fn normal_storage_path_uses_mode_specific_roots_and_ignores_test_override() {
+        let home = Path::new("/Users/example");
+        let override_directory = Some(OsStr::new("/project/test-state"));
         assert_eq!(
             resolve_app_support_dir(
-                Path::new("/Users/example"),
+                home,
+                BuildMode::Development,
                 false,
-                Some(OsStr::new("/project/test-state")),
+                override_directory,
                 Path::new("/tmp"),
                 42,
             ),
-            Path::new("/Users/example/Library/Application Support/Muxy")
+            Path::new("/Users/example/.muxy-dev")
+        );
+        assert_eq!(
+            resolve_app_support_dir(
+                home,
+                BuildMode::Production,
+                false,
+                override_directory,
+                Path::new("/tmp"),
+                42,
+            ),
+            Path::new("/Users/example/.muxy")
         );
     }
 
     #[test]
-    fn test_app_support_uses_a_nonempty_override() {
+    fn storage_path_uses_a_nonempty_test_override() {
         assert_eq!(
             resolve_app_support_dir(
                 Path::new("/Users/example"),
+                BuildMode::Development,
                 true,
                 Some(OsStr::new("/project/test-state")),
                 Path::new("/tmp"),
@@ -406,11 +390,12 @@ mod tests {
     }
 
     #[test]
-    fn test_app_support_falls_back_to_a_process_specific_temporary_directory() {
+    fn storage_path_falls_back_to_a_process_specific_test_directory() {
         for override_directory in [None, Some(OsStr::new(""))] {
             assert_eq!(
                 resolve_app_support_dir(
                     Path::new("/Users/example"),
+                    BuildMode::Production,
                     true,
                     override_directory,
                     Path::new("/tmp"),

--- a/crates/muxy-core/src/prefs/settings.rs
+++ b/crates/muxy-core/src/prefs/settings.rs
@@ -269,23 +269,35 @@ fn ui_scale_path() -> PathBuf {
     super::app_support_dir().join("ui-scale.json")
 }
 
-fn read_defaults(key: &str, kind: Kind) -> Value {
+fn read_defaults(key: &str, kind: Kind, existing: Option<&Value>) -> Value {
     match kind {
-        Kind::Bool(fallback) => Value::Bool(defaults::read_bool(key).unwrap_or(fallback)),
-        Kind::Int(fallback) => {
-            Value::Number(Number::from(defaults::read_i64(key).unwrap_or(fallback)))
-        }
-        Kind::Double(fallback) => Number::from_f64(defaults::read_f64(key).unwrap_or(fallback))
-            .map_or(Value::Null, Value::Number),
-        Kind::Str(fallback) => {
-            Value::String(defaults::read_string(key).unwrap_or_else(|| fallback.to_owned()))
-        }
+        Kind::Bool(fallback) => Value::Bool(
+            defaults::read_bool(key)
+                .or_else(|| existing.and_then(Value::as_bool))
+                .unwrap_or(fallback),
+        ),
+        Kind::Int(fallback) => Value::Number(Number::from(
+            defaults::read_i64(key)
+                .or_else(|| existing.and_then(Value::as_i64))
+                .unwrap_or(fallback),
+        )),
+        Kind::Double(fallback) => Number::from_f64(
+            defaults::read_f64(key)
+                .or_else(|| existing.and_then(Value::as_f64))
+                .unwrap_or(fallback),
+        )
+        .map_or(Value::Null, Value::Number),
+        Kind::Str(fallback) => Value::String(
+            defaults::read_string(key)
+                .or_else(|| existing.and_then(Value::as_str).map(str::to_owned))
+                .unwrap_or_else(|| fallback.to_owned()),
+        ),
     }
 }
 
 fn read_entry(entry: &Entry, existing: Option<&Value>) -> Option<Value> {
     match entry.source {
-        Source::Defaults(kind) => Some(read_defaults(entry.key, kind)),
+        Source::Defaults(kind) => Some(read_defaults(entry.key, kind, existing)),
         Source::UiScale => Some(Value::String(read_ui_scale())),
         Source::ThemeDark => Some(Value::String(
             crate::store::ghostty_conf::theme_selection()
@@ -419,9 +431,17 @@ fn read_ui_scale() -> String {
         .to_owned()
 }
 
+fn stored_setting(key: &str) -> Option<Value> {
+    super::read_json(&path())
+        .as_ref()
+        .and_then(|root| root.get(key))
+        .cloned()
+}
+
 pub fn string_value(key: &str, default: &str) -> String {
     special_string(key)
         .or_else(|| defaults::read_string(key))
+        .or_else(|| stored_setting(key).and_then(|value| value.as_str().map(str::to_owned)))
         .unwrap_or_else(|| default.to_owned())
 }
 
@@ -437,15 +457,21 @@ fn special_string(key: &str) -> Option<String> {
 }
 
 pub fn bool_value(key: &str, default: bool) -> bool {
-    defaults::read_bool(key).unwrap_or(default)
+    defaults::read_bool(key)
+        .or_else(|| stored_setting(key).and_then(|value| value.as_bool()))
+        .unwrap_or(default)
 }
 
 pub fn i64_value(key: &str, default: i64) -> i64 {
-    defaults::read_i64(key).unwrap_or(default)
+    defaults::read_i64(key)
+        .or_else(|| stored_setting(key).and_then(|value| value.as_i64()))
+        .unwrap_or(default)
 }
 
 pub fn f64_value(key: &str, default: f64) -> f64 {
-    defaults::read_f64(key).unwrap_or(default)
+    defaults::read_f64(key)
+        .or_else(|| stored_setting(key).and_then(|value| value.as_f64()))
+        .unwrap_or(default)
 }
 
 pub fn set_ui_scale(preset: crate::prefs::ScalePreset) {
@@ -967,7 +993,7 @@ mod tests {
     use serde_json::{Value, json};
 
     #[test]
-    fn keys_with_their_own_source_do_not_read_from_user_defaults() {
+    fn keys_with_their_own_source_do_not_read_from_portable_preferences() {
         assert!(super::special_string("muxy.ui.scale").is_some());
         assert!(super::special_string("muxy.theme.dark").is_some());
         assert!(super::special_string("muxy.theme.light").is_some());
@@ -975,6 +1001,26 @@ mod tests {
         assert!(super::special_string("muxy.tabs.maxWidth").is_none());
         assert!(super::special_string("ai.providers").is_none());
         assert!(super::special_string("not.a.settings.key").is_none());
+    }
+
+    #[test]
+    fn imported_settings_values_survive_when_portable_preferences_are_missing() {
+        assert_eq!(
+            super::read_defaults(
+                "muxy.tests.importedBool",
+                super::Kind::Bool(false),
+                Some(&Value::Bool(true)),
+            ),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            super::read_defaults(
+                "muxy.tests.importedString",
+                super::Kind::Str("fallback"),
+                Some(&Value::String("imported".to_owned())),
+            ),
+            Value::String("imported".to_owned())
+        );
     }
 
     #[test]

--- a/crates/muxy-core/src/store/persistence.rs
+++ b/crates/muxy-core/src/store/persistence.rs
@@ -1,18 +1,24 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 pub fn write_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> {
-    let temp = stage(path, contents)?;
-    std::fs::rename(&temp, path)
+    let temp = stage(path, contents, false)?;
+    publish_replacing(&temp, path)
 }
 
 #[cfg(unix)]
 pub fn write_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    let temp = stage(path, contents)?;
-    std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o600))?;
-    std::fs::rename(&temp, path)
+    let temp = stage(path, contents, true)?;
+    if let Err(error) = std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o600)) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(error);
+    }
+    publish_replacing(&temp, path)
 }
 
 #[cfg(not(unix))]
@@ -20,20 +26,60 @@ pub fn write_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     write_atomic(path, contents)
 }
 
-fn stage(path: &Path, contents: &[u8]) -> std::io::Result<PathBuf> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+fn stage(path: &Path, contents: &[u8], private: bool) -> std::io::Result<PathBuf> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    loop {
+        let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let mut name = path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("muxy"))
+            .to_os_string();
+        name.push(format!(".{}.{}.tmp", std::process::id(), sequence));
+        let temp = parent.join(name);
+        let opened = open_staging_file(&temp, private);
+        let mut file = match opened {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        };
+        let result = file.write_all(contents).and_then(|()| file.sync_all());
+        if let Err(error) = result {
+            drop(file);
+            let _ = std::fs::remove_file(&temp);
+            return Err(error);
+        }
+        return Ok(temp);
     }
-    let temp = path.with_extension(format!(
-        "{}.tmp",
-        path.extension()
-            .and_then(|value| value.to_str())
-            .unwrap_or("")
-    ));
-    let mut file = std::fs::File::create(&temp)?;
-    file.write_all(contents)?;
-    file.sync_all()?;
-    Ok(temp)
+}
+
+#[cfg(unix)]
+fn open_staging_file(path: &Path, private: bool) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(if private { 0o600 } else { 0o666 })
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_staging_file(path: &Path, _private: bool) -> std::io::Result<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+fn publish_replacing(temp: &Path, path: &Path) -> std::io::Result<()> {
+    match std::fs::rename(temp, path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = std::fs::remove_file(temp);
+            Err(error)
+        }
+    }
 }
 
 pub fn write_json<T: serde::Serialize>(path: &Path, value: &T) -> std::io::Result<()> {
@@ -43,7 +89,7 @@ pub fn write_json<T: serde::Serialize>(path: &Path, value: &T) -> std::io::Resul
 
 #[cfg(test)]
 mod tests {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{PermissionsExt, symlink};
 
     fn mode(path: &std::path::Path) -> u32 {
         std::fs::metadata(path)
@@ -51,6 +97,14 @@ mod tests {
             .permissions()
             .mode()
             & 0o777
+    }
+
+    #[test]
+    fn private_staging_is_private_from_creation() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("private.json");
+        let staged = super::stage(&path, b"{}", true).expect("stage");
+        assert_eq!(mode(&staged), 0o600);
     }
 
     #[test]
@@ -73,5 +127,18 @@ mod tests {
         super::write_private(&path, b"new").expect("write");
         assert_eq!(mode(&path), 0o600);
         assert_eq!(std::fs::read(&path).expect("read"), b"new");
+    }
+
+    #[test]
+    fn write_private_does_not_follow_a_predictable_temporary_symlink() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("private.json");
+        let external = dir.path().join("external.json");
+        std::fs::write(&external, b"external").expect("external");
+        symlink(&external, dir.path().join("private.json.tmp")).expect("symlink");
+
+        super::write_private(&path, b"private").expect("write");
+        assert_eq!(std::fs::read(&external).expect("external"), b"external");
+        assert_eq!(std::fs::read(&path).expect("private"), b"private");
     }
 }

--- a/crates/muxy/src/main.rs
+++ b/crates/muxy/src/main.rs
@@ -41,6 +41,10 @@ const TRAFFIC_LIGHT_HEIGHT: f32 = 14.0;
 const TRAFFIC_LIGHT_X: f32 = 9.0;
 
 fn main() {
+    if let Err(error) = muxy_core::migration::run_startup() {
+        eprintln!("failed to migrate Swift profile: {error}");
+        std::process::exit(1);
+    }
     let app_support = muxy_core::prefs::app_support_dir();
     let mode = muxy_core::build_mode!();
     let socket_path =

--- a/crates/muxy/src/terminal/ghostty/mod.rs
+++ b/crates/muxy/src/terminal/ghostty/mod.rs
@@ -745,7 +745,8 @@ impl GhosttySurfaceHandle {
 fn load_config(
     resources: &AppResources,
 ) -> Result<(GhosttyConfig, Option<TemporaryConfigFile>), ghostty_host::ConfigError> {
-    let paths = ConfigPaths::new(&resources.defaults_config);
+    let paths = ConfigPaths::new(&resources.defaults_config)
+        .with_user_override(Some(muxy_core::store::ghostty_conf::path()));
     let user_config = paths
         .user_override()
         .and_then(|path| fs::read_to_string(path).ok())

--- a/docs/development/dev-prod-isolation.md
+++ b/docs/development/dev-prod-isolation.md
@@ -4,24 +4,38 @@
 
 ```mermaid
 flowchart LR
-    A[Choose a run mode] --> B{Use real Muxy settings?}
-    B -->|Yes| C[scripts/run.sh debug]
-    B -->|No| D[scripts/run-test-app.sh debug]
-    C --> E[com.muxy.app]
-    C --> F[~/Library/Application Support/Muxy]
-    D --> G[com.muxy.tests]
-    D --> H[target/test-verification/state]
+    A[Choose a run mode] --> B{Mode}
+    B -->|Debug| C[scripts/run.sh debug]
+    B -->|Release| D[scripts/run.sh release]
+    B -->|Isolated test| E[scripts/run-test-app.sh debug or release]
+    C --> F[com.muxy.dev]
+    C --> G[~/.muxy-dev]
+    D --> H[com.muxy.app]
+    D --> I[~/.muxy]
+    E --> J[com.muxy.tests]
+    E --> K[target/test-verification/state]
 ```
 
 | Goal | Command |
 |---|---|
-| Run normally | `scripts/run.sh debug` |
-| Test without production settings | `scripts/run-test-app.sh debug` |
-| Test the release build safely | `scripts/run-test-app.sh release` |
+| Run normal development | `scripts/run.sh debug` |
+| Run the release profile | `scripts/run.sh release` |
+| Test debug without development state | `scripts/run-test-app.sh debug` |
+| Test release without production state | `scripts/run-test-app.sh release` |
 
-> `scripts/run.sh` uses your real Muxy settings. The test runner creates a staged `MuxyTests` app.
+Normal debug has its own bundle identity and storage root. It does not read release App Support or release defaults. The test runner creates a staged `MuxyTests` app with injected storage.
 
 `com.muxy.tests` and `target/test-verification` are permanent test infrastructure. Every phase reuses them instead of creating phase-numbered identities.
+
+## Storage identities
+
+| Profile | Bundle identifier | Display name | Storage |
+|---|---|---|---|
+| Debug | `com.muxy.dev` | `Muxy Dev` | `~/.muxy-dev` |
+| Release | `com.muxy.app` | `Muxy` | `~/.muxy` |
+| Staged test | `com.muxy.tests` | `MuxyTests` | Injected ignored directory |
+
+Release imports the retained Swift profile once, then reads and writes only `~/.muxy`. Normal debug never inspects the Swift source or the release root. See [Swift profile migration](swift-profile-migration.md) for the allowlist and retry contract.
 
 ## Why the test app looks fresh
 
@@ -33,7 +47,7 @@ Saved projects                  No saved projects
 Your preferences                Clean test preferences
 ```
 
-The test app uses a separate defaults domain and project-local files. Remove its state at any time:
+The test app uses a separate identity and project-local files. Remove its state at any time:
 
 ```bash
 rm -rf target/test-verification
@@ -43,36 +57,22 @@ rm -rf target/test-verification
 
 ```mermaid
 flowchart TB
-    D[Debug] --> DS[muxy-dev.sock]
+    D[Debug] --> DR[~/.muxy-dev]
+    D --> DS[muxy-dev.sock]
     D --> DP[sessions-dev]
     D --> DH[hooks-dev]
-    D --> DM[Mobile .dev keys · port 4866]
+    D --> DM[Mobile .dev keys and port 4866]
 
-    R[Release] --> RS[muxy.sock]
+    R[Release] --> RR[~/.muxy]
+    R --> RS[muxy.sock]
     R --> RP[sessions]
     R --> RH[hooks]
-    R --> RM[Mobile production keys · port 4865]
+    R --> RM[Mobile production keys and port 4865]
 ```
 
-Normal debug and release apps still share:
+Debug and release do not share normal application storage. Runtime endpoint names and mobile keys remain mode-specific as an additional boundary.
 
-- App Support
-- non-mobile settings
-- Ghostty configuration
-
-Only runtime endpoint names and mobile keys differ by build mode.
-
-## Mobile settings stay side by side
-
-```mermaid
-flowchart LR
-    J[settings.json] --> D[Debug .dev values]
-    J --> P[Release values]
-    D --> DU[Debug Settings UI]
-    P --> PU[Release Settings UI]
-```
-
-Editing one profile does not replace the other profile’s values.
+## Mobile settings
 
 | Profile | Port key | Default |
 |---|---|---:|
@@ -85,11 +85,12 @@ Mobile server startup is not implemented yet. That runtime work belongs to P12.
 
 ```mermaid
 flowchart LR
-    T[Tests] --> U[Unique defaults suite]
-    T --> V[Temporary file paths]
-    A[Acceptance launch] --> B[Staged test bundle]
-    B --> C[Project-local state]
-    P[Production Muxy] --> D[Production state]
+    T[Tests] --> U[com.muxy.tests]
+    T --> V[Injected files]
+    D[Debug] --> W[com.muxy.dev]
+    D --> X[~/.muxy-dev]
+    P[Release] --> Y[com.muxy.app]
+    P --> Z[~/.muxy]
 ```
 
-Tests inject their storage. They do not select the production defaults domain.
+Tests inject their storage. Debug selects development storage by build mode. Neither accepts a production storage override merely because an environment variable is present.

--- a/docs/development/swift-profile-migration.md
+++ b/docs/development/swift-profile-migration.md
@@ -1,0 +1,70 @@
+# Swift profile migration
+
+Muxy release performs one bounded import from the retained macOS Swift profile into the Rust-owned profile.
+
+## Locations
+
+| Purpose | Location |
+|---|---|
+| Swift source | `~/Library/Application Support/Muxy` |
+| Rust release root | `~/.muxy` |
+| Rust debug root | `~/.muxy-dev` |
+| Portable preferences | `<root>/preferences.json` |
+| Migration state | `~/.muxy/swift-profile-migration.json` |
+
+Debug never runs the importer. Recognized staged test executables may inject synthetic roots and sources. Normal applications do not accept storage overrides from the environment.
+
+## Import behavior
+
+Release checks the versioned migration state before inspecting the Swift source. Terminal outcomes return immediately.
+
+The App Support allowlist is:
+
+- `projects.json`
+- `recently-removed-projects.json`
+- `project-groups.json`
+- `workspaces.json`
+- `settings.json`
+- `ui-scale.json`
+- `keybindings.json`
+- `command-shortcuts.json`
+- `editor-settings.json`
+- `quick-terminal-shortcut.json`
+- `approved-devices.json`
+- `remote-devices.json`
+- `browser-profiles.json`
+- `ghostty.conf`
+- `worktrees/`
+- `logos/`
+
+Existing destination entries always win. Missing entries are reported but are not errors. Directory merges recurse into missing entries. Symlinks, sockets, devices, and other non-regular entries are not followed or copied.
+
+Every new regular file is copied to a uniquely created destination-side temporary file and published without replacing an entry created during the copy. Copy failures remove only temporary files owned by that attempt. The importer never modifies, moves, or deletes the Swift source.
+
+## Preferences
+
+Normal Rust preference reads and writes use private atomic `preferences.json` beneath the selected root. Rust does not read a preferences plist directly.
+
+During an eligible pending release migration on macOS, a narrow Foundation reader imports only the approved production `NSUserDefaults` keys. Existing keys in `preferences.json` win. Debug, Linux, completed migrations, source-missing migrations, abandoned migrations, and ordinary tests do not read the production suite.
+
+## Outcomes
+
+| Outcome | Startup behavior | Future Swift inspection |
+|---|---|---|
+| `completed` | Continue | Never |
+| `source_missing` | Continue | Never |
+| `pending` after first failure | Stop with an actionable error | Retry once on the next launch |
+| `abandoned` after second failure | Continue with imported data and Rust defaults for missing values | Never |
+
+The state records paths and error categories, not user values or copied contents. An unreadable, malformed, or unsupported state blocks startup without inspecting the Swift source. A root-local file lock prevents concurrent migration attempts.
+
+## Verification
+
+Run:
+
+```bash
+scripts/verify-p2-5-migration.sh --self-test
+scripts/verify-p2-5-migration.sh
+```
+
+The full verifier stages `com.muxy.tests` debug and release bundles under `target/test-verification`, uses an isolated `HOME`, hashes synthetic sources, and proves success, target-wins merge, source-missing completion, retry, abandonment, and terminal no-reinspection without touching real user state.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -105,6 +105,11 @@ if [[ "$PROFILE" == debug ]]; then
         "$STAGING_BUNDLE/Contents/Resources/muxy-dev-bin/muxy"
 fi
 install -m 0644 "$INFO_PLIST" "$STAGING_BUNDLE/Contents/Info.plist"
+if [[ "$PROFILE" == debug ]]; then
+    plutil -replace CFBundleName -string "Muxy Dev" "$STAGING_BUNDLE/Contents/Info.plist"
+    plutil -replace CFBundleDisplayName -string "Muxy Dev" "$STAGING_BUNDLE/Contents/Info.plist"
+    plutil -replace CFBundleIdentifier -string "com.muxy.dev" "$STAGING_BUNDLE/Contents/Info.plist"
+fi
 iconutil --convert icns --output "$STAGING_BUNDLE/Contents/Resources/AppIcon.icns" "$ICONSET"
 
 cp -R "$GHOSTTY_RESOURCES" "$STAGING_BUNDLE/Contents/Resources/ghostty"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -41,9 +41,27 @@ fi
 printf '==> Checking production defaults isolation\n'
 production_defaults_domain='com.muxy.'
 production_defaults_domain+='app'
-if rg -n -F "$production_defaults_domain" crates/ \
-    scripts/stage-test-app.sh scripts/run-test-app.sh; then
-    printf 'error: Rust and verification scripts must not select the production defaults domain\n' >&2
+production_defaults_matches="$(rg -n -F "$production_defaults_domain" crates/ \
+    scripts/stage-test-app.sh scripts/run-test-app.sh \
+    | rg -v '^crates/muxy-core/src/migration.rs:' || true)"
+if [[ -n "$production_defaults_matches" ]]; then
+    printf '%s\n' "$production_defaults_matches"
+    printf 'error: only the migration reader may select the production defaults domain\n' >&2
+    exit 1
+fi
+
+printf '==> Checking migration ownership\n'
+migration_owner='crates/muxy-core/src/migration.rs'
+migration_matches="$(rg -n 'NSUserDefaults|swift-profile-migration\.json|MUXY_TEST_SWIFT_' crates/ \
+    | rg -v "^${migration_owner}:" || true)"
+if [[ -n "$migration_matches" ]]; then
+    printf '%s\n' "$migration_matches"
+    printf 'error: migration-only state escaped %s\n' "$migration_owner" >&2
+    exit 1
+fi
+if rg -n 'Library/Preferences|plist::' crates/muxy-core/src \
+    || rg -n '^plist\.workspace' crates/muxy-core/Cargo.toml; then
+    printf 'error: normal core preferences must remain portable\n' >&2
     exit 1
 fi
 
@@ -135,9 +153,12 @@ printf '==> Running tests\n'
 cargo test --workspace --all-targets --all-features --locked --offline
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
+    printf '==> Checking staged migration safety guards\n'
+    "$SCRIPT_DIR/verify-p2-5-migration.sh" --self-test
+
     printf '==> Building debug application bundle\n'
     "$SCRIPT_DIR/build-app.sh" debug
 
     printf '==> Verifying debug application bundle\n'
-    "$SCRIPT_DIR/verify-bundle.sh" "$PROJECT_ROOT/target/debug/Muxy.app"
+    "$SCRIPT_DIR/verify-bundle.sh" "$PROJECT_ROOT/target/debug/Muxy.app" debug
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,6 +15,9 @@ readonly RESOURCES_SHA256="877081c96cf4bc97fa7a15c397ad285f6e5c544ec43778b090301
 readonly XCFRAMEWORK_DIR="$PROJECT_ROOT/vendor/GhosttyKit.xcframework"
 readonly GHOSTTY_RESOURCES_DIR="$PROJECT_ROOT/resources/ghostty"
 readonly TERMINFO_DIR="$PROJECT_ROOT/resources/terminfo"
+readonly SWIFT_HEADER="$PROJECT_ROOT/GhosttyKit/ghostty.h"
+readonly SWIFT_GHOSTTY_RESOURCES_DIR="$PROJECT_ROOT/Muxy/Resources/ghostty"
+readonly SWIFT_TERMINFO_DIR="$PROJECT_ROOT/Muxy/Resources/terminfo"
 readonly INSTALL_STAMP_NAME=".muxy-release"
 
 xcframework_archive=""
@@ -86,7 +89,7 @@ while (($# > 0)); do
 done
 
 [[ "$(uname -s)" == "Darwin" ]] || fail "GhosttyKit setup requires macOS"
-for command_name in xcode-select xcodebuild xcrun gh tar shasum plutil; do
+for command_name in cmp install xcode-select xcodebuild xcrun gh tar shasum plutil; do
     require_command "$command_name"
 done
 
@@ -149,6 +152,23 @@ validate_resources_install() {
         "$(stamp_value "$RESOURCES_SHA256")" ]] || return 1
     [[ "$(<"$TERMINFO_DIR/$INSTALL_STAMP_NAME")" == \
         "$(stamp_value "$RESOURCES_SHA256")" ]]
+}
+
+materialize_swift_bridges() {
+    local canonical_header="$XCFRAMEWORK_DIR/macos-arm64_x86_64/Headers/ghostty.h"
+
+    validate_xcframework_install || fail "canonical xcframework failed validation"
+    validate_resources_install || fail "canonical resources failed validation"
+    mkdir -p "$(dirname "$SWIFT_HEADER")" "$SWIFT_GHOSTTY_RESOURCES_DIR"
+    install -m 0644 "$canonical_header" "$SWIFT_HEADER"
+    rm -rf "$SWIFT_GHOSTTY_RESOURCES_DIR/shell-integration" "$SWIFT_TERMINFO_DIR"
+    cp -R "$GHOSTTY_RESOURCES_DIR/shell-integration" \
+        "$SWIFT_GHOSTTY_RESOURCES_DIR/shell-integration"
+    cp -R "$TERMINFO_DIR" "$SWIFT_TERMINFO_DIR"
+    cmp -s "$canonical_header" "$SWIFT_HEADER" || fail "Swift Ghostty header bridge differs"
+    validate_resources_contents "$SWIFT_GHOSTTY_RESOURCES_DIR" "$SWIFT_TERMINFO_DIR" || {
+        fail "Swift Ghostty resource mirrors failed validation"
+    }
 }
 
 verify_sha256() {
@@ -247,6 +267,7 @@ if validate_resources_install >/dev/null 2>&1; then
 fi
 
 if [[ "$need_xcframework" == false && "$need_resources" == false ]]; then
+    materialize_swift_bridges
     printf '==> GhosttyKit %s is already installed and valid\n' "$RELEASE_TAG"
     exit 0
 fi
@@ -273,4 +294,5 @@ else
     printf '==> Existing Ghostty runtime resources are valid\n'
 fi
 
+materialize_swift_bridges
 printf '==> GhosttyKit %s setup complete\n' "$RELEASE_TAG"

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -59,11 +59,22 @@ plist_value() {
     /usr/libexec/PlistBuddy -c "Print :$1" "$PLIST"
 }
 
-[[ "$(plist_value CFBundleName)" == "Muxy" ]] || fail "CFBundleName must be Muxy"
-[[ "$(plist_value CFBundleDisplayName)" == "Muxy" ]] || fail "CFBundleDisplayName must be Muxy"
+expected_name="Muxy"
+expected_identifier="com.muxy.app"
+if [[ "$PROFILE" == debug ]]; then
+    expected_name="Muxy Dev"
+    expected_identifier="com.muxy.dev"
+fi
+readonly expected_name expected_identifier
+[[ "$(plist_value CFBundleName)" == "$expected_name" ]] || {
+    fail "CFBundleName must be $expected_name for ${PROFILE:-release}"
+}
+[[ "$(plist_value CFBundleDisplayName)" == "$expected_name" ]] || {
+    fail "CFBundleDisplayName must be $expected_name for ${PROFILE:-release}"
+}
 [[ "$(plist_value CFBundleExecutable)" == "muxy" ]] || fail "CFBundleExecutable must be muxy"
-[[ "$(plist_value CFBundleIdentifier)" == "com.muxy.app" ]] || {
-    fail "CFBundleIdentifier must be com.muxy.app"
+[[ "$(plist_value CFBundleIdentifier)" == "$expected_identifier" ]] || {
+    fail "CFBundleIdentifier must be $expected_identifier for ${PROFILE:-release}"
 }
 [[ "$(plist_value CFBundlePackageType)" == "APPL" ]] || fail "CFBundlePackageType must be APPL"
 [[ "$(plist_value CFBundleIconFile)" == "AppIcon" ]] || fail "CFBundleIconFile must be AppIcon"

--- a/scripts/verify-cli-compat.sh
+++ b/scripts/verify-cli-compat.sh
@@ -49,7 +49,7 @@ readonly PRODUCTION_PID
 kill -0 "$PRODUCTION_PID" 2>/dev/null || fail "production socket owner is not live"
 
 "$SCRIPT_DIR/build-app.sh" debug
-"$SCRIPT_DIR/verify-bundle.sh" "$PROJECT_ROOT/target/debug/Muxy.app"
+"$SCRIPT_DIR/verify-bundle.sh" "$PROJECT_ROOT/target/debug/Muxy.app" debug
 "$SCRIPT_DIR/stage-test-app.sh" "$PROJECT_ROOT/target/debug/Muxy.app" p2-cli >/dev/null
 readonly STAGED_CLI="$APP/Contents/Resources/Muxy_Muxy.bundle/scripts/muxy-cli"
 [[ -x "$STAGED_CLI" ]] || fail "staged nested CLI is not executable"

--- a/scripts/verify-p2-5-migration.sh
+++ b/scripts/verify-p2-5-migration.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIR
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+readonly PROJECT_ROOT
+readonly VERIFICATION_ROOT="$PROJECT_ROOT/target/test-verification/p2-5-migration"
+readonly OWNERSHIP_MARKER="$VERIFICATION_ROOT/.muxy-p2-5-verifier"
+readonly OWNERSHIP_VALUE="muxy-p2-5-migration-verifier-v1"
+readonly REAL_HOME="$HOME"
+readonly REAL_SWIFT_SOURCE="$REAL_HOME/Library/Application Support/Muxy"
+APP_PID=""
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+state_value() {
+    local state="$1"
+    local key="$2"
+    plutil -extract "$key" raw -o - "$state"
+}
+
+state_array_contains() {
+    local state="$1"
+    local key="$2"
+    local value="$3"
+    plutil -extract "$key" xml1 -o - "$state" | grep -Fq "<string>$value</string>"
+}
+
+source_hash() {
+    local source="$1"
+    if [[ ! -d "$source" ]]; then
+        printf 'missing\n' | shasum -a 256 | cut -d ' ' -f 1
+        return
+    fi
+    find "$source" -type f -print | LC_ALL=C sort | while IFS= read -r path; do
+        printf '%s\n' "${path#"$source"/}"
+        shasum -a 256 "$path"
+    done | shasum -a 256 | cut -d ' ' -f 1
+}
+
+assert_verification_ancestors() {
+    local path
+    for path in "$PROJECT_ROOT/target" "$PROJECT_ROOT/target/test-verification" "$VERIFICATION_ROOT"; do
+        [[ ! -L "$path" ]] || return 1
+        [[ ! -e "$path" || -d "$path" ]] || return 1
+    done
+    if [[ -d "$PROJECT_ROOT/target" ]]; then
+        [[ "$(cd "$PROJECT_ROOT/target" && pwd -P)" == "$PROJECT_ROOT/target" ]] || return 1
+    fi
+    if [[ -d "$PROJECT_ROOT/target/test-verification" ]]; then
+        [[ "$(cd "$PROJECT_ROOT/target/test-verification" && pwd -P)" == "$PROJECT_ROOT/target/test-verification" ]] || return 1
+    fi
+}
+
+path_is_safe_under_verification_root() {
+    local path="$1"
+    [[ "$path" == "$VERIFICATION_ROOT"/* ]] || return 1
+    [[ "$path" != *"/../"* && "$path" != */.. && "$path" != *"/./"* && "$path" != */. ]] || return 1
+    local relative="${path#"$VERIFICATION_ROOT"/}"
+    local component cursor="$VERIFICATION_ROOT"
+    local old_ifs="$IFS"
+    IFS='/'
+    read -r -a components <<< "$relative"
+    IFS="$old_ifs"
+    for component in "${components[@]}"; do
+        [[ -n "$component" ]] || return 1
+        cursor="$cursor/$component"
+        [[ ! -L "$cursor" ]] || return 1
+    done
+}
+
+ownership_marker_is_valid() {
+    local marker="$1"
+    [[ ! -L "$marker" && -f "$marker" ]] || return 1
+    [[ "$(cat "$marker")" == "$OWNERSHIP_VALUE" ]]
+}
+
+ensure_verification_root() {
+    assert_verification_ancestors || fail "verification path has an unsafe ancestor"
+    mkdir -p "$PROJECT_ROOT/target/test-verification"
+    assert_verification_ancestors || fail "verification path changed while preparing it"
+    if [[ -e "$VERIFICATION_ROOT" ]]; then
+        ownership_marker_is_valid "$OWNERSHIP_MARKER" || fail "verification root is not owned by this verifier"
+    else
+        mkdir "$VERIFICATION_ROOT"
+        printf '%s\n' "$OWNERSHIP_VALUE" > "$OWNERSHIP_MARKER"
+    fi
+}
+
+reset_verification_root() {
+    ensure_verification_root
+    assert_verification_ancestors || fail "verification path became unsafe before reset"
+    ownership_marker_is_valid "$OWNERSHIP_MARKER" || fail "verification ownership marker changed"
+    rm -rf "$VERIFICATION_ROOT"
+    mkdir "$VERIFICATION_ROOT"
+    printf '%s\n' "$OWNERSHIP_VALUE" > "$OWNERSHIP_MARKER"
+}
+
+assert_safe_environment() {
+    local home="$1"
+    local root="$2"
+    local source="$3"
+    local defaults="$4"
+    local identifier="$5"
+    assert_verification_ancestors || return 1
+    path_is_safe_under_verification_root "$home" || return 1
+    path_is_safe_under_verification_root "$root" || return 1
+    path_is_safe_under_verification_root "$source" || return 1
+    path_is_safe_under_verification_root "$defaults" || return 1
+    [[ "$root" != "$source" ]] || return 1
+    [[ "$root" != "$REAL_HOME/.muxy" ]] || return 1
+    [[ "$root" != "$REAL_HOME/.muxy-dev" ]] || return 1
+    [[ "$source" != "$REAL_SWIFT_SOURCE" ]] || return 1
+    [[ "$identifier" == "com.muxy.tests" ]] || return 1
+}
+
+self_test() {
+    ensure_verification_root
+    local root="$VERIFICATION_ROOT/self-test"
+    local home="$root/home"
+    local state="$root/state"
+    local source="$root/swift"
+    local defaults="$root/defaults.json"
+    rm -rf "$root"
+    mkdir -p "$home" "$state" "$source"
+    printf '{}\n' > "$defaults"
+    assert_safe_environment "$home" "$state" "$source" "$defaults" "com.muxy.tests" || {
+        fail "self-test rejected a safe environment"
+    }
+    if assert_safe_environment "$REAL_HOME" "$state" "$source" "$defaults" "com.muxy.tests"; then
+        fail "self-test accepted the real HOME"
+    fi
+    if assert_safe_environment "$home" "$REAL_HOME/.muxy" "$source" "$defaults" "com.muxy.tests"; then
+        fail "self-test accepted the real release root"
+    fi
+    if assert_safe_environment "$home" "$state" "$REAL_SWIFT_SOURCE" "$defaults" "com.muxy.tests"; then
+        fail "self-test accepted the real Swift source"
+    fi
+    if assert_safe_environment "$home" "$state" "$source" "$REAL_HOME/defaults.json" "com.muxy.tests"; then
+        fail "self-test accepted defaults outside the isolated root"
+    fi
+    if assert_safe_environment "$home" "$state" "$source" "$defaults" "com.muxy.app"; then
+        fail "self-test accepted the production bundle identity"
+    fi
+    mkdir "$root/linked-target"
+    ln -s "$root/linked-target" "$root/linked-state"
+    if assert_safe_environment "$home" "$root/linked-state" "$source" "$defaults" "com.muxy.tests"; then
+        fail "self-test accepted a symlinked state ancestor"
+    fi
+    printf '%s\n' "$OWNERSHIP_VALUE" > "$root/marker-target"
+    ln -s "$root/marker-target" "$root/linked-marker"
+    if ownership_marker_is_valid "$root/linked-marker"; then
+        fail "self-test accepted a symlinked ownership marker"
+    fi
+    rm -f "$root/linked-marker"
+    rm -f "$root/linked-state"
+    rm -rf "$root"
+    printf 'P2.5 migration verifier self-test passed\n'
+}
+
+launch_app() {
+    local executable="$1"
+    local home="$2"
+    local root="$3"
+    local source="$4"
+    local defaults="$5"
+    local failure_path="$6"
+    local log="$7"
+    mkdir -p "$home" "$root" "$home/tmp"
+    env \
+        HOME="$home" \
+        CFFIXED_USER_HOME="$home" \
+        TMPDIR="$home/tmp" \
+        MUXY_TEST_APPLICATION_SUPPORT_DIRECTORY="$root" \
+        MUXY_TEST_SWIFT_APPLICATION_SUPPORT_DIRECTORY="$source" \
+        MUXY_TEST_SWIFT_DEFAULTS_PATH="$defaults" \
+        MUXY_TEST_MIGRATION_FAIL_PATH="$failure_path" \
+        "$executable" >"$log" 2>&1 &
+    APP_PID=$!
+}
+
+wait_for_outcome() {
+    local state="$1"
+    local expected="$2"
+    local attempt
+    for ((attempt = 0; attempt < 300; attempt++)); do
+        if [[ -f "$state" ]] && [[ "$(state_value "$state" outcome 2>/dev/null || true)" == "$expected" ]]; then
+            return 0
+        fi
+        sleep 0.05
+    done
+    return 1
+}
+
+wait_for_socket() {
+    local socket="$1"
+    local attempt
+    for ((attempt = 0; attempt < 300; attempt++)); do
+        [[ -S "$socket" ]] && return 0
+        sleep 0.05
+    done
+    return 1
+}
+
+stop_app() {
+    local socket="$1"
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill -TERM "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+    fi
+    APP_PID=""
+    rm -f "$socket"
+}
+
+expect_startup_failure() {
+    local state="$1"
+    local expected="$2"
+    wait_for_outcome "$state" "$expected" || fail "timed out waiting for $expected migration state"
+    local attempt
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        if ! kill -0 "$APP_PID" 2>/dev/null; then
+            set +e
+            wait "$APP_PID"
+            local status=$?
+            set -e
+            APP_PID=""
+            [[ $status -ne 0 ]] || fail "migration failure launch exited successfully"
+            return
+        fi
+        sleep 0.05
+    done
+    stop_app ""
+    fail "migration failure launch did not exit"
+}
+
+verify_staged_identity() {
+    local app="$1"
+    local plist="$app/Contents/Info.plist"
+    [[ "$(plutil -extract CFBundleIdentifier raw -o - "$plist")" == "com.muxy.tests" ]] || {
+        fail "staged bundle identifier is not com.muxy.tests"
+    }
+    [[ "$(plutil -extract CFBundleExecutable raw -o - "$plist")" == "MuxyTests" ]] || {
+        fail "staged executable is not MuxyTests"
+    }
+}
+
+run_acceptance() {
+    local debug_source="$PROJECT_ROOT/target/debug/Muxy.app"
+    local release_source="$PROJECT_ROOT/target/release/Muxy.app"
+    local debug_app release_app debug_executable release_executable
+    local home defaults source_hash_before source_hash_after state socket
+
+    reset_verification_root
+    "$SCRIPT_DIR/build-app.sh" debug
+    "$SCRIPT_DIR/build-app.sh" release
+    "$SCRIPT_DIR/verify-bundle.sh" "$debug_source" debug
+    "$SCRIPT_DIR/verify-bundle.sh" "$release_source" release
+    debug_app="$("$SCRIPT_DIR/stage-test-app.sh" "$debug_source" p2-5-debug)"
+    release_app="$("$SCRIPT_DIR/stage-test-app.sh" "$release_source" p2-5-release)"
+    verify_staged_identity "$debug_app"
+    verify_staged_identity "$release_app"
+    debug_executable="$debug_app/Contents/MacOS/MuxyTests"
+    release_executable="$release_app/Contents/MacOS/MuxyTests"
+
+    home="$VERIFICATION_ROOT/home"
+    defaults="$VERIFICATION_ROOT/defaults.json"
+    mkdir -p "$home"
+    cat > "$defaults" <<'JSON'
+{
+  "muxy.activeProjectID": "swift-project",
+  "muxy.sidebarExpanded": true,
+  "muxy.settings.selectedRoute": "builtin.appearance",
+  "muxy.unknown": "excluded"
+}
+JSON
+
+    local debug_root="$VERIFICATION_ROOT/debug-root"
+    local debug_source_fixture="$VERIFICATION_ROOT/debug-swift-source"
+    mkdir -p "$debug_source_fixture"
+    printf 'debug must not inspect this\n' > "$debug_source_fixture/sentinel"
+    source_hash_before="$(source_hash "$debug_source_fixture")"
+    assert_safe_environment "$home" "$debug_root" "$debug_source_fixture" "$defaults" "com.muxy.tests" || {
+        fail "debug launch environment is unsafe"
+    }
+    socket="$debug_root/muxy-dev.sock"
+    rm -f "$socket"
+    launch_app "$debug_executable" "$home" "$debug_root" "$debug_source_fixture" "$defaults" "sentinel" "$VERIFICATION_ROOT/debug.log"
+    wait_for_socket "$socket" || fail "debug staged launch did not start its development socket"
+    [[ ! -e "$debug_root/swift-profile-migration.json" ]] || fail "debug inspected the Swift source"
+    source_hash_after="$(source_hash "$debug_source_fixture")"
+    [[ "$source_hash_before" == "$source_hash_after" ]] || fail "debug changed the Swift source"
+    stop_app "$socket"
+
+    local success_root="$VERIFICATION_ROOT/success-root"
+    local success_source="$VERIFICATION_ROOT/success-swift-source"
+    mkdir -p "$success_source/logos/imported" "$success_source/sessions" "$success_root/extensions"
+    printf '[ ]\n' > "$success_source/projects.json"
+    printf '{"muxy.showTips":false,"muxy.app.blur":42}\n' > "$success_source/settings.json"
+    printf 'logo bytes\n' > "$success_source/logos/imported/logo.txt"
+    printf 'excluded runtime\n' > "$success_source/sessions/runtime"
+    printf '[]\n' > "$success_root/projects.json"
+    printf 'extension\n' > "$success_root/extensions/keep.txt"
+    source_hash_before="$(source_hash "$success_source")"
+    assert_safe_environment "$home" "$success_root" "$success_source" "$defaults" "com.muxy.tests" || {
+        fail "success launch environment is unsafe"
+    }
+    state="$success_root/swift-profile-migration.json"
+    socket="$success_root/muxy.sock"
+    rm -f "$socket"
+    launch_app "$release_executable" "$home" "$success_root" "$success_source" "$defaults" "" "$VERIFICATION_ROOT/success.log"
+    wait_for_outcome "$state" completed || fail "release migration did not complete"
+    wait_for_socket "$socket" || fail "release launch did not start after migration"
+    [[ "$(cat "$success_root/projects.json")" == "[]" ]] || fail "Swift replaced an existing destination"
+    [[ "$(cat "$success_root/logos/imported/logo.txt")" == "logo bytes" ]] || fail "missing allowlisted data was not imported"
+    [[ "$(cat "$success_root/extensions/keep.txt")" == "extension" ]] || fail "existing extension data changed"
+    [[ ! -e "$success_root/sessions" ]] || fail "excluded runtime data was imported"
+    state_array_contains "$state" existing_paths "projects.json" || fail "existing path was not reported"
+    state_array_contains "$state" imported_paths "logos/imported/logo.txt" || fail "imported path was not reported"
+    state_array_contains "$state" missing_paths "ui-scale.json" || fail "missing path was not reported"
+    [[ "$(plutil -extract 'muxy\.app\.blur' raw -o - "$success_root/settings.json")" == "42" ]] || fail "imported settings were not preserved"
+    [[ "$(state_value "$state" defaults_import_completed)" == "true" ]] || fail "defaults import was not reported complete"
+    [[ "$(plutil -extract 'muxy\.activeProjectID' raw -o - "$success_root/preferences.json")" == "swift-project" ]] || fail "allowed defaults were not imported"
+    if plutil -extract 'muxy\.unknown' raw -o - "$success_root/preferences.json" >/dev/null 2>&1; then
+        fail "unapproved defaults were imported"
+    fi
+    source_hash_after="$(source_hash "$success_source")"
+    [[ "$source_hash_before" == "$source_hash_after" ]] || fail "successful migration changed the Swift source"
+    stop_app "$socket"
+    rm -rf "$success_source"
+    launch_app "$release_executable" "$home" "$success_root" "$success_source" "$defaults" "" "$VERIFICATION_ROOT/success-relaunch.log"
+    wait_for_socket "$socket" || fail "completed migration inspected the removed source"
+    [[ "$(state_value "$state" outcome)" == "completed" ]] || fail "completed migration state changed"
+    [[ "$(state_value "$state" attempt_count)" == "1" ]] || fail "completed migration retried"
+    stop_app "$socket"
+
+    local missing_root="$VERIFICATION_ROOT/missing-root"
+    local missing_source="$VERIFICATION_ROOT/missing-swift-source"
+    state="$missing_root/swift-profile-migration.json"
+    socket="$missing_root/muxy.sock"
+    assert_safe_environment "$home" "$missing_root" "$missing_source" "$defaults" "com.muxy.tests" || {
+        fail "missing-source launch environment is unsafe"
+    }
+    launch_app "$release_executable" "$home" "$missing_root" "$missing_source" "$defaults" "" "$VERIFICATION_ROOT/missing.log"
+    wait_for_outcome "$state" source_missing || fail "missing source was not terminal"
+    wait_for_socket "$socket" || fail "missing-source launch did not continue"
+    stop_app "$socket"
+    mkdir -p "$missing_source"
+    printf 'late source\n' > "$missing_source/projects.json"
+    launch_app "$release_executable" "$home" "$missing_root" "$missing_source" "$defaults" "" "$VERIFICATION_ROOT/missing-relaunch.log"
+    wait_for_socket "$socket" || fail "source_missing state inspected the late source"
+    [[ "$(state_value "$state" outcome)" == "source_missing" ]] || fail "source_missing state changed"
+    [[ ! -e "$missing_root/projects.json" ]] || fail "source_missing outcome retried migration"
+    stop_app "$socket"
+
+    local failure_root="$VERIFICATION_ROOT/failure-root"
+    local failure_source="$VERIFICATION_ROOT/failure-swift-source"
+    mkdir -p "$failure_source"
+    printf '[]\n' > "$failure_source/projects.json"
+    printf '[]\n' > "$failure_source/recently-removed-projects.json"
+    source_hash_before="$(source_hash "$failure_source")"
+    state="$failure_root/swift-profile-migration.json"
+    socket="$failure_root/muxy.sock"
+    assert_safe_environment "$home" "$failure_root" "$failure_source" "$defaults" "com.muxy.tests" || {
+        fail "failure launch environment is unsafe"
+    }
+    launch_app "$release_executable" "$home" "$failure_root" "$failure_source" "$defaults" "recently-removed-projects.json" "$VERIFICATION_ROOT/failure-one.log"
+    expect_startup_failure "$state" pending
+    [[ "$(state_value "$state" attempt_count)" == "1" ]] || fail "first failure did not record attempt one"
+    [[ "$(state_value "$state" failure.path)" == "recently-removed-projects.json" ]] || fail "first failure path was not reported"
+    [[ -f "$failure_root/projects.json" ]] || fail "atomic import before failure was not preserved"
+    source_hash_after="$(source_hash "$failure_source")"
+    [[ "$source_hash_before" == "$source_hash_after" ]] || fail "first failure changed the Swift source"
+    launch_app "$release_executable" "$home" "$failure_root" "$failure_source" "$defaults" "recently-removed-projects.json" "$VERIFICATION_ROOT/failure-two.log"
+    wait_for_outcome "$state" abandoned || fail "second failure did not abandon migration"
+    wait_for_socket "$socket" || fail "abandoned migration did not continue startup"
+    [[ "$(state_value "$state" attempt_count)" == "2" ]] || fail "abandoned migration attempt count is not two"
+    [[ -f "$failure_root/projects.json" ]] || fail "abandonment removed imported data"
+    source_hash_after="$(source_hash "$failure_source")"
+    [[ "$source_hash_before" == "$source_hash_after" ]] || fail "second failure changed the Swift source"
+    stop_app "$socket"
+    rm -rf "$failure_source"
+    launch_app "$release_executable" "$home" "$failure_root" "$failure_source" "$defaults" "" "$VERIFICATION_ROOT/abandoned-relaunch.log"
+    wait_for_socket "$socket" || fail "abandoned migration inspected the removed source"
+    [[ "$(state_value "$state" outcome)" == "abandoned" ]] || fail "abandoned state changed"
+    [[ "$(state_value "$state" attempt_count)" == "2" ]] || fail "abandoned migration retried"
+    stop_app "$socket"
+
+    printf 'P2.5 staged migration verification passed\n'
+}
+
+trap 'stop_app ""' EXIT
+for command_name in codesign cut find grep plutil shasum sort; do
+    require_command "$command_name"
+done
+
+if (($# > 1)); then
+    printf 'Usage: scripts/verify-p2-5-migration.sh [--self-test]\n' >&2
+    exit 2
+fi
+if [[ "${1:-}" == "--self-test" ]]; then
+    self_test
+elif (($# == 0)); then
+    run_acceptance
+else
+    printf 'Usage: scripts/verify-p2-5-migration.sh [--self-test]\n' >&2
+    exit 2
+fi


### PR DESCRIPTION
## Summary

- isolate release, debug, and staged-test bundle identities and storage roots
- add a bounded, one-way Swift profile migration into `~/.muxy`
- move normal preferences to portable, private `preferences.json` storage
- preserve existing destination data and keep the Swift source immutable
- harden migration state, staging, locking, symlink handling, and retry behavior
- add staged migration acceptance, retained Swift build repair, and cutover documentation

## Verification

- `scripts/check.sh`
- `scripts/build-app.sh release`
- `scripts/stage-test-app.sh --self-test`
- `scripts/verify-p2-5-migration.sh --self-test`
- `scripts/verify-p2-5-migration.sh`
- `cargo test -p muxy-core --all-features --locked --offline migration`
- `cargo check -p muxy-core --all-features --locked --offline --target x86_64-unknown-linux-gnu`
- `swift test --disable-automatic-resolution --filter SettingsJSONStoreTests`

Implemented with OpenAI Codex.
