### PR TITLE
Dismiss Quick Terminal when it loses focus

### DIFF
--- a/Muxy/Services/QuickTerminal/QuickTerminalController.swift
+++ b/Muxy/Services/QuickTerminal/QuickTerminalController.swift
@@ -137,6 +137,7 @@ final class QuickTerminalController: NSObject {
         contentView?.clearTerminal(status: "Closed")
         session.terminate()
         panel?.onKeyDown = nil
+        panel?.onResignKey = nil
         panel?.contentView = nil
         panel?.close()
         panel = nil
@@ -248,6 +249,9 @@ final class QuickTerminalController: NSObject {
         panel.contentView = contentView
         panel.onKeyDown = { [weak contentView] event in
             contentView?.handleKeyDown(event) ?? false
+        }
+        panel.onResignKey = { [weak self] in
+            self?.hide()
         }
         contentView.onClose = { [weak self] in
             self?.hide()

--- a/Muxy/Views/QuickTerminal/QuickTerminalPanel.swift
+++ b/Muxy/Views/QuickTerminal/QuickTerminalPanel.swift
@@ -3,6 +3,7 @@ import AppKit
 @MainActor
 final class QuickTerminalPanel: NSPanel {
     var onKeyDown: ((NSEvent) -> Bool)?
+    var onResignKey: (() -> Void)?
 
     init(contentRect: NSRect) {
         super.init(
@@ -26,6 +27,11 @@ final class QuickTerminalPanel: NSPanel {
 
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    override func resignKey() {
+        super.resignKey()
+        onResignKey?()
+    }
 
     override func sendEvent(_ event: NSEvent) {
         if event.type == .keyDown, onKeyDown?(event) == true {

--- a/Tests/MuxyTests/Views/QuickTerminal/QuickTerminalPanelTests.swift
+++ b/Tests/MuxyTests/Views/QuickTerminal/QuickTerminalPanelTests.swift
@@ -6,6 +6,19 @@ import Testing
 @MainActor
 @Suite("Quick terminal panel")
 struct QuickTerminalPanelTests {
+    @Test("notifies when the panel resigns key status")
+    func notifiesWhenPanelResignsKeyStatus() {
+        let panel = QuickTerminalPanel(contentRect: .zero)
+        var notificationCount = 0
+        panel.onResignKey = {
+            notificationCount += 1
+        }
+
+        panel.resignKey()
+
+        #expect(notificationCount == 1)
+    }
+
     @Test("routes key-down events to the handler instead of dismissing")
     func routesKeyDownToHandler() throws {
         let panel = QuickTerminalPanel(contentRect: .zero)

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -52,7 +52,7 @@ Remote SSH panes and the quick terminal are never backed by a background session
 
 Assign Double Shift or a conventional global shortcut to open the quick terminal from anywhere. On a display with a camera cutout, it expands out of the cutout like a dynamic island. It always starts in your home directory and keeps the same shell, working directory, and history while hidden.
 
-Dismiss it with the assigned shortcut or the close button. Moving the pointer, clicking another app, and pressing Escape do not close it, so Escape reaches the terminal for `vim`, `less`, and other full-screen programs. On a display without a camera cutout, the terminal opens at the same top-center position.
+Dismiss it with the assigned shortcut, the close button, or a click anywhere outside the panel. Moving the pointer and pressing Escape do not close it, so Escape reaches the terminal for `vim`, `less`, and other full-screen programs. On a display without a camera cutout, the terminal opens at the same top-center position.
 
 Quick Terminal has no shortcut assigned by default. Open **Settings → Quick Terminal** to choose one. System-wide Double Shift requires **System Settings → Privacy & Security → Input Monitoring**; conventional global shortcuts do not.
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -151,7 +151,7 @@ The setting is stored as `muxy.terminalPersistentSession.enabled` in `settings.j
 
 ## Quick terminal
 
-The assigned shortcut is the only way to open the quick terminal. On a display with a camera cutout, the terminal expands out of it like a dynamic island. Open **Quick Terminal** in Settings to configure its shortcut, size, and appearance:
+The assigned shortcut is the only way to open the quick terminal. Dismiss it with the shortcut, the close button, or a click anywhere outside the panel. On a display with a camera cutout, the terminal expands out of it like a dynamic island. Open **Quick Terminal** in Settings to configure its shortcut, size, and appearance:
 
 - **Enable Quick Terminal** controls the entire feature. Turning it off stops the shortcut listener, closes the panel, and releases its shell while preserving its settings.
 - No shortcut is assigned by default.


### PR DESCRIPTION
Hide the Quick Terminal when its panel resigns key status, add coverage for the callback, and document click-outside dismissal behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Terminal now dismisses when clicking outside the panel.
  * Existing shortcut and close-button dismissal remain supported.
  * Pointer movement and Escape do not dismiss the terminal.

* **Documentation**
  * Updated terminal and settings guides to describe outside-click dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->