### PR TITLE
Add remote project workspace moves

### DIFF
--- a/Muxy/Services/Project/ProjectGroupStore.swift
+++ b/Muxy/Services/Project/ProjectGroupStore.swift
@@ -250,6 +250,32 @@ final class ProjectGroupStore {
         return didRemove
     }
 
+    func remoteWorkspaceMoveTargets(for project: Project) -> [ProjectGroup] {
+        guard let workspaceID = project.remoteWorkspaceID,
+              let source = groups.first(where: { $0.id == workspaceID })
+        else { return [] }
+        return groups.filter {
+            $0.type == .ssh && $0.id != source.id && $0.remoteDeviceID == source.remoteDeviceID
+        }
+    }
+
+    @discardableResult
+    func moveRemoteProject(id: UUID, fromGroup sourceGroupID: UUID, toGroup targetGroupID: UUID) -> Bool {
+        guard sourceGroupID != targetGroupID else { return false }
+        return commitMutation { groups in
+            guard let sourceIndex = groups.firstIndex(where: { $0.id == sourceGroupID }),
+                  let targetIndex = groups.firstIndex(where: { $0.id == targetGroupID }),
+                  groups[sourceIndex].type == .ssh,
+                  groups[targetIndex].type == .ssh,
+                  groups[sourceIndex].remoteDeviceID == groups[targetIndex].remoteDeviceID,
+                  let projectIndex = groups[sourceIndex].remoteProjects.firstIndex(where: { $0.id == id })
+            else { return false }
+            let project = groups[sourceIndex].remoteProjects.remove(at: projectIndex)
+            groups[targetIndex].remoteProjects.append(project)
+            return true
+        }
+    }
+
     func markRemoteProjectActive(id: UUID) {
         updateRemoteProject(id: id) { project in
             project.lastActiveAt = Date()

--- a/Muxy/Services/Project/ProjectGroupStore.swift
+++ b/Muxy/Services/Project/ProjectGroupStore.swift
@@ -252,10 +252,15 @@ final class ProjectGroupStore {
 
     func remoteWorkspaceMoveTargets(for project: Project) -> [ProjectGroup] {
         guard let workspaceID = project.remoteWorkspaceID,
-              let source = groups.first(where: { $0.id == workspaceID })
+              let source = groups.first(where: { $0.id == workspaceID }),
+              source.type == .ssh,
+              let sourceDeviceID = source.remoteDeviceID
         else { return [] }
         return groups.filter {
-            $0.type == .ssh && $0.id != source.id && $0.remoteDeviceID == source.remoteDeviceID
+            $0.type == .ssh
+                && $0.id != source.id
+                && $0.remoteDeviceID == sourceDeviceID
+                && !Self.containsRemoteProject(path: project.path, in: $0)
         }
     }
 
@@ -267,12 +272,23 @@ final class ProjectGroupStore {
                   let targetIndex = groups.firstIndex(where: { $0.id == targetGroupID }),
                   groups[sourceIndex].type == .ssh,
                   groups[targetIndex].type == .ssh,
-                  groups[sourceIndex].remoteDeviceID == groups[targetIndex].remoteDeviceID,
+                  let sourceDeviceID = groups[sourceIndex].remoteDeviceID,
+                  let targetDeviceID = groups[targetIndex].remoteDeviceID,
+                  sourceDeviceID == targetDeviceID,
                   let projectIndex = groups[sourceIndex].remoteProjects.firstIndex(where: { $0.id == id })
             else { return false }
-            let project = groups[sourceIndex].remoteProjects.remove(at: projectIndex)
+            let project = groups[sourceIndex].remoteProjects[projectIndex]
+            guard !Self.containsRemoteProject(path: project.path, in: groups[targetIndex]) else { return false }
+            groups[sourceIndex].remoteProjects.remove(at: projectIndex)
             groups[targetIndex].remoteProjects.append(project)
             return true
+        }
+    }
+
+    private static func containsRemoteProject(path: String, in group: ProjectGroup) -> Bool {
+        let standardizedPath = ProjectPickerPathService.standardizedRemotePath(path)
+        return group.remoteProjects.contains {
+            ProjectPickerPathService.standardizedRemotePath($0.path) == standardizedPath
         }
     }
 

--- a/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
@@ -393,10 +393,8 @@ struct ProjectGroupMembershipMenu: View {
     }
 
     var body: some View {
-        if project.remoteWorkspaceID != nil {
-            if !remoteTargetGroups.isEmpty {
-                remoteMembershipMenu
-            }
+        if project.remoteWorkspaceID != nil, !remoteTargetGroups.isEmpty {
+            remoteMembershipMenu
         } else if project.supportsLocalWorkspaceMembership, !localGroups.isEmpty {
             localMembershipMenu
         }

--- a/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
+++ b/Muxy/Views/Layouts/ProjectFocused/WorkspaceSwitcher.swift
@@ -388,23 +388,52 @@ struct ProjectGroupMembershipMenu: View {
         projectGroupStore.groups.filter { $0.type == .local }
     }
 
+    private var remoteTargetGroups: [ProjectGroup] {
+        projectGroupStore.remoteWorkspaceMoveTargets(for: project)
+    }
+
     var body: some View {
-        if project.supportsLocalWorkspaceMembership, !localGroups.isEmpty {
-            Menu(L10n.string("Move to Workspace")) {
-                ForEach(localGroups) { group in
-                    let isInGroup = group.projectIDs.contains(project.id)
-                    Button {
-                        if isInGroup {
-                            projectGroupStore.removeProject(projectID: project.id, fromGroup: group.id)
-                        } else {
-                            projectGroupStore.addProject(projectID: project.id, toGroup: group.id)
-                        }
-                    } label: {
-                        Label(group.name, systemImage: isInGroup ? "checkmark" : "")
+        if project.remoteWorkspaceID != nil {
+            if !remoteTargetGroups.isEmpty {
+                remoteMembershipMenu
+            }
+        } else if project.supportsLocalWorkspaceMembership, !localGroups.isEmpty {
+            localMembershipMenu
+        }
+    }
+
+    private var localMembershipMenu: some View {
+        Menu(L10n.string("Move to Workspace")) {
+            ForEach(localGroups) { group in
+                let isInGroup = group.projectIDs.contains(project.id)
+                Button {
+                    if isInGroup {
+                        projectGroupStore.removeProject(projectID: project.id, fromGroup: group.id)
+                    } else {
+                        projectGroupStore.addProject(projectID: project.id, toGroup: group.id)
                     }
+                } label: {
+                    Label(group.name, systemImage: isInGroup ? "checkmark" : "")
                 }
             }
         }
+    }
+
+    private var remoteMembershipMenu: some View {
+        Menu(L10n.string("Move to Workspace")) {
+            ForEach(remoteTargetGroups) { group in
+                Button {
+                    moveTo(group)
+                } label: {
+                    Label(group.name, systemImage: "network")
+                }
+            }
+        }
+    }
+
+    private func moveTo(_ group: ProjectGroup) {
+        guard let workspaceID = project.remoteWorkspaceID else { return }
+        projectGroupStore.moveRemoteProject(id: project.id, fromGroup: workspaceID, toGroup: group.id)
     }
 }
 

--- a/Muxy/Views/Layouts/Shared/ProjectActionsContextMenu.swift
+++ b/Muxy/Views/Layouts/Shared/ProjectActionsContextMenu.swift
@@ -7,6 +7,7 @@ enum ProjectActionsContextMenuPolicy {
         let worktreeCount: Int
         let supportsSwitchWorktree: Bool
         let hasLocalWorkspaces: Bool
+        let hasRemoteWorkspaces: Bool
     }
 
     enum Feature: Hashable {
@@ -61,10 +62,17 @@ enum ProjectActionsContextMenuPolicy {
         ) {
             features.insert(.switchWorktree)
         }
-        if project.supportsLocalWorkspaceMembership, context.hasLocalWorkspaces {
+        if showsWorkspaceMembership(for: project, context: context) {
             features.insert(.workspaceMembership)
         }
         return features
+    }
+
+    static func showsWorkspaceMembership(for project: Project, context: Context) -> Bool {
+        if project.remoteWorkspaceID != nil {
+            return context.hasRemoteWorkspaces
+        }
+        return project.supportsLocalWorkspaceMembership && context.hasLocalWorkspaces
     }
 }
 
@@ -94,7 +102,8 @@ struct ProjectActionsContextMenu: View {
                 isCheckingGitRepo: isCheckingGitRepo,
                 worktreeCount: worktreeCount,
                 supportsSwitchWorktree: onSwitchWorktree != nil,
-                hasLocalWorkspaces: projectGroupStore.groups.contains { $0.type == .local }
+                hasLocalWorkspaces: projectGroupStore.groups.contains { $0.type == .local },
+                hasRemoteWorkspaces: !projectGroupStore.remoteWorkspaceMoveTargets(for: project).isEmpty
             )
         )
     }

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -465,6 +465,98 @@ struct ProjectGroupStoreTests {
         #expect(persistence.savedGroups?.first?.remoteProjects.isEmpty == true)
     }
 
+    @Test("remoteWorkspaceMoveTargets lists same-device SSH workspaces except the source")
+    func remoteWorkspaceMoveTargets() {
+        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
+        let source = ProjectGroup(name: "Source", type: .ssh, remoteDeviceID: device.id)
+        let target = ProjectGroup(name: "Target", type: .ssh, remoteDeviceID: device.id)
+        let otherDevice = RemoteDevice(name: "Staging", ssh: SSHWorkspaceData(host: "staging.example.com", remoteRoot: "~"))
+        let crossDevice = ProjectGroup(name: "Cross", type: .ssh, remoteDeviceID: otherDevice.id)
+        let local = ProjectGroup(name: "Local")
+        let persistence = ProjectGroupPersistenceStub(initial: [source, target, crossDevice, local])
+        let store = makeStore(persistence: persistence, devices: [device, otherDevice])
+        let project = Project(name: "api", path: "~/code/api", remoteWorkspaceID: source.id)
+
+        let targets = store.remoteWorkspaceMoveTargets(for: project)
+
+        #expect(targets.map(\.name) == ["Target"])
+    }
+
+    @Test("remoteWorkspaceMoveTargets returns empty for a local project")
+    func remoteWorkspaceMoveTargetsForLocalProject() {
+        let target = ProjectGroup(name: "Target", type: .ssh, remoteDeviceID: UUID())
+        let store = makeStore(persistence: ProjectGroupPersistenceStub(initial: [target]))
+
+        #expect(store.remoteWorkspaceMoveTargets(for: Project(name: "A", path: "/a")).isEmpty)
+    }
+
+    @Test("moveRemoteProject moves the project between SSH workspaces and persists")
+    func moveRemoteProject() throws {
+        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
+        let source = ProjectGroup(name: "Source", type: .ssh, remoteDeviceID: device.id)
+        let target = ProjectGroup(name: "Target", type: .ssh, remoteDeviceID: device.id)
+        let persistence = ProjectGroupPersistenceStub(initial: [source, target])
+        let store = makeStore(persistence: persistence, devices: [device])
+        let remote = try #require(store.addRemoteProject(name: "api", path: "~/code/api", toGroup: source.id))
+        store.updateRemoteProject(id: remote.id) { $0.isPinned = true }
+
+        let moved = store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: target.id)
+
+        #expect(moved == true)
+        #expect(store.groups.first { $0.id == source.id }?.remoteProjects.isEmpty == true)
+        let movedProject = store.groups.first { $0.id == target.id }?.remoteProjects.first
+        #expect(movedProject?.id == remote.id)
+        #expect(movedProject?.path == "~/code/api")
+        #expect(movedProject?.isPinned == true)
+        #expect(persistence.savedGroups?.first { $0.id == target.id }?.remoteProjects.first?.id == remote.id)
+    }
+
+    @Test("moveRemoteProject rejects local workspaces and cross-device workspaces")
+    func moveRemoteProjectRejectsInvalidTargets() throws {
+        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
+        let otherDevice = RemoteDevice(name: "Staging", ssh: SSHWorkspaceData(host: "staging.example.com", remoteRoot: "~"))
+        let source = ProjectGroup(name: "Source", type: .ssh, remoteDeviceID: device.id)
+        let crossDevice = ProjectGroup(name: "Cross", type: .ssh, remoteDeviceID: otherDevice.id)
+        let local = ProjectGroup(name: "Local")
+        let persistence = ProjectGroupPersistenceStub(initial: [source, crossDevice, local])
+        let store = makeStore(persistence: persistence, devices: [device, otherDevice])
+        let remote = try #require(store.addRemoteProject(name: "api", path: "~/code/api", toGroup: source.id))
+        persistence.savedGroups = nil
+
+        #expect(!store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: crossDevice.id))
+        #expect(!store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: local.id))
+        #expect(store.groups.first { $0.id == source.id }?.remoteProjects.first?.id == remote.id)
+        #expect(persistence.savedGroups == nil)
+    }
+
+    @Test("moveRemoteProject ignores same-workspace and unknown workspaces")
+    func moveRemoteProjectIgnoresNoOpMoves() throws {
+        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
+        let source = ProjectGroup(name: "Source", type: .ssh, remoteDeviceID: device.id)
+        let persistence = ProjectGroupPersistenceStub(initial: [source])
+        let store = makeStore(persistence: persistence, devices: [device])
+        let remote = try #require(store.addRemoteProject(name: "api", path: "~/code/api", toGroup: source.id))
+
+        #expect(!store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: source.id))
+        #expect(!store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: UUID()))
+        #expect(store.groups.first?.remoteProjects.count == 1)
+    }
+
+    @Test("moveRemoteProject failure preserves in-memory groups")
+    func moveRemoteProjectPersistsAtomically() throws {
+        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
+        let source = ProjectGroup(name: "Source", type: .ssh, remoteDeviceID: device.id)
+        let target = ProjectGroup(name: "Target", type: .ssh, remoteDeviceID: device.id)
+        let persistence = ProjectGroupPersistenceStub(initial: [source, target])
+        let store = makeStore(persistence: persistence, devices: [device])
+        let remote = try #require(store.addRemoteProject(name: "api", path: "~/code/api", toGroup: source.id))
+        persistence.saveError = ProjectGroupSaveError()
+
+        #expect(!store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: target.id))
+        #expect(store.groups.first { $0.id == source.id }?.remoteProjects.first?.id == remote.id)
+        #expect(store.groups.first { $0.id == target.id }?.remoteProjects.isEmpty == true)
+    }
+
     @Test("project editing updates remote metadata and persists")
     func editRemoteProject() throws {
         let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))

--- a/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
+++ b/Tests/MuxyTests/Services/Project/ProjectGroupStoreTests.swift
@@ -490,6 +490,40 @@ struct ProjectGroupStoreTests {
         #expect(store.remoteWorkspaceMoveTargets(for: Project(name: "A", path: "/a")).isEmpty)
     }
 
+    @Test("remote project moves reject SSH workspaces without device IDs")
+    func remoteProjectMovesRejectMissingDeviceIDs() {
+        let remote = RemoteProject(name: "api", path: "~/code/api")
+        let source = ProjectGroup(name: "Source", type: .ssh, remoteProjects: [remote])
+        let target = ProjectGroup(name: "Target", type: .ssh)
+        let persistence = ProjectGroupPersistenceStub(initial: [source, target])
+        let store = makeStore(persistence: persistence)
+        let project = remote.asProject(workspaceID: source.id, sortOrder: 0)
+
+        #expect(store.remoteWorkspaceMoveTargets(for: project).isEmpty)
+        #expect(!store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: target.id))
+        #expect(store.groups.first { $0.id == source.id }?.remoteProjects.first?.id == remote.id)
+        #expect(store.groups.first { $0.id == target.id }?.remoteProjects.isEmpty == true)
+        #expect(persistence.savedGroups == nil)
+    }
+
+    @Test("remote project moves reject targets containing the same standardized path")
+    func remoteProjectMovesRejectDuplicateTargetPaths() {
+        let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))
+        let remote = RemoteProject(name: "api", path: "~/code/api")
+        let duplicate = RemoteProject(name: "duplicate", path: "~/code/./api")
+        let source = ProjectGroup(name: "Source", type: .ssh, remoteDeviceID: device.id, remoteProjects: [remote])
+        let target = ProjectGroup(name: "Target", type: .ssh, remoteDeviceID: device.id, remoteProjects: [duplicate])
+        let persistence = ProjectGroupPersistenceStub(initial: [source, target])
+        let store = makeStore(persistence: persistence, devices: [device])
+        let project = remote.asProject(workspaceID: source.id, sortOrder: 0)
+
+        #expect(store.remoteWorkspaceMoveTargets(for: project).isEmpty)
+        #expect(!store.moveRemoteProject(id: remote.id, fromGroup: source.id, toGroup: target.id))
+        #expect(store.groups.first { $0.id == source.id }?.remoteProjects.first?.id == remote.id)
+        #expect(store.groups.first { $0.id == target.id }?.remoteProjects.map(\.id) == [duplicate.id])
+        #expect(persistence.savedGroups == nil)
+    }
+
     @Test("moveRemoteProject moves the project between SSH workspaces and persists")
     func moveRemoteProject() throws {
         let device = RemoteDevice(name: "Prod", ssh: SSHWorkspaceData(host: "example.com", remoteRoot: "~"))

--- a/Tests/MuxyTests/Views/Layouts/Shared/ProjectActionsContextMenuTests.swift
+++ b/Tests/MuxyTests/Views/Layouts/Shared/ProjectActionsContextMenuTests.swift
@@ -73,8 +73,8 @@ struct ProjectActionsContextMenuPolicyTests {
         #expect(localFeatures.contains(.workspaceMembership))
     }
 
-    @Test("SSH workspace projects do not expose local workspace membership")
-    func sshWorkspaceProjectMembership() {
+    @Test("SSH workspace projects do not expose workspace membership without move targets")
+    func sshWorkspaceProjectMembershipWithoutTargets() {
         let project = Project(
             name: "Remote",
             path: "~/code/remote",
@@ -88,11 +88,35 @@ struct ProjectActionsContextMenuPolicyTests {
                 isCheckingGitRepo: false,
                 worktreeCount: 1,
                 supportsSwitchWorktree: true,
-                hasLocalWorkspaces: true
+                hasLocalWorkspaces: true,
+                hasRemoteWorkspaces: false
             )
         )
 
         #expect(!features.contains(.workspaceMembership))
+    }
+
+    @Test("SSH workspace projects expose workspace membership with move targets")
+    func sshWorkspaceProjectMembershipWithTargets() {
+        let project = Project(
+            name: "Remote",
+            path: "~/code/remote",
+            remoteWorkspaceID: UUID()
+        )
+
+        let features = ProjectActionsContextMenuPolicy.features(
+            for: project,
+            context: ProjectActionsContextMenuPolicy.Context(
+                isGitRepo: true,
+                isCheckingGitRepo: false,
+                worktreeCount: 1,
+                supportsSwitchWorktree: true,
+                hasLocalWorkspaces: false,
+                hasRemoteWorkspaces: true
+            )
+        )
+
+        #expect(features.contains(.workspaceMembership))
     }
 
     @Test("non-Git projects do not expose switch worktree")
@@ -107,7 +131,8 @@ struct ProjectActionsContextMenuPolicyTests {
                 isCheckingGitRepo: false,
                 worktreeCount: 2,
                 supportsSwitchWorktree: true,
-                hasLocalWorkspaces: false
+                hasLocalWorkspaces: false,
+                hasRemoteWorkspaces: false
             )
         )
 
@@ -121,7 +146,8 @@ struct ProjectActionsContextMenuPolicyTests {
             isCheckingGitRepo: false,
             worktreeCount: 2,
             supportsSwitchWorktree: true,
-            hasLocalWorkspaces: true
+            hasLocalWorkspaces: true,
+            hasRemoteWorkspaces: false
         )
     }
 }


### PR DESCRIPTION
Allow remote projects to move between SSH workspaces on the same device from the project actions menu. Add atomic persistence, target validation, and tests for valid, invalid, and failed moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote projects can now be moved between eligible SSH workspaces on the same device.
  * Workspace menus display valid remote destinations while preserving local workspace behavior.
  * Workspace membership actions appear when remote destinations are available.

* **Bug Fixes**
  * Prevented moves to incompatible workspaces, different devices, identical workspaces, or destinations containing the same project path.
  * Preserved project metadata during remote moves.
  * Prevented changes from being applied when a move cannot be saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->