### PR TITLE
Preserve remote projects after SSH disconnects

### DIFF
--- a/Muxy/Resources/Localization/en.lproj/Localizable.strings
+++ b/Muxy/Resources/Localization/en.lproj/Localizable.strings
@@ -732,6 +732,7 @@
 "Repository unavailable" = "Repository unavailable";
 "Repository unavailable. Click to retry." = "Repository unavailable. Click to retry.";
 "Reconnect" = "Reconnect";
+"Reconnect to start a new SSH terminal session" = "Reconnect to start a new SSH terminal session";
 "Reconnect to the background terminal session" = "Reconnect to the background terminal session";
 "Reset" = "Reset";
 "Reset All" = "Reset All";
@@ -774,6 +775,7 @@
 "Runs new terminals in a background process so they survive quitting Muxy." = "Runs new terminals in a background process so they survive quitting Muxy.";
 "Runtime Error" = "Runtime Error";
 "SSH Host" = "SSH Host";
+"SSH connection ended" = "SSH connection ended";
 "Save" = "Save";
 "Saves your settings, projects, remote devices, shortcuts and customizations to a single .muxy file. Credentials such as SSH keys, passwords and paired mobile devices are never included." = "Saves your settings, projects, remote devices, shortcuts and customizations to a single .muxy file. Credentials such as SSH keys, passwords and paired mobile devices are never included.";
 "Scan this with the Muxy mobile app to add this Mac. The QR carries no token — first-time pairing still needs your approval." = "Scan this with the Muxy mobile app to add this Mac. The QR carries no token — first-time pairing still needs your approval.";
@@ -1070,6 +1072,7 @@
 "Could not paste image on remote device" = "Could not paste image on remote device";
 "Could not upload attachment to remote device" = "Could not upload attachment to remote device";
 "The SSH destination changed during upload." = "The SSH destination changed during upload.";
+"The SSH connection to this project ended. Reconnect to start a new terminal session." = "The SSH connection to this project ended. Reconnect to start a new terminal session.";
 "Creates the extension in %@/<name>" = "Creates the extension in %@/<name>";
 "Extension icon rail order" = "Extension icon rail order";
 "Extension Location" = "Extension Location";

--- a/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
@@ -161,7 +161,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
     func closeSurface(userdata: UnsafeMutableRawPointer?, needsConfirm: Bool) {
         guard let userdata else { return }
         let view = Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
+        let sourceSurface = view.surface
         DispatchQueue.main.async {
+            guard sourceSurface == view.surface else { return }
             guard !view.processExitHandled else { return }
             view.processExitHandled = true
             view.onProcessExit?()
@@ -191,7 +193,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
 
     private func handleCommandExit(target: ghostty_target_s) {
         guard let view = surfaceView(from: target) else { return }
+        guard let sourceSurface = target.target.surface else { return }
         DispatchQueue.main.async {
+            guard sourceSurface == view.surface else { return }
             if let paneID = TerminalViewRegistry.shared.paneID(for: view) {
                 DetectedAgentStore.shared.clearProvisionalAgent(for: paneID)
                 AgentStatusStore.shared.commandExited(

--- a/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
+++ b/Muxy/Services/Terminal/GhosttyRuntimeEventAdapter.swift
@@ -162,7 +162,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
         guard let userdata else { return }
         let view = Unmanaged<GhosttyTerminalNSView>.fromOpaque(userdata).takeUnretainedValue()
         let sourceSurface = view.surface
+        let sourceGeneration = view.surfaceGeneration
         DispatchQueue.main.async {
+            guard sourceGeneration == view.surfaceGeneration else { return }
             guard sourceSurface == view.surface else { return }
             guard !view.processExitHandled else { return }
             view.processExitHandled = true
@@ -194,7 +196,9 @@ final class GhosttyRuntimeEventAdapter: GhosttyRuntimeEventHandling {
     private func handleCommandExit(target: ghostty_target_s) {
         guard let view = surfaceView(from: target) else { return }
         guard let sourceSurface = target.target.surface else { return }
+        let sourceGeneration = view.surfaceGeneration
         DispatchQueue.main.async {
+            guard sourceGeneration == view.surfaceGeneration else { return }
             guard sourceSurface == view.surface else { return }
             if let paneID = TerminalViewRegistry.shared.paneID(for: view) {
                 DetectedAgentStore.shared.clearProvisionalAgent(for: paneID)

--- a/Muxy/Services/Terminal/PersistentSessionExitHandler.swift
+++ b/Muxy/Services/Terminal/PersistentSessionExitHandler.swift
@@ -47,7 +47,7 @@ final class PersistentSessionExitHandler {
                 logger.info("reattaching background session after attempt \(attempt)")
                 try? await Task.sleep(for: Self.backoff(attempt: attempt))
                 guard TerminalViewRegistry.shared.hasPersistentSession(for: paneID, sessionID: sessionID) else { return }
-                recoverySurface(paneID: paneID)?.reattachPersistentSession()
+                recoverySurface(paneID: paneID)?.reconnect()
             case .reportFailure:
                 logger.error("giving up on reattaching a background session after \(attempt - 1) attempt(s)")
                 recoveries.removeValue(forKey: paneID)

--- a/Muxy/Services/Terminal/TerminalProcessExitPolicy.swift
+++ b/Muxy/Services/Terminal/TerminalProcessExitPolicy.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum TerminalProcessExitPolicy {
+    enum Disposition: Equatable {
+        case closePane
+        case recoverRemoteConnection
+        case recoverPersistentSession(UUID)
+    }
+
+    static func disposition(isRemote: Bool, persistentSessionID: UUID?) -> Disposition {
+        if isRemote {
+            return .recoverRemoteConnection
+        }
+        if let persistentSessionID {
+            return .recoverPersistentSession(persistentSessionID)
+        }
+        return .closePane
+    }
+}

--- a/Muxy/Services/Terminal/TerminalSurface.swift
+++ b/Muxy/Services/Terminal/TerminalSurface.swift
@@ -136,7 +136,7 @@ protocol TerminalSessionRecoverySurface: AnyObject {
     var onSessionRecoveryFailed: ((Bool) -> Void)? { get set }
     var isSessionRecoveryFailed: Bool { get }
 
-    func reattachPersistentSession()
+    func reconnect()
     func reportSessionRecoveryFailure()
 }
 

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -107,7 +107,7 @@ final class GhosttyTerminalNSView: NSView,
     private var rawOutputToken: Int?
     private var surfaceConfigurationOverlay: ((ghostty_surface_t) -> Void)?
     private let terminalInputQueue = TerminalInputQueue()
-    private var surfaceGeneration = 0
+    nonisolated(unsafe) private(set) var surfaceGeneration = 0
     private static let imagePasteDelay: Duration = .milliseconds(300)
     private let remoteUploadSession = RemoteUploadSession()
     private var precedingRemoteUploadCleanup: Task<Void, Never>?
@@ -658,9 +658,7 @@ final class GhosttyTerminalNSView: NSView,
 
     func reconnect() {
         guard persistentSessionID != nil || workspaceContext.isRemote else { return }
-        if workspaceContext.isRemote {
-            guard isSessionRecoveryFailed else { return }
-        }
+        guard !workspaceContext.isRemote || isSessionRecoveryFailed else { return }
         destroySurface()
         isSessionRecoveryFailed = false
         onSessionRecoveryFailed?(false)

--- a/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
+++ b/Muxy/Views/Terminal/GhosttyTerminalNSView.swift
@@ -656,8 +656,11 @@ final class GhosttyTerminalNSView: NSView,
         onOfflineChange?(true)
     }
 
-    func reattachPersistentSession() {
-        guard persistentSessionID != nil else { return }
+    func reconnect() {
+        guard persistentSessionID != nil || workspaceContext.isRemote else { return }
+        if workspaceContext.isRemote {
+            guard isSessionRecoveryFailed else { return }
+        }
         destroySurface()
         isSessionRecoveryFailed = false
         onSessionRecoveryFailed?(false)
@@ -667,7 +670,8 @@ final class GhosttyTerminalNSView: NSView,
     }
 
     func reportSessionRecoveryFailure() {
-        guard persistentSessionID != nil, !isSessionRecoveryFailed else { return }
+        guard persistentSessionID != nil || workspaceContext.isRemote else { return }
+        guard !isSessionRecoveryFailed else { return }
         destroySurface()
         isSessionRecoveryFailed = true
         onSessionRecoveryFailed?(true)

--- a/Muxy/Views/Terminal/TerminalPane.swift
+++ b/Muxy/Views/Terminal/TerminalPane.swift
@@ -13,6 +13,7 @@ struct TerminalPane: View {
 
     @Bindable private var ownership = PaneOwnershipStore.shared
     @Environment(\.overlayActive) private var overlayActive
+    @Environment(\.paneWorkspaceContext) private var workspaceContext
 
     private var remoteOwnerName: String? {
         if case let .remote(_, name) = ownership.owner(for: state.id) {
@@ -46,7 +47,7 @@ struct TerminalPane: View {
 
     private func reconnectPane() {
         let surface = TerminalViewRegistry.shared.existingView(for: state.id)
-        (surface as? any TerminalSessionRecoverySurface)?.reattachPersistentSession()
+        (surface as? any TerminalSessionRecoverySurface)?.reconnect()
         onFocus()
     }
 
@@ -111,8 +112,12 @@ struct TerminalPane: View {
             }
 
             if showsUnreachableSessionPlaceholder {
-                UnreachableSessionPlaceholder(isFocused: focused, onReconnect: reconnectPane)
-                    .transition(.opacity)
+                UnreachableSessionPlaceholder(
+                    isFocused: focused,
+                    isRemote: workspaceContext.isRemote,
+                    onReconnect: reconnectPane
+                )
+                .transition(.opacity)
             } else if showsSleepingPlaceholder {
                 SleepingTabPlaceholder(isFocused: focused, onWake: wakePane)
                     .transition(.opacity)
@@ -123,7 +128,24 @@ struct TerminalPane: View {
 
 struct UnreachableSessionPlaceholder: View {
     let isFocused: Bool
+    let isRemote: Bool
     let onReconnect: () -> Void
+
+    private var title: String {
+        isRemote ? L10n.string("SSH connection ended") : L10n.string("Background session unreachable")
+    }
+
+    private var message: String {
+        isRemote
+            ? L10n.string("The SSH connection to this project ended. Reconnect to start a new terminal session.")
+            : L10n.string("Muxy could not reconnect to this terminal. The session was left running.")
+    }
+
+    private var accessibilityHint: String {
+        isRemote
+            ? L10n.string("Reconnect to start a new SSH terminal session")
+            : L10n.string("Reconnect to the background terminal session")
+    }
 
     var body: some View {
         VStack(spacing: UIMetrics.spacing7) {
@@ -131,10 +153,10 @@ struct UnreachableSessionPlaceholder: View {
             Image(systemName: "bolt.horizontal.circle")
                 .font(.system(size: UIMetrics.fontMega))
                 .foregroundStyle(MuxyTheme.fgMuted)
-            Text(L10n.resource("Background session unreachable"))
+            Text(title)
                 .font(.system(size: UIMetrics.fontHeadline, weight: .semibold))
                 .foregroundStyle(MuxyTheme.fg)
-            Text(L10n.resource("Muxy could not reconnect to this terminal. The session was left running."))
+            Text(message)
                 .font(.system(size: UIMetrics.fontBody))
                 .foregroundStyle(MuxyTheme.fgMuted)
                 .multilineTextAlignment(.center)
@@ -159,8 +181,8 @@ struct UnreachableSessionPlaceholder: View {
         .onTapGesture(perform: onReconnect)
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
-        .accessibilityLabel(L10n.string("Background session unreachable"))
-        .accessibilityHint(L10n.string("Reconnect to the background terminal session"))
+        .accessibilityLabel(title)
+        .accessibilityHint(accessibilityHint)
     }
 }
 
@@ -499,15 +521,26 @@ struct TerminalBridge: NSViewRepresentable {
     }
 
     private func makeProcessExitHandler(_ surface: any TerminalSurface) -> () -> Void {
-        guard let sessionID = surface.persistentSessionID else { return onProcessExit }
-        let paneID = state.id
-        let closePane = onProcessExit
-        return {
-            PersistentSessionExitHandler.shared.handleExit(
-                paneID: paneID,
-                sessionID: sessionID,
-                closePane: closePane
-            )
+        switch TerminalProcessExitPolicy.disposition(
+            isRemote: workspaceContext.isRemote,
+            persistentSessionID: surface.persistentSessionID
+        ) {
+        case .closePane:
+            return onProcessExit
+        case .recoverRemoteConnection:
+            return {
+                (surface as? any TerminalSessionRecoverySurface)?.reportSessionRecoveryFailure()
+            }
+        case let .recoverPersistentSession(sessionID):
+            let paneID = state.id
+            let closePane = onProcessExit
+            return {
+                PersistentSessionExitHandler.shared.handleExit(
+                    paneID: paneID,
+                    sessionID: sessionID,
+                    closePane: closePane
+                )
+            }
         }
     }
 

--- a/Tests/MuxyTests/Services/Terminal/GhosttyRuntimeEventAdapterTests.swift
+++ b/Tests/MuxyTests/Services/Terminal/GhosttyRuntimeEventAdapterTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import Muxy
+
+@Suite("Ghostty runtime event adapter")
+@MainActor
+struct GhosttyRuntimeEventAdapterTests {
+    @Test("delivers an exit callback for the current surface generation")
+    func deliversCurrentSurfaceExit() async {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+        var exitCount = 0
+        view.onProcessExit = { exitCount += 1 }
+
+        GhosttyRuntimeEventAdapter().closeSurface(
+            userdata: Unmanaged.passUnretained(view).toOpaque(),
+            needsConfirm: false
+        )
+        await drainMainQueue()
+
+        #expect(exitCount == 1)
+        #expect(view.processExitHandled)
+    }
+
+    @Test("ignores an exit callback from a replaced surface generation")
+    func ignoresReplacedSurfaceExit() async {
+        let view = GhosttyTerminalNSView(workingDirectory: "/tmp")
+        var exitCount = 0
+        view.onProcessExit = { exitCount += 1 }
+
+        GhosttyRuntimeEventAdapter().closeSurface(
+            userdata: Unmanaged.passUnretained(view).toOpaque(),
+            needsConfirm: false
+        )
+        view.destroySurface()
+        await drainMainQueue()
+
+        #expect(exitCount == 0)
+        #expect(!view.processExitHandled)
+    }
+
+    private func drainMainQueue() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/Tests/MuxyTests/Views/Terminal/TerminalProcessExitPolicyTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalProcessExitPolicyTests.swift
@@ -12,6 +12,14 @@ struct TerminalProcessExitPolicyTests {
         ) == .recoverRemoteConnection)
     }
 
+    @Test("remote recovery takes precedence over persistent session recovery")
+    func prioritizesRemoteRecovery() {
+        #expect(TerminalProcessExitPolicy.disposition(
+            isRemote: true,
+            persistentSessionID: UUID()
+        ) == .recoverRemoteConnection)
+    }
+
     @Test("recovers persistent local sessions")
     func recoversPersistentLocalSession() {
         let sessionID = UUID()

--- a/Tests/MuxyTests/Views/Terminal/TerminalProcessExitPolicyTests.swift
+++ b/Tests/MuxyTests/Views/Terminal/TerminalProcessExitPolicyTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import Muxy
+
+@Suite("Terminal process exit policy")
+struct TerminalProcessExitPolicyTests {
+    @Test("recovers remote connections instead of closing their panes")
+    func recoversRemoteConnection() {
+        #expect(TerminalProcessExitPolicy.disposition(
+            isRemote: true,
+            persistentSessionID: nil
+        ) == .recoverRemoteConnection)
+    }
+
+    @Test("recovers persistent local sessions")
+    func recoversPersistentLocalSession() {
+        let sessionID = UUID()
+        #expect(TerminalProcessExitPolicy.disposition(
+            isRemote: false,
+            persistentSessionID: sessionID
+        ) == .recoverPersistentSession(sessionID))
+    }
+
+    @Test("closes non-persistent local panes")
+    func closesNonPersistentLocalPane() {
+        #expect(TerminalProcessExitPolicy.disposition(
+            isRemote: false,
+            persistentSessionID: nil
+        ) == .closePane)
+    }
+}


### PR DESCRIPTION
## Summary

- keep remote project panes open when their SSH process exits
- show a reconnect state that starts a fresh SSH terminal session
- reject stale Ghostty exit callbacks by surface generation while preserving existing local session behavior

## Changes

- add an explicit terminal process-exit policy for remote, persistent local, and regular local panes
- recreate remote surfaces from the recovery placeholder
- guard asynchronous close and command-exit handling against replaced surfaces
- add focused policy and event-adapter regression coverage

## Testing

- `scripts/checks.sh --fix`
- `scripts/run-tests-isolated.sh swift test --filter GhosttyRuntimeEventAdapterTests`
- `scripts/run-tests-isolated.sh swift test --filter TerminalProcessExitPolicyTests`

## Screenshots

Not included because this changes terminal disconnect behavior and recovery messaging rather than a stable standalone screen.

## AI contribution

Implemented with `openai/gpt-5.6-sol`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved recovery for disconnected SSH terminal sessions, including reconnect prompts and remote-specific guidance.
  - Terminal panes now choose the appropriate recovery action for remote sessions, persistent sessions, or standard panes.
  - Added localized messages for new SSH sessions and ended connections.

- **Bug Fixes**
  - Prevented stale terminal views from being updated after a session is replaced.

- **Tests**
  - Added coverage for terminal recovery behavior and stale session exit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->